### PR TITLE
fix: replay mode loops by default instead of stopping at end

### DIFF
--- a/dimos/memory/timeseries/legacy.py
+++ b/dimos/memory/timeseries/legacy.py
@@ -355,13 +355,21 @@ class LegacyPickleStore(TimeSeriesStore[T]):
                 observer.on_completed()
                 return disp
 
+            prev_ts = first_ts
+
             def schedule_emission(message: tuple[float, T]) -> None:
-                nonlocal next_message, is_disposed
+                nonlocal next_message, is_disposed, start_local_time, start_replay_time, prev_ts
 
                 if is_disposed:
                     return
 
                 ts, data = message
+
+                # Detect loop restart: timestamp jumped backwards
+                if ts < prev_ts:
+                    start_local_time = time.time()
+                    start_replay_time = ts
+                prev_ts = ts
 
                 try:
                     next_message = next(iterator)

--- a/dimos/robot/unitree/go2/connection.py
+++ b/dimos/robot/unitree/go2/connection.py
@@ -107,7 +107,7 @@ class ReplayConnection(UnitreeWebRTCConnection):
     ) -> None:
         get_data(self.dir_name)
         self.replay_config = {
-            "loop": kwargs.get("loop"),
+            "loop": kwargs.get("loop", True),
             "seek": kwargs.get("seek"),
             "duration": kwargs.get("duration"),
         }


### PR DESCRIPTION
## Problem

Replay mode plays through the recorded data once and then stops. For development and testing, you want continuous playback so the robot keeps streaming data.

## Solution

- `ReplayConnection` now defaults `loop=True` in its replay config
- Fixed a timing bug in `LegacyPickleStore.stream()` where looped iterations fired instantly because the reference timestamps were never reset on loop restart. Now detects backwards timestamp jumps and resets timing.

**2 files changed, +10 -2**

## How to Test

```bash
dimos --replay run unitree-go2-basic
# Data should continuously loop instead of stopping after ~10s
```

## Contributor License Agreement
- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md)