### PR TITLE
fix(nix): add venv setup to dev install docs

### DIFF
--- a/docs/installation/nix.md
+++ b/docs/installation/nix.md
@@ -25,8 +25,8 @@ wget https://raw.githubusercontent.com/dimensionalOS/dimos/refs/heads/main/flake
 # enter the nix development shell (provides system deps)
 nix develop
 
-python3 -m venv env
-source env/bin/activate
+python3 -m venv .venv
+source .venv/bin/activate
 
 # install everything (depending on your use case you might not need all extras,
 # check your respective platform guides)
@@ -44,8 +44,8 @@ cd dimos
 # enter the nix development shell (provides system deps)
 nix develop
 
-python3 -m venv env
-source env/bin/activate
+python3 -m venv .venv
+source .venv/bin/activate
 
 pip install -e ".[misc,sim,visualization,agents,web,perception,unitree,manipulation,cpu,dev]"
 

--- a/docs/installation/nix.md
+++ b/docs/installation/nix.md
@@ -25,8 +25,8 @@ wget https://raw.githubusercontent.com/dimensionalOS/dimos/refs/heads/main/flake
 # enter the nix development shell (provides system deps)
 nix develop
 
-python3 -m venv .venv
-source .venv/bin/activate
+python3 -m venv env
+source env/bin/activate
 
 # install everything (depending on your use case you might not need all extras,
 # check your respective platform guides)
@@ -43,6 +43,9 @@ cd dimos
 
 # enter the nix development shell (provides system deps)
 nix develop
+
+python3 -m venv env
+source env/bin/activate
 
 pip install -e ".[misc,sim,visualization,agents,web,perception,unitree,manipulation,cpu,dev]"
 


### PR DESCRIPTION
## Summary
- Added `python3 -m venv .venv` and `source .venv/bin/activate` to the "Developing on DimOS" section in the Nix install docs

## Why
Without a venv, `pip install` in a Nix shell attempts to write to the read-only Nix store Python, causing failures. The "Using DimOS as a library" section already had this step, but it was missing from the dev setup.
