### PR TITLE
fix: Pubsub typing

### DIFF
--- a/dimos/core/transport.py
+++ b/dimos/core/transport.py
@@ -73,7 +73,7 @@ class pLCMTransport(PubSubTransport[T]):
     ) -> Callable[[], None]:
         if not self._started:
             self.start()
-        return self.lcm.subscribe(self.topic, lambda msg, topic: callback(msg))
+        return self.lcm.subscribe(LCMTopic(self.topic), lambda msg, topic: callback(msg))
 
     def start(self) -> None:
         self.lcm.start()

--- a/dimos/protocol/pubsub/impl/lcmpubsub.py
+++ b/dimos/protocol/pubsub/impl/lcmpubsub.py
@@ -154,8 +154,8 @@ class LCMPubSubBase(LCMService, AllPubSub[Topic, Any]):
     def subscribe_all(self, callback: Callable[[bytes, Topic], Any]) -> Callable[[], None]:
         return self.subscribe(Topic(re.compile(".*")), callback)  # type: ignore[arg-type]
 
-    def subscribe(  # type: ignore[override]
-        self, topic: Topic | str, callback: Callable[[bytes, Topic | str], Any]
+    def subscribe(
+        self, topic: Topic, callback: Callable[[bytes, Topic], None]
     ) -> Callable[[], None]:
         if self.l is None:
             logger.error("Tried to subscribe after LCM was closed")
@@ -165,8 +165,7 @@ class LCMPubSubBase(LCMService, AllPubSub[Topic, Any]):
 
             return noop
 
-        # Handle both Topic objects and raw strings
-        if isinstance(topic, Topic) and topic.is_pattern:
+        if topic.is_pattern:
 
             def handler(channel: str, msg: bytes) -> None:
                 if channel == "LCM_SELF_TEST":
@@ -179,7 +178,7 @@ class LCMPubSubBase(LCMService, AllPubSub[Topic, Any]):
 
             lcm_subscription = self.l.subscribe(pattern_str, handler)
         else:
-            topic_str = str(topic) if isinstance(topic, Topic) else topic
+            topic_str = str(topic)
             lcm_subscription = self.l.subscribe(topic_str, lambda _, msg: callback(msg, topic))
 
         # Set queue capacity to 10000 to handle high-volume bursts

--- a/dimos/protocol/pubsub/impl/lcmpubsub.py
+++ b/dimos/protocol/pubsub/impl/lcmpubsub.py
@@ -192,6 +192,10 @@ class LCMPubSubBase(LCMService, AllPubSub[Topic, Any]):
         return unsubscribe
 
 
+# these ignoress might be unsolvable
+# and should use composition not inheritance for encoding/decoding
+
+
 class LCM(  # type: ignore[misc]
     LCMEncoderMixin,  # type: ignore[type-arg]
     LCMPubSubBase,

--- a/dimos/protocol/pubsub/spec.py
+++ b/dimos/protocol/pubsub/spec.py
@@ -121,12 +121,16 @@ class AllPubSub(PubSub[TopicT, MsgT], ABC):
 
     def subscribe_new_topics(self, callback: Callable[[TopicT], Any]) -> Callable[[], None]:
         """Discover new topics by tracking seen topics from subscribe_all."""
+        import threading
+
         seen: set[TopicT] = set()
+        lock = threading.Lock()
 
         def on_msg(msg: MsgT, topic: TopicT) -> None:
-            if topic not in seen:
-                seen.add(topic)
-                callback(topic)
+            with lock:
+                if topic not in seen:
+                    seen.add(topic)
+                    callback(topic)
 
         return self.subscribe_all(on_msg)
 
@@ -145,17 +149,23 @@ class DiscoveryPubSub(PubSub[TopicT, MsgT], ABC):
 
     def subscribe_all(self, callback: Callable[[MsgT, TopicT], Any]) -> Callable[[], None]:
         """Subscribe to all topics by subscribing to each discovered topic."""
+        import threading
+
         subscriptions: list[Callable[[], None]] = []
+        lock = threading.Lock()
 
         def on_new_topic(topic: TopicT) -> None:
             unsub = self.subscribe(topic, callback)
-            subscriptions.append(unsub)
+            with lock:
+                subscriptions.append(unsub)
 
         discovery_unsub = self.subscribe_new_topics(on_new_topic)
 
         def unsubscribe_all() -> None:
             discovery_unsub()
-            for unsub in subscriptions:
+            with lock:
+                subs = subscriptions.copy()
+            for unsub in subs:
                 unsub()
 
         return unsubscribe_all

--- a/dimos/protocol/pubsub/spec.py
+++ b/dimos/protocol/pubsub/spec.py
@@ -28,9 +28,15 @@ class PubSubBaseMixin(Generic[TopicT, MsgT]):
     Depends on the basic publish and subscribe methods being implemented.
     """
 
+    def subscribe(
+        self, topic: TopicT, callback: Callable[[MsgT, TopicT], None]
+    ) -> Callable[[], None]:
+        """Subscribe to a topic. Implemented by subclasses."""
+        raise NotImplementedError
+
     @dataclass(slots=True)
     class _Subscription:
-        _bus: "PubSub[Any, Any]"
+        _bus: "PubSubBaseMixin[Any, Any]"
         _topic: Any
         _cb: Callable[[Any, Any], None]
         _unsubscribe_fn: Callable[[], None]
@@ -45,8 +51,8 @@ class PubSubBaseMixin(Generic[TopicT, MsgT]):
             self.unsubscribe()
 
     def sub(self, topic: TopicT, cb: Callable[[MsgT, TopicT], None]) -> "_Subscription":
-        unsubscribe_fn = self.subscribe(topic, cb)  # type: ignore[attr-defined]
-        return self._Subscription(self, topic, cb, unsubscribe_fn)  # type: ignore[arg-type]
+        unsubscribe_fn = self.subscribe(topic, cb)
+        return self._Subscription(self, topic, cb, unsubscribe_fn)
 
     async def aiter(self, topic: TopicT, *, max_pending: int | None = None) -> AsyncIterator[MsgT]:
         q: asyncio.Queue[MsgT] = asyncio.Queue(maxsize=max_pending or 0)
@@ -54,7 +60,7 @@ class PubSubBaseMixin(Generic[TopicT, MsgT]):
         def _cb(msg: MsgT, topic: TopicT) -> None:
             q.put_nowait(msg)
 
-        unsubscribe_fn = self.subscribe(topic, _cb)  # type: ignore[attr-defined]
+        unsubscribe_fn = self.subscribe(topic, _cb)
         try:
             while True:
                 yield await q.get()
@@ -70,7 +76,7 @@ class PubSubBaseMixin(Generic[TopicT, MsgT]):
         def _queue_cb(msg: MsgT, topic: TopicT) -> None:
             q.put_nowait(msg)
 
-        unsubscribe_fn = self.subscribe(topic, _queue_cb)  # type: ignore[attr-defined]
+        unsubscribe_fn = self.subscribe(topic, _queue_cb)
         try:
             yield q
         finally:

--- a/dimos/protocol/service/__init__.py
+++ b/dimos/protocol/service/__init__.py
@@ -1,5 +1,5 @@
-from dimos.protocol.service.lcmservice import LCMService
-from dimos.protocol.service.spec import Configurable, Service
+from dimos.protocol.service.lcmservice import LCMService as LCMService
+from dimos.protocol.service.spec import Configurable as Configurable, Service as Service
 
 __all__ = [
     "Configurable",


### PR DESCRIPTION
addresses comments from https://github.com/dimensionalOS/dimos/pull/1114
Removes type: ignore[override] by changing subscribe signature to match the AllPubSub[Topic, Any] base class contract.