### PR TITLE
chore: bump version to 0.0.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ name = "dimos"
 authors = [
     {name = "Dimensional Team", email = "build@dimensionalOS.com"},
 ]
-version = "0.0.9"
+version = "0.0.10"
 description = "Powering agentive generalist robotics"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1745,7 +1745,7 @@ wheels = [
 
 [[package]]
 name = "dimos"
-version = "0.0.9"
+version = "0.0.10"
 source = { editable = "." }
 dependencies = [
     { name = "annotation-protocol" },


### PR DESCRIPTION
Bumps version from 0.0.9 to 0.0.10 in pyproject.toml and uv.lock.