### PR TITLE
fix(ci): use path filter outputs for test should-run decisions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -150,9 +150,10 @@ jobs:
     with:
       should-run: ${{
         needs.check-changes.result == 'success' &&
-        ((needs.ros-dev.result == 'success') ||
-        (needs.ros-dev.result == 'skipped' &&
-        needs.check-changes.outputs.tests == 'true'))
+        (needs.check-changes.outputs.tests == 'true' ||
+         needs.check-changes.outputs.ros == 'true' ||
+         needs.check-changes.outputs.python == 'true' ||
+         needs.check-changes.outputs.dev == 'true')
         }}
       cmd: "pytest && pytest -m ros" # run tests that depend on ros as well
       dev-image: ros-dev:${{ (needs.check-changes.outputs.python == 'true' || needs.check-changes.outputs.dev == 'true' || needs.check-changes.outputs.ros == 'true') && needs.ros-dev.result == 'success' && needs.check-changes.outputs.branch-tag || 'dev' }}
@@ -165,9 +166,9 @@ jobs:
     with:
       should-run: ${{
         needs.check-changes.result == 'success' &&
-        ((needs.dev.result == 'success') ||
-        (needs.dev.result == 'skipped' &&
-        needs.check-changes.outputs.tests == 'true'))
+        (needs.check-changes.outputs.tests == 'true' ||
+         needs.check-changes.outputs.python == 'true' ||
+         needs.check-changes.outputs.dev == 'true')
         }}
       cmd: "pytest"
       dev-image: dev:${{ (needs.check-changes.outputs.python == 'true' || needs.check-changes.outputs.dev == 'true') && needs.dev.result == 'success' && needs.check-changes.outputs.branch-tag || 'dev' }}
@@ -181,9 +182,9 @@ jobs:
     with:
       should-run: ${{
         needs.check-changes.result == 'success' &&
-        ((needs.dev.result == 'success') ||
-        (needs.dev.result == 'skipped' &&
-        needs.check-changes.outputs.tests == 'true'))
+        (needs.check-changes.outputs.tests == 'true' ||
+         needs.check-changes.outputs.python == 'true' ||
+         needs.check-changes.outputs.dev == 'true')
         }}
       cmd: "pytest -m heavy"
       dev-image: dev:${{ (needs.check-changes.outputs.python == 'true' || needs.check-changes.outputs.dev == 'true') && needs.dev.result == 'success' && needs.check-changes.outputs.branch-tag || 'dev' }}
@@ -196,9 +197,9 @@ jobs:
     with:
       should-run: ${{
         needs.check-changes.result == 'success' &&
-        ((needs.dev.result == 'success') ||
-        (needs.dev.result == 'skipped' &&
-        needs.check-changes.outputs.tests == 'true'))
+        (needs.check-changes.outputs.tests == 'true' ||
+         needs.check-changes.outputs.python == 'true' ||
+         needs.check-changes.outputs.dev == 'true')
         }}
       cmd: "pytest -m lcm"
       dev-image: dev:${{ (needs.check-changes.outputs.python == 'true' || needs.check-changes.outputs.dev == 'true') && needs.dev.result == 'success' && needs.check-changes.outputs.branch-tag || 'dev' }}
@@ -211,9 +212,9 @@ jobs:
     with:
       should-run: ${{
         needs.check-changes.result == 'success' &&
-        ((needs.dev.result == 'success') ||
-        (needs.dev.result == 'skipped' &&
-        needs.check-changes.outputs.tests == 'true'))
+        (needs.check-changes.outputs.tests == 'true' ||
+         needs.check-changes.outputs.python == 'true' ||
+         needs.check-changes.outputs.dev == 'true')
         }}
       cmd: "pytest -m integration"
       dev-image: dev:${{ (needs.check-changes.outputs.python == 'true' || needs.check-changes.outputs.dev == 'true') && needs.dev.result == 'success' && needs.check-changes.outputs.branch-tag || 'dev' }}
@@ -226,9 +227,10 @@ jobs:
     with:
       should-run: ${{
         needs.check-changes.result == 'success' &&
-        ((needs.ros-dev.result == 'success') ||
-        (needs.ros-dev.result == 'skipped' &&
-        needs.check-changes.outputs.tests == 'true'))
+        (needs.check-changes.outputs.tests == 'true' ||
+         needs.check-changes.outputs.ros == 'true' ||
+         needs.check-changes.outputs.python == 'true' ||
+         needs.check-changes.outputs.dev == 'true')
         }}
       cmd: "MYPYPATH=/opt/ros/humble/lib/python3.10/site-packages mypy dimos"
       dev-image: ros-dev:${{ (needs.check-changes.outputs.python == 'true' || needs.check-changes.outputs.dev == 'true' || needs.check-changes.outputs.ros == 'true') && needs.ros-dev.result == 'success' && needs.check-changes.outputs.branch-tag || 'dev' }}


### PR DESCRIPTION
## Problem

PR #1279 removed `paths-ignore: '**.md'` from the `pull_request` trigger to fix branch protection blocking md-only PRs. But the test caller `should-run` expressions relied on `dev.result == 'success'` to decide whether to run tests.

Build jobs with `if: always()` report `success` even when `should-run=false` and all steps are skipped. So for md-only PRs:

1. `check-changes` correctly detects no code changes (all outputs `false`)
2. `dev` job runs with `should-run=false`, skips all steps, reports `success`
3. Test callers see `dev.result == 'success'` → `should-run = true` → **full test suite runs**

## Fix

Replace upstream job result checks with direct path filter output checks:

- **Non-ROS tests** (run-tests, run-heavy-tests, run-lcm-tests, run-integration-tests): `tests || python || dev`
- **ROS tests + mypy** (run-ros-tests, run-mypy): `tests || ros || python || dev`

When only `.md` files change, all path filter outputs are `false` → `should-run = false` → tests skip.

## Verification

After merging, open a PR that only changes `.md` files against `dev`. Test jobs should complete in seconds with all steps skipped, and `ci-complete` should pass.