### PR TITLE
fix: use sim camera intrinsics in viewer

### DIFF
--- a/dimos/robot/unitree/go2/connection.py
+++ b/dimos/robot/unitree/go2/connection.py
@@ -205,6 +205,9 @@ class GO2Connection(Module, spec.Camera, spec.Pointcloud):
         ip = ip if ip is not None else self._global_config.robot_ip
         self.connection = make_connection(ip, self._global_config)
 
+        if self._global_config.simulation:
+            self.camera_info_static = self.connection.camera_info_static
+
         Module.__init__(self, *args, **kwargs)
 
     @rpc
@@ -290,7 +293,7 @@ class GO2Connection(Module, spec.Camera, spec.Pointcloud):
 
     def publish_camera_info(self) -> None:
         while True:
-            self.camera_info.publish(_camera_info_static())
+            self.camera_info.publish(self.camera_info_static)
             time.sleep(1.0)
 
     @rpc

--- a/dimos/robot/unitree/go2/connection.py
+++ b/dimos/robot/unitree/go2/connection.py
@@ -205,7 +205,7 @@ class GO2Connection(Module, spec.Camera, spec.Pointcloud):
         ip = ip if ip is not None else self._global_config.robot_ip
         self.connection = make_connection(ip, self._global_config)
 
-        if self._global_config.simulation:
+        if hasattr(self.connection, "camera_info_static"):
             self.camera_info_static = self.connection.camera_info_static
 
         Module.__init__(self, *args, **kwargs)


### PR DESCRIPTION
## Problem

In simulation mode (Mujoco) the Rerun camera view rendered the image in the top-left corner instead of correctly. The `publish_camera_info` loop always fell back to the hardcoded Go2 camera intrinsics via `_camera_info_static()`, ignoring Mujoco's computed intrinsics

## Solution

When running in sim, `self.camera_info_static` is set from the Mujoco connection's computed intrinsics. `publish_camera_info` now simply publishes `self.camera_info_static` directly

## Breaking Changes

None

## How to Test

- Run `dimos --simulation run unitree-go2`
- camera image renders correctly in the viewport (not stuck in top-left corner)
- no change in behavior with hardware

## Contributor License Agreement

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).

Before&After
<img width="295" height="202" alt="Screenshot from 2026-03-10 13-44-56" src="https://github.com/user-attachments/assets/19e72e9e-1c77-48b7-884e-0732f67d9a14" />
<img width="295" height="202" alt="Screenshot from 2026-03-10 13-42-46" src="https://github.com/user-attachments/assets/abedb7f1-002b-4e99-b304-39a9577795d1" />