### PR TITLE
nix: Skip pre-commit install if hooks already exist

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -224,7 +224,7 @@
           fi
 
           [ -f "$PROJECT_ROOT/motd" ] && cat "$PROJECT_ROOT/motd"
-          [ -f "$PROJECT_ROOT/.pre-commit-config.yaml" ] && pre-commit install --install-hooks
+          [ -f "$PROJECT_ROOT/.pre-commit-config.yaml" ] && [ ! -f "$PROJECT_ROOT/.git/hooks/pre-commit" ] && pre-commit install --install-hooks
         '';
         devShells = {
           # basic shell (blends with your current environment)


### PR DESCRIPTION
Avoids running pre-commit install on every shell entry when hooks are already set up.