### PR TITLE
fix: increase RPC test timeout - CI flaky issue

### DIFF
--- a/dimos/protocol/rpc/test_spec.py
+++ b/dimos/protocol/rpc/test_spec.py
@@ -208,12 +208,12 @@ def test_exception_handling_sync(rpc_context, impl_name: str) -> None:
 
         try:
             # Test successful call
-            result, _ = client.call_sync("test_exc", (["ok"], {}), rpc_timeout=2.0)
+            result, _ = client.call_sync("test_exc", (["ok"], {}), rpc_timeout=5.0)
             assert result == "Success: ok"
 
             # Test builtin exception - should raise actual ValueError
             with pytest.raises(ValueError) as exc_info:
-                client.call_sync("test_exc", (["fail"], {}), rpc_timeout=2.0)
+                client.call_sync("test_exc", (["fail"], {}), rpc_timeout=5.0)
             assert "Test error message" in str(exc_info.value)
             # Check that the cause contains the remote traceback
             assert isinstance(exc_info.value.__cause__, RemoteError)
@@ -221,7 +221,7 @@ def test_exception_handling_sync(rpc_context, impl_name: str) -> None:
 
             # Test custom exception - should raise RemoteError
             with pytest.raises(RemoteError) as exc_info:
-                client.call_sync("test_exc", (["custom"], {}), rpc_timeout=2.0)
+                client.call_sync("test_exc", (["custom"], {}), rpc_timeout=5.0)
             assert "Custom error" in str(exc_info.value)
             assert "CustomTestError" in exc_info.value.remote_type
             assert "failing_function" in exc_info.value.remote_traceback


### PR DESCRIPTION
## Problem

`test_exception_handling_sync[lcm_rpc_context-lcm]` fails intermittently in CI with `TimeoutError` after 2.0s. LCM multicast discovery + RPC round-trip can exceed 2s on loaded CI runners.

#1381 
Closes DIM-642

## Solution

Increase `rpc_timeout` from 2.0s to 5.0s for all three `call_sync` invocations in the test. Only affects failure path - passing tests return instantly.

## Breaking Changes

None

## How to Test

pytest dimos/protocol/rpc/test_spec.py::test_exception_handling_sync -v

## Contributor License Agreement

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
