### PR TITLE
fix(pytest): autoconf

### DIFF
--- a/dimos/conftest.py
+++ b/dimos/conftest.py
@@ -18,6 +18,8 @@ import threading
 from dotenv import load_dotenv
 import pytest
 
+from dimos.protocol.service.lcmservice import autoconf
+
 load_dotenv()
 
 
@@ -49,6 +51,18 @@ def event_loop():
     loop = asyncio.new_event_loop()
     yield loop
     loop.close()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _autoconf(request):
+    """Run autoconf() before all tests with capture suspended so people see `sudo` commands."""
+
+    capman = request.config.pluginmanager.getplugin("capturemanager")
+    capman.suspend_global_capture(in_=True)
+    try:
+        autoconf()
+    finally:
+        capman.resume_global_capture()
 
 
 _session_threads = set()

--- a/dimos/perception/experimental/temporal_memory/test_temporal_memory_module.py
+++ b/dimos/perception/experimental/temporal_memory/test_temporal_memory_module.py
@@ -27,7 +27,6 @@ from dimos.core import Module, Out, rpc
 from dimos.models.vl.openai import OpenAIVlModel
 from dimos.msgs.sensor_msgs import Image
 from dimos.perception.experimental.temporal_memory import TemporalMemory, TemporalMemoryConfig
-from dimos.protocol import pubsub
 from dimos.utils.data import get_data
 from dimos.utils.logging_config import setup_logger
 from dimos.utils.testing import TimedSensorReplay
@@ -36,8 +35,6 @@ from dimos.utils.testing import TimedSensorReplay
 load_dotenv()
 
 logger = setup_logger()
-
-pubsub.lcm.autoconf()
 
 
 class VideoReplayModule(Module):

--- a/dimos/perception/test_spatial_memory_module.py
+++ b/dimos/perception/test_spatial_memory_module.py
@@ -24,15 +24,12 @@ from dimos import core
 from dimos.core import Module, Out, rpc
 from dimos.msgs.sensor_msgs import Image
 from dimos.perception.spatial_perception import SpatialMemory
-from dimos.protocol import pubsub
 from dimos.robot.unitree.type.odometry import Odometry
 from dimos.utils.data import get_data
 from dimos.utils.logging_config import setup_logger
 from dimos.utils.testing import TimedSensorReplay
 
 logger = setup_logger()
-
-pubsub.lcm.autoconf()
 
 
 class VideoReplayModule(Module):


### PR DESCRIPTION
* Make `pytest dimos` run `sudo` commands without `-s` by just temporarily disabling capture when executing `sudo`.