### PR TITLE
docs(install): remove direnv, simplify installation instructions

### DIFF
--- a/docs/installation/nix.md
+++ b/docs/installation/nix.md
@@ -13,42 +13,23 @@ curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix 
 mkdir -p "$HOME/.config/nix"; echo "experimental-features = nix-command flakes" >> "$HOME/.config/nix/nix.conf"
 ```
 
-# Install Direnv (optional)
-
-[direnv](https://direnv.net) is a convenient helper that allows you to automatically enter your nix and python env once you cd into the project dir.
-
-You can skip this step if you intend to type `nix develop` by hand.
-
-Following [direnv install docs](https://direnv.net/docs/installation.html) is recommended (many distros have native package support)
-
-but a quick oneliner binary install is
-```sh
-curl -sfL https://direnv.net/install.sh | bash
-```
-
 # Using DimOS as a library
 
 ```sh
-mkdir myproject
-cd myproject
+mkdir myproject && cd myproject
 
-# if on nixos you can pull our flake
+# pull the flake (needed for nix develop outside the repo)
 wget https://raw.githubusercontent.com/dimensionalOS/dimos/refs/heads/main/flake.nix
 wget https://raw.githubusercontent.com/dimensionalOS/dimos/refs/heads/main/flake.lock
 
-# if using direnv (recommended)
-wget https://raw.githubusercontent.com/dimensionalOS/dimos/refs/heads/main/.envrc.nix -O .envrc
-direnv allow
+# enter the nix development shell (provides system deps)
+nix develop
 
-# if using nix develop directly instead of direnv,
-# nix develop
-
-uv venv --python "3.12"
+uv venv --python 3.12
 source .venv/bin/activate
 
-# this will just pull everything (big checkout)
-# depending on what you are working on you might not need everything,
-# check your respective platform guides
+# install everything (depending on your use case you might not need all extras,
+# check your respective platform guides)
 uv pip install dimos[misc,sim,visualization,agents,web,perception,unitree,manipulation,cpu,dev]
 ```
 
@@ -60,16 +41,10 @@ export GIT_LFS_SKIP_SMUDGE=1
 git clone -b dev https://github.com/dimensionalOS/dimos.git
 cd dimos
 
-# if using direnv (recommended)
-cp .envrc.nix .envrc
-direnv allow
+# enter the nix development shell (provides system deps)
+nix develop
 
-# if using nix develop directly instead of direnv,
-# nix develop
-
-# create venv
 uv venv --python 3.12
-
 source .venv/bin/activate
 
 uv sync --all-extras

--- a/docs/installation/osx.md
+++ b/docs/installation/osx.md
@@ -1,6 +1,5 @@
-# osx install
+# macOS Install (12.6 or newer)
 
-## macOS 12.6 or newer
 ```sh
 # install homebrew
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
@@ -11,36 +10,16 @@ brew install gnu-sed gcc portaudio git-lfs libjpeg-turbo python pre-commit
 curl -LsSf https://astral.sh/uv/install.sh | sh && export PATH="$HOME/.local/bin:$PATH"
 ```
 
-# Install Direnv (optional)
-
-[direnv](https://direnv.net) is a convenient helper that allows you to automatically enter your python env once you cd into the project dir.
-
-You can skip this step if you intend to activate manually.
-
-Following [direnv install docs](https://direnv.net/docs/installation.html) is recommended (many distros have native package support)
-
-but a quick oneliner binary install is
-```sh
-curl -sfL https://direnv.net/install.sh | bash
-```
-
 # Using DimOS as a library
 
 ```sh
-mkdir myproject
-cd myproject
+mkdir myproject && cd myproject
 
-uv venv --python "3.12"
+uv venv --python 3.12
+source .venv/bin/activate
 
-# if using direnv (recommended)
-wget https://raw.githubusercontent.com/dimensionalOS/dimos/refs/heads/main/.envrc.venv -O .envrc
-direnv allow
-# if not using direnv
-# source .venv/bin/activate
-
-# this will just pull everything (big checkout)
-# depending on what you are working on you might not need everything,
-# check your respective platform guides
+# install everything (depending on your use case you might not need all extras,
+# check your respective platform guides)
 uv pip install dimos[misc,sim,visualization,agents,web,perception,unitree,manipulation,cpu,dev]
 ```
 
@@ -52,14 +31,8 @@ export GIT_LFS_SKIP_SMUDGE=1
 git clone -b dev https://github.com/dimensionalOS/dimos.git
 cd dimos
 
-# create venv
 uv venv --python 3.12
-
-# if using direnv (recommended)
-direnv allow
-
-# if not using direnv
-# source .venv/bin/activate
+source .venv/bin/activate
 
 uv sync --all-extras
 

--- a/docs/installation/ubuntu.md
+++ b/docs/installation/ubuntu.md
@@ -8,36 +8,16 @@ sudo apt-get install -y curl g++ portaudio19-dev git-lfs libturbojpeg python3-de
 curl -LsSf https://astral.sh/uv/install.sh | sh && export PATH="$HOME/.local/bin:$PATH"
 ```
 
-# Install Direnv (optional)
-
-[direnv](https://direnv.net) is a convenient helper that allows you to automatically enter your python env once you cd into the project dir.
-
-You can skip this step if you intend to activate manually.
-
-Following [direnv install docs](https://direnv.net/docs/installation.html) is recommended (many distros have native package support)
-
-but a quick oneliner binary install is
-```sh
-curl -sfL https://direnv.net/install.sh | bash
-```
-
 # Using DimOS as a library
 
 ```sh
-mkdir myproject
-cd myproject
+mkdir myproject && cd myproject
 
-uv venv --python "3.12"
+uv venv --python 3.12
+source .venv/bin/activate
 
-# if using direnv (recommended)
-wget https://raw.githubusercontent.com/dimensionalOS/dimos/refs/heads/main/.envrc.venv -O .envrc
-direnv allow
-# if not using direnv
-# source .venv/bin/activate
-
-# this will just pull everything (big checkout)
-# depending on what you are working on you might not need everything,
-# check your respective platform guides
+# install everything (depending on your use case you might not need all extras,
+# check your respective platform guides)
 uv pip install dimos[misc,sim,visualization,agents,web,perception,unitree,manipulation,cpu,dev]
 ```
 
@@ -48,6 +28,9 @@ uv pip install dimos[misc,sim,visualization,agents,web,perception,unitree,manipu
 export GIT_LFS_SKIP_SMUDGE=1
 git clone -b dev https://github.com/dimensionalOS/dimos.git
 cd dimos
+
+uv venv --python 3.12
+source .venv/bin/activate
 
 uv sync --all-extras
 


### PR DESCRIPTION
Removes direnv from the ubuntu, macOS, and nix installation guides. Replaces the wget-an-envrc-and-direnv-allow pattern with plain `source .venv/bin/activate`.

**Before** (library quickstart):
```sh
uv venv --python "3.12"
wget https://raw.githubusercontent.com/.../envrc.venv -O .envrc
direnv allow
# if not using direnv
# source .venv/bin/activate
uv pip install dimos[...]
```

**After**:
```sh
uv venv --python 3.12
source .venv/bin/activate
uv pip install dimos[...]
```

- `ubuntu.md`: removed direnv install section + usage
- `osx.md`: same
- `nix.md`: replaced direnv with plain `nix develop` + `source .venv/bin/activate`
- `development/README.md`: untouched (direnv is a legitimate nix setup option for contributors)

Net: **-96 lines, +23 lines**.