### PR TITLE
fix: restore RotatingFileHandler to prevent OOM from unbounded log growth

### DIFF
--- a/dimos/utils/logging_config.py
+++ b/dimos/utils/logging_config.py
@@ -62,7 +62,13 @@ def set_run_log_dir(log_dir: str | Path) -> None:
         for i, handler in enumerate(logger_obj.handlers):
             if isinstance(handler, logging.FileHandler) and handler.baseFilename != str(new_path):
                 handler.close()
-                new_handler = logging.FileHandler(new_path, mode="a", encoding="utf-8")
+                new_handler = logging.handlers.RotatingFileHandler(
+                    new_path,
+                    mode="a",
+                    maxBytes=10 * 1024 * 1024,  # 10 MiB
+                    backupCount=20,
+                    encoding="utf-8",
+                )
                 new_handler.setLevel(handler.level)
                 new_handler.setFormatter(handler.formatter)
                 logger_obj.handlers[i] = new_handler
@@ -273,12 +279,16 @@ def setup_logger(*, level: int | None = None) -> Any:
     console_handler.setFormatter(console_formatter)
     stdlib_logger.addHandler(console_handler)
 
-    # Plain FileHandler (not RotatingFileHandler) — rotation is unsafe with
-    # forkserver workers writing to the same file. Per-run logs are scoped to
-    # a single run so unbounded growth is not a concern.
-    file_handler = logging.FileHandler(
+    # RotatingFileHandler with a size cap to prevent unbounded log growth.
+    # Multiple forkserver workers may each open their own handler to the same
+    # file — a concurrent rotate can lose a few lines, but that is far
+    # preferable to unbounded growth causing OOM on resource-constrained
+    # devices (cameras + LCM at 30 fps can write ~100 MB/min of JSON logs).
+    file_handler = logging.handlers.RotatingFileHandler(
         log_file_path,
         mode="a",
+        maxBytes=10 * 1024 * 1024,  # 10 MiB
+        backupCount=20,
         encoding="utf-8",
     )
 


### PR DESCRIPTION
## Problem

The daemon PR (#1436) replaced `RotatingFileHandler` with plain `FileHandler` in `logging_config.py` to avoid a theoretical race when forkserver workers rotate the same file. However, this removed the 10 MiB × 20 backup size cap entirely.

Blueprints running cameras + LCM at 30 fps write ~100 MB/min of JSON logs. After 5-10 minutes the log file grows to 500 MB–1 GB, triggering the OOM killer and crashing the entire machine. Multiple people have reported this on current `dev`.

## Solution

Restore `RotatingFileHandler` with the original limits (10 MiB per file, 20 backups = 200 MiB cap). Both the main `setup_logger()` handler and the `set_run_log_dir()` migration handler are fixed.

The forkserver rotation race (multiple workers rotating the same file) can theoretically lose a few interleaved log lines, but this never caused issues in practice. Unbounded growth is a production-breaking OOM.

**Changes:**
- `setup_logger()`: `FileHandler` → `RotatingFileHandler(maxBytes=10MiB, backupCount=20)`
- `set_run_log_dir()`: migrated handlers also use `RotatingFileHandler` with same limits

## Breaking Changes

None. Restores pre-#1436 behavior.

## How to Test

```bash
cd /home/ubuntu/dimos
git fetch origin && git checkout fix/logging-oom-unbounded-file-handler
source .venv/bin/activate
# Run any blueprint with camera streams for >5 minutes — should no longer OOM
dimos run unitree-go2-basic --simulation
# Check log files stay bounded:
ls -lh ~/.local/state/dimos/logs/*/main.jsonl*
```

## Contributor License Agreement
- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md)