### PR TITLE
Fix: add missing library dependencies to flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,7 @@
           { vals.pkg=pkgs.gh;                 flags={}; }
           { vals.pkg=pkgs.stdenv.cc.cc.lib;   flags.ldLibraryGroup=true; }
           { vals.pkg=pkgs.stdenv.cc;          flags.ldLibraryGroup=true; }
+          { vals.pkg=pkgs.gfortran.cc.lib;    flags.ldLibraryGroup=true; }
           { vals.pkg=pkgs.cctools;            flags={}; onlyIf=pkgs.stdenv.isDarwin; } # for pip install opencv-python
           { vals.pkg=pkgs.pcre2;              flags={ ldLibraryGroup=pkgs.stdenv.isDarwin; packageConfGroup=pkgs.stdenv.isDarwin; }; }
           { vals.pkg=pkgs.libsysprof-capture; flags.packageConfGroup=true; onlyIf=pkgs.stdenv.isDarwin; }
@@ -128,6 +129,7 @@
           { vals.pkg=pkgs.libjpeg;       flags.ldLibraryGroup=true; }
           { vals.pkg=pkgs.libjpeg_turbo; flags.ldLibraryGroup=true; }
           { vals.pkg=pkgs.libpng;        flags={}; }
+          { vals.pkg=pkgs.libidn2;       flags.ldLibraryGroup=true; }
 
           ### Docs generators
           { vals.pkg=pkgs.pikchr;        flags={}; }


### PR DESCRIPTION
This adds two missing library dependencies (`gfortran.cc.lib` and `libidn2`) to the flake configuration. These packages are needed to run on the Jetson platform. Related: #1229 and #980