### PR TITLE
fix: add import-untyped to mypy ignore comments

### DIFF
--- a/dimos/core/__init__.py
+++ b/dimos/core/__init__.py
@@ -69,7 +69,7 @@ class CudaCleanupPlugin:
             import sys
 
             if "cupy" in sys.modules:
-                import cupy as cp  # type: ignore[import-not-found]
+                import cupy as cp  # type: ignore[import-not-found, import-untyped]
 
                 # Clear memory pools
                 mempool = cp.get_default_memory_pool()

--- a/dimos/models/manipulation/contact_graspnet_pytorch/inference.py
+++ b/dimos/models/manipulation/contact_graspnet_pytorch/inference.py
@@ -2,11 +2,11 @@ import argparse
 import glob
 import os
 
-from contact_graspnet_pytorch import config_utils  # type: ignore[import-not-found]
-from contact_graspnet_pytorch.contact_grasp_estimator import (  # type: ignore[import-not-found]
+from contact_graspnet_pytorch import config_utils  # type: ignore[import-not-found, import-untyped]
+from contact_graspnet_pytorch.contact_grasp_estimator import (  # type: ignore[import-not-found, import-untyped]
     GraspEstimator,
 )
-from contact_graspnet_pytorch.data import (  # type: ignore[import-not-found]
+from contact_graspnet_pytorch.data import (  # type: ignore[import-not-found, import-untyped]
     load_available_input_data,
 )
 import numpy as np

--- a/dimos/msgs/sensor_msgs/Image.py
+++ b/dimos/msgs/sensor_msgs/Image.py
@@ -47,7 +47,7 @@ if TYPE_CHECKING:
     )
 
 try:
-    import cupy as cp  # type: ignore[import-not-found]
+    import cupy as cp  # type: ignore[import-not-found, import-untyped]
 except Exception:
     cp = None
 

--- a/dimos/msgs/sensor_msgs/image_impls/AbstractImage.py
+++ b/dimos/msgs/sensor_msgs/image_impls/AbstractImage.py
@@ -25,7 +25,7 @@ import numpy as np
 import rerun as rr
 
 try:
-    import cupy as cp  # type: ignore[import-not-found]
+    import cupy as cp  # type: ignore[import-not-found, import-untyped]
 
     HAS_CUDA = True
 except Exception:  # pragma: no cover - optional dependency
@@ -35,7 +35,7 @@ except Exception:  # pragma: no cover - optional dependency
 # NVRTC defaults to C++11; libcu++ in recent CUDA requires at least C++17.
 if HAS_CUDA:
     try:
-        import cupy.cuda.compiler as _cupy_compiler  # type: ignore[import-not-found]
+        import cupy.cuda.compiler as _cupy_compiler  # type: ignore[import-not-found, import-untyped]
 
         if not getattr(_cupy_compiler, "_dimos_force_cxx17", False):
             _orig_compile_using_nvrtc = _cupy_compiler.compile_using_nvrtc

--- a/dimos/msgs/sensor_msgs/image_impls/CudaImage.py
+++ b/dimos/msgs/sensor_msgs/image_impls/CudaImage.py
@@ -30,8 +30,8 @@ from dimos.msgs.sensor_msgs.image_impls.AbstractImage import (
 )
 
 try:
-    import cupy as cp  # type: ignore[import-not-found]
-    from cupyx.scipy import (  # type: ignore[import-not-found]
+    import cupy as cp  # type: ignore[import-not-found, import-untyped]
+    from cupyx.scipy import (  # type: ignore[import-not-found, import-untyped]
         ndimage as cndimage,
         signal as csignal,
     )

--- a/dimos/perception/common/utils.py
+++ b/dimos/perception/common/utils.py
@@ -79,7 +79,7 @@ __all__ = [
 
 # Optional CuPy support
 try:  # pragma: no cover - optional dependency
-    import cupy as cp  # type: ignore[import-not-found]
+    import cupy as cp  # type: ignore[import-not-found, import-untyped]
 
     _HAS_CUDA = True
 except Exception:  # pragma: no cover - optional dependency


### PR DESCRIPTION
Add `import-untyped` to type ignore comments for cupy and contact_graspnet_pytorch imports. These third-party libraries are installed but missing py.typed markers.