### PR TITLE
feat: keyboard mapping to velocity and pose via existing interfaces (…

### DIFF
--- a/dimos/robot/unitree_webrtc/keyboard_pose_teleop.py
+++ b/dimos/robot/unitree_webrtc/keyboard_pose_teleop.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 import math
 import os
 import threading
-from typing import Optional
 
 import pygame
 
@@ -57,7 +56,7 @@ class KeyboardPoseTeleop(Module):
     _screen: pygame.Surface | None = None
     _clock: pygame.time.Clock | None = None
     _font: pygame.font.Font | None = None
-    _current_pose: Optional[PoseStamped] = None
+    _current_pose: PoseStamped | None = None
 
     def __init__(self) -> None:
         super().__init__()
@@ -239,4 +238,3 @@ class KeyboardPoseTeleop(Module):
 keyboard_pose_teleop = KeyboardPoseTeleop.blueprint
 
 __all__ = ["KeyboardPoseTeleop", "keyboard_pose_teleop"]
-

--- a/dimos/robot/unitree_webrtc/unitree_g1_blueprints.py
+++ b/dimos/robot/unitree_webrtc/unitree_g1_blueprints.py
@@ -59,8 +59,8 @@ from dimos.perception.spatial_perception import spatial_memory
 from dimos.robot.foxglove_bridge import foxglove_bridge
 from dimos.robot.unitree.connection.g1 import g1_connection
 from dimos.robot.unitree.connection.g1sim import g1_sim_connection
-from dimos.robot.unitree_webrtc.keyboard_teleop import keyboard_teleop
 from dimos.robot.unitree_webrtc.keyboard_pose_teleop import keyboard_pose_teleop
+from dimos.robot.unitree_webrtc.keyboard_teleop import keyboard_teleop
 from dimos.robot.unitree_webrtc.unitree_g1_skill_container import g1_skills
 from dimos.utils.monitoring import utilization
 from dimos.web.websocket_vis.websocket_vis_module import websocket_vis


### PR DESCRIPTION
…#1159)

This PR adds keyboard-based control for both velocity and pose using the existing control/navigation interfaces for the Unitree G1.> It keeps the existing KeyboardTeleop for continuous cmd_vel control and adds a new module to send small relative pose goals through the navigation stack.

Details:

- Velocity control
•	Reuse KeyboardTeleop to map keyboard input to Twist messages.
•	Commands are published to the existing /cmd_vel transport; no changes to the low-level control path.

- Pose control
•	Add KeyboardPoseTeleop, a pygame-based module that:
•	Subscribes to odom: In[PoseStamped] for the current robot pose.
•	Maps key presses (Arrow keys, Q/E, Space) to relative motion (forward, left, degrees).
•	Generates a new PoseStamped goal in the same frame as odom and publishes it on goal_pose: Out[PoseStamped].
•	Sends cancel_goal: Out[Bool] on Space for goal cancellation.
•	This reuses the existing navigation topics /odom, /goal_pose, and /cancel_goal instead of introducing new control interfaces.

- Blueprint wiring
•	Update unitree_g1_blueprints.with_joystick to include both:
•	keyboard_teleop() for velocity (cmd_vel).
•	keyboard_pose_teleop() for discrete pose goals.

## Breaking Changes

None. This change only adds a new module and extends the G1 joystick blueprint; existing behavior is preserved.

## How to Test
    #In a supported Linux/WSL environment:
     uv sync --extra dev --extra cpu --extra sim
     uv run dimos --simulation run unitree-g1-joystick

•	Focus the Keyboard Teleop window:
•	W/S: forward/backward
•	A/D: turn left/right
•	Q/E: strafe left/right
•	Shift / Ctrl: speed up / slow down
•	Space: emergency stop (cmd_vel = 0)
•	Focus the Keyboard Pose Teleop window:
•	ArrowUp/ArrowDown: move forward/backward by a fixed step (relative to current heading).
•	ArrowLeft/ArrowRight: move left/right by a fixed step.
•	Q/E: rotate in place by a fixed yaw step.
•	Space: cancel the current navigation goal.
•	ESC: close the pose teleop window.

## Contributor License Agreement

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
