### PR TITLE
Add navigation docker build workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -160,6 +160,7 @@ jobs:
           path: docker/navigation/ros-navigation-autonomy-stack
           fetch-depth: 1
           lfs: false
+          token: ${{ secrets.NAV_REPO_READ_TOKEN }}
 
       - uses: docker/login-action@v3
         with:


### PR DESCRIPTION
## Summary
- build and push the navigation docker image to GHCR on changes in docker/navigation

## Testing
- not run (workflow change only)