### PR TITLE
chore: close stale prs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,30 @@
+name: Close stale PRs
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 23
+          days-before-close: 7
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it
+            has not had recent activity. It will be closed in 7 days if no
+            further activity occurs.
+          close-pr-message: >
+            This pull request has been automatically closed because it has been
+            stale for 30 days with no activity. Feel free to reopen it if you
+            plan to continue working on it.
+          stale-pr-label: stale
+          exempt-pr-labels: pinned,do-not-close
+          days-before-issue-stale: -1
+          days-before-issue-close: -1


### PR DESCRIPTION
## Problem

Some PRs just stay open forever.

## Solution

* Sends a warning that the PR is stale after 30 days. After 7 more days it closes it.

## Breaking Changes

None.