### PR TITLE
build foxglove extension

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,3 +14,4 @@
 *.mp4 filter=lfs diff=lfs merge=lfs -text binary
 *.mov filter=lfs diff=lfs merge=lfs -text binary
 *.gif filter=lfs diff=lfs merge=lfs -text binary
+*.foxe filter=lfs diff=lfs merge=lfs -text binary

--- a/assets/dimensional.command-center-extension-0.0.1.foxe
+++ b/assets/dimensional.command-center-extension-0.0.1.foxe
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f31d3e1d3fc5695a8d445708996224734fd8bc1e2e2f01860e2313d876daf0f
+size 1229022

--- a/dimos/web/command-center-extension/package.json
+++ b/dimos/web/command-center-extension/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "publisher": "dimensional",
   "homepage": "",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "UNLICENSED",
   "main": "./dist/extension.js",
   "keywords": [],


### PR DESCRIPTION
Added a pre-build command-center binary: `dimensional.command-center-extension-0.0.1.foxe`

It's installed by dragging the .foxe file over Foxglove Studio and restarting.