### PR TITLE
silence unnecessary unitree go 2 tricks

### DIFF
--- a/dimos/skills/skills.py
+++ b/dimos/skills/skills.py
@@ -113,12 +113,9 @@ class SkillLibrary:
         # Key based only on the name
         key = name
 
-        print(f"Preparing to create instance with name: {name} and args: {kwargs}")
-
         if key not in self._instances:
             # Instead of creating an instance, store the args for later use
             self._instances[key] = kwargs
-            print(f"Stored args for later instance creation: {name} with args: {kwargs}")
 
     def call(self, name, **args):
         try:


### PR DESCRIPTION
Remove this:

```
Preparing to create instance with name: Backflip and args: {'robot': <__main__.UnitreeGo2 object at 0x737873fb3940>}
Stored args for later instance creation: Backflip with args: {'robot': <__main__.UnitreeGo2 object at 0x737873fb3940>}
Preparing to create instance with name: BalanceStand and args: {'robot': <__main__.UnitreeGo2 object at 0x737873fb3940>}
Stored args for later instance creation: BalanceStand with args: {'robot': <__main__.UnitreeGo2 object at 0x737873fb3940>}
Preparing to create instance with name: BodyHeight and args: {'robot': <__main__.UnitreeGo2 object at 0x737873fb3940>}
Stored args for later instance creation: BodyHeight with args: {'robot': <__main__.UnitreeGo2 object at 0x737873fb3940>}
Preparing to create instance with name: Bound and args: {'robot': <__main__.UnitreeGo2 object at 0x737873fb3940>}
Stored args for later instance creation: Bound with args: {'robot': <__main__.UnitreeGo2 object at 0x737873fb3940>}
Preparing to create instance with name: Content and args: {'robot': <__main__.UnitreeGo2 object at 0x737873fb3940>}
Stored args for later instance creation: Content with args: {'robot': <__main__.UnitreeGo2 object at 0x737873fb3940>}

```