### PR TITLE
fix(exploration): do not block agent loop

### DIFF
--- a/dimos/agents/agent.py
+++ b/dimos/agents/agent.py
@@ -131,6 +131,7 @@ class Agent(Module):
     def _process_message(
         self, state_graph: CompiledStateGraph[Any, Any, Any, Any], message: BaseMessage
     ) -> None:
+        self.agent_idle.publish(False)
         self._history.append(message)
         pretty_print_langchain_message(message)
         self.agent.publish(message)

--- a/dimos/agents/skills/navigation.py
+++ b/dimos/agents/skills/navigation.py
@@ -268,11 +268,11 @@ class NavigationSkillContainer(Module):
 
         goal_pose = self._get_goal_pose_from_result(best_match)
 
-        print("Goal pose for semantic nav:", goal_pose)
+        logger.info("Goal pose for semantic nav", pose=goal_pose)
         if not goal_pose:
             return f"Found a result for '{query}' but it didn't have a valid position."
 
-        message = "Found a location in the semantic map matching '{query}'."
+        message = f"Found a location in the semantic map matching '{query}'."
         return self._navigate_to(goal_pose, message)
 
     @skill
@@ -306,9 +306,7 @@ class NavigationSkillContainer(Module):
         metadata = result.get("metadata")
         if not metadata:
             return None
-        print(metadata)
         first = metadata[0]
-        print(first)
         pos_x = first.get("pos_x", 0)
         pos_y = first.get("pos_y", 0)
         theta = first.get("rot_z", 0)

--- a/dimos/agents/skills/navigation.py
+++ b/dimos/agents/skills/navigation.py
@@ -51,9 +51,6 @@ class NavigationSkillContainer(Module):
         "ObjectTracking.track",
         "ObjectTracking.stop_track",
         "ObjectTracking.is_tracking",
-        "WavefrontFrontierExplorer.stop_exploration",
-        "WavefrontFrontierExplorer.explore",
-        "WavefrontFrontierExplorer.is_exploration_active",
     ]
 
     color_image: In[Image]
@@ -160,48 +157,31 @@ class NavigationSkillContainer(Module):
         if not robot_location:
             return None
 
-        print("Found tagged location:", robot_location)
+        logger.info("Found tagged location", location=robot_location)
         goal_pose = PoseStamped(
             position=make_vector3(*robot_location.position),
             orientation=Quaternion.from_euler(Vector3(*robot_location.rotation)),
             frame_id="map",
         )
 
-        result = self._navigate_to(goal_pose)
-        if not result:
-            return "Error: Faild to reach the tagged location."
+        return self._navigate_to(goal_pose, f"Found a tagged location called '{query}'.")
 
-        return (
-            f"Successfuly arrived at location tagged '{robot_location.name}' from query '{query}'."
-        )
-
-    def _navigate_to(self, pose: PoseStamped) -> bool:
+    def _navigate_to(self, pose: PoseStamped, message: str) -> str:
         try:
-            set_goal_rpc, get_state_rpc, is_goal_reached_rpc = self.get_rpc_calls(
-                "NavigationInterface.set_goal",
-                "NavigationInterface.get_state",
-                "NavigationInterface.is_goal_reached",
-            )
+            set_goal_rpc = self.get_rpc_calls("NavigationInterface.set_goal")
         except Exception:
             logger.error("Navigation module not connected properly")
-            return False
+            return "Error: Navigation module is not connected, cannot set goal."
 
         logger.info(
             f"Navigating to pose: ({pose.position.x:.2f}, {pose.position.y:.2f}, {pose.position.z:.2f})"
         )
         set_goal_rpc(pose)
-        time.sleep(1.0)
 
-        while get_state_rpc() == NavigationState.FOLLOWING_PATH:
-            time.sleep(0.25)
-
-        time.sleep(1.0)
-        if not is_goal_reached_rpc():
-            logger.info("Navigation was cancelled or failed")
-            return False
-        else:
-            logger.info("Navigation goal reached")
-            return True
+        return (
+            f"{message}. Started navigating to that position. "
+            f"To cancel movement call the 'stop_navigation' tool."
+        )
 
     def _navigate_to_object(self, query: str) -> str | None:
         try:
@@ -292,20 +272,11 @@ class NavigationSkillContainer(Module):
         if not goal_pose:
             return f"Found a result for '{query}' but it didn't have a valid position."
 
-        result = self._navigate_to(goal_pose)
-
-        if not result:
-            return f"Failed to navigate for '{query}'"
-
-        return f"Successfuly arrived at '{query}'"
+        message = "Found a location in the semantic map matching '{query}'."
+        return self._navigate_to(goal_pose, message)
 
     @skill
-    def follow_human(self, person: str) -> str:
-        """Follow a specific person"""
-        return "Not implemented yet."
-
-    @skill
-    def stop_movement(self) -> str:
+    def stop_navigation(self) -> str:
         """Immediatly stop moving."""
 
         if not self._skill_started:
@@ -322,57 +293,7 @@ class NavigationSkillContainer(Module):
             logger.warning("Navigation module not connected, cannot cancel goal")
             return
 
-        try:
-            stop_exploration_rpc = self.get_rpc_calls("WavefrontFrontierExplorer.stop_exploration")
-        except Exception:
-            logger.warning("FrontierExplorer module not connected, cannot stop exploration")
-            return
-
         cancel_goal_rpc()
-        return stop_exploration_rpc()  # type: ignore[no-any-return]
-
-    @skill
-    def start_exploration(self, timeout: float = 240.0) -> str:
-        """A skill that performs autonomous frontier exploration.
-
-        This skill continuously finds and navigates to unknown frontiers in the environment
-        until no more frontiers are found or the exploration is stopped.
-
-        Don't call any other skills except stop_movement skill when needed.
-
-        Args:
-            timeout (float, optional): Maximum time (in seconds) allowed for exploration
-        """
-
-        if not self._skill_started:
-            raise ValueError(f"{self} has not been started.")
-
-        try:
-            return self._start_exploration(timeout)
-        finally:
-            self._cancel_goal_and_stop()
-
-    def _start_exploration(self, timeout: float) -> str:
-        try:
-            explore_rpc, is_exploration_active_rpc = self.get_rpc_calls(
-                "WavefrontFrontierExplorer.explore",
-                "WavefrontFrontierExplorer.is_exploration_active",
-            )
-        except Exception:
-            return "Error: The WavefrontFrontierExplorer module is not connected."
-
-        logger.info("Starting autonomous frontier exploration")
-
-        start_time = time.time()
-
-        has_started = explore_rpc()
-        if not has_started:
-            return "Error: Could not start exploration."
-
-        while time.time() - start_time < timeout and is_exploration_active_rpc():
-            time.sleep(0.5)
-
-        return "Exploration completed successfuly"
 
     def _get_goal_pose_from_result(self, result: dict[str, Any]) -> PoseStamped | None:
         similarity = 1.0 - (result.get("distance") or 1)

--- a/dimos/mapping/voxels.py
+++ b/dimos/mapping/voxels.py
@@ -61,7 +61,7 @@ class VoxelGridMapper(Module):
             else o3c.Device("CPU:0")
         )
 
-        print(f"VoxelGridMapper using device: {dev}")
+        logger.info(f"VoxelGridMapper using device: {dev}")
 
         self.vbg = o3d.t.geometry.VoxelBlockGrid(
             attr_names=("dummy",),

--- a/dimos/navigation/frontier_exploration/wavefront_frontier_goal_selector.py
+++ b/dimos/navigation/frontier_exploration/wavefront_frontier_goal_selector.py
@@ -815,9 +815,11 @@ class WavefrontFrontierExplorer(Module):
     @skill
     def begin_exploration(self) -> str:
         """Command the robot to move around and explore the area. Cancelled with end_exploration."""
-        self.explore()
+        started = self.explore()
+        if not started:
+            return "Exploration skill is already active. Use end_exploration to stop before starting again."
         return (
-            "Started exploration skill. The robot is now moving. Use stop_exploration "
+            "Started exploration skill. The robot is now moving. Use end_exploration "
             "to stop. You also need to cancel before starting a new movement tool."
         )
 

--- a/dimos/navigation/frontier_exploration/wavefront_frontier_goal_selector.py
+++ b/dimos/navigation/frontier_exploration/wavefront_frontier_goal_selector.py
@@ -28,6 +28,7 @@ from dimos_lcm.std_msgs import Bool
 import numpy as np
 from reactivex.disposable import Disposable
 
+from dimos.agents.annotation import skill
 from dimos.core import In, Module, Out, rpc
 from dimos.mapping.occupancy.inflation import simple_inflate
 from dimos.msgs.geometry_msgs import PoseStamped, Vector3
@@ -100,7 +101,7 @@ class WavefrontFrontierExplorer(Module):
     # LCM outputs
     goal_request: Out[PoseStamped]
 
-    def __init__(  # type: ignore[no-untyped-def]
+    def __init__(
         self,
         min_frontier_perimeter: float = 0.5,
         occupancy_threshold: int = 99,
@@ -110,7 +111,6 @@ class WavefrontFrontierExplorer(Module):
         info_gain_threshold: float = 0.03,
         num_no_gain_attempts: int = 2,
         goal_timeout: float = 15.0,
-        **kwargs,
     ) -> None:
         """
         Initialize the frontier explorer.
@@ -122,7 +122,7 @@ class WavefrontFrontierExplorer(Module):
             info_gain_threshold: Minimum percentage increase in costmap information required to continue exploration (0.05 = 5%)
             num_no_gain_attempts: Maximum number of consecutive attempts with no information gain
         """
-        super().__init__(**kwargs)
+        super().__init__()
         self.min_frontier_perimeter = min_frontier_perimeter
         self.occupancy_threshold = occupancy_threshold
         self.safe_distance = safe_distance
@@ -148,8 +148,6 @@ class WavefrontFrontierExplorer(Module):
         self.exploration_active = False
         self.exploration_thread: threading.Thread | None = None
         self.stop_event = threading.Event()
-
-        logger.info("WavefrontFrontierExplorer module initialized")
 
     @rpc
     def start(self) -> None:
@@ -813,6 +811,24 @@ class WavefrontFrontierExplorer(Module):
                         f"No frontier found (attempt {consecutive_failures}/{max_consecutive_failures}). Retrying in 2 seconds..."
                     )
                     threading.Event().wait(2.0)
+
+    @skill
+    def begin_exploration(self) -> str:
+        """Command the robot to move around and explore the area. Cancelled with end_exploration."""
+        self.explore()
+        return (
+            "Started exploration skill. The robot is now moving. Use stop_exploration "
+            "to stop. You also need to cancel before starting a new movement tool."
+        )
+
+    @skill
+    def end_exploration(self) -> str:
+        """Cancel the exploration. The robot will stop moving and remain where it is."""
+        stopped = self.stop_exploration()
+        if stopped:
+            return "Stopped exploration. The robot has stopped moving."
+        else:
+            return "Exploration skill was not active, so nothing was stopped."
 
 
 wavefront_frontier_explorer = WavefrontFrontierExplorer.blueprint

--- a/dimos/utils/cli/human/humancli.py
+++ b/dimos/utils/cli/human/humancli.py
@@ -64,18 +64,22 @@ class ThinkingIndicator:
         self._app: App[Any] = app
         self._chat_log = chat_log
         self._add_message = add_message_fn
-        self._timer: Any
+        self._timer: Any = None
         self._strips: list[Any] = []
         self.visible = False
         self._throb_dim = False
 
     def show(self) -> None:
+        if self.visible:
+            return
         self.visible = True
         self._throb_dim = False
         self._write_line()
         self._timer = self._app.set_interval(0.6, self._toggle_throb)
 
     def hide(self) -> None:
+        if not self.visible:
+            return
         self.visible = False
         if self._timer is not None:
             self._timer.stop()
@@ -102,9 +106,7 @@ class ThinkingIndicator:
         if not self._strips:
             return
         strip_ids = {id(s) for s in self._strips}
-        self._chat_log.lines = [
-            line for line in self._chat_log.lines if id(line) not in strip_ids
-        ]
+        self._chat_log.lines = [line for line in self._chat_log.lines if id(line) not in strip_ids]
         self._strips = []
         self._chat_log._line_cache.clear()
         self._chat_log.virtual_size = Size(

--- a/dimos/utils/cli/human/humancli.py
+++ b/dimos/utils/cli/human/humancli.py
@@ -18,7 +18,7 @@ from datetime import datetime
 import json
 import textwrap
 import threading
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolCall, ToolMessage
 from rich.highlighter import JSONHighlighter
@@ -26,6 +26,7 @@ from rich.theme import Theme
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Container
+from textual.geometry import Size
 from textual.widgets import Input, RichLog
 
 from dimos.core import pLCMTransport
@@ -33,6 +34,8 @@ from dimos.utils.cli import theme
 from dimos.utils.generic import truncate_display_string
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from textual.events import Key
 
 # Custom theme for JSON highlighting
@@ -47,6 +50,74 @@ JSON_THEME = Theme(
         "json.brace": theme.BRIGHT_WHITE,
     }
 )
+
+
+class ThinkingIndicator:
+    """Manages a throbbing 'thinking...' chat message in a RichLog."""
+
+    def __init__(
+        self,
+        app: App[Any],
+        chat_log: RichLog,
+        add_message_fn: Callable[[str, str, str, str], None],
+    ) -> None:
+        self._app: App[Any] = app
+        self._chat_log = chat_log
+        self._add_message = add_message_fn
+        self._timer: Any
+        self._strips: list[Any] = []
+        self.visible = False
+        self._throb_dim = False
+
+    def show(self) -> None:
+        self.visible = True
+        self._throb_dim = False
+        self._write_line()
+        self._timer = self._app.set_interval(0.6, self._toggle_throb)
+
+    def hide(self) -> None:
+        self.visible = False
+        if self._timer is not None:
+            self._timer.stop()
+            self._timer = None
+        self._remove_lines()
+
+    def detach_if_needed(self) -> bool:
+        if self.visible and self._strips:
+            self._remove_lines()
+            return True
+        return False
+
+    def reattach(self) -> None:
+        self._write_line()
+
+    def _write_line(self) -> None:
+        before_count = len(self._chat_log.lines)
+        color = theme.DIM if self._throb_dim else theme.ACCENT
+        timestamp = datetime.now().strftime("%H:%M:%S")
+        self._add_message(timestamp, "", "[italic]thinking...[/italic]", color)
+        self._strips = list(self._chat_log.lines[before_count:])
+
+    def _remove_lines(self) -> None:
+        if not self._strips:
+            return
+        strip_ids = {id(s) for s in self._strips}
+        self._chat_log.lines = [
+            line for line in self._chat_log.lines if id(line) not in strip_ids
+        ]
+        self._strips = []
+        self._chat_log._line_cache.clear()
+        self._chat_log.virtual_size = Size(
+            self._chat_log.virtual_size.width, len(self._chat_log.lines)
+        )
+        self._chat_log.refresh()
+
+    def _toggle_throb(self) -> None:
+        if not self.visible:
+            return
+        self._remove_lines()
+        self._throb_dim = not self._throb_dim
+        self._write_line()
 
 
 class HumanCLIApp(App):  # type: ignore[type-arg]
@@ -70,6 +141,7 @@ class HumanCLIApp(App):  # type: ignore[type-arg]
     Input {{
         dock: bottom;
     }}
+
     """
 
     BINDINGS = [
@@ -80,11 +152,14 @@ class HumanCLIApp(App):  # type: ignore[type-arg]
 
     def __init__(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
         super().__init__(*args, **kwargs)
-        self.human_transport = pLCMTransport("/human_input")  # type: ignore[var-annotated]
-        self.agent_transport = pLCMTransport("/agent")  # type: ignore[var-annotated]
+        self._human_transport = pLCMTransport("/human_input")  # type: ignore[var-annotated]
+        self._agent_transport = pLCMTransport("/agent")  # type: ignore[var-annotated]
+        self._agent_idle = pLCMTransport("/agent_idle")  # type: ignore[var-annotated]
         self.chat_log: RichLog | None = None
         self.input_widget: Input | None = None
         self._subscription_thread: threading.Thread | None = None
+        self._idle_subscription_thread: threading.Thread | None = None
+        self._thinking: ThinkingIndicator | None = None
         self._running = False
 
     def compose(self) -> ComposeResult:
@@ -106,16 +181,22 @@ class HumanCLIApp(App):  # type: ignore[type-arg]
         # Set custom highlighter for RichLog
         self.chat_log.highlighter = JSONHighlighter()  # type: ignore[union-attr]
 
-        # Start subscription thread
+        assert self.chat_log is not None
+        self._thinking = ThinkingIndicator(self, self.chat_log, self._add_message)
+
+        # Start subscription threads
         self._subscription_thread = threading.Thread(target=self._subscribe_to_agent, daemon=True)
         self._subscription_thread.start()
+        self._idle_subscription_thread = threading.Thread(
+            target=self._subscribe_to_idle, daemon=True
+        )
+        self._idle_subscription_thread.start()
 
         # Focus on input
         self.input_widget.focus()  # type: ignore[union-attr]
 
         self.chat_log.write(f"[{theme.ACCENT}]{theme.ascii_logo}[/{theme.ACCENT}]")  # type: ignore[union-attr]
 
-        # Welcome message
         self._add_system_message("Connected to DimOS Agent Interface")
 
     def on_unmount(self) -> None:
@@ -173,7 +254,18 @@ class HumanCLIApp(App):  # type: ignore[type-arg]
                     self._add_message, timestamp, "human", msg.content, theme.HUMAN
                 )
 
-        self.agent_transport.subscribe(receive_msg)
+        self._agent_transport.subscribe(receive_msg)
+
+    def _subscribe_to_idle(self) -> None:
+        def receive_idle(is_idle: bool) -> None:
+            assert self._thinking is not None
+
+            if not self._running:
+                return
+
+            self.call_from_thread(self._thinking.hide if is_idle else self._thinking.show)
+
+        self._agent_idle.subscribe(receive_idle)
 
     def _format_tool_call(self, tool_call: ToolCall) -> str:
         """Format a tool call for display."""
@@ -183,7 +275,9 @@ class HumanCLIApp(App):  # type: ignore[type-arg]
         return f"▶ {name}({args_str})"
 
     def _add_message(self, timestamp: str, sender: str, content: str, color: str) -> None:
-        """Add a message to the chat log."""
+        assert self._thinking is not None
+        reattach = self._thinking.detach_if_needed()
+
         # Strip leading/trailing whitespace from content
         content = content.strip() if content else ""
 
@@ -238,6 +332,9 @@ class HumanCLIApp(App):  # type: ignore[type-arg]
                     # Empty line
                     self.chat_log.write(indent + "│")  # type: ignore[union-attr]
 
+        if reattach:
+            self._thinking.reattach()
+
     def _add_system_message(self, content: str) -> None:
         """Add a system message to the chat."""
         timestamp = datetime.now().strftime("%H:%M:%S")
@@ -277,7 +374,7 @@ Tool calls are displayed in cyan with ▶ prefix"""
             return
 
         # Send to agent (message will be displayed when received back)
-        self.human_transport.publish(message)
+        self._human_transport.publish(message)
 
     def action_clear(self) -> None:
         """Clear the chat log."""


### PR DESCRIPTION
## Problem

`start_exploration` blocks the loop.

Closes DIM-531

https://linear.app/dimensional/issue/DIM-531/make-start-exploration-not-block

## Solution

* Made it run in the background, without blocking.
* Added `thinking...` to `humancli` so it's visible when the agent blocks.
* Moved the exploration skills to out of `NavigationSkillContainer` and into `WavefrontFrontierExplorer` where they belong.

## Breaking Changes

None

## How to Test

```bash
uv run dimos run unitree-go2-agentic
uv run humancli
# say "start exploring" and "stop"
```