### PR TITLE
feat(g1): added rerun visualization for G1

### DIFF
--- a/dimos/robot/unitree/g1/blueprints/primitive/uintree_g1_primitive_no_nav.py
+++ b/dimos/robot/unitree/g1/blueprints/primitive/uintree_g1_primitive_no_nav.py
@@ -18,6 +18,7 @@
 from dimos_lcm.sensor_msgs import CameraInfo
 
 from dimos.core.blueprints import autoconnect
+from dimos.core.global_config import global_config
 from dimos.core.transport import LCMTransport
 from dimos.hardware.sensors.camera import zed
 from dimos.hardware.sensors.camera.module import camera_module  # type: ignore[attr-defined]
@@ -29,11 +30,55 @@ from dimos.msgs.nav_msgs import Odometry, Path
 from dimos.msgs.sensor_msgs import Image, PointCloud2
 from dimos.msgs.std_msgs import Bool
 from dimos.navigation.frontier_exploration import wavefront_frontier_explorer
-from dimos.robot.foxglove_bridge import foxglove_bridge
+from dimos.protocol.pubsub.impl.lcmpubsub import LCM
 from dimos.web.websocket_vis.websocket_vis_module import websocket_vis
+
+rerun_config = {
+    "pubsubs": [LCM(autoconf=True)],
+    "visual_override": {
+        "world/camera_info": lambda camera_info: camera_info.to_rerun(
+            image_topic="/world/color_image",
+            optical_frame="camera_optical",
+        ),
+        "world/global_map": lambda grid: grid.to_rerun(voxel_size=0.1, mode="boxes"),
+        "world/navigation_costmap": lambda grid: grid.to_rerun(
+            colormap="Accent",
+            z_offset=0.015,
+            opacity=0.2,
+            background="#484981",
+        ),
+    },
+    "static": {
+        "world/tf/base_link": lambda rr: [
+            rr.Boxes3D(
+                half_sizes=[0.2, 0.15, 0.75],
+                colors=[(0, 255, 127)],
+                fill_mode="wireframe",
+            ),
+            rr.Transform3D(parent_frame="tf#/base_link"),
+        ]
+    },
+}
+
+match global_config.viewer_backend:
+    case "foxglove":
+        from dimos.robot.foxglove_bridge import foxglove_bridge
+
+        _with_vis = autoconnect(foxglove_bridge())
+    case "rerun":
+        from dimos.visualization.rerun.bridge import rerun_bridge
+
+        _with_vis = autoconnect(rerun_bridge(**rerun_config))
+    case "rerun-web":
+        from dimos.visualization.rerun.bridge import rerun_bridge
+
+        _with_vis = autoconnect(rerun_bridge(viewer_mode="web", **rerun_config))
+    case _:
+        _with_vis = autoconnect()
 
 uintree_g1_primitive_no_nav = (
     autoconnect(
+        _with_vis,
         camera_module(
             transform=Transform(
                 translation=Vector3(0.05, 0.0, 0.6),  # height of camera on G1 robot
@@ -53,7 +98,6 @@ uintree_g1_primitive_no_nav = (
         wavefront_frontier_explorer(),
         # Visualization
         websocket_vis(),
-        foxglove_bridge(),
     )
     .global_config(n_dask_workers=4, robot_model="unitree_g1")
     .transports(

--- a/dimos/robot/unitree/g1/blueprints/primitive/uintree_g1_primitive_no_nav.py
+++ b/dimos/robot/unitree/g1/blueprints/primitive/uintree_g1_primitive_no_nav.py
@@ -53,7 +53,7 @@ rerun_config = {
             rr.Boxes3D(
                 half_sizes=[0.2, 0.15, 0.75],
                 colors=[(0, 255, 127)],
-                fill_mode="wireframe",
+                fill_mode="MajorWireframe",
             ),
             rr.Transform3D(parent_frame="tf#/base_link"),
         ]


### PR DESCRIPTION
## Summary
- Add `viewer_backend` support to the G1 primitive blueprint, matching the existing Go2 pattern
- G1 blueprints now include `RerunBridgeModule` when `viewer_backend` is `rerun` or `rerun-web` (the default), enabling browser-based 3D visualization
- Includes G1-shaped wireframe box

<img width="3408" height="1966" alt="image" src="https://github.com/user-attachments/assets/3e9654d3-04b5-456f-b10e-7dae457e151c" />
