### PR TITLE
[DRAFT] Metric3D ONNX

### DIFF
--- a/dimos/models/depth/metric3d.py
+++ b/dimos/models/depth/metric3d.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import torch
+import onnxruntime as ort
 from PIL import Image
 import cv2
 import numpy as np
@@ -24,22 +24,52 @@ import numpy as np
 
 
 class Metric3D:
-    def __init__(self, gt_depth_scale=256.0):
-        # self.conf = get_config("zoedepth", "infer")
-        # self.depth_model = build_model(self.conf)
-        self.depth_model = torch.hub.load(
-            "yvanyin/metric3d", "metric3d_vit_small", pretrain=True
-        ).cuda()
-        if torch.cuda.device_count() > 1:
-            print(f"Using {torch.cuda.device_count()} GPUs!")
-            # self.depth_model = torch.nn.DataParallel(self.depth_model)
-        self.depth_model.eval()
-
-        self.intrinsic = [707.0493, 707.0493, 604.0814, 180.5066]
+    def __init__(self, onnx_model_path, gt_depth_scale=256.0, intrinsic=None, provider='auto'):
+        self.input_size = (616, 1064)  # for vit model; adjust if needed
+        self.gt_depth_scale = gt_depth_scale
+        self.intrinsic = intrinsic or [707.0493, 707.0493, 604.0814, 180.5066]
         self.intrinsic_scaled = None
-        self.gt_depth_scale = gt_depth_scale  # And this
         self.pad_info = None
         self.rgb_origin = None
+
+        # Provider selection logic
+        if provider == 'auto':
+            # Try CUDA, then TensorRT, then CPU
+            available_providers = ort.get_available_providers()
+            if 'CUDAExecutionProvider' in available_providers:
+                providers = [
+                    (
+                        'CUDAExecutionProvider',
+                        {'cudnn_conv_use_max_workspace': '0', 'device_id': '0'}
+                    )
+                ]
+            elif 'TensorrtExecutionProvider' in available_providers:
+                providers = [
+                    (
+                        'TensorrtExecutionProvider',
+                        {'trt_engine_cache_enable': True, 'trt_fp16_enable': True, 'device_id': 0, 'trt_dla_enable': False}
+                    )
+                ]
+            else:
+                providers = ['CPUExecutionProvider']
+        elif provider == 'cuda':
+            providers = [
+                (
+                    'CUDAExecutionProvider',
+                    {'cudnn_conv_use_max_workspace': '0', 'device_id': '0'}
+                )
+            ]
+        elif provider == 'tensorrt':
+            providers = [
+                (
+                    'TensorrtExecutionProvider',
+                    {'trt_engine_cache_enable': True, 'trt_fp16_enable': True, 'device_id': 0, 'trt_dla_enable': False}
+                )
+            ]
+        else:
+            providers = ['CPUExecutionProvider']
+
+        self.session = ort.InferenceSession(onnx_model_path, providers=providers)
 
     """
     Input: Single image in RGB format
@@ -56,52 +86,13 @@ class Metric3D:
         self.intrinsic = intrinsic
         print(f"Intrinsics updated to: {self.intrinsic}")
 
-    def infer_depth(self, img, debug=False):
-        if debug:
-            print(f"Input image: {img}")
-        try:
-            if isinstance(img, str):
-                print(f"Image type string: {type(img)}")
-                self.rgb_origin = cv2.imread(img)[:, :, ::-1]
-            else:
-                # print(f"Image type not string: {type(img)}, cv2 conversion assumed to be handled. If not, this will throw an error")
-                self.rgb_origin = img
-        except Exception as e:
-            print(f"Error parsing into infer_depth: {e}")
-
-        img = self.rescale_input(img, self.rgb_origin)
-
-        with torch.no_grad():
-            pred_depth, confidence, output_dict = self.depth_model.inference({"input": img})
-
-        # Convert to PIL format
-        depth_image = self.unpad_transform_depth(pred_depth)
-        out_16bit_numpy = (depth_image.squeeze().cpu().numpy() * self.gt_depth_scale).astype(
-            np.uint16
-        )
-        depth_map_pil = Image.fromarray(out_16bit_numpy)
-
-        return depth_map_pil
-
-    def save_depth(self, pred_depth):
-        # Save the depth map to a file
-        pred_depth_np = pred_depth.cpu().numpy()
-        output_depth_file = "output_depth_map.png"
-        cv2.imwrite(output_depth_file, pred_depth_np)
-        print(f"Depth map saved to {output_depth_file}")
-
-    # Adjusts input size to fit pretrained ViT model
-    def rescale_input(self, rgb, rgb_origin):
-        #### ajust input size to fit pretrained model
-        # keep ratio resize
-        input_size = (616, 1064)  # for vit model
-        # input_size = (544, 1216) # for convnext model
-        h, w = rgb_origin.shape[:2]
-        scale = min(input_size[0] / h, input_size[1] / w)
+    def prepare_input(self, rgb_image):
+        h, w = rgb_image.shape[:2]
+        scale = min(self.input_size[0] / h, self.input_size[1] / w)
         rgb = cv2.resize(
-            rgb_origin, (int(w * scale), int(h * scale)), interpolation=cv2.INTER_LINEAR
+            rgb_image, (int(w * scale), int(h * scale)), interpolation=cv2.INTER_LINEAR
         )
-        # remember to scale intrinsic, hold depth
+        # Scale intrinsics
         self.intrinsic_scaled = [
             self.intrinsic[0] * scale,
             self.intrinsic[1] * scale,
@@ -111,8 +102,8 @@ class Metric3D:
         # padding to input_size
         padding = [123.675, 116.28, 103.53]
         h, w = rgb.shape[:2]
-        pad_h = input_size[0] - h
-        pad_w = input_size[1] - w
+        pad_h = self.input_size[0] - h
+        pad_w = self.input_size[1] - w
         pad_h_half = pad_h // 2
         pad_w_half = pad_w // 2
         rgb = cv2.copyMakeBorder(
@@ -125,49 +116,70 @@ class Metric3D:
             value=padding,
         )
         self.pad_info = [pad_h_half, pad_h - pad_h_half, pad_w_half, pad_w - pad_w_half]
+        onnx_input = {
+            "image": np.ascontiguousarray(
+                np.transpose(rgb, (2, 0, 1))[None], dtype=np.float32
+            ),  # 1, 3, H, W
+        }
+        return onnx_input, rgb_image.shape[:2]
 
-        #### normalize
-        mean = torch.tensor([123.675, 116.28, 103.53]).float()[:, None, None]
-        std = torch.tensor([58.395, 57.12, 57.375]).float()[:, None, None]
-        rgb = torch.from_numpy(rgb.transpose((2, 0, 1))).float()
-        rgb = torch.div((rgb - mean), std)
-        rgb = rgb[None, :, :, :].cuda()
-        return rgb
+    def infer_depth(self, img, debug=False):
+        if debug:
+            print(f"Input image: {img}")
+        try:
+            if isinstance(img, str):
+                print(f"Image type string: {type(img)}")
+                self.rgb_origin = cv2.imread(img)[:, :, ::-1]
+            else:
+                self.rgb_origin = img
+        except Exception as e:
+            print(f"Error parsing into infer_depth: {e}")
+            return None
 
-    def unpad_transform_depth(self, pred_depth):
-        # un pad
-        pred_depth = pred_depth.squeeze()
-        pred_depth = pred_depth[
-            self.pad_info[0] : pred_depth.shape[0] - self.pad_info[1],
-            self.pad_info[2] : pred_depth.shape[1] - self.pad_info[3],
+        onnx_input, original_shape = self.prepare_input(self.rgb_origin)
+        outputs = self.session.run(None, onnx_input)
+        depth = outputs[0].squeeze()  # [H, W]
+
+        # Remove padding
+        pad_info = self.pad_info
+        depth = depth[
+            pad_info[0] : self.input_size[0] - pad_info[1],
+            pad_info[2] : self.input_size[1] - pad_info[3],
         ]
+        # Resize to original image size
+        depth = cv2.resize(
+            depth, (original_shape[1], original_shape[0]), interpolation=cv2.INTER_LINEAR
+        )
 
-        # upsample to original size
-        pred_depth = torch.nn.functional.interpolate(
-            pred_depth[None, None, :, :], self.rgb_origin.shape[:2], mode="bilinear"
-        ).squeeze()
-        ###################### canonical camera space ######################
+        # Convert canonical depth to metric using scaled intrinsics
+        if self.intrinsic_scaled is not None:
+            canonical_to_real_scale = self.intrinsic_scaled[0] / 1000.0
+            depth = depth * canonical_to_real_scale
 
-        #### de-canonical transform
-        canonical_to_real_scale = (
-            self.intrinsic_scaled[0] / 1000.0
-        )  # 1000.0 is the focal length of canonical camera
-        pred_depth = pred_depth * canonical_to_real_scale  # now the depth is metric
-        pred_depth = torch.clamp(pred_depth, 0, 1000)
-        return pred_depth
+        # Convert to 16-bit and PIL Image
+        out_16bit_numpy = (depth * self.gt_depth_scale).astype(np.uint16)
+        depth_map_pil = Image.fromarray(out_16bit_numpy)
+        return depth_map_pil
 
-    """Set new intrinsic value."""
-
-    def update_intrinsic(self, intrinsic):
-        self.intrinsic = intrinsic
+    def save_depth(self, pred_depth):
+        # Save the depth map to a file
+        if isinstance(pred_depth, Image.Image):
+            pred_depth_np = np.array(pred_depth)
+        else:
+            pred_depth_np = pred_depth
+        output_depth_file = "output_depth_map.png"
+        cv2.imwrite(output_depth_file, pred_depth_np)
+        print(f"Depth map saved to {output_depth_file}")
 
     def eval_predicted_depth(self, depth_file, pred_depth):
         if depth_file is not None:
             gt_depth = cv2.imread(depth_file, -1)
             gt_depth = gt_depth / self.gt_depth_scale
-            gt_depth = torch.from_numpy(gt_depth).float().cuda()
+            if isinstance(pred_depth, Image.Image):
+                pred_depth = np.array(pred_depth) / self.gt_depth_scale
+            else:
+                pred_depth = pred_depth / self.gt_depth_scale
             assert gt_depth.shape == pred_depth.shape
-
             mask = gt_depth > 1e-8
-            abs_rel_err = (torch.abs(pred_depth[mask] - gt_depth[mask]) / gt_depth[mask]).mean()
-            print("abs_rel_err:", abs_rel_err.item())
+            abs_rel_err = (np.abs(pred_depth[mask] - gt_depth[mask]) / gt_depth[mask]).mean()
+            print("abs_rel_err:", abs_rel_err)

--- a/onnx/metric3d_vit_small.onnx
+++ b/onnx/metric3d_vit_small.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58d5a045c6d3ed45644cef8066e00cd5e1cf19131fb589c887cb200dc459a028
+size 151472192


### PR DESCRIPTION
(DRAFT, can't repeat that enough)

Didn't have a way to test the Metric3D version of this. The tl;dr is: Metric3D can be substituted out for the ONNX equivalent, which compiles into a fused (and very very fast) neural net.

This means it can:
1. Run on TensorRT
2. Run on CUDA as a fallback
3. (If all else fails) run on CPU as a fallback

If you have a way to test it, let me know - I tried using the file `./tests/test_semantic_seg_webcam.py`, but I don't have `dimos_lcm`.