### PR TITLE
perf(rerun): render voxel maps as Points3D spheres instead of Boxes3D

### DIFF
--- a/dimos/hardware/sensors/lidar/fastlio2/fastlio_blueprints.py
+++ b/dimos/hardware/sensors/lidar/fastlio2/fastlio_blueprints.py
@@ -23,7 +23,7 @@ mid360_fastlio = autoconnect(
     FastLio2.blueprint(voxel_size=voxel_size, map_voxel_size=voxel_size, map_freq=-1),
     RerunBridgeModule.blueprint(
         visual_override={
-            "world/lidar": lambda grid: grid.to_rerun(voxel_size=voxel_size, mode="boxes"),
+            "world/lidar": lambda grid: grid.to_rerun(voxel_size=voxel_size, mode="spheres"),
         }
     ),
 ).global_config(n_workers=2, robot_model="mid360_fastlio2")
@@ -33,7 +33,7 @@ mid360_fastlio_voxels = autoconnect(
     VoxelGridMapper.blueprint(voxel_size=voxel_size, carve_columns=False),
     RerunBridgeModule.blueprint(
         visual_override={
-            "world/global_map": lambda grid: grid.to_rerun(voxel_size=voxel_size, mode="boxes"),
+            "world/global_map": lambda grid: grid.to_rerun(voxel_size=voxel_size, mode="spheres"),
             "world/lidar": None,
         }
     ),
@@ -44,7 +44,7 @@ mid360_fastlio_voxels_native = autoconnect(
     RerunBridgeModule.blueprint(
         visual_override={
             "world/lidar": None,
-            "world/global_map": lambda grid: grid.to_rerun(voxel_size=voxel_size, mode="boxes"),
+            "world/global_map": lambda grid: grid.to_rerun(voxel_size=voxel_size, mode="spheres"),
         }
     ),
 ).global_config(n_workers=2, robot_model="mid360_fastlio2")

--- a/dimos/hardware/sensors/lidar/fastlio2/fastlio_blueprints.py
+++ b/dimos/hardware/sensors/lidar/fastlio2/fastlio_blueprints.py
@@ -21,11 +21,7 @@ voxel_size = 0.05
 
 mid360_fastlio = autoconnect(
     FastLio2.blueprint(voxel_size=voxel_size, map_voxel_size=voxel_size, map_freq=-1),
-    RerunBridgeModule.blueprint(
-        visual_override={
-            "world/lidar": lambda grid: grid.to_rerun(voxel_size=voxel_size, mode="spheres"),
-        }
-    ),
+    RerunBridgeModule.blueprint(),
 ).global_config(n_workers=2, robot_model="mid360_fastlio2")
 
 mid360_fastlio_voxels = autoconnect(
@@ -33,7 +29,6 @@ mid360_fastlio_voxels = autoconnect(
     VoxelGridMapper.blueprint(voxel_size=voxel_size, carve_columns=False),
     RerunBridgeModule.blueprint(
         visual_override={
-            "world/global_map": lambda grid: grid.to_rerun(voxel_size=voxel_size, mode="spheres"),
             "world/lidar": None,
         }
     ),
@@ -44,7 +39,6 @@ mid360_fastlio_voxels_native = autoconnect(
     RerunBridgeModule.blueprint(
         visual_override={
             "world/lidar": None,
-            "world/global_map": lambda grid: grid.to_rerun(voxel_size=voxel_size, mode="spheres"),
         }
     ),
 ).global_config(n_workers=2, robot_model="mid360_fastlio2")

--- a/dimos/msgs/sensor_msgs/PointCloud2.py
+++ b/dimos/msgs/sensor_msgs/PointCloud2.py
@@ -650,7 +650,7 @@ class PointCloud2(Timestamped):
         self,
         voxel_size: float = 0.05,
         colors: list[int] | None = None,
-        mode: str = "points",
+        mode: str = "spheres",
         size: float | None = None,
         fill_mode: str = "solid",
         **kwargs: object,

--- a/dimos/msgs/sensor_msgs/PointCloud2.py
+++ b/dimos/msgs/sensor_msgs/PointCloud2.py
@@ -707,6 +707,7 @@ class PointCloud2(Timestamped):
                 positions=points,
                 radii=voxel_size / 2,
                 colors=point_colors,
+                class_ids=class_ids,
             )
 
     def filter_by_height(

--- a/dimos/robot/unitree/g1/blueprints/primitive/uintree_g1_primitive_no_nav.py
+++ b/dimos/robot/unitree/g1/blueprints/primitive/uintree_g1_primitive_no_nav.py
@@ -147,7 +147,7 @@ uintree_g1_primitive_no_nav = (
     autoconnect(
         _with_vis,
         _camera,
-        VoxelGridMapper.blueprint(voxel_size=0.05),
+        VoxelGridMapper.blueprint(),
         CostMapper.blueprint(),
         WavefrontFrontierExplorer.blueprint(),
         # Visualization

--- a/dimos/robot/unitree/g1/blueprints/primitive/uintree_g1_primitive_no_nav.py
+++ b/dimos/robot/unitree/g1/blueprints/primitive/uintree_g1_primitive_no_nav.py
@@ -52,7 +52,7 @@ def _convert_camera_info(camera_info: Any) -> Any:
 
 
 def _convert_global_map(grid: Any) -> Any:
-    return grid.to_rerun(voxel_size=0.1, mode="spheres")
+    return grid.to_rerun(voxel_size=0.05, mode="spheres")
 
 
 def _convert_navigation_costmap(grid: Any) -> Any:
@@ -152,7 +152,7 @@ uintree_g1_primitive_no_nav = (
     autoconnect(
         _with_vis,
         _camera,
-        VoxelGridMapper.blueprint(voxel_size=0.1),
+        VoxelGridMapper.blueprint(voxel_size=0.05),
         CostMapper.blueprint(),
         WavefrontFrontierExplorer.blueprint(),
         # Visualization

--- a/dimos/robot/unitree/g1/blueprints/primitive/uintree_g1_primitive_no_nav.py
+++ b/dimos/robot/unitree/g1/blueprints/primitive/uintree_g1_primitive_no_nav.py
@@ -51,10 +51,6 @@ def _convert_camera_info(camera_info: Any) -> Any:
     )
 
 
-def _convert_global_map(grid: Any) -> Any:
-    return grid.to_rerun(voxel_size=0.05, mode="spheres")
-
-
 def _convert_navigation_costmap(grid: Any) -> Any:
     return grid.to_rerun(
         colormap="Accent",
@@ -101,7 +97,6 @@ rerun_config = {
     "pubsubs": [LCM()],
     "visual_override": {
         "world/camera_info": _convert_camera_info,
-        "world/global_map": _convert_global_map,
         "world/navigation_costmap": _convert_navigation_costmap,
     },
     "static": {

--- a/dimos/robot/unitree/g1/blueprints/primitive/uintree_g1_primitive_no_nav.py
+++ b/dimos/robot/unitree/g1/blueprints/primitive/uintree_g1_primitive_no_nav.py
@@ -52,7 +52,7 @@ def _convert_camera_info(camera_info: Any) -> Any:
 
 
 def _convert_global_map(grid: Any) -> Any:
-    return grid.to_rerun(voxel_size=0.1, mode="boxes")
+    return grid.to_rerun(voxel_size=0.1, mode="spheres")
 
 
 def _convert_navigation_costmap(grid: Any) -> Any:

--- a/dimos/robot/unitree/go2/blueprints/agentic/unitree_go2_security.py
+++ b/dimos/robot/unitree/go2/blueprints/agentic/unitree_go2_security.py
@@ -29,7 +29,7 @@ def _convert_camera_info(camera_info: Any) -> Any:
 
 
 def _convert_global_map(grid: Any) -> Any:
-    return grid.to_rerun(voxel_size=0.1, mode="spheres")
+    return grid.to_rerun(voxel_size=0.05, mode="spheres")
 
 
 def _convert_navigation_costmap(grid: Any) -> Any:

--- a/dimos/robot/unitree/go2/blueprints/agentic/unitree_go2_security.py
+++ b/dimos/robot/unitree/go2/blueprints/agentic/unitree_go2_security.py
@@ -28,10 +28,6 @@ def _convert_camera_info(camera_info: Any) -> Any:
     )
 
 
-def _convert_global_map(grid: Any) -> Any:
-    return grid.to_rerun(voxel_size=0.05, mode="spheres")
-
-
 def _convert_navigation_costmap(grid: Any) -> Any:
     return grid.to_rerun(
         colormap="Accent",
@@ -80,7 +76,6 @@ rerun_config = {
     "pubsubs": [LCM()],
     "visual_override": {
         "world/camera_info": _convert_camera_info,
-        "world/global_map": _convert_global_map,
         "world/navigation_costmap": _convert_navigation_costmap,
     },
     "static": {

--- a/dimos/robot/unitree/go2/blueprints/agentic/unitree_go2_security.py
+++ b/dimos/robot/unitree/go2/blueprints/agentic/unitree_go2_security.py
@@ -29,7 +29,7 @@ def _convert_camera_info(camera_info: Any) -> Any:
 
 
 def _convert_global_map(grid: Any) -> Any:
-    return grid.to_rerun(voxel_size=0.1, mode="boxes")
+    return grid.to_rerun(voxel_size=0.1, mode="spheres")
 
 
 def _convert_navigation_costmap(grid: Any) -> Any:

--- a/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_basic.py
+++ b/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_basic.py
@@ -49,7 +49,7 @@ def _convert_camera_info(camera_info: Any) -> Any:
 
 
 def _convert_global_map(grid: Any) -> Any:
-    return grid.to_rerun(voxel_size=0.1, mode="boxes")
+    return grid.to_rerun(voxel_size=0.1, mode="spheres")
 
 
 def _convert_navigation_costmap(grid: Any) -> Any:

--- a/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_basic.py
+++ b/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_basic.py
@@ -49,7 +49,7 @@ def _convert_camera_info(camera_info: Any) -> Any:
 
 
 def _convert_global_map(grid: Any) -> Any:
-    return grid.to_rerun(voxel_size=0.1, mode="spheres")
+    return grid.to_rerun(voxel_size=0.05, mode="spheres")
 
 
 def _convert_navigation_costmap(grid: Any) -> Any:
@@ -111,9 +111,9 @@ rerun_config = {
         "world/navigation_costmap": _convert_navigation_costmap,
     },
     "max_hz": {
-        "world/global_map": 5,  # publishes at ~7.8 Hz
-        "world/color_image": 10,  # publishes at ~14 Hz
-        "world/global_costmap": 5,  # publishes at ~7.6 Hz
+        "world/global_map": 0,  # publishes at ~7.8 Hz
+        "world/color_image": 0,  # publishes at ~14 Hz
+        "world/global_costmap": 0,  # publishes at ~7.6 Hz
     },
     # slapping a go2 shaped box on top of tf/base_link
     "static": {

--- a/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_basic.py
+++ b/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_basic.py
@@ -48,10 +48,6 @@ def _convert_camera_info(camera_info: Any) -> Any:
     )
 
 
-def _convert_global_map(grid: Any) -> Any:
-    return grid.to_rerun(voxel_size=0.05, mode="spheres")
-
-
 def _convert_navigation_costmap(grid: Any) -> Any:
     return grid.to_rerun(
         colormap="Accent",
@@ -107,7 +103,6 @@ rerun_config = {
     # This is unsustainable once we move to multi robot etc
     "visual_override": {
         "world/camera_info": _convert_camera_info,
-        "world/global_map": _convert_global_map,
         "world/navigation_costmap": _convert_navigation_costmap,
     },
     "max_hz": {

--- a/dimos/robot/unitree/go2/blueprints/smart/unitree_go2.py
+++ b/dimos/robot/unitree/go2/blueprints/smart/unitree_go2.py
@@ -25,7 +25,7 @@ from dimos.robot.unitree.go2.blueprints.basic.unitree_go2_basic import unitree_g
 
 unitree_go2 = autoconnect(
     unitree_go2_basic,
-    VoxelGridMapper.blueprint(voxel_size=0.1),
+    VoxelGridMapper.blueprint(voxel_size=0.05),
     CostMapper.blueprint(),
     ReplanningAStarPlanner.blueprint(),
     WavefrontFrontierExplorer.blueprint(),

--- a/dimos/robot/unitree/go2/blueprints/smart/unitree_go2.py
+++ b/dimos/robot/unitree/go2/blueprints/smart/unitree_go2.py
@@ -25,7 +25,7 @@ from dimos.robot.unitree.go2.blueprints.basic.unitree_go2_basic import unitree_g
 
 unitree_go2 = autoconnect(
     unitree_go2_basic,
-    VoxelGridMapper.blueprint(voxel_size=0.05),
+    VoxelGridMapper.blueprint(),
     CostMapper.blueprint(),
     ReplanningAStarPlanner.blueprint(),
     WavefrontFrontierExplorer.blueprint(),


### PR DESCRIPTION
## Problem

endering each voxel as an `rr.Boxes3D` instance is expensive - each box is 12 line segments in the
Rerun line renderer, whereas `rr.Points3D` with a world-space radius is a single billboarded quad per point 

Closes #1631 

## Solution

Flip all `PointCloud2.to_rerun(mode="boxes")` callers to `mode="spheres"`. Same world-space voxel footprint, renders as  spheres instead of cubes, ~10x cheaper at high point counts

- option to switch to `mode=boxes` is still present
- voxel sizes are reduced to 0.05 (from 0.1), as the rerun maintains good fps with spherical voxels
- toggling default set to `0 hz`. Can be adjusted when needed (if, boxes are used)

## Breaking Changes

None

## How to Test

- Any blueprint should launch rerun - with spherical voxels
quick test -> `dimos --replay --replay-dir=unitree_go2_bigoffice run unitree-go2'

## Contributor License Agreement

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).

<img width="1435" height="863" alt="spherevoxels" src="https://github.com/user-attachments/assets/5cbc182e-4ebe-4c30-bad2-5dbd100bd622" />

Looks good. Able to maintain good fps (~20) with 400k voxels at 0.05 radius