### PR TITLE
fix: rate-limit rerun bridge to prevent viewer OOM

### DIFF
--- a/dimos/visualization/rerun/bridge.py
+++ b/dimos/visualization/rerun/bridge.py
@@ -261,8 +261,6 @@ class RerunBridgeModule(Module):
         # the viewer with data faster than it can evict, causing OOM.
         if self.config.min_interval_sec > 0:
             now = time.monotonic()
-            if not hasattr(self, "_last_log"):
-                self._last_log: dict[str, float] = {}
             last = self._last_log.get(entity_path, 0.0)
             if now - last < self.config.min_interval_sec:
                 return
@@ -288,6 +286,7 @@ class RerunBridgeModule(Module):
 
         super().start()
 
+        self._last_log: dict[str, float] = {}
         logger.info("Rerun bridge starting", viewer_mode=self.config.viewer_mode)
 
         # Initialize and spawn Rerun viewer


### PR DESCRIPTION
## Problem

After ~1 hour of running `unitree-go2-agentic` with the native Rerun viewer (stock or dimos-viewer), the system locks up:
- All CPU workers at 80%+
- RAM 30GB/31GB, swap 30GB/30GB
- Renderer crashpad handler messages

Killing the viewer process recovers the system — proving the viewer process is the memory hog.

## Root Cause

Rerun's `memory_limit` only governs the chunk store (data it can GC). It does **not** control GPU texture memory, render buffers, or texture caches. When 30fps camera images are logged unthrottled, the renderer's texture cache grows unbounded even though the chunk store stays within limits.

This is upstream Rerun behavior — affects both stock `rerun` and `dimos-viewer`.

## Fix

Per-entity-path rate limiting in `RerunBridgeModule._on_message()`:
- Default: 10 Hz max per entity path (`min_interval_sec=0.1`)
- Drops frames between intervals instead of logging every one
- Configurable: set `min_interval_sec=0` to disable for low-bandwidth deployments
- 30fps camera → 10fps to viewer = 3x less texture memory pressure

## Changes

- `bridge.py`: Add `min_interval_sec` to Config, rate-limit in `_on_message()`
- No viewer rebuild needed
- No breaking changes (new config field has default value)