### PR TITLE
reactive stream wrappers

### DIFF
--- a/dimos/utils/reactive.py
+++ b/dimos/utils/reactive.py
@@ -1,0 +1,130 @@
+import threading
+from typing import Optional, TypeVar, Generic
+
+import reactivex as rx
+from reactivex import operators as ops
+from reactivex.scheduler import ThreadPoolScheduler
+from reactivex.observable import Observable
+from rxpy_backpressure import BackPressure
+
+from dimos.utils.threadpool import get_scheduler
+
+T = TypeVar('T')
+
+# Observable ─► ReplaySubject─► observe_on(pool) ─► backpressure.latest ─► sub1 (fast)
+#                           ├──► observe_on(pool) ─► backpressure.latest ─► sub2 (slow)
+#                           └──► observe_on(pool) ─► backpressure.latest ─► sub3 (slower)
+def backpressure(
+    observable: Observable[T],
+    scheduler: Optional[ThreadPoolScheduler] = None,
+    drop_unprocessed: bool = True,
+) -> Observable[T]:
+    if scheduler is None:
+        scheduler = get_scheduler()
+
+    # hot, latest-cached core (similar to replay subject)
+    core = observable.pipe(
+        ops.replay(buffer_size=1),
+        ops.ref_count(),  # Shared but still synchronous!
+    )
+
+    # per-subscriber factory
+    def per_sub():
+        # Move processing to thread pool
+        base = core.pipe(ops.observe_on(scheduler))
+
+        # optional back-pressure handling
+        if not drop_unprocessed:
+            return base
+
+        def _subscribe(observer, sch=None):
+            return base.subscribe(BackPressure.LATEST(observer), scheduler=sch)
+
+        return rx.create(_subscribe)
+
+    # each `.subscribe()` call gets its own async backpressure chain
+    return rx.defer(lambda *_: per_sub())
+
+
+class LatestReader(Generic[T]):
+    """A callable object that returns the latest value from an observable."""
+
+    def __init__(self, initial_value: T, subscription, connection=None):
+        self._value = initial_value
+        self._subscription = subscription
+        self._connection = connection
+
+    def __call__(self) -> T:
+        """Return the latest value from the observable."""
+        return self._value
+
+    def dispose(self) -> None:
+        """Dispose of the subscription to the observable."""
+        self._subscription.dispose()
+        if self._connection:
+            self._connection.dispose()
+
+def getter_ondemand(
+    observable: Observable[T],
+    timeout: Optional[float] = 30.0
+) -> T:
+    def getter():
+        try:
+            # Wait for first value with optional timeout
+            value = observable.pipe(
+                ops.first(),
+                *([ops.timeout(timeout)] if timeout is not None else [])
+            ).run()
+            return value
+        except Exception as e:
+            raise Exception(f"No value received after {timeout} seconds") from e
+    return getter
+
+T = TypeVar("T")
+
+
+def getter_streaming(
+    source: Observable[T],
+    timeout: Optional[float] = 30.0,
+    *,
+    nonblocking: bool = False,
+) -> LatestReader[T]:
+    shared = source.pipe(
+        ops.replay(buffer_size=1),
+        ops.ref_count(),            # auto-connect & auto-disconnect
+    )
+
+    _val_lock = threading.Lock()
+    _val: T | None = None
+    _ready = threading.Event()
+
+    def _update(v: T) -> None:
+        nonlocal _val
+        with _val_lock:
+            _val = v
+        _ready.set()
+
+    sub = shared.subscribe(_update)
+
+    # If we’re in blocking mode, wait right now
+    if not nonblocking:
+        if timeout is not None and not _ready.wait(timeout):
+            sub.dispose()
+            raise TimeoutError(f"No value received after {timeout} s")
+        else:
+            _ready.wait()           # wait indefinitely if timeout is None
+
+    def reader() -> T:
+        if not _ready.is_set():                 # first call in non-blocking mode
+            if timeout is not None and not _ready.wait(timeout):
+                raise TimeoutError(f"No value received after {timeout} s")
+            else:
+                _ready.wait()
+        with _val_lock:
+            return _val    # type: ignore[return-value]
+
+    def _dispose() -> None:
+        sub.dispose()
+
+    reader.dispose = _dispose          # type: ignore[attr-defined]
+    return reader

--- a/dimos/utils/test_reactive.py
+++ b/dimos/utils/test_reactive.py
@@ -1,0 +1,157 @@
+import pytest
+import time
+import reactivex as rx
+from reactivex import operators as ops
+from typing import Callable, TypeVar, Any
+from dimos.utils.reactive import backpressure, getter_streaming, getter_ondemand
+from reactivex.disposable import Disposable
+
+
+def measure_time(func: Callable[[], Any], iterations: int = 1) -> float:
+    start_time = time.time()
+    result = func()
+    end_time = time.time()
+    total_time = end_time - start_time
+    return result, total_time
+
+def assert_time(func: Callable[[], Any], assertion: Callable[[int], bool], assert_fail_msg=None) -> None:
+    [result, total_time ] = measure_time(func)
+    assert assertion(total_time), assert_fail_msg + f", took {round(total_time, 2)}s"
+    return result
+
+def min_time(func: Callable[[], Any], min_t: int, assert_fail_msg="Function returned too fast"):
+    return assert_time(func, (lambda t: t > min_t), assert_fail_msg + f", min: {min_t} seconds")
+
+def max_time(func: Callable[[], Any], max_t: int, assert_fail_msg="Function took too long"):
+    return assert_time(func, (lambda t: t < max_t), assert_fail_msg + f", max: {max_t} seconds")
+
+T = TypeVar('T')
+
+def dispose_spy(source: rx.Observable[T]) -> rx.Observable[T]:
+    state = {"active": 0}
+
+    def factory(observer, scheduler=None):
+        state["active"] += 1
+        upstream = source.subscribe(observer, scheduler=scheduler)
+        def _dispose():
+            upstream.dispose()
+            state["active"] -= 1
+        return Disposable(_dispose)
+
+    proxy = rx.create(factory)
+    proxy.subs_number = lambda: state["active"]
+    proxy.is_disposed = lambda: state["active"] == 0
+    return proxy
+
+
+
+
+def test_backpressure_handling():
+    received_fast = []
+    received_slow = []
+    source = dispose_spy(rx.interval(0.1).pipe(ops.take(50)))
+
+    # Wrap with backpressure handling
+    safe_source = backpressure(source)
+
+    # Fast sub
+    subscription1 = safe_source.subscribe(lambda x: received_fast.append(x))
+
+    # Slow sub (shouldn't block above)
+    subscription2 = safe_source.subscribe(lambda x: (time.sleep(0.25), received_slow.append(x)))
+    
+    time.sleep(2.5)
+    
+    subscription1.dispose()
+    assert not source.is_disposed(), "Observable should not be disposed yet"
+    subscription2.dispose()
+    time.sleep(0.1)
+    assert source.is_disposed(), "Observable should be disposed"
+
+    # Check results
+    print("Fast observer received:", len(received_fast), received_fast)
+    print("Slow observer received:", len(received_slow), received_slow)
+    
+    # Fast observer should get all or nearly all items
+    assert len(received_fast) > 15, f"Expected fast observer to receive most items, got {len(received_fast)}"
+    
+    # Slow observer should get fewer items due to backpressure handling
+    assert len(received_slow) < len(received_fast), "Slow observer should receive fewer items than fast observer"
+    # Specifically, processing at 0.25s means ~4 items per second, so expect 8-10 items
+    assert 7 <= len(received_slow) <= 11, f"Expected 7-11 items, got {len(received_slow)}"
+    
+    # The slow observer should skip items (not process them in sequence)
+    # We test this by checking that the difference between consecutive items is sometimes > 1
+    has_skips = False
+    for i in range(1, len(received_slow)):
+        if received_slow[i] - received_slow[i-1] > 1:
+            has_skips = True
+            break
+    assert has_skips, "Slow observer should skip items due to backpressure"
+
+
+def test_getter_streaming_blocking():
+    source = dispose_spy(rx.interval(0.2).pipe(ops.take(50)))
+    assert source.is_disposed()
+
+    getter = min_time(lambda: getter_streaming(source), 0.2, "Latest getter needs to block until first msg is ready")
+    assert getter() == 0, f"Expected to get the first value of 0, got {getter()}"
+
+    time.sleep(0.5)
+    assert getter() >= 2, f"Expected value >= 2, got {getter()}"
+    time.sleep(0.5)
+    assert getter() >= 4, f"Expected value >= 4, got {getter()}"
+
+    getter.dispose()
+    assert source.is_disposed(), "Observable should be disposed"
+
+def test_getter_streaming_blocking_timeout():
+    source = dispose_spy(rx.interval(0.2).pipe(ops.take(50)))
+    with pytest.raises(Exception):
+        getter = getter_streaming(source, timeout=0.1)
+        getter.dispose()
+    assert source.is_disposed()
+
+def test_getter_streaming_nonblocking():
+    source = dispose_spy(rx.interval(0.2).pipe(ops.take(50)))
+
+    getter = max_time(lambda: getter_streaming(source, nonblocking=True), 0.1, "nonblocking getter init shouldn't block")
+    min_time(getter, 0.2, "Expected for first value call to block if cache is empty")
+    assert getter() == 0
+
+    time.sleep(0.5)
+    assert getter() >= 2, f"Expected value >= 2, got {getter()}"
+
+    # sub is active
+    assert not source.is_disposed()
+
+    time.sleep(0.5)
+    assert getter() >= 4, f"Expected value >= 4, got {getter()}"
+
+
+    getter.dispose()
+    assert source.is_disposed(), "Observable should be disposed"
+
+def test_getter_streaming_nonblocking_timeout():
+    source = dispose_spy(rx.interval(0.2).pipe(ops.take(50)))
+    getter = getter_streaming(source, timeout=0.1, nonblocking=True)
+    with pytest.raises(Exception):
+        getter()
+
+    assert not source.is_disposed(), "is not disposed, this is a job of the caller"
+
+def test_getter_ondemand():
+    source = dispose_spy(rx.interval(0.1).pipe(ops.take(50)))
+    getter = getter_ondemand(source)
+    assert source.is_disposed(), "Observable should be disposed"
+    assert min_time(getter, 0.05) == 0, f"Expected to get the first value of 0, got {getter()}"
+    assert source.is_disposed(), "Observable should be disposed"
+    assert getter() == 0, f"Expected to get the first value of 0, got {getter()}"
+    assert source.is_disposed(), "Observable should be disposed"
+
+def test_getter_ondemand_timeout():
+    source = dispose_spy(rx.interval(0.2).pipe(ops.take(50)))
+    getter = getter_ondemand(source, timeout=0.1)
+    with pytest.raises(Exception):
+        getter()
+    assert source.is_disposed(), "Observable should be disposed"


### PR DESCRIPTION
Provides reactiveX wrappers for simple function getters and rx backpressure handling system

```py
# blocks until the first msg received
getFrame = getter_streaming(camera_observable)
# immediate cache return
getFrame() -> Image 
# make sure to call when cleaning up your module (will unsubscribe from upstream)
getFrame.dispose()

# returns immediately
getFrame = getter_streaming(camera_observable, nonblocking=True)
# might block until the first msg received
getFrame() -> Image 
# make sure to call when cleaning up your module  (will unsubscribe from upstream)
getFrame.dispose()


getFrame = getter_ondemand(camera_observable)
# subscribes, waits for the message, returns it
getFrame() -> Image
# no need for getFrame.dispose(), it's not listening constantly

# probably we want to wrap all our streams with this:
robot.camera = backpressure(camera_observable)
# returns an Observable that you can consume slowly or as fast as possible without filling memory or blocking other subscribers
# !!! reactiveX otherwise will pass messages as fast as the slowest subscriber while filling memory
# so if our "user facing" streams are not wrapped in this, one system component can block all others

```

feel free to suggest better naming, I need to rewrite ros_observable_topic to depend on this stuff, now we have a double implementation of similar stuff