### PR TITLE
Ci shared docker cache

### DIFF
--- a/.github/workflows/_docker-build-template.yml
+++ b/.github/workflows/_docker-build-template.yml
@@ -59,6 +59,8 @@ jobs:
           context: ${{ inputs.context }}
           file:   docker/${{ inputs.dockerfile }}/Dockerfile
           tags:   ${{ inputs.to-image }}
-          cache-from: type=gha,scope=${{ inputs.dockerfile }}-${{ inputs.from-image }}
-          cache-to:   type=gha,mode=max,scope=${{ inputs.dockerfile }}-${{ inputs.from-image }}
+          cache-from: type=gha,scope=${{ inputs.dockerfile }}
+          cache-to:   type=gha,mode=max,scope=${{ inputs.dockerfile }}
+          #cache-from: type=gha,scope=${{ inputs.dockerfile }}-${{ inputs.from-image }}
+          #cache-to:   type=gha,mode=max,scope=${{ inputs.dockerfile }}-${{ inputs.from-image }}
           build-args: FROM_IMAGE=${{ inputs.from-image }}


### PR DESCRIPTION
for now we create a docker build cache per branch, we'll get a serious speedup if cache is shared

(before was worried about cache growing too much due to different build requirements, but builds rarely change)