### PR TITLE
fix TUI tools on MacOS/Linux when network not configured

### DIFF
--- a/dimos/utils/cli/dtop.py
+++ b/dimos/utils/cli/dtop.py
@@ -198,7 +198,11 @@ class ResourceSpyApp(App[None]):
     def __init__(self, topic_name: str = "/dimos/resource_stats") -> None:
         super().__init__()
         self._topic_name = topic_name
+        # start LCM before .run() takes over the terminal (raw mode),
+        # because autoconf uses typer.confirm() which deadlocks inside a TUI.
         self._lcm = PickleLCM(autoconf=True)
+        self._lcm.subscribe(Topic(self._topic_name), self._on_msg)
+        self._lcm.start()
         self._lock = threading.Lock()
         self._latest: dict[str, Any] | None = None
         self._last_msg_time: float = 0.0
@@ -209,8 +213,6 @@ class ResourceSpyApp(App[None]):
             yield Static(id="panels")
 
     def on_mount(self) -> None:
-        self._lcm.subscribe(Topic(self._topic_name), self._on_msg)
-        self._lcm.start()
         self.set_interval(0.5, self._refresh)
 
     async def on_unmount(self) -> None:

--- a/dimos/utils/cli/lcmspy/run_lcmspy.py
+++ b/dimos/utils/cli/lcmspy/run_lcmspy.py
@@ -80,7 +80,10 @@ class LCMSpyApp(App):  # type: ignore[type-arg]
 
     def __init__(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
         super().__init__(*args, **kwargs)
+        # start LCM before .run() takes over the terminal (raw mode),
+        # because autoconf uses typer.confirm() which deadlocks inside a TUI.
         self.spy = GraphLCMSpy(autoconf=True, graph_log_window=0.5)
+        self.spy.start()
         self.table: DataTable | None = None  # type: ignore[type-arg]
 
     def compose(self) -> ComposeResult:
@@ -92,7 +95,6 @@ class LCMSpyApp(App):  # type: ignore[type-arg]
         yield self.table
 
     def on_mount(self) -> None:
-        self.spy.start()
         self.set_interval(self.refresh_interval, self.refresh_table)
 
     async def on_unmount(self) -> None:


### PR DESCRIPTION
## Problem

Stuff like `lcmspy` doesn't work when the system isn't configured (Linux and MacOS)

Why?
- TUI takes over STDIN
- then `configure_system` runs, and tries to ask for yes/no input
- deadlock because user can't confirm yes/no 

## Solution

- patch so that system conf runs before starting the TUI system

## Breaking Changes

None

## How to Test

de-configure your multicast or network settings (maybe reboot) then run `lcmspy`

## Contributor License Agreement

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
