### PR TITLE
fix(annotations): module annotations are needed at runtime

### DIFF
--- a/dimos/core/_test_future_annotations_helper.py
+++ b/dimos/core/_test_future_annotations_helper.py
@@ -21,7 +21,7 @@ This file exists because `from __future__ import annotations` affects the entire
 from __future__ import annotations
 
 from dimos.core.module import Module
-from dimos.core.stream import In, Out  # noqa
+from dimos.core.stream import In, Out
 
 
 class FutureData:

--- a/dimos/core/module.py
+++ b/dimos/core/module.py
@@ -17,7 +17,6 @@ from dataclasses import dataclass
 from functools import partial
 import inspect
 import json
-import sys
 import threading
 from typing import (
     TYPE_CHECKING,
@@ -392,14 +391,8 @@ class Module(ModuleBase[ModuleConfigT]):
         """
         super().__init_subclass__(**kwargs)
 
-        # Get type hints for this class only (not inherited ones).
-        globalns = {}
-        for c in cls.__mro__:
-            if c.__module__ in sys.modules:
-                globalns.update(sys.modules[c.__module__].__dict__)
-
         try:
-            hints = get_type_hints(cls, globalns=globalns, include_extras=True)
+            hints = get_type_hints(cls, include_extras=True)
         except (NameError, AttributeError, TypeError):
             hints = {}
 
@@ -413,18 +406,9 @@ class Module(ModuleBase[ModuleConfigT]):
     def __init__(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
         self.ref = None  # type: ignore[assignment]
 
-        # Get type hints with proper namespace resolution for subclasses
-        # Collect namespaces from all classes in the MRO chain
-        globalns = {}
-        for cls in self.__class__.__mro__:
-            if cls.__module__ in sys.modules:
-                globalns.update(sys.modules[cls.__module__].__dict__)
-
         try:
-            hints = get_type_hints(self.__class__, globalns=globalns, include_extras=True)
+            hints = get_type_hints(self.__class__, include_extras=True)
         except (NameError, AttributeError, TypeError):
-            # If we still can't resolve hints, skip type hint processing
-            # This can happen with complex forward references
             hints = {}
 
         for name, ann in hints.items():

--- a/dimos/hardware/sensors/camera/realsense/camera.py
+++ b/dimos/hardware/sensors/camera/realsense/camera.py
@@ -28,6 +28,7 @@ from scipy.spatial.transform import Rotation  # type: ignore[import-untyped]
 from dimos.core.core import rpc
 from dimos.core.module import Module, ModuleConfig
 from dimos.core.module_coordinator import ModuleCoordinator
+from dimos.core.stream import Out
 from dimos.core.transport import LCMTransport
 from dimos.hardware.sensors.camera.spec import (
     OPTICAL_ROTATION,
@@ -44,8 +45,6 @@ from dimos.utils.reactive import backpressure
 
 if TYPE_CHECKING:
     import pyrealsense2 as rs  # type: ignore[import-not-found]
-
-    from dimos.core.stream import Out
 
 
 def default_base_transform() -> Transform:

--- a/dimos/hardware/sensors/camera/zed/camera.py
+++ b/dimos/hardware/sensors/camera/zed/camera.py
@@ -18,7 +18,6 @@ import atexit
 from dataclasses import dataclass, field
 import threading
 import time
-from typing import TYPE_CHECKING
 
 import cv2
 import pyzed.sl as sl
@@ -27,6 +26,7 @@ import reactivex as rx
 from dimos.core.core import rpc
 from dimos.core.module import Module, ModuleConfig
 from dimos.core.module_coordinator import ModuleCoordinator
+from dimos.core.stream import Out
 from dimos.core.transport import LCMTransport
 from dimos.hardware.sensors.camera.spec import (
     OPTICAL_ROTATION,
@@ -40,9 +40,6 @@ from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
 from dimos.robot.foxglove_bridge import FoxgloveBridge
 from dimos.spec import perception
 from dimos.utils.reactive import backpressure
-
-if TYPE_CHECKING:
-    from dimos.core.stream import Out
 
 
 def default_base_transform() -> Transform:

--- a/dimos/manipulation/grasping/graspgen_module.py
+++ b/dimos/manipulation/grasping/graspgen_module.py
@@ -25,13 +25,13 @@ import numpy as np
 from dimos.core.core import rpc
 from dimos.core.docker_runner import DockerModuleConfig
 from dimos.core.module import Module
+from dimos.core.stream import Out
 from dimos.msgs.geometry_msgs import PoseArray
 from dimos.msgs.std_msgs import Header
 from dimos.utils.logging_config import setup_logger
 from dimos.utils.transform_utils import matrix_to_pose
 
 if TYPE_CHECKING:
-    from dimos.core.stream import Out
     from dimos.msgs.sensor_msgs import PointCloud2
 
 logger = setup_logger()

--- a/dimos/manipulation/grasping/grasping.py
+++ b/dimos/manipulation/grasping/grasping.py
@@ -24,12 +24,12 @@ from typing import TYPE_CHECKING
 from dimos.agents.annotation import skill
 from dimos.core.core import rpc
 from dimos.core.module import Module
+from dimos.core.stream import Out
+from dimos.msgs.geometry_msgs import PoseArray
 from dimos.utils.logging_config import setup_logger
 from dimos.utils.transform_utils import quaternion_to_euler
 
 if TYPE_CHECKING:
-    from dimos.core.stream import Out
-    from dimos.msgs.geometry_msgs import PoseArray
     from dimos.msgs.sensor_msgs import PointCloud2
 
 logger = setup_logger()

--- a/dimos/perception/detection/type/detection2d/bbox.py
+++ b/dimos/perception/detection/type/detection2d/bbox.py
@@ -18,9 +18,8 @@ from dataclasses import dataclass
 import hashlib
 from typing import TYPE_CHECKING, Any
 
-from typing_extensions import Self
-
 if TYPE_CHECKING:
+    from typing_extensions import Self
     from ultralytics.engine.results import Results  # type: ignore[import-not-found]
 
     from dimos.msgs.sensor_msgs import Image

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -333,6 +333,9 @@ known-first-party = ["dimos"]
 combine-as-imports = true
 force-sort-within-sections = true
 
+[tool.ruff.lint.flake8-type-checking]
+runtime-evaluated-base-classes = ["dimos.core.module.Module"]
+
 [tool.mypy]
 python_version = "3.12"
 incremental = true


### PR DESCRIPTION
## Problem

* See https://github.com/dimensionalOS/dimos/pull/1364#discussion_r2850802372
* Annotations weren't read correctly, causing problems with modules and blueprints.
* When annotations are inside `if TYPE_CHECKING`, `get_type_hints` cannot read them.
* This is currently handled with a hack which reads the types from the parent file, in the hope that they have it.

Closes DIM-636

## Solution

Basically remove the hack and just add:

```toml
[tool.ruff.lint.flake8-type-checking]
runtime-evaluated-base-classes = ["dimos.core.module.Module"]
```

...to get ruff to enforce that annotations to modules always use real types, not types behind TYPE_CHECKING.

## Breaking Changes

None.

## How to Test

In a module file, move the import for `In/Out` to `TYPE_CHECKING`. Then run:

```bash
pre-commit run --all-files
```

It should be moved back outside.

## Contributor License Agreement

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
