### PR TITLE
Security: MCP server defaults to public network binding

### DIFF
--- a/dimos/core/global_config.py
+++ b/dimos/core/global_config.py
@@ -50,7 +50,7 @@ class GlobalConfig(BaseSettings):
     planner_strategy: NavigationStrategy = "simple"
     planner_robot_speed: float | None = None
     mcp_port: int = 9990
-    mcp_host: str = "0.0.0.0"
+    mcp_host: str = "127.0.0.1"
     dtop: bool = False
     obstacle_avoidance: bool = True
     detection_model: VlModelName = "moondream"


### PR DESCRIPTION
## Summary

Security: MCP server defaults to public network binding

## Problem

**Severity**: `High` | **File**: `dimos/core/global_config.py:L44`

The global configuration sets `mcp_host` to `0.0.0.0`, which typically exposes the MCP server on all network interfaces. If MCP endpoints allow tool invocation or robot control without strong authentication, this can allow unauthorized remote access and command execution over the network.

## Solution

Change the default host to `127.0.0.1` (or a Unix socket) and require explicit opt-in for external binding. Add mandatory authentication/authorization (e.g., mTLS or token-based auth) for non-local access, and document secure deployment defaults.

## Changes

- `dimos/core/global_config.py` (modified)