### PR TITLE
feat: auto-scaling voxel grid mapper

### DIFF
--- a/dimos/mapping/test_voxels.py
+++ b/dimos/mapping/test_voxels.py
@@ -180,10 +180,12 @@ def test_roundtrip(moment1: Go2MapperMoment, voxel_size: float, expected_points:
 
 
 def test_autoscale_skips_when_saturated() -> None:
-    """Test that autoscale skips frames when processing can't keep up.
+    """Test that autoscale skips frames when idle time < last processing duration.
 
-    Simulates a slow machine by pretending add_frame() took 500ms,
-    then feeding frames faster than that interval.
+    _last_ingest_time is set after processing completes, so elapsed_since_last
+    measures idle time between frames. We fake both _last_ingest_time and
+    _last_ingest_duration to simulate a machine that just finished a slow frame
+    and is receiving new frames immediately after.
     """
     data_dir = get_data("unitree_go2_office_walk2")
     lidar_store = TimedSensorReplay(f"{data_dir}/lidar")
@@ -196,15 +198,17 @@ def test_autoscale_skips_when_saturated() -> None:
     mapper._on_frame(frame)
     assert mapper._frames_processed == 1
 
-    # Fake that add_frame() took 500ms — simulates a slow machine
-    mapper._last_ingest_duration = 0.5
+    # Simulate: last frame just finished (ingest_time = now) and took 500ms.
+    # Next frames arriving with only 10ms idle time should be skipped.
+    mapper._last_ingest_time = time.monotonic()
+    mapper._last_ingest_duration = 0.5  # pretend last frame took 500ms
 
-    # Now feed 10 more frames with only 10ms between them (faster than 500ms threshold)
+    # Feed 10 frames with only 10ms idle time — well under the 500ms threshold
     frames_fed = 1  # already fed one
     for i in range(10):
         frame = lidar_store.find_closest_seek(1.5 + i * 0.1)
         if frame is not None:
-            time.sleep(0.01)  # 10ms between frames — way faster than 500ms
+            time.sleep(0.01)  # 10ms idle — way less than 500ms processing time
             mapper._on_frame(frame)
             frames_fed += 1
 
@@ -213,15 +217,28 @@ def test_autoscale_skips_when_saturated() -> None:
         f"processed {mapper._frames_processed}, skipped {mapper._frames_skipped}"
     )
 
-    # Most frames should be skipped since we faked 500ms processing time
-    # and only 100ms total elapsed
+    # Most frames should be skipped: idle time (10ms) < processing time (500ms)
     assert mapper._frames_skipped > 0
     assert mapper._frames_processed < frames_fed
-    # Total should add up
     assert mapper._frames_processed + mapper._frames_skipped == frames_fed
-    # Map should have data
     assert mapper.size() > 0
 
+    mapper.stop()
+
+
+def test_autoscale_min_frequency_zero_no_crash() -> None:
+    """Test that autoscale_min_frequency=0 doesn't raise ZeroDivisionError."""
+    data_dir = get_data("unitree_go2_office_walk2")
+    lidar_store = TimedSensorReplay(f"{data_dir}/lidar")
+
+    mapper = VoxelGridMapper(autoscale=True, autoscale_min_frequency=0)
+
+    for i in range(5):
+        frame = lidar_store.find_closest_seek(i)
+        if frame is not None:
+            mapper._on_frame(frame)  # must not raise ZeroDivisionError
+
+    assert mapper._frames_processed >= 1
     mapper.stop()
 
 

--- a/dimos/mapping/voxels.py
+++ b/dimos/mapping/voxels.py
@@ -131,13 +131,19 @@ class VoxelGridMapper(Module):
     def _on_frame(self, frame: PointCloud2) -> None:
         if self.config.autoscale and self._frames_processed > 0:
             now = time.monotonic()
+            # _last_ingest_time is set *after* processing completes, so this
+            # measures idle time since the last frame finished — not since it started.
+            # If idle time < last processing duration, we're falling behind: skip.
             elapsed_since_last = now - self._last_ingest_time
 
-            # Self-regulate: skip frames we can't keep up with.
-            # Use last processing duration as the throttle interval,
-            # but cap at min_frequency so the map never goes completely stale.
-            max_interval = 1.0 / self.config.autoscale_min_frequency
-            throttle_interval = min(self._last_ingest_duration, max_interval)
+            # Guard against misconfiguration: min_frequency=0 would divide by zero.
+            # Treat 0 (or negative) as "no minimum floor" → use processing time only.
+            if self.config.autoscale_min_frequency > 0:
+                max_interval = 1.0 / self.config.autoscale_min_frequency
+                throttle_interval = min(self._last_ingest_duration, max_interval)
+            else:
+                throttle_interval = self._last_ingest_duration
+
             if elapsed_since_last < throttle_interval:
                 self._frames_skipped += 1
                 return
@@ -146,7 +152,9 @@ class VoxelGridMapper(Module):
         self.add_frame(frame)
         ingest_duration = time.monotonic() - t0
 
-        self._last_ingest_time = t0
+        # Record completion time (not start time) so the next frame's elapsed
+        # measures idle time between frames, enabling real saturation detection.
+        self._last_ingest_time = time.monotonic()
         self._last_ingest_duration = ingest_duration
         self._frames_processed += 1
 


### PR DESCRIPTION
## Summary

Closes #1270 — Auto-scaling global voxel grid mapper.

## What

Adds adaptive frame skipping to `VoxelGridMapper` so it self-regulates on weaker machines instead of falling behind on lidar ingest.

## How

When `autoscale=True` (default), `_on_frame()` skips frames if they arrive faster than the last `add_frame()` processing duration. The system self-regulates: fast machines process every frame, slow machines find their natural ceiling.

`autoscale_min_frequency` (default 1.0 Hz) prevents the map from going completely stale — even if processing takes 2s, we'll still ingest at least 1 frame per second.

### Config

```python
@dataclass
class Config(ModuleConfig):
    autoscale: bool = True
    autoscale_min_frequency: float = 1.0  # never drop below this Hz
```

### Telemetry (Rerun)

Logs both ingest and publish timings separately to identify the real bottleneck:

- `voxel_mapper/ingest_time_ms` — `add_frame()` wall-clock cost
- `voxel_mapper/publish_time_ms` — `get_global_pointcloud2()` + publish cost
- `voxel_mapper/map_size` — total voxel count (correlates with publish cost growth)
- `voxel_mapper/frames_skipped` — cumulative frames dropped by autoscaler

## Testing

4 new tests:
- `test_autoscale_skips_when_saturated` — simulates slow machine (fakes 500ms processing), verifies frames are skipped
- `test_autoscale_disabled_processes_all` — verifies `autoscale=False` processes every frame
- `test_autoscale_min_frequency_respected` — verifies high min_frequency prevents excessive skipping
- `test_autoscale_rerun_logging` — verifies rerun telemetry is logged correctly

All existing tests unchanged and passing.

## How to Test

```bash
pytest -sv dimos/mapping/test_voxels.py -k autoscale
```

To observe autoscaling live with rerun on a real robot:
```bash
dimos run go2-nav  # or any blueprint using voxel_mapper
# Open Rerun viewer → check voxel_mapper/* time series
```