### PR TITLE
ci(macos): add macos_bug marker and skip known-crashing worker tests

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -98,7 +98,7 @@ jobs:
           CI: "1"
         run: |
           source .venv/bin/activate
-          python -m pytest --durations=10 -m 'not (tool or mujoco or macos_bug)' --timeout=120 dimos/
+          python -m pytest --durations=10 -m 'not (tool or mujoco)' --timeout=120 dimos/
 
       - name: Check disk usage (post-test)
         if: always()

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -74,6 +74,7 @@ jobs:
       - name: Build C++ extensions
         run: |
           source .venv/bin/activate
+          uv pip install pybind11
           python setup.py build_ext --inplace
 
       - name: Check disk usage

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -93,7 +93,7 @@ jobs:
           CI: "1"
         run: |
           source .venv/bin/activate
-          python -m pytest --durations=10 -m 'not (tool or mujoco)' --timeout=120 dimos/
+          python -m pytest --durations=10 -m 'not (tool or mujoco or macos_bug)' --timeout=120 dimos/
 
       - name: Check disk usage (post-test)
         if: always()

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -71,6 +71,11 @@ jobs:
         run: |
           uv sync --all-extras --no-extra dds --no-extra cuda --frozen
 
+      - name: Build C++ extensions
+        run: |
+          source .venv/bin/activate
+          python setup.py build_ext --inplace
+
       - name: Check disk usage
         run: |
           df -h .

--- a/dimos/conftest.py
+++ b/dimos/conftest.py
@@ -14,6 +14,7 @@
 
 import asyncio
 import os
+import platform
 import threading
 
 from dotenv import load_dotenv
@@ -34,6 +35,10 @@ def _has_ros() -> bool:
         return False
 
 
+def _is_macos() -> bool:
+    return platform.system() == "Darwin"
+
+
 def pytest_configure(config):
     config.addinivalue_line("markers", "tool: dev tooling")
     config.addinivalue_line("markers", "slow: tests that are too slow for the fast loop")
@@ -42,6 +47,7 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "skipif_no_openai: skip when OPENAI_API_KEY is not set")
     config.addinivalue_line("markers", "skipif_no_alibaba: skip when ALIBABA_API_KEY is not set")
     config.addinivalue_line("markers", "skipif_no_ros: skip when ROS dependencies are not present")
+    config.addinivalue_line("markers", "skipif_macos_bug: skip known-buggy tests on macOS")
 
     # Propagate coverage collection to subprocesses.
     if os.environ.get("_DIMOS_COV"):
@@ -55,6 +61,7 @@ def pytest_collection_modifyitems(config, items):
         "skipif_no_openai": (not os.getenv("OPENAI_API_KEY"), "OPENAI_API_KEY not set"),
         "skipif_no_alibaba": (not os.getenv("ALIBABA_API_KEY"), "ALIBABA_API_KEY not set"),
         "skipif_no_ros": (not _has_ros(), "ROS dependencies are not present"),
+        "skipif_macos_bug": (_is_macos(), "Some tests are buggy on Mac OS"),
     }
     for marker_name, (condition, reason) in _skipif_markers.items():
         if condition:

--- a/dimos/core/coordination/test_worker.py
+++ b/dimos/core/coordination/test_worker.py
@@ -99,7 +99,7 @@ def create_worker_manager():
 
 
 @pytest.mark.slow
-@pytest.mark.macos_bug
+@pytest.mark.skipif_macos_bug
 def test_worker_manager_basic(create_worker_manager):
     worker_manager = create_worker_manager(n_workers=2)
     module = worker_manager.deploy(SimpleModule, global_config, {})
@@ -118,7 +118,7 @@ def test_worker_manager_basic(create_worker_manager):
 
 
 @pytest.mark.slow
-@pytest.mark.macos_bug
+@pytest.mark.skipif_macos_bug
 def test_worker_manager_multiple_different_modules(create_worker_manager):
     worker_manager = create_worker_manager(n_workers=2)
     module1 = worker_manager.deploy(SimpleModule, global_config, {})
@@ -141,7 +141,7 @@ def test_worker_manager_multiple_different_modules(create_worker_manager):
 
 
 @pytest.mark.slow
-@pytest.mark.macos_bug
+@pytest.mark.skipif_macos_bug
 def test_worker_manager_parallel_deployment(create_worker_manager):
     worker_manager = create_worker_manager(n_workers=2)
     modules = worker_manager.deploy_parallel(
@@ -177,7 +177,7 @@ def test_worker_manager_parallel_deployment(create_worker_manager):
 
 
 @pytest.mark.slow
-@pytest.mark.macos_bug
+@pytest.mark.skipif_macos_bug
 def test_collect_stats(create_worker_manager):
     from dimos.core.resource_monitor.monitor import StatsMonitor
 
@@ -224,7 +224,7 @@ def test_collect_stats(create_worker_manager):
 
 
 @pytest.mark.slow
-@pytest.mark.macos_bug
+@pytest.mark.skipif_macos_bug
 def test_worker_pool_modules_share_workers(create_worker_manager):
     manager = create_worker_manager(n_workers=1)
     module1 = manager.deploy(SimpleModule, global_config, {})
@@ -271,7 +271,7 @@ def manager_and_modules():
 
 
 @pytest.mark.slow
-@pytest.mark.macos_bug
+@pytest.mark.skipif_macos_bug
 def test_health_check_alive_workers(manager_and_modules):
     manager, modules = manager_and_modules(n_workers=2)
     module = manager.deploy(SimpleModule, global_config, {})
@@ -282,7 +282,7 @@ def test_health_check_alive_workers(manager_and_modules):
 
 
 @pytest.mark.slow
-@pytest.mark.macos_bug
+@pytest.mark.skipif_macos_bug
 def test_add_workers_grows_pool(manager_and_modules):
     manager, modules = manager_and_modules(n_workers=1)
     manager.add_workers(2)
@@ -297,7 +297,7 @@ def test_add_workers_grows_pool(manager_and_modules):
 
 
 @pytest.mark.slow
-@pytest.mark.macos_bug
+@pytest.mark.skipif_macos_bug
 def test_load_balancing_distributes_modules(manager_and_modules):
     manager, modules = manager_and_modules(n_workers=2)
 

--- a/dimos/core/coordination/test_worker.py
+++ b/dimos/core/coordination/test_worker.py
@@ -99,6 +99,7 @@ def create_worker_manager():
 
 
 @pytest.mark.slow
+@pytest.mark.macos_bug
 def test_worker_manager_basic(create_worker_manager):
     worker_manager = create_worker_manager(n_workers=2)
     module = worker_manager.deploy(SimpleModule, global_config, {})
@@ -117,6 +118,7 @@ def test_worker_manager_basic(create_worker_manager):
 
 
 @pytest.mark.slow
+@pytest.mark.macos_bug
 def test_worker_manager_multiple_different_modules(create_worker_manager):
     worker_manager = create_worker_manager(n_workers=2)
     module1 = worker_manager.deploy(SimpleModule, global_config, {})
@@ -139,6 +141,7 @@ def test_worker_manager_multiple_different_modules(create_worker_manager):
 
 
 @pytest.mark.slow
+@pytest.mark.macos_bug
 def test_worker_manager_parallel_deployment(create_worker_manager):
     worker_manager = create_worker_manager(n_workers=2)
     modules = worker_manager.deploy_parallel(
@@ -174,6 +177,7 @@ def test_worker_manager_parallel_deployment(create_worker_manager):
 
 
 @pytest.mark.slow
+@pytest.mark.macos_bug
 def test_collect_stats(create_worker_manager):
     from dimos.core.resource_monitor.monitor import StatsMonitor
 
@@ -220,6 +224,7 @@ def test_collect_stats(create_worker_manager):
 
 
 @pytest.mark.slow
+@pytest.mark.macos_bug
 def test_worker_pool_modules_share_workers(create_worker_manager):
     manager = create_worker_manager(n_workers=1)
     module1 = manager.deploy(SimpleModule, global_config, {})
@@ -266,6 +271,7 @@ def manager_and_modules():
 
 
 @pytest.mark.slow
+@pytest.mark.macos_bug
 def test_health_check_alive_workers(manager_and_modules):
     manager, modules = manager_and_modules(n_workers=2)
     module = manager.deploy(SimpleModule, global_config, {})
@@ -276,6 +282,7 @@ def test_health_check_alive_workers(manager_and_modules):
 
 
 @pytest.mark.slow
+@pytest.mark.macos_bug
 def test_add_workers_grows_pool(manager_and_modules):
     manager, modules = manager_and_modules(n_workers=1)
     manager.add_workers(2)
@@ -290,6 +297,7 @@ def test_add_workers_grows_pool(manager_and_modules):
 
 
 @pytest.mark.slow
+@pytest.mark.macos_bug
 def test_load_balancing_distributes_modules(manager_and_modules):
     manager, modules = manager_and_modules(n_workers=2)
 

--- a/dimos/navigation/patrolling/test_create_patrol_router.py
+++ b/dimos/navigation/patrolling/test_create_patrol_router.py
@@ -41,7 +41,12 @@ def big_office() -> OccupancyGrid:
 
 @pytest.mark.slow
 @pytest.mark.parametrize(
-    "router_name, saturation", [("random", 0.20), ("coverage", 0.30), ("frontier", 0.20)]
+    "router_name, saturation",
+    [
+        ("random", 0.20),
+        pytest.param("coverage", 0.30, marks=pytest.mark.macos_bug),
+        ("frontier", 0.20),
+    ],
 )
 def test_patrolling_coverage(router_name, saturation, big_office) -> None:
     start = (-1.03, -13.48)

--- a/dimos/navigation/patrolling/test_create_patrol_router.py
+++ b/dimos/navigation/patrolling/test_create_patrol_router.py
@@ -41,12 +41,7 @@ def big_office() -> OccupancyGrid:
 
 @pytest.mark.slow
 @pytest.mark.parametrize(
-    "router_name, saturation",
-    [
-        ("random", 0.20),
-        pytest.param("coverage", 0.30, marks=pytest.mark.macos_bug),
-        ("frontier", 0.20),
-    ],
+    "router_name, saturation", [("random", 0.20), ("coverage", 0.30), ("frontier", 0.20)]
 )
 def test_patrolling_coverage(router_name, saturation, big_office) -> None:
     start = (-1.03, -13.48)

--- a/dimos/navigation/replanning_a_star/min_cost_astar.py
+++ b/dimos/navigation/replanning_a_star/min_cost_astar.py
@@ -28,8 +28,10 @@ try:
     )
 
     _USE_CPP = True
-except ImportError:
+    _CPP_IMPORT_ERROR: ImportError | None = None
+except ImportError as e:
     _USE_CPP = False
+    _CPP_IMPORT_ERROR = e
 
 logger = setup_logger()
 
@@ -154,7 +156,10 @@ def min_cost_astar(
                 return None
             return _reconstruct_path_from_coords(path_coords, costmap)
         else:
-            logger.warning("C++ A* module could not be imported. Using Python.")
+            logger.warning(
+                "C++ A* module could not be imported (%s). Using Python.",
+                _CPP_IMPORT_ERROR,
+            )
 
     open_set: list[tuple[float, float, tuple[int, int]]] = []  # Priority queue for nodes to explore
     closed_set: set[tuple[int, int]] = set()  # Set of explored nodes

--- a/dimos/perception/detection/type/detection3d/test_pointcloud.py
+++ b/dimos/perception/detection/type/detection3d/test_pointcloud.py
@@ -16,6 +16,7 @@ import numpy as np
 import pytest
 
 
+@pytest.mark.skipif_macos_bug
 def test_detection3dpc(detection3dpc) -> None:
     # def test_oriented_bounding_box(detection3dpc):
     """Test oriented bounding box calculation and values."""

--- a/dimos/types/test_timestamped.py
+++ b/dimos/types/test_timestamped.py
@@ -281,7 +281,7 @@ def test_time_window_collection() -> None:
     assert window.end_ts == 5.5
 
 
-@pytest.mark.macos_bug
+@pytest.mark.skipif_macos_bug
 def test_timestamp_alignment(test_scheduler) -> None:
     speed = 5.0
 

--- a/dimos/types/test_timestamped.py
+++ b/dimos/types/test_timestamped.py
@@ -281,6 +281,7 @@ def test_time_window_collection() -> None:
     assert window.end_ts == 5.5
 
 
+@pytest.mark.macos_bug
 def test_timestamp_alignment(test_scheduler) -> None:
     speed = 5.0
 

--- a/dimos/utils/test_reactive.py
+++ b/dimos/utils/test_reactive.py
@@ -246,6 +246,7 @@ def test_getter_ondemand() -> None:
         test_scheduler.executor.shutdown(wait=True)
 
 
+@pytest.mark.skipif_macos_bug
 def test_getter_ondemand_timeout() -> None:
     source = dispose_spy(rx.interval(0.2).pipe(ops.take(50)))
     getter = getter_ondemand(source, timeout=0.1)


### PR DESCRIPTION
## Problem

macOS CI fails on nearly every PR because `dimos/core/coordination/test_worker.py` hits a native segfault (exit 139) partway through execution - the crash surfaces during `test_load_balancing_distributes_modules` but is cumulative state from prior tests in the same file. 
Since the process dies, pytest reports no `FAILED` tests, just a red job, which trains the team to ignore macOS CI entirely

Closes #1752 

## Solution

- Introduces a `macos_bug` pytest marker convention for tests known to fail or crash on the macOS runner
- Updates the macOS workflow's pytest filter to exclude `macos_bug` alongside the existing `tool` and `mujoco` exclusions.

Linux CI is unaffected.

None

## How to Test

- macOS check should now get past `test_worker.py` instead of segfaulting
- Linux CI (`ci.yml`) should continue to run the full suite including `test_worker.py`, since the marker is only excluded in `macos.yml`
- To verify locally on macOS
   ```bash
   python -m pytest --durations=10 -m 'not (tool or mujoco or macos_bug)' --timeout=120 dimos/

## Contributor License Agreement

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
