### PR TITLE
Add ARM Support

### DIFF
--- a/dimos/perception/object_tracker.py
+++ b/dimos/perception/object_tracker.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# mypy: disable-error-code=redundant-cast
-
 from dataclasses import dataclass
 import threading
 import time

--- a/dimos/perception/object_tracker_2d.py
+++ b/dimos/perception/object_tracker_2d.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# mypy: disable-error-code=redundant-cast
-
 from dataclasses import dataclass
 import logging
 import threading

--- a/dimos/robot/drone/drone_tracking_module.py
+++ b/dimos/robot/drone/drone_tracking_module.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# mypy: disable-error-code=redundant-cast
-
 """Drone tracking module with visual servoing for object following."""
 
 import json


### PR DESCRIPTION
test on an Arm system with:
```
uv pip install "dimos[unitree] @ git+https://github.com/dimensionalOS/dimos.git@jeff/arm_support"
dimos --replay run unitree-go2
```
Just uses the stop-gap pypi package published at: https://github.com/jeff-hykin/open3d_jetson
Which is just pre-build wheel files for arm based on the open3d repo

closes DIM-405