### PR TITLE
Fix event loop leak

### DIFF
--- a/dimos/web/websocket_vis/websocket_vis_module.py
+++ b/dimos/web/websocket_vis/websocket_vis_module.py
@@ -92,6 +92,7 @@ class WebsocketVisModule(Module):
 
     def _start_broadcast_loop(self):
         """Start the broadcast event loop in a background thread."""
+
         def run_loop():
             self._broadcast_loop = asyncio.new_event_loop()
             asyncio.set_event_loop(self._broadcast_loop)


### PR DESCRIPTION
if I run `dimos/robot/unitree/unitree_go2.py` for a long period (I think around 10 minutes). It eventually breaks with `2025-08-11 20:39:48,184 - dimos.web.websocket_vis - ERROR - Failed to broadcast state update: [Errno 24] Too many open files`