### PR TITLE
docstring: Add docstrings for Transport-related classes and `transport.py` module

### DIFF
--- a/dimos/core/stream.py
+++ b/dimos/core/stream.py
@@ -17,11 +17,13 @@ from __future__ import annotations
 import enum
 from typing import (
     TYPE_CHECKING,
+    Annotated,
     Any,
     Generic,
     TypeVar,
 )
 
+from annotated_doc import Doc
 from dask.distributed import Actor
 import reactivex as rx
 from reactivex import operators as ops
@@ -79,15 +81,98 @@ class State(enum.Enum):
     FLOWING = "flowing"  # runtime: data observed
 
 
+# TODO: Would be better to auto-generate the class inheritance diagram -- easy for this to get out of sync
 class Transport(ObservableMixin[T]):
-    # used by local Output
-    def broadcast(self, selfstream: Out[T], value: T) -> None: ...
+    """Abstraction layer for message passing between modules.
+
+    Transport decouples module communication from the underlying protocol (e.g. LCM,
+    SharedMemory, Dask RPC), enabling the same module code to deploy across
+    single-machine dev, robot+laptop test, or distributed cluster environments.
+    Transport selection happens at blueprint configuration time, not in module code.
+
+    Available concrete implementations:
+
+        Class Inheritance:
+            Transport[T]
+            └── PubSubTransport[T] (topic-based publish-subscribe)
+                ├── LCMTransport (network, typed)
+                │   └── JpegLcmTransport
+                ├── pLCMTransport (network, pickled)
+                ├── SHMTransport (local, typed)
+                ├── pSHMTransport (local, pickled)
+                ├── JpegShmTransport (local, JPEG)*
+                └── ZenohTransport (network, distributed)
+
+        * JpegShmTransport extends PubSubTransport directly (not SHMTransport)
+
+        Functional groups:
+            Network-capable: LCM*, pLCM*, JpegLcm*, Zenoh*
+            Local-only:      SHM*, pSHM*, JpegShm*
+
+    Requirements for concrete Transport implementations:
+        - **Serialization**: Must be serializable (via ``__reduce__``) for distributed
+          deployment across process boundaries.
+        - **Lazy Initialization**: Resources (sockets, shared memory, threads)
+          allocated on first broadcast() or subscribe().
+
+    Error handling contract:
+        - Errors in subscriber callbacks must not prevent delivery to other subscribers.
+        - Errors must not propagate to the publisher.
+        - Transport remains operational after subscriber errors.
+
+    Backpressure strategy (via observable()):
+        Uses latest-value semantics optimized for robotics where current sensor
+        state matters more than historical completeness. Slow consumers skip
+        intermediate values; producers are never blocked.
+
+    See also:
+        docs/concepts/transport.md: Guide to the Transport concept.
+    """
+
+    def broadcast(
+        self,
+        selfstream: Annotated[
+            Out[T] | None,
+            Doc(
+                """The originating output stream. Provides routing context
+                and debugging. Implementations may ignore this if not needed."""
+            ),
+        ],
+        value: Annotated[T, Doc("The message to deliver to all subscribers.")],
+    ) -> None:
+        """Deliver a value to all subscribers."""
+        ...
 
     def publish(self, msg: T) -> None:
+        """Broadcast a message without stream context."""
         self.broadcast(None, msg)  # type: ignore[arg-type]
 
     # used by local Input
-    def subscribe(self, selfstream: In[T], callback: Callable[[T], any]) -> None: ...  # type: ignore[valid-type]
+    def subscribe(
+        self,
+        selfstream: Annotated[
+            In[T] | None,
+            Doc(
+                """The subscribing input stream. Provides routing context and debugging.
+                Implementations may ignore this parameter."""
+            ),
+        ],
+        callback: Annotated[
+            Callable[[T], Any],
+            Doc(
+                """Invoked for each received value. Errors in the callback
+                do not affect other subscribers or the publisher."""
+            ),
+        ],
+    ) -> Annotated[
+        Callable[[], None] | None,
+        Doc("Unsubscribe function, or None (implementation-specific)."),
+    ]:
+        """Register a callback to receive broadcasted values.
+
+        Subscriptions persist until explicitly removed or the transport is destroyed.
+        """
+        ...
 
 
 class Stream(Generic[T]):

--- a/dimos/core/transport.py
+++ b/dimos/core/transport.py
@@ -12,9 +12,53 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Pub/sub transports for streaming data between modules.
+
+This module provides transport implementations that connect module stream
+endpoints (`In[T]` and `Out[T]`). Transports handle underlying protocol
+details, allowing modules to communicate without knowing whether data travels
+via shared memory, LCM multicast, or other mechanisms.
+
+Transport categories:
+
+- **Network-capable** (LCM variants): For distributed systems where modules
+  may run on different machines. Supports serialization and multicast.
+- **Local-only** (SHM variants): For high-throughput communication between
+  processes on the same machine. Uses shared memory for near-zero-copy transfer.
+
+Selection guidance:
+
+- `LCMTransport`: Default for typed messages with `lcm_encode` support
+- `pLCMTransport`: Python objects without LCM encoding, network-capable
+- `JpegLcmTransport`: Images over network with compression
+- `pSHMTransport`: High-throughput local data (images, point clouds)
+- `SHMTransport`: Raw bytes over shared memory
+- `JpegShmTransport`: Local images with reduced memory footprint
+
+Example:
+    Configure transports via `.transports()` on blueprint sets:
+
+        from dimos.core.blueprints import autoconnect
+        from dimos.core.transport import LCMTransport, pSHMTransport
+        from dimos.msgs.sensor_msgs import Image
+
+        blueprint = autoconnect(
+            connection(),
+            perception(),
+        ).transports({
+            # Key: (stream_property_name, Type)
+            ("color_image", Image): LCMTransport("/robot/camera", Image),
+        })
+
+All transports lazily initialize on first `broadcast()` or `subscribe()`
+call. For the abstract interface, see `Transport` in `stream.py`.
+"""
+
 from __future__ import annotations
 
-from typing import Any, TypeVar
+from typing import Annotated, Any, TypeVar
+
+from annotated_doc import Doc
 
 import dimos.core.colors as colors
 
@@ -37,6 +81,16 @@ T = TypeVar("T")  # type: ignore[misc]
 
 
 class PubSubTransport(Transport[T]):
+    """Topic-based publish-subscribe transport.
+
+    Extends `Transport` with a topic attribute for routing messages. Use this
+    when modules need to communicate over named channels rather than direct
+    point-to-point connections.
+
+    The topic serves as a logical address that publishers broadcast to and
+    subscribers listen on, enabling many-to-many communication patterns.
+    """
+
     topic: Any
 
     def __init__(self, topic: Any) -> None:
@@ -51,6 +105,19 @@ class PubSubTransport(Transport[T]):
 
 
 class pLCMTransport(PubSubTransport[T]):
+    """LCM (Lightweight Communications and Marshalling) transport with pickle serialization for arbitrary Python objects.
+
+    Uses UDP multicast via LCM for low-latency pub/sub messaging across processes
+    and machines. The "p" prefix indicates pickle serialization.
+
+    Use when you need network messaging with Python objects that lack `lcm_encode`
+    support. For native LCM types, prefer `LCMTransport` (faster, cross-language).
+
+    See also:
+        LCMTransport: Native LCM encoding (faster, cross-language).
+        pSHMTransport: Pickle over shared memory (single-machine only).
+    """
+
     _started: bool = False
 
     def __init__(self, topic: str, **kwargs) -> None:  # type: ignore[no-untyped-def]
@@ -75,9 +142,37 @@ class pLCMTransport(PubSubTransport[T]):
 
 
 class LCMTransport(PubSubTransport[T]):
+    """Publish-subscribe transport using LCM (Lightweight Communications and Marshalling) native encoding over UDP multicast.
+
+    Default transport for typed messages (poses, images, point clouds, sensor readings)
+    that need to be shared across network boundaries. Uses LCM's native serialization
+    rather than pickle, enabling cross-language interoperability but requiring message
+    types that implement `lcm_encode`/`lcm_decode` methods.
+
+    For pickle-based serialization (Python-only, any type), use `pLCMTransport`.
+
+    More on LCM:
+      - It's a publish-subscribe messaging system that uses UDP multicast for its underlying transport.
+      - "provides a best-effort packet delivery mechanism and gives strong preference to the expedient delivery of recent messages" (LCM paper)
+
+    Further reading
+      - [The LCM paper](https://people.csail.mit.edu/albert/pubs/2010-huang-olson-moore-lcm-iros.pdf)
+    """
+
     _started: bool = False
 
-    def __init__(self, topic: str, type: type, **kwargs) -> None:  # type: ignore[no-untyped-def]
+    def __init__(
+        self,
+        topic: Annotated[str, Doc("Channel name for message routing.")],
+        type: Annotated[
+            type,
+            Doc(
+                """LCM message type (must have `lcm_encode`/`lcm_decode` methods,
+                typically auto-generated from `.lcm` schema files)."""
+            ),
+        ],
+        **kwargs: Annotated[Any, Doc("Passed to the underlying LCM instance.")],
+    ) -> None:
         super().__init__(LCMTopic(topic, type))
         if not hasattr(self, "lcm"):
             self.lcm = LCM(**kwargs)
@@ -100,6 +195,20 @@ class LCMTransport(PubSubTransport[T]):
 
 
 class JpegLcmTransport(LCMTransport):  # type: ignore[type-arg]
+    """LCM transport with JPEG compression for image transmission over networks.
+
+    Reduces bandwidth when transmitting images across network boundaries.
+
+    Trade-offs:
+        - Lower bandwidth via compression
+        - Lossy compression (some quality loss)
+        - CPU overhead for encode/decode
+
+    See also:
+        LCMTransport: Uncompressed LCM transport for general data.
+        JpegShmTransport: JPEG compression over shared memory (same-machine).
+    """
+
     def __init__(self, topic: str, type: type, **kwargs) -> None:  # type: ignore[no-untyped-def]
         self.lcm = JpegLCM(**kwargs)  # type: ignore[assignment]
         super().__init__(topic, type)
@@ -109,9 +218,32 @@ class JpegLcmTransport(LCMTransport):  # type: ignore[type-arg]
 
 
 class pSHMTransport(PubSubTransport[T]):
+    """Local-only transport using POSIX shared memory with pickle serialization.
+
+    Provides high-throughput, low-latency communication between processes on the
+    same machine. Data is shared via memory-mapped regions rather than copied
+    over network sockets, making this ideal for large payloads like camera frames
+    or point clouds.
+
+    Unlike network-capable transports (`pLCMTransport`, `LCMTransport`), this cannot
+    communicate across machines. Use `pLCMTransport` instead when network distribution is
+    needed.
+    """
+
     _started: bool = False
 
-    def __init__(self, topic: str, **kwargs) -> None:  # type: ignore[no-untyped-def]
+    def __init__(
+        self,
+        topic: Annotated[str, Doc("Channel identifier for publish/subscribe routing.")],
+        **kwargs: Annotated[
+            Any,
+            Doc(
+                """Passed to PickleSharedMemory. Key option:
+                default_capacity: Max payload size in bytes (default ~3.5MB).
+                This should be increased for very large data."""
+            ),
+        ],
+    ) -> None:
         super().__init__(topic)
         self.shm = PickleSharedMemory(**kwargs)
 
@@ -133,6 +265,22 @@ class pSHMTransport(PubSubTransport[T]):
 
 
 class SHMTransport(PubSubTransport[T]):
+    """Shared memory transport for raw bytes data.
+
+    Uses POSIX shared memory with minimal encoding overhead, providing high
+    throughput for local inter-process communication when data is already
+    in bytes format. Unlike `pSHMTransport`, which pickle-serializes Python
+    objects, this transport expects bytes-like data (bytes, bytearray,
+    or memoryview).
+
+    Use this transport when:
+        - Processes run on the same machine
+        - Data is already bytes-like (e.g., sensor buffers, encoded frames)
+        - Maximum throughput is critical
+
+    Use `pSHMTransport` instead when you need to send arbitrary Python objects.
+    """
+
     _started: bool = False
 
     def __init__(self, topic: str, **kwargs) -> None:  # type: ignore[no-untyped-def]
@@ -157,9 +305,34 @@ class SHMTransport(PubSubTransport[T]):
 
 
 class JpegShmTransport(PubSubTransport[T]):
+    """Shared memory transport with JPEG compression for Image objects.
+
+    Uses shared memory for fast local inter-process communication while applying
+    JPEG compression to reduce memory footprint. Only works for local consumers
+    (same machine); not suitable for network transport.
+
+    Trade-offs:
+        - Lower memory usage than uncompressed shared memory
+        - Adds CPU overhead for encode/decode
+        - Lossy compression (quality parameter controls fidelity vs size)
+    """
+
     _started: bool = False
 
-    def __init__(self, topic: str, quality: int = 75, **kwargs) -> None:  # type: ignore[no-untyped-def]
+    def __init__(
+        self,
+        topic: Annotated[str, Doc("Channel identifier for pub/sub routing.")],
+        quality: Annotated[
+            int,
+            Doc(
+                """JPEG compression quality (1-100). Lower values produce smaller
+                images with more artifacts."""
+            ),
+        ] = 75,
+        **kwargs: Annotated[
+            Any, Doc("Additional arguments passed to the underlying shared memory.")
+        ],
+    ) -> None:
         super().__init__(topic)
         self.shm = JpegSharedMemory(quality=quality, **kwargs)
         self.quality = quality


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Added comprehensive docstrings for Transport-related classes and the `transport.py` module following PEP 727 inline parameter documentation standards.

**Key additions:**
- Module-level docstring in `transport.py` with usage examples and transport selection guidance
- Detailed class docstrings for base `Transport` class and all concrete implementations (`PubSubTransport`, `LCMTransport`, `pLCMTransport`, `JpegLcmTransport`, `SHMTransport`, `pSHMTransport`, `JpegShmTransport`)
- Inline parameter documentation using `Annotated[T, Doc(...)]` for constructor parameters and method signatures
- Class hierarchy diagram in `Transport` docstring showing inheritance relationships
- Trade-off explanations for each transport variant (network vs local, compression overhead, etc.)

**Issue found:**
- Import inconsistency: `stream.py` imports `Doc` from `annotated_doc` while `transport.py` imports from `typing_extensions`. These should use the same source for consistency.

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with one minor import inconsistency that should be fixed
- Documentation-only changes that significantly improve code clarity. One syntax issue found: inconsistent `Doc` import sources between files (`annotated_doc` vs `typing_extensions`). No logic changes, no breaking changes, and docstrings are comprehensive and accurate. The TODO comment about auto-generating the class hierarchy diagram is good practice.
- Fix the import inconsistency in `dimos/core/transport.py` line 62 to match `dimos/core/stream.py`

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| dimos/core/stream.py | 4/5 | Added comprehensive docstrings for `Transport` class and its methods (`broadcast`, `publish`, `subscribe`). Includes class hierarchy diagram and transport selection guidance. Minor inconsistency: imports `Doc` from `annotated_doc` while `transport.py` imports from `typing_extensions`. |
| dimos/core/transport.py | 4/5 | Added module-level docstring and comprehensive docstrings for all transport classes (`PubSubTransport`, `LCMTransport`, `pLCMTransport`, `JpegLcmTransport`, `SHMTransport`, `pSHMTransport`, `JpegShmTransport`). Documented parameters using `Annotated[T, Doc(...)]`. Minor inconsistency: imports `Doc` from `typing_extensions` while `stream.py` imports from `annotated_doc`. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Module1 as Module A
    participant Out as Out[T]
    participant Transport as Transport[T]
    participant In as In[T]
    participant Module2 as Module B
    
    Note over Module1,Module2: Configuration Phase
    Module1->>Out: Create output stream
    Module2->>In: Create input stream
    Out->>Transport: Assign transport (e.g., LCMTransport)
    In->>Transport: Subscribe to transport
    
    Note over Module1,Module2: Runtime Phase - Publishing
    Module1->>Out: publish(msg)
    Out->>Transport: broadcast(selfstream, msg)
    Transport->>Transport: Lazy init on first broadcast()
    
    Note over Module1,Module2: Runtime Phase - Delivery
    Transport->>In: callback(msg)
    In->>Module2: Deliver message
    
    Note over Transport: Error Handling
    Module2--xModule2: Callback error
    Note over Transport: Error isolated - other subscribers<br/>and publisher unaffected
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->