### PR TITLE
fix(rerun): grid height raised to 0.5 for better visualization

### DIFF
--- a/dimos/robot/drone/blueprints/basic/drone_basic.py
+++ b/dimos/robot/drone/blueprints/basic/drone_basic.py
@@ -50,7 +50,7 @@ def _drone_rerun_blueprint() -> Any:
                 name="3D",
                 background=rrb.Background(kind="SolidColor", color=[0, 0, 0]),
                 line_grid=rrb.LineGrid3D(
-                    plane=rr.components.Plane3D.XY.with_distance(0.2),
+                    plane=rr.components.Plane3D.XY.with_distance(0.5),
                 ),
             ),
             column_shares=[1, 2],

--- a/dimos/robot/unitree/g1/blueprints/primitive/uintree_g1_primitive_no_nav.py
+++ b/dimos/robot/unitree/g1/blueprints/primitive/uintree_g1_primitive_no_nav.py
@@ -88,7 +88,7 @@ def _g1_rerun_blueprint() -> Any:
                 name="3D",
                 background=rrb.Background(kind="SolidColor", color=[0, 0, 0]),
                 line_grid=rrb.LineGrid3D(
-                    plane=rr.components.Plane3D.XY.with_distance(0.2),
+                    plane=rr.components.Plane3D.XY.with_distance(0.5),
                 ),
             ),
             column_shares=[1, 2],

--- a/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_basic.py
+++ b/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_basic.py
@@ -85,7 +85,7 @@ def _go2_rerun_blueprint() -> Any:
                 name="3D",
                 background=rrb.Background(kind="SolidColor", color=[0, 0, 0]),
                 line_grid=rrb.LineGrid3D(
-                    plane=rr.components.Plane3D.XY.with_distance(0.2),
+                    plane=rr.components.Plane3D.XY.with_distance(0.5),
                 ),
             ),
             column_shares=[1, 2],

--- a/dimos/visualization/rerun/bridge.py
+++ b/dimos/visualization/rerun/bridge.py
@@ -139,7 +139,7 @@ def _default_blueprint() -> Blueprint:
             origin="world",
             background=rrb.Background(kind="SolidColor", color=[0, 0, 0]),
             line_grid=rrb.LineGrid3D(
-                plane=rr.components.Plane3D.XY.with_distance(0.2),
+                plane=rr.components.Plane3D.XY.with_distance(0.5),
             ),
         ),
     )


### PR DESCRIPTION
## Problem

viz/rerun
Grid sometimes isn't visible when zoomed out on the map

## Solution

- changed height from 0.2 to 0.5

## Breaking Changes

None

## How to Test

- run any blueprint, the grid overlay on map is clearly visible
- `dimos --replay --replay-dir=unitree_go2_bigoffice run unitree-go2`

## Contributor License Agreement

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
