### PR TITLE
docs: Fix `_check_if_stuck docstring` (wrong return type) in `manipulation_module.py` and add a bit more detail

### DIFF
--- a/dimos/manipulation/visual_servoing/manipulation_module.py
+++ b/dimos/manipulation/visual_servoing/manipulation_module.py
@@ -501,11 +501,11 @@ class ManipulationModule(Module):
         return False, 0.0
 
     def _check_if_stuck(self) -> bool:
-        """
-        Check if robot is stuck by analyzing pose history.
+        """Check if robot is stuck based on recent pose history.
 
         Returns:
-            Tuple of (is_stuck, max_std_dev_mm)
+            True if stuck. False if moving or
+            not enough history to figure this out.
         """
         if len(self.ee_pose_history) < self.ee_pose_history.maxlen:  # type: ignore[operator]
             return False


### PR DESCRIPTION
1. Fix the return type in `_check_if_stuck docstring` in `manipulation_module.py` 
2. Add a bit more detail