### PR TITLE
fix(ci): skip test jobs entirely for non-code PRs, add builds to ci-complete

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -144,94 +144,94 @@ jobs:
 
   run-ros-tests:
     needs: [check-changes, ros-dev]
-    if: always()
+    if: ${{
+      always() &&
+      needs.check-changes.result == 'success' &&
+      (needs.check-changes.outputs.tests == 'true' ||
+       needs.check-changes.outputs.ros == 'true' ||
+       needs.check-changes.outputs.python == 'true' ||
+       needs.check-changes.outputs.dev == 'true')
+      }}
     uses: ./.github/workflows/tests.yml
     secrets: inherit
     with:
-      should-run: ${{
-        needs.check-changes.result == 'success' &&
-        (needs.check-changes.outputs.tests == 'true' ||
-         needs.check-changes.outputs.ros == 'true' ||
-         needs.check-changes.outputs.python == 'true' ||
-         needs.check-changes.outputs.dev == 'true')
-        }}
       cmd: "pytest && pytest -m ros" # run tests that depend on ros as well
       dev-image: ros-dev:${{ (needs.check-changes.outputs.python == 'true' || needs.check-changes.outputs.dev == 'true' || needs.check-changes.outputs.ros == 'true') && needs.ros-dev.result == 'success' && needs.check-changes.outputs.branch-tag || 'dev' }}
 
   run-tests:
     needs: [check-changes, dev]
-    if: always()
+    if: ${{
+      always() &&
+      needs.check-changes.result == 'success' &&
+      (needs.check-changes.outputs.tests == 'true' ||
+       needs.check-changes.outputs.python == 'true' ||
+       needs.check-changes.outputs.dev == 'true')
+      }}
     uses: ./.github/workflows/tests.yml
     secrets: inherit
     with:
-      should-run: ${{
-        needs.check-changes.result == 'success' &&
-        (needs.check-changes.outputs.tests == 'true' ||
-         needs.check-changes.outputs.python == 'true' ||
-         needs.check-changes.outputs.dev == 'true')
-        }}
       cmd: "pytest"
       dev-image: dev:${{ (needs.check-changes.outputs.python == 'true' || needs.check-changes.outputs.dev == 'true') && needs.dev.result == 'success' && needs.check-changes.outputs.branch-tag || 'dev' }}
 
   # we run in parallel with normal tests for speed
   run-heavy-tests:
     needs: [check-changes, dev]
-    if: always()
+    if: ${{
+      always() &&
+      needs.check-changes.result == 'success' &&
+      (needs.check-changes.outputs.tests == 'true' ||
+       needs.check-changes.outputs.python == 'true' ||
+       needs.check-changes.outputs.dev == 'true')
+      }}
     uses: ./.github/workflows/tests.yml
     secrets: inherit
     with:
-      should-run: ${{
-        needs.check-changes.result == 'success' &&
-        (needs.check-changes.outputs.tests == 'true' ||
-         needs.check-changes.outputs.python == 'true' ||
-         needs.check-changes.outputs.dev == 'true')
-        }}
       cmd: "pytest -m heavy"
       dev-image: dev:${{ (needs.check-changes.outputs.python == 'true' || needs.check-changes.outputs.dev == 'true') && needs.dev.result == 'success' && needs.check-changes.outputs.branch-tag || 'dev' }}
 
   run-lcm-tests:
     needs: [check-changes, dev]
-    if: always()
+    if: ${{
+      always() &&
+      needs.check-changes.result == 'success' &&
+      (needs.check-changes.outputs.tests == 'true' ||
+       needs.check-changes.outputs.python == 'true' ||
+       needs.check-changes.outputs.dev == 'true')
+      }}
     uses: ./.github/workflows/tests.yml
     secrets: inherit
     with:
-      should-run: ${{
-        needs.check-changes.result == 'success' &&
-        (needs.check-changes.outputs.tests == 'true' ||
-         needs.check-changes.outputs.python == 'true' ||
-         needs.check-changes.outputs.dev == 'true')
-        }}
       cmd: "pytest -m lcm"
       dev-image: dev:${{ (needs.check-changes.outputs.python == 'true' || needs.check-changes.outputs.dev == 'true') && needs.dev.result == 'success' && needs.check-changes.outputs.branch-tag || 'dev' }}
 
   run-integration-tests:
     needs: [check-changes, dev]
-    if: always()
+    if: ${{
+      always() &&
+      needs.check-changes.result == 'success' &&
+      (needs.check-changes.outputs.tests == 'true' ||
+       needs.check-changes.outputs.python == 'true' ||
+       needs.check-changes.outputs.dev == 'true')
+      }}
     uses: ./.github/workflows/tests.yml
     secrets: inherit
     with:
-      should-run: ${{
-        needs.check-changes.result == 'success' &&
-        (needs.check-changes.outputs.tests == 'true' ||
-         needs.check-changes.outputs.python == 'true' ||
-         needs.check-changes.outputs.dev == 'true')
-        }}
       cmd: "pytest -m integration"
       dev-image: dev:${{ (needs.check-changes.outputs.python == 'true' || needs.check-changes.outputs.dev == 'true') && needs.dev.result == 'success' && needs.check-changes.outputs.branch-tag || 'dev' }}
 
   run-mypy:
     needs: [check-changes, ros-dev]
-    if: always()
+    if: ${{
+      always() &&
+      needs.check-changes.result == 'success' &&
+      (needs.check-changes.outputs.tests == 'true' ||
+       needs.check-changes.outputs.ros == 'true' ||
+       needs.check-changes.outputs.python == 'true' ||
+       needs.check-changes.outputs.dev == 'true')
+      }}
     uses: ./.github/workflows/tests.yml
     secrets: inherit
     with:
-      should-run: ${{
-        needs.check-changes.result == 'success' &&
-        (needs.check-changes.outputs.tests == 'true' ||
-         needs.check-changes.outputs.ros == 'true' ||
-         needs.check-changes.outputs.python == 'true' ||
-         needs.check-changes.outputs.dev == 'true')
-        }}
       cmd: "MYPYPATH=/opt/ros/humble/lib/python3.10/site-packages mypy dimos"
       dev-image: ros-dev:${{ (needs.check-changes.outputs.python == 'true' || needs.check-changes.outputs.dev == 'true' || needs.check-changes.outputs.ros == 'true') && needs.ros-dev.result == 'success' && needs.check-changes.outputs.branch-tag || 'dev' }}
 
@@ -271,7 +271,7 @@ jobs:
   #         /entrypoint.sh bash -c "pytest -m module"
 
   ci-complete:
-    needs: [run-tests, run-heavy-tests, run-lcm-tests, run-integration-tests, run-ros-tests, run-mypy]
+    needs: [check-changes, ros, python, ros-python, dev, ros-dev, run-tests, run-heavy-tests, run-lcm-tests, run-integration-tests, run-ros-tests, run-mypy]
     runs-on: [self-hosted, Linux]
     if: always()
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,10 +3,6 @@ name: tests
 on:
  workflow_call:
    inputs:
-     should-run:
-       required: false
-       type: boolean
-       default: true
      dev-image:
        required: true
        type: string
@@ -31,19 +27,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        if: ${{ inputs.should-run }}
 
       - name: Fix permissions
-        if: ${{ inputs.should-run }}
         run: |
           git config --global --add safe.directory '*'
 
       - name: Run tests
-        if: ${{ inputs.should-run }}
         run: |
           /entrypoint.sh bash -c "${{ inputs.cmd }}"
 
       - name: check disk space
-        if: ${{ failure() && inputs.should-run }}
+        if: failure()
         run: |
           df -h


### PR DESCRIPTION
## Changes

1. **Job-level gating on test callers** — moves path filter checks from `should-run` input to `if:` condition at the job level. For md-only PRs, test jobs are fully **skipped** (no container spin-up, no runner allocation).

2. **Build jobs added to ci-complete** — `ros`, `python`, `ros-python`, `dev`, `ros-dev` are now in `ci-complete`'s `needs` list. Build failures are caught by the gate.

`always()` is kept in the `if:` so that skipped upstream builds don't prevent the condition from evaluating.

## After merging

Open a pure md-only PR against `dev` to verify test jobs show as **skipped** and `ci-complete` passes.