### PR TITLE
chore: remove unnecessary "prevent unwanted imports" comments

### DIFF
--- a/dimos/agents/agent.py
+++ b/dimos/agents/agent.py
@@ -103,7 +103,6 @@ class Agent(Module[AgentConfig]):
             model = MockModel(json_path=self.config.model_fixture)
 
         with self._lock:
-            # Here to prevent unwanted imports in the file.
             from langchain.agents import create_agent
 
             self._state_graph = create_agent(

--- a/dimos/agents/skills/navigation.py
+++ b/dimos/agents/skills/navigation.py
@@ -59,7 +59,6 @@ class NavigationSkillContainer(Module):
         super().__init__()
         self._skill_started = False
 
-        # Here to prevent unwanted imports in the file.
         from dimos.models.vl.qwen import QwenVlModel
 
         self._vl_model = QwenVlModel()

--- a/dimos/agents/skills/person_follow.py
+++ b/dimos/agents/skills/person_follow.py
@@ -176,7 +176,6 @@ class PersonFollowSkillContainer(Module):
 
         with self._lock:
             if self._tracker is None:
-                # Here to prevent unwanted imports in the file.
                 from dimos.models.segmentation.edge_tam import EdgeTAMProcessor
 
                 self._tracker = EdgeTAMProcessor()

--- a/dimos/agents/web_human_input.py
+++ b/dimos/agents/web_human_input.py
@@ -52,7 +52,6 @@ class WebInput(Module):
 
         normalizer = AudioNormalizer()
 
-        # Here to prevent unwanted imports in the file.
         from dimos.stream.audio.stt.node_whisper import WhisperNode
 
         stt_node = WhisperNode()

--- a/dimos/agents_deprecated/memory/spatial_vector_db.py
+++ b/dimos/agents_deprecated/memory/spatial_vector_db.py
@@ -56,7 +56,6 @@ class SpatialVectorDB:
         """
         self.collection_name = collection_name
 
-        # Here to prevent unwanted imports in the file.
         import chromadb
 
         # Use provided client or create in-memory client

--- a/dimos/models/vl/base.py
+++ b/dimos/models/vl/base.py
@@ -69,7 +69,6 @@ def vlm_detection_to_detection2d(
     Returns:
         Detection2DBBox instance or None if invalid
     """
-    # Here to prevent unwanted imports in the file.
     from dimos.perception.detection.type import Detection2DBBox
 
     # Validate list/tuple structure
@@ -255,7 +254,6 @@ class VlModel(Captioner, Resource, Configurable[VlModelConfig]):
     def query_detections(
         self, image: Image, query: str, **kwargs: object
     ) -> ImageDetections2D[Detection2DBBox]:
-        # Here to prevent unwanted imports in the file.
         from dimos.perception.detection.type import ImageDetections2D
 
         full_query = f"""show me bounding boxes in pixels for this query: `{query}`
@@ -316,7 +314,6 @@ class VlModel(Captioner, Resource, Configurable[VlModelConfig]):
         Returns:
             ImageDetections2D containing Detection2DPoint instances
         """
-        # Here to prevent unwanted imports in the file.
         from dimos.perception.detection.type import ImageDetections2D
 
         full_query = f"""Show me point coordinates in pixels for this query: `{query}`


### PR DESCRIPTION
## How to Run/Test
```bash
cd /home/ubuntu/dimos
git fetch origin
git checkout chore/remove-llm-comments
grep -rn "Here to prevent unwanted imports" --include="*.py"
# Should return nothing
```

## Summary
Removes 8 instances of the LLM-generated comment `# Here to prevent unwanted imports in the file.` that were introduced in PR #1365. The lazy imports themselves are correct and intentional — only the redundant comments are removed.

Reference: https://github.com/dimensionalOS/dimos/pull/1365/changes#r2867298612

## Changes
- Removed comment from `dimos/agents/agent.py` (line 106)
- Removed comment from `dimos/agents/skills/navigation.py` (line 62)
- Removed comment from `dimos/agents/skills/person_follow.py` (line 179)
- Removed comment from `dimos/agents/web_human_input.py` (line 55)
- Removed comment from `dimos/agents_deprecated/memory/spatial_vector_db.py` (line 59)
- Removed 3 comments from `dimos/models/vl/base.py` (lines 72, 258, 319)

## Testing
- [x] Pre-commit hooks pass (all 18 checks)
- [x] No functional code changed — comment-only removal
- [x] Verified zero remaining instances via grep
