### PR TITLE
Dynamic session providers for onnxruntime

### DIFF
--- a/dimos/simulation/mujoco/policy.py
+++ b/dimos/simulation/mujoco/policy.py
@@ -23,6 +23,9 @@ import numpy as np
 import onnxruntime as ort  # type: ignore[import-untyped]
 
 from dimos.simulation.mujoco.input_controller import InputController
+from dimos.utils.logging_config import setup_logger
+
+logger = setup_logger()
 
 
 class OnnxController(ABC):
@@ -38,6 +41,7 @@ class OnnxController(ABC):
     ) -> None:
         self._output_names = ["continuous_actions"]
         self._policy = ort.InferenceSession(policy_path, providers=ort.get_available_providers())
+        logger.info(f"Loaded policy: {policy_path} with providers: {self._policy.get_providers()}")
 
         self._action_scale = action_scale
         self._default_angles = default_angles


### PR DESCRIPTION
This merge request utilizes `onnxruntime.get_available_providers` to fetch ONNX Runtime Execution Providers, which will outperform the hard-coded default CPUExecutionProvider in cases where another Execution Provider exsists on the machine from which dimensional is ran. See https://onnxruntime.ai/docs/execution-providers/ for more information