### PR TITLE
Fix Local Mypy Fail on Dev

### DIFF
--- a/dimos/memory/timeseries/postgres.py
+++ b/dimos/memory/timeseries/postgres.py
@@ -17,8 +17,8 @@ from collections.abc import Iterator
 import pickle
 import re
 
-import psycopg2  # type: ignore[import-not-found]
-import psycopg2.extensions  # type: ignore[import-not-found]
+import psycopg2  # type: ignore[import-untyped]
+import psycopg2.extensions  # type: ignore[import-untyped]
 
 from dimos.core.resource import Resource
 from dimos.memory.timeseries.base import T, TimeSeriesStore


### PR DESCRIPTION
Fails for me on 3.10 and 3.12 and I'm just trying to keep local failures off of dev until I can get to the CI fix
```
Starting mypy for non-changed files (python 3.10)
dimos/memory/timeseries/postgres.py:20: error: Library stubs not installed for "psycopg2"  [import-untyped]
dimos/memory/timeseries/postgres.py:20: note: Error code "import-untyped" not covered by "type: ignore" comment
dimos/memory/timeseries/postgres.py:21: error: Library stubs not installed for "psycopg2.extensions"  [import-untyped]
dimos/memory/timeseries/postgres.py:21: note: Error code "import-untyped" not covered by "type: ignore" comment
dimos/memory/timeseries/postgres.py:21: note: Hint: "python3 -m pip install types-psycopg2"
dimos/memory/timeseries/postgres.py:21: note: (or run "mypy --install-types" to install all missing stub packages)
dimos/memory/timeseries/postgres.py:21: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
mypy-3.10-remaining failed!
Starting mypy for non-changed files (python 3.12)
dimos/memory/timeseries/postgres.py:20: error: Library stubs not installed for "psycopg2"  [import-untyped]
dimos/memory/timeseries/postgres.py:20: note: Error code "import-untyped" not covered by "type: ignore" comment
dimos/memory/timeseries/postgres.py:21: error: Library stubs not installed for "psycopg2.extensions"  [import-untyped]
dimos/memory/timeseries/postgres.py:21: note: Error code "import-untyped" not covered by "type: ignore" comment
dimos/memory/timeseries/postgres.py:21: note: Hint: "python3 -m pip install types-psycopg2"
dimos/memory/timeseries/postgres.py:21: note: (or run "mypy --install-types" to install all missing stub packages)
dimos/memory/timeseries/postgres.py:21: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
mypy-3.12-remaining failed!
```