### PR TITLE
docs(go2): add getting started guide

### DIFF
--- a/docs/platforms/quadruped/go2/index.md
+++ b/docs/platforms/quadruped/go2/index.md
@@ -42,6 +42,8 @@ dimos run unitree-go2
 
 That's it. DimOS connects via WebRTC (no jailbreak required), starts the full navigation stack, and opens the command center.
 
+> **Tip:** Keep the Unitree built-in obstacle avoidance enabled on the robot for now. DimOS handles path planning, but the onboard obstacle avoidance provides an extra safety layer.
+
 ### What's Running
 
 | Module | What It Does |


### PR DESCRIPTION
Adds a production-ready getting started guide for the Unitree Go2 at `docs/platforms/quadruped/go2/index.md`.

Covers: install, replay (no hardware), real robot, module overview, simulation, agentic control, available blueprints, and deep dive links to existing docs.