### PR TITLE
fix(ci): limit tests to 60 minutes max

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,7 @@ permissions:
 
 jobs:
   run-tests:
+    timeout-minutes: 60
     runs-on: [self-hosted, Linux]
     container:
       image: ghcr.io/dimensionalos/${{ inputs.dev-image }}


### PR DESCRIPTION
## Problem

Some runs get stuck. This has been running for 5+ hours: https://github.com/dimensionalOS/dimos/actions/runs/23092926633/job/67080566689?pr=1536

Closes DIM-XXX

## Solution

* Limit to 60 minutes

## Breaking Changes

<!-- Write "None" if not applicable -->

<!-- If applicable:
- what breaks
- who is affected
- migration steps
-->

## How to Test

<!-- MUST be reproducible. If this section is weak, reviewers can't approve confidently. -->

## Contributor License Agreement

- [ ] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
