### PR TITLE
Ruthwik/rerun bg

### DIFF
--- a/dimos/robot/unitree/g1/blueprints/primitive/uintree_g1_primitive_no_nav.py
+++ b/dimos/robot/unitree/g1/blueprints/primitive/uintree_g1_primitive_no_nav.py
@@ -77,12 +77,20 @@ def _static_base_link(rr: Any) -> list[Any]:
 
 def _g1_rerun_blueprint() -> Any:
     """Split layout: camera feed + 3D world view side by side."""
+    import rerun as rr
     import rerun.blueprint as rrb
 
     return rrb.Blueprint(
         rrb.Horizontal(
             rrb.Spatial2DView(origin="world/color_image", name="Camera"),
-            rrb.Spatial3DView(origin="world", name="3D"),
+            rrb.Spatial3DView(
+                origin="world",
+                name="3D",
+                background=rrb.Background(kind="SolidColor", color=[0, 0, 0]),
+                line_grid=rrb.LineGrid3D(
+                    plane=rr.components.Plane3D.XY.with_distance(0.2),
+                ),
+            ),
             column_shares=[1, 2],
         ),
     )

--- a/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_basic.py
+++ b/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_basic.py
@@ -74,12 +74,20 @@ def _static_base_link(rr: Any) -> list[Any]:
 
 def _go2_rerun_blueprint() -> Any:
     """Split layout: camera feed + 3D world view side by side."""
+    import rerun as rr
     import rerun.blueprint as rrb
 
     return rrb.Blueprint(
         rrb.Horizontal(
             rrb.Spatial2DView(origin="world/color_image", name="Camera"),
-            rrb.Spatial3DView(origin="world", name="3D"),
+            rrb.Spatial3DView(
+                origin="world",
+                name="3D",
+                background=rrb.Background(kind="SolidColor", color=[0, 0, 0]),
+                line_grid=rrb.LineGrid3D(
+                    plane=rr.components.Plane3D.XY.with_distance(0.2),
+                ),
+            ),
             column_shares=[1, 2],
         ),
     )


### PR DESCRIPTION
## Problem

rerun blueprint bg/grid modification

closes #1630 

## Solution

-Set pure black background (SolidColor [0,0,0]) on Go2 and G1 Spatial3DView blueprints to replace the default Rerun gradient
- Raise the grid plane 0.2m above ground so it renders above the costmap instead of underneath it

## Breaking Changes

None

## How to Test

Any go2 blueprint

## Contributor License Agreement

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).

<img width="946" height="640" alt="Screenshot from 2026-03-26 19-20-15" src="https://github.com/user-attachments/assets/2ae898fc-6a21-4c23-af10-5d575109bdb8" />
