### PR TITLE
Remove asyncio from dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ dependencies = [
     "scipy>=1.15.1",
     "pin>=3.3.0",  # Pinocchio IK library
     "reactivex",
-    "asyncio==3.4.3",
     "sortedcontainers==2.4.0",
     "pydantic",
     "python-dotenv",


### PR DESCRIPTION
asyncio is stdlib.

Having users install this old backport module will only result in things breaking for the user.