### PR TITLE
Add generic ignore to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# generic ignore pattern
+**/*.ignore
+**/*.ignore.*
+
 .vscode/
 
 # Ignore Python cache files


### PR DESCRIPTION
Small pattern I've found helpful across all git projects: ex: if the python ever generates log files its easy to have them include `.ignore` in the name to not be tracked, or when creating local debug files just add a `.ignore` 