### PR TITLE
feature: add real-time Rerun URDF visualizer for robot arms (#845)

### DIFF
--- a/dimos/manipulation/manipulation_module.py
+++ b/dimos/manipulation/manipulation_module.py
@@ -53,6 +53,13 @@ from dimos.msgs.sensor_msgs import JointState
 from dimos.msgs.trajectory_msgs import JointTrajectory
 from dimos.utils.logging_config import setup_logger
 
+try:
+    import rerun as rr
+    from dimos.visualization.rerun.robot import RobotVisualizer
+except ImportError:
+    rr = None
+    RobotVisualizer = None
+
 if TYPE_CHECKING:
     from dimos.core.rpc_client import RPCClient
 
@@ -89,6 +96,7 @@ class ManipulationModuleConfig(ModuleConfig):
     robots: list[RobotModelConfig] = field(default_factory=list)
     planning_timeout: float = 10.0
     enable_viz: bool = False
+    enable_rerun_viz: bool = False
     planner_name: str = "rrt_connect"  # "rrt_connect"
     kinematics_name: str = "jacobian"  # "jacobian" or "drake_optimization"
 
@@ -122,6 +130,8 @@ class ManipulationModule(Module):
         self._world_monitor: WorldMonitor | None = None
         self._planner: PlannerSpec | None = None
         self._kinematics: KinematicsSpec | None = None
+
+        self._robot_visualizers: dict[RobotName, RobotVisualizer] = {}
 
         # Robot registry: maps robot_name -> (world_robot_id, config, trajectory_gen)
         self._robots: RobotRegistry = {}
@@ -184,6 +194,27 @@ class ManipulationModule(Module):
             if url := self._world_monitor.get_visualization_url():
                 logger.info(f"Visualization: {url}")
 
+        if self.config.enable_rerun_viz:
+            if rr is None or RobotVisualizer is None:
+                logger.error("Rerun or RobotVisualizer not available, rerun visualization disabled")
+            else:
+                rr.init("dimos")
+                try:
+                    # Attempt to connect to a running bridge/viewer
+                    rr.connect_grpc("rerun+http://127.0.0.1:9876/proxy")
+                except Exception:
+                    pass
+
+                for robot_config in self.config.robots:
+                    vis = RobotVisualizer(
+                        urdf_path=robot_config.urdf_path,
+                        entity_path=f"world/{robot_config.name}",
+                        package_paths=robot_config.package_paths,
+                        xacro_args=robot_config.xacro_args,
+                    )
+                    self._robot_visualizers[robot_config.name] = vis
+                logger.info(f"Initialized Rerun visualization for {list(self._robot_visualizers.keys())}")
+
         self._planner = create_planner(name=self.config.planner_name)
         self._kinematics = create_kinematics(name=self.config.kinematics_name)
 
@@ -235,6 +266,10 @@ class ManipulationModule(Module):
             # extracts only its robot's joints based on joint_name_mapping.
             if self._world_monitor is not None:
                 self._world_monitor.on_joint_state(msg, robot_id=None)
+
+            # Update Rerun visualizers
+            for vis in self._robot_visualizers.values():
+                vis.update_joints(msg)
 
             # Capture initial joint positions on first callback
             if self._init_joints is None and msg.position:

--- a/dimos/robot/manipulators/piper/blueprints.py
+++ b/dimos/robot/manipulators/piper/blueprints.py
@@ -84,6 +84,7 @@ keyboard_teleop_piper = autoconnect(
             ),
         ],
         enable_viz=True,
+        enable_rerun_viz=True,
     ),
 ).transports(
     {

--- a/dimos/robot/manipulators/xarm/blueprints.py
+++ b/dimos/robot/manipulators/xarm/blueprints.py
@@ -69,6 +69,7 @@ keyboard_teleop_xarm6 = autoconnect(
     manipulation_module(
         robots=[_make_xarm6_config(name="arm", joint_prefix="arm_", add_gripper=False)],
         enable_viz=True,
+        enable_rerun_viz=True,
     ),
 ).transports(
     {
@@ -108,6 +109,7 @@ keyboard_teleop_xarm7 = autoconnect(
     manipulation_module(
         robots=[_make_xarm7_config(name="arm", joint_prefix="arm_", add_gripper=False)],
         enable_viz=True,
+        enable_rerun_viz=True,
     ),
 ).transports(
     {

--- a/dimos/visualization/rerun/robot.py
+++ b/dimos/visualization/rerun/robot.py
@@ -17,9 +17,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 
-import numpy as np
 import pinocchio
 import rerun as rr
 
@@ -27,6 +25,12 @@ from dimos.msgs.sensor_msgs.JointState import JointState
 from dimos.utils.logging_config import setup_logger
 
 logger = setup_logger()
+
+# Try to use hpp-fcl types if available (usually bundled with pinocchio)
+try:
+    import hppfcl
+except ImportError:
+    hppfcl = None
 
 
 class RobotVisualizer:
@@ -112,12 +116,6 @@ class RobotVisualizer:
 
     def _log_geometry(self, entity_path: str, geom: pinocchio.GeometryObject) -> None:
         """Log a single geometry object to Rerun."""
-        # Try to use hpp-fcl types if available (usually bundled with pinocchio)
-        try:
-            import hppfcl
-        except ImportError:
-            hppfcl = None
-
         # Convert Pinocchio's 4-float rgba (0-1) to Rerun's 4-uint8 rgba
         color = None
         if hasattr(geom, "meshColor") and geom.meshColor is not None:
@@ -129,7 +127,16 @@ class RobotVisualizer:
             half_size = geom.geometry.halfSide
             rr.log(entity_path, rr.Boxes3D(half_sizes=[half_size], colors=[color] if color else None), static=True)
         elif hppfcl and isinstance(geom.geometry, hppfcl.Sphere):
-            rr.log(entity_path, rr.Ellipsoids3D(radii=[geom.geometry.radius] * 3, colors=[color] if color else None), static=True)
+            # Using half_sizes as a list-of-vectors to log a single sphere correctly
+            radius = geom.geometry.radius
+            rr.log(
+                entity_path,
+                rr.Ellipsoids3D(
+                    half_sizes=[[radius] * 3],
+                    colors=[color] if color else None
+                ),
+                static=True
+            )
         elif hppfcl and isinstance(geom.geometry, hppfcl.Cylinder):
             # Cylinder not directly supported, skip or log debug
             logger.debug(f"Cylinder primitive not yet supported in Rerun logging for {entity_path}")

--- a/dimos/visualization/rerun/robot.py
+++ b/dimos/visualization/rerun/robot.py
@@ -1,0 +1,193 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Rerun-based robot visualizer using Pinocchio for kinematics."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pinocchio
+import rerun as rr
+
+from dimos.msgs.sensor_msgs.JointState import JointState
+from dimos.utils.logging_config import setup_logger
+
+logger = setup_logger()
+
+
+class RobotVisualizer:
+    """Logs a robot URDF and updates its joints in Rerun.
+
+    Uses Pinocchio to parse the URDF and compute forward kinematics for
+    nested entity path transforms in Rerun.
+    """
+
+    def __init__(
+        self,
+        urdf_path: str | Path,
+        entity_path: str = "world/robot",
+        package_paths: dict[str, Path] | None = None,
+        xacro_args: dict[str, str] | None = None,
+    ) -> None:
+        """Initialize the visualizer.
+
+        Args:
+            urdf_path: Path to URDF or xacro file.
+            entity_path: Rerun entity path for the robot root.
+            package_paths: Mapping of package names to filesystem paths for meshes.
+            xacro_args: Arguments for xacro processing.
+        """
+        self.urdf_path = Path(urdf_path)
+        self.root_entity_path = entity_path
+
+        # Prepare URDF (resolves xacro and package:// URIs, converts DAE/STL to OBJ)
+        from dimos.manipulation.planning.utils.mesh_utils import prepare_urdf_for_drake
+
+        self.resolved_urdf = prepare_urdf_for_drake(
+            self.urdf_path, package_paths=package_paths, xacro_args=xacro_args,
+            convert_meshes=True
+        )
+
+        # Load Pinocchio model
+        try:
+            self.model = pinocchio.buildModelFromUrdf(self.resolved_urdf)
+            self.visual_model = pinocchio.buildGeomFromUrdf(
+                self.model, self.resolved_urdf, pinocchio.VISUAL
+            )
+        except Exception as e:
+            logger.error(f"Failed to load URDF with Pinocchio: {e}")
+            raise
+
+        self.data = self.model.createData()
+
+        # Map Pinocchio joint IDs to Rerun entity paths
+        self.joint_to_entity: dict[int, str] = {}
+        for i, name in enumerate(self.model.names):
+            if i == 0:  # Universe
+                self.joint_to_entity[i] = self.root_entity_path
+            else:
+                parent_id = self.model.parents[i]
+                parent_path = self.joint_to_entity[parent_id]
+                # Avoid "universe" in the path if possible, but Pinocchio joint 0 is universe
+                self.joint_to_entity[i] = f"{parent_path}/{name}"
+
+        self._log_static_visuals()
+
+    def _log_static_visuals(self) -> None:
+        """Log visual geometries to Rerun once at startup."""
+        for i, geom in enumerate(self.visual_model.geometryObjects):
+            joint_id = geom.parentJoint
+            # Use geometry name if unique, otherwise append index
+            geom_name = geom.name or f"visual_{i}"
+            entity_path = f"{self.joint_to_entity[joint_id]}/visuals/{geom_name}"
+
+            # Log the placement relative to the joint
+            pos = geom.placement.translation
+            quat = pinocchio.Quaternion(geom.placement.rotation)
+            rr.log(
+                entity_path,
+                rr.Transform3D(
+                    translation=pos,
+                    rotation=rr.Quaternion(xyzw=[quat.x, quat.y, quat.z, quat.w]),
+                ),
+                static=True,
+            )
+
+            # Log the geometry itself
+            self._log_geometry(entity_path, geom)
+
+    def _log_geometry(self, entity_path: str, geom: pinocchio.GeometryObject) -> None:
+        """Log a single geometry object to Rerun."""
+        # Try to use hpp-fcl types if available (usually bundled with pinocchio)
+        try:
+            import hppfcl
+        except ImportError:
+            hppfcl = None
+
+        # Convert Pinocchio's 4-float rgba (0-1) to Rerun's 4-uint8 rgba
+        color = None
+        if hasattr(geom, "meshColor") and geom.meshColor is not None:
+            # pinocchio 3.x uses meshColor for rgba
+            color = [int(x * 255) for x in geom.meshColor]
+        # Some versions might use overrideMaterial or similar, but meshColor is common
+
+        if hppfcl and isinstance(geom.geometry, hppfcl.Box):
+            half_size = geom.geometry.halfSide
+            rr.log(entity_path, rr.Boxes3D(half_sizes=[half_size], colors=[color] if color else None), static=True)
+        elif hppfcl and isinstance(geom.geometry, hppfcl.Sphere):
+            rr.log(entity_path, rr.Ellipsoids3D(radii=[geom.geometry.radius] * 3, colors=[color] if color else None), static=True)
+        elif hppfcl and isinstance(geom.geometry, hppfcl.Cylinder):
+            # Cylinder not directly supported, skip or log debug
+            logger.debug(f"Cylinder primitive not yet supported in Rerun logging for {entity_path}")
+        elif hasattr(geom, "meshPath") and geom.meshPath and not geom.meshPath == "BOX":
+            # Log as Asset3D
+            mesh_path = Path(geom.meshPath)
+            if mesh_path.exists():
+                rr.log(entity_path, rr.Asset3D(path=mesh_path), static=True)
+            else:
+                logger.warning(f"Mesh file not found: {mesh_path} for {entity_path}")
+
+    def update_joints(self, joint_state: JointState) -> None:
+        """Update joint positions and log new transforms to Rerun.
+
+        Args:
+            joint_state: The current joint state.
+        """
+        # Build configuration vector q
+        q = pinocchio.neutral(self.model)
+        
+        # JointState might have fewer joints than the model, or in different order
+        for name, pos in zip(joint_state.name, joint_state.position):
+            joint_id = -1
+            # 1. Try exact match
+            if self.model.existJointName(name):
+                joint_id = self.model.getJointId(name)
+            # 2. Try stripping prefixes (e.g., arm/joint1 -> joint1, arm_joint1 -> joint1)
+            else:
+                for sep in ["/", "_"]:
+                    if sep in name:
+                        base_name = name.split(sep, 1)[-1]
+                        if self.model.existJointName(base_name):
+                            joint_id = self.model.getJointId(base_name)
+                            break
+            
+            if joint_id == -1:
+                continue
+
+            # For 1-DOF joints (revolute, prismatic), idx_q is the index in q
+            idx = self.model.joints[joint_id].idx_q
+            if idx >= 0:
+                q[idx] = pos
+
+        # Compute FK (we need liMi for local transforms)
+        pinocchio.forwardKinematics(self.model, self.data, q)
+
+        # Log local transforms to Rerun
+        # Skip joint 0 (universe)
+        for i in range(1, self.model.njoints):
+            entity_path = self.joint_to_entity[i]
+            # liMi is the transform from parent to child joint
+            m = self.data.liMi[i]
+            pos = m.translation
+            quat = pinocchio.Quaternion(m.rotation)
+            rr.log(
+                entity_path,
+                rr.Transform3D(
+                    translation=pos,
+                    rotation=rr.Quaternion(xyzw=[quat.x, quat.y, quat.z, quat.w]),
+                ),
+            )


### PR DESCRIPTION
## Problem

Robot arm visualization is currently tied to Drake Meshcat, which lives in a separate browser window and sits outside the core dimOS observability workflow.

This creates a fragmented developer experience when monitoring manipulation together with navigation maps, sensor streams, and point clouds in one place.

This PR delivers a unified visualization path by adding a Rerun-native URDF visualizer for robot arms.

Closes [#845](https://github.com/dimensionalOS/dimos/issues/845)

---

## Solution

Implemented a real-time URDF-to-Rerun pipeline so robot arms render and update directly in the Rerun viewer.

### Highlights
- **Pinocchio-based FK**: Uses the existing `pinocchio` dependency to compute forward kinematics on each `JointState` update.
- **Automatic mesh compatibility**: Reuses the existing mesh conversion path to transform `.stl` / `.dae` assets into `.obj` for Rerun `Asset3D`.
- **Robust joint name mapping**: Handles namespace differences between runtime joint names and URDF joint names.
- **Config-level toggle**: Adds `enable_rerun_viz` to `ManipulationModuleConfig`.
- **Blueprint defaults**: Enables Rerun visualization by default in the relevant keyboard teleop blueprints.

---

## Breaking Changes
- None. Existing Drake/Meshcat visualization remains supported via `enable_viz`.

---

## Files Updated

### `dimos/visualization/rerun/robot.py` (new)
- Added `RobotVisualizer` to load URDF visuals and publish geometry and transforms to Rerun.
- Uses `prepare_urdf_for_drake(..., convert_meshes=True)` so `.stl` / `.dae` assets are converted to `.obj` for Rerun `Asset3D`.
- Uses Pinocchio forward kinematics to compute per-link transforms from incoming `JointState` messages.
- Handles joint namespace mismatches by attempting exact match first, then prefix-stripped matching.

### `dimos/manipulation/manipulation_module.py` (modified)
- Added `enable_rerun_viz: bool = False` to `ManipulationModuleConfig`.
- Initializes `RobotVisualizer` instances when Rerun visualization is enabled.
- Updates planning state and Rerun visualization from the same joint-state stream.

### `dimos/robot/manipulators/xarm/blueprints.py` (modified)
- Enabled `enable_rerun_viz=True` in xArm keyboard teleop blueprints.

### `dimos/robot/manipulators/piper/blueprints.py` (modified)
- Enabled `enable_rerun_viz=True` in Piper keyboard teleop blueprints.

### `dimos/visualization/rerun/__init__.py` (new)
- Added package initialization for the `rerun` visualization module.

---

## Demonstration
[Watch the real-time arm movement in Rerun here](https://drive.google.com/file/d/1941myTrFXa4-lgnKMnDqqb3IzjC9go2N/view?usp=drive_link)

---

## How To Test

Use a 3-terminal validation flow.

### Terminal 1 (Viewer)
~~~bash
rerun
~~~

### Terminal 2 (Bridge)
~~~bash
dimos rerun-bridge --viewer-mode connect
~~~

### Terminal 3 (Simulation)
~~~bash
CI=1 dimos run keyboard-teleop-xarm7
~~~

### Verification Steps
1. Confirm the xArm7 model appears in the Rerun 3D scene.
2. Click the `Keyboard Teleop` (Pygame) window to focus it.
3. Press and hold `W` or `S`.
4. Verify that the robot arm in Rerun moves in sync with the teleop updates.

---

## Contributor License Agreement
- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).