### PR TITLE
feat(api): peek_stream

### DIFF
--- a/dimos/core/coordination/python_worker.py
+++ b/dimos/core/coordination/python_worker.py
@@ -409,6 +409,7 @@ def _handle_request(request: Any, state: _WorkerState) -> WorkerResponse:
                 protocol_config={
                     "allow_all_attrs": True,
                     "allow_public_attrs": True,
+                    "allow_pickle": True,
                 },
             )
             state.rpyc_thread = threading.Thread(target=state.rpyc_server.start, daemon=True)

--- a/dimos/core/coordination/rpyc_server.py
+++ b/dimos/core/coordination/rpyc_server.py
@@ -52,6 +52,7 @@ class RpycServer:
             protocol_config={
                 "allow_all_attrs": True,
                 "allow_public_attrs": True,
+                "allow_pickle": True,
             },
         )
         self._thread = Thread(target=self._server.start, daemon=True, name="coordinator-rpyc")

--- a/dimos/porcelain/dimos.py
+++ b/dimos/porcelain/dimos.py
@@ -141,6 +141,48 @@ class Dimos:
                 raise RuntimeError("No modules are running")
             return SkillsProxy(self._source)
 
+    def peek_stream(self, name: str, timeout: float = 1.0) -> Any:
+        """Fetch the next message from a named stream on any running module.
+
+        Blocks up to `timeout` seconds for the next emission. Returns
+        None if no value arrives in time.
+
+        Args:
+            name: Stream attribute name (e.g. "color_image").
+            timeout: Max seconds to wait. Capped internally at 25s to stay
+                under the rpyc sync request timeout.
+        """
+        effective_timeout = min(timeout, 25.0)
+
+        with self._lock:
+            source = self._source
+            if source is None:
+                raise RuntimeError("No modules are running")
+
+        stream = None
+        for module_name in source.list_module_names():
+            try:
+                module = source.get_rpyc_module(module_name)
+                if name in module.outputs:
+                    stream = module.outputs[name]
+                    break
+                if name in module.inputs:
+                    stream = module.inputs[name]
+                    break
+            except Exception:
+                continue
+
+        if stream is None:
+            raise LookupError(
+                f"No running module exposes a stream named {name!r}. "
+                f"Running modules: {source.list_module_names()}"
+            )
+
+        try:
+            return stream.get_next(effective_timeout)
+        except Exception:
+            return None
+
     def stop(self) -> None:
         """Stop all modules and clean up resources.
 

--- a/dimos/porcelain/local_module_source.py
+++ b/dimos/porcelain/local_module_source.py
@@ -53,7 +53,9 @@ class LocalModuleSource(ModuleSource):
 
             host, port, module_id = self._coordinator.get_module_endpoint(name)
 
-            conn = rpyc.connect(host, port, config={"sync_request_timeout": 30})
+            conn = rpyc.connect(
+                host, port, config={"sync_request_timeout": 30, "allow_pickle": True}
+            )
             module = conn.root.get_module(module_id)
             self._cache[name] = (conn, module)
             return module

--- a/dimos/porcelain/remote_module_source.py
+++ b/dimos/porcelain/remote_module_source.py
@@ -56,7 +56,9 @@ class RemoteModuleSource(ModuleSource):
     is_remote = True
 
     def __init__(self, host: str, port: int) -> None:
-        self._coord_conn = _rpyc_connect(host, port, config={"sync_request_timeout": 30})
+        self._coord_conn = _rpyc_connect(
+            host, port, config={"sync_request_timeout": 30, "allow_pickle": True}
+        )
         self._cache: dict[str, tuple[rpyc.Connection, Any]] = {}
         self._lock = threading.RLock()
 
@@ -71,7 +73,9 @@ class RemoteModuleSource(ModuleSource):
 
             endpoint = self._coord_conn.root.get_module_endpoint(name)
             host, port, module_id = endpoint[0], int(endpoint[1]), int(endpoint[2])
-            conn = _rpyc_connect(host, port, config={"sync_request_timeout": 30})
+            conn = _rpyc_connect(
+                host, port, config={"sync_request_timeout": 30, "allow_pickle": True}
+            )
             module = conn.root.get_module(module_id)
             self._cache[name] = (conn, module)
             return module

--- a/dimos/porcelain/test_dimos.py
+++ b/dimos/porcelain/test_dimos.py
@@ -14,11 +14,36 @@
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from dimos.agents.mcp.mcp_server import McpServer
+from dimos.core.module import Module
+from dimos.core.stream import Out
 from dimos.core.tests.stress_test_module import StressTestModule
 from dimos.porcelain.dimos import Dimos, _resolve_target
+
+
+class TickerModule(Module):
+    tick: Out[int]
+
+    async def main(self):
+        task = asyncio.create_task(self._publisher())
+        try:
+            yield
+        finally:
+            task.cancel()
+
+    async def _publisher(self) -> None:
+        i = 1001
+        try:
+            while True:
+                await asyncio.sleep(0.05)
+                self.tick.publish(i)
+                i += 1
+        except asyncio.CancelledError:
+            pass
 
 
 def test_resolve_module_class():
@@ -65,6 +90,25 @@ def test_repr_when_stopped(app):
 def test_skills_before_run(app):
     with pytest.raises(RuntimeError, match="No modules are running"):
         _ = app.skills
+
+
+def test_peek_stream_before_run(app):
+    with pytest.raises(RuntimeError, match="No modules are running"):
+        app.peek_stream("whatever")
+
+
+def test_peek_stream_unknown_raises(running_app):
+    with pytest.raises(LookupError, match="No running module exposes"):
+        running_app.peek_stream("definitely_not_a_stream")
+
+
+@pytest.mark.slow
+def test_peek_stream_returns_published_value(app):
+    app.run(TickerModule)
+    value = app.peek_stream("tick", timeout=2.0)
+    assert value is not None
+    assert isinstance(value, int)
+    assert value > 1000
 
 
 def test_restart_before_run(app):

--- a/dimos/project/test_get_logger.py
+++ b/dimos/project/test_get_logger.py
@@ -40,6 +40,7 @@ WHITELIST = [
         "dimos/hardware/sensors/camera/gstreamer/gstreamer_sender.py",
         'logger = logging.getLogger("gstreamer_tcp_sender")',
     ),
+    ("dimos/core/test_async_module_main.py", 'target = logging.getLogger("dimos/core/module.py")'),
 ]
 
 

--- a/docs/usage/python-api.md
+++ b/docs/usage/python-api.md
@@ -41,6 +41,26 @@ app.run("keyboard-teleop")  # This will say `KeyboardTeleop is already deployed`
 app.stop()
 ```
 
+## Peeking streams
+
+`peek_stream(name, timeout)` pulls the next message from any running
+module's stream. Useful for quick inspection without writing a
+subscriber:
+
+```python
+# Grab the image.
+img = app.peek_stream("color_image", 1.0)
+
+# Display it in a window.
+import cv2, numpy as np
+cv2.imshow("color_image", np.array(img.data))
+cv2.waitKey(0)
+```
+
+Note, `np.array` is used to turn it into a real numpy array. `img.data` is a
+proxy object. That works in most cases, but `cv2.imshow` checks the actual
+class, so it needs a real numpy array.
+
 ## Remote mode
 
 Start a daemon first (via CLI or another script), then connect to it:


### PR DESCRIPTION
## Problem

We need an easy way to get a sample value from a stream. Useful for agents.

Closes DIM-822

## Solution

* Add `app.peek_stream`.

## Breaking Changes

None.

## How to Test

```python
# Grab the image.
img = app.peek_stream("color_image", 1.0)

# Display it in a window.
import cv2, numpy as np
cv2.imshow("color_image", np.array(img.data))
cv2.waitKey(0)
```

## Contributor License Agreement

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
