### PR TITLE
bbox detections visual check

### DIFF
--- a/dimos/core/resource.py
+++ b/dimos/core/resource.py
@@ -21,3 +21,25 @@ class Resource(ABC):
 
     @abstractmethod
     def stop(self) -> None: ...
+
+    def dispose(self) -> None:
+        """
+        Makes a Resource disposable
+        So you can do a
+
+        from reactivex.disposable import CompositeDisposable
+
+        disposables = CompositeDisposable()
+
+        transport1 = LCMTransport(...)
+        transport2 = LCMTransport(...)
+
+        disposables.add(transport1)
+        disposables.add(transport2)
+
+        ...
+
+        disposables.dispose()
+
+        """
+        self.stop()


### PR DESCRIPTION
just renders detections test in fg
```sh
foxglove-bridge
foxglove-studio
pytest dimos/perception/detection/detectors/test_bbox_detectors.py
```
<img width="1307" height="988" alt="2026-01-15_12-11" src="https://github.com/user-attachments/assets/8449a8b5-b41e-4844-ab72-20ab8be1f3d9" />

