### PR TITLE
Remove redundant cuda pytest marker

### DIFF
--- a/dimos/models/depth/test_metric3d.py
+++ b/dimos/models/depth/test_metric3d.py
@@ -11,7 +11,6 @@ def sample_intrinsics() -> list[float]:
     """Sample camera intrinsics [fx, fy, cx, cy]."""
     return [500.0, 500.0, 320.0, 240.0]
 
-@pytest.mark.cuda
 @pytest.mark.gpu
 def test_metric3d_init(sample_intrinsics: list[float]) -> None:
     """Test Metric3D initialization."""
@@ -39,7 +38,6 @@ def test_metric3d_update_intrinsic_invalid(sample_intrinsics: list[float]) -> No
         model.update_intrinsic([1.0, 2.0])  # Only 2 values
 
 
-@pytest.mark.cuda
 @pytest.mark.gpu
 def test_metric3d_infer_depth(sample_intrinsics: list[float]) -> None:
     """Test depth inference on a sample image."""
@@ -65,7 +63,6 @@ def test_metric3d_infer_depth(sample_intrinsics: list[float]) -> None:
     model.stop()
 
 
-@pytest.mark.cuda
 @pytest.mark.gpu
 def test_metric3d_multiple_inferences(sample_intrinsics: list[float]) -> None:
     """Test multiple depth inferences."""

--- a/dimos/models/manipulation/contact_graspnet_pytorch/test_contact_graspnet.py
+++ b/dimos/models/manipulation/contact_graspnet_pytorch/test_contact_graspnet.py
@@ -14,7 +14,6 @@ def is_manipulation_installed() -> bool:
         return False
 
 @pytest.mark.integration
-@pytest.mark.cuda
 @pytest.mark.gpu
 @pytest.mark.skipif(not is_manipulation_installed(), reason="This test requires 'pip install .[manipulation]' to be run")
 def test_contact_graspnet_inference() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -390,7 +390,6 @@ markers = [
     "lcm: tests that run actual LCM bus (can't execute in CI)",
     "module: tests that need to run directly as modules",
     "gpu: tests that require GPU",
-    "cuda: tests which require CUDA (specifically CUDA not just GPU acceleration)",
     "tofix: temporarily disabled test",
     "e2e: end to end tests",
     "integration: slower integration tests",


### PR DESCRIPTION
## Summary
- Removes the `cuda` pytest marker, consolidating all GPU test marking under `gpu`
- The `cuda` marker was always paired with `gpu` and never independently filtered in `addopts`