### PR TITLE
docs(readme): link drone and mavlink entries to source

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ Our goal is to provide an easy-to-install, modern framework for general robotics
       🟥 <a href="docs/platforms/todo.md">Piper</a><br>
     </td>
     <td align="center" width="20%">
-      🟥 <a href="docs/platforms/todo.md">Mavlink</a><br>
-      🟥 <a href="docs/platforms/todo.md">DJI SDK</a><br>
+      🟥 <a href="dimos/robot/drone">Mavlink</a><br>
+      🟥 <a href="dimos/robot/drone">DJI SDK</a><br>
     </td>
     <td align="center" width="20%">
       🟥 <a href="https://github.com/dimensionalOS/openFT-sensor">Force Torque Sensor</a><br>


### PR DESCRIPTION
## Summary
Links the Mavlink and DJI SDK entries in the Hardware table to `dimos/robot/drone` (the drone module with full README) instead of the placeholder `docs/platforms/todo.md`.

Same link for both since the drone README covers both MAVLink and DJI SDK integration.

## Changes
- Mavlink → `dimos/robot/drone`
- DJI SDK → `dimos/robot/drone`