### PR TITLE
docs(readme): add system requirements section

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,33 @@ Dimensional is agent native -- "vibecode" your robots in natural language and bu
 
 </div>
 
+
+# System Requirements
+
+## Tested and Supported Hardware
+
+DimOS has been tested and validated on the following hardware configurations:
+
+### GPU
+- **NVIDIA RTX 4070 or better** (for perception, VLMs, and AI features)
+- CUDA support required
+- Minimum 8GB VRAM recommended
+
+### CPU
+- **Intel Core i7 (recent generation) or better**
+- AMD Ryzen 7 or better
+- Multi-core recommended for distributed execution
+
+### Memory
+- **16GB RAM minimum**
+- 32GB+ recommended for larger models and multi-robot deployments
+
+### Storage
+- **50GB+ free disk space**
+- SSD strongly recommended for model loading and data logging
+
+> **Note:** DimOS may run on older hardware (e.g., NVIDIA 3000-series GPUs), but performance and stability are not guaranteed. If you encounter issues, please upgrade to the recommended specifications above.
+
 # Installation
 
 ## System Install


### PR DESCRIPTION
## How to Run/Test
```bash
# View the updated README
cat README.md | grep -A 30 "# System Requirements"
```

## Summary
Add hardware requirements section to main README to help users understand minimum and recommended specifications for running DimOS. Previously, users were encountering issues running on older hardware (e.g., NVIDIA 3000-series GPUs) without knowing the recommended specs.

## Changes
- Added "System Requirements" section before "Installation"
- Specified tested and supported hardware:
  - GPU: NVIDIA RTX 4070+ (CUDA required)
  - CPU: Intel i7+ or AMD Ryzen 7+
  - Memory: 16GB min, 32GB+ recommended
  - Storage: 50GB+ SSD recommended
- Added note about older hardware not being guaranteed

## Testing
- [x] Pre-commit hooks pass
- [x] Documentation formatting verified
- [ ] CI checks pending
