### PR TITLE
Fix Manipulation Tests

### DIFF
--- a/dimos/models/manipulation/contact_graspnet_pytorch/test_contact_graspnet.py
+++ b/dimos/models/manipulation/contact_graspnet_pytorch/test_contact_graspnet.py
@@ -14,6 +14,7 @@ def is_manipulation_installed() -> bool:
         return False
 
 @pytest.mark.integration
+@pytest.mark.gpu
 @pytest.mark.skipif(not is_manipulation_installed(),
                    reason="This test requires 'pip install .[manipulation]' to be run")
 def test_contact_graspnet_inference() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,6 +197,7 @@ manipulation = [
     # Visualization (Optional)
     "kaleido>=0.2.1",
     "plotly>=5.9.0",
+    "xacro",
 ]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1897,6 +1897,7 @@ manipulation = [
     { name = "rtree" },
     { name = "tqdm" },
     { name = "trimesh" },
+    { name = "xacro" },
     { name = "xarm-python-sdk" },
 ]
 misc = [
@@ -2141,6 +2142,7 @@ requires-dist = [
     { name = "unitree-webrtc-connect-leshy", marker = "extra == 'unitree'", specifier = ">=2.0.7" },
     { name = "uvicorn", marker = "extra == 'web'", specifier = ">=0.34.0" },
     { name = "watchdog", marker = "extra == 'dev'", specifier = ">=3.0.0" },
+    { name = "xacro", marker = "extra == 'manipulation'" },
     { name = "xarm-python-sdk", marker = "extra == 'manipulation'", specifier = ">=1.17.0" },
     { name = "xarm-python-sdk", marker = "extra == 'misc'", specifier = ">=1.17.0" },
     { name = "xformers", marker = "extra == 'cuda'", specifier = ">=0.0.20" },
@@ -10549,6 +10551,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c7/79/12135bdf8b9c9367b8701c2c19a14c913c120b882d50b014ca0d38083c2c/wsproto-1.3.2.tar.gz", hash = "sha256:b86885dcf294e15204919950f666e06ffc6c7c114ca900b060d6e16293528294", size = 50116, upload-time = "2025-11-20T18:18:01.871Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/f5/10b68b7b1544245097b2a1b8238f66f2fc6dcaeb24ba5d917f52bd2eed4f/wsproto-1.3.2-py3-none-any.whl", hash = "sha256:61eea322cdf56e8cc904bd3ad7573359a242ba65688716b0710a5eb12beab584", size = 24405, upload-time = "2025-11-20T18:18:00.454Z" },
+]
+
+[[package]]
+name = "xacro"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/b2/12fc318d3563481fe01482dd8e925d38e83b62d64291ed16ab0b6d836a91/xacro-2.1.1.tar.gz", hash = "sha256:3e7adf33cdd90d9fbe8ca0d07d9118acf770a2ad8bf575977019a5c8a60d4d1b", size = 104752, upload-time = "2025-08-28T18:21:20.397Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/6b/3fcfd8589d0e319f5fb56f105acbe791198fd36bb54469a91fbe49d828c4/xacro-2.1.1-py3-none-any.whl", hash = "sha256:c3b330ebd984a3bce6d6482e0047eae5c5333fedd49b30b9b6df863a086b35f7", size = 27087, upload-time = "2025-08-28T18:21:19.165Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`xacro` was missing from the project.toml causing manipulation tests to fail for me on linux (with cuda)

The graspgen test requires cuda, so I added a GPU marker to avoid it failing on CPU only devices