### PR TITLE
docs: add Spec issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/spec.yml
+++ b/.github/ISSUE_TEMPLATE/spec.yml
@@ -1,0 +1,28 @@
+name: Spec
+description: Technical specification for a new module, feature, or system change
+title: "[Spec]: "
+body:
+  - type: textarea
+    id: spec
+    attributes:
+      label: Specification
+      description: Full technical spec in markdown
+      value: |
+        ## Summary
+        <!-- One sentence: what this adds/changes and why -->
+
+        ## Motivation
+        <!-- What problem does this solve? Link related issues. -->
+
+        ## Design
+
+        ### API / Interface
+        <!-- Public API, CLI flags, stream types, config options -->
+
+        ### Architecture
+        <!-- How it fits into DimOS. Which modules, streams, blueprints are involved? -->
+
+        ### Implementation Notes
+        <!-- Key decisions, algorithms, dependencies, constraints -->
+    validations:
+      required: true


### PR DESCRIPTION
Adds a Spec category to GitHub issue templates — single markdown text box for technical specifications.

## Contributor License Agreement
- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md)