### PR TITLE
feat(deps): add viewer extra for dimos-viewer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,10 @@ visualization = [
     "rerun-sdk>=0.20.0",
 ]
 
+viewer = [
+    "dimos-viewer>=0.1.0",
+]
+
 agents = [
     "langchain==1.2.3",
     "langchain-chroma>=1,<2",


### PR DESCRIPTION
## Problem

Closes DIM-646 (DimOS side)

Users need to manually install the DimOS interactive viewer. There should be a simple `pip install dimos[viewer]` path.

## Solution

Add `viewer` optional dependency extra pointing to `dimos-viewer>=0.1.0`:

```toml
[project.optional-dependencies]
viewer = [
    "dimos-viewer>=0.1.0",
]
```

This enables:
```bash
pip install dimos[viewer]  # installs the interactive Rerun viewer
dimos-viewer              # launches the viewer
```

### Dependencies

- **Blocked on**: [dimensionalOS/dimos-viewer#4](https://github.com/dimensionalOS/dimos-viewer/pull/4) being merged and published to PyPI
- The `uv.lock` file will need updating after `dimos-viewer` is published (run `uv lock`)

## Breaking Changes

None

## How to Test

After `dimos-viewer` is published to PyPI:
```bash
pip install dimos[viewer]
dimos-viewer  # should launch the interactive viewer
python -c "from dimos_viewer import __version__; print(__version__)"
```

## Contributor License Agreement
- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md)