### PR TITLE
refactor: rename --viewer-backend to --viewer

### DIFF
--- a/dimos/agents/conftest.py
+++ b/dimos/agents/conftest.py
@@ -78,7 +78,7 @@ def agent_setup(request):
             AgentTestRunner.blueprint(messages=messages),
         )
 
-        global_config.update(viewer_backend="none")
+        global_config.update(viewer="none")
 
         nonlocal coordinator
         coordinator = blueprint.build()

--- a/dimos/agents/mcp/conftest.py
+++ b/dimos/agents/mcp/conftest.py
@@ -77,7 +77,7 @@ def agent_setup(request):
             AgentTestRunner.blueprint(messages=messages),
         )
 
-        global_config.update(viewer_backend="none")
+        global_config.update(viewer="none")
 
         nonlocal coordinator
         coordinator = blueprint.build()

--- a/dimos/core/global_config.py
+++ b/dimos/core/global_config.py
@@ -31,7 +31,7 @@ class GlobalConfig(BaseSettings):
     robot_ips: str | None = None
     simulation: bool = False
     replay: bool = False
-    viewer_backend: ViewerBackend = "rerun-web"
+    viewer: ViewerBackend = "rerun-web"
     n_workers: int = 2
     memory_limit: str = "auto"
     mujoco_camera_position: str | None = None

--- a/dimos/core/test_blueprints.py
+++ b/dimos/core/test_blueprints.py
@@ -39,7 +39,7 @@ from dimos.spec.utils import Spec
 
 # Disable Rerun for tests (prevents viewer spawn and gRPC flush errors)
 _BUILD_WITHOUT_RERUN = {
-    "cli_config_overrides": {"viewer_backend": "none"},
+    "cli_config_overrides": {"viewer": "none"},
 }
 
 

--- a/dimos/core/test_e2e_daemon.py
+++ b/dimos/core/test_e2e_daemon.py
@@ -79,7 +79,7 @@ def _clean_registry(tmp_path, monkeypatch):
 @pytest.fixture()
 def coordinator():
     """Build a PingPong blueprint (1 worker) and yield the coordinator."""
-    global_config.update(viewer_backend="none", n_workers=1)
+    global_config.update(viewer="none", n_workers=1)
     bp = autoconnect(PingModule.blueprint(), PongModule.blueprint())
     coord = bp.build()
     yield coord
@@ -89,7 +89,7 @@ def coordinator():
 @pytest.fixture()
 def coordinator_2w():
     """Build a PingPong blueprint with 2 workers."""
-    global_config.update(viewer_backend="none", n_workers=2)
+    global_config.update(viewer="none", n_workers=2)
     bp = autoconnect(PingModule.blueprint(), PongModule.blueprint())
     coord = bp.build()
     yield coord
@@ -172,7 +172,7 @@ class TestDaemonE2E:
             started_at="2026-03-06T12:00:00+00:00",
             log_dir="/tmp/dimos-detail-test",
             cli_args=["--replay", "ping-pong"],
-            config_overrides={"n_workers": 1, "viewer_backend": "none"},
+            config_overrides={"n_workers": 1, "viewer": "none"},
         )
         entry.save()
 
@@ -183,7 +183,7 @@ class TestDaemonE2E:
         assert raw["started_at"] == "2026-03-06T12:00:00+00:00"
         assert raw["log_dir"] == "/tmp/dimos-detail-test"
         assert raw["cli_args"] == ["--replay", "ping-pong"]
-        assert raw["config_overrides"] == {"n_workers": 1, "viewer_backend": "none"}
+        assert raw["config_overrides"] == {"n_workers": 1, "viewer": "none"}
 
         runs = list_runs()
         assert len(runs) == 1
@@ -224,7 +224,7 @@ class TestDaemonE2E:
 @pytest.fixture()
 def live_blueprint():
     """Build PingPong and register. Yields (coord, entry). Cleans up on teardown."""
-    global_config.update(viewer_backend="none", n_workers=1)
+    global_config.update(viewer="none", n_workers=1)
     bp = autoconnect(PingModule.blueprint(), PongModule.blueprint())
     coord = bp.build()
     run_id = f"e2e-cli-{datetime.now(timezone.utc).strftime('%H%M%S%f')}"

--- a/dimos/core/test_native_module.py
+++ b/dimos/core/test_native_module.py
@@ -148,7 +148,7 @@ def test_autoconnect(args_file: str) -> None:
         },
     )
 
-    coordinator = blueprint.global_config(viewer_backend="none").build()
+    coordinator = blueprint.global_config(viewer="none").build()
     try:
         # Validate blueprint wiring: all modules deployed
         native = coordinator.get_instance(StubNativeModule)  # type: ignore[type-var]

--- a/dimos/manipulation/grasping/demo_grasping.py
+++ b/dimos/manipulation/grasping/demo_grasping.py
@@ -45,4 +45,4 @@ demo_grasping = autoconnect(
     ),
     foxglove_bridge(),
     agent(),
-).global_config(viewer_backend="foxglove")
+).global_config(viewer="foxglove")

--- a/dimos/manipulation/manipulation_blueprints.py
+++ b/dimos/manipulation/manipulation_blueprints.py
@@ -403,7 +403,7 @@ xarm_perception = (
             ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
         }
     )
-    .global_config(viewer_backend="foxglove")
+    .global_config(viewer="foxglove")
 )
 
 

--- a/dimos/perception/demo_object_scene_registration.py
+++ b/dimos/perception/demo_object_scene_registration.py
@@ -35,4 +35,4 @@ demo_object_scene_registration = autoconnect(
     object_scene_registration_module(target_frame="world", prompt_mode=YoloePromptMode.LRPC),
     foxglove_bridge(),
     agent(),
-).global_config(viewer_backend="foxglove")
+).global_config(viewer="foxglove")

--- a/dimos/robot/foxglove_bridge.py
+++ b/dimos/robot/foxglove_bridge.py
@@ -58,11 +58,9 @@ class FoxgloveBridge(Module):
     def start(self) -> None:
         super().start()
 
-        # Skip if Rerun is the selected viewer backend
-        if self._global_config and self._global_config.viewer_backend.startswith("rerun"):
-            logger.info(
-                "Foxglove bridge skipped", viewer_backend=self._global_config.viewer_backend
-            )
+        # Skip if Rerun is the selected viewer
+        if self._global_config and self._global_config.viewer.startswith("rerun"):
+            logger.info("Foxglove bridge skipped", viewer=self._global_config.viewer)
             return
 
         def run_bridge() -> None:

--- a/dimos/robot/unitree/g1/blueprints/primitive/uintree_g1_primitive_no_nav.py
+++ b/dimos/robot/unitree/g1/blueprints/primitive/uintree_g1_primitive_no_nav.py
@@ -79,11 +79,11 @@ rerun_config = {
     },
 }
 
-if global_config.viewer_backend == "foxglove":
+if global_config.viewer == "foxglove":
     from dimos.robot.foxglove_bridge import foxglove_bridge
 
     _with_vis = autoconnect(foxglove_bridge())
-elif global_config.viewer_backend.startswith("rerun"):
+elif global_config.viewer.startswith("rerun"):
     from dimos.visualization.rerun.bridge import _resolve_viewer_mode, rerun_bridge
 
     _with_vis = autoconnect(rerun_bridge(viewer_mode=_resolve_viewer_mode(), **rerun_config))

--- a/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_basic.py
+++ b/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_basic.py
@@ -93,14 +93,14 @@ rerun_config = {
 }
 
 
-if global_config.viewer_backend == "foxglove":
+if global_config.viewer == "foxglove":
     from dimos.robot.foxglove_bridge import foxglove_bridge
 
     with_vis = autoconnect(
         _transports_base,
         foxglove_bridge(shm_channels=["/color_image#sensor_msgs.Image"]),
     )
-elif global_config.viewer_backend.startswith("rerun"):
+elif global_config.viewer.startswith("rerun"):
     from dimos.visualization.rerun.bridge import _resolve_viewer_mode, rerun_bridge
 
     with_vis = autoconnect(

--- a/dimos/visualization/rerun/bridge.py
+++ b/dimos/visualization/rerun/bridge.py
@@ -142,7 +142,7 @@ def _default_blueprint() -> Blueprint:
     )
 
 
-# Maps global_config.viewer_backend -> bridge viewer_mode.
+# Maps global_config.viewer -> bridge viewer_mode.
 # Evaluated at blueprint construction time (main process), not in start() (worker process).
 _BACKEND_TO_MODE: dict[str, ViewerMode] = {
     "rerun": "native",
@@ -155,7 +155,7 @@ _BACKEND_TO_MODE: dict[str, ViewerMode] = {
 def _resolve_viewer_mode() -> ViewerMode:
     from dimos.core.global_config import global_config
 
-    return _BACKEND_TO_MODE.get(global_config.viewer_backend, "native")
+    return _BACKEND_TO_MODE.get(global_config.viewer, "native")
 
 
 @dataclass

--- a/dimos/web/websocket_vis/websocket_vis_module.py
+++ b/dimos/web/websocket_vis/websocket_vis_module.py
@@ -107,7 +107,7 @@ class WebsocketVisModule(Module):
 
         Args:
             port: Port to run the web server on
-            cfg: Optional global config for viewer backend settings
+            cfg: Optional global config for viewer settings
         """
         super().__init__(**kwargs)
         self._global_config = cfg
@@ -157,7 +157,7 @@ class WebsocketVisModule(Module):
 
         # Auto-open browser only for rerun-web (dashboard with Rerun iframe + command center)
         # For rerun and foxglove, users access the command center manually if needed
-        if self._global_config.viewer_backend == "rerun-web":
+        if self._global_config.viewer == "rerun-web":
             url = f"http://localhost:{self.port}/"
             logger.info(f"Dimensional Command Center: {url}")
 
@@ -234,7 +234,7 @@ class WebsocketVisModule(Module):
         async def serve_index(request):  # type: ignore[no-untyped-def]
             """Serve appropriate HTML based on viewer mode."""
             # If running native Rerun, redirect to standalone command center
-            if self._global_config.viewer_backend != "rerun-web":
+            if self._global_config.viewer != "rerun-web":
                 return RedirectResponse(url="/command-center")
 
             # Otherwise serve full dashboard with Rerun iframe

--- a/docs/usage/visualization.md
+++ b/docs/usage/visualization.md
@@ -4,29 +4,29 @@ Dimos supports three visualization backends: Rerun (web or native) and Foxglove.
 
 ## Quick Start
 
-Choose your viewer backend via the CLI (preferred):
+Choose your viewer via the CLI (preferred):
 
 ```bash
 # Rerun web viewer (default) - Full vis dashboard and teleop panel in browser
 dimos run unitree-go2
 
-# Explicitly select the viewer backend:
-dimos --viewer-backend rerun run unitree-go2
-dimos --viewer-backend rerun-web run unitree-go2
-dimos --viewer-backend foxglove run unitree-go2
+# Explicitly select the viewer mode:
+dimos --viewer rerun run unitree-go2
+dimos --viewer rerun-web run unitree-go2
+dimos --viewer foxglove run unitree-go2
 ```
 
 Alternative (environment variable):
 
 ```bash
 # Rerun web viewer - Full dashboard in browser
-VIEWER_BACKEND=rerun-web dimos run unitree-go2
+VIEWER=rerun-web dimos run unitree-go2
 
 # Rerun native viewer - native Rerun window + teleop panel at http://localhost:7779
-VIEWER_BACKEND=rerun dimos run unitree-go2
+VIEWER=rerun dimos run unitree-go2
 
 # Foxglove - Use Foxglove Studio instead of Rerun
-VIEWER_BACKEND=foxglove dimos run unitree-go2
+VIEWER=foxglove dimos run unitree-go2
 ```
 
 ## Viewer Modes Explained


### PR DESCRIPTION
Renames the GlobalConfig field `viewer_backend` → `viewer`, which auto-generates the CLI flag as `--viewer` instead of `--viewer-backend`.

Shorter, cleaner. All Python references, comments, and docs updated. No behavioral change.

**15 files, ±30 lines**