### PR TITLE
exclude .md changes from CICD builds

### DIFF
--- a/.github/workflows/code-cleanup.yml
+++ b/.github/workflows/code-cleanup.yml
@@ -1,5 +1,8 @@
 name: code-cleanup
-on: push
+on:
+  push:
+    paths-ignore:
+      - '**.md'
 
 permissions:
   contents: write

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,11 @@ on:
     branches:
       - main
       - dev
+    paths-ignore:
+      - '**.md'
   pull_request:
+    paths-ignore:
+      - '**.md'
 
 permissions:
   contents: read


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Adds `paths-ignore` filters to skip CI/CD workflows when only markdown files are modified, reducing unnecessary workflow runs and saving CI resources.

- Added `paths-ignore: - '**.md'` to `code-cleanup.yml` push trigger
- Added `paths-ignore: - '**.md'` to `docker.yml` push and pull_request triggers
- Syntax follows GitHub Actions standard patterns for glob-based path filtering

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The changes use standard GitHub Actions syntax for path filtering, are non-invasive, and only affect workflow trigger conditions. The `**.md` glob pattern correctly matches all markdown files at any depth. No logical or security issues identified.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| .github/workflows/code-cleanup.yml | 5/5 | Added `paths-ignore` filter to skip workflow when only .md files change |
| .github/workflows/docker.yml | 5/5 | Added `paths-ignore` filters to both push and pull_request triggers to skip workflow when only .md files change |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant GH as GitHub
    participant CW as code-cleanup.yml
    participant DW as docker.yml
    
    Dev->>GH: Push commit with changes
    
    alt Only .md files changed
        GH->>CW: Skip (paths-ignore: **.md)
        GH->>DW: Skip (paths-ignore: **.md)
        Note over CW,DW: Workflows do not run
    else Code files changed
        GH->>CW: Trigger workflow
        CW->>CW: Run pre-commit hooks
        CW->>GH: Auto-commit cleanup
        GH->>DW: Trigger workflow
        DW->>DW: Check file changes
        DW->>DW: Build Docker images
        DW->>DW: Run tests
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->