### PR TITLE
fix(ci): skip workflows on draft PRs

### DIFF
--- a/.github/workflows/code-cleanup.yml
+++ b/.github/workflows/code-cleanup.yml
@@ -1,6 +1,7 @@
 name: code-cleanup
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: write

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,6 +7,7 @@ on:
     paths-ignore:
       - '**.md'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read


### PR DESCRIPTION
Adds `types: [opened, synchronize, reopened, ready_for_review]` to `pull_request` triggers in:

- `code-cleanup.yml`
- `docker.yml`

This prevents CI from running on draft PRs, saving self-hosted runner time. Workflows will trigger when the PR is marked ready for review.

Fixes: draft PR #1395 triggering CI runs.