### PR TITLE
feat(logging): per-run log directory with unified main.jsonl (DIM-685)

### DIFF
--- a/dimos/robot/cli/dimos.py
+++ b/dimos/robot/cli/dimos.py
@@ -115,6 +115,17 @@ def run(
     cli_config_overrides: dict[str, Any] = ctx.obj
     global_config.update(**cli_config_overrides)
 
+    import time as _time
+
+    from dimos.constants import DIMOS_LOG_DIR
+    from dimos.utils.logging_config import set_run_log_dir
+
+    blueprint_name = "-".join(robot_types)
+    safe_name = blueprint_name.replace("/", "-").replace(" ", "-")
+    run_id = f"{_time.strftime('%Y%m%d-%H%M%S')}-{safe_name}"
+    log_dir = DIMOS_LOG_DIR / run_id
+    set_run_log_dir(log_dir)
+    logger.info("Logging to", log_dir=str(log_dir))
     blueprint = autoconnect(*map(get_by_name, robot_types))
     dimos = blueprint.build(cli_config_overrides=cli_config_overrides)
     dimos.loop()

--- a/dimos/utils/logging_config.py
+++ b/dimos/utils/logging_config.py
@@ -38,6 +38,22 @@ logging.getLogger("asyncio").setLevel(logging.ERROR)
 
 _LOG_FILE_PATH = None
 
+_RUN_LOG_DIR: Path | None = None
+
+
+def set_run_log_dir(log_dir: str | Path) -> None:
+    """Set per-run log directory. Call BEFORE blueprint.build()."""
+    global _RUN_LOG_DIR, _LOG_FILE_PATH
+    log_dir = Path(log_dir)
+    _RUN_LOG_DIR = log_dir
+    _RUN_LOG_DIR.mkdir(parents=True, exist_ok=True)
+    _LOG_FILE_PATH = None
+    os.environ["DIMOS_RUN_LOG_DIR"] = str(log_dir)
+
+
+def get_run_log_dir() -> Path | None:
+    return _RUN_LOG_DIR
+
 
 def _get_log_directory() -> Path:
     # Check if running from a git repository
@@ -61,6 +77,13 @@ def _get_log_directory() -> Path:
 
 
 def _get_log_file_path() -> Path:
+    if _RUN_LOG_DIR is not None:
+        return _RUN_LOG_DIR / "main.jsonl"
+    env_log_dir = os.environ.get("DIMOS_RUN_LOG_DIR")
+    if env_log_dir:
+        p = Path(env_log_dir)
+        p.mkdir(parents=True, exist_ok=True)
+        return p / "main.jsonl"
     log_dir = _get_log_directory()
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     pid = os.getpid()
@@ -229,21 +252,22 @@ def setup_logger(*, level: int | None = None) -> Any:
     console_formatter = structlog.stdlib.ProcessorFormatter(
         processor=_compact_console_processor,
     )
+
     console_handler.setFormatter(console_formatter)
     stdlib_logger.addHandler(console_handler)
 
-    # Create rotating file handler with JSON formatting.
-    file_handler = logging.handlers.RotatingFileHandler(
+    # Create file handler with JSON formatting.
+    file_handler = logging.FileHandler(
         log_file_path,
         mode="a",
-        maxBytes=10 * 1024 * 1024,  # 10MiB
-        backupCount=20,
         encoding="utf-8",
     )
+
     file_handler.setLevel(level)
     file_formatter = structlog.stdlib.ProcessorFormatter(
         processor=structlog.processors.JSONRenderer(),
     )
+
     file_handler.setFormatter(file_formatter)
     stdlib_logger.addHandler(file_handler)
 


### PR DESCRIPTION
## Problem
Closes DIM-685

every forkserver worker creates its own log file — a single run produces 6+ scattered `dimos_<ts>_<pid>.jsonl` files. agents can't grep one file for all output, and there's no way to tell which files belong to which run.

## Solution
all processes (main + workers) now write to one file per run:

```
logs/20260306-143022-unitree-go2/
  main.jsonl    ← everything
```

how it works:
- `set_run_log_dir()` sets `os.environ["DIMOS_RUN_LOG_DIR"]` before `blueprint.build()`
- forkserver context is created lazily during build — inherits the env var
- all workers read env var in `_get_log_file_path()` → write to same `main.jsonl`
- append mode, POSIX atomic writes (<4KB lines), no lock needed
- `FileHandler` instead of `RotatingFileHandler` (avoids multi-process rotation races)
- legacy fallback preserved when no run dir is set

zero changes to worker.py.

## Breaking Changes
None

## How to Test
```bash
cd /home/ubuntu/dimos
git fetch origin && git checkout feat/dim-685-per-run-logs
source .venv/bin/activate
dimos run unitree-go2 --simulation
# check logs/ for a new timestamped directory with main.jsonl
ls logs/
```

## Contributor License Agreement
- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md)