### PR TITLE
skill-reducer: Fix leading newline bug in `accumulate_string` reducer

### DIFF
--- a/dimos/protocol/skill/type.py
+++ b/dimos/protocol/skill/type.py
@@ -360,9 +360,21 @@ def accumulate_string(
     accumulator: SkillMsg[Literal[MsgType.reduced_stream]] | None,
     msg: SkillMsg[Literal[MsgType.stream]],
 ) -> SkillMsg[Literal[MsgType.reduced_stream]]:
-    """String concatenation reducer: joins values with newlines."""
-    acc_value = accumulator.content if accumulator else ""
-    return _make_skill_msg(msg, acc_value + "\n" + msg.content)  # type: ignore[operator]
+    """String concatenation reducer: joins values with newlines.
+
+    Examples:
+        >>> m = lambda s: SkillMsg('id', 'x', s, MsgType.stream)
+        >>> accumulate_string(None, m('A')).content  # no leading newline
+        'A'
+        >>> accumulate_string(accumulate_string(None, m('A')), m('B')).content
+        'A\\nB'
+        >>> # Edge case: empty string as first yield doesn't cause leading newline
+        >>> accumulate_string(accumulate_string(None, m('')), m('X')).content
+        'X'
+    """
+    prefix = f"{accumulator.content}\n" if accumulator and accumulator.content else ""
+    new_value = prefix + msg.content
+    return _make_skill_msg(msg, new_value)
 
 
 class Reducer:


### PR DESCRIPTION
The problem: The `accumulate_string` reducer was prepending a newline on the first call:

```
acc_value = accumulator.content if accumulator else ""
return _make_skill_msg(msg, acc_value + "\n" + msg.content)
# "" + "\n" + "first" → "\nfirst"  (bug)
```
 
This PR fixes this to make it consistent with sum_reducer and all_reducer, which check for a prior value before combining.

## Note

One edge case to highlight is when a skill yields an empty string as its first value -- we don't insert an empty line in that case in this PR. (But maybe that is behavior that is desired -- I'm not totally sure.)

---------

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Fixed the `accumulate_string` reducer to prevent a leading newline on the first call by checking for a prior value before concatenating.

- Changed initial value from empty string `""` to `None` to enable proper first-call detection
- Added conditional logic: `f"{acc_value}\n{msg.content}" if acc_value else msg.content`
- Now consistent with `sum_reducer` and `all_reducer` patterns
- Added docstring examples demonstrating correct behavior

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- The fix is a simple, well-tested bug correction that aligns with established patterns in the codebase. The change is minimal, the logic is correct, and docstring examples validate the expected behavior.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| dimos/protocol/skill/type.py | 5/5 | Fixed leading newline bug in `accumulate_string` reducer to match pattern used in `sum_reducer` and `all_reducer` |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant SC as SkillCoordinator
    participant AS as accumulate_string
    participant SM as SkillMsg
    
    Note over SC,AS: First stream message
    SC->>AS: accumulate_string(None, msg1)
    AS->>AS: acc_value = None
    AS->>AS: new_value = msg1.content (no newline)
    AS->>SM: _make_skill_msg(msg1, "A")
    SM-->>SC: SkillMsg(content="A")
    
    Note over SC,AS: Second stream message
    SC->>AS: accumulate_string(accumulator, msg2)
    AS->>AS: acc_value = "A"
    AS->>AS: new_value = "A\nB"
    AS->>SM: _make_skill_msg(msg2, "A\nB")
    SM-->>SC: SkillMsg(content="A\nB")
    
    Note over SC,AS: Third stream message
    SC->>AS: accumulate_string(accumulator, msg3)
    AS->>AS: acc_value = "A\nB"
    AS->>AS: new_value = "A\nB\nC"
    AS->>SM: _make_skill_msg(msg3, "A\nB\nC")
    SM-->>SC: SkillMsg(content="A\nB\nC")
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->