### PR TITLE
docs: README additions: temporal-memory fix, formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ dimos run unitree-go2
 | Run command | What it does |
 |-------------|-------------|
 | `dimos --replay run unitree-go2` | Go2 navigation replay — SLAM, costmap, A* planning |
-| `dimos --replay --replay-dir unitree_go2_office_walk2 run unitree-go2` | Go2 temporal memory replay |
+| `dimos --replay --replay-dir unitree_go2_office_walk2 run unitree-go2-temporal-memory` | Go2 temporal memory replay |
 | `dimos --simulation run unitree-go2-agentic-mcp` | Go2 agentic + MCP server in simulation |
 | `dimos --simulation run unitree-g1` | G1 humanoid in MuJoCo simulation |
 | `dimos --replay run drone-basic` | Drone video + telemetry replay |

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ uv venv --python "3.12"
 source .venv/bin/activate
 uv pip install 'dimos[base,unitree]'
 
-# Replay a recorded Go2 session (no hardware needed)
+# Replay a recorded quadruped session (no hardware needed)
 # NOTE: First run will show a black rerun window while ~75 MB downloads from LFS
 dimos --replay run unitree-go2
 ```
@@ -168,15 +168,15 @@ dimos --replay run unitree-go2
 # Install with simulation support
 uv pip install 'dimos[base,unitree,sim]'
 
-# Run Go2 in MuJoCo simulation
+# Run quadruped in MuJoCo simulation
 dimos --simulation run unitree-go2
 
-# Run G1 humanoid in simulation
+# Run humanoid in simulation
 dimos --simulation run unitree-g1-sim
 ```
 
 ```bash
-# Control a real robot (Unitree Go2 over WebRTC)
+# Control a real robot (Unitree quadruped over WebRTC)
 export ROBOT_IP=<YOUR_ROBOT_IP>
 dimos run unitree-go2
 ```
@@ -185,15 +185,15 @@ dimos run unitree-go2
 
 | Run command | What it does |
 |-------------|-------------|
-| `dimos --replay run unitree-go2` | Go2 navigation replay — SLAM, costmap, A* planning |
-| `dimos --replay --replay-dir unitree_go2_office_walk2 run unitree-go2-temporal-memory` | Go2 temporal memory replay |
-| `dimos --simulation run unitree-go2-agentic-mcp` | Go2 agentic + MCP server in simulation |
-| `dimos --simulation run unitree-g1` | G1 humanoid in MuJoCo simulation |
+| `dimos --replay run unitree-go2` | Quadruped navigation replay — SLAM, costmap, A* planning |
+| `dimos --replay --replay-dir unitree_go2_office_walk2 run unitree-go2-temporal-memory` | Quadruped temporal memory replay |
+| `dimos --simulation run unitree-go2-agentic-mcp` | Quadruped agentic + MCP server in simulation |
+| `dimos --simulation run unitree-g1` | Humanoid in MuJoCo simulation |
 | `dimos --replay run drone-basic` | Drone video + telemetry replay |
 | `dimos --replay run drone-agentic` | Drone + LLM agent with flight skills (replay) |
 | `dimos run demo-camera` | Webcam demo — no hardware needed |
 | `dimos run keyboard-teleop-xarm7` | Keyboard teleop with mock xArm7 (requires `dimos[manipulation]` extra) |
-| `dimos --simulation run unitree-go2-agentic-ollama` | Go2 agentic with local LLM (requires [Ollama](https://ollama.com) + `ollama serve`) |
+| `dimos --simulation run unitree-go2-agentic-ollama` | Quadruped agentic with local LLM (requires [Ollama](https://ollama.com) + `ollama serve`) |
 
 > Full blueprint docs: [docs/usage/blueprints.md](docs/usage/blueprints.md)
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Dimensional is agent native -- "vibecode" your robots in natural language and bu
       <a href="docs/capabilities/agents/readme.md"><img src="assets/readme/agentic_control.gif" alt="Agents" width="100%"></a>
     </td>
     <td align="center" width="50%">
-      <img src="assets/readme/spatial_memory.gif" alt="Spatial Memory" width="100%"></a>
+      <img src="assets/readme/spatial_memory.gif" alt="Spatial Memory" width="100%">
     </td>
   </tr>
   <tr>
@@ -113,8 +113,8 @@ Dimensional is agent native -- "vibecode" your robots in natural language and bu
       🟨 <a href="docs/capabilities/manipulation/readme.md">AgileX Piper</a><br>
     </td>
     <td align="center" width="20%">
-      🟧 <a href="dimos/robot/drone">MAVLink</a><br>
-      🟧 <a href="dimos/robot/drone">DJI Mavic</a><br>
+      🟧 <a href="dimos/robot/drone/README.md">MAVLink</a><br>
+      🟧 <a href="dimos/robot/drone/README.md">DJI Mavic</a><br>
     </td>
     <td align="center" width="20%">
       🟥 <a href="https://github.com/dimensionalOS/openFT-sensor">Force Torque Sensor</a><br>


### PR DESCRIPTION
- Add `dimos run demo-camera` to featured runfiles
- Fix temporal memory runfile to use `unitree-go2-temporal-memory` blueprint
- Use `unitree-go2-agentic-mcp` in CLI example
- Note `dimos[manipulation]` extra required for xarm runfile