### PR TITLE
Remove objectdb from go2 blueprints

### DIFF
--- a/dimos/robot/unitree_webrtc/unitree_go2_blueprints.py
+++ b/dimos/robot/unitree_webrtc/unitree_go2_blueprints.py
@@ -16,9 +16,10 @@
 
 import platform
 
-from dimos_lcm.foxglove_msgs.ImageAnnotations import (  # type: ignore[import-untyped]
-    ImageAnnotations,
+from dimos_lcm.foxglove_msgs.ImageAnnotations import (
+    ImageAnnotations,  # type: ignore[import-untyped]
 )
+from dimos_lcm.foxglove_msgs.SceneUpdate import SceneUpdate  # type: ignore[import-untyped]
 
 from dimos.agents.agent import llm_agent
 from dimos.agents.cli.human import human_input
@@ -43,7 +44,7 @@ from dimos.navigation.frontier_exploration import (
 from dimos.navigation.replanning_a_star.module import (
     replanning_a_star_planner,
 )
-from dimos.perception.detection.moduleDB import ObjectDBModule, detectionDB_module
+from dimos.perception.detection.module3D import Detection3DModule, detection3d_module
 from dimos.perception.spatial_perception import spatial_memory
 from dimos.protocol.mcp.mcp import MCPModule
 from dimos.robot.foxglove_bridge import foxglove_bridge
@@ -91,39 +92,39 @@ nav = autoconnect(
 detection = (
     autoconnect(
         nav,
-        detectionDB_module(
+        detection3d_module(
             camera_info=GO2Connection.camera_info_static,
         ),
     )
     .remappings(
         [
-            (ObjectDBModule, "pointcloud", "global_map"),
+            (Detection3DModule, "pointcloud", "global_map"),
         ]
     )
     .transports(
         {
             # Detection 3D module outputs
-            ("detections", ObjectDBModule): LCMTransport(
+            ("detections", Detection3DModule): LCMTransport(
                 "/detector3d/detections", Detection2DArray
             ),
-            ("annotations", ObjectDBModule): LCMTransport(
+            ("annotations", Detection3DModule): LCMTransport(
                 "/detector3d/annotations", ImageAnnotations
             ),
-            #            ("scene_update", ObjectDBModule): LCMTransport(
-            #                "/detector3d/scene_update", SceneUpdate
-            #            ),
-            ("detected_pointcloud_0", ObjectDBModule): LCMTransport(
+            ("scene_update", Detection3DModule): LCMTransport(
+                "/detector3d/scene_update", SceneUpdate
+            ),
+            ("detected_pointcloud_0", Detection3DModule): LCMTransport(
                 "/detector3d/pointcloud/0", PointCloud2
             ),
-            ("detected_pointcloud_1", ObjectDBModule): LCMTransport(
+            ("detected_pointcloud_1", Detection3DModule): LCMTransport(
                 "/detector3d/pointcloud/1", PointCloud2
             ),
-            ("detected_pointcloud_2", ObjectDBModule): LCMTransport(
+            ("detected_pointcloud_2", Detection3DModule): LCMTransport(
                 "/detector3d/pointcloud/2", PointCloud2
             ),
-            ("detected_image_0", ObjectDBModule): LCMTransport("/detector3d/image/0", Image),
-            ("detected_image_1", ObjectDBModule): LCMTransport("/detector3d/image/1", Image),
-            ("detected_image_2", ObjectDBModule): LCMTransport("/detector3d/image/2", Image),
+            ("detected_image_0", Detection3DModule): LCMTransport("/detector3d/image/0", Image),
+            ("detected_image_1", Detection3DModule): LCMTransport("/detector3d/image/1", Image),
+            ("detected_image_2", Detection3DModule): LCMTransport("/detector3d/image/2", Image),
         }
     )
 )


### PR DESCRIPTION
Devs have been running agentic go2, which crashes after a while due to objectdb being in a blueprint - it stores all detections permanently in mem, this is not a production ready module but an experiment, it's not viable as a direction for memory imo