### PR TITLE
fix(logging): remove black background from console log colors

### DIFF
--- a/dimos/utils/logging_config.py
+++ b/dimos/utils/logging_config.py
@@ -145,7 +145,7 @@ def _compact_console_processor(logger: Any, method_name: str, event_dict: Mappin
     level_short = level[:3].lower()
 
     # File path — fixed width, truncated from the left, padded on the right
-    file_path = event_dict.pop("logger_name", event_dict.pop("logger", ""))
+    file_path = event_dict.pop("logger", "")
     if len(file_path) > _CONSOLE_PATH_WIDTH:
         file_path = file_path[-_CONSOLE_PATH_WIDTH:]
     file_path = f"{file_path:<{_CONSOLE_PATH_WIDTH}s}"


### PR DESCRIPTION
## Summary
- Remove explicit black background (`40m`) from ANSI codes so log colors respect the terminal theme
- Change dim text from bold-black (`1;30;40m`) to dim (`2m`) for visibility on dark terminals


Before:
<img width="2012" height="452" alt="image" src="https://github.com/user-attachments/assets/a938e0a3-612b-4e0f-969a-8cc2807a2ee3" />
After:
<img width="2012" height="452" alt="image" src="https://github.com/user-attachments/assets/fe975336-fa10-4324-9a1e-acc8d76f4a54" />
