### PR TITLE
fix(deps): exclude dds extra from uv sync --all-extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ export GIT_LFS_SKIP_SMUDGE=1
 git clone -b dev https://github.com/dimensionalOS/dimos.git
 cd dimos
 
-uv sync --all-extras
+uv sync --all-extras --no-extra dds
 
 # Run fast test suite
 uv run pytest dimos

--- a/docs/installation/nix.md
+++ b/docs/installation/nix.md
@@ -44,10 +44,7 @@ cd dimos
 # enter the nix development shell (provides system deps)
 nix develop
 
-uv venv --python 3.12
-source .venv/bin/activate
-
-uv sync --all-extras
+uv sync --all-extras --no-extra dds
 
 # type check
 uv run mypy dimos

--- a/docs/installation/osx.md
+++ b/docs/installation/osx.md
@@ -31,10 +31,7 @@ export GIT_LFS_SKIP_SMUDGE=1
 git clone -b dev https://github.com/dimensionalOS/dimos.git
 cd dimos
 
-uv venv --python 3.12
-source .venv/bin/activate
-
-uv sync --all-extras
+uv sync --all-extras --no-extra dds
 
 # type check
 uv run mypy dimos

--- a/docs/installation/ubuntu.md
+++ b/docs/installation/ubuntu.md
@@ -29,10 +29,7 @@ export GIT_LFS_SKIP_SMUDGE=1
 git clone -b dev https://github.com/dimensionalOS/dimos.git
 cd dimos
 
-uv venv --python 3.12
-source .venv/bin/activate
-
-uv sync --all-extras
+uv sync --all-extras --no-extra dds
 
 # type check
 uv run mypy dimos


### PR DESCRIPTION
## Summary
`cyclonedds` requires building from source with `CYCLONEDDS_HOME` set, which fails on standard dev machines when running `uv sync --all-extras`.

## Changes
- Updated install docs (README, ubuntu, osx, nix) to use `uv sync --all-extras --no-extra dds`
- Added explanatory comment to the `dds` extra in pyproject.toml

## How to Test
```bash
uv sync --all-extras --no-extra dds
```
Should resolve without attempting to build cyclonedds.