### PR TITLE
docs(readme): add Trendshift trending badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 ![CUDA](https://img.shields.io/badge/CUDA-supported-76B900?style=flat-square&logo=nvidia&logoColor=white)
 [![Docker](https://img.shields.io/badge/Docker-ready-2496ED?style=flat-square&logo=docker&logoColor=white)](https://www.docker.com/)
 
+<a href="https://trendshift.io/repositories/23169" target="_blank"><img src="https://trendshift.io/api/badge/repositories/23169" alt="dimensionalOS%2Fdimos | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+
 <big><big>
 
 [Hardware](#hardware) •


### PR DESCRIPTION
## Problem
DimOS is #3 trending on GitHub — should show it off in the README.

## Solution
Added Trendshift badge between the shields.io badge row and the nav links, centered in the header section.

## Breaking Changes
None

## How to Test
Check the README renders correctly on GitHub.

## Contributor License Agreement
- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md)