### PR TITLE
Fully working v0 claude thinking demo with spatial memory/navigation as skills

### DIFF
--- a/dimos/skills/observe_stream.py
+++ b/dimos/skills/observe_stream.py
@@ -223,9 +223,6 @@ class ObserveStream(AbstractRobotSkill):
             self._stop_event.set()
             self._subscription.dispose()
             self._subscription = None
-            
-            skill_library = self._robot.get_skills()
-            self.unregister_as_running("ObserveStream", skill_library)
-            
+                        
             return "Observer stopped"
         return "Observer was not running"

--- a/tests/test_claude_agent_skills_query.py
+++ b/tests/test_claude_agent_skills_query.py
@@ -24,6 +24,7 @@ from dimos.robot.unitree.unitree_skills import MyUnitreeSkills
 from dimos.web.robot_web_interface import RobotWebInterface
 from dimos.skills.observe_stream import ObserveStream
 from dimos.skills.kill_skill import KillSkill
+from dimos.skills.navigation import Navigate, BuildSemanticMap
 import reactivex as rx
 import reactivex.operators as ops
 # Load API key from environment
@@ -66,9 +67,13 @@ Example: If the user asks to move forward 1 meter, call the Move function with d
 robot_skills = robot.get_skills()
 robot_skills.add(ObserveStream)
 robot_skills.add(KillSkill)
+robot_skills.add(Navigate)
+robot_skills.add(BuildSemanticMap)
 
 robot_skills.create_instance("ObserveStream", robot=robot, agent=agent)
 robot_skills.create_instance("KillSkill", robot=robot, skill_library=robot_skills)
+robot_skills.create_instance("Navigate", robot=robot)
+robot_skills.create_instance("BuildSemanticMap", robot=robot)
 
 # Subscribe to agent responses and send them to the subject
 agent.get_response_observable().subscribe(


### PR DESCRIPTION
Changes
- Added threading for GlobalPlanner in Navigate skill
- Added stop() methods to Navigate and BuildSemanticMap
- Improved skill termination handling in SkillLibrary

TODO: 
- KillSkill not working for Navigate(). Test stop_stream parameter
- Allow SemanticMap to build continuously in background
- Change threading to use @lukasapaukstys RX Threadpool disposable. Could not get this to work first try. 

This was the disposable threadpool scheduler impl in Navigate __call__() method

```python
def __call__(self):
        """
        Query the semantic map with the provided text query.
        
        Returns:
            A dictionary with the best matching position and query details
        """
        super().__call__()
        
        if not self.query:
            error_msg = "No query provided to Navigate skill"
            logger.error(error_msg)
            return error_msg
        
        logger.info(f"Querying semantic map for: '{self.query}'")
        
        # Setup the persistent ChromaDB client
        db_client = self._setup_persistent_chroma_db()
        
        # Setup output directory for any saved results
        output_dir = os.path.dirname(self.visual_memory_path)
        
        # Load the visual memory
        logger.info(f"Loading visual memory from {self.visual_memory_path}...")
        if os.path.exists(self.visual_memory_path):
            visual_memory = VisualMemory.load(self.visual_memory_path, output_dir=output_dir)
            logger.info(f"Loaded {visual_memory.count()} images from visual memory")
        else:
            visual_memory = VisualMemory(output_dir=output_dir)
            logger.warning("No existing visual memory found. Query results won't include images.")
        
        # Create SpatialMemory with the existing database and visual memory
        spatial_memory = SpatialMemory(
            collection_name=self.collection_name,
            chroma_client=db_client,
            visual_memory=visual_memory
        )
        
        # Run the query
        results = spatial_memory.query_by_text(self.query, limit=self.limit)
        
        if not results:
            logger.warning(f"No results found for query: '{self.query}'")
            return {
                "success": False,
                "query": self.query,
                "error": "No matching location found"
            }
        
        # Get the best match
        best_match = results[0]
        metadata = best_match.get('metadata', {})
        
        if isinstance(metadata, list) and metadata:
            metadata = metadata[0]
        
        # Extract coordinates from metadata
        if isinstance(metadata, dict) and 'x' in metadata and 'y' in metadata:
            x = metadata.get('x', 0)
            y = metadata.get('y', 0)
            z = metadata.get('z', 0)
            
            # Calculate similarity score (distance is inverse of similarity)
            similarity = 1.0 - (best_match.get('distance', 0) if best_match.get('distance') is not None else 0)
            
            logger.info(f"Found match for '{self.query}' at ({x:.2f}, {y:.2f}, {z:.2f}) with similarity: {similarity:.4f}")
            

            logger.info(f"Starting navigation to position: ({x:.2f}, {y:.2f})")

            # Reset the stop event before starting navigation
            self._stop_event.clear()
            
            # Test the scheduler with a simple function
            def test_thread():
                logger.critical("Test thread function executed successfully!")
            
            self._scheduler.schedule(test_thread)
            # Define a navigation function that will run on a separate thread
            def run_navigation():
                try:
                    logger.info(f"Starting global planner navigation to ({x:.2f}, {y:.2f})")
                    # Pass our stop_event to allow cancellation
                    result = self._robot.global_planner.set_goal((x, y), stop_event=self._stop_event)
                    if result:
                        logger.info("Global planner navigation completed successfully")
                    else:
                        logger.warning("Global planner navigation did not complete successfully")
                    return result
                except Exception as e:
                    logger.error(f"Error in navigation thread: {e}")
                    return False
            
            # Cancel any existing navigation task
            if hasattr(self, '_navigation_disposable') and self._navigation_disposable:
                logger.info("Canceling existing navigation")
                self._stop_event.set()
                self._navigation_disposable.dispose()
            
            # Create a fresh stop event for this navigation
            self._stop_event.clear()
            
            # Schedule the navigation on the thread pool using the DiMOS scheduler
            logger.info("Scheduling navigation on DimOS thread pool")
            self._navigation_disposable = self._scheduler.schedule(run_navigation)

            return {
                "success": True,
                "query": self.query,
                "position": (x, y, z),
                "similarity": similarity,
                "metadata": metadata
            }
        else:
            logger.warning(f"No valid position data found for query: '{self.query}'")
            return {
                "success": False,
                "query": self.query,
                "error": "No valid position data found"
            }
            ```