### PR TITLE
Defer o3dpickle

### DIFF
--- a/dimos/core/core.py
+++ b/dimos/core/core.py
@@ -20,13 +20,9 @@ from typing import (
     TypeVar,
 )
 
-from dimos.core.o3dpickle import register_picklers
-
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-# injects pickling system into o3d
-register_picklers()
 T = TypeVar("T")
 
 from typing import ParamSpec, TypeVar

--- a/dimos/core/module_coordinator.py
+++ b/dimos/core/module_coordinator.py
@@ -50,6 +50,9 @@ class ModuleCoordinator(Resource):  # type: ignore[misc]
         self._deployed_modules = {}
 
     def start(self) -> None:
+        from dimos.core.o3dpickle import register_picklers
+
+        register_picklers()
         for m in self._managers.values():
             m.start()
 


### PR DESCRIPTION
## Problem

o3dpickle takes about 60% of startup time for `dimos --help`.

## Solution

Defer initialisation to when we need it.