### PR TITLE
fix: pyproject version bump for dimos-viewer, viewer now with native keyboard teleop support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,7 +150,7 @@ misc = [
 
 visualization = [
     "rerun-sdk>=0.20.0",
-    "dimos-viewer>=0.30.0a2",
+    "dimos-viewer>=0.30.0a4",
 ]
 
 agents = [

--- a/uv.lock
+++ b/uv.lock
@@ -1992,7 +1992,7 @@ requires-dist = [
     { name = "dimos-lcm" },
     { name = "dimos-lcm", marker = "extra == 'docker'" },
     { name = "dimos-viewer", specifier = ">=0.30.0a2" },
-    { name = "dimos-viewer", marker = "extra == 'visualization'", specifier = ">=0.30.0a2" },
+    { name = "dimos-viewer", marker = "extra == 'visualization'", specifier = ">=0.30.0a4" },
     { name = "drake", marker = "platform_machine != 'aarch64' and sys_platform == 'darwin' and extra == 'manipulation'", specifier = "==1.45.0" },
     { name = "drake", marker = "platform_machine != 'aarch64' and sys_platform != 'darwin' and extra == 'manipulation'", specifier = ">=1.40.0" },
     { name = "edgetam-dimos", marker = "extra == 'misc'" },
@@ -2153,15 +2153,18 @@ wheels = [
 
 [[package]]
 name = "dimos-viewer"
-version = "0.30.0a2"
+version = "0.30.0a4"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/c0/97ed394f078e3e50a55076a86517bf422f75e75f0f85ccfae824c00877b9/dimos_viewer-0.30.0a2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2e64a509d617a4111106b661073e8ef7f416a1007a4c273bc2b6687128c63861", size = 34622193, upload-time = "2026-03-04T22:11:54.575Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/8e/75113b27ec4e63e42e361fd5acd09b65c17a8c67963b745834ecbece0004/dimos_viewer-0.30.0a2-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:600dcb51bbdb239b57c6826493b45ae0fab6b760d42350fca849f1815a6c4b85", size = 40670030, upload-time = "2026-03-04T22:11:57.509Z" },
-    { url = "https://files.pythonhosted.org/packages/86/05/d92d21223d0e3c0b51c264fb4ab1575eae7e76e776279ff7d2ba28291152/dimos_viewer-0.30.0a2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5a1f1f0e2dd9f6977903ec33cddfcad18f48c670d10bcb0a5313bd211f323d6e", size = 34622193, upload-time = "2026-03-04T22:12:00.467Z" },
-    { url = "https://files.pythonhosted.org/packages/96/ea/e49443c35d8fdbdcbcfbcdbc7a96a19dd28c15a2ac70b94baad1d4dda862/dimos_viewer-0.30.0a2-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:b936d624708afe4795e1b88fed908576252435a2419b037da2de7c558590a870", size = 40669950, upload-time = "2026-03-04T22:12:05.088Z" },
-    { url = "https://files.pythonhosted.org/packages/44/bc/88d4ecaf1e013b4125d860be20b4194545bd83436268835847e5d556b589/dimos_viewer-0.30.0a2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:559cfb985028e7acf956ac98432693211459733221c87b8be920d0eb04eb6510", size = 34622194, upload-time = "2026-03-04T21:20:09.199Z" },
-    { url = "https://files.pythonhosted.org/packages/89/cd/28f099b33fd9d6487d849f47409721f9dde7d7435571b06030d8757852af/dimos_viewer-0.30.0a2-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:684c15c66bd32b0f065dda79cef582356975972f7f0e0c5337ec621d34481e2b", size = 40670051, upload-time = "2026-03-04T21:20:13.039Z" },
+    { url = "https://files.pythonhosted.org/packages/49/f3/128202ec9d7bafeede5db43495b3a2fa6038324a70e0d521cbd221aa1e03/dimos_viewer-0.30.0a4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:31c81d031f8833d097bde68771abcc1980502001ca0c99bdcc9f25210542c00a", size = 34629385, upload-time = "2026-03-06T18:11:31.413Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/db/bf6086b5cca5de0ec4de90bc6bad4d0426355019a4f16db77f12308195c9/dimos_viewer-0.30.0a4-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:d43cba801b96a79a685824ef3fb820ec5b0436f38527eb6bf67cc6caa6d26c27", size = 38321847, upload-time = "2026-03-06T18:11:35.349Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/db/d88571d1d9e17689092472eff12f2622075f57be106b33ddb6bcb6f5ff2e/dimos_viewer-0.30.0a4-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:b4e7498e5f61604f8549d45c4eee8bd9ce7b4417ba19c8d53596c0a05dfb3370", size = 40679095, upload-time = "2026-03-06T18:11:39.106Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/8e/4d754bab4969bf4b3f457ed376b5398c507404a3acddc0f006689653b163/dimos_viewer-0.30.0a4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9b59afbb18e027a1c2e04750847082d3116db5bb53f4d1b382317b7ee4637396", size = 34629383, upload-time = "2026-03-06T18:11:42.616Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/71/7f320b2c500fcf29b78c3a3d805954c4c4dfbc7d55145731c129b10b7649/dimos_viewer-0.30.0a4-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:8c98ea5aa2f13af7dbff119642c4f972e286cb1007f97b03cfa878a93e9852e2", size = 38321847, upload-time = "2026-03-06T18:11:45.857Z" },
+    { url = "https://files.pythonhosted.org/packages/27/88/5bcda699c15d763eaaea79f1e74444765bb5c31afeda0b447495e36194b3/dimos_viewer-0.30.0a4-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:66f44bb78d4b93818fbb58598d54dfdae1c9cb9fa073dc9c9580fc8a53a9e1a1", size = 40679088, upload-time = "2026-03-06T18:11:49.598Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/08/5b4cc89adae0f0696a3536b99ae92c138ddb97e79b87a0d8efc73ac574e2/dimos_viewer-0.30.0a4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9c038f551f735944a9c0441907f5bb7ed2744656983404c870f3c78bf3f1bcd5", size = 34629383, upload-time = "2026-03-06T18:11:53.185Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/6b/ec88cd2024a02220b8047584d01d9cbef307646b889963e2b4eb7527b843/dimos_viewer-0.30.0a4-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:b164a866272c8adeadd3b720072b0f0e09574377fda692e01b3d3fec75adcc1a", size = 38321857, upload-time = "2026-03-06T18:11:56.86Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/a5/426213bd2023a77ff96cb2d51b96dd6e2fd5efccb751d356b100a0696a12/dimos_viewer-0.30.0a4-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:7fc1cf45596497062758b0d7278836cad64d12ffeb108e70e8240527856fb018", size = 40679181, upload-time = "2026-03-06T18:12:00.592Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

Bumps version to new keyboard teleop dimos-viewer


## Solution
NA

## Breaking Changes

None


## How to Test



## Contributor License Agreement

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
