### PR TITLE
Handle missing GStreamer dependencies gracefully

### DIFF
--- a/dimos/stream/audio/input/__init__.py
+++ b/dimos/stream/audio/input/__init__.py
@@ -13,7 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dimos.stream.audio.input.gstreamer import GstreamerInput
-from dimos.stream.audio.input.player import FilePlayerInput
+__all__ = []
 
-__all__ = ["GstreamerInput", "FilePlayerInput"]
+try:
+    from dimos.stream.audio.input.gstreamer import GstreamerInput
+
+    __all__.append("GstreamerInput")
+except ImportError:  # pragma: no cover - exercised when optional deps missing
+    GstreamerInput = None  # type: ignore[assignment]
+
+try:
+    from dimos.stream.audio.input.player import FilePlayerInput  # type: ignore[attr-defined]
+
+    __all__.append("FilePlayerInput")
+except ImportError:  # pragma: no cover - optional feature
+    FilePlayerInput = None  # type: ignore[assignment]

--- a/dimos/stream/audio/input/gstreamer.py
+++ b/dimos/stream/audio/input/gstreamer.py
@@ -20,12 +20,15 @@ import time
 import numpy as np
 from reactivex import Observable, create, disposable
 
-import gi
+try:
+    import gi
 
-gi.require_version("Gst", "1.0")
-gi.require_version("GstApp", "1.0")
-gi.require_version("GstAudio", "1.0")
-from gi.repository import Gst, GstApp, GstAudio, GLib
+    gi.require_version("Gst", "1.0")
+    gi.require_version("GstApp", "1.0")
+    gi.require_version("GstAudio", "1.0")
+    from gi.repository import Gst, GstApp, GstAudio, GLib
+except (ImportError, ValueError) as exc:  # pragma: no cover - exercised in CI without GStreamer
+    raise ImportError("GStreamer dependencies are not available") from exc
 
 from dimos.stream.audio.base import AbstractAudioEmitter, AudioEvent
 from dimos.utils.gstreamer_manager import ensure_mainloop_running


### PR DESCRIPTION
## Summary
- raise a clear ImportError when the GStreamer GI bindings are missing so tests can skip cleanly
- guard the audio input package exports so optional backends do not break imports when dependencies are absent

## Testing
- pytest dimos/stream/audio/test_gstreamer.py -k basic *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_b_68e371b1f364832c88bdfc00dc818b47