### PR TITLE
Keep traceback in consume_audio

### DIFF
--- a/dimos/stream/audio/node_output.py
+++ b/dimos/stream/audio/node_output.py
@@ -96,7 +96,7 @@ class SounddeviceAudioOutput(AbstractAudioTransform):
 
         except Exception as e:
             logger.error(f"Error starting audio output stream: {e}")
-            raise e
+            raise
 
         # Subscribe to the observable
         self._subscription = audio_observable.subscribe(  # type: ignore[assignment]


### PR DESCRIPTION
The path through consume_audio looks mostly fine, but It re-raises the caught exception object and loses the cleaner traceback shape. this patch changes that to a plain raise so the original stack stays intact. Happy to adjust if you’d prefer a different approach.
Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.