### PR TITLE
fix(data): add pre-generated xarm7.urdf to xarm_description LFS archive

### DIFF
--- a/data/.lfs/xarm_description.tar.gz
+++ b/data/.lfs/xarm_description.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0b247baea9b52f583824b0bc90e1e38640e6090aca7f4ae1a1a72a24e5a66fee
-size 12706830
+oid sha256:6e25f1ede8e4022f5053a61717191a2c338ea5af5b81e26bd2c880343aff1316
+size 12709222


### PR DESCRIPTION
## Problem

`dimos run keyboard-teleop-xarm7` crashes with:
```
FileNotFoundError: Model file not found: data/xarm_description/urdf/xarm7/xarm7.urdf
```

The blueprint references `xarm7.urdf` via `LfsPath`, but only `xarm7.urdf.xacro` existed in the archive. `CartesianIKTask`/`PinocchioIK` need a plain URDF — they don't process xacro at runtime.

`xarm6.urdf` was already pre-generated; xarm7 was missed when the keyboard teleop blueprints were added in #1308.

## Fix

Generated `xarm7.urdf` from `xarm_device.urdf.xacro` (dof=7, limited=true) using DimOS's own xacro processor with package_paths resolution, and repacked the `xarm_description.tar.gz` LFS archive.

## Verification

```python
# Round-trip: extract from tarball → load with pinocchio
from dimos.utils.data import get_data
import pinocchio
xarm = get_data('xarm_description')
model = pinocchio.buildModelFromUrdf(str(xarm / 'urdf/xarm7/xarm7.urdf'))
# Loaded: 7 joints — ['universe', 'joint1', ..., 'joint7']
```

Depends on #1309 (lazy realsense import fix).