### PR TITLE
fix(tests): disable Rerun in blueprint tests to prevent viewer spawn

### DIFF
--- a/dimos/core/test_blueprints.py
+++ b/dimos/core/test_blueprints.py
@@ -35,6 +35,11 @@ from dimos.core.stream import In, Out
 from dimos.core.transport import LCMTransport
 from dimos.protocol import pubsub
 
+# Disable Rerun for tests (prevents viewer spawn and gRPC flush errors)
+_BUILD_WITHOUT_RERUN = {
+    "global_config": GlobalConfig(rerun_enabled=False, viewer_backend="foxglove"),
+}
+
 
 class Scratch:
     pass
@@ -162,10 +167,7 @@ def test_build_happy_path() -> None:
 
     blueprint_set = autoconnect(module_a(), module_b(), module_c())
 
-    # Disable Rerun for tests (prevents viewer spawn and gRPC flush errors)
-    coordinator = blueprint_set.build(
-        global_config=GlobalConfig(rerun_enabled=False, viewer_backend="foxglove")
-    )
+    coordinator = blueprint_set.build(**_BUILD_WITHOUT_RERUN)
 
     try:
         assert isinstance(coordinator, ModuleCoordinator)
@@ -301,10 +303,7 @@ def test_remapping() -> None:
     assert ("color_image", Data1) not in blueprint_set._all_name_types
 
     # Build and verify connections work
-    # Disable Rerun for tests (prevents viewer spawn and gRPC flush errors)
-    coordinator = blueprint_set.build(
-        global_config=GlobalConfig(rerun_enabled=False, viewer_backend="foxglove")
-    )
+    coordinator = blueprint_set.build(**_BUILD_WITHOUT_RERUN)
 
     try:
         source_instance = coordinator.get_instance(SourceModule)
@@ -357,10 +356,7 @@ def test_future_annotations_autoconnect() -> None:
 
     blueprint_set = autoconnect(FutureModuleOut.blueprint(), FutureModuleIn.blueprint())
 
-    # Disable Rerun for tests (prevents viewer spawn and gRPC flush errors)
-    coordinator = blueprint_set.build(
-        global_config=GlobalConfig(rerun_enabled=False, viewer_backend="foxglove")
-    )
+    coordinator = blueprint_set.build(**_BUILD_WITHOUT_RERUN)
 
     try:
         out_instance = coordinator.get_instance(FutureModuleOut)


### PR DESCRIPTION
Rerun caused pytest to fail, this should fix it.

(dimos-ros) dimensional@dimensional-cpu-0:~/dimos$ pytest -q dimos/core/test_blueprints.py
================================ test session starts ================================
platform linux -- Python 3.12.12, pytest-8.3.5, pluggy-1.6.0
rootdir: /home/dimensional/dimos
configfile: pyproject.toml
plugins: launch-testing-3.4.6, ament-lint-0.17.3, ament-pep257-0.17.3, ament-flake8-0.17.3, ament-xmllint-0.17.3, ament-copyright-0.17.3, launch-testing-ros-0.26.8, requests-mock-1.12.1, typeguard-4.4.4, mock-3.15.0, asyncio-0.26.0, dash-3.3.0, timeout-2.4.0, env-1.1.5, anyio-4.12.0, langsmith-0.5.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 11 items                                                                  

dimos/core/test_blueprints.py ...........                                     [100%]

================================ 11 passed in 19.08s ================================
(dimos-ros) dimensional@dimensional-cpu-0:~/dimos$ 