### PR TITLE
docs: add -s flag addopts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -410,7 +410,7 @@ env = [
   "GOOGLE_MAPS_API_KEY=AIzafake_google_key",
   "PYTHONWARNINGS=ignore:cupyx.jit.rawkernel is experimental:FutureWarning",
 ]
-addopts = "-v -p no:warnings -ra --color=yes -m 'not (vis or exclude or tool or lcm or ros or heavy or gpu or module or e2e or integration or neverending or mujoco)'"
+addopts = "-v -s -p no:warnings -ra --color=yes -m 'not (vis or exclude or tool or lcm or ros or heavy or gpu or module or e2e or integration or neverending or mujoco)'"
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 


### PR DESCRIPTION
## Summary
LCM autoconf prompts for system configuration during test collection, which fails without `-s` since pytest captures stdin by default.

Added `-s` to addopts
