### PR TITLE
fix(command-center): add command to build

### DIFF
--- a/dimos/web/command-center-extension/README.md
+++ b/dimos/web/command-center-extension/README.md
@@ -1,0 +1,11 @@
+# command-center-extension
+
+## Build and use
+
+Install the Node dependencies:
+
+    npm install
+
+Build the package:
+
+    npm run build:inline

--- a/dimos/web/command-center-extension/package.json
+++ b/dimos/web/command-center-extension/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "build": "foxglove-extension build",
     "build:standalone": "vite build",
+    "build:inline": "vite build && node scripts/inline-html.js",
     "dev": "vite",
     "preview": "vite preview",
     "foxglove:prepublish": "foxglove-extension build --mode production",

--- a/dimos/web/command-center-extension/scripts/inline-html.js
+++ b/dimos/web/command-center-extension/scripts/inline-html.js
@@ -1,0 +1,28 @@
+const { execSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const dataDir = path.join(__dirname, "..", "..", "..", "..", "data");
+const outPath = path.join(dataDir, "command_center.html");
+const archivePath = path.join(dataDir, ".lfs", "command_center.html.tar.gz");
+
+// Inline JS into HTML
+const distDir = path.join(__dirname, "..", "dist-standalone");
+const jsFile = fs.readdirSync(path.join(distDir, "assets")).find((f) => f.startsWith("main") && f.endsWith(".js"));
+const html = fs.readFileSync(path.join(distDir, "index.html"), "utf8");
+const js = fs.readFileSync(path.join(distDir, "assets", jsFile), "utf8");
+
+const scriptTag = `<script type="module" crossorigin src="/assets/${jsFile}"></script>`;
+const idx = html.indexOf(scriptTag);
+const output = html.slice(0, idx) + `<script type="module">${js}</script>` + html.slice(idx + scriptTag.length);
+
+fs.writeFileSync(outPath, output);
+console.log(`Created ${outPath}`);
+
+// Recreate the LFS archive
+if (fs.existsSync(archivePath)) {
+  fs.unlinkSync(archivePath);
+}
+
+execSync(`tar -czf "${archivePath}" -C "${dataDir}" command_center.html`);
+console.log(`Created ${archivePath}`);


### PR DESCRIPTION
## Problem

We were missing a script to regenerate the inlined command center HTML file.

## Solution

* Add a command to do it.

## Breaking Changes

None.

## How to Test

Change a file in the command center.

Run:

```bash
cd dimos/web/command-center-extension/
npm run build:inline
```

Start a blueprint and see the new command center.

## Contributor License Agreement

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
