### PR TITLE
[Tiny] use ip instead of ifconfig

### DIFF
--- a/dimos/protocol/service/lcmservice.py
+++ b/dimos/protocol/service/lcmservice.py
@@ -70,13 +70,9 @@ def check_multicast() -> list[str]:
                 ["ip", "route", "show", "224.0.0.0/4"], capture_output=True, text=True
             )
             if not result.stdout.strip():
-                commands_needed.append(
-                    f"{sudo}ip route add -net 224.0.0.0 netmask 240.0.0.0 dev {loopback_interface}"
-                )
+                commands_needed.append(f"{sudo}ip route add 224.0.0.0/4 dev {loopback_interface}")
         except Exception:
-            commands_needed.append(
-                f"{sudo}ip route add -net 224.0.0.0 netmask 240.0.0.0 dev {loopback_interface}"
-            )
+            commands_needed.append(f"{sudo}ip route add 224.0.0.0/4 dev {loopback_interface}")
 
     elif system == "Darwin":  # macOS
         loopback_interface = "lo0"
@@ -85,13 +81,9 @@ def check_multicast() -> list[str]:
             result = subprocess.run(["netstat", "-nr"], capture_output=True, text=True)
             route_exists = "224.0.0.0/4" in result.stdout or "224.0.0/4" in result.stdout
             if not route_exists:
-                commands_needed.append(
-                    f"{sudo}ip route add -net 224.0.0.0/4 -interface {loopback_interface}"
-                )
+                commands_needed.append(f"{sudo}ip route add 224.0.0.0/4 dev {loopback_interface}")
         except Exception:
-            commands_needed.append(
-                f"{sudo}ip route add -net 224.0.0.0/4 -interface {loopback_interface}"
-            )
+            commands_needed.append(f"{sudo}ip route add 224.0.0.0/4 dev {loopback_interface}")
 
     else:
         # For other systems, skip multicast configuration

--- a/dimos/protocol/service/test_lcmservice.py
+++ b/dimos/protocol/service/test_lcmservice.py
@@ -102,7 +102,7 @@ def test_check_multicast_missing_route() -> None:
 
             result = check_multicast()
             sudo = get_sudo_prefix()
-            assert result == [f"{sudo}ip route add -net 224.0.0.0 netmask 240.0.0.0 dev lo"]
+            assert result == [f"{sudo}ip route add 224.0.0.0/4 dev lo"]
 
 
 def test_check_multicast_all_missing() -> None:
@@ -128,7 +128,7 @@ def test_check_multicast_all_missing() -> None:
             sudo = get_sudo_prefix()
             expected = [
                 f"{sudo}ip l set lo multicast on",
-                f"{sudo}ip route add -net 224.0.0.0 netmask 240.0.0.0 dev lo",
+                f"{sudo}ip route add 224.0.0.0/4 dev lo",
             ]
             assert result == expected
 
@@ -144,7 +144,7 @@ def test_check_multicast_subprocess_exception() -> None:
             sudo = get_sudo_prefix()
             expected = [
                 f"{sudo}ip l set lo multicast on",
-                f"{sudo}ip route add -net 224.0.0.0 netmask 240.0.0.0 dev lo",
+                f"{sudo}ip route add 224.0.0.0/4 dev lo",
             ]
             assert result == expected
 
@@ -167,7 +167,7 @@ def test_check_multicast_macos() -> None:
 
             result = check_multicast()
             sudo = get_sudo_prefix()
-            expected = [f"{sudo}ip route add -net 224.0.0.0/4 -interface lo0"]
+            expected = [f"{sudo}ip route add 224.0.0.0/4 dev lo0"]
             assert result == expected
 
 
@@ -489,9 +489,7 @@ def test_autoconf_with_config_needed_success() -> None:
                         call("System configuration required. Executing commands..."),
                         call(f"  Running: {sudo}ip l set lo multicast on"),
                         call("  ✓ Success"),
-                        call(
-                            f"  Running: {sudo}ip route add -net 224.0.0.0 netmask 240.0.0.0 dev lo"
-                        ),
+                        call(f"  Running: {sudo}ip route add 224.0.0.0/4 dev lo"),
                         call("  ✓ Success"),
                         call(f"  Running: {sudo}sysctl -w net.core.rmem_max={TARGET_RMEM_SIZE}"),
                         call("  ✓ Success"),
@@ -542,10 +540,7 @@ def test_autoconf_with_command_failures() -> None:
                             "ip",
                             "route",
                             "add",
-                            "-net",
-                            "224.0.0.0",
-                            "netmask",
-                            "240.0.0.0",
+                            "224.0.0.0/4",
                             "dev",
                             "lo",
                         ],


### PR DESCRIPTION
- super small change, test with any `dimos run` command
- ifconfig is deprecated, not installed on default ubuntu, and we already use the ip command which can do what we want
- tests updated

(this matters for day-1 install instructions)