### PR TITLE
docs-infra: Add infra for docstrings (minimal Ruff rules, doctest deps, mkdocs extensions)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,8 @@ plugins:
   - mkdocstrings:
       handlers:
         python:
+          extensions:
+            - griffe_typingdoc
           options:
             docstring_style: google
             members_order: alphabetical

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,9 @@ dependencies = [
     # Class Extraction
     "pydantic",
 
+    # For documenting parameters etc
+    "annotated-doc",
+
     # Developer Specific
     "ipykernel",
 
@@ -266,7 +269,7 @@ exclude = [
 ]
 
 [tool.ruff.lint]
-extend-select = ["E", "W", "F", "B", "UP", "N", "I", "C90", "A", "RUF", "TCH"]
+extend-select = ["E", "W", "F", "B", "UP", "N", "I", "C90", "A", "RUF", "TCH", "D300"]
 # TODO: All of these should be fixed, but it's easier commit autofixes first
 ignore = ["A001", "A002", "B008", "B017", "B019", "B023", "B024", "B026", "B904", "C901", "E402", "E501", "E721", "E722", "E741", "F401", "F403", "F811", "F821", "F821", "F821", "N801", "N802", "N803", "N806", "N812", "N813", "N813", "N816", "N817", "N999", "RUF002", "RUF003", "RUF006", "RUF009", "RUF012", "RUF034", "RUF043", "RUF059", "UP007"]
 


### PR DESCRIPTION
- docs-infra: Add xdoctest dep for testing examples in docstrings (but not to CI yet). I.e., can at least test examples in docs locally
- docs-infra: Add minimal Ruff rules for docstrings to pyproject.toml. Add griffe_typingdoc for PEP 727 docs to mkdocs.yml

I have ignored a bunch of Ruff docstring rules because I didn't want to have to contend with changing existing docstrings / didn't know what conventions might be preferred, but it'd be much better to enable those (some of these include relatively uncontroversial things like indentation things).

Rules that I'd recommend adding back at some point:
- D2 - All D2xx formatting rules (whitespace, blank lines, etc.)
- D400 - First line must end with period
- D402 - First line should not be function signature
- D403 - First line ends with question mark
- D419 - Empty docstring check