### PR TITLE
fix(tests): check for ros

### DIFF
--- a/dimos/conftest.py
+++ b/dimos/conftest.py
@@ -24,6 +24,15 @@ from dimos.protocol.service.lcmservice import autoconf
 load_dotenv()
 
 
+def _has_ros() -> bool:
+    try:
+        import rclpy  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
 def pytest_configure(config):
     config.addinivalue_line("markers", "tool: dev tooling")
     config.addinivalue_line("markers", "slow: tests that are too slow for the fast loop")
@@ -31,6 +40,7 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "skipif_in_ci: skip when CI env var is set")
     config.addinivalue_line("markers", "skipif_no_openai: skip when OPENAI_API_KEY is not set")
     config.addinivalue_line("markers", "skipif_no_alibaba: skip when ALIBABA_API_KEY is not set")
+    config.addinivalue_line("markers", "skipif_no_ros: skip when ROS dependencies are not present")
 
 
 @pytest.hookimpl()
@@ -39,6 +49,7 @@ def pytest_collection_modifyitems(config, items):
         "skipif_in_ci": (bool(os.getenv("CI")), "Skipped in CI"),
         "skipif_no_openai": (not os.getenv("OPENAI_API_KEY"), "OPENAI_API_KEY not set"),
         "skipif_no_alibaba": (not os.getenv("ALIBABA_API_KEY"), "ALIBABA_API_KEY not set"),
+        "skipif_no_ros": (not _has_ros(), "ROS dependencies are not present"),
     }
     for marker_name, (condition, reason) in _skipif_markers.items():
         if condition:

--- a/dimos/protocol/pubsub/impl/test_rospubsub.py
+++ b/dimos/protocol/pubsub/impl/test_rospubsub.py
@@ -50,6 +50,7 @@ def subscriber() -> Generator[DimosROS, None, None]:
     yield from ros_node()
 
 
+@pytest.mark.skipif_no_ros
 def test_basic_conversion(publisher, subscriber):
     """Test Vector3 publish/subscribe through ROS.
 
@@ -75,6 +76,7 @@ def test_basic_conversion(publisher, subscriber):
     assert msg.z == 3.0
 
 
+@pytest.mark.skipif_no_ros
 @pytest.mark.slow
 def test_pointcloud2_pubsub(publisher, subscriber):
     """Test PointCloud2 publish/subscribe through ROS.
@@ -132,6 +134,7 @@ def test_pointcloud2_pubsub(publisher, subscriber):
     assert abs(original.ts - converted.ts) < 0.001
 
 
+@pytest.mark.skipif_no_ros
 def test_pointcloud2_empty_pubsub(publisher, subscriber):
     """Test empty PointCloud2 publish/subscribe.
 
@@ -160,6 +163,7 @@ def test_pointcloud2_empty_pubsub(publisher, subscriber):
     assert len(received[0]) == 0
 
 
+@pytest.mark.skipif_no_ros
 def test_posestamped_pubsub(publisher, subscriber):
     """Test PoseStamped publish/subscribe through ROS.
 
@@ -200,6 +204,7 @@ def test_posestamped_pubsub(publisher, subscriber):
     np.testing.assert_allclose(converted.orientation.w, original.orientation.w, rtol=1e-5)
 
 
+@pytest.mark.skipif_no_ros
 def test_pointstamped_pubsub(publisher, subscriber):
     """Test PointStamped publish/subscribe through ROS.
 
@@ -242,6 +247,7 @@ def test_pointstamped_pubsub(publisher, subscriber):
     assert converted.point.z == original.point.z
 
 
+@pytest.mark.skipif_no_ros
 def test_twist_pubsub(publisher, subscriber):
     """Test Twist publish/subscribe through ROS.
 


### PR DESCRIPTION
## Problem

```
ERROR dimos/protocol/pubsub/impl/test_rospubsub.py::test_basic_conversion - ImportError: rclpy is not installed. ROS pubsub requires ROS 2.
ERROR dimos/protocol/pubsub/impl/test_rospubsub.py::test_pointcloud2_empty_pubsub - ImportError: rclpy is not installed. ROS pubsub requires ROS 2.
ERROR dimos/protocol/pubsub/impl/test_rospubsub.py::test_posestamped_pubsub - ImportError: rclpy is not installed. ROS pubsub requires ROS 2.
ERROR dimos/protocol/pubsub/impl/test_rospubsub.py::test_pointstamped_pubsub - ImportError: rclpy is not installed. ROS pubsub requires ROS 2.
ERROR dimos/protocol/pubsub/impl/test_rospubsub.py::test_twist_pubsub - ImportError: rclpy is not installed. ROS pubsub requires ROS 2
```

## Solution

Skip those tests if `rclpy` is not available.

## Breaking Changes

None.

## How to Test

```
uv run pytest dimos/protocol/pubsub/impl/test_rospubsub.py
```

## Contributor License Agreement

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
