### PR TITLE
fix(xarm7-sim): fix broken e2e tests

### DIFF
--- a/data/.lfs/xarm7.tar.gz
+++ b/data/.lfs/xarm7.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dc5c96439cc415d7d7b1296363b5684354aaef22c7dbe8e50bce81183401511c
-size 6297600
+oid sha256:47dd79f13845ae6a35368345b7443a9190c7584d548caddd9c3eae224442c6fc
+size 3280557

--- a/dimos/e2e_tests/test_simulation_module.py
+++ b/dimos/e2e_tests/test_simulation_module.py
@@ -38,7 +38,7 @@ class TestSimulationModuleE2E:
         joint_state_topic = "/xarm/joint_states#sensor_msgs.JointState"
         lcm_spy.save_topic(joint_state_topic)
 
-        start_blueprint("simulation-xarm7")
+        start_blueprint("xarm7-trajectory-sim")
         lcm_spy.wait_for_saved_topic(joint_state_topic, timeout=15.0)
 
         with lcm_spy._messages_lock:
@@ -52,7 +52,7 @@ class TestSimulationModuleE2E:
         robot_state_topic = "/xarm/robot_state#sensor_msgs.RobotState"
         lcm_spy.save_topic(robot_state_topic)
 
-        start_blueprint("simulation-xarm7")
+        start_blueprint("xarm7-trajectory-sim")
         lcm_spy.wait_for_saved_topic(robot_state_topic, timeout=15.0)
 
         with lcm_spy._messages_lock:
@@ -66,7 +66,7 @@ class TestSimulationModuleE2E:
         joint_command_topic = "/xarm/joint_position_command#sensor_msgs.JointCommand"
         lcm_spy.save_topic(joint_state_topic)
 
-        start_blueprint("simulation-xarm7")
+        start_blueprint("xarm7-trajectory-sim")
         lcm_spy.wait_for_saved_topic(joint_state_topic, timeout=15.0)
 
         target_positions = [0.2, -0.2, 0.1, -0.1, 0.15, -0.15, 0.05]

--- a/dimos/simulation/sim_blueprints.py
+++ b/dimos/simulation/sim_blueprints.py
@@ -21,12 +21,11 @@ from dimos.msgs.sensor_msgs import (  # type: ignore[attr-defined]
 )
 from dimos.msgs.trajectory_msgs import JointTrajectory
 from dimos.simulation.manipulators.sim_module import simulation
-from dimos.utils.data import get_data
+from dimos.utils.data import LfsPath
 
 xarm7_trajectory_sim = simulation(
     engine="mujoco",
-    config_path=lambda: get_data("xarm7")
-    / "scene.xml",  # avoid triggering LFS downloads during tests
+    config_path=LfsPath("xarm7/scene.xml"),
     headless=True,
 ).transports(
     {


### PR DESCRIPTION
## Problem

Tests were broken:

```bash
uv run pytest -sxvm e2e dimos/e2e_tests/test_simulation_module.py
```

Closes DIM-555

https://linear.app/dimensional/issue/DIM-555/fix-test-simulation-modulepy

## Solution

* Used `LfsPath`.
* Fix the blueprint name.,
* Fixed the archive. It could not be extracted because it was a `.tar` file with a `.tar.gz` extension.

## Breaking Changes

None

## How to Test

```bash
uv run pytest -sxvm e2e dimos/e2e_tests/test_simulation_module.py
```