### PR TITLE
feat(tool-streams): add tool streams

### DIFF
--- a/dimos/agents/annotation.py
+++ b/dimos/agents/annotation.py
@@ -13,14 +13,59 @@
 # limitations under the License.
 
 from collections.abc import Callable
+import functools
+import inspect
+import threading
 from typing import Any, TypeVar, cast
 
 from dimos.core.core import rpc
 
 F = TypeVar("F", bound=Callable[..., Any])
 
+_SKILL_CONTEXT = threading.local()
+
+
+def current_skill_context() -> dict[str, Any] | None:
+    """Return the per-call context for the currently executing `@skill`.
+
+    Returns a (possibly empty) dict inside a `@skill` call and `None` when no
+    skill is currently on the stack in this thread. The MCP server populates
+    `{"progress_token": <token>}` when the caller supplied
+    `params._meta.progressToken`. Otherwise the dict is empty. Downstream code
+    uses the `None` vs. `{}` distinction to tell "outside any skill" from
+    "inside a skill that didn't get a token."
+    """
+    return getattr(_SKILL_CONTEXT, "context", None)
+
 
 def skill(func: F) -> F:
-    wrapped = rpc(func)
+    if inspect.iscoroutinefunction(func):
+
+        @functools.wraps(func)
+        async def async_context_wrapper(*args: Any, **kwargs: Any) -> Any:
+            context = kwargs.pop("_mcp_context", None) or {}
+            previous = getattr(_SKILL_CONTEXT, "context", None)
+            _SKILL_CONTEXT.context = context
+            try:
+                return await func(*args, **kwargs)
+            finally:
+                _SKILL_CONTEXT.context = previous
+
+        context_wrapper: Callable[..., Any] = async_context_wrapper
+    else:
+
+        @functools.wraps(func)
+        def sync_context_wrapper(*args: Any, **kwargs: Any) -> Any:
+            context = kwargs.pop("_mcp_context", None) or {}
+            previous = getattr(_SKILL_CONTEXT, "context", None)
+            _SKILL_CONTEXT.context = context
+            try:
+                return func(*args, **kwargs)
+            finally:
+                _SKILL_CONTEXT.context = previous
+
+        context_wrapper = sync_context_wrapper
+
+    wrapped = rpc(context_wrapper)
     wrapped.__skill__ = True  # type: ignore[attr-defined]
     return cast("F", wrapped)

--- a/dimos/agents/mcp/fixtures/test_tool_stream_agent.json
+++ b/dimos/agents/mcp/fixtures/test_tool_stream_agent.json
@@ -1,0 +1,33 @@
+{
+  "responses": [
+    {
+      "content": "",
+      "tool_calls": [
+        {
+          "name": "start_streaming",
+          "args": {
+            "count": 3
+          },
+          "id": "call_toolstream_001",
+          "type": "tool_call"
+        }
+      ]
+    },
+    {
+      "content": "I've started the streaming process. You'll receive 3 updates shortly.",
+      "tool_calls": []
+    },
+    {
+      "content": "Received the first streaming update: Update 1 of 3.",
+      "tool_calls": []
+    },
+    {
+      "content": "Received the second streaming update: Update 2 of 3.",
+      "tool_calls": []
+    },
+    {
+      "content": "Received the third and final streaming update: Update 3 of 3. All updates complete.",
+      "tool_calls": []
+    }
+  ]
+}

--- a/dimos/agents/mcp/mcp_client.py
+++ b/dimos/agents/mcp/mcp_client.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import Callable
 from queue import Empty, Queue
 from threading import Event, RLock, Thread
 import time
@@ -26,6 +27,7 @@ from langchain_core.tools import StructuredTool
 from langgraph.graph.state import CompiledStateGraph
 from reactivex.disposable import Disposable
 
+from dimos.agents.mcp import tool_stream
 from dimos.agents.system_prompt import SYSTEM_PROMPT
 from dimos.agents.utils import pretty_print_langchain_message
 from dimos.constants import DEFAULT_THREAD_JOIN_TIMEOUT
@@ -61,6 +63,7 @@ class McpClient(Module):
     _stop_event: Event
     _http_client: httpx.Client
     _seq_ids: SequentialIds
+    _tool_stream_cleanup: Callable[[], None] | None
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
@@ -77,6 +80,7 @@ class McpClient(Module):
         self._stop_event = Event()
         self._http_client = httpx.Client(timeout=120.0)
         self._seq_ids = SequentialIds()
+        self._tool_stream_cleanup = None
 
     def __reduce__(self) -> Any:
         return (self.__class__, (), {})
@@ -99,6 +103,32 @@ class McpClient(Module):
 
         result: dict[str, Any] = data.get("result")
         return result
+
+    def _mcp_tool_call(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        progress_token = str(uuid.uuid4())
+        return self._mcp_request(
+            "tools/call",
+            {
+                "name": name,
+                "arguments": arguments,
+                "_meta": {"progressToken": progress_token},
+            },
+        )
+
+    def _on_tool_stream_message(self, msg: dict[str, Any]) -> None:
+        method = msg.get("method")
+        params = msg.get("params") or {}
+        if method == tool_stream.NOTIFICATIONS_PROGRESS_METHOD:
+            text = params.get("message") or ""
+            tool_name = (params.get("_meta") or {}).get("tool_name") or "tool"
+        elif method == tool_stream.NOTIFICATIONS_MESSAGE_METHOD:
+            text = params.get("data") or ""
+            tool_name = params.get("logger") or "tool"
+        else:
+            return
+        if not text:
+            return
+        self._message_queue.put(HumanMessage(content=f"[tool:{tool_name}] {text}"))
 
     def _fetch_tools(self, timeout: float = 60.0, interval: float = 1.0) -> list[StructuredTool]:
         result = self._try_fetch_tools(timeout=timeout, interval=interval)
@@ -139,7 +169,7 @@ class McpClient(Module):
         input_schema = mcp_tool.get("inputSchema", {"type": "object", "properties": {}})
 
         def call_tool(**kwargs: Any) -> str:
-            result = self._mcp_request("tools/call", {"name": name, "arguments": kwargs})
+            result = self._mcp_tool_call(name, kwargs)
             content = result.get("content", [])
             parts = [c.get("text", "") for c in content if c.get("type") == "text"]
             text = "\n".join(parts)
@@ -171,6 +201,13 @@ class McpClient(Module):
 
         self.register_disposable(Disposable(self.human_input.subscribe(_on_human_input)))
 
+        # Subscribe directly over LCM rather than through the server's GET
+        # /mcp SSE channel.  HTTP would add a startup race: the first few
+        # updates of a short-lived stream can fire before the SSE connection
+        # is established.  External clients like Claude Code still use GET
+        # /mcp, which the server fans out to from the same LCM topic.
+        self._tool_stream_cleanup = tool_stream.subscribe(self._on_tool_stream_message)
+
     @rpc
     def on_system_modules(self, _modules: list[RPCClient]) -> None:
         tools = self._fetch_tools()
@@ -192,6 +229,11 @@ class McpClient(Module):
 
     @rpc
     def stop(self) -> None:
+        # Unsubscribe first so no new tool-stream messages can arrive while
+        # the worker thread is draining and joining.
+        if self._tool_stream_cleanup is not None:
+            self._tool_stream_cleanup()
+            self._tool_stream_cleanup = None
         self._stop_event.set()
         if self._thread.is_alive():
             self._thread.join(timeout=DEFAULT_THREAD_JOIN_TIMEOUT)
@@ -243,7 +285,7 @@ class McpClient(Module):
                     tool_args[key] = continuation_context[context_key]
 
         try:
-            result = self._mcp_request("tools/call", {"name": tool_name, "arguments": tool_args})
+            result = self._mcp_tool_call(tool_name, tool_args)
             content = result.get("content", [])
             parts = [c.get("text", "") for c in content if c.get("type") == "text"]
             text = "\n".join(parts)

--- a/dimos/agents/mcp/mcp_server.py
+++ b/dimos/agents/mcp/mcp_server.py
@@ -14,6 +14,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import AsyncGenerator, Callable
 import concurrent.futures
 import json
 import os
@@ -24,10 +25,11 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from starlette.requests import Request
-from starlette.responses import Response
+from starlette.responses import Response, StreamingResponse
 import uvicorn
 
 from dimos.agents.annotation import skill
+from dimos.agents.mcp import tool_stream
 from dimos.core.core import rpc
 from dimos.core.module import Module
 from dimos.core.rpc_client import RpcCall, RPCClient
@@ -39,15 +41,19 @@ if TYPE_CHECKING:
 logger = setup_logger()
 
 
+_SSE_KEEPALIVE_INTERVAL = 20.0  # seconds
+
 app = FastAPI()
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
-    allow_methods=["POST"],
+    allow_methods=["POST", "GET"],
     allow_headers=["*"],
 )
 app.state.skills = []
 app.state.rpc_calls = {}
+app.state.sse_queues = []
+app.state.event_loop = None
 
 
 def _jsonrpc_result(req_id: Any, result: Any) -> dict[str, Any]:
@@ -67,7 +73,7 @@ def _handle_initialize(req_id: Any) -> dict[str, Any]:
         req_id,
         {
             "protocolVersion": "2025-11-25",
-            "capabilities": {"tools": {}},
+            "capabilities": {"tools": {}, "logging": {}},
             "serverInfo": {"name": "dimensional", "version": "1.0.0"},
         },
     )
@@ -93,28 +99,34 @@ async def _handle_tools_call(
 ) -> dict[str, Any]:
     name = params.get("name", "")
     args: dict[str, Any] = params.get("arguments") or {}
+    meta = params.get("_meta") or {}
+    progress_token = meta.get("progressToken")
 
     rpc_call = rpc_calls.get(name)
     if rpc_call is None:
         logger.warning("MCP tool not found", tool=name)
         return _jsonrpc_result_text(req_id, f"Tool not found: {name}")
 
-    logger.info("MCP tool call", tool=name, args=args)
+    logger.info("MCP tool call", tool=name, args=args, progress_token=progress_token)
     t0 = time.monotonic()
 
+    # _mcp_context is a reserved kwarg consumed by the `@skill` wrapper;
+    # it never reaches the user-visible skill signature.
+    call_kwargs = dict(args)
+    if progress_token is not None:
+        call_kwargs["_mcp_context"] = {"progress_token": progress_token}
+
     try:
-        result = await asyncio.get_event_loop().run_in_executor(None, lambda: rpc_call(**args))
+        result = await asyncio.get_event_loop().run_in_executor(
+            None, lambda: rpc_call(**call_kwargs)
+        )
     except Exception as e:
         logger.exception("MCP tool error", tool=name, duration=f"{time.monotonic() - t0:.3f}s")
         return _jsonrpc_result_text(req_id, f"Error running tool '{name}': {e}")
 
     duration = f"{time.monotonic() - t0:.3f}s"
-
-    if result is None:
-        logger.info("MCP tool done (async)", tool=name, duration=duration)
-        return _jsonrpc_result_text(req_id, "It has started. You will be updated later.")
-
     response = str(result)[:200]
+
     if hasattr(result, "agent_encode"):
         logger.info("MCP tool done", tool=name, duration=duration, response=response)
         return _jsonrpc_result(req_id, {"content": result.agent_encode()})
@@ -161,23 +173,99 @@ async def mcp_endpoint(request: Request) -> Response:
             {"jsonrpc": "2.0", "id": None, "error": {"code": -32700, "message": "Parse error"}},
             status_code=400,
         )
+
     result = await handle_request(body, request.app.state.skills, request.app.state.rpc_calls)
+
     if result is None:
         return Response(status_code=204)
     return JSONResponse(result)
 
 
+def _sse_frame(data: dict[str, Any]) -> str:
+    """Format a JSON-RPC message as an SSE ``event: message`` frame."""
+    return f"event: message\ndata: {json.dumps(data)}\n\n"
+
+
+def _fan_out_to_sse_queues(msg: dict[str, Any]) -> None:
+    """LCM subscriber callback: forward a tool-stream frame to every active SSE client."""
+    loop = app.state.event_loop
+    if loop is None:
+        return
+    for queue in list(app.state.sse_queues):
+        try:
+            asyncio.run_coroutine_threadsafe(queue.put(msg), loop)
+        except RuntimeError:
+            pass
+
+
+@app.get("/mcp")
+async def mcp_sse_endpoint() -> StreamingResponse:
+    """Persistent server-to-client SSE channel for MCP notifications.
+
+    This is the Streamable-HTTP transport's out-of-band channel for
+    server-initiated messages.  Every tool-stream update is fanned out here,
+    so the subscription is live for the full client session and independent
+    of any particular ``tools/call`` request.
+    """
+    queue: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue()
+    # Remember the loop so the LCM subscriber (running on an LCM thread)
+    # can schedule queue.put via run_coroutine_threadsafe.
+    app.state.event_loop = asyncio.get_running_loop()
+    app.state.sse_queues.append(queue)
+
+    async def event_generator() -> AsyncGenerator[str, None]:
+        try:
+            # Initial comment flushes the response headers and unblocks
+            # any synchronous client that's waiting on iter_lines().
+            yield ": connected\n\n"
+            while True:
+                try:
+                    msg = await asyncio.wait_for(queue.get(), timeout=_SSE_KEEPALIVE_INTERVAL)
+                except asyncio.TimeoutError:
+                    yield ": keepalive\n\n"
+                    continue
+                if msg is None:
+                    return
+                yield _sse_frame(msg)
+        except asyncio.CancelledError:
+            pass
+        finally:
+            try:
+                app.state.sse_queues.remove(queue)
+            except ValueError:
+                pass
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "Connection": "keep-alive"},
+    )
+
+
 class McpServer(Module):
     _uvicorn_server: uvicorn.Server | None = None
     _serve_future: concurrent.futures.Future[None] | None = None
+    _tool_stream_cleanup: Callable[[], None] | None = None
 
     @rpc
     def start(self) -> None:
         super().start()
         self._start_server()
+        self._tool_stream_cleanup = tool_stream.subscribe(_fan_out_to_sse_queues)
 
     @rpc
     def stop(self) -> None:
+        if self._tool_stream_cleanup is not None:
+            self._tool_stream_cleanup()
+            self._tool_stream_cleanup = None
+
+        for queue in list(app.state.sse_queues):
+            try:
+                queue.put_nowait(None)
+            except Exception:
+                pass
+        app.state.sse_queues.clear()
+
         if self._uvicorn_server:
             self._uvicorn_server.should_exit = True
             loop = self._loop
@@ -248,7 +336,7 @@ class McpServer(Module):
 
         _port = port if port is not None else global_config.mcp_port
         _host = global_config.listen_host
-        config = uvicorn.Config(app, host=_host, port=_port, log_level="info")
+        config = uvicorn.Config(app, host=_host, port=_port, log_level="warning", access_log=False)
         server = uvicorn.Server(config)
         self._uvicorn_server = server
         loop = self._loop

--- a/dimos/agents/mcp/test_mcp_client_unit.py
+++ b/dimos/agents/mcp/test_mcp_client_unit.py
@@ -14,8 +14,11 @@
 from __future__ import annotations
 
 import json
+from queue import Empty, Queue
 from unittest.mock import MagicMock, patch
 
+from langchain_core.messages import HumanMessage
+from langchain_core.messages.base import BaseMessage
 import pytest
 
 from dimos.agents.mcp.mcp_client import McpClient
@@ -143,3 +146,86 @@ def test_mcp_request_error_propagation(mcp_client: McpClient) -> None:
         raise AssertionError("Expected RuntimeError")
     except RuntimeError as e:
         assert "Unknown: bad/method" in str(e)
+
+
+def test_tool_stream_notification_becomes_human_message(mcp_client: McpClient) -> None:
+    """A `notifications/message` delivered over LCM becomes a HumanMessage."""
+    mcp_client._message_queue = Queue()
+
+    notification = {
+        "jsonrpc": "2.0",
+        "method": "notifications/message",
+        "params": {
+            "level": "info",
+            "logger": "follow_person",
+            "data": "Person follow stopped: lost track.",
+        },
+    }
+    mcp_client._on_tool_stream_message(notification)
+
+    msg: BaseMessage = mcp_client._message_queue.get_nowait()
+    assert isinstance(msg, HumanMessage)
+    assert "[tool:follow_person]" in str(msg.content)
+    assert "Person follow stopped: lost track." in str(msg.content)
+
+
+def test_tool_stream_ignores_unrelated_frames(mcp_client: McpClient) -> None:
+    """Unknown methods and empty bodies are dropped on the floor."""
+
+    mcp_client._message_queue = Queue()
+
+    mcp_client._on_tool_stream_message({"jsonrpc": "2.0", "method": "notifications/other"})
+    mcp_client._on_tool_stream_message(
+        {"jsonrpc": "2.0", "method": "notifications/message", "params": {"data": ""}}
+    )
+    mcp_client._on_tool_stream_message(
+        {"jsonrpc": "2.0", "method": "notifications/progress", "params": {"message": ""}}
+    )
+
+    with pytest.raises(Empty):
+        mcp_client._message_queue.get_nowait()
+
+
+def test_tool_stream_progress_frame_becomes_human_message(mcp_client: McpClient) -> None:
+    """A `notifications/progress` frame is routed as a HumanMessage."""
+
+    mcp_client._message_queue = Queue()
+
+    progress_frame = {
+        "jsonrpc": "2.0",
+        "method": "notifications/progress",
+        "params": {
+            "progressToken": "pt-abc",
+            "progress": 1,
+            "message": "Found a person",
+            "_meta": {"tool_name": "follow_person"},
+        },
+    }
+    mcp_client._on_tool_stream_message(progress_frame)
+
+    msg: BaseMessage = mcp_client._message_queue.get_nowait()
+    assert isinstance(msg, HumanMessage)
+    assert str(msg.content) == "[tool:follow_person] Found a person"
+
+
+def test_mcp_tool_call_sends_progress_token(mcp_client: McpClient) -> None:
+    """Every `tools/call` request carries a `_meta.progressToken`."""
+    captured: dict[str, object] = {}
+
+    def fake_request(method: str, params: dict[str, object] | None = None) -> dict[str, object]:
+        captured["method"] = method
+        captured["params"] = params
+        return {"content": [{"type": "text", "text": "ok"}]}
+
+    mcp_client._mcp_request = fake_request
+    mcp_client._mcp_tool_call("add", {"x": 1, "y": 2})
+
+    assert captured["method"] == "tools/call"
+    params = captured["params"]
+    assert isinstance(params, dict)
+    assert params["name"] == "add"
+    assert params["arguments"] == {"x": 1, "y": 2}
+    meta = params["_meta"]
+    assert isinstance(meta, dict)
+    token = meta["progressToken"]
+    assert isinstance(token, str) and len(token) > 0

--- a/dimos/agents/mcp/test_mcp_server.py
+++ b/dimos/agents/mcp/test_mcp_server.py
@@ -65,6 +65,56 @@ def test_mcp_module_request_flow() -> None:
         )
     )
     assert response["result"]["content"][0]["text"] == "5"
+    rpc_calls["add"].assert_called_once_with(x=2, y=3)
+
+
+def test_mcp_module_injects_progress_token_as_mcp_context() -> None:
+    """When the client sends `_meta.progressToken`, the RPC call receives it as
+    an `_mcp_context` kwarg so the `@skill` wrapper can stash it in the
+    thread-local that `ToolStream` reads on construction."""
+    schema = json.dumps({"type": "object", "properties": {"x": {"type": "integer"}}})
+    skills = [SkillInfo(class_name="TestSkills", func_name="echo", args_schema=schema)]
+    rpc_calls = _make_rpc_calls(skills, {"echo": "ok"})
+
+    asyncio.run(
+        handle_request(
+            {
+                "method": "tools/call",
+                "id": 7,
+                "params": {
+                    "name": "echo",
+                    "arguments": {"x": 42},
+                    "_meta": {"progressToken": "pt-srv-test"},
+                },
+            },
+            skills,
+            rpc_calls,
+        )
+    )
+
+    rpc_calls["echo"].assert_called_once_with(x=42, _mcp_context={"progress_token": "pt-srv-test"})
+
+
+def test_mcp_module_without_progress_token_does_not_inject_context() -> None:
+    """Absence of `progressToken` preserves the legacy call shape. The skill
+    sees only the arguments it declared."""
+    schema = json.dumps({"type": "object", "properties": {}})
+    skills = [SkillInfo(class_name="TestSkills", func_name="ping", args_schema=schema)]
+    rpc_calls = _make_rpc_calls(skills, {"ping": "pong"})
+
+    asyncio.run(
+        handle_request(
+            {
+                "method": "tools/call",
+                "id": 8,
+                "params": {"name": "ping", "arguments": {}},
+            },
+            skills,
+            rpc_calls,
+        )
+    )
+
+    rpc_calls["ping"].assert_called_once_with()
 
 
 def test_mcp_module_handles_errors() -> None:

--- a/dimos/agents/mcp/test_tool_stream.py
+++ b/dimos/agents/mcp/test_tool_stream.py
@@ -1,0 +1,531 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from threading import Event, Thread
+import time
+
+import httpx
+from langchain_core.messages import HumanMessage
+import pytest
+
+from dimos.agents import annotation as annotation_module
+from dimos.agents.annotation import skill
+from dimos.agents.mcp.mcp_adapter import McpAdapter
+from dimos.agents.mcp.mcp_server import McpServer
+from dimos.agents.mcp.tool_stream import (
+    NOTIFICATIONS_MESSAGE_METHOD,
+    NOTIFICATIONS_PROGRESS_METHOD,
+    ToolStream,
+    make_notification,
+    make_progress_notification,
+)
+from dimos.constants import DEFAULT_THREAD_JOIN_TIMEOUT
+from dimos.core.coordination.blueprints import autoconnect
+from dimos.core.coordination.module_coordinator import ModuleCoordinator
+from dimos.core.core import rpc
+from dimos.core.global_config import global_config
+from dimos.core.module import Module
+from dimos.protocol.rpc.pubsubrpc import LCMRPC
+
+
+class StreamingModule(Module):
+    """Returns a status string immediately and fires `count` updates from a
+    background thread."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._stream_threads: list[Thread] = []
+        self._stop_streaming = Event()
+
+    @skill
+    def start_streaming(self, count: int) -> str:
+        """Starts streaming count updates back to the agent."""
+        self.start_tool("start_streaming")
+
+        def _stream_loop() -> None:
+            try:
+                for i in range(count):
+                    if self._stop_streaming.wait(timeout=0.1):
+                        return
+                    self.tool_update("start_streaming", f"Update {i + 1} of {count}")
+            finally:
+                self.stop_tool("start_streaming")
+
+        thread = Thread(target=_stream_loop, daemon=True)
+        self._stream_threads.append(thread)
+        thread.start()
+        return f"Started streaming {count} updates."
+
+    @rpc
+    def stop(self) -> None:
+        self._stop_streaming.set()
+        for thread in self._stream_threads:
+            thread.join(timeout=DEFAULT_THREAD_JOIN_TIMEOUT)
+        super().stop()
+
+
+@pytest.fixture
+def mcp_server():
+    """Start a blueprint with StreamingModule + McpServer, wait for readiness."""
+    global_config.update(viewer="none")
+    blueprint = autoconnect(StreamingModule.blueprint(), McpServer.blueprint())
+    coordinator = ModuleCoordinator.build(blueprint)
+
+    adapter = McpAdapter()
+    if not adapter.wait_for_ready(timeout=15):
+        coordinator.stop()
+        pytest.fail("MCP server did not become ready")
+
+    yield adapter
+
+    coordinator.stop()
+
+
+_NOTIFICATION_METHODS = {NOTIFICATIONS_MESSAGE_METHOD, NOTIFICATIONS_PROGRESS_METHOD}
+
+
+def _frame_tool_name(frame: dict) -> str | None:
+    params = frame.get("params") or {}
+    if frame.get("method") == NOTIFICATIONS_PROGRESS_METHOD:
+        return (params.get("_meta") or {}).get("tool_name")
+    return params.get("logger")
+
+
+def _read_sse_notifications(
+    url: str,
+    expected: int,
+    timeout: float = 10.0,
+    tool_name: str | None = None,
+) -> list[dict]:
+    """Open `GET url` as SSE and collect `expected` notification frames.
+
+    Returns both `notifications/message` and `notifications/progress` frames.
+    Callers can disambiguate by `method`.
+    """
+    collected: list[dict] = []
+    deadline = time.monotonic() + timeout
+    with httpx.Client(timeout=timeout) as client:
+        with client.stream(
+            "GET",
+            url,
+            headers={"Accept": "text/event-stream"},
+        ) as response:
+            assert response.headers["content-type"].startswith("text/event-stream")
+            for line in response.iter_lines():
+                if time.monotonic() > deadline:
+                    break
+                if not line or not line.startswith("data: "):
+                    continue
+                try:
+                    data = json.loads(line[6:])
+                except json.JSONDecodeError:
+                    continue
+                if data.get("method") not in _NOTIFICATION_METHODS:
+                    continue
+                if tool_name is not None and _frame_tool_name(data) != tool_name:
+                    continue
+                collected.append(data)
+                if len(collected) >= expected:
+                    return collected
+    return collected
+
+
+@pytest.fixture
+def background_threads():
+    threads: list[Thread] = []
+    yield threads
+    for thread in threads:
+        thread.join(timeout=DEFAULT_THREAD_JOIN_TIMEOUT)
+
+
+@pytest.mark.slow
+def test_tool_stream_persistent_sse(
+    mcp_server: McpAdapter, background_threads: list[Thread]
+) -> None:
+    """Tool-stream updates flow through the persistent GET /mcp SSE channel as
+    `notifications/progress` frames bound to the client's `progressToken`,
+    including updates fired from a background thread after the POST response for
+    `tools/call` has already been sent."""
+    adapter = mcp_server
+    adapter.initialize()
+
+    notifications_ready = Event()
+    notifications = []
+
+    def _collect() -> None:
+        result = _read_sse_notifications(
+            adapter.url, expected=3, timeout=15.0, tool_name="start_streaming"
+        )
+        notifications.extend(result)
+        notifications_ready.set()
+
+    reader = Thread(target=_collect, daemon=True)
+    background_threads.append(reader)
+    reader.start()
+
+    # Give the GET SSE subscriber a moment to attach before firing the tool.
+    time.sleep(0.2)
+
+    progress_token = "pt-test-stream"
+    result = adapter.call(
+        "tools/call",
+        {
+            "name": "start_streaming",
+            "arguments": {"count": 3},
+            "_meta": {"progressToken": progress_token},
+        },
+    )
+    assert "Started streaming" in result["result"]["content"][0]["text"]
+
+    assert notifications_ready.wait(timeout=15.0), "Did not receive notifications in time"
+
+    assert len(notifications) == 3
+    assert [n["method"] for n in notifications] == [NOTIFICATIONS_PROGRESS_METHOD] * 3
+    assert [n["params"]["progressToken"] for n in notifications] == [progress_token] * 3
+    assert [n["params"]["progress"] for n in notifications] == [1, 2, 3]
+    assert [n["params"]["message"] for n in notifications] == [
+        "Update 1 of 3",
+        "Update 2 of 3",
+        "Update 3 of 3",
+    ]
+    for n in notifications:
+        assert n["params"]["_meta"]["tool_name"] == "start_streaming"
+
+
+@pytest.mark.slow
+def test_tool_stream_agent(agent_setup) -> None:
+    """Tool stream updates arrive at the agent as HumanMessages."""
+    history = agent_setup(
+        blueprints=[StreamingModule.blueprint()],
+        messages=[
+            HumanMessage("Start streaming 3 updates using the start_streaming tool with count=3.")
+        ],
+    )
+
+    # agent_setup returns after the initial tool call round-trip.  The tool
+    # stream updates arrive asynchronously afterwards — poll the history list
+    # (which is still being mutated by the /agent transport callback).
+    deadline = time.monotonic() + 10.0
+    while time.monotonic() < deadline:
+        stream_updates = [
+            m
+            for m in history
+            if isinstance(m, HumanMessage) and "[tool:start_streaming]" in str(m.content)
+        ]
+        if len(stream_updates) >= 3:
+            break
+        time.sleep(0.2)
+
+    stream_updates = [
+        m
+        for m in history
+        if isinstance(m, HumanMessage) and "[tool:start_streaming]" in str(m.content)
+    ]
+    assert len(stream_updates) == 3
+    assert "Update 1 of 3" in stream_updates[0].content
+    assert "Update 2 of 3" in stream_updates[1].content
+    assert "Update 3 of 3" in stream_updates[2].content
+
+
+@pytest.fixture()
+def skill_context():
+    """Save/restore `_SKILL_CONTEXT.context` around a test.
+
+    On entry the context is set to `{}` so the body runs inside a simulated
+    @skill call with no progress token (the most common case). The yielded
+    setter lets tests override that. Pass `None` for "outside any skill" or a
+    dict with a `progress_token` for the progress-notification path.
+    """
+    previous = getattr(annotation_module._SKILL_CONTEXT, "context", None)
+    annotation_module._SKILL_CONTEXT.context = {}
+
+    def set_context(value):
+        annotation_module._SKILL_CONTEXT.context = value
+
+    yield set_context
+
+    annotation_module._SKILL_CONTEXT.context = previous
+
+
+@pytest.fixture()
+def stream_with_transport_mock(mocker, skill_context):
+    """ToolStream wired to a mock pLCMTransport so unit tests can inspect publishes.
+
+    Constructs the stream inside a simulated `@skill` context with no progress
+    token, so the strict-construction rule is satisfied and the stream takes the
+    `notifications/message` fallback path.
+    """
+    mock_transport = mocker.MagicMock()
+    mocker.patch("dimos.agents.mcp.tool_stream.pLCMTransport", return_value=mock_transport)
+    stream = ToolStream("test_tool")
+    return stream, mock_transport
+
+
+def test_tool_stream_outside_skill_raises(skill_context) -> None:
+    """Constructing a ToolStream outside any @skill call raises RuntimeError."""
+    skill_context(None)
+    with pytest.raises(RuntimeError, match="must be constructed inside a @skill"):
+        ToolStream("out_of_context")
+
+
+def test_send_publishes_notification(stream_with_transport_mock) -> None:
+    stream, mock_transport = stream_with_transport_mock
+    stream.send("hello")
+    mock_transport.start.assert_called_once()
+    mock_transport.publish.assert_called_once()
+    frame = mock_transport.publish.call_args.args[0]
+    assert frame["method"] == NOTIFICATIONS_MESSAGE_METHOD
+    assert frame["params"]["logger"] == "test_tool"
+    assert frame["params"]["data"] == "hello"
+
+
+def test_send_after_stop_does_not_raise(stream_with_transport_mock) -> None:
+    stream, mock_transport = stream_with_transport_mock
+    stream.stop()
+    stream.send("should be ignored")
+    mock_transport.publish.assert_not_called()
+
+
+def test_stop_tears_down_transport(stream_with_transport_mock) -> None:
+    stream, mock_transport = stream_with_transport_mock
+    stream.send("kick off transport")
+    stream.stop()
+    mock_transport.stop.assert_called_once()
+
+
+def test_stop_without_send_does_nothing(stream_with_transport_mock) -> None:
+    stream, mock_transport = stream_with_transport_mock
+    stream.stop()
+    mock_transport.start.assert_not_called()
+    mock_transport.stop.assert_not_called()
+
+
+def test_double_stop_is_safe(stream_with_transport_mock) -> None:
+    stream, mock_transport = stream_with_transport_mock
+    stream.send("hello")
+    stream.stop()
+    stream.stop()
+    assert stream.is_closed
+    mock_transport.stop.assert_called_once()
+
+
+def test_make_notification_shape() -> None:
+    assert make_notification("greet", "hi") == {
+        "jsonrpc": "2.0",
+        "method": NOTIFICATIONS_MESSAGE_METHOD,
+        "params": {"level": "info", "logger": "greet", "data": "hi"},
+    }
+
+
+def test_make_progress_notification_shape() -> None:
+    frame = make_progress_notification(
+        "pt-abc", progress=2, message="Halfway", tool_name="fan", total=5
+    )
+    assert frame == {
+        "jsonrpc": "2.0",
+        "method": NOTIFICATIONS_PROGRESS_METHOD,
+        "params": {
+            "progressToken": "pt-abc",
+            "progress": 2,
+            "total": 5,
+            "message": "Halfway",
+            "_meta": {"tool_name": "fan"},
+        },
+    }
+
+
+@pytest.fixture()
+def stream_with_progress_context(mocker, skill_context):
+    """ToolStream constructed with a skill-context progress_token set."""
+    mock_transport = mocker.MagicMock()
+    mocker.patch("dimos.agents.mcp.tool_stream.pLCMTransport", return_value=mock_transport)
+    skill_context({"progress_token": "pt-unit-1"})
+    stream = ToolStream("progress_tool")
+    return stream, mock_transport
+
+
+def test_send_with_progress_token_emits_progress_notifications(
+    stream_with_progress_context,
+) -> None:
+    stream, mock_transport = stream_with_progress_context
+    stream.send("one")
+    stream.send("two")
+    stream.send("three")
+
+    assert mock_transport.publish.call_count == 3
+    frames = [call.args[0] for call in mock_transport.publish.call_args_list]
+    assert [f["method"] for f in frames] == [NOTIFICATIONS_PROGRESS_METHOD] * 3
+    assert [f["params"]["progressToken"] for f in frames] == ["pt-unit-1"] * 3
+    assert [f["params"]["progress"] for f in frames] == [1, 2, 3]
+    assert [f["params"]["message"] for f in frames] == ["one", "two", "three"]
+    assert all(f["params"]["_meta"]["tool_name"] == "progress_tool" for f in frames)
+
+
+def test_send_without_progress_token_falls_back_to_message(
+    stream_with_transport_mock,
+) -> None:
+    stream, mock_transport = stream_with_transport_mock
+    stream.send("hi")
+    frame = mock_transport.publish.call_args.args[0]
+    assert frame["method"] == NOTIFICATIONS_MESSAGE_METHOD
+    assert frame["params"]["logger"] == "test_tool"
+
+
+def test_skill_wrapper_sets_and_restores_context() -> None:
+    """The @skill wrapper pops _mcp_context and save/restores the thread-local."""
+    observed: list[dict | None] = []
+
+    @skill
+    def inner() -> str:
+        observed.append(annotation_module.current_skill_context())
+        return "ok"
+
+    assert annotation_module.current_skill_context() is None
+    assert inner(_mcp_context={"progress_token": "pt-X"}) == "ok"
+    assert observed == [{"progress_token": "pt-X"}]
+    # Restored to None after the call.
+    assert annotation_module.current_skill_context() is None
+
+
+def test_skill_wrapper_without_context_still_sets_empty_dict() -> None:
+    """Even without an _mcp_context kwarg, inside the call the context is {}.
+
+    This lets ToolStream distinguish "inside a skill with no client token"
+    (construct OK, fall back to notifications/message) from "outside any
+    skill entirely" (RuntimeError).
+    """
+    observed: list[dict | None] = []
+
+    @skill
+    def inner() -> None:
+        observed.append(annotation_module.current_skill_context())
+
+    assert annotation_module.current_skill_context() is None
+    inner()
+    assert observed == [{}]
+    assert annotation_module.current_skill_context() is None
+
+
+def test_skill_wrapper_nested_calls_restore_outer_context() -> None:
+    """Nested @skill calls on the same thread must not clobber the outer frame."""
+    outer_seen: list[dict | None] = []
+
+    @skill
+    def inner_skill() -> None:
+        pass
+
+    @skill
+    def outer_skill() -> None:
+        inner_skill(_mcp_context={"progress_token": "inner"})
+        outer_seen.append(annotation_module.current_skill_context())
+
+    outer_skill(_mcp_context={"progress_token": "outer"})
+    assert outer_seen == [{"progress_token": "outer"}]
+
+
+class _ToolHelperTestModule(Module):
+    """A minimal module used to exercise the start_tool/tool_update/stop_tool helpers.
+
+    The `@skill` wrapper establishes the `_SKILL_CONTEXT` for the duration
+    of the call, so `self.start_tool(...)` runs under a live context.
+    """
+
+    @skill
+    def start(self, name: str) -> str:
+        self.start_tool(name)
+        return "started"
+
+    @skill
+    def double_start(self, name: str) -> str:
+        self.start_tool(name)
+        self.start_tool(name)  # should raise
+        return "unreachable"
+
+
+@pytest.fixture()
+def tool_helper_module(mocker):
+    """A _ToolHelperTestModule whose ToolStream instances share a mock transport.
+
+    The module is constructed normally; the event-loop thread and LCM RPC
+    transport are patched out because these tests only exercise the
+    start_tool/tool_update/stop_tool helpers.
+    """
+    mock_transport = mocker.MagicMock()
+    mocker.patch("dimos.agents.mcp.tool_stream.pLCMTransport", return_value=mock_transport)
+    mocker.patch("dimos.core.module.get_loop", return_value=(None, None))
+    mocker.patch.object(LCMRPC, "__init__", return_value=None)
+    mocker.patch.object(LCMRPC, "serve_module_rpc")
+    mocker.patch.object(LCMRPC, "start")
+    module = _ToolHelperTestModule()
+    yield module, mock_transport
+    module._close_all_tools()
+
+
+def test_start_tool_duplicate_raises(tool_helper_module, skill_context) -> None:
+    module, _ = tool_helper_module
+    module.start_tool("job")
+    with pytest.raises(RuntimeError, match="already active"):
+        module.start_tool("job")
+    module.stop_tool("job")
+
+
+def test_tool_update_without_start_is_lenient(tool_helper_module) -> None:
+    module, mock_transport = tool_helper_module
+    # No start_tool call. tool_update should warn and return, not raise.
+    module.tool_update("missing", "hello")
+    mock_transport.publish.assert_not_called()
+
+
+def test_stop_tool_without_start_is_noop(tool_helper_module) -> None:
+    module, mock_transport = tool_helper_module
+    module.stop_tool("missing")
+    mock_transport.stop.assert_not_called()
+
+
+def test_tool_update_routes_to_registered_stream(tool_helper_module, skill_context) -> None:
+    module, mock_transport = tool_helper_module
+    module.start_tool("job")
+    module.tool_update("job", "progress 1")
+    module.tool_update("job", "progress 2")
+    module.stop_tool("job")
+
+    texts = [c.args[0]["params"]["data"] for c in mock_transport.publish.call_args_list]
+    assert texts == ["progress 1", "progress 2"]
+
+
+def test_stop_tool_pops_from_registry(tool_helper_module, skill_context) -> None:
+    module, mock_transport = tool_helper_module
+    module.start_tool("job")
+    # A send is required for ToolStream to lazily construct the transport;
+    # otherwise stop() has nothing to tear down.
+    module.tool_update("job", "hello")
+    assert "job" in module._tools
+    module.stop_tool("job")
+    assert "job" not in module._tools
+    mock_transport.stop.assert_called_once()
+
+
+def test_close_all_tools_stops_outstanding(tool_helper_module, skill_context) -> None:
+    module, mock_transport = tool_helper_module
+    module.start_tool("a")
+    module.tool_update("a", "kick a")
+    module.start_tool("b")
+    module.tool_update("b", "kick b")
+
+    module._close_all_tools()
+    assert module._tools == {}
+    # Both ToolStream instances share the same mocked transport, so two
+    # stop calls landed on it.
+    assert mock_transport.stop.call_count == 2

--- a/dimos/agents/mcp/tool_stream.py
+++ b/dimos/agents/mcp/tool_stream.py
@@ -1,0 +1,177 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Server-initiated tool-stream notifications.
+
+A skill uses `ToolStream` to push text updates out to any connected MCP client
+(Claude Code, our own `McpClient`, curl, ...) while the skill's background work is
+still running.
+
+Transport: each `ToolStream.send` publishes a ready-made JSON-RPC
+`notifications/message` frame on the shared `/tool_streams` LCM topic. Skill
+workers and the `McpServer` process typically live in different workers, so we
+lean on LCM's local-multicast bus to cross that boundary. `McpServer` subscribes
+to the topic once, forwards each frame to every connected `GET /mcp` SSE client,
+and drops frames when nobody is listening.
+
+Each `ToolStream` instance owns its own `pLCMTransport`, created lazily on the
+first `send` and torn down by `stop`. There is no module-level or process-level
+state. The stream's lifetime is exactly the owning skill's lifetime.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import threading
+from typing import Any
+import uuid
+
+from dimos.agents.annotation import current_skill_context
+from dimos.core.transport import pLCMTransport
+from dimos.utils.logging_config import setup_logger
+
+logger = setup_logger()
+
+TOOL_STREAM_TOPIC = "/tool_streams"
+NOTIFICATIONS_MESSAGE_METHOD = "notifications/message"
+NOTIFICATIONS_PROGRESS_METHOD = "notifications/progress"
+
+ToolStreamCallback = Callable[[dict[str, Any]], Any]
+
+
+def make_notification(tool_name: str, text: str) -> dict[str, Any]:
+    """Build an MCP `notifications/message` frame (log-style fallback)."""
+    return {
+        "jsonrpc": "2.0",
+        "method": NOTIFICATIONS_MESSAGE_METHOD,
+        "params": {
+            "level": "info",
+            "logger": tool_name,
+            "data": text,
+        },
+    }
+
+
+def make_progress_notification(
+    progress_token: str | int,
+    progress: int,
+    message: str,
+    tool_name: str | None = None,
+    total: int | None = None,
+) -> dict[str, Any]:
+    """Build an MCP `notifications/progress` frame bound to `progress_token`."""
+    params: dict[str, Any] = {"progressToken": progress_token, "progress": progress}
+    if total is not None:
+        params["total"] = total
+    if message:
+        params["message"] = message
+    if tool_name is not None:
+        params["_meta"] = {"tool_name": tool_name}
+    return {"jsonrpc": "2.0", "method": NOTIFICATIONS_PROGRESS_METHOD, "params": params}
+
+
+def subscribe(callback: ToolStreamCallback) -> Callable[[], None]:
+    """Subscribe to the tool-stream LCM topic and return a cleanup callable."""
+    transport: pLCMTransport[dict[str, Any]] = pLCMTransport(TOOL_STREAM_TOPIC)
+    transport.start()
+    unsubscribe = transport.subscribe(callback)
+
+    def cleanup() -> None:
+        try:
+            unsubscribe()
+        except Exception:
+            logger.exception("tool-stream unsubscribe failed")
+        try:
+            transport.stop()
+        except Exception:
+            logger.exception("tool-stream transport stop failed")
+
+    return cleanup
+
+
+class ToolStream:
+    """A streaming channel for pushing updates from a skill to the agent.
+
+    Each `ToolStream` is tied to a single logical tool invocation.  It **must**
+    be constructed inside a `@skill` call on the skill's own thread. That's
+    where the per-call context (including the caller's `progressToken`) lives
+    and can be captured. Constructing a `ToolStream` outside a `@skill` call
+    raises `RuntimeError`.
+
+    Once constructed, the instance is free-threaded: background threads
+    spawned by the skill can call `send` and `stop` safely because
+    the progress token is already captured on the instance.
+
+    If the client that made the `tools/call` request did not supply a
+    `progressToken`, the stream still constructs successfully (the per-call
+    context is an empty dict, not `None`) and `send` falls back to emitting
+    `notifications/message` log frames.
+
+    Callers should use`Module.start_tool` / `tool_update` / `stop_tool` instead
+    of constructing `ToolStream` directly.
+    """
+
+    def __init__(self, tool_name: str) -> None:
+        self.tool_name: str = tool_name
+        self.id: str = str(uuid.uuid4())
+        self._closed: threading.Event = threading.Event()
+        self._lock = threading.Lock()
+        self._transport: pLCMTransport[dict[str, Any]] | None = None
+        context = current_skill_context()
+        if context is None:
+            raise RuntimeError(
+                f"ToolStream({tool_name!r}) must be constructed inside a @skill "
+                f"call so the caller's progress token can be captured. Construct "
+                f"it in the skill method's main thread, not in __init__ or a "
+                f"detached background thread."
+            )
+        self._progress_token: str | int | None = context.get("progress_token")
+        self._progress: int = 0
+
+    def send(self, message: str) -> None:
+        with self._lock:
+            if self._closed.is_set():
+                logger.warning("send on closed ToolStream", stream_id=self.id)
+                return
+            if self._transport is None:
+                self._transport = pLCMTransport(TOOL_STREAM_TOPIC)
+                self._transport.start()
+            self._progress += 1
+            progress = self._progress
+            transport = self._transport
+            progress_token = self._progress_token
+        if progress_token is not None:
+            frame = make_progress_notification(
+                progress_token, progress, message, tool_name=self.tool_name
+            )
+        else:
+            frame = make_notification(self.tool_name, message)
+        transport.publish(frame)
+
+    def stop(self) -> None:
+        with self._lock:
+            if self._closed.is_set():
+                return
+            self._closed.set()
+            transport = self._transport
+            self._transport = None
+        if transport is not None:
+            try:
+                transport.stop()
+            except Exception:
+                logger.exception("tool-stream transport stop failed", stream_id=self.id)
+
+    @property
+    def is_closed(self) -> bool:
+        return self._closed.is_set()

--- a/dimos/agents/skills/person_follow.py
+++ b/dimos/agents/skills/person_follow.py
@@ -17,12 +17,10 @@ from threading import Event, RLock, Thread
 import time
 from typing import Any
 
-from langchain_core.messages import HumanMessage
 import numpy as np
 from reactivex.disposable import Disposable
 from turbojpeg import TurboJPEG
 
-from dimos.agents.agent_spec import AgentSpec
 from dimos.agents.annotation import skill
 from dimos.constants import DEFAULT_THREAD_JOIN_TIMEOUT
 from dimos.core.core import rpc
@@ -66,7 +64,6 @@ class PersonFollowSkillContainer(Module):
     global_map: In[PointCloud2]
     cmd_vel: Out[Twist]
 
-    _agent_spec: AgentSpec
     _frequency: float = 20.0  # Hz - control loop frequency
     _max_lost_frames: int = 15  # number of frames to wait before declaring person lost
     _patrolling_module_spec: PatrollingModuleSpec
@@ -101,6 +98,11 @@ class PersonFollowSkillContainer(Module):
     @rpc
     def stop(self) -> None:
         self._stop_following()
+
+        thread = self._thread
+        if thread is not None:
+            thread.join(timeout=DEFAULT_THREAD_JOIN_TIMEOUT)
+            self._thread = None
 
         with self._lock:
             if self._tracker is not None:
@@ -140,6 +142,10 @@ class PersonFollowSkillContainer(Module):
         """
 
         self._stop_following()
+
+        if self._thread is not None:
+            self._thread.join(timeout=DEFAULT_THREAD_JOIN_TIMEOUT)
+            self._thread = None
 
         self._should_stop.clear()
 
@@ -228,12 +234,13 @@ class PersonFollowSkillContainer(Module):
 
         logger.info(f"EdgeTAM initialized with {len(initial_detections)} detections")
 
+        self.start_tool("follow_person")
         self._thread = Thread(target=self._follow_loop, args=(tracker, query), daemon=True)
         self._thread.start()
 
         message = (
             "Found the person. Starting to follow. You can stop following by calling "
-            "the 'stop_following' tool."
+            "the 'stop_following' tool. You will receive streaming updates."
         )
 
         if self._patrolling_module_spec.is_patrolling():
@@ -304,8 +311,11 @@ class PersonFollowSkillContainer(Module):
 
     def _send_stop_reason(self, query: str, reason: str) -> None:
         self.cmd_vel.publish(Twist.zero())
-        message = f"Person follow stopped for '{query}'. Reason: {reason}."
-        self._agent_spec.add_message(HumanMessage(message))
+        self.tool_update(
+            "follow_person",
+            f"Person follow stopped for '{query}'. Reason: {reason}.",
+        )
+        self.stop_tool("follow_person")
         logger.info("Person follow stopped", query=query, reason=reason)
 
 

--- a/dimos/agents/skills/speak_skill.py
+++ b/dimos/agents/skills/speak_skill.py
@@ -18,6 +18,7 @@ import time
 from reactivex import Subject
 
 from dimos.agents.annotation import skill
+from dimos.constants import DEFAULT_THREAD_JOIN_TIMEOUT
 from dimos.core.core import rpc
 from dimos.core.module import Module
 from dimos.stream.audio.node_output import SounddeviceAudioOutput
@@ -46,7 +47,7 @@ class SpeakSkill(Module):
         with self._bg_threads_lock:
             threads = list(self._bg_threads)
         for t in threads:
-            t.join(timeout=2.0)
+            t.join(timeout=DEFAULT_THREAD_JOIN_TIMEOUT)
         if self._tts_node:
             self._tts_node.dispose()
             self._tts_node = None

--- a/dimos/core/module.py
+++ b/dimos/core/module.py
@@ -121,10 +121,14 @@ class ModuleBase(Configurable, CompositeResource):
     _module_closed_lock: threading.Lock
     _loop_thread_timeout: float = 2.0
     _main_gen: AsyncGenerator[None, None] | None = None
+    _tools: dict[str, Any]
+    _tools_lock: threading.Lock
 
     def __init__(self, config_args: dict[str, Any]) -> None:
         super().__init__(**config_args)
         self._module_closed_lock = threading.Lock()
+        self._tools = {}
+        self._tools_lock = threading.Lock()
         self._loop, self._loop_thread = get_loop()
         try:
             self.rpc = self.config.rpc_transport(  # type: ignore[call-arg]
@@ -174,6 +178,7 @@ class ModuleBase(Configurable, CompositeResource):
                 return
             self._module_closed = True
 
+        self._close_all_tools()
         self._close_rpc()
 
         # Save into local variables to avoid race when stopping concurrently
@@ -199,6 +204,16 @@ class ModuleBase(Configurable, CompositeResource):
             attr.stop()
             attr.owner = None
 
+    def _close_all_tools(self) -> None:
+        with self._tools_lock:
+            streams = list(self._tools.values())
+            self._tools.clear()
+        for stream in streams:
+            try:
+                stream.stop()
+            except Exception:
+                logger.exception("failed to stop tool-stream during module close")
+
     def _close_rpc(self) -> None:
         if self.rpc:
             self.rpc.stop()  # type: ignore[attr-defined]
@@ -215,6 +230,8 @@ class ModuleBase(Configurable, CompositeResource):
         state.pop("_rpc", None)
         state.pop("_tf", None)
         state.pop("_main_gen", None)
+        state.pop("_tools", None)
+        state.pop("_tools_lock", None)
         return state
 
     def __setstate__(self, state) -> None:  # type: ignore[no-untyped-def]
@@ -227,6 +244,8 @@ class ModuleBase(Configurable, CompositeResource):
         self._rpc = None
         self._tf = None
         self._main_gen = None
+        self._tools = {}
+        self._tools_lock = threading.Lock()
 
     @property
     def tf(self):  # type: ignore[no-untyped-def]
@@ -443,6 +462,66 @@ class ModuleBase(Configurable, CompositeResource):
         on_msg, dispatcher_disp = self._make_async_dispatch(async_cb)
         sub = observable.subscribe(on_msg)
         return self.register_disposable(CompositeDisposable(sub, dispatcher_disp))
+
+    def start_tool(self, name: str) -> None:
+        """Open a tool-stream channel named `name` for this module.
+
+        Must be called from inside a `@skill` method's main thread. The caller's
+        `progressToken` is captured at this moment so later updates can be
+        routed as `notifications/progress` frames bound to the originating
+        `tools/call`.
+
+        Raises `RuntimeError` if a tool with the same name is already active on
+        this module (two concurrent streams for the same logical tool is almost
+        always a programmer error; `stop_tool` the previous one first).
+        """
+        # Lazy import
+        from dimos.agents.mcp.tool_stream import ToolStream
+
+        stream = ToolStream(name)
+        with self._tools_lock:
+            # Defensive check to prevent duplicate tools with the same name.
+            if name in self._tools:
+                # Unwind the already-constructed stream before raising so the
+                # LCM transport doesn't leak.
+                try:
+                    stream.stop()
+                except Exception:
+                    logger.exception("failed to unwind duplicate ToolStream")
+                raise RuntimeError(
+                    f"Tool {name!r} is already active on {type(self).__name__}. "
+                    f"Call stop_tool({name!r}) first."
+                )
+            self._tools[name] = stream
+
+    def tool_update(self, name: str, message: str) -> None:
+        """Publish `message` on the tool-stream channel named `name`.
+
+        Safe to call from any thread. If `name` is not currently active (never
+        started, or already stopped), logs a warning and returns. Background
+        loops racing against teardown don't need to guard themselves.
+        """
+        with self._tools_lock:
+            stream = self._tools.get(name)
+        if stream is None:
+            logger.warning(
+                "tool_update on unknown tool",
+                tool=name,
+                module=type(self).__name__,
+            )
+            return
+        stream.send(message)
+
+    def stop_tool(self, name: str) -> None:
+        """Close the tool-stream channel named `name`."""
+        with self._tools_lock:
+            stream = self._tools.pop(name, None)
+        if stream is None:
+            return
+        try:
+            stream.stop()
+        except Exception:
+            logger.exception("Failed to stop tool-stream", tool=name)
 
     def _start_main(self) -> None:
         """

--- a/dimos/experimental/security_demo/depth_estimator.py
+++ b/dimos/experimental/security_demo/depth_estimator.py
@@ -22,6 +22,7 @@ from PIL import Image as PILImage
 import torch
 from transformers import AutoImageProcessor, AutoModelForDepthEstimation
 
+from dimos.constants import DEFAULT_THREAD_JOIN_TIMEOUT
 from dimos.msgs.sensor_msgs.Image import Image, ImageFormat
 
 _DEPTH_MODEL_NAME = "depth-anything/Depth-Anything-V2-Small-hf"
@@ -63,7 +64,7 @@ class DepthEstimator:
         self._stop.set()
         self._event.set()
         if self._thread is not None:
-            self._thread.join(timeout=5.0)
+            self._thread.join(timeout=DEFAULT_THREAD_JOIN_TIMEOUT)
             self._thread = None
 
     def submit(self, image: Image) -> None:

--- a/dimos/experimental/security_demo/security_module.py
+++ b/dimos/experimental/security_demo/security_module.py
@@ -17,6 +17,7 @@ from __future__ import annotations  # noqa: I001
 import threading
 import time
 from typing import TYPE_CHECKING, Any, Literal
+from dimos.constants import DEFAULT_THREAD_JOIN_TIMEOUT
 
 import cv2
 import numpy as np
@@ -393,6 +394,6 @@ class SecurityModule(Module):
         with self._lock:
             thread = self._main_thread
         if thread is not None:
-            thread.join(timeout=2.0)
+            thread.join(timeout=DEFAULT_THREAD_JOIN_TIMEOUT)
             with self._lock:
                 self._main_thread = None

--- a/dimos/perception/perceive_loop_skill.py
+++ b/dimos/perception/perceive_loop_skill.py
@@ -21,7 +21,6 @@ from threading import RLock
 from typing import TYPE_CHECKING, Any
 
 import cv2
-from langchain_core.messages import HumanMessage
 
 from dimos.agents.agent_spec import AgentSpec
 from dimos.agents.annotation import skill
@@ -122,6 +121,7 @@ class PerceiveLoopSkill(Module):
                 on_next=self._on_image,
                 on_error=lambda e: logger.exception("Error in perceive loop", exc_info=e),
             )
+        self.start_tool("look_out_for")
 
         return (
             f"Started looking for {json.dumps(description_of_things)}. This will "
@@ -165,10 +165,14 @@ class PerceiveLoopSkill(Module):
             self._model_started = False
 
         if then is None:
-            self._agent_spec.add_message(
-                HumanMessage(f"Found a match for {active_lookout_str}. Please announce audibly.")
+            self.tool_update(
+                "look_out_for",
+                f"Found a match for {active_lookout_str}. Please announce audibly.",
             )
+            self.stop_tool("look_out_for")
             return
+
+        self.stop_tool("look_out_for")
 
         best = max(detections.detections, key=lambda d: d.bbox_2d_volume())
         continuation_context: dict[str, Any] = {
@@ -194,6 +198,7 @@ class PerceiveLoopSkill(Module):
             if self._model_started:
                 self._vl_model.stop()
                 self._model_started = False
+        self.stop_tool("look_out_for")
 
 
 def _write_debug_image(image: Image, detections: ImageDetections2D[Detection2DBBox]) -> None:

--- a/docs/usage/data_streams/quality_filter.md
+++ b/docs/usage/data_streams/quality_filter.md
@@ -233,7 +233,7 @@ class CameraModule(Module):
         if self.config.frequency > 0:
             stream = stream.pipe(sharpness_barrier(self.config.frequency))
 
-        self._disposables.add(
+        self.register_disposable(
             stream.subscribe(self.color_image.publish),
         )
 

--- a/docs/usage/data_streams/reactivex.md
+++ b/docs/usage/data_streams/reactivex.md
@@ -290,7 +290,7 @@ from dimos.core.module import Module
 class MyModule(Module):
     def start(self):
         source = rx.interval(0.05)
-        self._disposables.add(source.subscribe(lambda x: print(f"got {x}")))
+        self.register_disposable(source.subscribe(lambda x: print(f"got {x}")))
 
 module = MyModule()
 module.start()

--- a/docs/usage/sensor_streams/quality_filter.md
+++ b/docs/usage/sensor_streams/quality_filter.md
@@ -233,7 +233,7 @@ class CameraModule(Module):
         if self.config.frequency > 0:
             stream = stream.pipe(sharpness_barrier(self.config.frequency))
 
-        self._disposables.add(
+        self.register_disposable(
             stream.subscribe(self.color_image.publish),
         )
 

--- a/docs/usage/sensor_streams/reactivex.md
+++ b/docs/usage/sensor_streams/reactivex.md
@@ -290,7 +290,7 @@ from dimos.core.module import Module
 class MyModule(Module):
     def start(self):
         source = rx.interval(0.05)
-        self._disposables.add(source.subscribe(lambda x: print(f"got {x}")))
+        self.register_disposable(source.subscribe(lambda x: print(f"got {x}")))
 
 module = MyModule()
 module.start()

--- a/docs/usage/tool_streams.md
+++ b/docs/usage/tool_streams.md
@@ -1,0 +1,127 @@
+# Tool Streams
+
+Some tools return quickly but keep doing work in the background. For example,
+`look_out_for` starts a perception loop and waits minutes for a match;
+`follow_person` returns "started following" right away and then keeps publishing
+status until the target is lost or the skill is cancelled.
+
+Tool streams are the channel those background updates travel on. Every update is
+routed to the MCP client that made the original `tools/call` so it can display
+the progress alongside the tool's response.
+
+Under the hood, tool streams turn into MCP `notifications/progress` frames bound
+to the client's `progressToken`.
+
+For the dimos-internal `McpClient`, each update lands on the agent's message
+queue as a `HumanMessage` tagged `[tool:<tool_name>]` so the model can reason
+about it. If a client didn't send a `progressToken` (raw curl, older tools), the
+stream falls back to `notifications/message` log frames so updates still arrive,
+just without the per-call UI affordance.
+
+Skills never touch the wire format. `Module` exposes three helpers:
+`start_tool`, `tool_update`, `stop_tool`. The framework handles the rest.
+
+## Quick example: inline updates
+
+```python
+import time
+
+from dimos.agents.annotation import skill
+from dimos.core.module import Module
+
+
+class Counter(Module):
+    @skill
+    def count_to(self, n: int) -> str:
+        """Count to `n`, streaming a status update per step."""
+        self.start_tool("count_to")
+        for i in range(n):
+            self.tool_update("count_to", f"At {i + 1} of {n}")
+            time.sleep(0.1)
+        self.stop_tool("count_to")
+        return f"Counted to {n}."
+```
+
+Each `tool_update` shows up in the MCP client as a progress notification bound
+to the original `count_to` call. The skill's return value is still the final
+`tools/call` result; the streamed updates are *in addition* to it, not *instead
+of* it.
+
+## Background-thread example
+
+Most real skills don't block their `tools/call` response. They kick off
+background work and return immediately. The background thread publishes updates
+for as long as the work is running. This is the `follow_person` / `look_out_for`
+shape.
+
+```python
+import time
+from threading import Thread
+
+from dimos.agents.annotation import skill
+from dimos.core.module import Module
+
+
+class Streamer(Module):
+    @skill
+    def start_streaming(self, count: int) -> str:
+        """Kick off `count` updates from a background thread."""
+        self.start_tool("start_streaming")
+
+        def _loop() -> None:
+            try:
+                for i in range(count):
+                    time.sleep(0.1)
+                    self.tool_update("start_streaming", f"Update {i + 1} of {count}")
+            finally:
+                self.stop_tool("start_streaming")
+
+        # Thread cleanup ignored for this example.
+        Thread(target=_loop, daemon=True).start()
+        return f"Started streaming {count} updates."
+```
+
+The skill returns right away with `"Started streaming 3 updates."`. The
+background loop then fires `tool_update` calls from a worker thread, and each
+one reaches the client as a progress frame attached to the original call. When
+the loop finishes (or errors), `stop_tool` tears the channel down.
+
+## The rules
+
+- **`start_tool` must run on the skill's main thread.** The `@skill` wrapper
+establishes a per-call context on the thread where the skill is invoked;
+`start_tool` reads that context to capture the caller's `progressToken`.
+Constructing a tool stream from a detached thread raises `RuntimeError` with a
+message that names the invariant.
+
+- **`start_tool("x")` while another `"x"` is already open on the same module
+raises.** Two concurrent streams for the same logical tool is almost always a
+bug. If you really need to restart, call `stop_tool("x")` first.
+
+- **`tool_update` and `stop_tool` are thread-safe.** Background workers can fire
+updates from any thread once `start_tool` has registered the channel.
+
+## What a client sees
+
+When an MCP client calls `tools/call` with a `progressToken`, every
+`tool_update` on that call is delivered as a `notifications/progress` JSON-RPC
+frame:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/progress",
+  "params": {
+    "progressToken": "pt-abc123",
+    "progress": 1,
+    "message": "Update 1 of 3",
+    "_meta": {"tool_name": "start_streaming"}
+  }
+}
+```
+
+The `progressToken` is the one the client supplied on its `tools/call` request.
+`progress` is a per-stream monotonic counter (1, 2, 3, ...). The dimos-specific
+`_meta.tool_name` hint is used by our internal `McpClient` to route the update
+into the agent transcript as `[tool:start_streaming] Update 1 of 3`; external
+clients that don't recognize it simply pass it through.

--- a/docs/usage/transforms.md
+++ b/docs/usage/transforms.md
@@ -241,7 +241,7 @@ class RobotBaseModule(Module):
             )
             self.tf.publish(robot_pose)
 
-        self._disposables.add(
+        self.register_disposable(
             rx.interval(0.1).subscribe(publish_pose)
         )
 
@@ -268,7 +268,7 @@ class CameraModule(Module):
             )
             self.tf.publish(camera_mount, optical_frame)
 
-        self._disposables.add(
+        self.register_disposable(
             rx.interval(0.1).subscribe(publish_transforms)
         )
 

--- a/examples/docker_hello_world/hello_docker.py
+++ b/examples/docker_hello_world/hello_docker.py
@@ -71,7 +71,7 @@ class HelloDockerModule(Module):
     @rpc
     def start(self) -> None:
         super().start()
-        self._disposables.add(Disposable(self.prompt.subscribe(self._on_prompt)))
+        self.register_disposable(Disposable(self.prompt.subscribe(self._on_prompt)))
 
     def _cowsay(self, text: str) -> str:
         """Run cowsay inside the container and return the ASCII art."""
@@ -103,7 +103,7 @@ class PromptModule(Module):
     @rpc
     def start(self) -> None:
         super().start()
-        self._disposables.add(Disposable(self.greeting.subscribe(self._on_greeting)))
+        self.register_disposable(Disposable(self.greeting.subscribe(self._on_greeting)))
 
     @rpc
     def send(self, text: str) -> None:


### PR DESCRIPTION
## Problem

* Agents don't have a coherent idea of what response is coming from what tool.

Closes DIM-633

## Solution

* Added MCP streaming. Now agents receive updates from one tool in the same tool context.

## Breaking Changes

None

## How to Test

<!-- MUST be reproducible. If this section is weak, reviewers can't approve confidently. -->

## Contributor License Agreement

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
