### PR TITLE
fix: add 30s timeout to WebRTC connection_ready.wait() to prevent indefinite hang

### DIFF
--- a/dimos/robot/unitree/connection.py
+++ b/dimos/robot/unitree/connection.py
@@ -118,7 +118,28 @@ class UnitreeWebRTCConnection(Resource):
         self.thread.start()
 
         if not self.connection_ready.wait(timeout=CONNECT_TIMEOUT):
+            # Cancel the async connection task and disconnect to avoid leaving
+            # a half-open WebRTC session on the robot side (which would cause
+            # the next connection attempt to hang as well).
+            async def _cleanup() -> None:
+                if self.task is not None:
+                    self.task.cancel()
+                    try:
+                        await self.task
+                    except (asyncio.CancelledError, Exception):
+                        pass
+                if hasattr(self, "conn") and self.conn is not None:
+                    try:
+                        await self.conn.disconnect()
+                    except Exception:
+                        pass
+
             if self.loop.is_running():
+                future = asyncio.run_coroutine_threadsafe(_cleanup(), self.loop)
+                try:
+                    future.result(timeout=5.0)
+                except Exception:
+                    pass
                 self.loop.call_soon_threadsafe(self.loop.stop)
             if self.thread.is_alive():
                 self.thread.join(timeout=2.0)

--- a/dimos/robot/unitree/connection.py
+++ b/dimos/robot/unitree/connection.py
@@ -111,10 +111,25 @@ class UnitreeWebRTCConnection(Resource):
             self.task = self.loop.create_task(async_connect())
             self.loop.run_forever()
 
+        CONNECT_TIMEOUT = 30  # seconds
+
         self.loop = asyncio.new_event_loop()
         self.thread = threading.Thread(target=start_background_loop, daemon=True)
         self.thread.start()
-        self.connection_ready.wait()
+
+        if not self.connection_ready.wait(timeout=CONNECT_TIMEOUT):
+            if self.loop.is_running():
+                self.loop.call_soon_threadsafe(self.loop.stop)
+            if self.thread.is_alive():
+                self.thread.join(timeout=2.0)
+            raise TimeoutError(
+                f"WebRTC connection to {self.ip} timed out after {CONNECT_TIMEOUT}s. "
+                "Common causes:\n"
+                "  - Another WebRTC client is connected (close the Unitree mobile app)\n"
+                "  - Robot is unreachable on the network\n"
+                "  - Port 9991 (encrypted SDP) is not responding\n"
+                "Tip: only one WebRTC client can connect to the Go2 at a time."
+            )
 
     def start(self) -> None:
         pass


### PR DESCRIPTION
## Problem

`Blueprint.build()` and direct `UnitreeWebRTCConnection(ip)` hang indefinitely when the WebRTC SDP exchange fails. The root cause is `connection_ready.wait()` in `connect()` has no timeout — if the connection never establishes, the event is never set and the thread blocks forever with no error.

**Common trigger:** Go2 only allows one WebRTC client at a time. If the Unitree mobile app is open, the SDP exchange returns `"sdp": "reject"` and the event never fires. The process appears to hang with no indication of what went wrong.

## Fix

Add a 30-second timeout with thread cleanup and a descriptive `TimeoutError` listing common causes:

```python
CONNECT_TIMEOUT = 30  # seconds

if not self.connection_ready.wait(timeout=CONNECT_TIMEOUT):
    if self.loop.is_running():
        self.loop.call_soon_threadsafe(self.loop.stop)
    if self.thread.is_alive():
        self.thread.join(timeout=2.0)
    raise TimeoutError(
        f"WebRTC connection to {self.ip} timed out after {CONNECT_TIMEOUT}s. "
        "Common causes:\n"
        "  - Another WebRTC client is connected (close the Unitree mobile app)\n"
        "  - Robot is unreachable on the network\n"
        "  - Port 9991 (encrypted SDP) is not responding\n"
        "Tip: only one WebRTC client can connect to the Go2 at a time."
    )
```

## Testing

Tested on: Go2 Pro, stock firmware, STA mode (home WiFi), DimOS v0.0.10.post2, macOS Apple Silicon.

- Normal connection: connects as before, no behavior change
- Mobile app connected: raises `TimeoutError` after 30s with helpful message
- Robot unreachable: raises `TimeoutError` after 30s

Closes #1438 (previous PR targeting main — same fix, retargeted to dev as requested).