### PR TITLE
feat(go2): rage mode via webrtc

### DIFF
--- a/dimos/protocol/pubsub/test_spec.py
+++ b/dimos/protocol/pubsub/test_spec.py
@@ -282,6 +282,7 @@ async def test_async_iterator(
 
 
 @pytest.mark.slow
+@pytest.mark.skipif_macos_bug
 @pytest.mark.parametrize("pubsub_context, topic, values", testdata)
 def test_high_volume_messages(
     pubsub_context: Callable[[], Any], topic: Any, values: list[Any]

--- a/dimos/robot/all_blueprints.py
+++ b/dimos/robot/all_blueprints.py
@@ -89,6 +89,7 @@ all_blueprints = {
     "unitree-go2-temporal-memory": "dimos.robot.unitree.go2.blueprints.agentic.unitree_go2_temporal_memory:unitree_go2_temporal_memory",
     "unitree-go2-vlm-stream-test": "dimos.robot.unitree.go2.blueprints.smart.unitree_go2_vlm_stream_test:unitree_go2_vlm_stream_test",
     "unitree-go2-webrtc-keyboard-teleop": "dimos.robot.unitree.go2.blueprints.basic.unitree_go2_webrtc_keyboard_teleop:unitree_go2_webrtc_keyboard_teleop",
+    "unitree-go2-webrtc-rage-keyboard-teleop": "dimos.robot.unitree.go2.blueprints.basic.unitree_go2_webrtc_rage_keyboard_teleop:unitree_go2_webrtc_rage_keyboard_teleop",
     "unity-sim": "dimos.simulation.unity.blueprint:unity_sim",
     "xarm-perception": "dimos.manipulation.blueprints:xarm_perception",
     "xarm-perception-agent": "dimos.manipulation.blueprints:xarm_perception_agent",

--- a/dimos/robot/unitree/connection.py
+++ b/dimos/robot/unitree/connection.py
@@ -302,20 +302,24 @@ class UnitreeWebRTCConnection(Resource):
         """Enable Rage Mode on the Go2 via WebRTC.
         Assumes the robot is already in BalanceStand.
         """
-        self.publish_request(
-            RTC_TOPIC["SPORT_MOD"],
-            {"api_id": self._SPORT_API_ID_RAGEMODE, "parameter": {"data": True}},
+        rage_ok = bool(
+            self.publish_request(
+                RTC_TOPIC["SPORT_MOD"],
+                {"api_id": self._SPORT_API_ID_RAGEMODE, "parameter": {"data": True}},
+            )
         )
         time.sleep(2.0)
 
-        self.publish_request(
-            RTC_TOPIC["SPORT_MOD"],
-            {
-                "api_id": SPORT_CMD["SwitchJoystick"],
-                "parameter": {"data": True},
-            },
+        joystick_ok = bool(
+            self.publish_request(
+                RTC_TOPIC["SPORT_MOD"],
+                {
+                    "api_id": SPORT_CMD["SwitchJoystick"],
+                    "parameter": {"data": True},
+                },
+            )
         )
-        return True
+        return rage_ok and joystick_ok
 
     def liedown(self) -> bool:
         return bool(

--- a/dimos/robot/unitree/connection.py
+++ b/dimos/robot/unitree/connection.py
@@ -79,6 +79,8 @@ class SerializableVideoFrame:
 
 
 class UnitreeWebRTCConnection(Resource):
+    _SPORT_API_ID_RAGEMODE: int = 2059
+
     def __init__(self, ip: str, mode: str = "ai") -> None:
         self.ip = ip
         self.mode = mode
@@ -295,6 +297,33 @@ class UnitreeWebRTCConnection(Resource):
     def free_walk(self) -> bool:
         """Activate FreeWalk locomotion mode — enables walking and velocity commands."""
         return bool(self.publish_request(RTC_TOPIC["SPORT_MOD"], {"api_id": SPORT_CMD["FreeWalk"]}))
+
+    def set_rage_mode(self, enable: bool) -> bool:
+        """Toggle Rage Mode on the Go2 via WebRTC"""
+        self.publish_request(
+            RTC_TOPIC["SPORT_MOD"],
+            {"api_id": SPORT_CMD["BalanceStand"]},
+        )
+        time.sleep(0.3)
+
+        self.publish_request(
+            RTC_TOPIC["SPORT_MOD"],
+            {"api_id": self._SPORT_API_ID_RAGEMODE, "parameter": {"data": bool(enable)}},
+        )
+
+        if enable:
+            time.sleep(2.0)
+
+        self.publish_request(
+            RTC_TOPIC["SPORT_MOD"],
+            {
+                "api_id": SPORT_CMD["SwitchJoystick"],
+                "parameter": {"data": bool(enable)},
+            },
+        )
+
+        print(f"[Go2 WebRTC] Rage Mode {'enabled' if enable else 'disabled'}")
+        return True
 
     def liedown(self) -> bool:
         return bool(

--- a/dimos/robot/unitree/connection.py
+++ b/dimos/robot/unitree/connection.py
@@ -298,31 +298,23 @@ class UnitreeWebRTCConnection(Resource):
         """Activate FreeWalk locomotion mode — enables walking and velocity commands."""
         return bool(self.publish_request(RTC_TOPIC["SPORT_MOD"], {"api_id": SPORT_CMD["FreeWalk"]}))
 
-    def set_rage_mode(self, enable: bool) -> bool:
-        """Toggle Rage Mode on the Go2 via WebRTC"""
+    def enable_rage_mode(self) -> bool:
+        """Enable Rage Mode on the Go2 via WebRTC.
+        Assumes the robot is already in BalanceStand.
+        """
         self.publish_request(
             RTC_TOPIC["SPORT_MOD"],
-            {"api_id": SPORT_CMD["BalanceStand"]},
+            {"api_id": self._SPORT_API_ID_RAGEMODE, "parameter": {"data": True}},
         )
-        time.sleep(0.3)
-
-        self.publish_request(
-            RTC_TOPIC["SPORT_MOD"],
-            {"api_id": self._SPORT_API_ID_RAGEMODE, "parameter": {"data": bool(enable)}},
-        )
-
-        if enable:
-            time.sleep(2.0)
+        time.sleep(2.0)
 
         self.publish_request(
             RTC_TOPIC["SPORT_MOD"],
             {
                 "api_id": SPORT_CMD["SwitchJoystick"],
-                "parameter": {"data": bool(enable)},
+                "parameter": {"data": True},
             },
         )
-
-        print(f"[Go2 WebRTC] Rage Mode {'enabled' if enable else 'disabled'}")
         return True
 
     def liedown(self) -> bool:

--- a/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_webrtc_rage_keyboard_teleop.py
+++ b/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_webrtc_rage_keyboard_teleop.py
@@ -34,7 +34,7 @@ from dimos.robot.unitree.keyboard_teleop import KeyboardTeleop
 
 unitree_go2_webrtc_rage_keyboard_teleop = autoconnect(
     unitree_go2_webrtc_keyboard_teleop,
-    GO2Connection.blueprint(rage_mode=True),
+    GO2Connection.blueprint(mode="rage"),
     KeyboardTeleop.blueprint(linear_speed=1.25, angular_speed=1.2),
 ).global_config(obstacle_avoidance=True)
 

--- a/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_webrtc_rage_keyboard_teleop.py
+++ b/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_webrtc_rage_keyboard_teleop.py
@@ -35,7 +35,7 @@ from dimos.robot.unitree.keyboard_teleop import KeyboardTeleop
 unitree_go2_webrtc_rage_keyboard_teleop = autoconnect(
     unitree_go2_webrtc_keyboard_teleop,
     GO2Connection.blueprint(rage_mode=True),
-    KeyboardTeleop.blueprint(linear_speed=1.5, angular_speed=1.2),
+    KeyboardTeleop.blueprint(linear_speed=1.25, angular_speed=1.2),
 ).global_config(obstacle_avoidance=True)
 
 __all__ = ["unitree_go2_webrtc_rage_keyboard_teleop"]

--- a/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_webrtc_rage_keyboard_teleop.py
+++ b/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_webrtc_rage_keyboard_teleop.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unitree Go2 keyboard teleop via WebRTC with Rage Mode enabled.
+
+Same topology as unitree-go2-webrtc-keyboard-teleop, but GO2Connection is
+configured with rage_mode=True so FsmRageMode is toggled on after
+BalanceStand at connection start.
+
+Usage:
+    dimos run unitree-go2-webrtc-rage-keyboard-teleop
+"""
+
+from __future__ import annotations
+
+from dimos.core.coordination.blueprints import autoconnect
+from dimos.robot.unitree.go2.blueprints.basic.unitree_go2_webrtc_keyboard_teleop import (
+    unitree_go2_webrtc_keyboard_teleop,
+)
+from dimos.robot.unitree.go2.connection import GO2Connection
+from dimos.robot.unitree.keyboard_teleop import KeyboardTeleop
+
+unitree_go2_webrtc_rage_keyboard_teleop = autoconnect(
+    unitree_go2_webrtc_keyboard_teleop,
+    GO2Connection.blueprint(rage_mode=True),
+    KeyboardTeleop.blueprint(linear_speed=1.5, angular_speed=1.2),
+).global_config(obstacle_avoidance=True)
+
+__all__ = ["unitree_go2_webrtc_rage_keyboard_teleop"]

--- a/dimos/robot/unitree/go2/connection.py
+++ b/dimos/robot/unitree/go2/connection.py
@@ -58,6 +58,14 @@ logger = logging.getLogger(__name__)
 
 class ConnectionConfig(ModuleConfig):
     ip: str = Field(default_factory=lambda m: m["g"].robot_ip)
+    rage_mode: bool = Field(
+        default=False,
+        description=(
+            "Enable Rage Mode on connect. Toggles FsmRageMode via mcf AI "
+            "controller (api_id 2059) + SwitchJoystick. Widens forward "
+            "envelope to ~2.5 m/s. See data/notes/go2_firmware_modes.md."
+        ),
+    )
 
 
 class Go2ConnectionProtocol(Protocol):
@@ -73,6 +81,7 @@ class Go2ConnectionProtocol(Protocol):
     def liedown(self) -> bool: ...
     def balance_stand(self) -> bool: ...
     def set_obstacle_avoidance(self, enabled: bool = True) -> None: ...
+    def set_rage_mode(self, enable: bool) -> bool: ...
     def publish_request(self, topic: str, data: dict) -> dict: ...  # type: ignore[type-arg]
 
 
@@ -141,6 +150,9 @@ class ReplayConnection(UnitreeWebRTCConnection):
 
     def set_obstacle_avoidance(self, enabled: bool = True) -> None:
         pass
+
+    def set_rage_mode(self, enable: bool) -> bool:
+        return True
 
     @simple_mcache
     def lidar_stream(self):  # type: ignore[no-untyped-def]
@@ -252,6 +264,9 @@ class GO2Connection(Module, Camera, Pointcloud):
         time.sleep(3)
         self.connection.balance_stand()
         self.connection.set_obstacle_avoidance(self.config.g.obstacle_avoidance)
+
+        if self.config.rage_mode:
+            self.connection.set_rage_mode(True)
 
         # self.record("go2_bigoffice")
 

--- a/dimos/robot/unitree/go2/connection.py
+++ b/dimos/robot/unitree/go2/connection.py
@@ -58,14 +58,7 @@ logger = logging.getLogger(__name__)
 
 class ConnectionConfig(ModuleConfig):
     ip: str = Field(default_factory=lambda m: m["g"].robot_ip)
-    rage_mode: bool = Field(
-        default=False,
-        description=(
-            "Enable Rage Mode on connect. Toggles FsmRageMode via mcf AI "
-            "controller (api_id 2059) + SwitchJoystick. Widens forward "
-            "envelope to ~2.5 m/s. See data/notes/go2_firmware_modes.md."
-        ),
-    )
+    rage_mode: bool = False
 
 
 class Go2ConnectionProtocol(Protocol):
@@ -81,7 +74,7 @@ class Go2ConnectionProtocol(Protocol):
     def liedown(self) -> bool: ...
     def balance_stand(self) -> bool: ...
     def set_obstacle_avoidance(self, enabled: bool = True) -> None: ...
-    def set_rage_mode(self, enable: bool) -> bool: ...
+    def enable_rage_mode(self) -> bool: ...
     def publish_request(self, topic: str, data: dict) -> dict: ...  # type: ignore[type-arg]
 
 
@@ -151,7 +144,7 @@ class ReplayConnection(UnitreeWebRTCConnection):
     def set_obstacle_avoidance(self, enabled: bool = True) -> None:
         pass
 
-    def set_rage_mode(self, enable: bool) -> bool:
+    def enable_rage_mode(self) -> bool:
         return True
 
     @simple_mcache
@@ -263,10 +256,11 @@ class GO2Connection(Module, Camera, Pointcloud):
         self.standup()
         time.sleep(3)
         self.connection.balance_stand()
-        self.connection.set_obstacle_avoidance(self.config.g.obstacle_avoidance)
 
         if self.config.rage_mode:
-            self.connection.set_rage_mode(True)
+            self.connection.enable_rage_mode()
+
+        self.connection.set_obstacle_avoidance(self.config.g.obstacle_avoidance)
 
         # self.record("go2_bigoffice")
 
@@ -331,6 +325,13 @@ class GO2Connection(Module, Camera, Pointcloud):
     def liedown(self) -> bool:
         """Make the robot lie down."""
         return self.connection.liedown()
+
+    @rpc
+    def enable_rage_mode(self) -> bool:
+        """Enable Rage Mode (~2.5 m/s forward velocity envelope)."""
+        result = self.connection.enable_rage_mode()
+        logger.info("Rage Mode enabled")
+        return result
 
     @rpc
     def publish_request(self, topic: str, data: dict[str, Any]) -> dict[Any, Any]:

--- a/dimos/robot/unitree/go2/connection.py
+++ b/dimos/robot/unitree/go2/connection.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from enum import Enum
 import logging
 import sys
 from threading import Thread
@@ -56,9 +57,14 @@ else:
 logger = logging.getLogger(__name__)
 
 
+class Go2Mode(str, Enum):
+    DEFAULT = "default"
+    RAGE = "rage"
+
+
 class ConnectionConfig(ModuleConfig):
     ip: str = Field(default_factory=lambda m: m["g"].robot_ip)
-    rage_mode: bool = False
+    mode: Go2Mode = Go2Mode.DEFAULT
 
 
 class Go2ConnectionProtocol(Protocol):
@@ -257,7 +263,7 @@ class GO2Connection(Module, Camera, Pointcloud):
         time.sleep(3)
         self.connection.balance_stand()
 
-        if self.config.rage_mode:
+        if self.config.mode == Go2Mode.RAGE:
             self.connection.enable_rage_mode()
 
         self.connection.set_obstacle_avoidance(self.config.g.obstacle_avoidance)

--- a/dimos/robot/unitree/go2/connection.py
+++ b/dimos/robot/unitree/go2/connection.py
@@ -333,8 +333,17 @@ class GO2Connection(Module, Camera, Pointcloud):
         return self.connection.liedown()
 
     @rpc
+    def balance_stand(self) -> bool:
+        """Enter BalanceStand: neutral state for switching locomotion modes"""
+        return self.connection.balance_stand()
+
+    @rpc
     def enable_rage_mode(self) -> bool:
-        """Enable Rage Mode (~2.5 m/s forward velocity envelope)."""
+        """Enable Rage Mode (~2.5 m/s forward velocity envelope).
+        Ensures BalanceStand precondition regardless of current FSM state.
+        """
+        self.connection.balance_stand()
+        time.sleep(0.3)
         result = self.connection.enable_rage_mode()
         logger.info("Rage Mode enabled")
         return result

--- a/dimos/robot/unitree/keyboard_teleop.py
+++ b/dimos/robot/unitree/keyboard_teleop.py
@@ -29,10 +29,10 @@ from dimos.msgs.geometry_msgs.Vector3 import Vector3
 # Force X11 driver to avoid OpenGL threading issues
 os.environ["SDL_VIDEODRIVER"] = "x11"
 
-DEFAULT_LINEAR_SPEED: float = 0.5  # m/s, WASD/QE base magnitude
-DEFAULT_ANGULAR_SPEED: float = 0.8  # rad/s, A/D yaw-rate magnitude
-DEFAULT_BOOST_MULTIPLIER: float = 2.0  # Shift multiplier
-DEFAULT_SLOW_MULTIPLIER: float = 0.5  # Ctrl multiplier
+DEFAULT_LINEAR_SPEED: float = 0.5  # m/s
+DEFAULT_ANGULAR_SPEED: float = 0.8  # rad/s
+DEFAULT_BOOST_MULTIPLIER: float = 2.0
+DEFAULT_SLOW_MULTIPLIER: float = 0.5
 
 
 class KeyboardTeleop(Module):

--- a/dimos/robot/unitree/keyboard_teleop.py
+++ b/dimos/robot/unitree/keyboard_teleop.py
@@ -29,11 +29,20 @@ from dimos.msgs.geometry_msgs.Vector3 import Vector3
 # Force X11 driver to avoid OpenGL threading issues
 os.environ["SDL_VIDEODRIVER"] = "x11"
 
+DEFAULT_LINEAR_SPEED: float = 0.5  # m/s, WASD/QE base magnitude
+DEFAULT_ANGULAR_SPEED: float = 0.8  # rad/s, A/D yaw-rate magnitude
+DEFAULT_BOOST_MULTIPLIER: float = 2.0  # Shift multiplier
+DEFAULT_SLOW_MULTIPLIER: float = 0.5  # Ctrl multiplier
+
 
 class KeyboardTeleop(Module):
     """Pygame-based keyboard control module.
 
     Outputs standard Twist messages on /cmd_vel for velocity control.
+
+    Speed constants can be tuned at the top of this file, or overridden
+    per-instance by passing linear_speed / angular_speed /
+    boost_multiplier / slow_multiplier to the constructor.
     """
 
     cmd_vel: Out[Twist]  # Standard velocity commands
@@ -45,9 +54,20 @@ class KeyboardTeleop(Module):
     _clock: pygame.time.Clock | None = None
     _font: pygame.font.Font | None = None
 
-    def __init__(self, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        linear_speed: float = DEFAULT_LINEAR_SPEED,
+        angular_speed: float = DEFAULT_ANGULAR_SPEED,
+        boost_multiplier: float = DEFAULT_BOOST_MULTIPLIER,
+        slow_multiplier: float = DEFAULT_SLOW_MULTIPLIER,
+        **kwargs: Any,
+    ) -> None:
         super().__init__(**kwargs)
         self._stop_event = threading.Event()
+        self.linear_speed = linear_speed
+        self.angular_speed = angular_speed
+        self.boost_multiplier = boost_multiplier
+        self.slow_multiplier = slow_multiplier
 
     @rpc
     def start(self) -> None:
@@ -115,28 +135,28 @@ class KeyboardTeleop(Module):
 
             # Forward/backward (W/S)
             if pygame.K_w in self._keys_held:
-                twist.linear.x = 0.5
+                twist.linear.x = self.linear_speed
             if pygame.K_s in self._keys_held:
-                twist.linear.x = -0.5
+                twist.linear.x = -self.linear_speed
 
             # Strafe left/right (Q/E)
             if pygame.K_q in self._keys_held:
-                twist.linear.y = 0.5
+                twist.linear.y = self.linear_speed
             if pygame.K_e in self._keys_held:
-                twist.linear.y = -0.5
+                twist.linear.y = -self.linear_speed
 
             # Turning (A/D)
             if pygame.K_a in self._keys_held:
-                twist.angular.z = 0.8
+                twist.angular.z = self.angular_speed
             if pygame.K_d in self._keys_held:
-                twist.angular.z = -0.8
+                twist.angular.z = -self.angular_speed
 
-            # Apply speed modifiers (Shift = 2x, Ctrl = 0.5x)
+            # Apply speed modifiers (Shift = boost, Ctrl = slow)
             speed_multiplier = 1.0
             if pygame.K_LSHIFT in self._keys_held or pygame.K_RSHIFT in self._keys_held:
-                speed_multiplier = 2.0
+                speed_multiplier = self.boost_multiplier
             elif pygame.K_LCTRL in self._keys_held or pygame.K_RCTRL in self._keys_held:
-                speed_multiplier = 0.5
+                speed_multiplier = self.slow_multiplier
 
             twist.linear.x *= speed_multiplier
             twist.linear.y *= speed_multiplier
@@ -165,9 +185,9 @@ class KeyboardTeleop(Module):
         # Determine active speed multiplier
         speed_mult_text = ""
         if pygame.K_LSHIFT in self._keys_held or pygame.K_RSHIFT in self._keys_held:
-            speed_mult_text = " [BOOST 2x]"
+            speed_mult_text = f" [BOOST {self.boost_multiplier:g}x]"
         elif pygame.K_LCTRL in self._keys_held or pygame.K_RCTRL in self._keys_held:
-            speed_mult_text = " [SLOW 0.5x]"
+            speed_mult_text = f" [SLOW {self.slow_multiplier:g}x]"
 
         texts = [
             "Keyboard Teleop" + speed_mult_text,

--- a/dimos/robot/unitree/mujoco_connection.py
+++ b/dimos/robot/unitree/mujoco_connection.py
@@ -241,6 +241,10 @@ class MujocoConnection:
     def set_obstacle_avoidance(self, enabled: bool = True) -> None:
         pass
 
+    def set_rage_mode(self, enable: bool) -> bool:
+        # No Rage equivalent in simulation — stub the protocol surface.
+        return True
+
     def get_video_frame(self) -> NDArray[Any] | None:
         if self.shm_data is None:
             return None

--- a/dimos/robot/unitree/mujoco_connection.py
+++ b/dimos/robot/unitree/mujoco_connection.py
@@ -241,8 +241,7 @@ class MujocoConnection:
     def set_obstacle_avoidance(self, enabled: bool = True) -> None:
         pass
 
-    def set_rage_mode(self, enable: bool) -> bool:
-        # No Rage equivalent in simulation — stub the protocol surface.
+    def enable_rage_mode(self) -> bool:
         return True
 
     def get_video_frame(self) -> NDArray[Any] | None:


### PR DESCRIPTION
## Problem

No Rage Mode (~2.5 m/s forward velocity) on the Go2 via WebRTC

## Solution

- Added enable_rage_mode() to WebRTC Connection using undocumented api_id 2059 (AI controller's FsmRageMode), with SwitchJoystick to route velocity commands through the existing WebRTC joystick channel
- Expose as rpc on GO2Connection so it can be called from any module/agent at runtime
- Added `unitree-go2-webrtc-rage-keyboard-teleop` blueprint with higher base speeds (1.25 m/s linear, 1.2 rad/s angular) tuned for rage's envelope

## Breaking Changes

None

## How to Test

`dimos run unitree-go2-webrtc-rage-keyboard-teleop`

Robot should stand up, enter Rage Mode (visible gait change), then accept keyboard velocity commands
WASD at base speed should move at ~1.25 m/s, Shift+W should hit ~2.5 m/s

## Contributor License Agreement

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
