### PR TITLE
Allow LCM encoder to pass through raw bytes

### DIFF
--- a/dimos/protocol/pubsub/encoders.py
+++ b/dimos/protocol/pubsub/encoders.py
@@ -105,7 +105,9 @@ class LCMTopicProto(Protocol):
 class LCMEncoderMixin(PubSubEncoderMixin[LCMTopicProto, DimosMsg, bytes]):
     """Encoder mixin for DimosMsg using LCM binary encoding."""
 
-    def encode(self, msg: DimosMsg, _: LCMTopicProto) -> bytes:
+    def encode(self, msg: DimosMsg | bytes, _: LCMTopicProto) -> bytes:
+        if isinstance(msg, bytes):
+            return msg
         return msg.lcm_encode()
 
     def decode(self, msg: bytes, topic: LCMTopicProto) -> DimosMsg:


### PR DESCRIPTION
Skip lcm_encode() when the message is already bytes, assume msg is already LCM encoded. small functionality for
https://github.com/dimensionalOS/dimos/issues/1222