### PR TITLE
chore: add PyPI metadata (license, keywords, classifiers, URLs)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ authors = [
 version = "0.0.10.post1"
 description = "Powering agentive generalist robotics"
 requires-python = ">=3.10"
-readme = "README.md"
+readme = {file = "README.md", content-type = "text/markdown"}
 license = {text = "Apache-2.0"}
 keywords = ["robotics", "ros", "agents", "dimos", "dimensional", "openclaw", "roboclaw", "humanoid", "unitree"]
 classifiers = [
@@ -41,6 +41,10 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Software Development :: Libraries :: Application Frameworks",
+    "Topic :: Scientific/Engineering :: Image Processing",
+    "Topic :: Scientific/Engineering :: Visualization",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: MacOS",
 ]
 
 dependencies = [
@@ -95,7 +99,7 @@ doclinks = "dimos.utils.docs.doclinks:main"
 dtop = "dimos.utils.cli.dtop:main"
 
 [project.urls]
-Homepage = "https://github.com/dimensionalOS/dimos"
+Homepage = "https://dimensionalos.com"
 Repository = "https://github.com/dimensionalOS/dimos"
 Issues = "https://github.com/dimensionalOS/dimos/issues"
 Changelog = "https://github.com/dimensionalOS/dimos/releases"


### PR DESCRIPTION
## What

Adds standard PyPI metadata fields to `pyproject.toml` so the [PyPI page](https://pypi.org/project/dimos/) shows verified project links, license, and proper classifiers.

## Changes

| Field | Value |
|-------|-------|
| `license` | Apache-2.0 |
| `keywords` | robotics, ros, autonomous, ai, agents, dimos |
| `classifiers` | Alpha, Python 3.10-3.12, AI/Robotics, Apache |
| `[project.urls]` | Homepage, Docs, Repository, Issues, Changelog |

## Before / After

**Before:** Blank sidebar on PyPI — no links, no license badge, no classifiers.

**After:** Verified project links, license badge, Python version badges, topic tags.

## Contributor License Agreement
- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md)