### PR TITLE
docs(readme): restore banner image

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,6 @@
 
 <img width="1000" alt="banner_bordered_trimmed" src="https://github.com/user-attachments/assets/15283d94-ad95-42c9-abd5-6565a222a837" />
 
-![Dimensional](assets/dimensional-dark.svg#gh-dark-mode-only)
-![Dimensional](assets/dimensional-light.svg#gh-light-mode-only)
-
 <h2>The Agentive Operating System for Generalist Robotics</h2>
 
 [![Discord](https://img.shields.io/discord/1341146487186391173?style=flat-square&logo=discord&logoColor=white&label=Discord&color=5865F2)](https://discord.gg/dimos)


### PR DESCRIPTION
Restores the Dimensional banner image from main to the dev README, above the SVG logos.