### PR TITLE
feat(sim): dimsim as connection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,9 +76,6 @@ jobs:
           - os: ubuntu
             pyver: "3.14t"
             experimental: false
-          - os: ubuntu
-            pyver: "3.15"
-            experimental: true
       fail-fast: true
     runs-on: ${{ matrix.os }}-latest
     continue-on-error: ${{ matrix.experimental }}
@@ -112,13 +109,13 @@ jobs:
         if: ${{ endsWith(matrix.pyver, 't') }}
         run: echo "PYTHON_GIL=0" >> $GITHUB_ENV
       - name: Run tests
-        run: uv run pytest --numprocesses=3 --cov=dimos/ --junitxml=junit.xml -m 'not (tool or self_hosted or mujoco)'
+        run: uv run pytest --numprocesses=3 --cov=dimos/ --junitxml=junit.xml -m 'not (tool or self_hosted or mujoco or dimsim)'
       - name: Re-run the failing tests with maximum verbosity
         if: failure()
         env:
           COLOR: yes
         run: >-  # `exit 1` makes sure that the job remains red with flaky runs
-          uv run pytest --no-cov -vvvvv --lf  -m 'not (tool or self_hosted or mujoco)' && exit 1
+          uv run pytest --no-cov -vvvvv --lf  -m 'not (tool or self_hosted or mujoco or dimsim)' && exit 1
         shell: bash
       - name: Turn coverage into xml
         run: uv run python -m coverage xml

--- a/dimos/agents/skills/person_follow.py
+++ b/dimos/agents/skills/person_follow.py
@@ -78,14 +78,18 @@ class PersonFollowSkillContainer(Module):
         self._should_stop: Event = Event()
         self._lock = RLock()
 
-        # Use MuJoCo camera intrinsics in simulation mode
+        # Use simulator camera intrinsics in simulation mode
         camera_info = self.config.camera_info
-        if self.config.g.simulation:
+        if self.config.g.simulation == "mujoco":
             from dimos.robot.unitree.mujoco_connection import MujocoConnection
 
             camera_info = MujocoConnection.camera_info_static
+        elif self.config.g.simulation == "dimsim":
+            from dimos.robot.unitree.dimsim_connection import DimSimConnection
 
-        self._visual_servo = VisualServoing2D(camera_info, self.config.g.simulation)
+            camera_info = DimSimConnection.camera_info_static
+
+        self._visual_servo = VisualServoing2D(camera_info, bool(self.config.g.simulation))
         self._detection_navigation = DetectionNavigation(self.tf, camera_info)
 
     @rpc

--- a/dimos/conftest.py
+++ b/dimos/conftest.py
@@ -20,19 +20,27 @@ import platform
 import tempfile
 import threading
 
-# Pick a per-xdist-worker bucket and pin env vars *before* any dimos
-# module is imported. ``LCMConfig`` captures ``LCM_DEFAULT_URL`` at import
-# time; ``GlobalConfig`` captures ``MCP_PORT``; ``run_registry`` captures
-# ``XDG_STATE_HOME``. ``LCM_DEFAULT_URL`` in particular has to be an env
-# var (not just a fixture) because subprocess workers spawned by
+# With pytest-xdist, pick a per-worker bucket and pin env vars *before*
+# any dimos module is imported, so parallel workers don't share LCM bus,
+# MCP port, or state directory. ``LCMConfig`` captures ``LCM_DEFAULT_URL``
+# at import time; ``GlobalConfig`` captures ``MCP_PORT``; ``run_registry``
+# captures ``XDG_STATE_HOME``. ``LCM_DEFAULT_URL`` in particular has to be
+# an env var (not just a fixture) because subprocess workers spawned by
 # ``ModuleCoordinator`` create their own ``LCMConfig`` / ``LCMRPC``
 # instances internally and can't receive a fixture value — they inherit
 # our env at fork time.
-_worker = os.environ.get("PYTEST_XDIST_WORKER", "main")
-_BUCKET = int.from_bytes(hashlib.blake2b(_worker.encode(), digest_size=2).digest(), "big") % 5000
-os.environ["LCM_DEFAULT_URL"] = f"udpm://239.255.76.67:{7700 + _BUCKET}?ttl=0"
-os.environ["MCP_PORT"] = str(20000 + _BUCKET)
-os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp(prefix=f"dimos-test-state-{_worker}-")
+#
+# Single-worker runs (no xdist) keep the defaults, so external processes
+# with hard-coded ports (e.g. the dimsim Deno bridge, which binds to LCM
+# 7667) can still talk to the test bus.
+_worker = os.environ.get("PYTEST_XDIST_WORKER")
+if _worker:
+    _BUCKET = (
+        int.from_bytes(hashlib.blake2b(_worker.encode(), digest_size=2).digest(), "big") % 5000
+    )
+    os.environ["LCM_DEFAULT_URL"] = f"udpm://239.255.76.67:{7700 + _BUCKET}?ttl=0"
+    os.environ["MCP_PORT"] = str(20000 + _BUCKET)
+    os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp(prefix=f"dimos-test-state-{_worker}-")
 
 # Raise the open-file limit. Each LCM transport opens at least one
 # multicast socket; with pytest-xdist workers running many in parallel,
@@ -77,6 +85,7 @@ def pytest_configure(config):
         "self_hosted: tests that need the self-hosted runner (LFS, ROS, CUDA, etc.)",
     )
     config.addinivalue_line("markers", "mujoco: tests which open mujoco")
+    config.addinivalue_line("markers", "dimsim: tests which require dimsim")
     config.addinivalue_line("markers", "skipif_in_ci: skip when CI env var is set")
     config.addinivalue_line("markers", "skipif_no_openai: skip when OPENAI_API_KEY is not set")
     config.addinivalue_line("markers", "skipif_no_alibaba: skip when ALIBABA_API_KEY is not set")
@@ -90,20 +99,20 @@ def pytest_configure(config):
 
 @pytest.fixture(scope="session")
 def mcp_port() -> int:
-    """The MCP server port pinned for this xdist worker."""
-    return 20000 + _BUCKET
+    """The MCP server port pinned for this xdist worker (or the default)."""
+    return int(os.environ.get("MCP_PORT", "9990"))
 
 
 @pytest.fixture(scope="session")
 def mcp_url(mcp_port: int) -> str:
-    """The MCP server URL pinned for this xdist worker."""
+    """The MCP server URL pinned for this xdist worker (or the default)."""
     return f"http://localhost:{mcp_port}/mcp"
 
 
 @pytest.fixture(scope="session")
 def lcm_url() -> str:
-    """The LCM bus URL pinned for this xdist worker."""
-    return f"udpm://239.255.76.67:{7700 + _BUCKET}?ttl=0"
+    """The LCM bus URL pinned for this xdist worker (or the default)."""
+    return os.environ.get("LCM_DEFAULT_URL", "udpm://239.255.76.67:7667?ttl=0")
 
 
 @pytest.hookimpl(tryfirst=True)

--- a/dimos/core/global_config.py
+++ b/dimos/core/global_config.py
@@ -36,7 +36,7 @@ class GlobalConfig(BaseSettings):
     xarm7_ip: str | None = None
     xarm6_ip: str | None = None
     can_port: str | None = None
-    simulation: bool = False
+    simulation: str = ""
     replay: bool = False
     replay_db: str = "go2_short"
     new_memory: bool = False
@@ -65,6 +65,8 @@ class GlobalConfig(BaseSettings):
     obstacle_avoidance: bool = True
     detection_model: VlModelName = "moondream"
     listen_host: str = "127.0.0.1"
+    dimsim_scene: str = "apt"
+    dimsim_port: int = 8090
 
     model_config = SettingsConfigDict(
         env_file=".env",
@@ -84,7 +86,7 @@ class GlobalConfig(BaseSettings):
         if self.replay:
             return "replay"
         if self.simulation:
-            return "mujoco"
+            return self.simulation
         return "webrtc"
 
     @property

--- a/dimos/core/transport.py
+++ b/dimos/core/transport.py
@@ -133,10 +133,12 @@ class LCMTransport(PubSubTransport[T]):
 
         self.lcm.publish(self.topic, msg)
 
-    def subscribe(self, callback: Callable[[T], None], selfstream: In[T] = None) -> None:  # type: ignore[assignment, override]
+    def subscribe(
+        self, callback: Callable[[T], Any], selfstream: Stream[T] | None = None
+    ) -> Callable[[], None]:
         if not self._started:
             self.start()
-        return self.lcm.subscribe(self.topic, lambda msg, topic: callback(msg))  # type: ignore[arg-type, return-value]
+        return self.lcm.subscribe(self.topic, lambda msg, topic: callback(msg))  # type: ignore[arg-type]
 
 
 class JpegLcmTransport(LCMTransport):  # type: ignore[type-arg]

--- a/dimos/e2e_tests/conftest.py
+++ b/dimos/e2e_tests/conftest.py
@@ -20,6 +20,7 @@ import pytest
 
 from dimos.core.transport import pLCMTransport
 from dimos.e2e_tests.conf_types import StartPersonTrack
+from dimos.e2e_tests.dim_sim_client import DimSimClient
 from dimos.e2e_tests.dimos_cli_call import DimosCliCall
 from dimos.e2e_tests.lcm_spy import LcmSpy
 from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
@@ -66,12 +67,17 @@ def follow_points(lcm_spy: LcmSpy):
 
 
 @pytest.fixture
-def start_blueprint() -> Iterator[Callable[..., DimosCliCall]]:
+def start_blueprint(mcp_port: int) -> Iterator[Callable[..., DimosCliCall]]:
     dimos_robot_call = DimosCliCall()
+    dimos_robot_call.mcp_port = mcp_port
 
-    def set_name_and_start(*demo_args: str, mcp_port: int | None = None) -> DimosCliCall:
+    def set_name_and_start(
+        *demo_args: str,
+        simulator: str | None = None,
+    ) -> DimosCliCall:
         dimos_robot_call.demo_args = list(demo_args)
-        dimos_robot_call.mcp_port = mcp_port
+        if simulator is not None:
+            dimos_robot_call.simulator = simulator
         dimos_robot_call.start()
         return dimos_robot_call
 
@@ -148,6 +154,96 @@ def explore_office(
         (-4.71, 1.17),
         (4.30, 0.87),
     ]
+
+    def explore() -> None:
+        direct_cmd_vel_explorer.follow_points(points)
+
+    return explore
+
+
+@pytest.fixture
+def dim_sim():
+    client = DimSimClient()
+    client.start()
+    yield client
+    client.stop()
+
+
+@pytest.fixture
+def spawn_wall_on_pose(lcm_spy: LcmSpy, dim_sim: DimSimClient):
+    """Spawn a dim_sim wall when the robot's /odom comes within `threshold` metres of `point`."""
+    odom_topic = "/odom#geometry_msgs.PoseStamped"
+    stop_event = threading.Event()
+    workers: list[threading.Thread] = []
+    errors: list[BaseException] = []
+
+    def spawn(*, point, threshold, wall) -> None:
+        px, py = point
+        threshold_sq = threshold * threshold
+        triggered = threading.Event()
+
+        def on_odom(data):
+            if triggered.is_set():
+                return
+            pose = PoseStamped.lcm_decode(data)
+            dx = pose.x - px
+            dy = pose.y - py
+            if dx * dx + dy * dy < threshold_sq:
+                triggered.set()
+
+        def worker():
+            try:
+                with lcm_spy.topic_listener(odom_topic, on_odom):
+                    while not stop_event.is_set():
+                        if triggered.wait(timeout=0.1):
+                            dim_sim.add_wall(*wall)
+                            return
+            except BaseException as e:
+                errors.append(e)
+
+        thread = threading.Thread(target=worker, daemon=True)
+        thread.start()
+        workers.append(thread)
+
+    yield spawn
+
+    stop_event.set()
+    for thread in workers:
+        thread.join(timeout=5.0)
+    if errors:
+        raise errors[0]
+
+
+@pytest.fixture
+def explore_house(
+    direct_cmd_vel_explorer: DirectCmdVelExplorer,
+) -> Callable[[], None]:
+    points = [
+        (3.881, 4.803),
+        (4.160, 1.615),
+        (1.596, 1.505),
+        (1.649, 0.137),
+        (-3.644, -0.064),
+        (-3.759, -2.661),
+        (-4.186, -4.830),
+        (-3.759, -2.661),
+        (-1.070, -3.285),
+        (-2.504, -2.452),
+        (-2.647, 5.243),
+        (-3.663, 3.591),
+        (-1.178, 1.974),
+        (-2.416, 2.629),
+        (-2.581, 0.164),
+        (1.834, 0.072),
+        (3.010, -3.883),
+        (1.756, -3.742),
+        (6.336, -4.077),
+        (8.264, -5.119),
+        (6.258, -0.964),
+        (6.453, 5.327),
+    ]
+
+    direct_cmd_vel_explorer.linear_speed = 0.5
 
     def explore() -> None:
         direct_cmd_vel_explorer.follow_points(points)

--- a/dimos/e2e_tests/dim_sim_client.py
+++ b/dimos/e2e_tests/dim_sim_client.py
@@ -1,0 +1,56 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dimos.core.transport import LCMTransport
+from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
+from dimos.simulation.dimsim.scene_client import SceneClient
+
+
+class DimSimClient:
+    _client: SceneClient | None = None
+
+    def __init__(self) -> None:
+        self._client = None
+        self._goal_request: LCMTransport[PoseStamped] = LCMTransport("/goal_request", PoseStamped)
+
+    def start(self) -> None:
+        # self.client should be started lazily to avoid starting the dimsim
+        # process before pytest fixtures are ready
+        self._goal_request.start()
+
+    def stop(self) -> None:
+        self.client.stop()
+        self._goal_request.stop()
+
+    @property
+    def client(self) -> SceneClient:
+        if self._client is None:
+            self._client = SceneClient()
+            self._client.start()
+        return self._client
+
+    def set_agent_position(self, x: float, y: float, z: float = 0.52) -> None:
+        self.client.set_agent_position(y, z, x)
+
+    def add_wall(self, x1: float, y1: float, x2: float, y2: float) -> None:
+        self.client.add_wall(y1, x1, y2, x2)
+
+    def publish_goal(self, x: float, y: float) -> None:
+        self._goal_request.publish(
+            PoseStamped(
+                position=(x, y, 0),
+                orientation=(0, 0, 0, 1),
+                frame_id="world",
+            )
+        )

--- a/dimos/e2e_tests/dimos_cli_call.py
+++ b/dimos/e2e_tests/dimos_cli_call.py
@@ -22,6 +22,7 @@ class DimosCliCall:
     process: subprocess.Popen[bytes] | None
     demo_args: list[str] | None = None
     mcp_port: int | None = None
+    simulator: str = "mujoco"
 
     def __init__(self) -> None:
         self.process = None
@@ -48,7 +49,14 @@ class DimosCliCall:
             ]
 
         self.process = subprocess.Popen(
-            ["dimos", *global_overrides, "--simulation", *args, *blueprint_overrides],
+            [
+                "dimos",
+                *global_overrides,
+                "--simulation",
+                self.simulator,
+                *args,
+                *blueprint_overrides,
+            ],
             start_new_session=True,
         )
 

--- a/dimos/e2e_tests/lcm_spy.py
+++ b/dimos/e2e_tests/lcm_spy.py
@@ -73,25 +73,21 @@ class LcmSpy(LCMService):
         with self._saved_topics_lock:
             self._saved_topics.add(topic)
 
-    def register_topic_listener(self, topic: str, listener: Callable[[bytes], None]) -> int:
+    def register_topic_listener(self, topic: str, listener: Callable[[bytes], None]) -> None:
         with self._topic_listeners_lock:
-            listeners = self._topic_listeners.setdefault(topic, [])
-            listener_index = len(listeners)
-            listeners.append(listener)
-            return listener_index
+            self._topic_listeners.setdefault(topic, []).append(listener)
 
-    def unregister_topic_listener(self, topic: str, listener_index: int) -> None:
+    def unregister_topic_listener(self, topic: str, listener: Callable[[bytes], None]) -> None:
         with self._topic_listeners_lock:
-            listeners = self._topic_listeners[topic]
-            listeners.pop(listener_index)
+            self._topic_listeners[topic].remove(listener)
 
     @contextmanager
     def topic_listener(self, topic: str, listener: Callable[[bytes], None]) -> Iterator[None]:
-        listener_index = self.register_topic_listener(topic, listener)
+        self.register_topic_listener(topic, listener)
         try:
             yield
         finally:
-            self.unregister_topic_listener(topic, listener_index)
+            self.unregister_topic_listener(topic, listener)
 
     def wait_until(
         self,

--- a/dimos/e2e_tests/test_dimos_cli_e2e.py
+++ b/dimos/e2e_tests/test_dimos_cli_e2e.py
@@ -18,13 +18,13 @@ import pytest
 @pytest.mark.skipif_in_ci
 @pytest.mark.self_hosted
 @pytest.mark.skipif_no_openai
-def test_dimos_skills(lcm_spy, start_blueprint, human_input, mcp_port) -> None:
+def test_dimos_skills(lcm_spy, start_blueprint, human_input) -> None:
     lcm_spy.save_topic("/agent")
     lcm_spy.save_topic("/rpc/McpClient/on_system_modules/res")
     lcm_spy.save_topic("/rpc/DemoCalculatorSkill/sum_numbers/req")
     lcm_spy.save_topic("/rpc/DemoCalculatorSkill/sum_numbers/res")
 
-    start_blueprint("run", "demo-skill", mcp_port=mcp_port)
+    start_blueprint("run", "demo-skill")
 
     lcm_spy.wait_for_saved_topic("/rpc/McpClient/on_system_modules/res")
 

--- a/dimos/e2e_tests/test_dimsim_path_replaning.py
+++ b/dimos/e2e_tests/test_dimsim_path_replaning.py
@@ -1,0 +1,60 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+
+@pytest.mark.dimsim
+def test_path_replanning(
+    lcm_spy, start_blueprint, dim_sim, direct_cmd_vel_explorer, spawn_wall_on_pose
+) -> None:
+    start_blueprint(
+        "--dimsim-scene=empty",
+        "run",
+        "unitree-go2-agentic",
+        simulator="dimsim",
+    )
+    lcm_spy.save_topic("/rpc/McpClient/on_system_modules/res")
+    lcm_spy.wait_for_saved_topic("/rpc/McpClient/on_system_modules/res", timeout=1200.0)
+
+    # robot spawns at (3, 2)
+
+    # side wall
+    dim_sim.add_wall(2, -2.5, 12, -2.5)
+    # other side wall
+    dim_sim.add_wall(2, 3.5, 12, 3.5)
+    # back wall (behind robot)
+    dim_sim.add_wall(2, -2.5, 2, 3.5)
+    # forward wall (far end)
+    dim_sim.add_wall(12, -2.5, 12, 3.5)
+    # dividing wall at x=7 with doors at y=[-1.5,-0.5] and y=[1.5,2.5]
+    dim_sim.add_wall(7, -2.5, 7, -1.5)
+    dim_sim.add_wall(7, -0.5, 7, 1.5)
+    dim_sim.add_wall(7, 2.5, 7, 3.5)
+
+    direct_cmd_vel_explorer.linear_speed = 0.8
+    direct_cmd_vel_explorer.follow_points([(10, 2), (2.5, 2), (3, 2)])
+
+    # When the robot comes within 1.5 m of the left door's centre, drop a wall
+    # in the opening so the planner has to bail out and route through the
+    # right door at y=-1 instead.
+    spawn_wall_on_pose(
+        point=(7, 2),
+        threshold=1.5,
+        wall=(7, 1.5, 7, 2.5),
+    )
+
+    dim_sim.publish_goal(10.913, 0.588)
+
+    lcm_spy.wait_until_odom_position(10.913, 0.588, threshold=1, timeout=120)

--- a/dimos/e2e_tests/test_dimsim_spatial_memory.py
+++ b/dimos/e2e_tests/test_dimsim_spatial_memory.py
@@ -1,0 +1,32 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+
+@pytest.mark.dimsim
+def test_go_to_the_bed(lcm_spy, start_blueprint, human_input, dim_sim, explore_house) -> None:
+    start_blueprint(
+        "run",
+        "unitree-go2-agentic",
+        simulator="dimsim",
+    )
+    lcm_spy.save_topic("/rpc/McpClient/on_system_modules/res")
+    lcm_spy.wait_for_saved_topic("/rpc/McpClient/on_system_modules/res", timeout=1200.0)
+
+    explore_house()
+
+    human_input("go to the bed")
+
+    lcm_spy.wait_until_odom_position(-3.567, -1.332, threshold=2)

--- a/dimos/e2e_tests/test_dimsim_walk_forward.py
+++ b/dimos/e2e_tests/test_dimsim_walk_forward.py
@@ -1,0 +1,37 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+
+@pytest.mark.dimsim
+def test_walk_forward(lcm_spy, start_blueprint, human_input, dim_sim) -> None:
+    start_blueprint(
+        "run",
+        "--disable",
+        "spatial-memory",
+        "--disable",
+        "security-module",
+        "unitree-go2-agentic",
+        simulator="dimsim",
+    )
+    lcm_spy.save_topic("/rpc/McpClient/on_system_modules/res")
+    lcm_spy.wait_for_saved_topic("/rpc/McpClient/on_system_modules/res", timeout=1200.0)
+
+    origin_x, origin_y = 1, 2
+    dim_sim.set_agent_position(origin_x, origin_y)
+
+    human_input("move forward 3 meter")
+
+    lcm_spy.wait_until_odom_position(origin_x + 3, origin_y, threshold=0.4)

--- a/dimos/experimental/security_demo/security_module.py
+++ b/dimos/experimental/security_demo/security_module.py
@@ -123,7 +123,7 @@ def _create_visual_servo(
 
         camera_info = MujocoConnection.camera_info_static
 
-    return VisualServoing2D(camera_info, global_config.simulation)
+    return VisualServoing2D(camera_info, bool(global_config.simulation))
 
 
 class SecurityModule(Module):
@@ -168,6 +168,7 @@ class SecurityModule(Module):
         self._latest_pose: PoseStamped | None = None
         self._latest_image: Image | None = None
         self._has_active_goal = False
+        self._depth_started = False
 
     @rpc
     def start(self) -> None:
@@ -178,8 +179,6 @@ class SecurityModule(Module):
         )
         self.register_disposable(Disposable(self.goal_reached.subscribe(self._on_goal_reached)))
         self.register_disposable(Disposable(self.color_image.subscribe(self._on_color_image)))
-
-        self._depth_estimator.start()
 
     @rpc
     def stop(self) -> None:
@@ -198,6 +197,10 @@ class SecurityModule(Module):
         with self._lock:
             if self._main_thread is not None and self._main_thread.is_alive():
                 return "Security patrol is already running. Use `stop_security_patrol` to stop."
+
+        if not self._depth_started:
+            self._depth_estimator.start()
+            self._depth_started = True
 
         self._router.reset()
 

--- a/dimos/msgs/sensor_msgs/CameraInfo.py
+++ b/dimos/msgs/sensor_msgs/CameraInfo.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import math
 import time
 from typing import TYPE_CHECKING
 
@@ -119,6 +120,41 @@ class CameraInfo(Timestamped):
             D=[0.0, 0.0, 0.0, 0.0, 0.0],
             K=[fx, 0.0, cx, 0.0, fy, cy, 0.0, 0.0, 1.0],
             P=[fx, 0.0, cx, 0.0, 0.0, fy, cy, 0.0, 0.0, 0.0, 1.0, 0.0],
+            frame_id=frame_id,
+        )
+
+    @classmethod
+    def from_fov(
+        cls,
+        fov_deg: float,
+        width: int,
+        height: int,
+        axis: str = "vertical",
+        frame_id: str = "",
+    ) -> CameraInfo:
+        """Create CameraInfo from field of view and image dimensions.
+
+        Args:
+            fov_deg: Field of view in degrees along ``axis``
+            width: Image width (pixels)
+            height: Image height (pixels)
+            axis: Which image axis ``fov_deg`` refers to ("vertical" or "horizontal")
+            frame_id: Frame ID
+        """
+        fov_rad = math.radians(fov_deg)
+        if axis == "vertical":
+            f = (height / 2) / math.tan(fov_rad / 2)
+        elif axis == "horizontal":
+            f = (width / 2) / math.tan(fov_rad / 2)
+        else:
+            raise ValueError(f"axis must be 'vertical' or 'horizontal', got {axis!r}")
+        return cls.from_intrinsics(
+            fx=f,
+            fy=f,
+            cx=width / 2.0,
+            cy=height / 2.0,
+            width=width,
+            height=height,
             frame_id=frame_id,
         )
 

--- a/dimos/msgs/sensor_msgs/Image.py
+++ b/dimos/msgs/sensor_msgs/Image.py
@@ -505,6 +505,11 @@ class Image(Timestamped):
     @classmethod
     def lcm_decode(cls, data: bytes, **kwargs: Any) -> Image:
         msg = LCMImage.lcm_decode(data)
+
+        # JPEG-compressed images use a different decode path.
+        if msg.encoding == "jpeg":
+            return cls.lcm_jpeg_decode(data, **kwargs)
+
         fmt, dtype, channels = _parse_lcm_encoding(msg.encoding)
         arr: np.ndarray[Any, Any] = np.frombuffer(msg.data, dtype=dtype)
         if channels == 1:

--- a/dimos/robot/unitree/dimsim_connection.py
+++ b/dimos/robot/unitree/dimsim_connection.py
@@ -1,0 +1,141 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import Callable
+import functools
+from typing import Any
+
+from reactivex import Observable, Subject
+
+from dimos.core.global_config import GlobalConfig
+from dimos.core.transport import LCMTransport
+from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
+from dimos.msgs.geometry_msgs.Quaternion import Quaternion
+from dimos.msgs.geometry_msgs.Transform import Transform
+from dimos.msgs.geometry_msgs.Twist import Twist
+from dimos.msgs.geometry_msgs.Vector3 import Vector3
+from dimos.msgs.sensor_msgs.CameraInfo import CameraInfo
+from dimos.msgs.sensor_msgs.Image import Image
+from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
+from dimos.protocol.tf.tf import LCMTF
+from dimos.simulation.dimsim.dimsim_process import DimSimProcess
+from dimos.utils.logging_config import setup_logger
+
+logger = setup_logger()
+
+_WIDTH = 640
+_HEIGHT = 288
+_FOV_DEG = 46
+
+
+class DimSimConnection:
+    camera_info_static: CameraInfo = CameraInfo.from_fov(
+        fov_deg=_FOV_DEG,
+        width=_WIDTH,
+        height=_HEIGHT,
+        axis="horizontal",
+        frame_id="camera_optical",
+    )
+
+    def __init__(self, global_config: GlobalConfig) -> None:
+        self._dimsim_process: DimSimProcess = DimSimProcess(global_config)
+        self._odom_transport: LCMTransport[PoseStamped] = LCMTransport("/odom", PoseStamped)
+        self._unsubscribe_odom: Callable[[], None] | None = None
+        self._tf = LCMTF()
+
+    def start(self) -> None:
+        self._dimsim_process.start()
+        self._odom_transport.start()
+        self._unsubscribe_odom = self._odom_transport.subscribe(self._handle_odom)
+        self._tf.start()
+
+    def stop(self) -> None:
+        self._tf.stop()
+        if self._unsubscribe_odom is not None:
+            self._unsubscribe_odom()
+        self._odom_transport.stop()
+        self._dimsim_process.stop()
+
+    @functools.cache
+    def lidar_stream(self) -> Observable[PointCloud2]:
+        return Subject()
+
+    @functools.cache
+    def odom_stream(self) -> Observable[PoseStamped]:
+        return Subject()
+
+    @functools.cache
+    def video_stream(self) -> Observable[Image]:
+        return Subject()
+
+    def move(self, twist: Twist, duration: float = 0.0) -> bool:
+        return True
+
+    def standup(self) -> bool:
+        return True
+
+    def liedown(self) -> bool:
+        return True
+
+    def balance_stand(self) -> bool:
+        return True
+
+    def set_obstacle_avoidance(self, enabled: bool = True) -> None:
+        pass
+
+    def enable_rage_mode(self) -> bool:
+        return True
+
+    def publish_request(self, topic: str, data: dict[str, Any]) -> dict[Any, Any]:
+        return {}
+
+    def _handle_odom(self, msg: PoseStamped) -> None:
+        self._tf.publish(*_odom_to_tf(msg))
+
+
+def _odom_to_tf(odom: PoseStamped) -> list[Transform]:
+    """Build transform chain from odometry pose.
+
+    Transform tree: world -> base_link -> {camera_link -> camera_optical, lidar_link}
+    """
+    camera_link = Transform(
+        translation=Vector3(0.3, 0.0, 0.0),  # camera 30cm forward
+        rotation=Quaternion(0.0, 0.0, 0.0, 1.0),
+        frame_id="base_link",
+        child_frame_id="camera_link",
+        ts=odom.ts,
+    )
+
+    camera_optical = Transform(
+        translation=Vector3(0.0, 0.0, 0.0),
+        rotation=Quaternion(-0.5, 0.5, -0.5, 0.5),
+        frame_id="camera_link",
+        child_frame_id="camera_optical",
+        ts=odom.ts,
+    )
+
+    lidar_link = Transform(
+        translation=Vector3(0.0, 0.0, 0.0),
+        rotation=Quaternion(0.0, 0.0, 0.0, 1.0),
+        frame_id="base_link",
+        child_frame_id="lidar_link",
+        ts=odom.ts,
+    )
+
+    return [
+        Transform.from_pose("base_link", odom),
+        camera_link,
+        camera_optical,
+        lidar_link,
+    ]

--- a/dimos/robot/unitree/go2/connection.py
+++ b/dimos/robot/unitree/go2/connection.py
@@ -87,17 +87,14 @@ def _camera_info_static() -> CameraInfo:
     fx, fy, cx, cy = (819.553492, 820.646595, 625.284099, 336.808987)
     width, height = (1280, 720)
 
-    return CameraInfo(
-        frame_id="camera_optical",
-        height=height,
+    return CameraInfo.from_intrinsics(
+        fx=fx,
+        fy=fy,
+        cx=cx,
+        cy=cy,
         width=width,
-        distortion_model="plumb_bob",
-        D=[0.0, 0.0, 0.0, 0.0, 0.0],
-        K=[fx, 0.0, cx, 0.0, fy, cy, 0.0, 0.0, 1.0],
-        R=[1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0],
-        P=[fx, 0.0, cx, 0.0, 0.0, fy, cy, 0.0, 0.0, 0.0, 1.0, 0.0],
-        binning_x=0,
-        binning_y=0,
+        height=height,
+        frame_id="camera_optical",
     )
 
 
@@ -126,6 +123,10 @@ def make_connection(ip: str | None, cfg: GlobalConfig) -> Go2ConnectionProtocol:
         from dimos.robot.unitree.mujoco_connection import MujocoConnection
 
         return MujocoConnection(cfg)
+    elif connection_type == "dimsim":
+        from dimos.robot.unitree.dimsim_connection import DimSimConnection
+
+        return DimSimConnection(cfg)
     else:
         assert ip is not None, "IP address must be provided"
         return UnitreeWebRTCConnection(ip)

--- a/dimos/robot/unitree/mujoco_connection.py
+++ b/dimos/robot/unitree/mujoco_connection.py
@@ -20,7 +20,6 @@ import base64
 from collections.abc import Callable
 import functools
 import json
-import math
 import os
 from pathlib import Path
 import pickle
@@ -96,29 +95,13 @@ class MujocoConnection:
         self._stop_events: list[threading.Event] = []
         self._is_cleaned_up = False
 
-    @staticmethod
-    def _compute_camera_info() -> CameraInfo:
-        """Compute camera intrinsics from MuJoCo camera parameters.
-
-        Uses pinhole camera model: f = height / (2 * tan(fovy / 2))
-        """
-        fovy = math.radians(VIDEO_CAMERA_FOV)
-        f = VIDEO_HEIGHT / (2 * math.tan(fovy / 2))
-        cx = VIDEO_WIDTH / 2.0
-        cy = VIDEO_HEIGHT / 2.0
-
-        return CameraInfo(
-            frame_id="camera_optical",
-            height=VIDEO_HEIGHT,
-            width=VIDEO_WIDTH,
-            distortion_model="plumb_bob",
-            D=[0.0, 0.0, 0.0, 0.0, 0.0],
-            K=[f, 0.0, cx, 0.0, f, cy, 0.0, 0.0, 1.0],
-            R=[1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0],
-            P=[f, 0.0, cx, 0.0, 0.0, f, cy, 0.0, 0.0, 0.0, 1.0, 0.0],
-        )
-
-    camera_info_static: CameraInfo = _compute_camera_info()
+    camera_info_static: CameraInfo = CameraInfo.from_fov(
+        fov_deg=VIDEO_CAMERA_FOV,
+        width=VIDEO_WIDTH,
+        height=VIDEO_HEIGHT,
+        axis="vertical",
+        frame_id="camera_optical",
+    )
 
     def start(self) -> None:
         self.shm_data = ShmWriter()

--- a/dimos/simulation/dimsim/deno_utils.py
+++ b/dimos/simulation/dimsim/deno_utils.py
@@ -1,0 +1,94 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+import platform
+import shutil
+import stat
+import subprocess
+import tempfile
+import urllib.request
+import zipfile
+
+from dimos.constants import STATE_DIR
+from dimos.utils.logging_config import setup_logger
+
+logger = setup_logger()
+
+DENO_VERSION = "v2.6.10"
+
+
+def ensure_deno() -> str:
+    which = shutil.which("deno")
+    if which:
+        return which
+
+    exe_name = "deno.exe" if platform.system() == "Windows" else "deno"
+    deno_dir = STATE_DIR / "deno" / DENO_VERSION
+    deno_path = deno_dir / exe_name
+    if deno_path.exists():
+        return str(deno_path)
+
+    triple = _deno_triple()
+    url = f"https://github.com/denoland/deno/releases/download/{DENO_VERSION}/deno-{triple}.zip"
+    logger.info(f"Downloading deno {DENO_VERSION} from {url}")
+    deno_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        with tempfile.TemporaryDirectory(dir=str(deno_dir.parent)) as tmp:
+            tmp_path = Path(tmp)
+            zip_path = tmp_path / "deno.zip"
+            with urllib.request.urlopen(url, timeout=60) as resp, open(zip_path, "wb") as f:
+                shutil.copyfileobj(resp, f)
+            with zipfile.ZipFile(zip_path) as z:
+                z.extractall(tmp_path)
+            extracted = tmp_path / exe_name
+            if not extracted.exists():
+                raise RuntimeError(f"deno binary not found in archive from {url}")
+            extracted.chmod(extracted.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+            extracted.replace(deno_path)
+    except Exception as e:
+        raise RuntimeError(
+            f"deno is required to run DimSim from source. Auto-download failed: {e}. "
+            "Install manually from https://deno.com/"
+        ) from e
+
+    return str(deno_path)
+
+
+def ensure_playwright_chromium(deno_path: str) -> None:
+    subprocess.run(
+        [deno_path, "run", "--allow-all", "npm:playwright@1.58.2", "install", "chromium"],
+        check=True,
+    )
+
+
+def _deno_triple() -> str:
+    system = platform.system()
+    machine = platform.machine().lower()
+    if system == "Linux":
+        if machine in ("x86_64", "amd64"):
+            return "x86_64-unknown-linux-gnu"
+        if machine in ("aarch64", "arm64"):
+            return "aarch64-unknown-linux-gnu"
+    elif system == "Darwin":
+        if machine in ("x86_64", "amd64"):
+            return "x86_64-apple-darwin"
+        if machine in ("arm64", "aarch64"):
+            return "aarch64-apple-darwin"
+    elif system == "Windows" and machine in ("amd64", "x86_64"):
+        return "x86_64-pc-windows-msvc"
+    raise RuntimeError(
+        f"Unsupported platform for deno auto-install: {system} {machine}. "
+        "Install deno manually from https://deno.com/"
+    )

--- a/dimos/simulation/dimsim/dimsim_process.py
+++ b/dimos/simulation/dimsim/dimsim_process.py
@@ -1,0 +1,153 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from pathlib import Path
+import subprocess
+import threading
+import time
+from typing import IO
+
+from dimos.constants import STATE_DIR
+from dimos.core.global_config import GlobalConfig
+from dimos.simulation.dimsim.deno_utils import ensure_deno, ensure_playwright_chromium
+from dimos.utils.logging_config import setup_logger
+
+logger = setup_logger()
+
+_VIDEO_RATE = 50
+_LIDAR_RATE = 1000
+_DIMSIM_REPO_URL = "https://github.com/paul-nechifor/DimSim.git"
+_DIMSIM_REPO_BRANCH = "run-from-repo"
+
+
+class DimSimProcess:
+    def __init__(self, global_config: GlobalConfig) -> None:
+        self.global_config = global_config
+        self.process: subprocess.Popen[bytes] | None = None
+
+    def start(self) -> None:
+        deno_path = ensure_deno()
+        repo_dir = _ensure_repo()
+        base_cmd = _deno_cmd(deno_path, repo_dir)
+
+        scene = self.global_config.dimsim_scene
+        port = self.global_config.dimsim_port
+
+        ensure_playwright_chromium(deno_path)
+        _kill_port_holder(port)
+
+        render = os.environ.get("DIMSIM_RENDER", "gpu").strip()
+        if os.environ.get("CI"):
+            render = "cpu"
+
+        cmd = [
+            *base_cmd,
+            "dev",
+            "--scene",
+            scene,
+            "--port",
+            str(port),
+            "--no-depth",
+            "--headless",
+            "--render",
+            render,
+            "--image-rate",
+            str(_VIDEO_RATE),
+            "--lidar-rate",
+            str(_LIDAR_RATE),
+        ]
+
+        self.process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+        self._start_log_reader()
+
+    def stop(self) -> None:
+        if self.process:
+            if self.process.stderr:
+                self.process.stderr.close()
+            try:
+                self.process.terminate()
+                self.process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                logger.warning("DimSim process did not stop gracefully, killing")
+                self.process.kill()
+                self.process.wait(timeout=2)
+            except Exception as e:
+                logger.error(f"Error stopping DimSim process: {e}")
+            self.process = None
+
+    def _start_log_reader(self) -> None:
+        assert self.process is not None
+
+        def _reader(stream: IO[bytes] | None, label: str) -> None:
+            if stream is None:
+                return
+            for raw in stream:
+                line = raw.decode("utf-8", errors="replace").rstrip()
+                if line:
+                    logger.info(f"[dimsim {label}] {line}")
+
+        for stream, label in [
+            (self.process.stdout, "out"),
+            (self.process.stderr, "err"),
+        ]:
+            t = threading.Thread(target=_reader, args=(stream, label), daemon=True)
+            t.start()
+
+
+def _kill_port_holder(port: int) -> None:
+    """Kill any process listening on the given port."""
+    try:
+        result = subprocess.run(
+            ["lsof", "-ti", f":{port}"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        pids = result.stdout.strip()
+        if pids:
+            for pid in pids.splitlines():
+                logger.info(f"Killing stale process {pid} on port {port}")
+                subprocess.run(["kill", pid], timeout=5)
+            time.sleep(0.5)
+    except Exception as e:
+        logger.warning(f"Failed to check/kill port {port}: {e}")
+
+
+def _ensure_repo() -> Path:
+    repo_dir = STATE_DIR / "dimsim_repo"
+    if (repo_dir / ".git").exists():
+        return repo_dir
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    logger.info(f"Cloning DimSim into {repo_dir}")
+    subprocess.run(
+        [
+            "git",
+            "clone",
+            "--depth",
+            "1",
+            "--branch",
+            _DIMSIM_REPO_BRANCH,
+            _DIMSIM_REPO_URL,
+            str(repo_dir),
+        ],
+        check=True,
+    )
+    return repo_dir
+
+
+def _deno_cmd(deno_path: str, repo_dir: Path) -> list[str]:
+    cli_ts = repo_dir / "dimos-cli" / "cli.ts"
+    return [deno_path, "run", "--allow-all", "--unstable-net", str(cli_ts)]

--- a/dimos/simulation/dimsim/scene_client.py
+++ b/dimos/simulation/dimsim/scene_client.py
@@ -1,0 +1,928 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Python SDK for DimSim scene manipulation.
+
+Connects to the DimSim bridge server over WebSocket and sends exec commands
+to the browser-side SceneEditor.  Provides high-level helpers for common
+operations (load map, add NPC, manage colliders) and a raw ``exec()`` escape
+hatch for arbitrary Three.js code.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import threading
+from typing import Any, cast
+import uuid
+
+import websocket
+
+from dimos.utils.logging_config import setup_logger
+
+logger = setup_logger()
+
+EMBODIMENT_PRESETS: dict[str, dict[str, Any]] = {
+    # -- Ground robots (character controller + gravity + collision) --
+    "unitree-go2": {
+        "radius": 0.12,
+        "halfHeight": 0.25,
+        "lidarMountHeight": 0.35,
+        "embodimentType": "quadruped",
+        "avatarUrl": ["/agent-model/unitree_go2.glb", "/agent-model/robot.glb"],
+        # Physics
+        "maxSpeed": 3.0,
+        "turnRate": 3.0,
+        "gravity": -9.81,
+        "maxStepHeight": 0.25,
+        "maxSlopeAngle": 45,
+    },
+    "quadruped": {  # alias for unitree-go2
+        "radius": 0.12,
+        "halfHeight": 0.25,
+        "lidarMountHeight": 0.35,
+        "embodimentType": "quadruped",
+        "avatarUrl": ["/agent-model/unitree_go2.glb", "/agent-model/robot.glb"],
+        "maxSpeed": 3.0,
+        "turnRate": 3.0,
+        "gravity": -9.81,
+        "maxStepHeight": 0.25,
+        "maxSlopeAngle": 45,
+    },
+    "differential-drive": {
+        "radius": 0.15,
+        "halfHeight": 0.2,
+        "lidarMountHeight": 0.35,
+        "embodimentType": "quadruped",  # ground physics
+        "avatarUrl": ["/agent-model/robot.glb"],
+        "maxSpeed": 2.0,
+        "turnRate": 2.5,  # differential drive turns by wheel speed diff
+        "gravity": -9.81,
+        "maxStepHeight": 0.05,  # small wheels can't climb steps
+        "maxSlopeAngle": 20,
+    },
+    "ackermann": {
+        "radius": 0.3,
+        "halfHeight": 0.4,
+        "lidarMountHeight": 0.8,
+        "embodimentType": "quadruped",  # ground physics
+        "avatarUrl": ["/agent-model/robot.glb"],
+        "maxSpeed": 5.0,
+        "turnRate": 1.2,  # car-like: slow turn rate (limited steering angle)
+        "gravity": -9.81,
+        "maxStepHeight": 0.1,
+        "maxSlopeAngle": 30,
+    },
+    "holonomic": {
+        "radius": 0.2,
+        "halfHeight": 0.25,
+        "lidarMountHeight": 0.4,
+        "embodimentType": "quadruped",  # ground physics (strafing via cmd_vel.linear.y)
+        "avatarUrl": ["/agent-model/robot.glb"],
+        "maxSpeed": 2.5,
+        "turnRate": 4.0,  # omnidirectional: fast rotation
+        "gravity": -9.81,
+        "maxStepHeight": 0.05,
+        "maxSlopeAngle": 15,
+    },
+    "humanoid": {
+        "radius": 0.2,
+        "halfHeight": 0.8,
+        "lidarMountHeight": 1.6,
+        "embodimentType": "quadruped",  # ground physics
+        "avatarUrl": ["/agent-model/robot.glb"],
+        "maxSpeed": 1.5,
+        "turnRate": 2.0,
+        "gravity": -9.81,
+        "maxStepHeight": 0.3,  # can step over things
+        "maxSlopeAngle": 45,
+    },
+    "small-robot": {
+        "radius": 0.08,
+        "halfHeight": 0.15,
+        "lidarMountHeight": 0.25,
+        "embodimentType": "quadruped",
+        "avatarUrl": ["/agent-model/robot.glb"],
+        "maxSpeed": 1.0,
+        "turnRate": 3.0,
+        "gravity": -9.81,
+        "maxStepHeight": 0.03,
+        "maxSlopeAngle": 15,
+    },
+    # -- Flight robots (6DoF, no gravity) --
+    "drone": {
+        "radius": 0.2,
+        "halfHeight": 0.1,
+        "lidarMountHeight": 0.15,
+        "embodimentType": "drone",
+        "avatarUrl": ["/agent-model/robot.glb"],
+        "maxSpeed": 5.0,
+        "turnRate": 4.0,
+        "gravity": 0,  # no gravity in flight
+        "maxAltitude": 20.0,
+    },
+}
+
+
+class SceneExecError(RuntimeError):
+    """Raised when browser-side JS execution fails."""
+
+
+class SceneClient:
+    """WebSocket client for DimSim scene manipulation.
+
+    Connects to the DimSim bridge server's control channel and sends
+    ``{type: "exec", code, id}`` commands.  The browser-side SceneEditor
+    evaluates the JS and returns ``{type: "execResult", id, success, result}``.
+
+    All high-level methods (load_map, add_npc, etc.) are thin wrappers that
+    generate JS code using the helpers already exposed in the SceneEditor
+    sandbox: ``loadGLTF``, ``addCollider``, ``removeCollider``, ``addNPC``,
+    ``removeNPC``.
+
+    Parameters
+    ----------
+    host : str
+        Bridge server host (default ``"localhost"``).
+    port : int
+        Bridge server port (default ``8090``).
+    channel : str
+        Multi-page channel name (default ``""`` = single page mode).
+    timeout : float
+        Default timeout in seconds for exec commands.
+    """
+
+    def __init__(
+        self,
+        host: str = "localhost",
+        port: int = 8090,
+        channel: str = "",
+        timeout: float = 30.0,
+    ):
+        self.host = host
+        self.port = port
+        self.channel = channel
+        self.timeout = timeout
+        self._pending: dict[str, threading.Event] = {}
+        self._results: dict[str, dict[str, Any]] = {}
+        self._ws: websocket.WebSocket | None = None
+        self._recv_thread: threading.Thread | None = None
+        self._closed = False
+
+    def start(self) -> None:
+        url = f"ws://{self.host}:{self.port}?ch=control"
+        if self.channel:
+            url += f"&channel={self.channel}"
+        self._ws = websocket.WebSocket()
+        self._ws.connect(url)  # type: ignore[no-untyped-call]
+        self._ws.settimeout(1.0)
+        self._recv_thread = threading.Thread(target=self._recv_loop, daemon=True)
+        self._recv_thread.start()
+
+    def stop(self) -> None:
+        """Close the WebSocket connection."""
+        self._closed = True
+        if self._ws:
+            try:
+                self._ws.close()
+            except Exception:
+                pass
+        self._ws = None
+
+    def _recv_loop(self) -> None:
+        while not self._closed and self._ws:
+            try:
+                raw = self._ws.recv()
+            except websocket.WebSocketTimeoutException:
+                continue
+            except (websocket.WebSocketConnectionClosedException, OSError):
+                break
+            if isinstance(raw, bytes):
+                continue
+            try:
+                msg = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            if msg.get("type") == "execResult" and "id" in msg:
+                mid = msg["id"]
+                if mid in self._pending:
+                    self._results[mid] = msg
+                    self._pending[mid].set()
+
+    def exec(self, code: str, timeout: float | None = None) -> Any:
+        """Execute arbitrary JS in the browser SceneEditor sandbox.
+
+        The code runs as an async function body with access to:
+        ``scene``, ``THREE``, ``RAPIER``, ``rapierWorld``, ``renderer``,
+        ``camera``, ``agent``, ``assets``, ``assetsGroup``,
+        ``loadGLTF(url)``, ``addCollider(obj, shape?)``,
+        ``removeCollider(obj)``, ``addNPC(opts)``, ``removeNPC(name)``.
+
+        Use ``return`` to send a value back to Python.
+
+        Parameters
+        ----------
+        code : str
+            JavaScript code to execute.
+        timeout : float, optional
+            Seconds to wait for result (default: ``self.timeout``).
+
+        Returns
+        -------
+        Any
+            The serialized return value from the JS code.
+
+        Raises
+        ------
+        SceneExecError
+            If the JS execution fails.
+        TimeoutError
+            If no result within timeout.
+        """
+        timeout = timeout if timeout is not None else self.timeout
+        msg_id = str(uuid.uuid4())
+        event = threading.Event()
+        self._pending[msg_id] = event
+
+        cmd: dict[str, Any] = {"type": "exec", "code": code, "id": msg_id}
+        if self.channel:
+            cmd["channel"] = self.channel
+        self._ws.send(json.dumps(cmd))  # type: ignore[union-attr]
+
+        if not event.wait(timeout):
+            self._pending.pop(msg_id, None)
+            raise TimeoutError(f"exec timed out after {timeout}s")
+
+        result = self._results.pop(msg_id)
+        self._pending.pop(msg_id, None)
+
+        if not result.get("success"):
+            raise SceneExecError(result.get("error", "unknown error"))
+        return result.get("result")
+
+    def load_map(
+        self,
+        url: str,
+        position: tuple[float, float, float] = (0, 0, 0),
+        scale: float = 1.0,
+        collider: str | None = "trimesh",
+        name: str | None = None,
+        auto_scale: bool | float = True,
+    ) -> dict[str, Any]:
+        """Load a GLTF/GLB map into the scene.
+
+        Parameters
+        ----------
+        url : str
+            URL or path to the .glb/.gltf file (can be absolute URL,
+            ``/local-assets/...``, or ``/proxy?url=...`` for CORS).
+        position : tuple
+            (x, y, z) world position.
+        scale : float
+            Uniform scale factor (applied before auto_scale).
+        collider : str or None
+            Collider shape: ``"trimesh"`` (default), ``"box"``, ``"sphere"``,
+            or ``None`` to skip collider.
+        name : str, optional
+            Name for the loaded model (for later lookup via ``scene.getObjectByName``).
+        auto_scale : bool or float
+            If True, auto-detect cm/m mismatch and normalize (default 50m max).
+            If a number, use that as the max dimension in meters.
+            If False, skip auto-scaling.
+
+        Returns
+        -------
+        dict
+            ``{name, uuid, collider, scaleFactor}`` info about the loaded model.
+        """
+        name_js = f"model.name = {json.dumps(name)};" if name else ""
+        collider_js = (
+            f"const col = addCollider(model, {json.dumps(collider)});"
+            if collider
+            else "const col = null;"
+        )
+        if auto_scale is False:
+            auto_scale_js = "const scaleFactor = 1.0;"
+        else:
+            max_dim = 50 if auto_scale is True else float(auto_scale)
+            auto_scale_js = f"const scaleFactor = autoScale(model, {max_dim});"
+        code = f"""
+const gltf = await loadGLTF({json.dumps(url)});
+const model = gltf.scene;
+model.position.set({position[0]}, {position[1]}, {position[2]});
+model.scale.setScalar({scale});
+model.updateMatrixWorld(true);
+{auto_scale_js}
+model.traverse(c => {{ if (c.isMesh) {{ c.castShadow = true; c.receiveShadow = true; }} }});
+{name_js}
+scene.add(model);
+{collider_js}
+return {{ name: model.name, uuid: model.uuid, collider: col, scaleFactor }};
+"""
+        return cast("dict[str, Any]", self.exec(code))
+
+    def remove_object(self, name: str) -> bool:
+        """Remove a named object from the scene.
+
+        Disposes geometry/materials and removes any associated collider.
+
+        Parameters
+        ----------
+        name : str
+            The ``object.name`` to find and remove.
+
+        Returns
+        -------
+        bool
+            True if object was found and removed.
+        """
+        code = f"""
+const obj = scene.getObjectByName({json.dumps(name)});
+if (!obj) return false;
+removeCollider(obj);
+obj.name = "";
+obj.traverse(c => {{ if (c.isMesh) {{ c.geometry?.dispose(); c.material?.dispose(); }} }});
+scene.remove(obj);
+return true;
+"""
+        return cast("bool", self.exec(code))
+
+    def add_npc(
+        self,
+        url: str,
+        name: str | None = None,
+        position: tuple[float, float, float] = (0, 0, 0),
+        rotation: float | None = None,
+        scale: float | None = None,
+        animation: str | int = 0,
+        collider: bool = True,
+    ) -> dict[str, Any]:
+        """Add an animated NPC character to the scene.
+
+        Parameters
+        ----------
+        url : str
+            URL to animated GLTF/GLB model.
+        name : str, optional
+            NPC name (auto-generated if omitted).
+        position : tuple
+            (x, y, z) world position.
+        rotation : float, optional
+            Y-axis rotation in radians.
+        scale : float, optional
+            Uniform scale factor.
+        animation : str or int
+            Animation clip name (substring match) or index (default: 0).
+        collider : bool
+            Whether to add a trimesh collider (default: True).
+
+        Returns
+        -------
+        dict
+            ``{name, animations, activeAnimation, collider}``
+        """
+        opts: dict[str, Any] = {
+            "url": url,
+            "position": {"x": position[0], "y": position[1], "z": position[2]},
+            "animation": animation,
+            "collider": collider,
+        }
+        if name:
+            opts["name"] = name
+        if rotation is not None:
+            opts["rotation"] = rotation
+        if scale is not None:
+            opts["scale"] = scale
+        return cast("dict[str, Any]", self.exec(f"return await addNPC({json.dumps(opts)});"))
+
+    def remove_npc(self, name: str) -> bool:
+        """Remove an NPC by name. Stops animation and removes collider.
+
+        Parameters
+        ----------
+        name : str
+            NPC name (as returned by ``add_npc``).
+
+        Returns
+        -------
+        bool
+            True if NPC was found and removed.
+        """
+        return cast("bool", self.exec(f"return removeNPC({json.dumps(name)});"))
+
+    def add_collider(
+        self,
+        name: str,
+        shape: str = "trimesh",
+    ) -> dict[str, Any]:
+        """Add a physics collider to a named scene object.
+
+        Parameters
+        ----------
+        name : str
+            Object name to find in scene.
+        shape : str
+            ``"trimesh"`` (default), ``"box"``, or ``"sphere"``.
+
+        Returns
+        -------
+        dict
+            ``{shape, uuid, size}``
+        """
+        code = f"""
+const obj = scene.getObjectByName({json.dumps(name)});
+if (!obj) throw new Error("Object not found: {name}");
+return addCollider(obj, {json.dumps(shape)});
+"""
+        return cast("dict[str, Any]", self.exec(code))
+
+    def remove_collider(self, name: str) -> bool:
+        """Remove collider from a named scene object.
+
+        Parameters
+        ----------
+        name : str
+            Object name to find in scene.
+
+        Returns
+        -------
+        bool
+            True if a collider existed and was removed.
+        """
+        code = f"""
+const obj = scene.getObjectByName({json.dumps(name)});
+if (!obj) throw new Error("Object not found: {name}");
+return removeCollider(obj);
+"""
+        return cast("bool", self.exec(code))
+
+    def add_object(
+        self,
+        geometry: str = "box",
+        size: tuple[float, ...] = (1, 1, 1),
+        color: int = 0x888888,
+        position: tuple[float, float, float] = (0, 0, 0),
+        name: str | None = None,
+        dynamic: bool = False,
+        mass: float = 1.0,
+        restitution: float = 0.3,
+        collider: str | None = "box",
+    ) -> dict[str, Any]:
+        """Add a primitive object to the scene with optional physics.
+
+        Parameters
+        ----------
+        geometry : str
+            ``"box"`` (default), ``"sphere"``, or ``"cylinder"``.
+        size : tuple
+            Dimensions — (w, h, d) for box, (radius,) for sphere,
+            (radiusTop, radiusBottom, height) for cylinder.
+        color : int
+            Hex color (e.g. ``0xFF0000`` for red).
+        position : tuple
+            (x, y, z) world position.
+        name : str, optional
+            Object name.
+        dynamic : bool
+            If True, object responds to gravity and collisions.
+        mass : float
+            Mass in kg (only for dynamic objects).
+        restitution : float
+            Bounciness 0-1 (only for dynamic objects).
+        collider : str or None
+            Collider shape, or None to skip.
+
+        Returns
+        -------
+        dict
+            ``{name, uuid, collider}``
+        """
+        if geometry == "sphere":
+            r = size[0] if size else 0.5
+            geom_js = f"new THREE.SphereGeometry({r}, 24, 24)"
+        elif geometry == "cylinder":
+            rt = size[0] if len(size) > 0 else 0.5
+            rb = size[1] if len(size) > 1 else rt
+            h = size[2] if len(size) > 2 else 1.0
+            geom_js = f"new THREE.CylinderGeometry({rt}, {rb}, {h}, 24)"
+        else:
+            w = size[0] if len(size) > 0 else 1
+            h = size[1] if len(size) > 1 else 1
+            d = size[2] if len(size) > 2 else 1
+            geom_js = f"new THREE.BoxGeometry({w}, {h}, {d})"
+
+        name_js = f"mesh.name = {json.dumps(name)};" if name else ""
+
+        if collider:
+            opts = {"shape": collider, "dynamic": dynamic, "mass": mass, "restitution": restitution}
+            collider_js = f"const col = addCollider(mesh, {json.dumps(opts)});"
+        else:
+            collider_js = "const col = null;"
+
+        code = f"""
+const mesh = new THREE.Mesh(
+    {geom_js},
+    new THREE.MeshStandardMaterial({{ color: {color} }})
+);
+{name_js}
+mesh.position.set({position[0]}, {position[1]}, {position[2]});
+mesh.castShadow = true;
+mesh.receiveShadow = true;
+scene.add(mesh);
+{collider_js}
+return {{ name: mesh.name, uuid: mesh.uuid, collider: col }};
+"""
+        return cast("dict[str, Any]", self.exec(code))
+
+    def add_wall(
+        self,
+        x1: float,
+        y1: float,
+        x2: float,
+        y2: float,
+        *,
+        height: float = 2.0,
+        thickness: float = 0.2,
+        color: int = 0x888888,
+        name: str | None = None,
+        refresh_lidar: bool = True,
+    ) -> dict[str, Any]:
+        """Add a 2 m tall, 0.2 m thick wall along the floor segment ``(x1, y1) → (x2, y2)``.
+
+        Parameters
+        ----------
+        x1, y1, x2, y2 : float
+            Endpoints of the wall on the floor (Three.js x, z).
+        height : float
+            Wall height in meters (default 2.0).
+        thickness : float
+            Wall thickness in meters (default 0.2).
+        color : int
+            Hex color (default ``0x888888``).
+        name : str, optional
+            Object name.
+        refresh_lidar : bool
+            Resend the Rapier snapshot to the bridge so server-side LiDAR
+            sees the new wall (default ``True``).
+
+        Returns
+        -------
+        dict
+            ``{name, uuid, lidarRefreshed}``.
+        """
+        dx = x2 - x1
+        dz = y2 - y1
+        length = math.hypot(dx, dz)
+        if length < 1e-6:
+            raise ValueError(f"Wall has zero length: ({x1}, {y1}) -> ({x2}, {y2})")
+
+        cx = (x1 + x2) / 2
+        cy = height / 2
+        cz = (y1 + y2) / 2
+        # Three.js +Y rotation is CCW viewed from +Y down: rotating local +X
+        # by θ takes it to (cos θ, 0, -sin θ).  We want local +X (the wall's
+        # length axis) to point along (dx, dz), so θ = -atan2(dz, dx).
+        rot_y = -math.atan2(dz, dx)
+        name_js = json.dumps(name) if name is not None else "null"
+        refresh_js = "true" if refresh_lidar else "false"
+
+        code = f"""
+const length = {length};
+const halfL = length / 2;
+const halfH = {height / 2};
+const halfT = {thickness / 2};
+const cx = {cx}, cy = {cy}, cz = {cz};
+const rotY = {rot_y};
+
+const mesh = new THREE.Mesh(
+  new THREE.BoxGeometry(length, {height}, {thickness}),
+  new THREE.MeshStandardMaterial({{ color: {color} }})
+);
+const _name = {name_js};
+if (_name) mesh.name = _name;
+mesh.position.set(cx, cy, cz);
+mesh.rotation.y = rotY;
+mesh.castShadow = true;
+mesh.receiveShadow = true;
+scene.add(mesh);
+
+// Free-floating colliders (createCollider(desc) with no parent body) don't
+// reliably block Rapier 0.14's kinematic character controller — they get
+// treated as detached, so the agent walks straight through them.  Attach
+// the collider to a per-wall fixed rigid body instead.  Engine.js's
+// worldBody isn't exposed to the SceneEditor sandbox, but creating extra
+// fixed bodies is cheap.
+const _bodyDesc = RAPIER.RigidBodyDesc.fixed().setTranslation(cx, cy, cz);
+const _q = new THREE.Quaternion().setFromEuler(new THREE.Euler(0, rotY, 0));
+_bodyDesc.setRotation({{ x: _q.x, y: _q.y, z: _q.z, w: _q.w }});
+const _body = rapierWorld.createRigidBody(_bodyDesc);
+const desc = RAPIER.ColliderDesc.cuboid(halfL, halfH, halfT);
+desc.setFriction(0.9);
+rapierWorld.createCollider(desc, _body);
+
+let lidarRefreshed = false;
+if ({refresh_js}) {{
+  const _bridge = window.__dimosBridge;
+  if (_bridge && _bridge.wsSensors && _bridge.wsSensors.readyState === 1) {{
+    const snap = rapierWorld.takeSnapshot();
+    const pos = (typeof agent !== "undefined" && agent.getPosition)
+      ? agent.getPosition() : [0, 0.5, 0];
+    const buf = new Uint8Array(16 + snap.byteLength);
+    const dv = new DataView(buf.buffer);
+    dv.setUint32(0, 0x44535332, false); // "DSS2"
+    dv.setFloat32(4, pos[0], true);
+    dv.setFloat32(8, pos[1], true);
+    dv.setFloat32(12, pos[2], true);
+    buf.set(snap, 16);
+    _bridge.wsSensors.send(buf.buffer);
+    lidarRefreshed = true;
+  }}
+}}
+
+return {{ name: mesh.name || null, uuid: mesh.uuid, lidarRefreshed }};
+"""
+        return cast("dict[str, Any]", self.exec(code))
+
+    def refresh_lidar_snapshot(self) -> bool:
+        """Resend a fresh Rapier world snapshot to the bridge server.
+
+        The server-side LiDAR raycaster runs against a Rapier world rebuilt
+        from a snapshot the browser sent once at scene init; any colliders
+        added after that (e.g. via ``add_wall(refresh_lidar=False)``) are
+        otherwise invisible to LiDAR.  Call this once after a batch of wall
+        additions to make them visible.
+
+        Returns
+        -------
+        bool
+            ``True`` if a snapshot was sent, ``False`` if the dimos sensor
+            socket wasn't available (e.g. running standalone without the
+            bridge).
+        """
+        code = """
+const _bridge = window.__dimosBridge;
+if (!_bridge || !_bridge.wsSensors || _bridge.wsSensors.readyState !== 1) return false;
+const snap = rapierWorld.takeSnapshot();
+const pos = (typeof agent !== "undefined" && agent.getPosition)
+  ? agent.getPosition() : [0, 0.5, 0];
+const buf = new Uint8Array(16 + snap.byteLength);
+const dv = new DataView(buf.buffer);
+dv.setUint32(0, 0x44535332, false);
+dv.setFloat32(4, pos[0], true);
+dv.setFloat32(8, pos[1], true);
+dv.setFloat32(12, pos[2], true);
+buf.set(snap, 16);
+_bridge.wsSensors.send(buf.buffer);
+return true;
+"""
+        return cast("bool", self.exec(code))
+
+    def set_embodiment(
+        self,
+        preset: str | None = None,
+        *,
+        radius: float | None = None,
+        half_height: float | None = None,
+        lidar_mount_height: float | None = None,
+        avatar_url: str | list[str] | None = None,
+        physics: str | None = None,
+        # Physics parameters
+        max_speed: float | None = None,
+        turn_rate: float | None = None,
+        gravity: float | None = None,
+        max_step_height: float | None = None,
+        ground_snap_dist: float | None = None,
+        max_slope_angle: float | None = None,
+        friction: float | None = None,
+        max_altitude: float | None = None,
+    ) -> dict[str, Any]:
+        """Set the robot embodiment — from a preset or fully custom.
+
+        Use a named preset as a starting point, then override any field.
+        Or skip the preset and specify everything manually.
+
+        **Presets** (see ``EMBODIMENT_PRESETS``):
+        - Ground: ``"unitree-go2"``, ``"differential-drive"``, ``"ackermann"``,
+          ``"holonomic"``, ``"humanoid"``, ``"small-robot"``
+        - Flight: ``"drone"``
+
+        **Physics modes**:
+        - ``"ground"`` — gravity, collision, ground snap, slope limits
+        - ``"flight"`` — 6DoF, optional gravity, altitude ceiling
+
+        **Avatar URL** can be:
+        - Built-in: ``"/agent-model/robot.glb"``
+        - Local asset: ``"/local-assets/my-drone.glb"`` (see :meth:`upload_asset`)
+        - Any URL: ``"https://example.com/robot.glb"``
+
+        Parameters
+        ----------
+        preset : str, optional
+            Named preset to start from.
+        radius : float, optional
+            Agent capsule radius in meters.
+        half_height : float, optional
+            Agent capsule half-height in meters.
+        lidar_mount_height : float, optional
+            Height of lidar sensor in meters.
+        avatar_url : str or list[str], optional
+            GLTF model URL(s).
+        physics : str, optional
+            ``"ground"`` or ``"flight"``.
+        max_speed : float, optional
+            Linear speed multiplier (default varies by preset).
+        turn_rate : float, optional
+            Angular speed multiplier (default: same as max_speed).
+        gravity : float, optional
+            Gravity in m/s² (default -9.81 for ground, 0 for flight).
+        max_step_height : float, optional
+            Max step-up height in meters (ground only, default 0.25).
+        ground_snap_dist : float, optional
+            Ground snap distance in meters (ground only, default 0.5).
+        max_slope_angle : float, optional
+            Max climbable slope in degrees (ground only, default 45).
+        friction : float, optional
+            Capsule friction coefficient (default 0.8).
+        max_altitude : float, optional
+            Altitude ceiling in meters (flight only).
+
+        Returns
+        -------
+        dict
+            The final embodiment config that was sent.
+
+        Examples
+        --------
+        >>> scene.set_embodiment("drone")
+        >>> scene.set_embodiment("differential-drive", max_speed=1.5)
+        >>> scene.set_embodiment("ackermann", turn_rate=0.8, max_slope_angle=15)
+        >>> scene.set_embodiment(
+        ...     radius=0.3, half_height=0.5, physics="ground",
+        ...     avatar_url="/local-assets/my-robot.glb",
+        ...     max_speed=2.0, max_step_height=0.1,
+        ... )
+        """
+        # Start from preset defaults
+        if preset:
+            if preset not in EMBODIMENT_PRESETS:
+                available = ", ".join(sorted(EMBODIMENT_PRESETS))
+                raise ValueError(f"Unknown preset '{preset}'. Available: {available}")
+            cfg = dict(EMBODIMENT_PRESETS[preset])
+        else:
+            cfg = dict(EMBODIMENT_PRESETS["unitree-go2"])
+
+        # Apply overrides — geometry
+        if radius is not None:
+            cfg["radius"] = radius
+        if half_height is not None:
+            cfg["halfHeight"] = half_height
+        if lidar_mount_height is not None:
+            cfg["lidarMountHeight"] = lidar_mount_height
+        if avatar_url is not None:
+            cfg["avatarUrl"] = avatar_url if isinstance(avatar_url, list) else [avatar_url]
+        if physics is not None:
+            cfg["embodimentType"] = "drone" if physics == "flight" else "quadruped"
+
+        # Apply overrides — physics parameters
+        if max_speed is not None:
+            cfg["maxSpeed"] = max_speed
+        if turn_rate is not None:
+            cfg["turnRate"] = turn_rate
+        if gravity is not None:
+            cfg["gravity"] = gravity
+        if max_step_height is not None:
+            cfg["maxStepHeight"] = max_step_height
+        if ground_snap_dist is not None:
+            cfg["groundSnapDist"] = ground_snap_dist
+        if max_slope_angle is not None:
+            cfg["maxSlopeAngle"] = max_slope_angle
+        if friction is not None:
+            cfg["friction"] = friction
+        if max_altitude is not None:
+            cfg["maxAltitude"] = max_altitude
+
+        msg = {"type": "embodimentConfig", **cfg}
+        if self.channel:
+            msg["channel"] = self.channel
+        self._ws.send(json.dumps(msg))  # type: ignore[union-attr]
+
+        # Swap the avatar model browser-side via exec
+        avatar_urls = cfg.get("avatarUrl", [])
+        if avatar_urls:
+            urls_js = json.dumps(avatar_urls)
+            r = cfg.get("radius", 0.12)
+            hh = cfg.get("halfHeight", 0.25)
+            self.exec(f"""
+                if (agent.model) {{
+                    agent.group.remove(agent.model);
+                    agent.model = null;
+                }}
+                agent.avatarUrl = {urls_js};
+                agent.radius = {r};
+                agent.halfHeight = {hh};
+                agent._loadGLB();
+                return "avatar_swap_initiated";
+            """)
+
+        return cfg
+
+    def clear_scene(self) -> int:
+        """Remove all user-added objects from the scene.
+
+        Preserves the agent, camera, lights, and renderer. Removes everything
+        else (loaded maps, NPCs, etc.).
+
+        Returns
+        -------
+        int
+            Number of objects removed.
+        """
+        code = """
+const keep = new Set();
+// Keep agent and its children
+if (agent && agent.group) keep.add(agent.group.uuid);
+// Keep camera, renderer internals, lights
+scene.children.forEach(c => {
+  if (c === camera || c.isLight || c.isAmbientLight || c.isDirectionalLight
+      || c.isHemisphereLight || c === agent?.group) {
+    keep.add(c.uuid);
+  }
+});
+const toRemove = scene.children.filter(c => !keep.has(c.uuid));
+let count = 0;
+for (const obj of toRemove) {
+  removeCollider(obj);
+  obj.name = "";
+  obj.traverse(c => { if (c.isMesh) { c.geometry?.dispose(); c.material?.dispose(); } });
+  scene.remove(obj);
+  count++;
+}
+return count;
+"""
+        return cast("int", self.exec(code))
+
+    def get_scene_info(self) -> dict[str, Any]:
+        """Get info about the current scene (object names, counts).
+
+        Returns
+        -------
+        dict
+            ``{objectCount, objects: [{name, type, uuid}]}``
+        """
+        code = """
+const objects = [];
+scene.traverse(obj => {
+  if (obj === scene) return;
+  objects.push({ name: obj.name || "(unnamed)", type: obj.type, uuid: obj.uuid });
+});
+return { objectCount: objects.length, objects: objects.slice(0, 100) };
+"""
+        return cast("dict[str, Any]", self.exec(code))
+
+    def set_agent_position(
+        self,
+        x: float,
+        y: float,
+        z: float,
+    ) -> None:
+        """Teleport the agent to a world position.
+
+        Sends a teleport command to the server-side physics engine, which
+        updates the agent's kinematic body directly.  The new position is
+        then broadcast to the browser for rendering.
+
+        Parameters
+        ----------
+        x, y, z : float
+            Target position in Three.js world coordinates (Y-up).
+        """
+        cmd: dict[str, Any] = {"type": "teleport", "x": x, "y": y, "z": z}
+        if self.channel:
+            cmd["channel"] = self.channel
+        self._ws.send(json.dumps(cmd))  # type: ignore[union-attr]
+
+    def get_agent_position(self) -> dict[str, Any]:
+        """Get the agent's current world position.
+
+        Returns
+        -------
+        dict
+            ``{x, y, z}``
+        """
+        code = """
+const p = agent.group.position;
+return { x: p.x, y: p.y, z: p.z };
+"""
+        return cast("dict[str, Any]", self.exec(code))

--- a/dimos/simulation/mujoco/direct_cmd_vel_explorer.py
+++ b/dimos/simulation/mujoco/direct_cmd_vel_explorer.py
@@ -45,7 +45,7 @@ class DirectCmdVelExplorer:
         self._cmd_vel = LCMTransport("/cmd_vel", Twist)
         self._odom = LCMTransport("/odom", PoseStamped)
         self._pose = None
-        self._unsub = self._odom.subscribe(self._on_odom)  # type: ignore[func-returns-value]
+        self._unsub = self._odom.subscribe(self._on_odom)
 
     def stop(self) -> None:
         if self._unsub:

--- a/dimos/simulation/unity/module.py
+++ b/dimos/simulation/unity/module.py
@@ -695,17 +695,15 @@ class UnityBridgeModule(Module):
         # Use the same intrinsics as rerun_static_pinhole (120° HFOV pinhole
         # approximation of the cylindrical panorama).
         self.camera_info.publish(
-            CameraInfo(
-                height=height,
+            CameraInfo.from_intrinsics(
+                fx=_CAM_FX,
+                fy=_CAM_FY,
+                cx=_CAM_CX,
+                cy=_CAM_CY,
                 width=width,
-                distortion_model="plumb_bob",
-                D=[0.0, 0.0, 0.0, 0.0, 0.0],
-                K=[_CAM_FX, 0.0, _CAM_CX, 0.0, _CAM_FY, _CAM_CY, 0.0, 0.0, 1.0],
-                R=[1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0],
-                P=[_CAM_FX, 0.0, _CAM_CX, 0.0, 0.0, _CAM_FY, _CAM_CY, 0.0, 0.0, 0.0, 1.0, 0.0],
+                height=height,
                 frame_id="camera",
-                ts=ts,
-            )
+            ).with_ts(ts)
         )
 
     def _send_to_unity(self, topic: str, data: bytes) -> None:

--- a/dimos/stream/audio/node_output.py
+++ b/dimos/stream/audio/node_output.py
@@ -79,7 +79,9 @@ class SounddeviceAudioOutput(AbstractAudioTransform):
         """
         self.audio_observable = audio_observable  # type: ignore[assignment]
 
-        # Create and start the output stream
+        # Try to create and start the output stream. If no audio device is
+        # available (e.g. in CI / headless), log and continue — audio events
+        # will still be drained from the observable and silently dropped.
         try:
             self._stream = sd.OutputStream(
                 device=self.device_index,
@@ -95,10 +97,11 @@ class SounddeviceAudioOutput(AbstractAudioTransform):
                 f"Started audio output: {self.sample_rate}Hz, "
                 f"{self.channels} channels, {self.block_size} samples per frame"
             )
-
         except Exception as e:
-            logger.error(f"Error starting audio output stream: {e}")
-            raise e
+            self._stream = None
+            logger.warning(
+                f"No audio output device available ({e}); audio events will be consumed and dropped"
+            )
 
         # Subscribe to the observable
         self._subscription = audio_observable.subscribe(  # type: ignore[assignment]

--- a/dimos/stream/audio/test_node_output.py
+++ b/dimos/stream/audio/test_node_output.py
@@ -1,0 +1,38 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import reactivex as rx
+
+from dimos.stream.audio.node_output import SounddeviceAudioOutput
+
+
+@pytest.fixture
+def sound_device():
+    out = SounddeviceAudioOutput()
+    yield out
+    out.stop()
+
+
+def test_consume_audio_survives_missing_device(mocker, sound_device) -> None:
+    mocker.patch(
+        "dimos.stream.audio.node_output.sd.OutputStream",
+        side_effect=Exception("Error querying device -1"),
+    )
+
+    sound_device.consume_audio(rx.empty())
+
+    assert sound_device._stream is None
+    assert not sound_device._running.is_set()
+    assert sound_device._subscription is not None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -516,6 +516,7 @@ module = [
     "ultralytics.*",
     "unitree_sdk2py.*",
     "unitree_webrtc_connect.*",
+    "websocket",
     "xarm.*",
     "ament_index_python.*",
 ]
@@ -539,7 +540,7 @@ env = [
   "GOOGLE_MAPS_API_KEY=AIzafake_google_key",
   "PYTHONWARNINGS=ignore:cupyx.jit.rawkernel is experimental:FutureWarning",
 ]
-addopts = "--dist=loadfile --durations=10 --timeout=600 --timeout-method=thread -v -ra --showlocals --cov-report=xml -p no:launch_testing -p no:launch_ros --import-mode=importlib --color=yes -m 'not (tool or self_hosted or mujoco)'"
+addopts = "--dist=loadfile --durations=10 --timeout=600 --timeout-method=thread -v -ra --showlocals --cov-report=xml -p no:launch_testing -p no:launch_ros --import-mode=importlib --color=yes -m 'not (tool or self_hosted or mujoco or dimsim)'"
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 


### PR DESCRIPTION
## Problem

We need a light-er weight simulator.

Closes DIM-xxx

## Solution

* Add the DimSim simulator.
* Add tests which use it.

## Breaking Changes

The `--simulation` flag now takes a parameter: either `mujoco` or `dimsim`.

## How to Test

Run the apt scene:

```bash
uv run dimos --simulation=dimsim run unitree-go2-agentic
```

Run the empty scene:

```bash
uv run dimos --dimsim-scene=empty --simulation=dimsim run unitree-go2-agentic
```

Run the dimsim tests:
```bash
uv run pytest -m dimsim
```

## Contributor License Agreement

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).