### PR TITLE
fix(manip): tests

### DIFF
--- a/dimos/robot/catalog/piper.py
+++ b/dimos/robot/catalog/piper.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 from typing import Any
 
-from dimos.core.global_config import global_config
 from dimos.robot.config import GripperConfig, RobotConfig
 from dimos.utils.data import LfsPath
 
@@ -83,10 +82,6 @@ def piper(
             close_position=0.0,
         ),
     }
-    if global_config.simulation and adapter_type == "mock":
-        defaults.update(adapter_type="sim_mujoco", address=str(PIPER_SIM_PATH))
-        defaults.setdefault("adapter_kwargs", {})["headless"] = False
-
     defaults.update(overrides)
     return RobotConfig(**defaults)
 

--- a/dimos/robot/catalog/ufactory.py
+++ b/dimos/robot/catalog/ufactory.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 from typing import Any
 
-from dimos.core.global_config import global_config
 from dimos.robot.config import GripperConfig, RobotConfig
 from dimos.utils.data import LfsPath
 
@@ -100,10 +99,6 @@ def xarm7(
         if add_gripper
         else None,
     }
-    if global_config.simulation and adapter_type == "mock":
-        defaults.update(adapter_type="sim_mujoco", address=str(XARM7_SIM_PATH))
-        defaults.setdefault("adapter_kwargs", {})["headless"] = False
-
     defaults.update(overrides)
     return RobotConfig(**defaults)
 
@@ -156,10 +151,6 @@ def xarm6(
         if add_gripper
         else None,
     }
-    if global_config.simulation and adapter_type == "mock":
-        defaults.update(adapter_type="sim_mujoco", address=str(XARM6_SIM_PATH))
-        defaults.setdefault("adapter_kwargs", {})["headless"] = False
-
     defaults.update(overrides)
     return RobotConfig(**defaults)
 


### PR DESCRIPTION
## Problem

The xarm7(), xarm6(), and piper() catalog functions check if adapter_type="mock".
and if `global_config.simulation` was true, to set `adapter_type` to sim on the 2nd check. so, test fails when `adaper_type` is set to mock and result wil be `sim`, as env_variable `sim` is true.

## Solution

Removed the global_config.simulation swap from all three catalog functions and dropped the global_config import.
we dont set adapter, based on global_config.simulation for now

## Breaking Changes

None

## How to Test

Tests pass
`SIMULATION=true pytest dimos/robot/test_robot_config.py`
`SIMULATION=true pytest dimos/e2e_tests/test_control_coordinator.py`

## Contributor License Agreement

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
