### PR TITLE
Rename QuestButtons to Buttons with generic field names

### DIFF
--- a/dimos/control/blueprints.py
+++ b/dimos/control/blueprints.py
@@ -35,7 +35,7 @@ from dimos.control.coordinator import TaskConfig, control_coordinator
 from dimos.core.transport import LCMTransport
 from dimos.msgs.geometry_msgs import PoseStamped
 from dimos.msgs.sensor_msgs import JointState
-from dimos.teleop.quest.quest_types import QuestButtons
+from dimos.teleop.quest.quest_types import Buttons
 from dimos.utils.data import LfsPath
 
 _PIPER_MODEL_PATH = LfsPath("piper_description/mujoco_model/piper_no_gripper_description.xml")
@@ -499,7 +499,7 @@ coordinator_teleop_xarm6 = control_coordinator(
         ("cartesian_command", PoseStamped): LCMTransport(
             "/coordinator/cartesian_command", PoseStamped
         ),
-        ("buttons", QuestButtons): LCMTransport("/teleop/buttons", QuestButtons),
+        ("buttons", Buttons): LCMTransport("/teleop/buttons", Buttons),
     }
 )
 
@@ -535,7 +535,7 @@ coordinator_teleop_piper = control_coordinator(
         ("cartesian_command", PoseStamped): LCMTransport(
             "/coordinator/cartesian_command", PoseStamped
         ),
-        ("buttons", QuestButtons): LCMTransport("/teleop/buttons", QuestButtons),
+        ("buttons", Buttons): LCMTransport("/teleop/buttons", Buttons),
     }
 )
 
@@ -588,7 +588,7 @@ coordinator_teleop_dual = control_coordinator(
         ("cartesian_command", PoseStamped): LCMTransport(
             "/coordinator/cartesian_command", PoseStamped
         ),
-        ("buttons", QuestButtons): LCMTransport("/teleop/buttons", QuestButtons),
+        ("buttons", Buttons): LCMTransport("/teleop/buttons", Buttons),
     }
 )
 

--- a/dimos/control/coordinator.py
+++ b/dimos/control/coordinator.py
@@ -44,7 +44,7 @@ from dimos.msgs.geometry_msgs import (
 from dimos.msgs.sensor_msgs import (
     JointState,  # noqa: TC001 - needed at runtime for Out[JointState]
 )
-from dimos.teleop.quest.quest_types import QuestButtons  # noqa: TC001 - needed for teleop buttons
+from dimos.teleop.quest.quest_types import Buttons  # noqa: TC001 - needed for teleop buttons
 from dimos.utils.logging_config import setup_logger
 
 if TYPE_CHECKING:
@@ -149,7 +149,7 @@ class ControlCoordinator(Module[ControlCoordinatorConfig]):
     cartesian_command: In[PoseStamped]
 
     # Input: Teleop buttons for engage/disengage signaling
-    buttons: In[QuestButtons]
+    buttons: In[Buttons]
 
     config: ControlCoordinatorConfig
     default_config = ControlCoordinatorConfig
@@ -490,7 +490,7 @@ class ControlCoordinator(Module[ControlCoordinatorConfig]):
 
             task.on_cartesian_command(msg, t_now)
 
-    def _on_buttons(self, msg: QuestButtons) -> None:
+    def _on_buttons(self, msg: Buttons) -> None:
         """Forward button state to all tasks."""
         with self._task_lock:
             for task in self._tasks.values():

--- a/dimos/control/task.py
+++ b/dimos/control/task.py
@@ -35,7 +35,7 @@ from dimos.hardware.manipulators.spec import ControlMode
 
 if TYPE_CHECKING:
     from dimos.msgs.geometry_msgs import Pose, PoseStamped
-    from dimos.teleop.quest.quest_types import QuestButtons
+    from dimos.teleop.quest.quest_types import Buttons
 
 # =============================================================================
 # Data Types
@@ -291,7 +291,7 @@ class ControlTask(Protocol):
         """
         ...
 
-    def on_buttons(self, msg: QuestButtons) -> bool:
+    def on_buttons(self, msg: Buttons) -> bool:
         """Handle button state from teleop controllers."""
         ...
 
@@ -315,7 +315,7 @@ class BaseControlTask(ControlTask):
     in tasks that don't need them. Only override what your task uses.
     """
 
-    def on_buttons(self, msg: QuestButtons) -> bool:
+    def on_buttons(self, msg: Buttons) -> bool:
         """No-op default."""
         return False
 

--- a/dimos/control/tasks/teleop_task.py
+++ b/dimos/control/tasks/teleop_task.py
@@ -52,7 +52,7 @@ if TYPE_CHECKING:
     from numpy.typing import NDArray
 
     from dimos.msgs.geometry_msgs import Pose, PoseStamped
-    from dimos.teleop.quest.quest_types import QuestButtons
+    from dimos.teleop.quest.quest_types import Buttons
 
 logger = setup_logger()
 
@@ -276,19 +276,19 @@ class TeleopIKTask(BaseControlTask):
     # Task-specific methods
     # =========================================================================
 
-    def on_buttons(self, msg: QuestButtons) -> bool:
+    def on_buttons(self, msg: Buttons) -> bool:
         """Press-and-hold engage: hold primary button to track, release to stop.
 
-        Checks only the button matching self._config.hand (left_x or right_a).
+        Checks only the button matching self._config.hand (left_primary or right_primary).
         If hand is not set, listens to both.
         """
         hand = self._config.hand
         if hand == "left":
-            primary = msg.left_x
+            primary = msg.left_primary
         elif hand == "right":
-            primary = msg.right_a
+            primary = msg.right_primary
         else:
-            primary = msg.left_x or msg.right_a
+            primary = msg.left_primary or msg.right_primary
 
         if primary and not self._prev_primary:
             # Rising edge: reset initial pose so compute() recaptures

--- a/dimos/teleop/README.md
+++ b/dimos/teleop/README.md
@@ -17,7 +17,7 @@ QuestTeleopModule
     │  WebXR → robot frame transform
     │  Pose computation + button state packing
     ▼
-PoseStamped / TwistStamped / QuestButtons outputs
+PoseStamped / TwistStamped / Buttons outputs
 ```
 
 ## Modules
@@ -61,7 +61,7 @@ teleop/
 ├── quest/
 │   ├── quest_teleop_module.py   # Base Quest teleop module
 │   ├── quest_extensions.py      # ArmTeleop, TwistTeleop, VisualizingTeleop
-│   ├── quest_types.py           # QuestControllerState, QuestButtons
+│   ├── quest_types.py           # QuestControllerState, Buttons
 │   └── web/                     # Deno bridge + WebXR client
 │       ├── teleop_server.ts
 │       └── static/index.html

--- a/dimos/teleop/blueprints.py
+++ b/dimos/teleop/blueprints.py
@@ -24,7 +24,7 @@ from dimos.core.blueprints import autoconnect
 from dimos.core.transport import LCMTransport
 from dimos.msgs.geometry_msgs import PoseStamped
 from dimos.teleop.quest.quest_extensions import arm_teleop_module, visualizing_teleop_module
-from dimos.teleop.quest.quest_types import QuestButtons
+from dimos.teleop.quest.quest_types import Buttons
 
 # -----------------------------------------------------------------------------
 # Quest Teleop Blueprints
@@ -37,7 +37,7 @@ arm_teleop = autoconnect(
     {
         ("left_controller_output", PoseStamped): LCMTransport("/teleop/left_delta", PoseStamped),
         ("right_controller_output", PoseStamped): LCMTransport("/teleop/right_delta", PoseStamped),
-        ("buttons", QuestButtons): LCMTransport("/teleop/buttons", QuestButtons),
+        ("buttons", Buttons): LCMTransport("/teleop/buttons", Buttons),
     }
 )
 
@@ -48,7 +48,7 @@ arm_teleop_visualizing = autoconnect(
     {
         ("left_controller_output", PoseStamped): LCMTransport("/teleop/left_delta", PoseStamped),
         ("right_controller_output", PoseStamped): LCMTransport("/teleop/right_delta", PoseStamped),
-        ("buttons", QuestButtons): LCMTransport("/teleop/buttons", QuestButtons),
+        ("buttons", Buttons): LCMTransport("/teleop/buttons", Buttons),
     }
 )
 
@@ -68,7 +68,7 @@ arm_teleop_xarm6 = autoconnect(
         ("right_controller_output", PoseStamped): LCMTransport(
             "/coordinator/cartesian_command", PoseStamped
         ),
-        ("buttons", QuestButtons): LCMTransport("/teleop/buttons", QuestButtons),
+        ("buttons", Buttons): LCMTransport("/teleop/buttons", Buttons),
     }
 )
 
@@ -83,7 +83,7 @@ arm_teleop_piper = autoconnect(
         ("left_controller_output", PoseStamped): LCMTransport(
             "/coordinator/cartesian_command", PoseStamped
         ),
-        ("buttons", QuestButtons): LCMTransport("/teleop/buttons", QuestButtons),
+        ("buttons", Buttons): LCMTransport("/teleop/buttons", Buttons),
     }
 )
 
@@ -100,7 +100,7 @@ arm_teleop_dual = autoconnect(
         ("left_controller_output", PoseStamped): LCMTransport(
             "/coordinator/cartesian_command", PoseStamped
         ),
-        ("buttons", QuestButtons): LCMTransport("/teleop/buttons", QuestButtons),
+        ("buttons", Buttons): LCMTransport("/teleop/buttons", Buttons),
     }
 )
 

--- a/dimos/teleop/quest/__init__.py
+++ b/dimos/teleop/quest/__init__.py
@@ -30,15 +30,15 @@ from dimos.teleop.quest.quest_teleop_module import (
     quest_teleop_module,
 )
 from dimos.teleop.quest.quest_types import (
-    QuestButtons,
+    Buttons,
     QuestControllerState,
     ThumbstickState,
 )
 
 __all__ = [
     "ArmTeleopModule",
+    "Buttons",
     "Hand",
-    "QuestButtons",
     "QuestControllerState",
     "QuestTeleopConfig",
     "QuestTeleopModule",

--- a/dimos/teleop/quest/quest_extensions.py
+++ b/dimos/teleop/quest/quest_extensions.py
@@ -56,7 +56,7 @@ class TwistTeleopModule(QuestTeleopModule):
     Outputs:
         - left_twist: TwistStamped (linear + angular velocity)
         - right_twist: TwistStamped (linear + angular velocity)
-        - buttons: QuestButtons (inherited)
+        - buttons: Buttons (inherited)
     """
 
     default_config = TwistTeleopConfig
@@ -105,7 +105,7 @@ class ArmTeleopModule(QuestTeleopModule):
     Outputs:
         - left_controller_output: PoseStamped (inherited)
         - right_controller_output: PoseStamped (inherited)
-        - buttons: QuestButtons (inherited)
+        - buttons: Buttons (inherited)
     """
 
     default_config = ArmTeleopConfig
@@ -140,7 +140,7 @@ class VisualizingTeleopModule(ArmTeleopModule):
     Outputs:
         - left_controller_output: PoseStamped (inherited)
         - right_controller_output: PoseStamped (inherited)
-        - buttons: QuestButtons (inherited)
+        - buttons: Buttons (inherited)
     """
 
     def _get_output_pose(self, hand: Hand) -> PoseStamped | None:

--- a/dimos/teleop/quest/quest_teleop_module.py
+++ b/dimos/teleop/quest/quest_teleop_module.py
@@ -33,7 +33,7 @@ from dimos.core.module import ModuleConfig
 from dimos.msgs.geometry_msgs import PoseStamped
 from dimos.msgs.sensor_msgs import Joy
 from dimos.teleop.base import TeleopProtocol
-from dimos.teleop.quest.quest_types import QuestButtons, QuestControllerState
+from dimos.teleop.quest.quest_types import Buttons, QuestControllerState
 from dimos.teleop.utils.teleop_transforms import webxr_to_robot
 from dimos.utils.logging_config import setup_logger
 
@@ -55,7 +55,7 @@ class QuestTeleopStatus:
     right_engaged: bool
     left_pose: PoseStamped | None
     right_pose: PoseStamped | None
-    buttons: QuestButtons
+    buttons: Buttons
 
 
 @dataclass
@@ -76,7 +76,7 @@ class QuestTeleopModule(Module[QuestTeleopConfig], TeleopProtocol):
     Outputs:
         - left_controller_output: PoseStamped (output pose for left hand)
         - right_controller_output: PoseStamped (output pose for right hand)
-        - buttons: QuestButtons (button states for both controllers)
+        - buttons: Buttons (button states for both controllers)
     """
 
     default_config = QuestTeleopConfig
@@ -90,7 +90,7 @@ class QuestTeleopModule(Module[QuestTeleopConfig], TeleopProtocol):
     # Outputs: delta poses for each controller
     left_controller_output: Out[PoseStamped]
     right_controller_output: Out[PoseStamped]
-    buttons: Out[QuestButtons]
+    buttons: Out[Buttons]
 
     # -------------------------------------------------------------------------
     # Initialization
@@ -198,7 +198,7 @@ class QuestTeleopModule(Module[QuestTeleopConfig], TeleopProtocol):
                 right_engaged=self._is_engaged[Hand.RIGHT],
                 left_pose=self._current_poses.get(Hand.LEFT),
                 right_pose=self._current_poses.get(Hand.RIGHT),
-                buttons=QuestButtons.from_controllers(left, right),
+                buttons=Buttons.from_controllers(left, right),
             )
 
     # -------------------------------------------------------------------------
@@ -351,7 +351,7 @@ class QuestTeleopModule(Module[QuestTeleopConfig], TeleopProtocol):
         Override to customize button output format (e.g., different bit layout,
         keep analog values, add extra streams).
         """
-        buttons = QuestButtons.from_controllers(left, right)
+        buttons = Buttons.from_controllers(left, right)
         self.buttons.publish(buttons)
 
 

--- a/dimos/teleop/quest/quest_types.py
+++ b/dimos/teleop/quest/quest_types.py
@@ -37,7 +37,7 @@ class QuestControllerState:
     Preserves full-fidelity analog values (trigger, grip as floats, thumbstick axes)
     from the raw Joy message in a readable format. Use this when you need analog
     precision (e.g., proportional grip control). Subclasses can publish this
-    alongside QuestButtons for float access.
+    alongside Buttons for float access.
 
     Axes layout:
         0: thumbstick X, 1: thumbstick Y, 2: trigger (analog), 3: grip (analog)
@@ -91,16 +91,16 @@ class QuestControllerState:
         )
 
 
-class QuestButtons(UInt32):
-    """Packed button states for both Quest controllers in a single UInt32.
+class Buttons(UInt32):
+    """Packed button states for both controllers in a single UInt32.
 
     All values are collapsed to bools for lightweight transport. Analog values
     (trigger, grip) are thresholded at 0.5. If you need the original float
     values, access them from QuestControllerState and publish them in a subclass.
 
     Bit layout:
-        Left (bits 0-6): trigger, grip, touchpad, thumbstick, X, Y, menu
-        Right (bits 8-14): trigger, grip, touchpad, thumbstick, A, B, menu
+        Left  (bits 0-6): trigger, grip, touchpad, thumbstick, primary, secondary, menu
+        Right (bits 8-14): trigger, grip, touchpad, thumbstick, primary, secondary, menu
     """
 
     # Bit positions
@@ -109,29 +109,29 @@ class QuestButtons(UInt32):
         "left_grip": 1,
         "left_touchpad": 2,
         "left_thumbstick": 3,
-        "left_x": 4,
-        "left_y": 5,
+        "left_primary": 4,
+        "left_secondary": 5,
         "left_menu": 6,
         "right_trigger": 8,
         "right_grip": 9,
         "right_touchpad": 10,
         "right_thumbstick": 11,
-        "right_a": 12,
-        "right_b": 13,
+        "right_primary": 12,
+        "right_secondary": 13,
         "right_menu": 14,
     }
 
     def __getattr__(self, name: str) -> bool:
-        if name in QuestButtons.BITS:
-            return bool(self.data & (1 << QuestButtons.BITS[name]))
+        if name in Buttons.BITS:
+            return bool(self.data & (1 << Buttons.BITS[name]))
         raise AttributeError(f"'{type(self).__name__}' has no attribute '{name}'")
 
     def __setattr__(self, name: str, value: bool) -> None:
-        if name in QuestButtons.BITS:
+        if name in Buttons.BITS:
             if value:
-                self.data |= 1 << QuestButtons.BITS[name]
+                self.data |= 1 << Buttons.BITS[name]
             else:
-                self.data &= ~(1 << QuestButtons.BITS[name])
+                self.data &= ~(1 << Buttons.BITS[name])
         else:
             super().__setattr__(name, value)
 
@@ -140,8 +140,8 @@ class QuestButtons(UInt32):
         cls,
         left: "QuestControllerState | None",
         right: "QuestControllerState | None",
-    ) -> "QuestButtons":
-        """Create QuestButtons from two QuestControllerState instances."""
+    ) -> "Buttons":
+        """Create Buttons from two QuestControllerState instances."""
         # Safe: cls() calls UInt32.__init__ which sets self.data = 0 before bit ops.
         buttons = cls()
 
@@ -150,8 +150,8 @@ class QuestButtons(UInt32):
             buttons.left_grip = left.grip > 0.5
             buttons.left_touchpad = left.touchpad
             buttons.left_thumbstick = left.thumbstick_press
-            buttons.left_x = left.primary
-            buttons.left_y = left.secondary
+            buttons.left_primary = left.primary
+            buttons.left_secondary = left.secondary
             buttons.left_menu = left.menu
 
         if right:
@@ -159,11 +159,11 @@ class QuestButtons(UInt32):
             buttons.right_grip = right.grip > 0.5
             buttons.right_touchpad = right.touchpad
             buttons.right_thumbstick = right.thumbstick_press
-            buttons.right_a = right.primary
-            buttons.right_b = right.secondary
+            buttons.right_primary = right.primary
+            buttons.right_secondary = right.secondary
             buttons.right_menu = right.menu
 
         return buttons
 
 
-__all__ = ["QuestButtons", "QuestControllerState", "ThumbstickState"]
+__all__ = ["Buttons", "QuestControllerState", "ThumbstickState"]


### PR DESCRIPTION
### Summary:

Renamed QuestButtons → Buttons
Generalized field names (left_x/right_a -> left_primary/right_primary, etc.)

### Test
- Zero remaining QuestButtons / old field name references (grep verified)
- Buttons import tested