### PR TITLE
fix(ci): run tests when pyproject.toml or uv.lock changes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -58,6 +58,8 @@ jobs:
 
             tests:
               - dimos/**
+              - pyproject.toml
+              - uv.lock
 
       - name: Determine Branch Tag
         id: set-tag


### PR DESCRIPTION
## Problem

The `tests` path filter in `docker.yml` only matches `dimos/**`. Changes to `pyproject.toml` (root level) skip tests and mypy entirely — broken deps, bad extras, or syntax errors go undetected.

## Fix

Added `pyproject.toml` and `uv.lock` to the `tests` path filter:

```yaml
tests:
  - dimos/**
  - pyproject.toml  # ← added
  - uv.lock         # ← added
```

Now any dependency or config change triggers the test + mypy jobs.

## Contributor License Agreement
- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md)