### PR TITLE
fix replay leak

### DIFF
--- a/dimos/utils/testing/replay.py
+++ b/dimos/utils/testing/replay.py
@@ -389,7 +389,7 @@ class TimedSensorReplay(SensorReplay[T]):
                         if hasattr(scheduler, "dispose"):
                             scheduler.dispose()
 
-                disp.add(scheduler.schedule_relative(delay, lambda sc, _: emit()))
+                scheduler.schedule_relative(delay, lambda sc, _: emit())
 
             schedule_emission(next_message)
 


### PR DESCRIPTION
* The leak was only affecting replay.
* `schedule_relative` returns a disposable, but the disposable is for cancelling scheduled action, not for cleaning up the resources. The code was adding the disposable to `disp` which was cleaned up at the end. The issue was that, by storing the cancelation Disposable, it actually holds on to the data. 