### PR TITLE
feat: never leave child processes alive after the parent

### DIFF
--- a/dimos/core/coordination/process_lifecycle.py
+++ b/dimos/core/coordination/process_lifecycle.py
@@ -1,0 +1,130 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Process-lifecycle utilities: tag descendants by run id, sweep strays.
+
+Every descendant of a `dimos run` invocation inherits `DIMOS_RUN_ID` in
+its environment. kill_run_processes scans the system via psutil and
+terminates any process whose environment matches a given run id.
+
+spawn_watchdog launches a small sidecar process that watches the main
+PID; when main dies for any reason (including SIGKILL) the sidecar invokes
+the sweep so workers and grandchildren cannot survive as orphans.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+import os
+import subprocess
+import sys
+import time
+
+import psutil
+
+from dimos.utils.logging_config import setup_logger
+
+logger = setup_logger()
+
+DIMOS_RUN_ID_ENV = "DIMOS_RUN_ID"
+
+
+def _iter_matching_processes(run_id: str, exclude_pids: frozenset[int]) -> list[psutil.Process]:
+    """Return live processes whose environment contains DIMOS_RUN_ID=run_id."""
+    matches: list[psutil.Process] = []
+    for proc in psutil.process_iter(attrs=["pid"]):
+        pid = proc.info["pid"]
+        if pid in exclude_pids:
+            continue
+        try:
+            env = proc.environ()
+        except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+            continue
+        except OSError:
+            # /proc entry may transiently fail on slow systems.
+            continue
+        if env.get(DIMOS_RUN_ID_ENV) == run_id:
+            matches.append(proc)
+    return matches
+
+
+def kill_run_processes(
+    run_id: str,
+    *,
+    exclude_pids: Iterable[int] = (),
+    term_timeout: float = 2.0,
+    kill_timeout: float = 1.0,
+) -> int:
+    """Terminate every process tagged with `DIMOS_RUN_ID == run_id`."""
+    excluded = frozenset({os.getpid(), *exclude_pids})
+    targets = _iter_matching_processes(run_id, excluded)
+    if not targets:
+        return 0
+
+    for proc in targets:
+        try:
+            proc.terminate()
+        except psutil.NoSuchProcess:
+            pass
+
+    _, alive = psutil.wait_procs(targets, timeout=term_timeout)
+    if alive:
+        for proc in alive:
+            try:
+                proc.kill()
+            except psutil.NoSuchProcess:
+                pass
+        psutil.wait_procs(alive, timeout=kill_timeout)
+
+    return len(targets)
+
+
+def spawn_watchdog(
+    run_id: str, log_dir: str | os.PathLike[str] | None = None
+) -> subprocess.Popen[bytes]:
+    """Launch a sidecar that kills run processes if main dies abruptly."""
+    env = {k: v for k, v in os.environ.items() if k != DIMOS_RUN_ID_ENV}
+    if log_dir is not None:
+        env["DIMOS_RUN_LOG_DIR"] = str(log_dir)
+
+    main_pid = os.getpid()
+    cmd = [
+        sys.executable,
+        "-m",
+        "dimos.core.coordination.watchdog_main",
+        str(main_pid),
+        run_id,
+    ]
+    proc = subprocess.Popen(
+        cmd,
+        env=env,
+        start_new_session=True,
+        close_fds=True,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    return proc
+
+
+def wait_for_pid_exit(pid: int, poll_interval: float = 0.5) -> None:
+    while True:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return
+        except PermissionError:
+            # Process exists under a different UID — still alive from our POV.
+            pass
+        time.sleep(poll_interval)

--- a/dimos/core/coordination/test_process_lifecycle.py
+++ b/dimos/core/coordination/test_process_lifecycle.py
@@ -1,0 +1,188 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+import uuid
+
+import psutil
+import pytest
+from pytest_mock import MockerFixture
+
+from dimos.core.coordination.process_lifecycle import (
+    DIMOS_RUN_ID_ENV,
+    kill_run_processes,
+    spawn_watchdog,
+    wait_for_pid_exit,
+)
+
+
+def _wait_gone(proc: subprocess.Popen, timeout: float = 3.0) -> bool:
+    try:
+        proc.wait(timeout=timeout)
+        return True
+    except subprocess.TimeoutExpired:
+        return False
+
+
+@pytest.fixture
+def run_id() -> str:
+    return f"test-{uuid.uuid4().hex[:12]}"
+
+
+@pytest.fixture
+def spawn_tagged():
+    """Factory that spawns subprocesses tagged with DIMOS_RUN_ID; auto-cleans."""
+    procs: list[subprocess.Popen[bytes]] = []
+
+    def _spawn(rid: str, code: str = "import time; time.sleep(60)") -> subprocess.Popen[bytes]:
+        env = {**os.environ, DIMOS_RUN_ID_ENV: rid}
+        proc = subprocess.Popen(
+            [sys.executable, "-c", code],
+            env=env,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        procs.append(proc)
+        return proc
+
+    yield _spawn
+
+    for proc in procs:
+        if proc.poll() is None:
+            proc.kill()
+            try:
+                proc.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                pass
+
+
+def test_kill_run_processes_kills_only_matching_run_id(spawn_tagged, run_id):
+    other_id = f"test-{uuid.uuid4().hex[:12]}"
+    a1 = spawn_tagged(run_id)
+    a2 = spawn_tagged(run_id)
+    b = spawn_tagged(other_id)
+
+    killed = kill_run_processes(run_id)
+    assert killed == 2
+    assert _wait_gone(a1)
+    assert _wait_gone(a2)
+    # The other child must still be alive.
+    assert b.poll() is None
+
+
+def test_kill_run_processes_no_match_returns_zero(run_id: str) -> None:
+    assert kill_run_processes(run_id) == 0
+
+
+def test_kill_run_processes_excludes_current_process(
+    monkeypatch: pytest.MonkeyPatch, run_id: str
+) -> None:
+    # Tag ourselves with a run id; kill_run_processes must skip self.
+    monkeypatch.setenv(DIMOS_RUN_ID_ENV, run_id)
+    assert kill_run_processes(run_id) == 0
+
+
+def test_kill_run_processes_respects_explicit_exclude_pids(spawn_tagged, run_id):
+    keeper = spawn_tagged(run_id)
+    target = spawn_tagged(run_id)
+
+    killed = kill_run_processes(run_id, exclude_pids=[keeper.pid])
+    assert killed == 1
+    assert _wait_gone(target)
+    assert keeper.poll() is None
+
+
+def test_kill_run_processes_escalates_to_sigkill_on_sigterm_ignorer(spawn_tagged, run_id):
+    # A subprocess that ignores SIGTERM. We kill it via kill_run_processes
+    # with a short term_timeout so it escalates to SIGKILL.
+    code = "import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(60)"
+    proc = spawn_tagged(run_id, code=code)
+    # Give the child a moment to install the SIG_IGN handler.
+    time.sleep(0.3)
+    killed = kill_run_processes(run_id, term_timeout=0.3, kill_timeout=2.0)
+    assert killed == 1
+    assert _wait_gone(proc, timeout=3.0)
+
+
+def test_kill_run_processes_tolerates_psutil_errors(mocker: MockerFixture, run_id: str) -> None:
+    # All psutil access errors should be swallowed, not raised.
+    bad = mocker.MagicMock(spec=psutil.Process)
+    bad.info = {"pid": 99999999}
+    bad.environ.side_effect = psutil.AccessDenied(pid=99999999)
+    mocker.patch("psutil.process_iter", return_value=[bad])
+
+    assert kill_run_processes(run_id) == 0
+
+
+def test_wait_for_pid_exit_returns_when_pid_gone():
+    # Spawn a short-lived child, wait for it.
+    proc = subprocess.Popen(
+        [sys.executable, "-c", "pass"],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    proc.wait(timeout=2)
+    # PID is now gone — wait_for_pid_exit should return immediately.
+    start = time.monotonic()
+    wait_for_pid_exit(proc.pid, poll_interval=0.1)
+    assert time.monotonic() - start < 0.5
+
+
+@pytest.mark.slow
+def test_spawn_watchdog_sweeps_on_parent_death(spawn_tagged, run_id):
+    # The sleeper is tagged with run_id and should be swept by the watchdog
+    # once the helper (acting as "main") dies.
+    sleeper = spawn_tagged(run_id)
+    # The helper becomes "main": it spawns the watchdog pointing at its own
+    # pid, then sleeps. Killing it should trigger the watchdog sweep.
+    helper_code = (
+        "import subprocess, sys, time, os; "
+        f"subprocess.Popen([sys.executable, '-m', 'dimos.core.coordination.watchdog_main', str(os.getpid()), {run_id!r}], "
+        "start_new_session=True, close_fds=True, "
+        "stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL); "
+        "time.sleep(30)"
+    )
+    helper = spawn_tagged(run_id, code=helper_code)
+
+    # Wait a moment for the watchdog to start polling.
+    time.sleep(1.0)
+    assert sleeper.poll() is None
+    helper.kill()
+    helper.wait(timeout=2)
+
+    # Watchdog should detect helper death and sweep within a few seconds.
+    deadline = time.monotonic() + 8.0
+    while time.monotonic() < deadline:
+        if sleeper.poll() is not None:
+            break
+        time.sleep(0.1)
+    assert sleeper.poll() is not None, "watchdog did not sweep the sleeper"
+
+
+def test_spawn_watchdog_strips_run_id_env(mocker: MockerFixture, run_id: str) -> None:
+    mocker.patch.dict(os.environ, {DIMOS_RUN_ID_ENV: run_id})
+    popen_mock = mocker.patch("dimos.core.coordination.process_lifecycle.subprocess.Popen")
+    popen_mock.return_value = mocker.MagicMock(pid=12345)
+    spawn_watchdog(run_id)
+
+    kwargs = popen_mock.call_args.kwargs
+    assert DIMOS_RUN_ID_ENV not in kwargs["env"]
+    assert kwargs["start_new_session"] is True

--- a/dimos/core/coordination/watchdog_main.py
+++ b/dimos/core/coordination/watchdog_main.py
@@ -1,0 +1,54 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Watchdog sidecar: terminate run descendants when main dies."""
+
+from __future__ import annotations
+
+import sys
+import time
+
+from dimos.core.coordination.process_lifecycle import (
+    kill_run_processes,
+    wait_for_pid_exit,
+)
+from dimos.utils.logging_config import setup_logger
+
+logger = setup_logger()
+
+# Give the main process's graceful-shutdown handler a head start after its
+# PID disappears. Without this we'd race the pipe-based worker shutdown and
+# kill workers that are about to exit on their own.
+_GRACE_PERIOD_SECONDS = 0.5
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 3:
+        print(f"usage: {argv[0]} <main_pid> <run_id>", file=sys.stderr)
+        return 2
+
+    main_pid = int(argv[1])
+    run_id = argv[2]
+
+    wait_for_pid_exit(main_pid)
+
+    time.sleep(_GRACE_PERIOD_SECONDS)
+
+    kill_run_processes(run_id)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/dimos/core/daemon.py
+++ b/dimos/core/daemon.py
@@ -21,6 +21,7 @@ import signal
 import sys
 from typing import TYPE_CHECKING
 
+from dimos.core.coordination.process_lifecycle import kill_run_processes
 from dimos.utils.logging_config import setup_logger
 
 if TYPE_CHECKING:
@@ -74,8 +75,18 @@ def daemonize(log_dir: Path) -> None:
     devnull.close()
 
 
-def install_signal_handlers(entry: RunEntry, coordinator: ModuleCoordinator) -> None:
-    """Install SIGTERM/SIGINT handlers that stop the coordinator and clean the registry."""
+def install_signal_handlers(
+    entry: RunEntry,
+    coordinator: ModuleCoordinator,
+    *,
+    sigint: bool = True,
+) -> None:
+    """Install SIGTERM/SIGINT handlers that stop the coordinator and clean the registry.
+
+    When `sigint` is False, only SIGTERM is wired. This is useful for foreground
+    mode where the default SIGINT behavior (`KeyboardInterrupt`) should be
+    preserved so Ctrl+C produces a visible traceback.
+    """
 
     def _shutdown(signum: int, frame: object) -> None:
         logger.info("Received signal, shutting down", signal=signum)
@@ -83,8 +94,13 @@ def install_signal_handlers(entry: RunEntry, coordinator: ModuleCoordinator) -> 
             coordinator.stop()
         except Exception:
             logger.error("Error during coordinator stop", exc_info=True)
+        try:
+            kill_run_processes(entry.run_id)
+        except Exception:
+            logger.error("Error during run-process sweep", exc_info=True)
         entry.remove()
         sys.exit(0)
 
     signal.signal(signal.SIGTERM, _shutdown)
-    signal.signal(signal.SIGINT, _shutdown)
+    if sigint:
+        signal.signal(signal.SIGINT, _shutdown)

--- a/dimos/core/run_registry.py
+++ b/dimos/core/run_registry.py
@@ -25,6 +25,7 @@ import signal
 import time
 
 from dimos.constants import STATE_DIR
+from dimos.core.coordination.process_lifecycle import kill_run_processes
 from dimos.utils.logging_config import setup_logger
 
 logger = setup_logger()
@@ -107,13 +108,31 @@ def list_runs(alive_only: bool = True) -> list[RunEntry]:
 
 
 def cleanup_stale() -> int:
-    """Remove registry entries for dead processes. Returns count removed."""
+    """Remove registry entries for dead processes. Returns count removed.
+
+    Before removing each stale entry, sweeps any descendants that outlived their
+    main process (e.g., because main was SIGKILL'd and the watchdog also died).
+    Sweep runs strictly on entries whose main PID is dead. A live run is never
+    swept, so concurrent `dimos run` invocations are safe.
+    """
+
     REGISTRY_DIR.mkdir(parents=True, exist_ok=True)
     removed = 0
     for f in list(REGISTRY_DIR.glob("*.json")):
         try:
             entry = RunEntry.load(f)
             if not is_pid_alive(entry.pid):
+                try:
+                    killed = kill_run_processes(entry.run_id)
+                    if killed:
+                        logger.info(
+                            "Swept descendants of stale run",
+                            run_id=entry.run_id,
+                            pid=entry.pid,
+                            killed=killed,
+                        )
+                except Exception:
+                    logger.error("Error sweeping stale run", run_id=entry.run_id, exc_info=True)
                 entry.remove()
                 removed += 1
         except Exception:

--- a/dimos/robot/cli/dimos.py
+++ b/dimos/robot/cli/dimos.py
@@ -35,6 +35,7 @@ import typer
 
 from dimos.agents.mcp.mcp_adapter import McpAdapter, McpError
 from dimos.constants import CONFIG_DIR, LOG_DIR
+from dimos.core.daemon import daemonize, install_signal_handlers
 from dimos.core.global_config import GlobalConfig, global_config
 from dimos.core.run_registry import get_most_recent, is_pid_alive, stop_entry
 from dimos.utils.logging_config import setup_logger
@@ -204,6 +205,10 @@ def run(
 
     from dimos.core.coordination.blueprints import autoconnect
     from dimos.core.coordination.module_coordinator import ModuleCoordinator
+    from dimos.core.coordination.process_lifecycle import (
+        DIMOS_RUN_ID_ENV,
+        spawn_watchdog,
+    )
     from dimos.core.run_registry import (
         RunEntry,
         check_port_conflicts,
@@ -236,6 +241,10 @@ def run(
     run_id = generate_run_id(blueprint_name)
     log_dir = LOG_DIR / run_id
 
+    # Tag every descendant with the run id so the watchdog and stale-run
+    # cleanup can identify them via os.environ after main dies.
+    os.environ[DIMOS_RUN_ID_ENV] = run_id
+
     # Route structured logs (main.jsonl) to the per-run directory.
     # Workers inherit DIMOS_RUN_LOG_DIR env var via forkserver.
     set_run_log_dir(log_dir)
@@ -261,11 +270,6 @@ def run(
     coordinator = ModuleCoordinator.build(blueprint, kwargs)
 
     if daemon:
-        from dimos.core.daemon import (
-            daemonize,
-            install_signal_handlers,
-        )
-
         # Health check before daemonizing — catch early crashes
         if not coordinator.health_check():
             typer.echo("Error: health check failed — a worker process died.", err=True)
@@ -298,6 +302,7 @@ def run(
             original_argv=sys.argv,
         )
         entry.save()
+        spawn_watchdog(run_id, log_dir=log_dir)
         install_signal_handlers(entry, coordinator)
         coordinator.loop()
     else:
@@ -314,6 +319,11 @@ def run(
             original_argv=sys.argv,
         )
         entry.save()
+        spawn_watchdog(run_id, log_dir=log_dir)
+        # Foreground: only SIGTERM goes through the handler. SIGINT stays at
+        # default so Ctrl+C raises KeyboardInterrupt and the try/finally below
+        # runs with a visible traceback.
+        install_signal_handlers(entry, coordinator, sigint=False)
         try:
             coordinator.loop()
         finally:


### PR DESCRIPTION
## Problem

Certain child processes might not get shut down correctly, especially processes started by modules.

Closes DIM-XXX

## Solution

* Mark all processes by adding a `DIMOS_RUN_ID` env var for them.
* Start a watchdog process which watches for the main process to die. When it dies, all children (and children of children, etc) are killed.
* Also kill when a new process starts.

## Breaking Changes

None.

## How to Test

<!-- MUST be reproducible. If this section is weak, reviewers can't approve confidently. -->

## Contributor License Agreement

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
