### PR TITLE
[codex] Reconstruct rerun TF trees in the bridge

### DIFF
--- a/dimos/protocol/tf/test_tf.py
+++ b/dimos/protocol/tf/test_tf.py
@@ -325,6 +325,33 @@ class TestMultiTBuffer:
         assert latest is not None
         assert latest.translation.x == 2.0
 
+    def test_subscribe_receives_transform_updates(self) -> None:
+        ttbuffer = MultiTBuffer()
+        received: list[str] = []
+        unsubscribe = ttbuffer.subscribe(lambda transform: received.append(transform.child_frame_id))
+
+        ttbuffer.receive_transform(
+            Transform(frame_id="world", child_frame_id="robot", ts=time.time()),
+            Transform(frame_id="robot", child_frame_id="camera", ts=time.time()),
+        )
+
+        unsubscribe()
+
+        assert received == ["robot", "camera"]
+
+    def test_entity_path_for_frame_reconstructs_chain(self) -> None:
+        ttbuffer = MultiTBuffer()
+        base_time = time.time()
+
+        ttbuffer.receive_transform(
+            Transform(frame_id="world", child_frame_id="robot", ts=base_time),
+            Transform(frame_id="robot", child_frame_id="camera", ts=base_time),
+            Transform(frame_id="camera", child_frame_id="camera_optical", ts=base_time),
+        )
+
+        assert ttbuffer.get_frame_chain("camera_optical") == ["world", "robot", "camera", "camera_optical"]
+        assert ttbuffer.entity_path_for_frame("camera_optical") == "world/tf/robot/camera/camera_optical"
+
     def test_get_transform_at_time(self) -> None:
         ttbuffer = MultiTBuffer()
         base_time = time.time()

--- a/dimos/protocol/tf/test_tf.py
+++ b/dimos/protocol/tf/test_tf.py
@@ -352,6 +352,45 @@ class TestMultiTBuffer:
         assert ttbuffer.get_frame_chain("camera_optical") == ["world", "robot", "camera", "camera_optical"]
         assert ttbuffer.entity_path_for_frame("camera_optical") == "world/tf/robot/camera/camera_optical"
 
+    def test_entity_path_strips_non_world_tree_root(self) -> None:
+        # Tree rooted at "map" (not "world") — the real root must not leak
+        # into the entity path when the caller uses the default root_frame.
+        ttbuffer = MultiTBuffer()
+        base_time = time.time()
+
+        ttbuffer.receive_transform(
+            Transform(frame_id="map", child_frame_id="robot", ts=base_time),
+            Transform(frame_id="robot", child_frame_id="camera", ts=base_time),
+        )
+
+        assert ttbuffer.entity_path_for_frame("camera") == "world/tf/robot/camera"
+
+    def test_subscriber_unsubscribing_itself_does_not_skip_next(self) -> None:
+        # Regression: iterating self._subscribers directly lets an unsubscribing
+        # callback skip the next one (list mutated during iteration).
+        ttbuffer = MultiTBuffer()
+        received_a: list[str] = []
+        received_b: list[str] = []
+
+        unsub_a: list = []
+
+        def callback_a(transform: Transform) -> None:
+            received_a.append(transform.child_frame_id)
+            unsub_a[0]()  # unsubscribe self during dispatch
+
+        def callback_b(transform: Transform) -> None:
+            received_b.append(transform.child_frame_id)
+
+        unsub_a.append(ttbuffer.subscribe(callback_a))
+        ttbuffer.subscribe(callback_b)
+
+        ttbuffer.receive_transform(
+            Transform(frame_id="world", child_frame_id="robot", ts=time.time()),
+        )
+
+        assert received_a == ["robot"]
+        assert received_b == ["robot"]
+
     def test_get_transform_at_time(self) -> None:
         ttbuffer = MultiTBuffer()
         base_time = time.time()

--- a/dimos/protocol/tf/tf.py
+++ b/dimos/protocol/tf/tf.py
@@ -135,7 +135,9 @@ class MultiTBuffer(ObservableMixin[Transform]):
             if key not in self.buffers:
                 self.buffers[key] = TBuffer(self.buffer_size)
             self.buffers[key].add(transform)
-            for callback in self._subscribers:
+            # Snapshot subscribers so callbacks that unsubscribe themselves
+            # don't skip the next subscriber (list mutated during iteration).
+            for callback in list(self._subscribers):
                 callback(transform)
 
     def receive_tfmessage(self, msg: TFMessage) -> None:
@@ -247,7 +249,12 @@ class MultiTBuffer(ObservableMixin[Transform]):
         time_tolerance: float | None = None,
     ) -> str:
         chain = self.get_frame_chain(child_frame, root_frame, time_point, time_tolerance)
-        if root_frame is not None and chain and chain[0] == root_frame:
+        # When a root_frame is specified, `prefix` represents the tree root, so
+        # strip the topmost frame from the chain. It's either `root_frame` (when
+        # matched during the walk) or the tree's actual topmost frame (when the
+        # tree is rooted elsewhere). Without this, a mismatched root_frame would
+        # silently leak the real root into the path, e.g. `world/tf/map/robot`.
+        if root_frame is not None and chain:
             chain = chain[1:]
         if not chain:
             return prefix

--- a/dimos/protocol/tf/tf.py
+++ b/dimos/protocol/tf/tf.py
@@ -16,10 +16,12 @@
 
 from abc import abstractmethod
 from collections import deque
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from functools import reduce
 from typing import TypeVar
 
+from dimos.core.stream import ObservableMixin
 from dimos.memory.timeseries.inmemory import InMemoryStore
 from dimos.msgs.geometry_msgs import PoseStamped, Transform
 from dimos.msgs.tf2_msgs import TFMessage
@@ -113,10 +115,19 @@ class TBuffer(InMemoryStore[Transform]):
 
 # stores multiple transform buffers
 # creates a new buffer on demand when new transform is detected
-class MultiTBuffer:
+class MultiTBuffer(ObservableMixin[Transform]):
     def __init__(self, buffer_size: float = 10.0) -> None:
         self.buffers: dict[tuple[str, str], TBuffer] = {}
         self.buffer_size = buffer_size
+        self._subscribers: list[Callable[[Transform], None]] = []
+
+    def subscribe(self, callback: Callable[[Transform], None]) -> Callable[[], None]:
+        self._subscribers.append(callback)
+
+        def unsubscribe() -> None:
+            self._subscribers.remove(callback)
+
+        return unsubscribe
 
     def receive_transform(self, *args: Transform) -> None:
         for transform in args:
@@ -124,6 +135,12 @@ class MultiTBuffer:
             if key not in self.buffers:
                 self.buffers[key] = TBuffer(self.buffer_size)
             self.buffers[key].add(transform)
+            for callback in self._subscribers:
+                callback(transform)
+
+    def receive_tfmessage(self, msg: TFMessage) -> None:
+        for transform in msg.transforms:
+            self.receive_transform(transform)
 
     def get_frames(self) -> set[str]:
         frames = set()
@@ -161,6 +178,80 @@ class MultiTBuffer:
             return transform.inverse() if transform else None
 
         return None
+
+    def get_parent_transform(
+        self,
+        child_frame: str,
+        time_point: float | None = None,
+        time_tolerance: float | None = None,
+    ) -> Transform | None:
+        latest: Transform | None = None
+
+        for (parent, child), buffer in self.buffers.items():
+            if child != child_frame:
+                continue
+
+            transform = buffer.get(
+                time_point,
+                1.0 if time_tolerance is None else time_tolerance,
+            )
+            if transform is None:
+                continue
+
+            if latest is None or transform.ts >= latest.ts:
+                latest = Transform(
+                    translation=transform.translation,
+                    rotation=transform.rotation,
+                    frame_id=parent,
+                    child_frame_id=child,
+                    ts=transform.ts,
+                )
+
+        return latest
+
+    def get_frame_chain(
+        self,
+        child_frame: str,
+        root_frame: str | None = None,
+        time_point: float | None = None,
+        time_tolerance: float | None = None,
+    ) -> list[str]:
+        chain = [child_frame]
+        visited = {child_frame}
+        current_frame = child_frame
+
+        while True:
+            parent_transform = self.get_parent_transform(current_frame, time_point, time_tolerance)
+            if parent_transform is None:
+                break
+
+            parent_frame = parent_transform.frame_id
+            if parent_frame in visited:
+                break
+
+            chain.append(parent_frame)
+            if root_frame is not None and parent_frame == root_frame:
+                break
+
+            visited.add(parent_frame)
+            current_frame = parent_frame
+
+        return list(reversed(chain))
+
+    def entity_path_for_frame(
+        self,
+        child_frame: str,
+        prefix: str = "world/tf",
+        root_frame: str | None = "world",
+        time_point: float | None = None,
+        time_tolerance: float | None = None,
+    ) -> str:
+        chain = self.get_frame_chain(child_frame, root_frame, time_point, time_tolerance)
+        if root_frame is not None and chain and chain[0] == root_frame:
+            chain = chain[1:]
+        if not chain:
+            return prefix
+        return "/".join([prefix, *chain])
 
     def get(self, *args, **kwargs) -> Transform | None:  # type: ignore[no-untyped-def]
         simple = self.get_transform(*args, **kwargs)

--- a/dimos/visualization/rerun/bridge.py
+++ b/dimos/visualization/rerun/bridge.py
@@ -316,8 +316,12 @@ class RerunBridgeModule(Module):
         super().start()
 
         self._last_log: dict[str, float] = {}
-        self._tf_buffer = MultiTBuffer()
-        self._disposables.add(Disposable(self._tf_buffer.subscribe(self._log_tf_transform)))
+        # `_tf_buffer` is an injection point: tests (or callers) may pre-install
+        # a buffer on the instance before start() to bypass rerun side effects.
+        # If set, don't clobber it or double-subscribe.
+        if not hasattr(self, "_tf_buffer"):
+            self._tf_buffer = MultiTBuffer()
+            self._disposables.add(Disposable(self._tf_buffer.subscribe(self._log_tf_transform)))
         logger.info("Rerun bridge starting", viewer_mode=self.config.viewer_mode)
 
         # Initialize and spawn Rerun viewer

--- a/dimos/visualization/rerun/bridge.py
+++ b/dimos/visualization/rerun/bridge.py
@@ -37,8 +37,10 @@ import typer
 from dimos.core.core import rpc
 from dimos.core.module import Module, ModuleConfig
 from dimos.msgs.sensor_msgs import Image, PointCloud2
+from dimos.msgs.tf2_msgs import TFMessage
 from dimos.protocol.pubsub.impl.lcmpubsub import LCM
 from dimos.protocol.pubsub.patterns import Glob, pattern_matches
+from dimos.protocol.tf import MultiTBuffer
 from dimos.utils.logging_config import setup_logger
 
 # Message types with large payloads that need rate-limiting.
@@ -209,6 +211,22 @@ class RerunBridgeModule(Module):
     default_config = Config
     config: Config
 
+    def _topic_name(self, topic: Any) -> str:
+        topic_str = getattr(topic, "topic", None) or getattr(topic, "name", None) or str(topic)
+        return str(topic_str).split("#")[0]
+
+    def _is_tf_message(self, msg: Any, topic: Any) -> bool:
+        return isinstance(msg, TFMessage) or self._topic_name(topic) == "/tf"
+
+    def _log_tf_transform(self, transform: Any) -> None:
+        import rerun as rr
+
+        entity_path = self._tf_buffer.entity_path_for_frame(
+            transform.child_frame_id,
+            prefix=f"{self.config.entity_prefix}/tf",
+        )
+        rr.log(entity_path, transform.to_rerun())
+
     @lru_cache(maxsize=256)
     def _visual_override_for_entity_path(
         self, entity_path: str
@@ -259,6 +277,10 @@ class RerunBridgeModule(Module):
         """Handle incoming message - log to rerun."""
         import rerun as rr
 
+        if self._is_tf_message(msg, topic):
+            self._tf_buffer.receive_tfmessage(msg)
+            return
+
         # convert a potentially complex topic object into an str rerun entity path
         entity_path: str = self._get_entity_path(topic)
 
@@ -294,6 +316,8 @@ class RerunBridgeModule(Module):
         super().start()
 
         self._last_log: dict[str, float] = {}
+        self._tf_buffer = MultiTBuffer()
+        self._disposables.add(Disposable(self._tf_buffer.subscribe(self._log_tf_transform)))
         logger.info("Rerun bridge starting", viewer_mode=self.config.viewer_mode)
 
         # Initialize and spawn Rerun viewer

--- a/dimos/visualization/rerun/test_bridge_tf.py
+++ b/dimos/visualization/rerun/test_bridge_tf.py
@@ -1,0 +1,77 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import time
+import types
+
+from dimos.msgs.geometry_msgs import Transform
+from dimos.msgs.tf2_msgs import TFMessage
+from dimos.protocol.pubsub.impl.lcmpubsub import Topic
+from dimos.protocol.tf import MultiTBuffer
+from dimos.visualization.rerun.bridge import RerunBridgeModule
+
+
+class _DummyRPC:
+    def serve_module_rpc(self, _module) -> None:  # type: ignore[no-untyped-def]
+        return None
+
+    def start(self) -> None:
+        return None
+
+    def stop(self) -> None:
+        return None
+
+
+class FakeTransform3D:
+    def __init__(self, **kwargs) -> None:  # type: ignore[no-untyped-def]
+        self.kwargs = kwargs
+
+
+class FakeQuaternion:
+    def __init__(self, **kwargs) -> None:  # type: ignore[no-untyped-def]
+        self.kwargs = kwargs
+
+
+def test_bridge_reconstructs_tf_paths(monkeypatch) -> None:
+    logged: list[tuple[str, FakeTransform3D, bool]] = []
+    fake_rerun = types.SimpleNamespace(
+        Quaternion=FakeQuaternion,
+        Transform3D=FakeTransform3D,
+        log=lambda path, archetype, static=False: logged.append((path, archetype, static)),
+    )
+    monkeypatch.setitem(sys.modules, "rerun", fake_rerun)
+
+    bridge = RerunBridgeModule(viewer_mode="none", pubsubs=[], rpc_transport=_DummyRPC)
+    bridge._tf_buffer = MultiTBuffer()
+    unsubscribe = bridge._tf_buffer.subscribe(bridge._log_tf_transform)
+
+    try:
+        bridge._on_message(
+            TFMessage(
+                Transform(frame_id="world", child_frame_id="robot", ts=time.time()),
+                Transform(frame_id="robot", child_frame_id="camera", ts=time.time()),
+            ),
+            Topic("/tf", TFMessage),
+        )
+    finally:
+        unsubscribe()
+        bridge.stop()
+
+    assert [path for path, _, _ in logged] == [
+        "world/tf/robot",
+        "world/tf/robot/camera",
+    ]
+    assert logged[1][1].kwargs["parent_frame"] == "tf#/robot"
+    assert logged[1][1].kwargs["child_frame"] == "tf#/camera"


### PR DESCRIPTION
## Summary
- teach `MultiTBuffer` to publish transform updates and reconstruct hierarchical frame chains
- make `RerunBridgeModule` own a TF buffer and log `/tf` messages at reconstructed Rerun entity paths
- add focused tests for TF subscriptions, path reconstruction, and rerun bridge TF interception

## Why
Standalone `rerun-bridge` was logging TF updates as flat child-frame paths, so the viewer could not reconstruct the real TF tree unless a blueprint hardcoded extra TF-specific visualization setup.

## Impact
`rerun-bridge` now reconstructs TF entity paths internally from the buffered transform graph, which makes standalone visualization behave more like the rest of the TF stack and removes the need for callers to rely on partial TF message layout.

## Validation
- `ruff check dimos/protocol/tf/tf.py dimos/protocol/tf/test_tf.py dimos/visualization/rerun/bridge.py dimos/visualization/rerun/test_bridge_tf.py`
- focused pytest run for the new TF buffer and rerun bridge tests (with repo autoconf stubbed to avoid sandbox-only system prompts)

Closes #1627