### PR TITLE
fix: broken tests

### DIFF
--- a/dimos/e2e_tests/test_control_coordinator.py
+++ b/dimos/e2e_tests/test_control_coordinator.py
@@ -82,7 +82,7 @@ class TestControlCoordinatorE2E:
 
         # Wait for it to be ready
         lcm_spy.wait_for_saved_topic(
-            "/coordinator/joint_state#sensor_msgs.JointState", timeout=20.0
+            "/coordinator/joint_state#sensor_msgs.JointState", timeout=15.0
         )
 
         # Create RPC client
@@ -166,7 +166,7 @@ class TestControlCoordinatorE2E:
         # Start coordinator
         start_blueprint("coordinator-mock")
         lcm_spy.wait_for_saved_topic(
-            "/coordinator/joint_state#sensor_msgs.JointState", timeout=20.0
+            "/coordinator/joint_state#sensor_msgs.JointState", timeout=15.0
         )
 
         client = RPCClient(None, ControlCoordinator)
@@ -211,7 +211,7 @@ class TestControlCoordinatorE2E:
         # Start dual-arm mock coordinator
         start_blueprint("coordinator-dual-mock")
         lcm_spy.wait_for_saved_topic(
-            "/coordinator/joint_state#sensor_msgs.JointState", timeout=20.0
+            "/coordinator/joint_state#sensor_msgs.JointState", timeout=15.0
         )
 
         client = RPCClient(None, ControlCoordinator)

--- a/dimos/e2e_tests/test_control_coordinator.py
+++ b/dimos/e2e_tests/test_control_coordinator.py
@@ -46,10 +46,7 @@ class TestControlCoordinatorE2E:
         start_blueprint("coordinator-mock")
 
         # Wait for joint state to be published (proves tick loop is running)
-        lcm_spy.wait_for_saved_topic(
-            joint_state_topic,
-            timeout=15.0,
-        )
+        lcm_spy.wait_for_saved_topic(joint_state_topic)
 
         # Create RPC client and query
         client = RPCClient(None, ControlCoordinator)
@@ -81,9 +78,7 @@ class TestControlCoordinatorE2E:
         start_blueprint("coordinator-mock")
 
         # Wait for it to be ready
-        lcm_spy.wait_for_saved_topic(
-            "/coordinator/joint_state#sensor_msgs.JointState", timeout=15.0
-        )
+        lcm_spy.wait_for_saved_topic("/coordinator/joint_state#sensor_msgs.JointState")
 
         # Create RPC client
         client = RPCClient(None, ControlCoordinator)
@@ -138,7 +133,7 @@ class TestControlCoordinatorE2E:
         start_blueprint("coordinator-mock")
 
         # Wait for initial message
-        lcm_spy.wait_for_saved_topic(joint_state_topic, timeout=10.0)
+        lcm_spy.wait_for_saved_topic(joint_state_topic)
 
         # Collect messages for 1 second
         time.sleep(1.0)
@@ -165,9 +160,7 @@ class TestControlCoordinatorE2E:
 
         # Start coordinator
         start_blueprint("coordinator-mock")
-        lcm_spy.wait_for_saved_topic(
-            "/coordinator/joint_state#sensor_msgs.JointState", timeout=15.0
-        )
+        lcm_spy.wait_for_saved_topic("/coordinator/joint_state#sensor_msgs.JointState")
 
         client = RPCClient(None, ControlCoordinator)
         try:
@@ -210,9 +203,7 @@ class TestControlCoordinatorE2E:
 
         # Start dual-arm mock coordinator
         start_blueprint("coordinator-dual-mock")
-        lcm_spy.wait_for_saved_topic(
-            "/coordinator/joint_state#sensor_msgs.JointState", timeout=15.0
-        )
+        lcm_spy.wait_for_saved_topic("/coordinator/joint_state#sensor_msgs.JointState")
 
         client = RPCClient(None, ControlCoordinator)
         try:

--- a/dimos/e2e_tests/test_control_coordinator.py
+++ b/dimos/e2e_tests/test_control_coordinator.py
@@ -48,7 +48,7 @@ class TestControlCoordinatorE2E:
         # Wait for joint state to be published (proves tick loop is running)
         lcm_spy.wait_for_saved_topic(
             joint_state_topic,
-            timeout=10.0,
+            timeout=15.0,
         )
 
         # Create RPC client and query
@@ -82,7 +82,7 @@ class TestControlCoordinatorE2E:
 
         # Wait for it to be ready
         lcm_spy.wait_for_saved_topic(
-            "/coordinator/joint_state#sensor_msgs.JointState", timeout=10.0
+            "/coordinator/joint_state#sensor_msgs.JointState", timeout=20.0
         )
 
         # Create RPC client
@@ -166,7 +166,7 @@ class TestControlCoordinatorE2E:
         # Start coordinator
         start_blueprint("coordinator-mock")
         lcm_spy.wait_for_saved_topic(
-            "/coordinator/joint_state#sensor_msgs.JointState", timeout=10.0
+            "/coordinator/joint_state#sensor_msgs.JointState", timeout=20.0
         )
 
         client = RPCClient(None, ControlCoordinator)
@@ -211,7 +211,7 @@ class TestControlCoordinatorE2E:
         # Start dual-arm mock coordinator
         start_blueprint("coordinator-dual-mock")
         lcm_spy.wait_for_saved_topic(
-            "/coordinator/joint_state#sensor_msgs.JointState", timeout=10.0
+            "/coordinator/joint_state#sensor_msgs.JointState", timeout=20.0
         )
 
         client = RPCClient(None, ControlCoordinator)

--- a/dimos/manipulation/test_manipulation_module.py
+++ b/dimos/manipulation/test_manipulation_module.py
@@ -149,7 +149,7 @@ class TestManipulationModuleIntegration:
         """Test planning to a joint configuration."""
         module._on_joint_state(joint_state_zeros)
 
-        target = [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
+        target = JointState(position=[0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1])
         success = module.plan_to_joints(target)
 
         assert success is True
@@ -203,7 +203,7 @@ class TestManipulationModuleIntegration:
         """Test that trajectory joint names are translated for coordinator."""
         module._on_joint_state(joint_state_zeros)
 
-        success = module.plan_to_joints([0.05] * 7)
+        success = module.plan_to_joints(JointState(position=[0.05] * 7))
         assert success is True
 
         traj = module._planned_trajectories["test_arm"]
@@ -224,7 +224,7 @@ class TestCoordinatorIntegration:
         """Test execute sends trajectory to coordinator."""
         module._on_joint_state(joint_state_zeros)
 
-        success = module.plan_to_joints([0.05] * 7)
+        success = module.plan_to_joints(JointState(position=[0.05] * 7))
         assert success is True
 
         # Mock the coordinator client
@@ -253,7 +253,7 @@ class TestCoordinatorIntegration:
         """Test handling of coordinator rejection."""
         module._on_joint_state(joint_state_zeros)
 
-        module.plan_to_joints([0.05] * 7)
+        module.plan_to_joints(JointState(position=[0.05] * 7))
 
         # Mock coordinator to reject
         mock_client = MagicMock()
@@ -273,7 +273,7 @@ class TestCoordinatorIntegration:
         module._on_joint_state(joint_state_zeros)
 
         # Plan - should go through PLANNING -> COMPLETED
-        module.plan_to_joints([0.05] * 7)
+        module.plan_to_joints(JointState(position=[0.05] * 7))
         assert module._state == ManipulationState.COMPLETED
 
         # Reset works from COMPLETED
@@ -281,7 +281,7 @@ class TestCoordinatorIntegration:
         assert module._state == ManipulationState.IDLE
 
         # Plan again
-        module.plan_to_joints([0.05] * 7)
+        module.plan_to_joints(JointState(position=[0.05] * 7))
 
         # Mock coordinator
         mock_client = MagicMock()

--- a/dimos/teleop/quest/__init__.py
+++ b/dimos/teleop/quest/__init__.py
@@ -14,41 +14,30 @@
 
 """Quest teleoperation module."""
 
-from dimos.teleop.quest.quest_extensions import (
-    ArmTeleopModule,
-    TwistTeleopModule,
-    VisualizingTeleopModule,
-    arm_teleop_module,
-    twist_teleop_module,
-    visualizing_teleop_module,
-)
-from dimos.teleop.quest.quest_teleop_module import (
-    Hand,
-    QuestTeleopConfig,
-    QuestTeleopModule,
-    QuestTeleopStatus,
-    quest_teleop_module,
-)
-from dimos.teleop.quest.quest_types import (
-    Buttons,
-    QuestControllerState,
-    ThumbstickState,
-)
+import lazy_loader as lazy
 
-__all__ = [
-    "ArmTeleopModule",
-    "Buttons",
-    "Hand",
-    "QuestControllerState",
-    "QuestTeleopConfig",
-    "QuestTeleopModule",
-    "QuestTeleopStatus",
-    "ThumbstickState",
-    "TwistTeleopModule",
-    "VisualizingTeleopModule",
-    # Blueprints
-    "arm_teleop_module",
-    "quest_teleop_module",
-    "twist_teleop_module",
-    "visualizing_teleop_module",
-]
+__getattr__, __dir__, __all__ = lazy.attach(
+    __name__,
+    submod_attrs={
+        "quest_types": [
+            "Buttons",
+            "QuestControllerState",
+            "ThumbstickState",
+        ],
+        "quest_teleop_module": [
+            "Hand",
+            "QuestTeleopConfig",
+            "QuestTeleopModule",
+            "QuestTeleopStatus",
+            "quest_teleop_module",
+        ],
+        "quest_extensions": [
+            "ArmTeleopModule",
+            "TwistTeleopModule",
+            "VisualizingTeleopModule",
+            "arm_teleop_module",
+            "twist_teleop_module",
+            "visualizing_teleop_module",
+        ],
+    },
+)

--- a/dimos/teleop/quest/__init__.py
+++ b/dimos/teleop/quest/__init__.py
@@ -14,30 +14,41 @@
 
 """Quest teleoperation module."""
 
-import lazy_loader as lazy
-
-__getattr__, __dir__, __all__ = lazy.attach(
-    __name__,
-    submod_attrs={
-        "quest_types": [
-            "Buttons",
-            "QuestControllerState",
-            "ThumbstickState",
-        ],
-        "quest_teleop_module": [
-            "Hand",
-            "QuestTeleopConfig",
-            "QuestTeleopModule",
-            "QuestTeleopStatus",
-            "quest_teleop_module",
-        ],
-        "quest_extensions": [
-            "ArmTeleopModule",
-            "TwistTeleopModule",
-            "VisualizingTeleopModule",
-            "arm_teleop_module",
-            "twist_teleop_module",
-            "visualizing_teleop_module",
-        ],
-    },
+from dimos.teleop.quest.quest_extensions import (
+    ArmTeleopModule,
+    TwistTeleopModule,
+    VisualizingTeleopModule,
+    arm_teleop_module,
+    twist_teleop_module,
+    visualizing_teleop_module,
 )
+from dimos.teleop.quest.quest_teleop_module import (
+    Hand,
+    QuestTeleopConfig,
+    QuestTeleopModule,
+    QuestTeleopStatus,
+    quest_teleop_module,
+)
+from dimos.teleop.quest.quest_types import (
+    Buttons,
+    QuestControllerState,
+    ThumbstickState,
+)
+
+__all__ = [
+    "ArmTeleopModule",
+    "Buttons",
+    "Hand",
+    "QuestControllerState",
+    "QuestTeleopConfig",
+    "QuestTeleopModule",
+    "QuestTeleopStatus",
+    "ThumbstickState",
+    "TwistTeleopModule",
+    "VisualizingTeleopModule",
+    # Blueprints
+    "arm_teleop_module",
+    "quest_teleop_module",
+    "twist_teleop_module",
+    "visualizing_teleop_module",
+]

--- a/dimos/utils/cli/lcmspy/test_lcmspy.py
+++ b/dimos/utils/cli/lcmspy/test_lcmspy.py
@@ -176,7 +176,8 @@ def test_lcmspy_global_totals() -> None:
     spy.msg("/imu", b"imu data")
 
     # The spy itself should have accumulated all messages
-    assert len(spy.message_history) == 3
+    # (may be > 3 due to async LCM discovery packets on the subscription thread)
+    assert len(spy.message_history) >= 3
 
     # Check global statistics
     global_freq = spy.freq(1.0)

--- a/dimos/utils/cli/lcmspy/test_lcmspy.py
+++ b/dimos/utils/cli/lcmspy/test_lcmspy.py
@@ -175,9 +175,9 @@ def test_lcmspy_global_totals() -> None:
     spy.msg("/odom", b"odometry data")
     spy.msg("/imu", b"imu data")
 
-    # The spy itself should have accumulated all messages
-    # (may be > 3 due to async LCM discovery packets on the subscription thread)
-    assert len(spy.message_history) >= 3
+    # Verify each test topic received exactly one message (ignore LCM discovery packets)
+    for t in ("/video", "/odom", "/imu"):
+        assert len(spy.topic[t].message_history) == 1
 
     # Check global statistics
     global_freq = spy.freq(1.0)

--- a/docker/python/Dockerfile
+++ b/docker/python/Dockerfile
@@ -48,4 +48,4 @@ COPY . /app/
 
 # Install dependencies with UV (10-100x faster than pip)
 RUN uv pip install --upgrade 'pip>=24' 'setuptools>=70' 'wheel' 'packaging>=24' && \
-    uv pip install '.[misc,cpu,sim,drone,unitree,web,perception,visualization]'
+    uv pip install '.[misc,cpu,sim,drone,unitree,web,perception,visualization,manipulation]'

--- a/docker/python/Dockerfile
+++ b/docker/python/Dockerfile
@@ -49,3 +49,6 @@ COPY . /app/
 # Install dependencies with UV (10-100x faster than pip)
 RUN uv pip install --upgrade 'pip>=24' 'setuptools>=70' 'wheel' 'packaging>=24' && \
     uv pip install '.[misc,cpu,sim,drone,unitree,web,perception,visualization,manipulation]'
+
+# Remove pydrake .pyi stubs that use Python 3.12 syntax (breaks mypy on 3.10)
+RUN rm -f /usr/local/lib/python3.10/dist-packages/pydrake/*.pyi

--- a/docker/python/Dockerfile
+++ b/docker/python/Dockerfile
@@ -51,4 +51,4 @@ RUN uv pip install --upgrade 'pip>=24' 'setuptools>=70' 'wheel' 'packaging>=24' 
     uv pip install '.[misc,cpu,sim,drone,unitree,web,perception,visualization,manipulation]'
 
 # Remove pydrake .pyi stubs that use Python 3.12 syntax (breaks mypy on 3.10)
-RUN rm -f /usr/local/lib/python3.10/dist-packages/pydrake/*.pyi
+RUN find /usr/local/lib/python3.10/dist-packages/pydrake -name '*.pyi' -delete

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -384,10 +384,6 @@ ignore_missing_imports = true
 module = ["dimos.rxpy_backpressure", "dimos.rxpy_backpressure.*"]
 follow_imports = "skip"
 
-[[tool.mypy.overrides]]
-module = ["pydrake", "pydrake.*"]
-follow_imports = "skip"
-
 [tool.pytest.ini_options]
 testpaths = ["dimos"]
 markers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -362,6 +362,8 @@ module = [
     "open_clip",
     "piper_sdk.*",
     "plotext",
+    "pydrake",
+    "pydrake.*",
     "plum.*",
     "pycuda",
     "pycuda.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -384,6 +384,10 @@ ignore_missing_imports = true
 module = ["dimos.rxpy_backpressure", "dimos.rxpy_backpressure.*"]
 follow_imports = "skip"
 
+[[tool.mypy.overrides]]
+module = ["pydrake", "pydrake.*"]
+follow_imports = "skip"
+
 [tool.pytest.ini_options]
 testpaths = ["dimos"]
 markers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -386,6 +386,10 @@ ignore_missing_imports = true
 module = ["dimos.rxpy_backpressure", "dimos.rxpy_backpressure.*"]
 follow_imports = "skip"
 
+[[tool.mypy.overrides]]
+module = ["pydrake", "pydrake.*"]
+follow_imports = "skip"
+
 [tool.pytest.ini_options]
 testpaths = ["dimos"]
 markers = [


### PR DESCRIPTION
### Summary fixes
- Fix manipulation tests to pass `JointState` instead of raw lists to `plan_to_joints()`
- Increase e2e coordinator test timeout from 10s to 15s
- Fix lcmspy global totals test flaking from async LCM discovery packets

### Tests verified, no errors
- `time uv run pytest --durations=0 dimos`
- `time ./bin/pytest-slow --durations=0`

### FYI - Potential fail

Tests require `rclpy`, which is tied to a specific Python version per ROS distro:
- Ubuntu 22.04 + ROS Humble -> Python 3.10
- Ubuntu 24.04 + ROS Jazzy -> Python 3.12

If the python version doesn't match (python 3.12 via uv on Ubuntu 22.04), `rclpy` can't be installed and the tests will fail with `ModuleNotFoundError`

But, if someone already has these versions, can make this change
 `pytest.importorskip("rclpy")` so they skip cleanly instead of erroring out in file `dimos/protocol/pubsub/impl/test_rospubsub.py`