### PR TITLE
Fix: Escaped brackets in pip install to avoid zsh glob expansion

### DIFF
--- a/docs/installation/osx.md
+++ b/docs/installation/osx.md
@@ -1,6 +1,6 @@
 # macOS Install (12.6 or newer)
 
-```sh
+\`\`\`sh
 # install homebrew
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 # install dependencies
@@ -8,11 +8,11 @@ brew install gnu-sed gcc portaudio git-lfs libjpeg-turbo python pre-commit
 
 # install uv
 curl -LsSf https://astral.sh/uv/install.sh | sh && export PATH="$HOME/.local/bin:$PATH"
-```
+\`\`\`
 
 # Using DimOS as a library
 
-```sh
+\`\`\`sh
 mkdir myproject && cd myproject
 
 uv venv --python 3.12
@@ -20,12 +20,13 @@ source .venv/bin/activate
 
 # install everything (depending on your use case you might not need all extras,
 # check your respective platform guides)
-uv pip install dimos[misc,sim,visualization,agents,web,perception,unitree,manipulation,cpu,dev]
-```
+# FIXED: Escaped brackets to avoid zsh glob expansion
+uv pip install "dimos\[misc,sim,visualization,agents,web,perception,unitree,manipulation,cpu,dev]"
+\`\`\`
 
 # Developing on DimOS
 
-```sh
+\`\`\`sh
 # this allows getting large files on-demand (and not pulling all immediately)
 export GIT_LFS_SKIP_SMUDGE=1
 git clone -b dev https://github.com/dimensionalOS/dimos.git
@@ -38,4 +39,4 @@ uv run mypy dimos
 
 # tests (around a minute to run)
 uv run pytest dimos
-```
+\`\`\`


### PR DESCRIPTION
Fixed zsh glob pattern issue by escaping square brackets in pip install command. The brackets [misc,sim,...] were being treated as glob patterns by zsh, causing installation to fail. Fixes #1404