### PR TITLE
feat(vis): default viewer backend to rerun-web

### DIFF
--- a/dimos/core/global_config.py
+++ b/dimos/core/global_config.py
@@ -30,7 +30,7 @@ class GlobalConfig(BaseSettings):
     robot_ip: str | None = None
     simulation: bool = False
     replay: bool = False
-    viewer_backend: ViewerBackend = "rerun"
+    viewer_backend: ViewerBackend = "rerun-web"
     n_dask_workers: int = 2
     memory_limit: str = "auto"
     mujoco_camera_position: str | None = None

--- a/docs/usage/visualization.md
+++ b/docs/usage/visualization.md
@@ -7,7 +7,7 @@ Dimos supports three visualization backends: Rerun (web or native) and Foxglove.
 Choose your viewer backend via the CLI (preferred):
 
 ```bash
-# Rerun native viewer (default) - native Rerun window + teleop panel at http://localhost:7779
+# Rerun web viewer (default) - Full vis dashboard and teleop panel in browser
 dimos run unitree-go2
 
 # Explicitly select the viewer backend:
@@ -19,10 +19,11 @@ dimos --viewer-backend foxglove run unitree-go2
 Alternative (environment variable):
 
 ```bash
-VIEWER_BACKEND=rerun dimos run unitree-go2
-
 # Rerun web viewer - Full dashboard in browser
 VIEWER_BACKEND=rerun-web dimos run unitree-go2
+
+# Rerun native viewer - native Rerun window + teleop panel at http://localhost:7779
+VIEWER_BACKEND=rerun dimos run unitree-go2
 
 # Foxglove - Use Foxglove Studio instead of Rerun
 VIEWER_BACKEND=foxglove dimos run unitree-go2


### PR DESCRIPTION
## Summary
Switch default `viewer_backend` from `rerun` (native) to `rerun-web` for broader compatibility without requiring a native rerun viewer install.

One-line change in `dimos/core/global_config.py`.