### PR TITLE
Patch: Docker build missing ROS compressed image transport package

### DIFF
--- a/docker/unitree/agents/Dockerfile
+++ b/docker/unitree/agents/Dockerfile
@@ -54,6 +54,7 @@ RUN apt-get update && apt-get install -y \
     ros-${ROS_DISTRO}-desktop \
     ros-${ROS_DISTRO}-ros-base \
     ros-${ROS_DISTRO}-image-tools \
+    ros-${ROS_DISTRO}-compressed-image-transport \
     ros-${ROS_DISTRO}-vision-msgs \
     ros-${ROS_DISTRO}-rviz2 \
     ros-${ROS_DISTRO}-rqt \

--- a/docker/unitree/agents_interface/Dockerfile
+++ b/docker/unitree/agents_interface/Dockerfile
@@ -54,6 +54,7 @@ RUN apt-get update && apt-get install -y \
     ros-${ROS_DISTRO}-desktop \
     ros-${ROS_DISTRO}-ros-base \
     ros-${ROS_DISTRO}-image-tools \
+    ros-${ROS_DISTRO}-compressed-image-transport \
     ros-${ROS_DISTRO}-vision-msgs \
     ros-${ROS_DISTRO}-rviz2 \
     ros-${ROS_DISTRO}-rqt \

--- a/docker/unitree/ros/Dockerfile
+++ b/docker/unitree/ros/Dockerfile
@@ -53,6 +53,7 @@ RUN apt-get update && apt-get install -y \
     ros-${ROS_DISTRO}-desktop \
     ros-${ROS_DISTRO}-ros-base \
     ros-${ROS_DISTRO}-image-tools \
+    ros-${ROS_DISTRO}-compressed-image-transport \
     ros-${ROS_DISTRO}-vision-msgs \
     ros-${ROS_DISTRO}-rviz2 \
     ros-${ROS_DISTRO}-rqt \

--- a/docker/unitree/ros_dimos/Dockerfile
+++ b/docker/unitree/ros_dimos/Dockerfile
@@ -54,6 +54,7 @@ RUN apt-get update && apt-get install -y \
     ros-${ROS_DISTRO}-desktop \
     ros-${ROS_DISTRO}-ros-base \
     ros-${ROS_DISTRO}-image-tools \
+    ros-${ROS_DISTRO}-compressed-image-transport \
     ros-${ROS_DISTRO}-vision-msgs \
     ros-${ROS_DISTRO}-rviz2 \
     ros-${ROS_DISTRO}-rqt \


### PR DESCRIPTION
Required due to update in GO2 ROS SDK.