### PR TITLE
Ci pre-commit and docker builds run in parallel

### DIFF
--- a/.github/workflows/code-cleanup.yml
+++ b/.github/workflows/code-cleanup.yml
@@ -1,4 +1,4 @@
-name: cleanup
+name: code-cleanup
 on: push
 
 permissions:
@@ -27,7 +27,3 @@ jobs:
       uses: stefanzweifel/git-auto-commit-action@v5
       with:
         commit_message: "CI code cleanup"
-
-  docker:
-    needs: [pre-commit]
-    uses: ./.github/workflows/docker.yml

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,11 +1,10 @@
 name: docker
-on: workflow_call
+on: push
 
 permissions:
   contents: read
   packages: write
   pull-requests: read
-
 
 jobs:
   check-changes:


### PR DESCRIPTION
as mentioned. will cause double docker build if pre-commit makes a commit but this is extremely rare, can be handled with actions parallelism config later