### PR TITLE
fix(agentspy): wrap subscribe topic string in Topic type

### DIFF
--- a/dimos/utils/cli/agentspy/agentspy.py
+++ b/dimos/utils/cli/agentspy/agentspy.py
@@ -63,7 +63,9 @@ class AgentMessageMonitor:
 
     def start(self) -> None:
         """Start monitoring messages."""
-        self.transport.subscribe(self.topic, self._handle_message)
+        from dimos.protocol.pubsub.impl.lcmpubsub import Topic
+
+        self.transport.subscribe(Topic(self.topic), self._handle_message)
 
     def stop(self) -> None:
         """Stop monitoring."""

--- a/dimos/utils/cli/agentspy/agentspy.py
+++ b/dimos/utils/cli/agentspy/agentspy.py
@@ -29,7 +29,7 @@ from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.widgets import Footer, RichLog
 
-from dimos.protocol.pubsub.impl.lcmpubsub import PickleLCM
+from dimos.protocol.pubsub.impl.lcmpubsub import PickleLCM, Topic
 from dimos.utils.cli import theme
 
 # Type alias for all message types we might receive
@@ -63,8 +63,6 @@ class AgentMessageMonitor:
 
     def start(self) -> None:
         """Start monitoring messages."""
-        from dimos.protocol.pubsub.impl.lcmpubsub import Topic
-
         self.transport.subscribe(Topic(self.topic), self._handle_message)
 
     def stop(self) -> None:
@@ -72,7 +70,7 @@ class AgentMessageMonitor:
         # PickleLCM doesn't have explicit stop method
         pass
 
-    def _handle_message(self, msg: Any, topic: str) -> None:
+    def _handle_message(self, msg: Any, topic: Topic) -> None:
         """Handle incoming messages."""
         # Check if it's one of the message types we care about
         if isinstance(msg, SystemMessage | ToolMessage | AIMessage | HumanMessage):


### PR DESCRIPTION
## Problem

- .subscribe() in PickleLCM now accepts Topic type only (not raw strings). AgentSpy was passing a plain string, causing it to fail at runtime.

## Solution

- Wraps self.topic in Topic() to match the updated subscribe API.

## Breaking Changes
None

## How to Test

- run `agentspy` in terminal and it works

## Contributor License Agreement

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
