### PR TITLE
Fix: Robust LangChain Provider String Handling

### DIFF
--- a/dimos/protocol/mcp/README.md
+++ b/dimos/protocol/mcp/README.md
@@ -9,20 +9,22 @@ uv sync --extra base --extra unitree
 ```
 
 Add to Claude Code (one command):
-```bash
-claude mcp add --transport stdio dimos --scope project -- python -m dimos.protocol.mcp
-```
 
+```bash
+claude mcp add --transport stdio dimos --scope project -- uv run python -m dimos.protocol.mcp
+```
 
 ## Usage
 
 **Terminal 1** - Start DimOS:
+
 ```bash
 uv run dimos run unitree-go2-agentic-mcp
 ```
 
 **Claude Code** - Use robot skills:
-```
+
+```text
 > move forward 1 meter
 > go to the kitchen
 > tag this location as "desk"


### PR DESCRIPTION
This merge request fixes provider string formatting issues when initializing LangChain chat models such that values are correctly passed to `init_chat_model`.

## Quick Start

```bash
uv run dimos run unitree-go2-agentic
```
