### PR TITLE
fix(ci): actually skip CI on draft PRs

### DIFF
--- a/.github/workflows/code-cleanup.yml
+++ b/.github/workflows/code-cleanup.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   pre-commit:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: self-hosted
     steps:
     - name: Fix permissions

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,6 +16,7 @@ permissions:
 
 jobs:
   check-changes:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: [self-hosted, Linux]
     outputs:
       ros:    ${{ steps.filter.outputs.ros }}


### PR DESCRIPTION
## Problem

PR #1398 claimed to skip CI on draft PRs but only added `ready_for_review` to the trigger types. The `synchronize` event still fires on every push regardless of draft status, wasting self-hosted runner time.

## Fix

Added `if: github.event.pull_request.draft == false` to:
- `check-changes` job in `docker.yml`
- `pre-commit` job in `code-cleanup.yml`

These are the entry-point jobs — all downstream jobs depend on them via `needs`, so everything skips when a PR is draft.

## 2-line change

```yaml
# docker.yml
check-changes:
  if: github.event.pull_request.draft == false  # ← added

# code-cleanup.yml
pre-commit:
  if: github.event.pull_request.draft == false  # ← added
```

## Contributor License Agreement
- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md)