### PR TITLE
feat(agents): paged, multi-fidelity context memory for McpClient

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -321,6 +321,71 @@ If multiple modules match the spec, use `.remappings()` to resolve. Source: `dim
 5. Update the system prompt — add to the `# AVAILABLE SKILLS` section.
 6. Expose as `my_container = MySkillContainer.blueprint` and include in the agentic blueprint.
 
+### Context Memory
+
+Under default langchain wiring, `McpClient`'s conversation history grows unbounded. Once the prompt exceeds the model's context window, the state graph raises `context_length_exceeded` deep inside the worker thread's `_thread_loop` — the thread silently dies, `agent_idle` stays at `False`, and every subsequently enqueued message sits in the queue unprocessed.
+
+The fix is a paged, multi-fidelity memory layer in `dimos/agents/memory/`. `MemoryEngine` wraps history as a `PageTable` of `Page` objects, each renderable at four fidelity levels. Before every turn, `MemoryEngine.assemble()` runs a two-phase greedy selector that returns a `list[BaseMessage]` fitting inside the model's effective input budget. Degradations, evictions, and turn-level exceptions are published as `FaultEvent`s on an observability stream.
+
+#### Fidelity levels
+
+| Level | What it contains | When it's used |
+|-------|------------------|----------------|
+| `FULL` | Original `BaseMessage` content verbatim — text plus full-resolution image data URIs. | Pinned pages: system prompt, `BOOTSTRAP` pages, and the last `pin_recent_evidence` `EVIDENCE` pages. |
+| `COMPRESSED` | Text: first two sentences + `...`. Images: 96×96 JPEG thumbnail at quality 30, priced at `detail="low"` (85 tokens). | First degradation step for text and images. |
+| `STRUCTURED` | Text: `{"role": ..., "summary": "<=80 chars", "tokens": N}` JSON. Images: `[image artefact uuid=<uuid> src=... dims=... size=...]` bracket form. | Second degradation step — preserves routing metadata and the artefact UUID for rehydration. |
+| `POINTER` | `[page <uuid>]` for text, `[artefact uuid=<uuid>]` for images. | Cheapest fallback. The selector drops here before declaring physical insufficiency. |
+
+#### Pin policy
+
+`PageTable` manages three pinning rules automatically; the selector is forbidden from degrading pinned pages.
+
+- The system prompt (if any) is pinned at `FULL` and never degraded.
+- Pages ingested with `page_type_hint=PageType.BOOTSTRAP` are pinned at `FULL`.
+- The most recent `pin_recent_evidence` `EVIDENCE` pages (default 3) are hard-pinned at `FULL` on every `assemble()` call. This is the "recent images stay crisp" invariant — regression-guarded by `test_history_compaction_keeps_recent_images_at_full_under_pressure` in `dimos/agents/mcp/test_mcp_client_history_compaction.py`.
+
+#### McpClient knobs
+
+New fields on `McpClientConfig` (`dimos/agents/mcp/mcp_client.py`):
+
+| Field | Default | What it controls |
+|-------|---------|------------------|
+| `token_budget: int \| None` | `None` | When `None`, resolved from `model` via `resolve_budget(model_name=...)`. Override only for testing or non-standard deployments. |
+| `pin_recent_evidence: int` | `3` | Number of most-recent `EVIDENCE` pages hard-pinned at `FULL` per turn. |
+| `output_reserve_tokens: int` | `4096` | Tokens reserved in the input budget for the model's output. |
+
+#### Fault observability
+
+`McpClient` publishes `FaultEvent`s on its new `faults: Out[FaultEvent]` stream. Subscribers can log, alert, or drive autoscaling off this stream without coupling to the memory internals.
+
+| `FaultKind` | Meaning |
+|-------------|---------|
+| `PAGE_EVICTED` | A page was evicted from the assembled prompt. |
+| `PAGE_DEGRADED` | A page was rendered at a lower fidelity than `FULL` to fit the budget. |
+| `REFETCH_FAULT` | The LLM called `get_artefact` to rehydrate a previously degraded `EVIDENCE` page. |
+| `PHYSICAL_INSUFFICIENCY` | Either the pinned pages alone exceed the effective input budget (even at `POINTER` for every non-pinned page), OR `_thread_loop` caught a per-turn exception from `_process_message`. Inspect `details["exception"]` to distinguish — present on the thread-recovery path, absent on the budget path. |
+| `PIN_REBALANCE` | The auto-pin set (e.g. the "last 3 `EVIDENCE`" window) shifted because a new `EVIDENCE` page was ingested. |
+
+#### The `get_artefact` tool
+
+`MemoryEngine` auto-registers a `get_artefact` tool on `McpClient` during `on_system_modules`, alongside the MCP skills. When the LLM encounters a degraded `EVIDENCE` page in its context — either `[artefact uuid=X]` or `[image artefact uuid=X ...]` — it calls `get_artefact(uuid=X)` to mark the page for `FULL` rehydration on the next `assemble()`. The system prompt is explicitly unchanged: the tool is self-describing via its `args_schema` and description.
+
+#### Thread recovery
+
+`McpClient._thread_loop` wraps each call to `_process_message` in `try/except Exception`. On exception it calls `self._engine.emit_physical_insufficiency(exception=exc)` — which emits a `PHYSICAL_INSUFFICIENCY` fault with `details["exception"] = repr(exc)` — and continues draining the queue. This is the direct fix for the original "thread dies silently" bug and is regression-guarded by `test_thread_loop_recovers_from_process_message_exception` in `dimos/agents/mcp/test_mcp_client_history_compaction.py`.
+
+#### Where the code lives
+
+- `dimos/agents/memory/pages.py` — `Page`, `FidelityLevel`, `PageType`, `Representation`.
+- `dimos/agents/memory/page_table.py` — `PageTable` with pin management.
+- `dimos/agents/memory/ingestion.py` — `ingest_message()` (splits multimodal `HumanMessage`s into `list[Page]`).
+- `dimos/agents/memory/selector.py` — `assemble_prompt()` (two-phase greedy selector).
+- `dimos/agents/memory/engine.py` — `MemoryEngine` (public façade).
+- `dimos/agents/memory/budget.py` — `ModelBudget`, `resolve_budget()`.
+- `dimos/agents/memory/tokens.py` — `TiktokenCounter`, `HeuristicCounter`.
+- `dimos/agents/memory/faults.py` — `FaultObserver`, `FaultKind`, `FaultEvent`.
+- `dimos/agents/memory/artefact_tool.py` — `build_get_artefact_tool()`.
+
 ---
 
 ## Testing

--- a/dimos/agents/mcp/mcp_client.py
+++ b/dimos/agents/mcp/mcp_client.py
@@ -26,6 +26,8 @@ from langchain_core.tools import StructuredTool
 from langgraph.graph.state import CompiledStateGraph
 from reactivex.disposable import Disposable
 
+from dimos.agents.memory.engine import MemoryEngine
+from dimos.agents.memory.faults import FaultEvent
 from dimos.agents.system_prompt import SYSTEM_PROMPT
 from dimos.agents.utils import pretty_print_langchain_message
 from dimos.constants import DEFAULT_THREAD_JOIN_TIMEOUT
@@ -44,6 +46,10 @@ class McpClientConfig(ModuleConfig):
     model: str = "gpt-4o"
     model_fixture: str | None = None
     mcp_server_url: str = "http://localhost:9990/mcp"
+    # Memory engine knobs. See ``dimos.agents.memory.MemoryEngine``.
+    token_budget: int | None = None
+    pin_recent_evidence: int = 3
+    output_reserve_tokens: int = 4096
 
 
 class McpClient(Module):
@@ -51,12 +57,13 @@ class McpClient(Module):
     agent: Out[BaseMessage]
     human_input: In[str]
     agent_idle: Out[bool]
+    faults: Out["FaultEvent"]
 
     _lock: RLock
     _state_graph: CompiledStateGraph[Any, Any, Any, Any] | None
     _message_queue: Queue[BaseMessage]
     _tool_registry: dict[str, dict[str, Any]]
-    _history: list[BaseMessage]
+    _engine: MemoryEngine
     _thread: Thread
     _stop_event: Event
     _http_client: httpx.Client
@@ -68,7 +75,19 @@ class McpClient(Module):
         self._state_graph = None
         self._message_queue = Queue()
         self._tool_registry = {}
-        self._history = []
+        # Memory engine owns context state. SystemMessage is NOT ingested
+        # here — create_agent(system_prompt=...) handles that path; the
+        # engine budgets for the system prompt via ModelBudget.system_overhead.
+        # Future edits must keep system_overhead large enough to cover the
+        # configured SYSTEM_PROMPT + tool schemas or the selector will
+        # under-budget the content window.
+        self._engine = MemoryEngine(
+            model_name=self.config.model,
+            token_budget=self.config.token_budget,
+            pin_recent_evidence=self.config.pin_recent_evidence,
+            output_reserve_tokens=self.config.output_reserve_tokens,
+            faults_out=self.faults,
+        )
         self._thread = Thread(
             target=self._thread_loop,
             name=f"{self.__class__.__name__}-thread",
@@ -151,7 +170,7 @@ class McpClient(Module):
                 if item.get("type") != "text":
                     uuid_ = str(uuid.uuid4())
                     text += f"Tool call started with UUID: {uuid_}. You will be updated with the result soon."
-                    _append_image_to_history(self, name, uuid_, item)
+                    _queue_image_artefact_message(self, name, uuid_, item)
 
             return text
 
@@ -174,6 +193,7 @@ class McpClient(Module):
     @rpc
     def on_system_modules(self, _modules: list[RPCClient]) -> None:
         tools = self._fetch_tools()
+        tools.append(self._engine.get_artefact_tool())  # memory rehydration tool
 
         model: str | Any = self.config.model
         if self.config.model_fixture is not None:
@@ -271,30 +291,55 @@ class McpClient(Module):
             with self._lock:
                 if not self._state_graph:
                     raise ValueError("No state graph initialized")
-                self._process_message(self._state_graph, message)
+                try:
+                    self._process_message(self._state_graph, message)
+                except Exception as exc:
+                    self._engine.emit_physical_insufficiency(exception=exc)
+                    logger.exception(
+                        "mcp_client turn failed; continuing to drain queue"
+                    )
 
     def _process_message(
-        self, state_graph: CompiledStateGraph[Any, Any, Any, Any], message: BaseMessage
+        self,
+        state_graph: CompiledStateGraph[Any, Any, Any, Any],
+        message: BaseMessage,
     ) -> None:
         self.agent_idle.publish(False)
-        self._history.append(message)
+        # Ingest the inbound message into the memory engine; this becomes
+        # a Page (or several, for multimodal) and drives the next
+        # assemble. Edge case: under a physically-insufficient budget
+        # the fresh input itself may be degraded. The engine emits a
+        # PHYSICAL_INSUFFICIENCY fault in that case.
+        self._engine.ingest(message)
         pretty_print_langchain_message(message)
         self.agent.publish(message)
 
-        for update in state_graph.stream({"messages": self._history}, stream_mode="updates"):
-            for node_output in update.values():
-                for msg in node_output.get("messages", []):
-                    self._history.append(msg)
-                    pretty_print_langchain_message(msg)
-                    self.agent.publish(msg)
+        assembled = self._engine.assemble()
+        try:
+            for update in state_graph.stream(
+                {"messages": assembled.messages}, stream_mode="updates"
+            ):
+                for node_output in update.values():
+                    for msg in node_output.get("messages", []):
+                        self._engine.ingest(msg)
+                        pretty_print_langchain_message(msg)
+                        self.agent.publish(msg)
+        finally:
+            if self._message_queue.empty():
+                self.agent_idle.publish(True)
 
-        if self._message_queue.empty():
-            self.agent_idle.publish(True)
 
-
-def _append_image_to_history(
+def _queue_image_artefact_message(
     mcp_client: McpClient, func_name: str, uuid_: str, result: Any
 ) -> None:
+    """Queue a HumanMessage containing an image artefact returned by a
+    non-text tool result.
+
+    Ingestion splits this multimodal message into a CONVERSATION page
+    (with the preamble text) plus one EVIDENCE page per image artefact
+    automatically — see ``dimos.agents.memory.ingestion``. The caller
+    doesn't need to set a page type hint.
+    """
     mcp_client.add_message(
         HumanMessage(
             content=[

--- a/dimos/agents/mcp/test_mcp_client_history_compaction.py
+++ b/dimos/agents/mcp/test_mcp_client_history_compaction.py
@@ -1,0 +1,395 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration tests for :class:`McpClient` ↔ :class:`MemoryEngine`.
+
+Two tests live here:
+
+* ``test_history_compaction_keeps_recent_images_at_full_under_pressure``
+  — drives a real :class:`MemoryEngine` from a bypass-constructed
+  :class:`McpClient` under a tight token budget and locks in the key
+  compaction invariants (effective-budget ceiling, recent-evidence
+  pinning, degrade-fault emission, no physical insufficiency).
+
+* ``test_thread_loop_recovers_from_process_message_exception`` —
+  regression guard for the motivating bug: *"once the worker thread
+  dies, subsequent messages accumulate in the queue but never get
+  processed; ``agent_idle`` stays at ``False`` forever."* Verifies the
+  ``try/except`` wrapper in ``_thread_loop`` keeps the worker alive
+  across turn failures AND forwards the exception to the fault stream.
+"""
+from __future__ import annotations
+
+import base64
+import time
+from dataclasses import dataclass, field
+from queue import Queue
+from threading import Event, RLock, Thread
+from unittest.mock import MagicMock
+
+import cv2
+import numpy as np
+import pytest
+from langchain_core.messages import HumanMessage
+
+from dimos.agents.mcp.mcp_client import McpClient
+from dimos.agents.memory.engine import MemoryEngine
+from dimos.agents.memory.faults import FaultEvent, FaultKind
+from dimos.agents.memory.pages import FidelityLevel, PageType
+
+
+# --- fixtures / helpers ------------------------------------------------
+#
+# Kept file-local rather than shared via conftest.py: other test files
+# in this package use their own small helpers (e.g. ``_image_msg``
+# inside ``test_artefact_tool.py``) rather than any common fixture
+# module.
+
+
+class _FakeOut:
+    """Minimal ``Out[FaultEvent]`` stand-in that records every publish.
+
+    Mirrors the pattern from ``test_artefact_tool.py`` so the engine's
+    real :class:`FaultObserver` has somewhere to deliver events without
+    pulling in the full LCM transport stack.
+    """
+
+    def __init__(self) -> None:
+        self.published: list[FaultEvent] = []
+
+    def publish(self, ev: FaultEvent) -> None:
+        self.published.append(ev)
+
+
+@dataclass
+class _FakeAgentIdleStream:
+    """Stand-in for ``client.agent_idle`` (an ``Out[bool]``)."""
+
+    idle_history: list[bool] = field(default_factory=list)
+
+    def publish(self, value: bool) -> None:
+        self.idle_history.append(value)
+
+
+def _image_msg(size: int = 256) -> HumanMessage:
+    """Build a real JPEG-encoded image :class:`HumanMessage`.
+
+    Matches the shape used by ``test_artefact_tool.py``; reproduced
+    inline here because importing from another test file is brittle
+    (pytest test modules aren't a public API).
+    """
+    img = np.full((size, size, 3), 128, dtype=np.uint8)
+    ok, buf = cv2.imencode(".jpg", img, [int(cv2.IMWRITE_JPEG_QUALITY), 80])
+    assert ok
+    b64 = base64.b64encode(buf.tobytes()).decode("ascii")
+    return HumanMessage(
+        content=[
+            {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{b64}"}},
+        ]
+    )
+
+
+def _make_config_mock(
+    *,
+    model: str = "gpt-4o",
+    token_budget: int = 8000,
+    pin_recent_evidence: int = 3,
+    output_reserve_tokens: int = 256,
+) -> MagicMock:
+    """Build a ``config`` MagicMock with the engine knobs populated.
+
+    :class:`McpClient`'s ``__init__`` reads ``self.config.model`` etc. to
+    construct the engine. We bypass ``__init__`` in these tests, so the
+    config need only satisfy the assertions we actually exercise.
+    """
+    cfg = MagicMock()
+    cfg.model = model
+    cfg.token_budget = token_budget
+    cfg.pin_recent_evidence = pin_recent_evidence
+    cfg.output_reserve_tokens = output_reserve_tokens
+    return cfg
+
+
+def _build_bypass_client(
+    *,
+    faults_out: _FakeOut,
+    agent_idle: _FakeAgentIdleStream | None = None,
+    state_graph: object | None = None,
+) -> McpClient:
+    """Construct an :class:`McpClient` via ``__new__`` with a real
+    :class:`MemoryEngine` and MagicMock stubs for every other attribute
+    the test does not explicitly drive.
+
+    This sidesteps pydantic ``ModuleConfig`` validation and
+    :meth:`Module.__init__`'s transport wiring, both of which would
+    require a full blueprint / coordinator harness we don't have in
+    unit-test scope.
+    """
+    client = McpClient.__new__(McpClient)
+    client.config = _make_config_mock()
+    client._engine = MemoryEngine(
+        model_name=client.config.model,
+        token_budget=client.config.token_budget,
+        pin_recent_evidence=client.config.pin_recent_evidence,
+        output_reserve_tokens=client.config.output_reserve_tokens,
+        faults_out=faults_out,  # type: ignore[arg-type]
+    )
+    client._lock = RLock()
+    client._message_queue = Queue()
+    client._tool_registry = {}
+    client._stop_event = Event()
+    client._state_graph = state_graph if state_graph is not None else MagicMock()
+    client._http_client = MagicMock()
+    client._seq_ids = MagicMock()
+    if agent_idle is not None:
+        client.agent_idle = agent_idle  # type: ignore[assignment]
+    return client
+
+
+# --- Test 1 — compaction invariants -----------------------------------
+
+
+def test_history_compaction_keeps_recent_images_at_full_under_pressure() -> None:
+    """Under a tight token budget, compaction keeps the most recent
+    EVIDENCE pages at FULL fidelity, degrades older
+    CONVERSATION pages, fits under the effective budget, and stays
+    physically sufficient.
+
+    This locks in:
+
+    * Ingestion correctly produces EVIDENCE pages for images and
+      CONVERSATION pages for text.
+    * The selector targets
+      ``budget.effective_budget_for_messages(n_surviving)`` (NOT the
+      raw ``input_budget``).
+    * The pin policy — ``pin_recent_evidence=3`` keeps the last three
+      EVIDENCE pages ``pinned_at_full=True`` so the selector cannot
+      degrade them.
+    """
+    fake_faults_out = _FakeOut()
+    client = _build_bypass_client(faults_out=fake_faults_out)
+
+    # Ingest images first. The pin rebalance in MemoryEngine.ingest
+    # keeps the LAST 3 EVIDENCE pages pinned regardless of ingest order,
+    # so seeding all 10 up front and then burying them under text is
+    # the cleanest way to stress the selector: if the recent-evidence
+    # invariant holds, all 3 kept-pinned images survive; if the engine
+    # were to re-pin by wall-clock-recency instead of evidence-recency
+    # (a plausible refactor bug), the text-heavy tail would displace
+    # the images and the test would catch it.
+    for _ in range(10):
+        client._engine.ingest(_image_msg())
+
+    # ~100 tokens each at the heuristic's 4-chars-per-token rate; 100
+    # turns at that weight is enough to comfortably exceed an 8000-token
+    # budget once per-message overhead is reserved, which forces Phase 1
+    # evictions on the CONVERSATION tail.
+    for i in range(100):
+        client._engine.ingest(HumanMessage(content=f"filler turn #{i} " * 20))
+
+    result = client._engine.assemble()
+
+    # --- Assertion 1: effective-budget ceiling ---
+    effective_cap = client._engine.budget.effective_budget_for_messages(
+        len(result.messages)
+    )
+    assert result.total_tokens <= effective_cap, (
+        f"selector exceeded effective cap: total_tokens={result.total_tokens}, "
+        f"effective_cap={effective_cap}, n_messages={len(result.messages)}"
+    )
+
+    # --- Assertion 2: last 3 EVIDENCE pages are rendered at FULL ---
+    evidence_pages = [
+        p for p in client._engine.pages() if p.type is PageType.EVIDENCE
+    ]
+    # ``turn_seq`` descending → newest first. Ties are broken by ingest
+    # order, but ``ingest_message`` assigns a fresh turn_seq to each
+    # ingest call so there are no ties here.
+    evidence_by_recency = sorted(
+        evidence_pages, key=lambda p: p.turn_seq, reverse=True
+    )
+    top_three = evidence_by_recency[:3]
+    assert len(top_three) == 3, (
+        f"expected at least 3 EVIDENCE pages, got {len(top_three)}"
+    )
+    for page in top_three:
+        assert page.id in result.chosen_levels, (
+            f"recent EVIDENCE page {page.id} (turn_seq={page.turn_seq}) "
+            f"was evicted entirely; pin policy broken"
+        )
+        assert result.chosen_levels[page.id] == FidelityLevel.FULL, (
+            f"recent EVIDENCE page {page.id} (turn_seq={page.turn_seq}) "
+            f"rendered at {result.chosen_levels[page.id]!r}, expected FULL"
+        )
+
+    # --- Assertion 3: at least one PAGE_DEGRADED fault was emitted ---
+    degrade_events = [
+        ev for ev in fake_faults_out.published
+        if ev.kind is FaultKind.PAGE_DEGRADED
+    ]
+    assert degrade_events, (
+        "no PAGE_DEGRADED faults emitted; either the budget was not "
+        "actually under pressure (test fixture drifted) or the engine "
+        "is silently degrading without telling the fault stream"
+    )
+
+    # --- Assertion 4: no physical insufficiency ---
+    # 3 pinned images × ~1105 tokens + at least some text easily fits
+    # in 8000 tokens after per-message overhead. If this flips True,
+    # either the pin policy over-counted pages (the auto-pin set is
+    # larger than it should be) or the effective-budget math regressed.
+    assert result.physical_insufficient is False, (
+        f"unexpectedly flipped physical_insufficient=True on a budget "
+        f"that should comfortably fit 3 pinned images plus degraded "
+        f"text; published faults: {[ev.kind for ev in fake_faults_out.published]}"
+    )
+
+
+# --- Test 2 — regression guard for the motivating bug ------------------
+
+
+def test_thread_loop_recovers_from_process_message_exception() -> None:
+    """Regression guard for the original motivating bug.
+
+    Original bug: a turn-level exception in ``_process_message`` killed
+    the ``McpClient`` worker thread. ``agent_idle`` stayed at ``False``
+    forever and every subsequent enqueued message sat in the queue
+    unprocessed.
+
+    The fix wraps the call in a ``try/except`` that catches the
+    exception, routes it through
+    ``self._engine.emit_physical_insufficiency(exception=exc)``, logs
+    it, and continues draining. This test drives three messages through
+    the worker, makes the second one raise, and proves:
+
+    * All three messages are processed (the thread survived).
+    * The fault stream received a ``PHYSICAL_INSUFFICIENCY`` event
+      carrying the exception in ``details["exception"]``.
+    * ``agent_idle`` is restored to ``True`` after the final message.
+    * The thread exits cleanly via ``_stop_event``.
+    """
+    fake_faults_out = _FakeOut()
+    fake_idle = _FakeAgentIdleStream()
+    client = _build_bypass_client(
+        faults_out=fake_faults_out,
+        agent_idle=fake_idle,
+        state_graph=MagicMock(),  # passes the ``if not self._state_graph`` guard
+    )
+
+    # Monkeypatch ``_process_message`` so the second call raises. Mirrors
+    # the real method's externally-observable contract (publishes
+    # idle=False on entry; idle=True on clean exit when the queue is
+    # empty) without touching any LangGraph state machine.
+    call_count = {"n": 0}
+
+    def fake_process(state_graph: object, message: object) -> None:
+        call_count["n"] += 1
+        client.agent_idle.publish(False)
+        if call_count["n"] == 2:
+            raise RuntimeError("simulated turn-level failure")
+        if client._message_queue.empty():
+            client.agent_idle.publish(True)
+
+    client._process_message = fake_process  # type: ignore[assignment]
+
+    client._thread = Thread(target=client._thread_loop, daemon=True)
+    try:
+        client._thread.start()
+
+        for i in (1, 2, 3):
+            client._message_queue.put(HumanMessage(content=f"turn {i}"))
+
+        # Poll the queue until it drains, with a hard 5-second cap. The
+        # 5-second ceiling is the exact condition that pathologically
+        # triggered the original bug: if the thread dies mid-queue, the
+        # queue NEVER drains and the test must fail here (not silently
+        # time out on the whole test suite).
+        deadline = time.monotonic() + 5.0
+        while not client._message_queue.empty():
+            if time.monotonic() >= deadline:
+                pytest.fail(
+                    "thread hung after 5s; queue never drained — the "
+                    "try/except wrapper in _thread_loop regressed and "
+                    "the original motivating bug is back"
+                )
+            time.sleep(0.05)
+
+        # Give the worker a beat to finish its last iteration: after the
+        # final ``get()`` returns a message, the loop body runs
+        # ``_process_message`` (which publishes idle=True when the queue
+        # is empty) before blocking on the next ``get(timeout=0.5)``.
+        # 0.1s is an order of magnitude tighter than the get() timeout
+        # while being generous to the scheduler.
+        time.sleep(0.1)
+    finally:
+        # Unconditional teardown — even if an assertion below fails we
+        # must stop the daemon thread so subsequent pytest test
+        # sessions don't accumulate a pile of zombie workers.
+        client._stop_event.set()
+        client._thread.join(timeout=2.0)
+
+    # --- Assertion 1: all three messages processed ---
+    assert call_count["n"] == 3, (
+        f"expected 3 processed turns, got {call_count['n']}. "
+        "If this is 2, the thread died on the simulated exception "
+        "and the queue stalled — exactly the original bug."
+    )
+
+    # --- Assertion 2: PHYSICAL_INSUFFICIENCY fault was emitted ---
+    assert any(
+        ev.kind is FaultKind.PHYSICAL_INSUFFICIENCY
+        for ev in fake_faults_out.published
+    ), (
+        "no PHYSICAL_INSUFFICIENCY fault observed; "
+        "_thread_loop's except-branch did not call emit_physical_insufficiency"
+    )
+
+    # --- Assertion 3: idle restored to True after the final turn ---
+    # Explicit ``is True`` — the stream takes bool, not truthy values;
+    # a regression that publishes ``1`` or ``"True"`` would be bad and
+    # we want the test to catch it.
+    assert fake_idle.idle_history, "agent_idle never received any publish"
+    assert fake_idle.idle_history[-1] is True, (
+        f"agent_idle did not return to True; history tail: "
+        f"{fake_idle.idle_history[-5:]!r}"
+    )
+
+    # --- Assertion 4: thread exited cleanly ---
+    assert client._thread.is_alive() is False, (
+        "thread still alive after stop_event set + join(timeout=2.0); "
+        "worker loop is hung on something other than the message queue"
+    )
+
+    # --- Assertion 5: exception forwarded through the fault stream ---
+    # ``MemoryEngine.emit_physical_insufficiency`` stringifies the
+    # exception via ``repr()`` and stores it in ``details["exception"]``.
+    # Filter the PHYSICAL_INSUFFICIENCY events down to those carrying
+    # an exception payload — this test configuration can only emit them
+    # via the ``_thread_loop`` except branch, but being explicit keeps
+    # the assertion robust if a future change adds another
+    # physical-insufficiency emission path.
+    phys_events_with_exc = [
+        ev for ev in fake_faults_out.published
+        if ev.kind is FaultKind.PHYSICAL_INSUFFICIENCY
+        and "exception" in ev.details
+    ]
+    assert phys_events_with_exc, (
+        "no PHYSICAL_INSUFFICIENCY fault carried an 'exception' key; "
+        "emit_physical_insufficiency(exception=exc) contract regressed"
+    )
+    exc_repr = phys_events_with_exc[0].details["exception"]
+    assert "simulated turn-level failure" in exc_repr, (
+        f"exception text did not propagate into fault details; got: "
+        f"{exc_repr!r}. ``emit_physical_insufficiency`` must forward "
+        f"the exception into ``details['exception']``."
+    )

--- a/dimos/agents/memory/__init__.py
+++ b/dimos/agents/memory/__init__.py
@@ -1,0 +1,32 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Paged, multi-fidelity memory layer for agent conversation history.
+
+The memory package turns an unbounded ``list[BaseMessage]`` into a
+multi-resolution :class:`PageTable` that the agent draws from each turn.
+On every turn the :class:`MemoryEngine` assembles a prompt under a token
+budget; older pages are served at lower fidelity (thumbnail, structured
+JSON or 1-line pointer) and can be rehydrated on demand via the
+``get_artefact`` tool.
+
+Public re-exports are added incrementally as each submodule lands; see
+:mod:`dimos.agents.memory.pages`, :mod:`dimos.agents.memory.tokens`,
+:mod:`dimos.agents.memory.budget`, :mod:`dimos.agents.memory.faults`,
+:mod:`dimos.agents.memory.page_table`, :mod:`dimos.agents.memory.ingestion`,
+:mod:`dimos.agents.memory.selector`, :mod:`dimos.agents.memory.artefact_tool`
+and :mod:`dimos.agents.memory.engine`.
+"""
+
+__all__: list[str] = []

--- a/dimos/agents/memory/artefact_tool.py
+++ b/dimos/agents/memory/artefact_tool.py
@@ -1,0 +1,113 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The ``get_artefact`` tool — the LLM's way to rehydrate evidence pages.
+
+When an EVIDENCE page has been degraded to STRUCTURED or POINTER, the LLM
+sees one of two bracket forms in its context: ``[artefact uuid=<uuid>]``
+(POINTER) or ``[image artefact uuid=<uuid> src=... dims=... size=...]``
+(STRUCTURED). Both forms carry the page's ``artefact_uuid``, not its
+internal ``page.id``. If the LLM needs the full image, it calls this
+tool with that UUID; the next assembled prompt will then include the
+page at FULL fidelity.
+
+The tool is self-describing: its ``description`` and ``args_schema`` are
+the *only* way the LLM discovers it. The plan explicitly keeps the
+system prompt unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from langchain_core.tools import StructuredTool
+
+    from dimos.agents.memory.engine import MemoryEngine
+
+
+__all__ = [
+    "GET_ARTEFACT_TOOL_NAME",
+    "build_get_artefact_tool",
+]
+
+
+GET_ARTEFACT_TOOL_NAME = "get_artefact"
+"""Canonical name for the tool; used by tests and by the engine."""
+
+_TOOL_DESCRIPTION = (
+    "Rehydrate a degraded artefact back to full fidelity. Call this tool "
+    "whenever you see one of these references in your context and need "
+    "the original image, sensor snapshot or tool output:\n"
+    "  - `[artefact uuid=<UUID>]` (POINTER fidelity)\n"
+    "  - `[image artefact uuid=<UUID> src=... dims=... size=...]` "
+    "(STRUCTURED fidelity)\n"
+    "The next assistant turn will include the full artefact content. "
+    "Pass the exact UUID from the `uuid=` field of the reference (the "
+    "value immediately following `uuid=` and before the next space or "
+    "closing bracket)."
+)
+
+
+class _GetArtefactArgs(BaseModel):
+    """Arguments for ``get_artefact``."""
+
+    uuid: str = Field(
+        description="The artefact UUID extracted from the degraded reference "
+        "(e.g. the part after 'uuid=' in '[artefact uuid=abc-123]')."
+    )
+
+
+def build_get_artefact_tool(engine: "MemoryEngine") -> "StructuredTool":
+    """Build a :class:`StructuredTool` bound to *engine*.
+
+    The returned tool is side-effectful: calling it mutates the engine's
+    page table so the next :meth:`MemoryEngine.assemble` call renders the
+    requested page at FULL. It returns a short acknowledgement string
+    (never the full artefact body — that arrives via the next prompt).
+    """
+    # Deferred import: ``langchain_core`` is an optional extra, and the
+    # memory package imports cleanly even in environments that have not
+    # installed it. Importing at module scope would break those users.
+    from langchain_core.tools import StructuredTool
+
+    def _invoke(uuid: str) -> str:
+        ok = engine.request_full(uuid)
+        if not ok:
+            # A page evicted from an *assembled prompt* still lives in
+            # the ``PageTable`` and remains resolvable via
+            # ``get_by_artefact``. The only way a UUID lookup truly
+            # misses is if the page was never ingested, the UUID string
+            # is malformed, or the engine was ``clear()``ed (e.g.
+            # between sessions).
+            return (
+                f"No artefact found with UUID '{uuid}'. The UUID may be "
+                "malformed, or the page table may have been cleared (e.g. "
+                "after a new session). Double-check the `uuid=` value from "
+                "the artefact reference and try again."
+            )
+        return (
+            f"Artefact '{uuid}' scheduled for full-fidelity rehydration on the "
+            "next turn. Continue your reasoning and reference the artefact on "
+            "the next message."
+        )
+
+    return StructuredTool.from_function(
+        func=_invoke,
+        name=GET_ARTEFACT_TOOL_NAME,
+        description=_TOOL_DESCRIPTION,
+        args_schema=_GetArtefactArgs,
+    )

--- a/dimos/agents/memory/budget.py
+++ b/dimos/agents/memory/budget.py
@@ -1,0 +1,260 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Model context-window budgeting.
+
+:class:`ModelBudget` captures the three numbers the selector needs to cap
+input length:
+
+* ``context_window`` — the model's hard limit.
+* ``output_reserve`` — tokens reserved for the response.
+* ``system_overhead`` — slack for chat formatting / tool schemas.
+
+The effective limit on the *assembled prompt* is ``input_budget``
+(``context_window - output_reserve - system_overhead``).
+
+:func:`resolve_budget` is the factory used by :class:`MemoryEngine`. It
+looks up a model name, honours a user-supplied override and defaults to
+a conservative 32K window for anything unknown.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = [
+    "DEFAULT_CONTEXT_WINDOW",
+    "DEFAULT_OUTPUT_RESERVE",
+    "DEFAULT_PER_MESSAGE_OVERHEAD",
+    "DEFAULT_SYSTEM_OVERHEAD",
+    "ModelBudget",
+    "resolve_budget",
+]
+
+DEFAULT_CONTEXT_WINDOW = 32_000
+"""Conservative default window for unknown models."""
+
+DEFAULT_OUTPUT_RESERVE = 4096
+"""Default tokens reserved for the LLM's response."""
+
+DEFAULT_SYSTEM_OVERHEAD = 256
+"""Default formatting/overhead slack."""
+
+DEFAULT_PER_MESSAGE_OVERHEAD = 4
+"""Default per-message framing cost (OpenAI chat-completions is ~4 tok/msg)."""
+
+
+@dataclass(frozen=True)
+class ModelBudget:
+    """Immutable token budget for one chat turn.
+
+    Attributes:
+        context_window: Model's hard token limit (input + output).
+        output_reserve: Tokens held back for the response.
+        system_overhead: Small fixed overhead for chat formatting, the
+            tool-calling preamble, etc.
+        per_message_overhead: Per-message role/framing cost paid on top of
+            the encoded content. OpenAI's chat completions charges ~4
+            tokens per message for role + separators; the selector
+            subtracts ``per_message_overhead * n_messages`` from
+            :attr:`input_budget` to keep the assembled prompt below the
+            hard limit.
+    """
+
+    context_window: int
+    output_reserve: int = DEFAULT_OUTPUT_RESERVE
+    system_overhead: int = DEFAULT_SYSTEM_OVERHEAD
+    per_message_overhead: int = DEFAULT_PER_MESSAGE_OVERHEAD
+
+    def __post_init__(self) -> None:
+        if self.context_window <= 0:
+            raise ValueError(
+                f"ModelBudget.context_window must be positive, got {self.context_window}"
+            )
+        if self.output_reserve < 0:
+            raise ValueError(
+                f"ModelBudget.output_reserve must be non-negative, got {self.output_reserve}"
+            )
+        if self.system_overhead < 0:
+            raise ValueError(
+                f"ModelBudget.system_overhead must be non-negative, got {self.system_overhead}"
+            )
+        if self.per_message_overhead < 0:
+            raise ValueError(
+                f"ModelBudget.per_message_overhead must be non-negative, got "
+                f"{self.per_message_overhead}"
+            )
+        if self.output_reserve + self.system_overhead >= self.context_window:
+            raise ValueError(
+                f"ModelBudget: output_reserve ({self.output_reserve}) + "
+                f"system_overhead ({self.system_overhead}) must be strictly less "
+                f"than context_window ({self.context_window})"
+            )
+
+    @property
+    def input_budget(self) -> int:
+        """Hard ceiling for the assembled prompt (excluding response)."""
+        return self.context_window - self.output_reserve - self.system_overhead
+
+    def effective_budget_for_messages(self, n_messages: int) -> int:
+        """Input budget after subtracting per-message framing overhead.
+
+        The selector shrinks this ceiling as messages accumulate; recompute
+        after every add/remove.
+
+        Args:
+            n_messages: Number of messages currently in the assembled
+                prompt.
+
+        Returns:
+            ``input_budget - per_message_overhead * n_messages``. May go
+            negative if the caller tries to pack more messages than the
+            budget can frame; the selector treats that as "over budget"
+            and evicts.
+
+        Raises:
+            ValueError: if *n_messages* is negative.
+        """
+        if n_messages < 0:
+            raise ValueError(
+                f"n_messages must be non-negative, got {n_messages}"
+            )
+        return self.input_budget - self.per_message_overhead * n_messages
+
+
+# Known model windows. Numbers are the widely-documented context lengths
+# as of 2026-04. Conservative where ambiguity exists. Keep this table
+# sorted alphabetically for easy review.
+_MODEL_WINDOWS: dict[str, int] = {
+    # --- OpenAI ---
+    "gpt-3.5-turbo": 16_385,
+    "gpt-3.5-turbo-16k": 16_385,
+    "gpt-4": 8_192,
+    "gpt-4-32k": 32_768,
+    "gpt-4-turbo": 128_000,
+    "gpt-4-turbo-preview": 128_000,
+    "gpt-4.1": 1_047_576,
+    "gpt-4.1-mini": 1_047_576,
+    "gpt-4.1-nano": 1_047_576,
+    "gpt-4o": 128_000,
+    "gpt-4o-mini": 128_000,
+    "gpt-5": 400_000,
+    "gpt-5-mini": 400_000,
+    "o1": 200_000,
+    "o1-mini": 128_000,
+    "o1-preview": 128_000,
+    "o3-mini": 200_000,
+    # --- Anthropic ---
+    "claude-3-5-sonnet": 200_000,
+    "claude-3-5-sonnet-latest": 200_000,
+    "claude-3-haiku": 200_000,
+    "claude-3-opus": 200_000,
+    "claude-3-sonnet": 200_000,
+    "claude-4-opus": 200_000,
+    "claude-4-sonnet": 200_000,
+    # --- Llama / ollama ---
+    "llama2": 4_096,
+    "llama3": 8_192,
+    "llama3.1": 128_000,
+    "llama3.2": 128_000,
+    "llama3.3": 128_000,
+    "llama4": 128_000,
+    # --- Qwen / Mistral / misc ---
+    "mistral": 32_768,
+    "mistral-large": 128_000,
+    "mixtral": 32_768,
+    "qwen2": 32_768,
+    "qwen2.5": 131_072,
+    "qwen3": 131_072,
+}
+
+
+def _normalize_model(name: str) -> str:
+    """Strip provider prefixes and tag suffixes for table lookup.
+
+    LangChain / ollama model strings are commonly prefixed (``ollama:``,
+    ``openai:``) or tagged (``llama3.2:latest``, ``gpt-4o-2024-08-06``).
+    The table keys are plain family names; we peel the decorations off so
+    operator-supplied strings still resolve to known windows.
+    """
+    s = name.strip()
+    for prefix in ("ollama:", "openai:", "anthropic:", "groq:"):
+        if s.startswith(prefix):
+            s = s[len(prefix):]
+            break
+    # Drop ollama ``:tag`` and OpenAI ``-YYYY-MM-DD`` date suffixes.
+    if ":" in s:
+        s = s.split(":", 1)[0]
+    return s
+
+
+def resolve_budget(
+    model_name: str,
+    *,
+    override: int | None = None,
+    output_reserve: int = DEFAULT_OUTPUT_RESERVE,
+    system_overhead: int = DEFAULT_SYSTEM_OVERHEAD,
+    per_message_overhead: int = DEFAULT_PER_MESSAGE_OVERHEAD,
+) -> ModelBudget:
+    """Resolve a :class:`ModelBudget` for *model_name*.
+
+    All arguments after ``model_name`` are keyword-only; callers must pass
+    ``override=...`` etc. explicitly.
+
+    Args:
+        model_name: Provider-qualified model string (e.g. ``"gpt-4o"`` or
+            ``"ollama:llama3.2:latest"``).
+        override: If set, use this as the ``context_window`` instead of the
+            table lookup. Useful when operators want to keep prompts
+            artificially small for cost / latency control.
+        output_reserve: Tokens held back for the response.
+        system_overhead: Formatting / tool-schema slack.
+        per_message_overhead: Per-message role/framing cost. See
+            :class:`ModelBudget`.
+
+    Returns:
+        A frozen :class:`ModelBudget`. Unknown models fall back to
+        :data:`DEFAULT_CONTEXT_WINDOW`.
+
+    Raises:
+        ValueError: if *override* or any other argument is non-positive /
+            negative (validation is done in :class:`ModelBudget`).
+    """
+    if override is not None:
+        window = override
+    else:
+        normalized = _normalize_model(model_name)
+        window = _MODEL_WINDOWS.get(normalized)
+        if window is None:
+            # Longest-prefix match: for something like
+            # ``o1-mini-2024-09-12`` both ``o1`` and ``o1-mini`` are
+            # prefixes; we must pick the more specific (longer) one so
+            # ``o1-mini`` wins and reports 128K rather than o1's 200K.
+            best_key: str | None = None
+            for key in _MODEL_WINDOWS:
+                if normalized.startswith(key) and (
+                    best_key is None or len(key) > len(best_key)
+                ):
+                    best_key = key
+            if best_key is not None:
+                window = _MODEL_WINDOWS[best_key]
+        if window is None:
+            window = DEFAULT_CONTEXT_WINDOW
+
+    return ModelBudget(
+        context_window=window,
+        output_reserve=output_reserve,
+        system_overhead=system_overhead,
+        per_message_overhead=per_message_overhead,
+    )

--- a/dimos/agents/memory/engine.py
+++ b/dimos/agents/memory/engine.py
@@ -1,0 +1,286 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Façade that wires the memory layer into the agent.
+
+:class:`MemoryEngine` is the single object the agent module talks to: it
+owns the :class:`~dimos.agents.memory.page_table.PageTable`, the token
+counter, the fault observer, and the monotonic turn counter. It exposes
+two lifecycle methods — :meth:`ingest` and :meth:`assemble` — plus
+:meth:`get_artefact_tool` for wiring the ``get_artefact`` LangChain tool
+into the agent's tool list.
+
+Thread safety: :class:`MemoryEngine` is called from the agent's single
+worker thread. The underlying :class:`PageTable` is still locked because
+other threads (UI probes, structlog consumers) may iterate it.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import TYPE_CHECKING
+
+from dimos.agents.memory.budget import (
+    DEFAULT_OUTPUT_RESERVE,
+    DEFAULT_SYSTEM_OVERHEAD,
+    ModelBudget,
+    resolve_budget,
+)
+from dimos.agents.memory.faults import FaultObserver
+from dimos.agents.memory.ingestion import ingest_message
+from dimos.agents.memory.page_table import PageTable
+from dimos.agents.memory.pages import FidelityLevel, Page, PageType
+from dimos.agents.memory.selector import AssembledPrompt, assemble_prompt
+from dimos.agents.memory.tokens import HeuristicCounter, TiktokenCounter, TokenCounter
+
+if TYPE_CHECKING:
+    from langchain_core.messages.base import BaseMessage
+    from langchain_core.tools import StructuredTool
+
+    from dimos.agents.memory.faults import FaultEvent
+    from dimos.core.stream import Out
+
+__all__ = [
+    "MemoryEngine",
+]
+
+
+def _make_default_counter(model: str) -> TokenCounter:
+    """Best-effort :class:`TokenCounter` construction.
+
+    If tiktoken is installed we prefer it because it matches provider
+    billing; otherwise we fall back to the character-heuristic. Any
+    unexpected failure downgrades silently — the heuristic is correct
+    enough that losing tiktoken is not a correctness issue.
+    """
+    try:
+        return TiktokenCounter(model)
+    except Exception:  # pragma: no cover — pure defensive path
+        return HeuristicCounter()
+
+
+class MemoryEngine:
+    """Owner of the agent's memory state.
+
+    Args:
+        model_name: LangChain / ollama / anthropic model string. Used to
+            pick a default context window and to parameterise the
+            :class:`TiktokenCounter` backend.
+        token_budget: If set, used directly as the context window
+            (overriding the model lookup). ``None`` uses the table default.
+        pin_recent_evidence: How many of the most recent EVIDENCE pages
+            stay pinned at FULL.
+        output_reserve_tokens: Tokens held back for the LLM's response.
+        system_overhead: Formatting / tool-schema slack.
+        faults_out: Optional ``Out[FaultEvent]`` stream for live observability.
+        token_counter: Optional override for the token counter (tests use
+            this to force a deterministic backend).
+    """
+
+    def __init__(
+        self,
+        *,
+        model_name: str,
+        token_budget: int | None = None,
+        pin_recent_evidence: int = 3,
+        output_reserve_tokens: int = DEFAULT_OUTPUT_RESERVE,
+        system_overhead: int = DEFAULT_SYSTEM_OVERHEAD,
+        faults_out: "Out[FaultEvent] | None" = None,
+        token_counter: TokenCounter | None = None,
+    ) -> None:
+        self.model_name = model_name
+        self._budget: ModelBudget = resolve_budget(
+            model_name,
+            override=token_budget,
+            output_reserve=output_reserve_tokens,
+            system_overhead=system_overhead,
+        )
+        self._table = PageTable(pin_recent_evidence=pin_recent_evidence)
+        self._counter: TokenCounter = token_counter or _make_default_counter(model_name)
+        self._observer = FaultObserver(stream_out=faults_out)
+        self._turn_seq = 0
+        self._lock = threading.RLock()
+
+    # --- introspection -------------------------------------------------
+
+    @property
+    def budget(self) -> ModelBudget:
+        """The immutable budget used for assembly (exposed for tests)."""
+        return self._budget
+
+    @property
+    def page_table(self) -> PageTable:
+        return self._table
+
+    @property
+    def observer(self) -> FaultObserver:
+        return self._observer
+
+    @property
+    def turn_seq(self) -> int:
+        """Current turn counter; increments on every :meth:`ingest`."""
+        return self._turn_seq
+
+    def pages(self) -> list[Page]:
+        """Snapshot of all pages in ingest order."""
+        return self._table.ordered()
+
+    # --- lifecycle -----------------------------------------------------
+
+    def ingest(
+        self,
+        msg: "BaseMessage",
+        *,
+        page_type_hint: PageType | None = None,
+    ) -> list[Page]:
+        """Turn *msg* into one or more :class:`Page` objects and add
+        them to the page table.
+
+        Increments the turn counter, runs ingestion, stores each
+        produced page in content-part order, and rebalances evidence
+        pins exactly once per call if any of the produced pages is
+        EVIDENCE. Emits a ``PIN_REBALANCE`` fault when the pinned-at-full
+        set changes so operators can see evidence pressure at a glance.
+
+        Returns:
+            The full list of pages produced by :func:`ingest_message`
+            for this call, in ingest order. A multimodal ``HumanMessage``
+            may split into a CONVERSATION page followed by one EVIDENCE
+            page per image; simple messages produce a single-element
+            list.
+        """
+        with self._lock:
+            self._turn_seq += 1
+            pages = ingest_message(
+                msg,
+                turn_seq=self._turn_seq,
+                ts=time.time(),
+                token_counter=self._counter,
+                page_type_hint=page_type_hint,
+            )
+            for page in pages:
+                self._table.add(page)
+            if any(p.type is PageType.EVIDENCE for p in pages):
+                diff = self._table.rebalance_evidence_pins()
+                if not diff.empty:
+                    self._observer.pin_rebalance(
+                        self._turn_seq,
+                        pinned_page_ids=diff.pinned,
+                        unpinned_page_ids=diff.unpinned,
+                    )
+            return pages
+
+    def assemble(self) -> AssembledPrompt:
+        """Build the per-turn assembled prompt and emit observability faults.
+
+        The returned :class:`AssembledPrompt` can be fed directly into
+        LangGraph's ``state_graph.stream({"messages": ...})``.
+        """
+        with self._lock:
+            pages = self._table.ordered()
+            result = assemble_prompt(pages, budget=self._budget)
+
+            # Fault emission — after assembly so we can attach levels.
+            for pid in result.evicted_page_ids:
+                self._observer.evict(pid, self._turn_seq, reason="over_budget")
+            for pid in result.degraded_page_ids:
+                page = self._table.get(pid)
+                if page is None:  # pragma: no cover — defensive
+                    continue
+                chosen = result.chosen_levels.get(pid, FidelityLevel.POINTER)
+                self._observer.degrade(
+                    pid,
+                    self._turn_seq,
+                    from_level=page.max_available().name,
+                    to_level=chosen.name,
+                )
+
+            if result.physical_insufficient:
+                # Report the *effective* cap the selector actually
+                # enforced (``input_budget - per_message_overhead *
+                # n_surviving``), not the gross ``input_budget``.
+                # Otherwise operators see ``needed=X, available=input_budget``
+                # and wonder why the selector gave up when X was well
+                # under the gross ceiling. ``n_surviving`` is the count
+                # of messages that actually go on the wire
+                # (``result.messages``), which matches the ``n`` the
+                # selector fed into
+                # :meth:`ModelBudget.effective_budget_for_messages` at the
+                # point it flipped ``physical_insufficient=True``.
+                # ``result.total_tokens`` is still content-only per round
+                # 9, so the comparison is apples-to-apples.
+                n_surviving = len(result.messages)
+                self._observer.physical_insufficiency(
+                    self._turn_seq,
+                    needed=result.total_tokens,
+                    available=self._budget.effective_budget_for_messages(n_surviving),
+                )
+
+            return result
+
+    def emit_physical_insufficiency(self, exception: Exception | None = None) -> None:
+        """Public hook for callers (the agent worker thread) to report a
+        failed turn — typically because the LLM returned
+        ``context_length_exceeded`` *despite* our best-effort assembly.
+
+        Reports ``available=input_budget`` (gross) rather than the
+        effective cap because this method is invoked by the worker after
+        an LLM-side ``context_length_exceeded``, where the surviving-
+        message count is not known at the call site. The asymmetry with
+        :meth:`assemble`'s emission is deliberate: that path knows
+        exactly how many messages it queued up and can subtract their
+        per-message overhead; this path only knows the budget ceiling.
+        """
+        self._observer.physical_insufficiency(
+            self._turn_seq,
+            needed=-1,
+            available=self._budget.input_budget,
+            exception=repr(exception) if exception is not None else None,
+        )
+
+    def clear(self) -> None:
+        """Reset the page table. Does not reset the turn counter — that
+        keeps monotonicity across clears (tests rely on this)."""
+        with self._lock:
+            self._table.clear()
+
+    # --- artefact rehydration -----------------------------------------
+
+    def request_full(self, artefact_uuid: str) -> bool:
+        """Flag an EVIDENCE page for FULL-fidelity rendering on the next
+        :meth:`assemble`. Used by the ``get_artefact`` tool.
+
+        Returns:
+            ``True`` if the UUID was found and the page was flagged.
+            ``False`` if no such artefact exists in the table.
+        """
+        with self._lock:
+            page = self._table.get_by_artefact(artefact_uuid)
+            if page is None:
+                return False
+            self._table.mark_pinned_full(page.id)
+            self._observer.refetch(page.id, self._turn_seq, artefact_uuid)
+            return True
+
+    def get_artefact_tool(self) -> "StructuredTool":
+        """Build the LangChain tool that lets the LLM rehydrate evidence.
+
+        Deferred import: this method is the only path that needs
+        LangChain's tool runtime, so we pay the import cost only when a
+        consumer actually asks for the tool.
+        """
+        from dimos.agents.memory.artefact_tool import build_get_artefact_tool
+
+        return build_get_artefact_tool(self)

--- a/dimos/agents/memory/faults.py
+++ b/dimos/agents/memory/faults.py
@@ -1,0 +1,247 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fault events emitted by the memory engine.
+
+Every observable mutation of the :class:`~dimos.agents.memory.page_table.PageTable`
+— an eviction, a fidelity drop, a pin rebalance, a rehydrate request — is
+surfaced as a :class:`FaultEvent` so operators can tune the token budget
+without spelunking into logs.
+
+:class:`FaultObserver` routes events to two sinks in parallel:
+
+1. A structured-logging JSONL stream (``structlog``) for post-hoc analysis.
+2. An optional ``Out[FaultEvent]`` stream on the owning module for live UI.
+
+Design goals:
+
+* Never raise — an observability path must not kill the agent.
+* Cheap to call from tight loops; event construction is the bulk of the cost.
+* Stable on-the-wire shape: dataclass fields only, no references to live
+  ``Page`` objects (we copy the ``page_id`` string instead).
+
+Implementation notes:
+
+* :class:`FaultEvent` ``ts`` and ``details`` use ``default_factory``
+  values so tests can construct events positionally without boilerplate.
+* :class:`FaultObserver` exposes observability helpers beyond the core
+  :meth:`emit`:
+
+  - ``counts``: per-``FaultKind`` counter (useful for regression tests
+    and metrics scrape).
+  - ``last_event``: reference to the most recent emitted event.
+  - Convenience emitters: :meth:`evict`, :meth:`degrade`,
+    :meth:`refetch`, :meth:`physical_insufficiency`,
+    :meth:`pin_rebalance`. Each constructs a :class:`FaultEvent` and
+    calls :meth:`emit`; useful so call sites don't have to import the
+    ``FaultKind`` enum for common paths.
+* :meth:`FaultEvent.to_dict` helper for JSON-friendly serialization
+  (used by structlog and tests).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+import time
+from typing import TYPE_CHECKING, Any
+
+from dimos.utils.logging_config import setup_logger
+
+if TYPE_CHECKING:
+    from dimos.core.stream import Out
+
+__all__ = [
+    "FaultEvent",
+    "FaultKind",
+    "FaultObserver",
+]
+
+_logger = setup_logger()
+
+
+class FaultKind(Enum):
+    """What happened to a page that we want operators to know about."""
+
+    PAGE_EVICTED = "page_evicted"
+    """A page was fully dropped from the assembled prompt (non-pinned only)."""
+
+    PAGE_DEGRADED = "page_degraded"
+    """A page rendered at a lower fidelity than its maximum (e.g. FULL -> COMPRESSED)."""
+
+    REFETCH_FAULT = "refetch_fault"
+    """The LLM called ``get_artefact`` to pull an EVIDENCE page back to FULL."""
+
+    PHYSICAL_INSUFFICIENCY = "physical_insufficiency"
+    """The token budget cannot fit even the minimum-fidelity assembly — an
+    exception was either raised or narrowly avoided. Operators should bump
+    the budget or shrink pinning."""
+
+    PIN_REBALANCE = "pin_rebalance"
+    """The set of ``pinned_at_full`` pages changed (usually because a new
+    EVIDENCE page was ingested and the oldest previously-pinned image
+    dropped to non-pinned)."""
+
+
+@dataclass(frozen=True)
+class FaultEvent:
+    """One observable memory-layer event.
+
+    Attributes:
+        kind: See :class:`FaultKind`.
+        page_id: The affected page. ``None`` for events that are not
+            page-scoped (e.g. ``PHYSICAL_INSUFFICIENCY`` reflecting a whole
+            turn rather than one page).
+        turn_seq: The ingest turn number at the moment of the event. Useful
+            for reconstructing ordering in a trace.
+        ts: ``time.time()`` at emission.
+        details: Free-form payload (e.g. ``{"from": "FULL", "to": "COMPRESSED"}``).
+            Must be JSON-serialisable; the observer does not enforce this,
+            but the structlog renderer will complain loudly if it is not.
+    """
+
+    kind: FaultKind
+    page_id: str | None
+    turn_seq: int
+    ts: float = field(default_factory=time.time)
+    details: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a plain dict; stable schema for logs and UIs."""
+        return {
+            "kind": self.kind.value,
+            "page_id": self.page_id,
+            "turn_seq": self.turn_seq,
+            "ts": self.ts,
+            "details": dict(self.details),
+        }
+
+
+class FaultObserver:
+    """Sink for :class:`FaultEvent`.
+
+    The observer is deliberately tolerant: any exception raised by a
+    downstream sink is caught and logged but never re-raised, because the
+    caller is almost always on the agent worker thread and we do not want
+    an observability failure to kill a turn.
+
+    Args:
+        stream_out: Optional ``Out[FaultEvent]`` to publish events on. When
+            present, events are published to the stream *after* being
+            logged to structlog.
+    """
+
+    def __init__(self, stream_out: "Out[FaultEvent] | None" = None) -> None:
+        self._stream = stream_out
+        self._last_event: FaultEvent | None = None
+        # Kept for tests — number of events seen of each kind. Not exposed
+        # as a metric yet; operators consume the ``Out`` stream instead.
+        self.counts: dict[FaultKind, int] = {k: 0 for k in FaultKind}
+
+    @property
+    def last_event(self) -> FaultEvent | None:
+        """Most recently emitted event, or ``None`` if the observer is fresh."""
+        return self._last_event
+
+    def emit(self, event: FaultEvent) -> None:
+        """Publish *event* to structlog and (if configured) the ``Out`` stream.
+
+        This is the single entry point — callers never touch either sink
+        directly. Guaranteed not to raise.
+        """
+        self._last_event = event
+        self.counts[event.kind] = self.counts.get(event.kind, 0) + 1
+
+        try:
+            _logger.info(
+                "memory_fault",
+                kind=event.kind.value,
+                page_id=event.page_id,
+                turn_seq=event.turn_seq,
+                ts=event.ts,
+                **event.details,
+            )
+        except Exception:  # pragma: no cover — logging must never break the agent
+            pass
+
+        if self._stream is not None:
+            try:
+                self._stream.publish(event)
+            except Exception:  # pragma: no cover
+                _logger.exception("FaultObserver: failed to publish event to Out stream")
+
+    # --- convenience emitters used by the rest of the package -----------
+
+    def evict(self, page_id: str, turn_seq: int, reason: str) -> None:
+        self.emit(FaultEvent(
+            kind=FaultKind.PAGE_EVICTED,
+            page_id=page_id,
+            turn_seq=turn_seq,
+            details={"reason": reason},
+        ))
+
+    def degrade(
+        self,
+        page_id: str,
+        turn_seq: int,
+        *,
+        from_level: str,
+        to_level: str,
+    ) -> None:
+        self.emit(FaultEvent(
+            kind=FaultKind.PAGE_DEGRADED,
+            page_id=page_id,
+            turn_seq=turn_seq,
+            details={"from": from_level, "to": to_level},
+        ))
+
+    def refetch(self, page_id: str, turn_seq: int, artefact_uuid: str) -> None:
+        self.emit(FaultEvent(
+            kind=FaultKind.REFETCH_FAULT,
+            page_id=page_id,
+            turn_seq=turn_seq,
+            details={"artefact_uuid": artefact_uuid},
+        ))
+
+    def physical_insufficiency(
+        self,
+        turn_seq: int,
+        *,
+        needed: int,
+        available: int,
+        exception: str | None = None,
+    ) -> None:
+        details: dict[str, Any] = {"needed": needed, "available": available}
+        if exception is not None:
+            details["exception"] = exception
+        self.emit(FaultEvent(
+            kind=FaultKind.PHYSICAL_INSUFFICIENCY,
+            page_id=None,
+            turn_seq=turn_seq,
+            details=details,
+        ))
+
+    def pin_rebalance(
+        self,
+        turn_seq: int,
+        *,
+        pinned_page_ids: list[str],
+        unpinned_page_ids: list[str],
+    ) -> None:
+        self.emit(FaultEvent(
+            kind=FaultKind.PIN_REBALANCE,
+            page_id=None,
+            turn_seq=turn_seq,
+            details={"pinned": pinned_page_ids, "unpinned": unpinned_page_ids},
+        ))

--- a/dimos/agents/memory/ingestion.py
+++ b/dimos/agents/memory/ingestion.py
@@ -1,0 +1,788 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Turn a LangChain :class:`BaseMessage` into one or more :class:`Page` objects.
+
+Ingestion runs once per message; all four fidelity representations are
+computed up-front and cached on the resulting page(s). Doing the expensive
+work here means the selector loop can stay fast (it just picks which rung
+of the ladder to render).
+
+The hot path is the image-artefact case: we decode the base64 JPEG, resize
+to 96x96, re-encode at quality 30, and store the thumbnail as a
+``image_url`` part ready to be handed back to the LLM at COMPRESSED
+fidelity.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import re
+import time
+from typing import Any
+import uuid as uuid_module
+
+import cv2
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+from langchain_core.messages.base import BaseMessage
+import numpy as np
+
+from dimos.agents.memory.pages import (
+    FidelityLevel,
+    MessageRole,
+    Page,
+    PageType,
+    Representation,
+)
+from dimos.agents.memory.tokens import (
+    IMAGE_FULL_COST,
+    IMAGE_THUMB_COST,
+    TokenCounter,
+)
+
+__all__ = [
+    "THUMBNAIL_JPEG_QUALITY",
+    "THUMBNAIL_SIZE",
+    "ingest_message",
+]
+
+
+THUMBNAIL_SIZE = 96
+"""Width/height of the COMPRESSED image representation, in pixels."""
+
+THUMBNAIL_JPEG_QUALITY = 30
+"""JPEG quality used for the COMPRESSED image representation."""
+
+
+# ---------------------------------------------------------------------------
+# Helpers — role / page-type / artefact extraction
+# ---------------------------------------------------------------------------
+
+
+def _role_of(msg: BaseMessage) -> MessageRole:
+    if isinstance(msg, SystemMessage):
+        return "system"
+    if isinstance(msg, HumanMessage):
+        return "human"
+    if isinstance(msg, AIMessage):
+        return "ai"
+    if isinstance(msg, ToolMessage):
+        return "tool"
+    # Fall-through: LangChain has more message subclasses (FunctionMessage
+    # etc.) but the concrete ones in play for us are the four above.
+    raise TypeError(f"Unsupported BaseMessage subclass: {type(msg).__name__}")
+
+
+def _default_page_type(msg: BaseMessage, *, has_images: bool) -> PageType:
+    if isinstance(msg, SystemMessage):
+        return PageType.BOOTSTRAP
+    if has_images:
+        return PageType.EVIDENCE
+    return PageType.CONVERSATION
+
+
+def _default_provenance(msg: BaseMessage) -> str:
+    if isinstance(msg, SystemMessage):
+        return "system"
+    if isinstance(msg, HumanMessage):
+        return "user_input"
+    if isinstance(msg, AIMessage):
+        return "llm_response"
+    if isinstance(msg, ToolMessage):
+        return "tool_response"
+    return "unknown"
+
+
+# Pattern used both for artefact id detection (on ingest) and lookup hints
+# (so tests can round-trip). Lifted from the existing McpClient convention:
+#     "Tool call started with UUID: <uuid>"
+# and
+#     "This is the artefact for the '<tool>' tool with UUID:=<uuid>."
+_UUID_RE = re.compile(r"UUID\s*[:=]\s*=?\s*([0-9a-fA-F-]{8,})")
+
+
+def _extract_artefact_uuid(text: str) -> str | None:
+    m = _UUID_RE.search(text)
+    if m:
+        return m.group(1)
+    return None
+
+
+def _split_content_parts(
+    content: Any,
+) -> tuple[list[str], list[dict[str, Any]]]:
+    """Split a multimodal content field into ordered text and image parts.
+
+    Returns ``(text_parts, image_parts)`` where text_parts is the list of
+    text strings in original order (empty strings filtered out) and
+    image_parts is the list of ``image_url``/``image`` dicts in original
+    order. Plain-string content becomes a single-element text list.
+    Unknown LangChain part types are JSON-stringified onto the text side
+    so nothing is silently lost.
+
+    The split rules in ``ingest_message`` rely on ``len(text_parts)`` and
+    ``len(image_parts)`` separately, so we return the raw lists rather
+    than a pre-joined string.
+    """
+    if isinstance(content, str):
+        return ([content] if content else [], [])
+    if not isinstance(content, list):
+        return ([str(content)], [])
+
+    texts: list[str] = []
+    images: list[dict[str, Any]] = []
+    for part in content:
+        if not isinstance(part, dict):
+            texts.append(str(part))
+            continue
+        ptype = part.get("type")
+        if ptype == "text":
+            t = str(part.get("text", ""))
+            if t:
+                texts.append(t)
+        elif ptype in ("image_url", "image"):
+            images.append(part)
+        else:
+            texts.append(json.dumps(part, default=str))
+    return texts, images
+
+
+# ---------------------------------------------------------------------------
+# Image thumbnailing
+# ---------------------------------------------------------------------------
+
+
+def _decode_image_url(image_part: dict[str, Any]) -> np.ndarray | None:
+    """Decode a LangChain ``image_url`` content part into a BGR ndarray.
+
+    Supports only ``data:image/...;base64,...`` URLs; external HTTP URLs
+    are returned as ``None`` because we can't reliably fetch them during
+    ingestion.
+    """
+    url = image_part.get("image_url", {}).get("url") if image_part.get("type") == "image_url" \
+        else image_part.get("source", {}).get("data")
+    if not isinstance(url, str):
+        return None
+
+    prefix = "base64,"
+    idx = url.find(prefix)
+    if idx < 0:
+        return None
+    try:
+        raw = base64.b64decode(url[idx + len(prefix):], validate=True)
+    except Exception:
+        return None
+    arr = np.frombuffer(raw, dtype=np.uint8)
+    if arr.size == 0:
+        return None
+    img = cv2.imdecode(arr, cv2.IMREAD_COLOR)
+    return img
+
+
+def _image_src_tag(image_part: dict[str, Any]) -> str:
+    """Short, grep-friendly source tag for the STRUCTURED bracketed format.
+
+    The ``src`` field of the STRUCTURED rendering is a short provenance
+    tag — never the full base64 payload, which would defeat the purpose
+    of the STRUCTURED tier. For ``data:`` URIs we return the mime prefix
+    (``data:image/jpeg``), for HTTP(S) URLs we return the URL, and for
+    anything we cannot interpret we return ``unknown``. Spaces are
+    escaped to ``%20`` so the whole bracketed artefact stays
+    single-tokenable and the format stays grep-friendly.
+    """
+    url: Any = ""
+    if image_part.get("type") == "image_url":
+        url = image_part.get("image_url", {}).get("url", "")
+    elif image_part.get("type") == "image":
+        url = image_part.get("source", {}).get("data", "")
+    if not isinstance(url, str) or not url:
+        return "unknown"
+    if url.startswith("data:"):
+        # ``data:image/jpeg;base64,AAAA...`` -> ``data:image/jpeg``.
+        head = url.split(";", 1)[0] if ";" in url else url.split(",", 1)[0]
+        return head.replace(" ", "%20")
+    return url.replace(" ", "%20")
+
+
+def _encode_thumbnail(bgr: np.ndarray) -> str | None:
+    """Resize *bgr* to 96x96 and JPEG-encode it at quality 30."""
+    thumb = cv2.resize(
+        bgr,
+        (THUMBNAIL_SIZE, THUMBNAIL_SIZE),
+        interpolation=cv2.INTER_AREA,
+    )
+    ok, buf = cv2.imencode(
+        ".jpg",
+        thumb,
+        [int(cv2.IMWRITE_JPEG_QUALITY), THUMBNAIL_JPEG_QUALITY],
+    )
+    if not ok:
+        return None
+    return base64.b64encode(buf.tobytes()).decode("ascii")
+
+
+# ---------------------------------------------------------------------------
+# Representation builders
+# ---------------------------------------------------------------------------
+
+
+_TEXT_TRUNCATION_SENTENCES = 2
+_STRUCTURED_SUMMARY_MAX_CHARS = 80
+
+
+def _sentence_truncate(text: str, max_sentences: int = _TEXT_TRUNCATION_SENTENCES) -> str:
+    """Return the first *max_sentences* sentences of *text*, with a marker.
+
+    Sentence boundaries are approximated with a regex (``. ! ?`` followed
+    by whitespace). Good enough for logs; the plan never claims this is
+    linguistically correct.
+    """
+    if not text:
+        return text
+    # Find sentence terminators followed by whitespace or end-of-string.
+    boundaries = [m.end() for m in re.finditer(r"[.!?]+(?:\s+|$)", text)]
+    if len(boundaries) >= max_sentences:
+        cutoff = boundaries[max_sentences - 1]
+        head = text[:cutoff].rstrip()
+        tail = text[cutoff:].strip()
+        if tail:
+            return head + " ... (truncated)"
+        return head
+    return text
+
+
+def _short_summary(role: MessageRole, text: str, tokens: int) -> str:
+    snippet = text.strip().replace("\n", " ")
+    if len(snippet) > _STRUCTURED_SUMMARY_MAX_CHARS:
+        snippet = snippet[: _STRUCTURED_SUMMARY_MAX_CHARS - 1] + "…"
+    return json.dumps(
+        {"role": role, "summary": snippet, "tokens": tokens},
+        ensure_ascii=False,
+    )
+
+
+def _build_text_representations(
+    role: MessageRole,
+    text: str,
+    page_id: str,
+    token_counter: TokenCounter,
+) -> dict[FidelityLevel, Representation]:
+    """Build POINTER/STRUCTURED/COMPRESSED/FULL for a text message."""
+    # Guard against fully-empty text — we still need a non-empty FULL rep
+    # because ``Representation`` enforces that. Substitute a single-space
+    # placeholder; this is only reached for deliberately-empty messages.
+    full_text = text if text else " "
+    compressed_text = _sentence_truncate(full_text) or full_text
+    full_tokens = token_counter.count_text(full_text)
+    compressed_tokens = token_counter.count_text(compressed_text)
+    structured_text = _short_summary(role, full_text, full_tokens)
+    structured_tokens = token_counter.count_text(structured_text)
+    pointer_text = f"[page {page_id}]"
+    pointer_tokens = token_counter.count_text(pointer_text)
+
+    # Force monotonicity even if the heuristic disagrees (e.g. structured
+    # summary ends up longer than the compressed truncation). The selector
+    # relies on monotonic costs; we pick min(upper, lower+1)-style caps.
+    structured_tokens = min(structured_tokens, max(pointer_tokens, structured_tokens))
+    compressed_tokens = max(compressed_tokens, structured_tokens)
+    full_tokens = max(full_tokens, compressed_tokens)
+
+    return {
+        FidelityLevel.POINTER: Representation(FidelityLevel.POINTER, pointer_text, pointer_tokens),
+        FidelityLevel.STRUCTURED: Representation(
+            FidelityLevel.STRUCTURED, structured_text, structured_tokens
+        ),
+        FidelityLevel.COMPRESSED: Representation(
+            FidelityLevel.COMPRESSED, compressed_text, compressed_tokens
+        ),
+        FidelityLevel.FULL: Representation(FidelityLevel.FULL, full_text, full_tokens),
+    }
+
+
+def _build_image_representations(
+    image_part: dict[str, Any],
+    *,
+    page_id: str,
+    provenance: str,
+    artefact_uuid: str,
+    token_counter: TokenCounter,
+    preamble_text: str = "",
+) -> dict[FidelityLevel, Representation]:
+    """Build all four representations for a message whose payload is one image.
+
+    Structure of the four rungs:
+
+    * FULL:        original image part (plus optional text preamble).
+    * COMPRESSED:  96x96 q30 thumbnail as an ``image_url`` content part.
+    * STRUCTURED:  one-line bracketed summary
+                   ``"[image artefact uuid=<artefact_uuid> src=... dims=... size=...]"``.
+                   The UUID here MUST be the ``artefact_uuid`` (the key
+                   :class:`PageTable._by_artefact` indexes on and that
+                   :meth:`MemoryEngine.request_full` looks up against) —
+                   NOT the ``page.id``. An LLM that extracts the UUID
+                   from this bracket and hands it to ``get_artefact``
+                   relies on both representations agreeing.
+    * POINTER:     ``"[artefact uuid=<artefact_uuid>]"``.
+
+    If the image can't be decoded (external URL, corrupt base64), we fall
+    back to a structured-only rung and a text FULL rung that just points
+    the LLM at the artefact UUID. This keeps the memory layer resilient to
+    half-formed messages from misbehaving tools.
+    """
+    bgr = _decode_image_url(image_part)
+
+    # POINTER
+    pointer_text = f"[artefact uuid={artefact_uuid}]"
+    pointer_tokens = token_counter.count_text(pointer_text)
+
+    # STRUCTURED — single-line bracketed text artefact. Do NOT swap it
+    # for a JSON blob; a JSON rep would double-stringify inside prompts.
+    if bgr is not None:
+        height, width = int(bgr.shape[0]), int(bgr.shape[1])
+        dims_str = f"{width}x{height}"
+        # Rough size of the original base64 payload in bytes (~4/3 expansion).
+        url_str = image_part.get("image_url", {}).get("url", "")
+        est_size_kb = max(1, (len(url_str) * 3 // 4) // 1024)
+        size_str = f"{est_size_kb}kB"
+    else:
+        # Unknown dims/size survive as ``unknown`` rather than crashing or
+        # emitting ``None``; the format must never break the bracket.
+        dims_str = "unknown"
+        size_str = "unknown"
+    src_tag = _image_src_tag(image_part)
+    # The UUID inside the STRUCTURED bracket MUST be the ``artefact_uuid``
+    # (the key ``PageTable._by_artefact`` is indexed on, which
+    # ``MemoryEngine.request_full`` / ``PageTable.get_by_artefact``
+    # resolve against) — NOT the ``page.id`` (which carries a ``"page-"``
+    # prefix and is a different string entirely). If an LLM extracted the
+    # UUID from a STRUCTURED rep and called ``get_artefact`` with a
+    # ``page.id`` here, it would hit the "not found" path even though the
+    # page was live in
+    # the table. The POINTER at line 341 was always correct; this line
+    # brings STRUCTURED into agreement.
+    structured_text = (
+        f"[image artefact uuid={artefact_uuid} "
+        f"src={src_tag} dims={dims_str} size={size_str}]"
+    )
+    structured_tokens = token_counter.count_text(structured_text)
+
+    # COMPRESSED — thumbnail (or text fallback when we can't decode).
+    if bgr is not None:
+        thumb_b64 = _encode_thumbnail(bgr)
+    else:
+        thumb_b64 = None
+
+    if thumb_b64 is not None:
+        thumb_url = f"data:image/jpeg;base64,{thumb_b64}"
+        compressed_content: str | list[dict[str, Any]] = [
+            {
+                "type": "image_url",
+                "image_url": {"url": thumb_url, "detail": "low"},
+            },
+        ]
+        if preamble_text:
+            compressed_content = [
+                {"type": "text", "text": preamble_text},
+                *compressed_content,  # type: ignore[misc]
+            ]
+        compressed_tokens = IMAGE_THUMB_COST + (
+            token_counter.count_text(preamble_text) if preamble_text else 0
+        )
+    else:
+        # Fall back to the structured text — same cost, same content.
+        compressed_content = structured_text
+        compressed_tokens = structured_tokens
+
+    # FULL — the original part (optionally with its preamble).
+    if preamble_text:
+        full_content: list[dict[str, Any]] = [
+            {"type": "text", "text": preamble_text},
+            image_part,
+        ]
+    else:
+        full_content = [image_part]
+    full_tokens = IMAGE_FULL_COST + (
+        token_counter.count_text(preamble_text) if preamble_text else 0
+    )
+
+    # Enforce POINTER <= STRUCTURED <= COMPRESSED <= FULL monotonicity.
+    # The new bracketed STRUCTURED format is always longer than POINTER
+    # in practice, but we clamp defensively in case a future counter
+    # tokenises them unexpectedly.
+    structured_tokens = max(structured_tokens, pointer_tokens)
+    compressed_tokens = max(compressed_tokens, structured_tokens)
+    full_tokens = max(full_tokens, compressed_tokens)
+
+    return {
+        FidelityLevel.POINTER: Representation(
+            FidelityLevel.POINTER, pointer_text, pointer_tokens
+        ),
+        FidelityLevel.STRUCTURED: Representation(
+            FidelityLevel.STRUCTURED, structured_text, structured_tokens
+        ),
+        FidelityLevel.COMPRESSED: Representation(
+            FidelityLevel.COMPRESSED, compressed_content, compressed_tokens
+        ),
+        FidelityLevel.FULL: Representation(
+            FidelityLevel.FULL, full_content, full_tokens
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def ingest_message(
+    msg: BaseMessage,
+    *,
+    turn_seq: int,
+    token_counter: TokenCounter,
+    ts: float | None = None,
+    page_id: str | None = None,
+    page_type_hint: PageType | None = None,
+) -> list[Page]:
+    """Turn *msg* into one or more :class:`Page` objects.
+
+    A multimodal ``HumanMessage`` splits into one EVIDENCE page per
+    image part, with any accompanying text kept on a separate
+    CONVERSATION page. Non-multimodal messages always yield exactly one
+    page, wrapped in a list. Every page produced from a single call
+    shares the same ``turn_seq`` and ``ts``.
+
+    Split rules (exhaustive):
+
+    * ``SystemMessage`` → one BOOTSTRAP page, pinned at FULL.
+    * ``AIMessage`` → one CONVERSATION page. ``ai_tool_calls`` is
+      preserved verbatim, and its serialized-JSON token cost is added
+      to every representation's ``token_estimate`` (see the
+      "AI tool_calls token accounting" note below).
+    * ``ToolMessage`` → one CONVERSATION page carrying ``tool_call_id``.
+    * ``HumanMessage`` with string content → one CONVERSATION page.
+    * ``HumanMessage`` with list content: classify each part by type.
+      Let T = text parts, I = image parts (``image_url`` or ``image``).
+
+      - ``len(I) == 0``: one CONVERSATION page from the joined text parts.
+      - ``len(T) == 0`` and ``len(I) == 1``: one EVIDENCE page from the
+        single image (no preamble).
+      - ``len(T) == 0`` and ``len(I) >= 2``: one EVIDENCE page per image
+        in original content-part order.
+      - ``len(T) >= 1`` and ``len(I) >= 1``: one CONVERSATION page from
+        the joined text plus one EVIDENCE page per image, ordered
+        ``[CONVERSATION, EVIDENCE_1, ..., EVIDENCE_n]``. The CONVERSATION
+        page's FULL text appends ``"\\n\\nAttached artefacts: [uuid1]
+        [uuid2] ..."`` so the LLM can reference the pages it may want
+        to rehydrate via the ``get_artefact`` tool.
+
+    Unsupported message types still raise :class:`TypeError`.
+
+    Args:
+        msg: The LangChain message to ingest.
+        turn_seq: Monotonic per-agent turn counter. Every page produced
+            from this call shares this value.
+        token_counter: Backend used to size each representation.
+        ts: ``float | None = None`` — wall-clock timestamp (seconds
+            since epoch) to attach to every produced Page's provenance.
+            Defaults to ``time.time()`` when omitted (one ``time.time()``
+            call per ``ingest_message`` invocation, not per page).
+        page_id: Stable id. **Only honored when the call produces
+            exactly one page.** In multi-page results (multimodal split)
+            every page is assigned a fresh synthesized UUID and the
+            caller-supplied ``page_id`` is silently ignored — see the
+            "multi-page id contract" note below.
+        page_type_hint: If given, overrides the auto-detected
+            :class:`PageType` on the **single-page CONVERSATION** path
+            (e.g. force BOOTSTRAP, CONSTRAINT, PLAN, PREFERENCE). The
+            hint is IGNORED for single-EVIDENCE pages (EVIDENCE is
+            structural) and for any multi-page result (no mixed
+            semantics). See the "page_type_hint" note below.
+
+    Signature notes:
+
+    * ``ts`` is passed in from the engine so ingestion does not read the
+      clock itself by default — this keeps the module side-effect free
+      and lets tests inject deterministic timestamps. When ``ts`` is
+      omitted, ``ingest_message`` falls back to ``time.time()`` so
+      ergonomic callers can skip it.
+    * ``page_id`` is optional because the common path should synthesise
+      ids, but deterministic tests and the ``get_artefact`` correlation
+      path both benefit from being able to pin one.
+
+    Multi-page id contract: when a multimodal ``HumanMessage`` produces
+    more than one page, the explicit ``page_id`` kwarg is silently
+    ignored and every page is assigned a fresh synthesized UUID. This
+    differs from the single-page path,
+    where ``page_id`` was always honored. We chose silent-ignore over
+    ``ValueError`` because callers who want pinned ids for the
+    artefact-rehydration path only ever pass single-image messages;
+    the multi-image case is a sink for whichever tool-result gets
+    batched, and there is no sensible disambiguation scheme across
+    N synthesized pages.
+
+    ``page_type_hint`` semantics:
+
+    * Single CONVERSATION page (message is System/AI/Tool/Human-text):
+      hint is honored and replaces the auto-detected :class:`PageType`.
+    * Single EVIDENCE page (one image, no text): hint is IGNORED —
+      EVIDENCE is structural.
+    * Multi-page result (cases e.3/e.4): hint is IGNORED entirely —
+      mixing CONVERSATION + EVIDENCE pages under a single caller-
+      supplied type would produce incoherent semantics.
+
+    Returns:
+        A non-empty ``list[Page]`` in ingest order (CONVERSATION first
+        when present, then EVIDENCE pages in original content-part
+        order). The list is handed to :class:`PageTable` as a batch by
+        :class:`MemoryEngine.ingest`.
+
+    AI ``tool_calls`` token accounting:
+        When the input is an :class:`AIMessage` with ``tool_calls``,
+        the serialized JSON cost of the ``tool_calls`` payload is
+        added to every representation's ``token_estimate``. This is
+        necessary because :meth:`Page.as_message` reattaches
+        ``tool_calls`` at every fidelity level to preserve
+        LangChain's AIMessage/ToolMessage pairing — the payload is in
+        the wire-format message regardless of fidelity.
+
+        The serialization is ``json.dumps(ai_tool_calls, sort_keys=True,
+        default=str)`` so equal payloads produce equal token counts
+        (deterministic for tests) and non-JSON-serializable args
+        (datetimes, paths, etc.) fall back to ``repr`` rather than
+        crashing. Counting is done via :meth:`TokenCounter.count_text`
+        (the content-only counter). AIMessages WITHOUT ``tool_calls``
+        are a zero-overhead path.
+    """
+    if ts is None:
+        ts = time.time()
+
+    role = _role_of(msg)
+    text_parts, image_parts = _split_content_parts(msg.content)
+    joined_text = " ".join(t for t in text_parts if t)
+    has_text = bool(joined_text.strip())
+    n_images = len(image_parts)
+
+    # Cases (a)-(d), (e.1): no images → exactly one CONVERSATION/BOOTSTRAP page.
+    if n_images == 0:
+        return [
+            _build_single_text_page(
+                msg,
+                role=role,
+                text=joined_text,
+                turn_seq=turn_seq,
+                ts=ts,
+                token_counter=token_counter,
+                page_id=page_id,
+                page_type_hint=page_type_hint,
+            )
+        ]
+
+    # Case (e.2): exactly one image and no text → exactly one EVIDENCE page.
+    # ``page_id`` is honored; ``page_type_hint`` is IGNORED (EVIDENCE is
+    # structural).
+    if n_images == 1 and not has_text:
+        return [
+            _build_single_evidence_page(
+                msg,
+                role=role,
+                image_part=image_parts[0],
+                preamble_text="",
+                turn_seq=turn_seq,
+                ts=ts,
+                token_counter=token_counter,
+                page_id=page_id,
+                artefact_uuid=None,
+            )
+        ]
+
+    # Cases (e.3) and (e.4): multi-page result. ``page_id`` is silently
+    # ignored (see "multi-page id contract" note); ``page_type_hint`` is
+    # ignored entirely.
+    extracted_uuid = _extract_artefact_uuid(joined_text) if has_text else None
+    evidence_pages: list[Page] = []
+    evidence_uuids: list[str] = []
+    for i, image_part in enumerate(image_parts):
+        # The MCP convention embeds an artefact UUID in the accompanying
+        # text; we honor it only for the first image, since a single
+        # preamble cannot disambiguate across N images.
+        if i == 0 and extracted_uuid:
+            artefact_uuid = extracted_uuid
+        else:
+            artefact_uuid = _new_uuid()
+        evidence_uuids.append(artefact_uuid)
+        evidence_pages.append(
+            _build_single_evidence_page(
+                msg,
+                role=role,
+                image_part=image_part,
+                preamble_text="",
+                turn_seq=turn_seq,
+                ts=ts,
+                token_counter=token_counter,
+                page_id=None,
+                artefact_uuid=artefact_uuid,
+            )
+        )
+
+    # Case (e.3): pure images — no CONVERSATION page.
+    if not has_text:
+        return evidence_pages
+
+    # Case (e.4): CONVERSATION preamble + EVIDENCE pages. The trailing
+    # ``Attached artefacts: [uuid1] [uuid2] ...`` line gives the LLM
+    # something to quote when it decides whether to call ``get_artefact``.
+    attached_line = "Attached artefacts: " + " ".join(
+        f"[{u}]" for u in evidence_uuids
+    )
+    conv_text = f"{joined_text}\n\n{attached_line}"
+    conv_page = _build_single_text_page(
+        msg,
+        role=role,
+        text=conv_text,
+        turn_seq=turn_seq,
+        ts=ts,
+        token_counter=token_counter,
+        page_id=None,
+        page_type_hint=None,
+        force_type=PageType.CONVERSATION,
+    )
+    return [conv_page, *evidence_pages]
+
+
+def _build_single_text_page(
+    msg: BaseMessage,
+    *,
+    role: MessageRole,
+    text: str,
+    turn_seq: int,
+    ts: float,
+    token_counter: TokenCounter,
+    page_id: str | None,
+    page_type_hint: PageType | None,
+    force_type: PageType | None = None,
+) -> Page:
+    """Build one text-only :class:`Page` (cases a-d and e.1, plus the
+    CONVERSATION page in case e.4)."""
+    pid = page_id or _new_page_id()
+    reps = _build_text_representations(role, text, pid, token_counter)
+
+    # Account for the serialized ``tool_calls`` payload on AI pages.
+    # :meth:`Page.as_message` reattaches ``tool_calls`` at EVERY fidelity
+    # level to preserve LangChain's AIMessage/ToolMessage pairing, so the
+    # payload is in the outgoing wire-format message regardless of which
+    # rung the selector picks. The token cost must therefore be added
+    # uniformly to every representation's ``token_estimate``. Adding the
+    # same constant to all four rungs preserves the
+    # POINTER <= STRUCTURED <= COMPRESSED <= FULL monotonicity invariant
+    # that the selector relies on.
+    tool_calls = _clone_tool_calls(msg)
+    if tool_calls:
+        tool_calls_json = json.dumps(tool_calls, sort_keys=True, default=str)
+        tool_calls_tokens = token_counter.count_text(tool_calls_json)
+        if tool_calls_tokens:
+            reps = {
+                level: Representation(
+                    level, rep.content, rep.token_estimate + tool_calls_tokens
+                )
+                for level, rep in reps.items()
+            }
+
+    page_type = (
+        force_type
+        if force_type is not None
+        else (page_type_hint or _default_page_type(msg, has_images=False))
+    )
+    page = Page(
+        id=pid,
+        type=page_type,
+        provenance=_default_provenance(msg),
+        turn_seq=turn_seq,
+        ts=ts,
+        role=role,
+        representations=reps,
+        tool_call_id=getattr(msg, "tool_call_id", None),
+        ai_tool_calls=tool_calls,
+    )
+    if page.type is PageType.BOOTSTRAP:
+        page.pinned_at_full = True
+        page.pinned = True
+        page.min_fidelity = FidelityLevel.FULL
+    return page
+
+
+def _build_single_evidence_page(
+    msg: BaseMessage,
+    *,
+    role: MessageRole,
+    image_part: dict[str, Any],
+    preamble_text: str,
+    turn_seq: int,
+    ts: float,
+    token_counter: TokenCounter,
+    page_id: str | None,
+    artefact_uuid: str | None,
+) -> Page:
+    """Build one EVIDENCE :class:`Page` wrapping a single image part.
+
+    ``artefact_uuid`` is caller-supplied when the split logic has
+    already allocated uuids for a multi-page result; if ``None`` we
+    extract from ``preamble_text`` (MCP convention) or synthesize.
+    """
+    pid = page_id or _new_page_id()
+    if artefact_uuid is None:
+        artefact_uuid = (
+            _extract_artefact_uuid(preamble_text) if preamble_text else None
+        ) or _new_uuid()
+    reps = _build_image_representations(
+        image_part,
+        page_id=pid,
+        provenance=_default_provenance(msg),
+        artefact_uuid=artefact_uuid,
+        token_counter=token_counter,
+        preamble_text=preamble_text,
+    )
+    return Page(
+        id=pid,
+        type=PageType.EVIDENCE,
+        provenance=_default_provenance(msg),
+        turn_seq=turn_seq,
+        ts=ts,
+        role=role,
+        representations=reps,
+        artefact_uuid=artefact_uuid,
+        tool_call_id=getattr(msg, "tool_call_id", None),
+        ai_tool_calls=_clone_tool_calls(msg),
+    )
+
+
+def _new_page_id() -> str:
+    return f"page-{uuid_module.uuid4()}"
+
+
+def _new_uuid() -> str:
+    return str(uuid_module.uuid4())
+
+
+def _clone_tool_calls(msg: BaseMessage) -> list[dict[str, Any]] | None:
+    """Extract ``tool_calls`` from an :class:`AIMessage`, if any.
+
+    We take a shallow copy so downstream mutations (e.g. the selector
+    producing a new :class:`AIMessage`) cannot bleed back into the stored
+    page.
+    """
+    calls = getattr(msg, "tool_calls", None)
+    if not calls:
+        return None
+    return [dict(c) for c in calls]

--- a/dimos/agents/memory/page_table.py
+++ b/dimos/agents/memory/page_table.py
@@ -1,0 +1,248 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""In-memory page store for the agent's conversation state.
+
+:class:`PageTable` is the physical-memory analogue: it owns every
+:class:`Page` the agent has seen, with O(1) lookups by id and by
+artefact UUID. The selector reads from here, the ingestor writes to here,
+and the engine coordinates both.
+
+Threading: callers hold the module's own RLock during turn processing, but
+the table also keeps an internal :class:`threading.RLock` so that background
+readers (e.g. a UI probe subscribed to the ``agent`` stream) can safely
+iterate without racing the ingest writer.
+
+Pinning policy:
+
+* ``pinned`` pages are never evicted (the selector must keep them in the
+  assembled prompt at a minimum of ``min_fidelity``).
+* ``pinned_at_full`` further requires ``FULL`` rendering.
+* :meth:`PageTable.rebalance_evidence_pins` is called by the engine after
+  every EVIDENCE page is added: it ensures *exactly* the last
+  ``pin_recent_evidence`` EVIDENCE pages carry ``pinned_at_full`` and
+  returns the diff so the observer can emit a ``PIN_REBALANCE`` event.
+
+Implementation notes:
+
+* Auto-rebalance is caller-driven, not implicit on ``add``. The engine
+  invokes ``rebalance_evidence_pins`` itself under its own lock so it
+  can emit the ``PIN_REBALANCE`` fault event with the right
+  ``turn_seq``. Keeping ``add`` storage-only avoids coupling this
+  module to ``FaultObserver``.
+* ``rebalance_evidence_pins`` returns a :class:`PinRebalance` dataclass
+  so the caller receives both the newly-pinned and newly-unpinned ids
+  for a single self-contained fault event without a separate
+  before/after diff.
+* ``_auto_pinned_ids`` tracks pages that *this rebalancer* installed,
+  so manual promotions via :meth:`mark_pinned_full` (the one-way
+  REFETCH_FAULT upgrade path) are never implicitly un-pinned.
+* Public API: :meth:`mark_pinned_full`, :meth:`evidence_pages`,
+  :meth:`clear`, :meth:`__len__`, the :attr:`pin_recent_evidence`
+  property, and the exported :class:`PinRebalance` dataclass. All
+  consumed by the engine or :mod:`dimos.agents.memory.artefact_tool`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import threading
+from typing import TYPE_CHECKING
+
+from dimos.agents.memory.pages import FidelityLevel, Page, PageType
+
+if TYPE_CHECKING:
+    pass
+
+__all__ = [
+    "PageTable",
+    "PinRebalance",
+]
+
+
+@dataclass(frozen=True)
+class PinRebalance:
+    """Diff returned by :meth:`PageTable.rebalance_evidence_pins`.
+
+    Attributes:
+        pinned: Page ids that were newly marked ``pinned_at_full``.
+        unpinned: Page ids that lost ``pinned_at_full`` (they drop back to
+            plain ``pinned=False`` unless they had some other pin).
+    """
+
+    pinned: list[str]
+    unpinned: list[str]
+
+    @property
+    def empty(self) -> bool:
+        return not self.pinned and not self.unpinned
+
+
+class PageTable:
+    """Thread-safe store for :class:`Page` objects.
+
+    Operations that matter for correctness hold :attr:`_lock`; iteration
+    helpers (:meth:`ordered`, :meth:`__len__`) return defensive copies so
+    callers never observe the store mid-mutation.
+
+    Args:
+        pin_recent_evidence: How many of the *most recent* EVIDENCE pages
+            should carry ``pinned_at_full``. Default matches the locked
+            plan decision (``3``).
+    """
+
+    def __init__(self, pin_recent_evidence: int = 3) -> None:
+        if pin_recent_evidence < 0:
+            raise ValueError(
+                f"pin_recent_evidence must be non-negative, got {pin_recent_evidence}"
+            )
+        self._pages: list[Page] = []
+        self._by_id: dict[str, Page] = {}
+        self._by_artefact: dict[str, Page] = {}
+        self._lock = threading.RLock()
+        self._pin_recent_evidence = pin_recent_evidence
+        # Ids whose ``pinned_at_full`` was flipped *by the auto rebalancer*
+        # rather than by an explicit REFETCH_FAULT promotion. Only pages in
+        # this set may be un-pinned by a subsequent rebalance — pages that
+        # the LLM has rehydrated stay pinned for the rest of the session
+        # (per the plan's one-way-upgrade rule).
+        self._auto_pinned_ids: set[str] = set()
+
+    # --- basic store operations ---------------------------------------
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._pages)
+
+    @property
+    def pin_recent_evidence(self) -> int:
+        return self._pin_recent_evidence
+
+    def add(self, page: Page) -> None:
+        """Append *page* to the store (turn_seq order is the caller's job).
+
+        Raises ``ValueError`` if a page with the same id or artefact UUID
+        already exists; that would desynchronise the lookups.
+        """
+        with self._lock:
+            if page.id in self._by_id:
+                raise ValueError(f"PageTable already contains a page with id {page.id!r}")
+            if page.artefact_uuid and page.artefact_uuid in self._by_artefact:
+                raise ValueError(
+                    f"PageTable already contains an artefact UUID {page.artefact_uuid!r}"
+                )
+            self._pages.append(page)
+            self._by_id[page.id] = page
+            if page.artefact_uuid:
+                self._by_artefact[page.artefact_uuid] = page
+
+    def get(self, page_id: str) -> Page | None:
+        with self._lock:
+            return self._by_id.get(page_id)
+
+    def get_by_artefact(self, artefact_uuid: str) -> Page | None:
+        with self._lock:
+            return self._by_artefact.get(artefact_uuid)
+
+    def ordered(self) -> list[Page]:
+        """Return a new list of pages in ingest order (cheap — shallow copy)."""
+        with self._lock:
+            return list(self._pages)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._pages.clear()
+            self._by_id.clear()
+            self._by_artefact.clear()
+            self._auto_pinned_ids.clear()
+
+    # --- pinning -------------------------------------------------------
+
+    def evidence_pages(self) -> list[Page]:
+        """Return EVIDENCE pages in ingest order."""
+        with self._lock:
+            return [p for p in self._pages if p.type is PageType.EVIDENCE]
+
+    def rebalance_evidence_pins(self) -> PinRebalance:
+        """Ensure exactly the last ``pin_recent_evidence`` EVIDENCE pages
+        carry ``pinned_at_full``.
+
+        The rebalance is *idempotent*: calling it repeatedly without any
+        intervening mutation returns an empty :class:`PinRebalance`. It
+        preserves the ``pinned`` flag for pages the LLM has explicitly
+        rehydrated via ``get_artefact`` — those pages are handled as a
+        separate, strictly additive set (we never implicitly un-pin them,
+        per the plan's 'one-way upgrade' decision for REFETCH_FAULT).
+
+        Returns:
+            A :class:`PinRebalance` describing which page ids transitioned.
+        """
+        with self._lock:
+            evidence = [p for p in self._pages if p.type is PageType.EVIDENCE]
+            n = self._pin_recent_evidence
+            # The "target" set is the last ``n`` evidence pages by ingest
+            # order; earlier pages must drop their ``pinned_at_full``.
+            target_ids = {p.id for p in evidence[-n:]} if n > 0 else set()
+
+            pinned_ids: list[str] = []
+            unpinned_ids: list[str] = []
+
+            for page in evidence:
+                should_pin = page.id in target_ids
+                if should_pin and not page.pinned_at_full:
+                    # Auto-pin this page. Track it so a subsequent
+                    # rebalance knows it's safe to un-pin.
+                    page.pinned_at_full = True
+                    page.pinned = True
+                    page.min_fidelity = FidelityLevel.FULL
+                    self._auto_pinned_ids.add(page.id)
+                    pinned_ids.append(page.id)
+                elif not should_pin and page.id in self._auto_pinned_ids:
+                    # Only un-pin pages that this rebalancer installed.
+                    # Pages elevated via :meth:`mark_pinned_full` (e.g. by
+                    # a REFETCH_FAULT) are left alone — the plan treats
+                    # rehydrate as a one-way upgrade.
+                    page.pinned_at_full = False
+                    page.pinned = False
+                    page.min_fidelity = FidelityLevel.POINTER
+                    self._auto_pinned_ids.discard(page.id)
+                    unpinned_ids.append(page.id)
+
+            return PinRebalance(pinned=pinned_ids, unpinned=unpinned_ids)
+
+    # --- rehydration ---------------------------------------------------
+
+    def mark_pinned_full(self, page_id: str) -> bool:
+        """Promote a page to ``pinned_at_full`` (one-way upgrade).
+
+        This is the hook used by :mod:`dimos.agents.memory.artefact_tool`
+        when the LLM asks for a full artefact — we never want to revert
+        that decision automatically because the LLM would just ask again
+        next turn.
+
+        Returns:
+            ``True`` if the page existed and was flipped (or was already
+            pinned). ``False`` if no such page.
+        """
+        with self._lock:
+            page = self._by_id.get(page_id)
+            if page is None:
+                return False
+            page.pinned_at_full = True
+            page.pinned = True
+            page.min_fidelity = FidelityLevel.FULL
+            # This is a manual promotion — make sure the auto-rebalance
+            # tracker does not consider itself responsible for this pin.
+            self._auto_pinned_ids.discard(page.id)
+            return True

--- a/dimos/agents/memory/pages.py
+++ b/dimos/agents/memory/pages.py
@@ -1,0 +1,343 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Core data types for the paged, multi-fidelity memory layer.
+
+Each unit of conversation state is a :class:`Page`. A page stores all four
+fidelity levels eagerly so the selector can pick any one on demand without
+re-running the ingestor (which may involve image resizing or tokenization).
+
+Invariants enforced by :meth:`Page.__post_init__`:
+
+* ``representations`` contains at least ``POINTER``, ``STRUCTURED`` and one of
+  ``COMPRESSED``/``FULL``.
+* ``min_fidelity >= POINTER``.
+* ``pinned_at_full`` implies both ``pinned`` and ``min_fidelity == FULL``.
+* All representations are non-empty and their token estimates are
+  monotonically non-decreasing in fidelity level.
+
+Implementation notes:
+
+* ``Page.ai_tool_calls: list[dict] | None`` — stores the OpenAI
+  tool-call payload so ``Page.as_message`` can reattach it at every
+  fidelity level, preserving LangChain ``AIMessage``/``ToolMessage``
+  pairing across selector downgrades.
+* ``Page.rep_at(level)`` has a third fallback rung ("fall up" to the
+  lowest available representation when no rung ``<= level`` exists).
+  Documented in ``rep_at``'s own docstring as defensive; unreachable in
+  practice given the POINTER invariant but kept for robustness.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum, IntEnum
+from typing import Any, Literal
+
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+from langchain_core.messages.base import BaseMessage
+
+__all__ = [
+    "FidelityLevel",
+    "MessageRole",
+    "Page",
+    "PageType",
+    "Representation",
+]
+
+MessageRole = Literal["system", "human", "ai", "tool"]
+
+# Runtime-checkable counterpart of the :data:`MessageRole` ``Literal`` alias.
+# ``Literal`` is only meaningful to static type checkers, so we keep a
+# frozenset around for ``Page.__post_init__`` to enforce at runtime.
+_VALID_ROLES: frozenset[str] = frozenset({"system", "human", "ai", "tool"})
+
+
+class FidelityLevel(IntEnum):
+    """Fidelity ladder for a page.
+
+    ``POINTER < STRUCTURED < COMPRESSED < FULL`` — higher is more expensive
+    to include in a prompt but also more informative. Integer values are
+    chosen so ordinary numeric comparisons work (``level >= min_fidelity``).
+    """
+
+    POINTER = 0
+    STRUCTURED = 1
+    COMPRESSED = 2
+    FULL = 3
+
+
+class PageType(Enum):
+    """Why this page exists in the agent's memory."""
+
+    BOOTSTRAP = "bootstrap"
+    """System prompts, tool schemas — always pinned at FULL."""
+
+    CONSTRAINT = "constraint"
+    """Hard rules or invariants the agent must obey."""
+
+    PLAN = "plan"
+    """Current plan or open goals."""
+
+    PREFERENCE = "preference"
+    """User preferences carried across turns."""
+
+    EVIDENCE = "evidence"
+    """Images, sensor snapshots, or tool outputs with artefacts."""
+
+    CONVERSATION = "conversation"
+    """Plain user/AI/tool message turns."""
+
+
+@dataclass
+class Representation:
+    """A single fidelity rendering of a page.
+
+    Attributes:
+        level: Which rung of the fidelity ladder this representation sits on.
+        content: Either a plain string (text rendering) or a list of
+            LangChain multimodal content parts
+            (``[{"type": "text", ...}, {"type": "image_url", ...}]``).
+        token_estimate: Cached token count for this representation; set by
+            the ingestor so the selector never has to re-tokenize.
+    """
+
+    level: FidelityLevel
+    content: str | list[dict[str, Any]]
+    token_estimate: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.level, FidelityLevel):
+            raise TypeError(
+                "Representation.level must be a FidelityLevel, got "
+                f"{type(self.level).__name__}"
+            )
+        if self.token_estimate < 0:
+            raise ValueError(
+                f"Representation.token_estimate must be non-negative, got {self.token_estimate}"
+            )
+        if isinstance(self.content, str):
+            if not self.content:
+                raise ValueError("Representation text content must be non-empty")
+        elif isinstance(self.content, list):
+            if not self.content:
+                raise ValueError("Representation multimodal content must be non-empty")
+        else:
+            raise TypeError(
+                f"Representation.content must be str or list[dict], got {type(self.content).__name__}"
+            )
+
+
+@dataclass
+class Page:
+    """One addressable unit of conversation state.
+
+    A page owns four representations (ingested eagerly). The selector picks
+    the lowest representation that still fits the token budget after
+    satisfying pins and minimum-fidelity invariants.
+
+    Attributes:
+        id: Stable internal identifier, unique per page within a session.
+        type: What kind of state this page carries (see :class:`PageType`).
+        provenance: Human-readable origin string, e.g. ``"user_input"``,
+            ``"tool:camera.capture"``, ``"system"``.
+        turn_seq: Monotonic per-agent turn counter assigned at ingestion.
+        ts: ``time.time()`` snapshot at ingestion.
+        role: LangChain role — ``system``, ``human``, ``ai`` or ``tool``.
+        representations: Precomputed renderings keyed by fidelity.
+        min_fidelity: Lower bound the selector may not drop below. For
+            tool-call pairing and BOOTSTRAP pages we force ``FULL``.
+        pinned: If True this page can never be evicted (it always occupies
+            at least ``min_fidelity`` tokens in the assembled prompt).
+        pinned_at_full: Stricter variant: the page must render at FULL.
+            Used for the last ``pin_recent_evidence`` images.
+        artefact_uuid: UUID embedded in tool-artefact messages; populated on
+            EVIDENCE pages so the LLM can refer to them via ``get_artefact``.
+        tool_call_id: If this is a ``ToolMessage``, the tool-call ID it is
+            paired with. The selector keeps such pairs at the same fidelity
+            bucket (LangChain rejects orphan tool messages at the API layer).
+    """
+
+    id: str
+    type: PageType
+    provenance: str
+    turn_seq: int
+    ts: float
+    role: MessageRole
+    representations: dict[FidelityLevel, Representation]
+    min_fidelity: FidelityLevel = FidelityLevel.POINTER
+    pinned: bool = False
+    pinned_at_full: bool = False
+    artefact_uuid: str | None = None
+    tool_call_id: str | None = None
+    # AI tool_calls payload preserved verbatim so we can rebuild pairing on egress.
+    ai_tool_calls: list[dict[str, Any]] | None = field(default=None)
+
+    def __post_init__(self) -> None:
+        if not self.id:
+            raise ValueError("Page.id must be a non-empty string")
+        if not isinstance(self.type, PageType):
+            raise TypeError(
+                f"Page.type must be a PageType, got {type(self.type).__name__}"
+            )
+        if not isinstance(self.min_fidelity, FidelityLevel):
+            raise TypeError(
+                "Page.min_fidelity must be a FidelityLevel, got "
+                f"{type(self.min_fidelity).__name__}"
+            )
+        if self.role not in _VALID_ROLES:
+            raise ValueError(
+                f"Page.role must be one of {sorted(_VALID_ROLES)}, got {self.role!r}"
+            )
+        if self.turn_seq < 0:
+            raise ValueError(f"Page.turn_seq must be non-negative, got {self.turn_seq}")
+        if self.ts < 0:
+            raise ValueError(f"Page.ts must be non-negative, got {self.ts}")
+
+        # Representation-set invariants: must cover POINTER + STRUCTURED +
+        # at least one of COMPRESSED/FULL. Each representation's declared
+        # level must match its dict key.
+        if FidelityLevel.POINTER not in self.representations:
+            raise ValueError(f"Page {self.id}: POINTER representation is required")
+        if FidelityLevel.STRUCTURED not in self.representations:
+            raise ValueError(f"Page {self.id}: STRUCTURED representation is required")
+        has_full = FidelityLevel.FULL in self.representations
+        has_compressed = FidelityLevel.COMPRESSED in self.representations
+        if not (has_full or has_compressed):
+            raise ValueError(
+                f"Page {self.id}: at least one of COMPRESSED/FULL representation required"
+            )
+
+        for level, rep in self.representations.items():
+            if rep.level != level:
+                raise ValueError(
+                    f"Page {self.id}: representations[{level.name}].level "
+                    f"is {rep.level.name}; they must match"
+                )
+
+        # Token estimates must be monotonic across fidelity. A degenerate
+        # equal chain is OK (e.g. empty text) but higher levels must never
+        # be *cheaper*. This is the sanity knob the selector relies on.
+        ladder = sorted(self.representations.items(), key=lambda kv: kv[0])
+        prev_tokens = -1
+        for _level, rep in ladder:
+            if rep.token_estimate < prev_tokens:
+                raise ValueError(
+                    f"Page {self.id}: token estimates must be monotonic across fidelity"
+                    f" (got {[r.token_estimate for _, r in ladder]})"
+                )
+            prev_tokens = rep.token_estimate
+
+        if self.min_fidelity < FidelityLevel.POINTER:
+            raise ValueError("Page.min_fidelity must be >= POINTER")
+
+        if self.pinned_at_full:
+            # The three pin-related flags must be set consistently by
+            # the caller. Silent auto-mutation ("upgrade companion
+            # flags") breaks round-trip construction — callers who pass
+            # ``pinned_at_full=True, pinned=False`` would read back
+            # ``pinned=True`` because the constructor rewrote the input.
+            # Every production caller (ingestion.py BOOTSTRAP path,
+            # page_table.py auto-rebalance, page_table.mark_pinned_full)
+            # already sets all three explicitly, so rejection is safe.
+            if not self.pinned:
+                raise ValueError(
+                    f"Page {self.id}: pinned_at_full=True requires pinned=True; "
+                    f"got pinned=False. The three pin-related flags must be set "
+                    f"consistently by the caller."
+                )
+            if self.min_fidelity is not FidelityLevel.FULL:
+                raise ValueError(
+                    f"Page {self.id}: pinned_at_full=True requires "
+                    f"min_fidelity=FidelityLevel.FULL; got min_fidelity="
+                    f"{self.min_fidelity.name}. The three pin-related flags "
+                    f"must be set consistently by the caller."
+                )
+
+        # Tool messages must always carry a tool_call_id so the selector can
+        # keep pair integrity. The inverse also holds: only tool messages may
+        # carry a ``tool_call_id`` — setting it on any other role is a bug in
+        # the caller and would silently misroute pairing downstream.
+        if self.role == "tool" and not self.tool_call_id:
+            raise ValueError(f"Page {self.id} (role=tool) requires tool_call_id")
+        if self.role != "tool" and self.tool_call_id is not None:
+            raise ValueError(
+                f"Page {self.id} (role={self.role!r}) must not carry "
+                "tool_call_id; only role='tool' pages may."
+            )
+
+    def max_available(self) -> FidelityLevel:
+        """Highest fidelity representation actually present in this page."""
+        return max(self.representations.keys())
+
+    def rep_at(self, level: FidelityLevel) -> Representation:
+        """Return representation at *level*, with a lenient fallback.
+
+        Resolution order:
+
+        1. Exact match at *level* if present.
+        2. Otherwise the highest representation whose level is strictly
+           ``<= level`` (degrade gracefully).
+        3. Otherwise the lowest representation that exists (fall *up* to
+           something rather than raise).
+
+        **Contract change vs. the step-2 draft.** An earlier iteration
+        raised :class:`ValueError` when no rung ``<= level`` existed; this
+        implementation never raises. The relaxation is safe because
+        :meth:`__post_init__` enforces that every page carries a
+        ``POINTER`` representation — and ``POINTER`` is ``0``, the minimum
+        of :class:`FidelityLevel`. Therefore for *any* requested
+        ``level``, branch (2) already finds ``POINTER`` and branch (3) is
+        a defensive no-op that only fires if a future refactor violates
+        that invariant.
+
+        The selector is expected to call :meth:`max_available` before
+        :meth:`rep_at` when it needs "highest-feasible-under-budget"
+        semantics; this helper simply refuses to crash.
+        """
+        if level in self.representations:
+            return self.representations[level]
+
+        lower = [lvl for lvl in self.representations if lvl <= level]
+        if lower:
+            return self.representations[max(lower)]
+        return self.representations[min(self.representations.keys())]
+
+    def as_message(self, level: FidelityLevel) -> BaseMessage:
+        """Render this page as a LangChain :class:`BaseMessage` at *level*.
+
+        The returned message preserves the page's role and, for tool
+        messages, its ``tool_call_id``; AI tool-call payloads are also
+        reattached so LangChain's graph keeps its bookkeeping intact.
+        """
+        rep = self.rep_at(level)
+        content: Any = rep.content
+
+        if self.role == "system":
+            return SystemMessage(content=content)
+        if self.role == "human":
+            return HumanMessage(content=content)
+        if self.role == "ai":
+            # AIMessage accepts extra kwargs (tool_calls) which are required
+            # by the LangGraph executor when the message is replayed from
+            # history.
+            if self.ai_tool_calls:
+                return AIMessage(content=content, tool_calls=self.ai_tool_calls)
+            return AIMessage(content=content)
+        if self.role == "tool":
+            if self.tool_call_id is None:  # pragma: no cover - guarded in __post_init__
+                raise ValueError(f"Page {self.id}: tool role requires tool_call_id")
+            return ToolMessage(content=content, tool_call_id=self.tool_call_id)
+
+        raise ValueError(f"Page {self.id}: unknown role {self.role!r}")

--- a/dimos/agents/memory/selector.py
+++ b/dimos/agents/memory/selector.py
@@ -1,0 +1,364 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Two-phase greedy selector — MMU for the agent's conversation.
+
+Given a list of :class:`Page` objects (from a :class:`PageTable`) and a
+:class:`ModelBudget`, :func:`assemble_prompt` returns a list of LangChain
+:class:`BaseMessage` objects whose total token cost is guaranteed not to
+exceed the budget's ``input_budget``.
+
+The algorithm runs in two phases:
+
+**Phase 1 — pin satisfaction and eviction.**
+Every page starts at its ``min_fidelity``. Pinned pages are non-droppable.
+If the sum already exceeds the budget, we evict the least-valuable
+non-pinned page and record the eviction on :class:`AssembledPrompt`.
+If we cannot get under budget even after dropping every non-pinned page,
+we set ``physical_insufficient=True`` so the caller can emit a
+``PHYSICAL_INSUFFICIENCY`` fault.
+
+**Phase 2 — greedy upgrade.**
+The remaining pages are upgraded, cheapest cost per unit value first,
+until the next upgrade would exceed the budget. Recency dominates: more
+recent pages tie-break ahead of older ones, so the assembled prompt
+always contains recent turns at their maximum available fidelity when it
+fits.
+
+Tool-call pairing: ``(AIMessage with tool_calls, matching ToolMessage)``
+pairs are treated as an atomic unit — they are always selected or
+degraded together. LangChain rejects orphan tool messages at the API
+boundary, so breaking a pair would crash the state graph.
+
+System prompts (BOOTSTRAP pages) always render at FULL. The plan locks
+this; the rationale is that ``create_agent`` bundles the tool schema
+into the system prompt and truncating it corrupts tool dispatch.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from dimos.agents.memory.pages import FidelityLevel, Page, PageType
+
+if TYPE_CHECKING:
+    from langchain_core.messages.base import BaseMessage
+
+    from dimos.agents.memory.budget import ModelBudget
+
+__all__ = [
+    "AssembledPrompt",
+    "assemble_prompt",
+]
+
+
+@dataclass
+class AssembledPrompt:
+    """Result of one :func:`assemble_prompt` call.
+
+    Attributes:
+        messages: LangChain messages in ingest order, ready for ``state_graph.stream``.
+        total_tokens: Sum of representation ``token_estimate`` values for
+            the chosen fidelity of each non-evicted page. This is a
+            **content-only** sum — the per-message ChatML prelude
+            (~4 tokens per message) is *not* included here. Per-message
+            overhead is reserved on the :class:`ModelBudget` side via
+            ``effective_budget_for_messages``; keeping it off
+            :attr:`total_tokens` preserves the counter contract that
+            ``count_text``/``count_message`` return content tokens only.
+        chosen_levels: Which fidelity each included page was rendered at,
+            keyed by page id. Useful for tests and for debugging.
+        evicted_page_ids: Non-pinned pages dropped from this turn.
+        degraded_page_ids: Pages rendered below their max-available fidelity.
+        physical_insufficient: ``True`` when even the minimum-fidelity
+            assembly (all non-pinned dropped) doesn't fit the budget. The
+            caller emits a ``PHYSICAL_INSUFFICIENCY`` fault.
+    """
+
+    messages: list[BaseMessage]
+    total_tokens: int
+    chosen_levels: dict[str, FidelityLevel]
+    evicted_page_ids: list[str] = field(default_factory=list)
+    degraded_page_ids: list[str] = field(default_factory=list)
+    physical_insufficient: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Algorithm
+# ---------------------------------------------------------------------------
+
+
+def assemble_prompt(
+    pages: list[Page],
+    *,
+    budget: "ModelBudget",
+) -> AssembledPrompt:
+    """Build a token-capped prompt from the given pages.
+
+    The pages must already be in ingest order (newest last). This order
+    is preserved in :attr:`AssembledPrompt.messages`.
+
+    Args:
+        pages: All pages from the :class:`PageTable`, in ingest order.
+        budget: The token ceiling; we target
+            ``budget.effective_budget_for_messages(n_surviving)``, which
+            is ``input_budget - per_message_overhead * n_surviving``. The
+            cap therefore floats as Phase-1 evictions reduce
+            ``n_surviving`` — each evicted page frees both its content
+            tokens and its share of the per-message ChatML prelude.
+
+    Returns:
+        A populated :class:`AssembledPrompt`.
+    """
+    if not pages:
+        return AssembledPrompt(messages=[], total_tokens=0, chosen_levels={})
+
+    # Build atomic selection groups: tool-call pairs are one group; every
+    # other page stands alone.
+    groups = _build_selection_groups(pages)
+
+    # Phase 1: start everyone at their ``min_fidelity``; evict non-pinned
+    # groups if the floor over-budgets.
+    chosen: dict[str, FidelityLevel] = {}
+    for p in pages:
+        chosen[p.id] = _starting_level(p)
+
+    total = sum(chosen_token_cost(p, chosen[p.id]) for p in pages)
+    evicted_ids: set[str] = set()
+
+    # Per-message overhead (~4 tokens × n messages for the ChatML
+    # prelude) is owned by :class:`ModelBudget`, not by representation
+    # ``token_estimate`` values (which are content-only). The effective
+    # cap therefore depends on how many messages survive; every Phase-1
+    # eviction frees both the evicted content tokens AND one per-message
+    # overhead slot, so we must recompute ``cap`` after each eviction
+    # rather than pin it to the initial
+    # ``input_budget - per_message_overhead * len(pages)``.
+    surviving_count = len(pages)
+    cap = budget.effective_budget_for_messages(surviving_count)
+
+    # Evict least-valuable non-pinned group first. Utility order:
+    # 1. Recency (older = lower value).
+    # 2. Page type (CONVERSATION is expendable, EVIDENCE less so).
+    if total > cap:
+        eviction_order = _group_eviction_order(groups)
+        for group in eviction_order:
+            if total <= cap:
+                break
+            if any(p.pinned for p in group):
+                continue  # pinned groups cannot be evicted
+            saved = sum(chosen_token_cost(p, chosen[p.id]) for p in group)
+            if saved == 0:
+                continue
+            total -= saved
+            for p in group:
+                evicted_ids.add(p.id)
+            surviving_count -= len(group)
+            cap = budget.effective_budget_for_messages(surviving_count)
+
+    physical_insufficient = total > cap
+
+    # Phase 2: greedy upgrade of surviving groups. We operate on
+    # representation-level upgrades, not whole groups, so a tool-call pair
+    # that cannot afford FULL can still upgrade to STRUCTURED together.
+    if not physical_insufficient:
+        _upgrade_until_full(groups, chosen, evicted_ids, cap_remaining=cap - total)
+
+    # Final bookkeeping + message assembly.
+    degraded_ids: list[str] = []
+    messages: list[BaseMessage] = []
+    total_tokens = 0
+
+    for p in pages:
+        if p.id in evicted_ids:
+            continue
+        level = chosen[p.id]
+        rep = p.rep_at(level)
+        messages.append(p.as_message(level))
+        total_tokens += rep.token_estimate
+        if level < p.max_available():
+            degraded_ids.append(p.id)
+
+    return AssembledPrompt(
+        messages=messages,
+        total_tokens=total_tokens,
+        chosen_levels={pid: lvl for pid, lvl in chosen.items() if pid not in evicted_ids},
+        evicted_page_ids=sorted(evicted_ids),
+        degraded_page_ids=degraded_ids,
+        physical_insufficient=physical_insufficient,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def chosen_token_cost(page: Page, level: FidelityLevel) -> int:
+    """Return the cached token cost of *page* rendered at *level*."""
+    return page.rep_at(level).token_estimate
+
+
+def _starting_level(page: Page) -> FidelityLevel:
+    """Floor fidelity for Phase 1.
+
+    BOOTSTRAP pages start at FULL (they are always pinned at FULL). Other
+    pages start at ``min_fidelity`` — which is POINTER for ordinary
+    conversation and FULL for pinned-at-full evidence.
+    """
+    if page.type is PageType.BOOTSTRAP:
+        return FidelityLevel.FULL
+    return max(page.min_fidelity, FidelityLevel.POINTER)
+
+
+def _build_selection_groups(pages: list[Page]) -> list[list[Page]]:
+    """Partition *pages* into atomic selection groups.
+
+    Every group is a list of pages that must be chosen and rendered at the
+    same fidelity bucket (i.e. all FULL or all <= STRUCTURED). The only
+    kind of multi-page group in practice today is ``(AIMessage with
+    tool_calls, ToolMessage(s) matching those calls)`` — LangChain's graph
+    rejects orphan tool messages.
+
+    Groups preserve the input order: the first page in each group is the
+    earliest by ingest order.
+    """
+    groups: list[list[Page]] = []
+    # Map tool_call_id -> index of the group whose AI message owns it.
+    call_id_to_group: dict[str, int] = {}
+
+    for page in pages:
+        if page.role == "ai" and page.ai_tool_calls:
+            groups.append([page])
+            gidx = len(groups) - 1
+            for call in page.ai_tool_calls:
+                call_id = call.get("id")
+                if isinstance(call_id, str):
+                    call_id_to_group[call_id] = gidx
+            continue
+
+        if page.role == "tool" and page.tool_call_id in call_id_to_group:
+            gidx = call_id_to_group[page.tool_call_id]
+            groups[gidx].append(page)
+            continue
+
+        groups.append([page])
+
+    return groups
+
+
+def _group_eviction_order(groups: list[list[Page]]) -> list[list[Page]]:
+    """Return groups ordered from most-expendable to least-expendable.
+
+    Only non-pinned groups will actually be evicted; we still include all
+    groups in the ordering for a stable iteration order.
+
+    Heuristic:
+
+    * Oldest first (low ``turn_seq``).
+    * Within a turn, CONVERSATION outranks PLAN outranks PREFERENCE outranks
+      CONSTRAINT (i.e. CONVERSATION is the most expendable).
+
+    EVIDENCE groups that aren't pinned also follow the age rule but are
+    slightly stickier (they get a small constant added). BOOTSTRAP is
+    always pinned so never participates.
+    """
+    def _expendability(group: list[Page]) -> tuple[int, int, str]:
+        head = group[0]
+        # Lower tuple = evict earlier.
+        type_sticky = {
+            PageType.BOOTSTRAP: 1000,  # never evicted (safety)
+            PageType.CONSTRAINT: 500,
+            PageType.PREFERENCE: 400,
+            PageType.PLAN: 300,
+            PageType.EVIDENCE: 100,
+            PageType.CONVERSATION: 0,
+        }.get(head.type, 0)
+        return (head.turn_seq, type_sticky, head.id)
+
+    return sorted(groups, key=_expendability)
+
+
+def _upgrade_until_full(
+    groups: list[list[Page]],
+    chosen: dict[str, FidelityLevel],
+    evicted_ids: set[str],
+    *,
+    cap_remaining: int,
+) -> None:
+    """Phase 2: greedily upgrade remaining groups within the budget.
+
+    We iterate until no upgrade fits. Each iteration picks the single
+    upgrade with the best (lowest) delta cost that still satisfies two
+    tie-breakers: recency first, then group identity.
+
+    This is O(N * U) where N is the number of upgrade opportunities and
+    U is the number of upgrades applied. Good enough for the scale we
+    care about (hundreds of pages).
+    """
+    if cap_remaining <= 0:
+        return
+
+    while cap_remaining > 0:
+        best: tuple[float, int, int, list[Page], FidelityLevel] | None = None
+        # (delta_cost, -turn_seq, group_idx, group, target_level)
+        #
+        # Lower delta is better; higher turn_seq (negated so "smaller
+        # negative") wins ties. group_idx keeps ordering stable.
+
+        for gidx, group in enumerate(groups):
+            if any(p.id in evicted_ids for p in group):
+                continue
+            # Current common upgrade level for this group: we upgrade the
+            # whole group together. We pick the *minimum* current level in
+            # the group; that is the one that needs upgrading the most.
+            current = min(chosen[p.id] for p in group)
+            if current >= FidelityLevel.FULL:
+                continue
+            target = FidelityLevel(current + 1)
+
+            delta = 0
+            group_has_target = False
+            for p in group:
+                if chosen[p.id] >= target:
+                    continue
+                # If this page doesn't have the higher rung cached, we use
+                # its fallback (which ``rep_at`` resolves) and skip
+                # upgrading its stored level beyond what actually exists.
+                if target > p.max_available():
+                    continue
+                old = chosen_token_cost(p, chosen[p.id])
+                new = chosen_token_cost(p, target)
+                delta += new - old
+                group_has_target = True
+
+            if not group_has_target:
+                continue
+            if delta > cap_remaining:
+                continue
+
+            head = group[0]
+            candidate = (delta, -head.turn_seq, gidx, group, target)
+            if best is None or candidate < best:
+                best = candidate
+
+        if best is None:
+            break
+
+        delta, _recency, _gidx, group, target = best
+        for p in group:
+            if target <= p.max_available() and chosen[p.id] < target:
+                chosen[p.id] = target
+        cap_remaining -= delta

--- a/dimos/agents/memory/test_artefact_tool.py
+++ b/dimos/agents/memory/test_artefact_tool.py
@@ -1,0 +1,183 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for :mod:`dimos.agents.memory.artefact_tool`."""
+from __future__ import annotations
+
+import base64
+import re
+
+import cv2
+import numpy as np
+from langchain_core.messages import HumanMessage, SystemMessage
+
+from dimos.agents.memory.artefact_tool import (
+    GET_ARTEFACT_TOOL_NAME,
+    build_get_artefact_tool,
+)
+from dimos.agents.memory.engine import MemoryEngine
+from dimos.agents.memory.faults import FaultEvent, FaultKind
+from dimos.agents.memory.pages import FidelityLevel, PageType
+from dimos.agents.memory.tokens import HeuristicCounter
+
+
+class _FakeOut:
+    def __init__(self) -> None:
+        self.published: list[FaultEvent] = []
+
+    def publish(self, ev: FaultEvent) -> None:
+        self.published.append(ev)
+
+
+def _image_msg(size: int = 256) -> HumanMessage:
+    img = np.full((size, size, 3), 128, dtype=np.uint8)
+    ok, buf = cv2.imencode(".jpg", img, [int(cv2.IMWRITE_JPEG_QUALITY), 80])
+    assert ok
+    b64 = base64.b64encode(buf.tobytes()).decode("ascii")
+    return HumanMessage(
+        content=[
+            {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{b64}"}},
+        ]
+    )
+
+
+def test_tool_name_is_get_artefact() -> None:
+    eng = MemoryEngine(model_name="gpt-4o", token_counter=HeuristicCounter())
+    tool = build_get_artefact_tool(eng)
+    assert tool.name == GET_ARTEFACT_TOOL_NAME
+
+
+def test_tool_has_non_empty_description_mentioning_artefact() -> None:
+    eng = MemoryEngine(model_name="gpt-4o", token_counter=HeuristicCounter())
+    tool = build_get_artefact_tool(eng)
+    assert tool.description
+    assert "artefact" in tool.description.lower()
+
+
+def test_tool_invoke_schedules_full_and_emits_refetch_fault() -> None:
+    out_stream = _FakeOut()
+    eng = MemoryEngine(
+        model_name="gpt-4o",
+        token_budget=1300,
+        pin_recent_evidence=1,
+        output_reserve_tokens=0,
+        system_overhead=0,
+        token_counter=HeuristicCounter(),
+        faults_out=out_stream,  # type: ignore[arg-type]
+    )
+    eng.ingest(SystemMessage(content="sys"))
+    eng.ingest(_image_msg())
+    eng.ingest(_image_msg())
+
+    old_evidence = [p for p in eng.pages() if p.type is PageType.EVIDENCE][0]
+    uuid = old_evidence.artefact_uuid
+    assert uuid is not None
+
+    tool = eng.get_artefact_tool()
+    # StructuredTool.invoke takes a dict of args. Test both the underlying
+    # function (direct call) and the .invoke() dispatch path.
+    msg = tool.func(uuid=uuid)  # type: ignore[misc]
+    assert "scheduled" in msg.lower() or uuid in msg
+
+    assert FaultKind.REFETCH_FAULT in [ev.kind for ev in out_stream.published]
+
+    # Next assemble() should render the rehydrated page at FULL even under
+    # pressure, because the flag is one-way.
+    out2 = eng.assemble()
+    assert out2.chosen_levels[old_evidence.id] == FidelityLevel.FULL
+
+
+def test_tool_invoke_unknown_uuid_returns_diagnostic() -> None:
+    eng = MemoryEngine(model_name="gpt-4o", token_counter=HeuristicCounter())
+    tool = build_get_artefact_tool(eng)
+    msg = tool.func(uuid="this-does-not-exist")  # type: ignore[misc]
+    assert "no artefact" in msg.lower() or "not found" in msg.lower() or "artefact" in msg.lower()
+
+
+def test_tool_args_schema_requires_uuid_field() -> None:
+    eng = MemoryEngine(model_name="gpt-4o", token_counter=HeuristicCounter())
+    tool = build_get_artefact_tool(eng)
+    schema = tool.args_schema
+    # args_schema may be a pydantic class — inspect via ``model_fields``.
+    if hasattr(schema, "model_fields"):
+        assert "uuid" in schema.model_fields  # type: ignore[union-attr]
+
+
+def test_llm_can_rehydrate_from_structured_representation() -> None:
+    """End-to-end: the UUID an LLM extracts from the STRUCTURED bracket
+    must route to the correct page when passed to ``get_artefact``.
+
+    This is the real coverage for the rehydration contract. We simulate
+    what the LLM actually does: read the STRUCTURED text, parse the
+    UUID out with a regex, hand it to the tool, and verify the page
+    comes back at FULL on the next assembly.
+
+    Scenario: tiny budget + ``pin_recent_evidence=0`` so the ingested
+    image is not auto-pinned and gets driven down to a non-FULL rung by
+    Phase 1. We then extract the UUID from the STRUCTURED rep itself
+    (which is what the LLM sees when the selector picks that level, and
+    is always readable off the page regardless of the assembled
+    fidelity — this keeps the test robust to selector tuning while still
+    exercising the UUID-agreement invariant end-to-end).
+    """
+    out_stream = _FakeOut()
+    eng = MemoryEngine(
+        model_name="gpt-4o",
+        token_budget=2000,
+        pin_recent_evidence=0,
+        output_reserve_tokens=0,
+        system_overhead=0,
+        token_counter=HeuristicCounter(),
+        faults_out=out_stream,  # type: ignore[arg-type]
+    )
+    eng.ingest(SystemMessage(content="sys"))
+    eng.ingest(_image_msg())
+
+    evidence = [p for p in eng.pages() if p.type is PageType.EVIDENCE][0]
+
+    # Read the STRUCTURED rep directly off the page. This is exactly the
+    # string the LLM sees whenever the selector picks STRUCTURED; the
+    # test stays robust to selector tuning (the UUID-agreement invariant
+    # is a property of ingestion, not assembly).
+    structured = evidence.rep_at(FidelityLevel.STRUCTURED).content
+    assert isinstance(structured, str)
+    assert structured.startswith("[image artefact uuid=")
+
+    match = re.search(r"\[image artefact uuid=([a-f0-9\-]+) ", structured)
+    assert match is not None, (
+        f"STRUCTURED rep did not match expected bracket shape: {structured!r}"
+    )
+    extracted_uuid = match.group(1)
+
+    # The extracted UUID must be the artefact UUID the PageTable indexes
+    # on, not the page.id (which carries a ``"page-"`` prefix).
+    assert extracted_uuid == evidence.artefact_uuid
+    assert extracted_uuid != evidence.id
+
+    tool = eng.get_artefact_tool()
+    msg = tool.func(uuid=extracted_uuid)  # type: ignore[misc]
+    assert "scheduled" in msg.lower() or extracted_uuid in msg, (
+        f"Expected success-path response; got: {msg!r}"
+    )
+    assert "no artefact" not in msg.lower(), (
+        f"Got 'not found' path from a UUID the LLM would legitimately "
+        f"extract from STRUCTURED — UUID-agreement invariant regressed. "
+        f"msg={msg!r}"
+    )
+
+    assert FaultKind.REFETCH_FAULT in [ev.kind for ev in out_stream.published]
+
+    # Next assemble() must render the rehydrated page at FULL (pinned-at-full
+    # is a one-way flag set by ``request_full``).
+    out2 = eng.assemble()
+    assert out2.chosen_levels[evidence.id] == FidelityLevel.FULL

--- a/dimos/agents/memory/test_budget.py
+++ b/dimos/agents/memory/test_budget.py
@@ -1,0 +1,204 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for :mod:`dimos.agents.memory.budget`."""
+from __future__ import annotations
+
+import pytest
+
+from dimos.agents.memory.budget import (
+    DEFAULT_CONTEXT_WINDOW,
+    DEFAULT_OUTPUT_RESERVE,
+    DEFAULT_PER_MESSAGE_OVERHEAD,
+    DEFAULT_SYSTEM_OVERHEAD,
+    ModelBudget,
+    resolve_budget,
+)
+
+
+# --- ModelBudget -------------------------------------------------------
+
+
+def test_input_budget_arithmetic() -> None:
+    b = ModelBudget(context_window=128_000, output_reserve=4096, system_overhead=256)
+    assert b.input_budget == 128_000 - 4096 - 256
+
+
+def test_input_budget_honours_defaults() -> None:
+    b = ModelBudget(context_window=32_000)
+    assert b.output_reserve == DEFAULT_OUTPUT_RESERVE
+    assert b.system_overhead == DEFAULT_SYSTEM_OVERHEAD
+    assert b.per_message_overhead == DEFAULT_PER_MESSAGE_OVERHEAD
+    assert b.input_budget == 32_000 - DEFAULT_OUTPUT_RESERVE - DEFAULT_SYSTEM_OVERHEAD
+
+
+def test_default_per_message_overhead_value() -> None:
+    # Contract: default is 4 tokens/message (OpenAI chat-completions).
+    assert DEFAULT_PER_MESSAGE_OVERHEAD == 4
+    b = ModelBudget(context_window=32_000)
+    assert b.per_message_overhead == 4
+
+
+def test_model_budget_rejects_negative_per_message_overhead() -> None:
+    with pytest.raises(ValueError, match="per_message_overhead"):
+        ModelBudget(context_window=32_000, per_message_overhead=-1)
+
+
+# --- effective_budget_for_messages ------------------------------------
+
+
+def test_effective_budget_subtracts_per_message_overhead() -> None:
+    b = ModelBudget(
+        context_window=10_000,
+        output_reserve=1000,
+        system_overhead=100,
+        per_message_overhead=4,
+    )
+    # input_budget = 10_000 - 1000 - 100 = 8_900
+    assert b.input_budget == 8_900
+    assert b.effective_budget_for_messages(0) == 8_900
+    assert b.effective_budget_for_messages(1) == 8_900 - 4
+    assert b.effective_budget_for_messages(10) == 8_900 - 40
+    assert b.effective_budget_for_messages(100) == 8_900 - 400
+
+
+def test_effective_budget_zero_overhead_is_no_op() -> None:
+    b = ModelBudget(context_window=10_000, per_message_overhead=0)
+    assert b.effective_budget_for_messages(0) == b.input_budget
+    assert b.effective_budget_for_messages(999) == b.input_budget
+
+
+def test_effective_budget_rejects_negative_n_messages() -> None:
+    b = ModelBudget(context_window=10_000)
+    with pytest.raises(ValueError, match="n_messages"):
+        b.effective_budget_for_messages(-1)
+
+
+def test_effective_budget_may_go_negative_when_over_packed() -> None:
+    # Selector contract: over-packing is allowed to return a negative
+    # ceiling so the caller can detect "over budget" and evict.
+    b = ModelBudget(context_window=1000, output_reserve=500, system_overhead=50)
+    # input_budget = 1000 - 500 - 50 = 450; 200 messages * 4 = 800.
+    assert b.effective_budget_for_messages(200) == 450 - 800
+
+
+def test_model_budget_rejects_zero_context_window() -> None:
+    with pytest.raises(ValueError, match="context_window"):
+        ModelBudget(context_window=0)
+
+
+def test_model_budget_rejects_negative_reserve() -> None:
+    with pytest.raises(ValueError, match="output_reserve"):
+        ModelBudget(context_window=1000, output_reserve=-1)
+
+
+def test_model_budget_rejects_reserve_exceeding_window() -> None:
+    with pytest.raises(ValueError, match="strictly less"):
+        ModelBudget(context_window=4096, output_reserve=4096, system_overhead=0)
+
+
+def test_model_budget_is_frozen() -> None:
+    b = ModelBudget(context_window=1000, output_reserve=100, system_overhead=10)
+    with pytest.raises(Exception):  # dataclasses.FrozenInstanceError
+        b.context_window = 2000  # type: ignore[misc]
+
+
+# --- resolve_budget ----------------------------------------------------
+
+
+def test_resolve_budget_known_openai_models() -> None:
+    b = resolve_budget("gpt-4o")
+    assert b.context_window == 128_000
+
+    b = resolve_budget("gpt-4.1")
+    assert b.context_window == 1_047_576
+
+
+def test_resolve_budget_known_ollama_model_with_prefix() -> None:
+    b = resolve_budget("ollama:llama3.2")
+    assert b.context_window == 128_000
+
+
+def test_resolve_budget_ollama_tagged_model() -> None:
+    # Real-world ollama strings include tags like ``:latest``.
+    b = resolve_budget("ollama:llama3.2:latest")
+    assert b.context_window == 128_000
+
+
+def test_resolve_budget_override_wins_over_table() -> None:
+    b = resolve_budget("gpt-4o", override=8000)
+    assert b.context_window == 8000
+
+
+def test_resolve_budget_falls_back_to_default_for_unknown() -> None:
+    b = resolve_budget("totally-made-up-model-v99")
+    assert b.context_window == DEFAULT_CONTEXT_WINDOW
+
+
+def test_resolve_budget_family_prefix_match() -> None:
+    # "llama3.1-8b-instruct" is not in the table but should match the
+    # ``llama3.1`` family entry.
+    b = resolve_budget("llama3.1-8b-instruct")
+    assert b.context_window == 128_000
+
+
+def test_resolve_budget_respects_custom_reserve_and_overhead() -> None:
+    b = resolve_budget("gpt-4o", output_reserve=2000, system_overhead=100)
+    assert b.output_reserve == 2000
+    assert b.system_overhead == 100
+    assert b.input_budget == 128_000 - 2000 - 100
+
+
+def test_resolve_budget_override_validated() -> None:
+    with pytest.raises(ValueError):
+        resolve_budget("gpt-4o", override=-1)
+
+
+def test_resolve_budget_kwargs_are_keyword_only() -> None:
+    # Contract: everything after ``model_name`` is keyword-only. Passing
+    # ``override`` positionally must fail.
+    with pytest.raises(TypeError):
+        resolve_budget("gpt-4o", 8000)  # type: ignore[misc]
+
+
+def test_resolve_budget_propagates_per_message_overhead() -> None:
+    b = resolve_budget("gpt-4o", per_message_overhead=7)
+    assert b.per_message_overhead == 7
+    # And it shows up in the effective-budget arithmetic.
+    assert b.effective_budget_for_messages(3) == b.input_budget - 21
+
+
+def test_resolve_budget_longest_prefix_match_o1_mini_dated() -> None:
+    # Regression: ``o1-mini-2024-09-12`` must resolve to the ``o1-mini``
+    # entry (128K), NOT the ``o1`` entry (200K). The old first-match
+    # implementation returned 200_000; longest-prefix returns 128_000.
+    b = resolve_budget("o1-mini-2024-09-12")
+    assert b.context_window == 128_000, (
+        "Expected longest-prefix match to 'o1-mini' (128K); got "
+        f"{b.context_window}. If this returned 200_000 the fallback is "
+        "using first-match instead of longest-prefix."
+    )
+
+
+def test_resolve_budget_longest_prefix_match_llama3_point_1() -> None:
+    # ``llama3.1-8b-instruct`` must match ``llama3.1`` (128K), not the
+    # shorter ``llama3`` (8_192).
+    b = resolve_budget("llama3.1-8b-instruct")
+    assert b.context_window == 128_000
+
+
+def test_resolve_budget_longest_prefix_match_gpt_4o_mini_dated() -> None:
+    # Both ``gpt-4`` and ``gpt-4o`` and ``gpt-4o-mini`` are prefixes of
+    # ``gpt-4o-mini-2024-07-18``; longest wins.
+    b = resolve_budget("gpt-4o-mini-2024-07-18")
+    assert b.context_window == 128_000

--- a/dimos/agents/memory/test_engine.py
+++ b/dimos/agents/memory/test_engine.py
@@ -1,0 +1,303 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for :mod:`dimos.agents.memory.engine`."""
+from __future__ import annotations
+
+import base64
+
+import cv2
+import numpy as np
+from langchain_core.messages import HumanMessage, SystemMessage
+
+from dimos.agents.memory.engine import MemoryEngine
+from dimos.agents.memory.faults import FaultEvent, FaultKind
+from dimos.agents.memory.pages import FidelityLevel, PageType
+from dimos.agents.memory.tokens import HeuristicCounter
+
+
+class _FakeOut:
+    def __init__(self) -> None:
+        self.published: list[FaultEvent] = []
+
+    def publish(self, ev: FaultEvent) -> None:
+        self.published.append(ev)
+
+
+def _image_msg(size: int = 256) -> HumanMessage:
+    img = np.full((size, size, 3), 64, dtype=np.uint8)
+    ok, buf = cv2.imencode(".jpg", img, [int(cv2.IMWRITE_JPEG_QUALITY), 80])
+    assert ok
+    b64 = base64.b64encode(buf.tobytes()).decode("ascii")
+    return HumanMessage(
+        content=[
+            {"type": "text", "text": "camera snapshot"},
+            {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{b64}"}},
+        ]
+    )
+
+
+def _engine(token_budget: int = 8000, pin_recent_evidence: int = 3) -> MemoryEngine:
+    return MemoryEngine(
+        model_name="gpt-4o",
+        token_budget=token_budget,
+        pin_recent_evidence=pin_recent_evidence,
+        output_reserve_tokens=0,
+        system_overhead=0,
+        token_counter=HeuristicCounter(),
+    )
+
+
+def test_ingest_increments_turn_seq_and_stores_page() -> None:
+    eng = _engine()
+    assert eng.turn_seq == 0
+    pages = eng.ingest(HumanMessage(content="hi"))
+    assert eng.turn_seq == 1
+    # ``ingest`` returns ``list[Page]``. A text-only HumanMessage yields
+    # exactly one page.
+    assert len(pages) == 1
+    page = pages[0]
+    assert page.id in {p.id for p in eng.pages()}
+
+
+def test_assemble_keeps_recent_evidence_at_full() -> None:
+    eng = _engine(token_budget=4000, pin_recent_evidence=3)
+    eng.ingest(SystemMessage(content="You are a robot."))
+    for _ in range(5):
+        eng.ingest(_image_msg())
+    out = eng.assemble()
+
+    # The last 3 evidence pages should render at FULL; earlier ones may be
+    # degraded.
+    evidence_pages = [p for p in eng.pages() if p.type is PageType.EVIDENCE]
+    recent_ids = {p.id for p in evidence_pages[-3:]}
+    for pid in recent_ids:
+        assert out.chosen_levels[pid] == FidelityLevel.FULL
+
+
+def test_assemble_never_exceeds_input_budget_unless_insufficient() -> None:
+    eng = _engine(token_budget=4000, pin_recent_evidence=1)
+    eng.ingest(SystemMessage(content="system prompt"))
+    for i in range(10):
+        eng.ingest(HumanMessage(content=f"turn {i}: " + "x" * 500))
+    out = eng.assemble()
+    if not out.physical_insufficient:
+        assert out.total_tokens <= eng.budget.input_budget
+
+
+def test_pin_rebalance_fault_emitted_when_evidence_set_changes() -> None:
+    out_stream = _FakeOut()
+    eng = MemoryEngine(
+        model_name="gpt-4o",
+        token_budget=8000,
+        pin_recent_evidence=2,
+        output_reserve_tokens=0,
+        system_overhead=0,
+        token_counter=HeuristicCounter(),
+        faults_out=out_stream,  # type: ignore[arg-type]
+    )
+    eng.ingest(_image_msg())
+    eng.ingest(_image_msg())
+    eng.ingest(_image_msg())
+    kinds = [ev.kind for ev in out_stream.published]
+    assert FaultKind.PIN_REBALANCE in kinds
+
+
+def test_request_full_rehydrates_evidence_and_emits_refetch_fault() -> None:
+    out_stream = _FakeOut()
+    eng = MemoryEngine(
+        model_name="gpt-4o",
+        # Tight enough that the non-pinned image cannot afford a FULL
+        # upgrade, but loose enough that it survives Phase 1 eviction at
+        # its POINTER floor.
+        token_budget=1300,
+        pin_recent_evidence=1,
+        output_reserve_tokens=0,
+        system_overhead=0,
+        token_counter=HeuristicCounter(),
+        faults_out=out_stream,  # type: ignore[arg-type]
+    )
+    eng.ingest(SystemMessage(content="sys"))
+    eng.ingest(_image_msg())  # e1
+    eng.ingest(_image_msg())  # e2
+
+    # At this point e1 is no longer pinned (only 1 evidence is pinned).
+    e1 = [p for p in eng.pages() if p.type is PageType.EVIDENCE][0]
+    uuid = e1.artefact_uuid
+    assert uuid is not None
+
+    out1 = eng.assemble()
+    # e1 almost certainly below FULL because the budget is tight.
+    assert out1.chosen_levels[e1.id] < FidelityLevel.FULL
+
+    ok = eng.request_full(uuid)
+    assert ok is True
+    assert FaultKind.REFETCH_FAULT in [ev.kind for ev in out_stream.published]
+
+    # Unknown UUID → False, no extra fault beyond what's already there.
+    assert eng.request_full("not-a-uuid") is False
+
+
+def test_physical_insufficiency_emitted_when_pins_exceed_budget() -> None:
+    out_stream = _FakeOut()
+    eng = MemoryEngine(
+        model_name="gpt-4o",
+        token_budget=200,  # tiny — images cost ~1105 each at FULL
+        pin_recent_evidence=3,
+        output_reserve_tokens=0,
+        system_overhead=0,
+        token_counter=HeuristicCounter(),
+        faults_out=out_stream,  # type: ignore[arg-type]
+    )
+    eng.ingest(_image_msg())
+    eng.ingest(_image_msg())
+    eng.ingest(_image_msg())
+    out = eng.assemble()
+    assert out.physical_insufficient is True
+    assert FaultKind.PHYSICAL_INSUFFICIENCY in [ev.kind for ev in out_stream.published]
+
+
+def test_physical_insufficient_fault_reports_effective_budget() -> None:
+    """The PHYSICAL_INSUFFICIENCY fault must report the cap the selector
+    actually enforced (``effective_budget_for_messages(n_surviving)``),
+    not the gross ``input_budget``. Otherwise operators see
+    ``needed=X, available=input_budget`` and wonder why the selector
+    gave up when X looks well under the gross ceiling.
+    """
+    out_stream = _FakeOut()
+    eng = MemoryEngine(
+        model_name="gpt-4o",
+        token_budget=200,  # tiny — images cost ~1105 each at FULL
+        pin_recent_evidence=3,
+        output_reserve_tokens=0,
+        system_overhead=0,
+        token_counter=HeuristicCounter(),
+        faults_out=out_stream,  # type: ignore[arg-type]
+    )
+    # One BOOTSTRAP system page (always pinned at FULL) plus three image
+    # EVIDENCE pages (all pinned by pin_recent_evidence=3). With
+    # token_budget=200, the pinned pages cannot fit even at FULL, so
+    # physical_insufficient flips True and at least one pinned page
+    # survives on the wire (BOOTSTRAP cannot be evicted).
+    eng.ingest(SystemMessage(content="you are a robot"))
+    eng.ingest(_image_msg())
+    eng.ingest(_image_msg())
+    eng.ingest(_image_msg())
+    result = eng.assemble()
+
+    assert result.physical_insufficient is True
+    n_surviving = len(result.messages)
+    assert n_surviving >= 1, (
+        "precondition: at least one message must survive so the "
+        "strictly-less-than assertion below is meaningful"
+    )
+
+    ev = eng.observer.last_event
+    assert ev is not None
+    assert ev.kind is FaultKind.PHYSICAL_INSUFFICIENCY
+    expected_available = eng.budget.effective_budget_for_messages(n_surviving)
+    assert ev.details["available"] == expected_available, (
+        f"expected available={expected_available} for n_surviving="
+        f"{n_surviving}, got {ev.details['available']}"
+    )
+    # Effective cap must be strictly less than the gross
+    # ``input_budget`` whenever ``n_surviving`` is positive and
+    # ``per_message_overhead`` is positive (both true here).
+    assert ev.details["available"] < eng.budget.input_budget, (
+        f"available={ev.details['available']} must be strictly less than "
+        f"input_budget={eng.budget.input_budget} — effective-cap reporting "
+        f"regressed to the gross budget"
+    )
+    # Sanity: ``needed`` is still content-only.
+    assert ev.details["needed"] == result.total_tokens
+
+
+def test_emit_physical_insufficiency_still_reports_input_budget() -> None:
+    """``emit_physical_insufficiency`` intentionally reports
+    ``available=input_budget`` (gross), not the effective cap. The
+    asymmetry with ``assemble()``'s emission is deliberate — this hook
+    is invoked by the worker after an LLM-side context_length_exceeded
+    where the surviving-message count is not known at the call site.
+    This regression lock flags any future attempt to unify the two
+    paths without reading the docstring rationale.
+    """
+    out_stream = _FakeOut()
+    eng = MemoryEngine(
+        model_name="gpt-4o",
+        token_budget=8000,
+        pin_recent_evidence=3,
+        output_reserve_tokens=0,
+        system_overhead=0,
+        token_counter=HeuristicCounter(),
+        faults_out=out_stream,  # type: ignore[arg-type]
+    )
+    eng.emit_physical_insufficiency(Exception("context_length_exceeded"))
+
+    ev = eng.observer.last_event
+    assert ev is not None
+    assert ev.kind is FaultKind.PHYSICAL_INSUFFICIENCY
+    # Gross, not effective — intentional asymmetry documented on
+    # ``MemoryEngine.emit_physical_insufficiency``.
+    assert ev.details["available"] == eng.budget.input_budget
+    assert ev.details["needed"] == -1
+
+
+def test_emit_physical_insufficiency_hook_from_worker_thread() -> None:
+    out_stream = _FakeOut()
+    eng = MemoryEngine(
+        model_name="gpt-4o",
+        token_budget=8000,
+        pin_recent_evidence=3,
+        output_reserve_tokens=0,
+        system_overhead=0,
+        token_counter=HeuristicCounter(),
+        faults_out=out_stream,  # type: ignore[arg-type]
+    )
+    eng.emit_physical_insufficiency(Exception("context_length_exceeded"))
+    kinds = [ev.kind for ev in out_stream.published]
+    assert FaultKind.PHYSICAL_INSUFFICIENCY in kinds
+    ev = next(e for e in out_stream.published if e.kind == FaultKind.PHYSICAL_INSUFFICIENCY)
+    assert "context_length_exceeded" in ev.details.get("exception", "")
+
+
+def test_clear_resets_pages_but_keeps_turn_seq() -> None:
+    eng = _engine()
+    eng.ingest(HumanMessage(content="x"))
+    eng.ingest(HumanMessage(content="y"))
+    assert eng.turn_seq == 2
+    eng.clear()
+    assert eng.pages() == []
+    assert eng.turn_seq == 2
+
+
+def test_budget_resolved_from_model_name() -> None:
+    eng = MemoryEngine(model_name="gpt-4o", token_counter=HeuristicCounter())
+    assert eng.budget.context_window == 128_000
+
+
+def test_long_session_stays_within_budget() -> None:
+    """End-to-end soak test: 50 text turns + 20 images must stay under budget."""
+    eng = _engine(token_budget=8000, pin_recent_evidence=3)
+    eng.ingest(SystemMessage(content="robot"))
+    for i in range(50):
+        eng.ingest(HumanMessage(content=f"user turn {i}: " + "word " * 20))
+        if i % 2 == 0:
+            eng.ingest(_image_msg())
+    out = eng.assemble()
+    if not out.physical_insufficient:
+        assert out.total_tokens <= eng.budget.input_budget
+
+    # Last 3 images still at FULL.
+    evidence_pages = [p for p in eng.pages() if p.type is PageType.EVIDENCE]
+    for p in evidence_pages[-3:]:
+        assert out.chosen_levels[p.id] == FidelityLevel.FULL

--- a/dimos/agents/memory/test_faults.py
+++ b/dimos/agents/memory/test_faults.py
@@ -1,0 +1,171 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for :mod:`dimos.agents.memory.faults`."""
+from __future__ import annotations
+
+import pytest
+
+from dimos.agents.memory.faults import FaultEvent, FaultKind, FaultObserver
+
+
+class _FakeOut:
+    """Minimal ``Out``-like stream for tests; records what was published."""
+
+    def __init__(self) -> None:
+        self.published: list[FaultEvent] = []
+
+    def publish(self, ev: FaultEvent) -> None:
+        self.published.append(ev)
+
+
+# --- FaultEvent dataclass ------------------------------------------------
+
+
+def test_fault_event_required_fields() -> None:
+    ev = FaultEvent(kind=FaultKind.PAGE_EVICTED, page_id="p1", turn_seq=3)
+    assert ev.kind == FaultKind.PAGE_EVICTED
+    assert ev.page_id == "p1"
+    assert ev.turn_seq == 3
+    assert ev.ts > 0
+    assert ev.details == {}
+
+
+def test_fault_event_is_frozen() -> None:
+    ev = FaultEvent(kind=FaultKind.PAGE_EVICTED, page_id="p1", turn_seq=0)
+    with pytest.raises(Exception):
+        ev.page_id = "p2"  # type: ignore[misc]
+
+
+def test_fault_event_to_dict_stable_schema() -> None:
+    ev = FaultEvent(
+        kind=FaultKind.PAGE_DEGRADED,
+        page_id="p7",
+        turn_seq=12,
+        ts=42.0,
+        details={"from": "FULL", "to": "COMPRESSED"},
+    )
+    d = ev.to_dict()
+    assert d == {
+        "kind": "page_degraded",
+        "page_id": "p7",
+        "turn_seq": 12,
+        "ts": 42.0,
+        "details": {"from": "FULL", "to": "COMPRESSED"},
+    }
+
+
+def test_fault_event_details_copied_on_to_dict() -> None:
+    d_orig = {"x": 1}
+    ev = FaultEvent(kind=FaultKind.PAGE_EVICTED, page_id="p", turn_seq=0, details=d_orig)
+    out = ev.to_dict()
+    out["details"]["x"] = 999  # must not leak back into the dataclass
+    assert ev.details["x"] == 1
+
+
+# --- FaultObserver -------------------------------------------------------
+
+
+def test_observer_records_last_event_and_counts() -> None:
+    obs = FaultObserver()
+    assert obs.last_event is None
+    ev = FaultEvent(kind=FaultKind.PAGE_EVICTED, page_id="p1", turn_seq=0)
+    obs.emit(ev)
+    assert obs.last_event is ev
+    assert obs.counts[FaultKind.PAGE_EVICTED] == 1
+    assert obs.counts[FaultKind.PAGE_DEGRADED] == 0
+
+
+def test_observer_publishes_to_stream() -> None:
+    out = _FakeOut()
+    obs = FaultObserver(stream_out=out)  # type: ignore[arg-type]
+    ev = FaultEvent(kind=FaultKind.PAGE_EVICTED, page_id="p1", turn_seq=0)
+    obs.emit(ev)
+    assert out.published == [ev]
+
+
+def test_observer_swallows_stream_errors() -> None:
+    class ExplodingOut:
+        def publish(self, _ev: FaultEvent) -> None:
+            raise RuntimeError("boom")
+
+    obs = FaultObserver(stream_out=ExplodingOut())  # type: ignore[arg-type]
+    ev = FaultEvent(kind=FaultKind.PAGE_EVICTED, page_id="p1", turn_seq=0)
+    obs.emit(ev)  # must not raise
+    assert obs.last_event is ev
+
+
+# --- convenience emitters ----------------------------------------------
+
+
+def test_observer_evict_helper() -> None:
+    out = _FakeOut()
+    obs = FaultObserver(stream_out=out)  # type: ignore[arg-type]
+    obs.evict("p3", 5, reason="over_budget")
+    assert len(out.published) == 1
+    ev = out.published[0]
+    assert ev.kind == FaultKind.PAGE_EVICTED
+    assert ev.page_id == "p3"
+    assert ev.turn_seq == 5
+    assert ev.details == {"reason": "over_budget"}
+
+
+def test_observer_degrade_helper_records_level_transition() -> None:
+    out = _FakeOut()
+    obs = FaultObserver(stream_out=out)  # type: ignore[arg-type]
+    obs.degrade("p1", 1, from_level="FULL", to_level="COMPRESSED")
+    ev = out.published[0]
+    assert ev.kind == FaultKind.PAGE_DEGRADED
+    assert ev.details == {"from": "FULL", "to": "COMPRESSED"}
+
+
+def test_observer_refetch_helper_records_uuid() -> None:
+    out = _FakeOut()
+    obs = FaultObserver(stream_out=out)  # type: ignore[arg-type]
+    obs.refetch("p2", 4, artefact_uuid="abc-123")
+    ev = out.published[0]
+    assert ev.kind == FaultKind.REFETCH_FAULT
+    assert ev.details == {"artefact_uuid": "abc-123"}
+
+
+def test_observer_physical_insufficiency_helper() -> None:
+    out = _FakeOut()
+    obs = FaultObserver(stream_out=out)  # type: ignore[arg-type]
+    obs.physical_insufficiency(7, needed=9000, available=8000, exception="ctx_overflow")
+    ev = out.published[0]
+    assert ev.kind == FaultKind.PHYSICAL_INSUFFICIENCY
+    assert ev.page_id is None
+    assert ev.details == {
+        "needed": 9000,
+        "available": 8000,
+        "exception": "ctx_overflow",
+    }
+
+
+def test_observer_pin_rebalance_helper() -> None:
+    out = _FakeOut()
+    obs = FaultObserver(stream_out=out)  # type: ignore[arg-type]
+    obs.pin_rebalance(2, pinned_page_ids=["p4", "p5", "p6"], unpinned_page_ids=["p1"])
+    ev = out.published[0]
+    assert ev.kind == FaultKind.PIN_REBALANCE
+    assert ev.details == {
+        "pinned": ["p4", "p5", "p6"],
+        "unpinned": ["p1"],
+    }
+
+
+def test_no_stream_observer_still_counts() -> None:
+    obs = FaultObserver()
+    obs.evict("p", 0, reason="r")
+    obs.evict("p2", 0, reason="r2")
+    assert obs.counts[FaultKind.PAGE_EVICTED] == 2

--- a/dimos/agents/memory/test_ingestion.py
+++ b/dimos/agents/memory/test_ingestion.py
@@ -1,0 +1,844 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for :mod:`dimos.agents.memory.ingestion`."""
+from __future__ import annotations
+
+import base64
+import json
+import time
+
+import cv2
+import numpy as np
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+
+from dimos.agents.memory.ingestion import (
+    THUMBNAIL_JPEG_QUALITY,
+    THUMBNAIL_SIZE,
+    _build_text_representations,
+    ingest_message,
+)
+from dimos.agents.memory.pages import FidelityLevel, PageType
+from dimos.agents.memory.tokens import HeuristicCounter
+
+
+def _make_jpeg_data_url(size: int = 256, color: int = 128) -> str:
+    img = np.full((size, size, 3), color, dtype=np.uint8)
+    ok, buf = cv2.imencode(".jpg", img, [int(cv2.IMWRITE_JPEG_QUALITY), 80])
+    assert ok
+    b64 = base64.b64encode(buf.tobytes()).decode("ascii")
+    return f"data:image/jpeg;base64,{b64}"
+
+
+# --- text messages ----------------------------------------------------
+#
+# All simple (non-multimodal) messages must produce exactly one Page.
+# The ``len(pages) == 1`` assertion is mandatory in every single-page
+# test so any regression that accidentally over-produces is caught
+# immediately.
+
+
+def test_ingest_human_text_creates_conversation_page_with_four_reps() -> None:
+    msg = HumanMessage(content="Move forward two meters and stop.")
+    pages = ingest_message(
+        msg, turn_seq=0, ts=1.0, token_counter=HeuristicCounter()
+    )
+    assert len(pages) == 1
+    page = pages[0]
+    assert page.type is PageType.CONVERSATION
+    assert page.role == "human"
+    assert set(page.representations.keys()) == {
+        FidelityLevel.POINTER,
+        FidelityLevel.STRUCTURED,
+        FidelityLevel.COMPRESSED,
+        FidelityLevel.FULL,
+    }
+
+
+def test_ingest_text_token_estimates_are_monotonic() -> None:
+    msg = HumanMessage(
+        content="This is a multi-sentence message. It has more than one sentence. "
+        "And in fact quite a bit more content to compress down. Lots of content. More."
+    )
+    pages = ingest_message(
+        msg, turn_seq=0, ts=1.0, token_counter=HeuristicCounter()
+    )
+    assert len(pages) == 1
+    page = pages[0]
+    p, s, c, f = (
+        page.representations[FidelityLevel.POINTER].token_estimate,
+        page.representations[FidelityLevel.STRUCTURED].token_estimate,
+        page.representations[FidelityLevel.COMPRESSED].token_estimate,
+        page.representations[FidelityLevel.FULL].token_estimate,
+    )
+    assert p <= s <= c <= f
+
+
+def test_ingest_system_message_becomes_bootstrap_and_pinned_full() -> None:
+    msg = SystemMessage(content="You are a helpful robot.")
+    pages = ingest_message(
+        msg, turn_seq=0, ts=1.0, token_counter=HeuristicCounter()
+    )
+    assert len(pages) == 1
+    page = pages[0]
+    assert page.type is PageType.BOOTSTRAP
+    assert page.role == "system"
+    assert page.pinned is True
+    assert page.pinned_at_full is True
+    assert page.min_fidelity is FidelityLevel.FULL
+
+
+def test_ingest_ai_message_preserves_tool_calls() -> None:
+    msg = AIMessage(
+        content="calling tool",
+        tool_calls=[
+            {"id": "c1", "name": "add", "args": {"x": 1, "y": 2}, "type": "tool_call"}
+        ],
+    )
+    pages = ingest_message(
+        msg, turn_seq=1, ts=2.0, token_counter=HeuristicCounter()
+    )
+    assert len(pages) == 1
+    page = pages[0]
+    assert page.role == "ai"
+    assert page.ai_tool_calls is not None
+    assert page.ai_tool_calls[0]["id"] == "c1"
+    # Round-trip via as_message should keep the tool call.
+    rendered = page.as_message(FidelityLevel.FULL)
+    assert isinstance(rendered, AIMessage)
+    assert rendered.tool_calls[0]["id"] == "c1"
+
+
+def test_ingest_tool_message_preserves_tool_call_id() -> None:
+    msg = ToolMessage(content="42", tool_call_id="call-abc")
+    pages = ingest_message(
+        msg, turn_seq=2, ts=3.0, token_counter=HeuristicCounter()
+    )
+    assert len(pages) == 1
+    page = pages[0]
+    assert page.role == "tool"
+    assert page.tool_call_id == "call-abc"
+
+
+def test_ingest_empty_text_does_not_crash() -> None:
+    msg = HumanMessage(content="")
+    pages = ingest_message(
+        msg, turn_seq=0, ts=1.0, token_counter=HeuristicCounter()
+    )
+    assert len(pages) == 1
+    page = pages[0]
+    # Representations must still be non-empty.
+    assert page.representations[FidelityLevel.FULL].content
+    assert page.representations[FidelityLevel.COMPRESSED].content
+
+
+def test_ingest_page_type_hint_overrides_default() -> None:
+    msg = HumanMessage(content="A preference statement")
+    pages = ingest_message(
+        msg,
+        turn_seq=0,
+        ts=1.0,
+        token_counter=HeuristicCounter(),
+        page_type_hint=PageType.PREFERENCE,
+    )
+    assert len(pages) == 1
+    assert pages[0].type is PageType.PREFERENCE
+
+
+def test_ingest_explicit_page_id_honored() -> None:
+    # Explicit id is honored on single-page results.
+    msg = HumanMessage(content="x")
+    pages = ingest_message(
+        msg, turn_seq=0, ts=1.0, token_counter=HeuristicCounter(), page_id="fixed-id"
+    )
+    assert len(pages) == 1
+    assert pages[0].id == "fixed-id"
+
+
+def test_ingest_message_ts_defaults_to_now_when_omitted() -> None:
+    """Regression: ts is optional; omission falls back to time.time()."""
+    before = time.time()
+    pages = ingest_message(
+        HumanMessage(content="hello"),
+        turn_seq=0,
+        token_counter=HeuristicCounter(),
+    )
+    after = time.time()
+    assert len(pages) == 1
+    page = pages[0]
+    assert before <= page.ts <= after, (
+        f"page.ts={page.ts} not in [{before}, {after}]"
+    )
+
+
+# --- multimodal / image messages --------------------------------------
+
+
+def test_ingest_image_human_message_becomes_evidence_page() -> None:
+    # Multimodal ``[text, image]`` splits into [CONVERSATION, EVIDENCE].
+    # The EVIDENCE page carries the artefact UUID.
+    data_url = _make_jpeg_data_url(size=128)
+    msg = HumanMessage(
+        content=[
+            {"type": "text", "text": "camera snapshot"},
+            {"type": "image_url", "image_url": {"url": data_url}},
+        ]
+    )
+    pages = ingest_message(
+        msg, turn_seq=3, ts=1.0, token_counter=HeuristicCounter()
+    )
+    assert len(pages) == 2
+    conv, evidence = pages
+    assert conv.type is PageType.CONVERSATION
+    assert evidence.type is PageType.EVIDENCE
+    assert evidence.artefact_uuid is not None
+
+
+def test_ingest_image_full_representation_is_original_image_part() -> None:
+    # Case (e.2): single image, no text → exactly one EVIDENCE page.
+    data_url = _make_jpeg_data_url()
+    msg = HumanMessage(
+        content=[{"type": "image_url", "image_url": {"url": data_url}}]
+    )
+    pages = ingest_message(
+        msg, turn_seq=0, ts=1.0, token_counter=HeuristicCounter()
+    )
+    assert len(pages) == 1
+    page = pages[0]
+    full_content = page.representations[FidelityLevel.FULL].content
+    assert isinstance(full_content, list)
+    # Find the image part in the full rendering.
+    img_parts = [p for p in full_content if isinstance(p, dict) and p.get("type") == "image_url"]
+    assert len(img_parts) == 1
+    assert img_parts[0]["image_url"]["url"] == data_url
+
+
+def test_ingest_image_compressed_representation_is_96x96_thumbnail() -> None:
+    data_url = _make_jpeg_data_url(size=512)
+    msg = HumanMessage(
+        content=[{"type": "image_url", "image_url": {"url": data_url}}]
+    )
+    pages = ingest_message(
+        msg, turn_seq=0, ts=1.0, token_counter=HeuristicCounter()
+    )
+    assert len(pages) == 1
+    page = pages[0]
+    compressed = page.representations[FidelityLevel.COMPRESSED].content
+    assert isinstance(compressed, list)
+    img_part = next(p for p in compressed if isinstance(p, dict) and p.get("type") == "image_url")
+    url = img_part["image_url"]["url"]
+    assert url.startswith("data:image/jpeg;base64,")
+    # Decode the thumbnail and assert size.
+    b64 = url.split("base64,", 1)[1]
+    raw = base64.b64decode(b64)
+    arr = np.frombuffer(raw, dtype=np.uint8)
+    thumb = cv2.imdecode(arr, cv2.IMREAD_COLOR)
+    assert thumb is not None
+    assert thumb.shape[:2] == (THUMBNAIL_SIZE, THUMBNAIL_SIZE)
+    assert img_part["image_url"].get("detail") == "low"
+    # Sanity — quality 30 should produce something substantially smaller
+    # than the source.
+    assert len(raw) < 12 * 1024  # 96x96 q30 is ~2-4 KB in practice
+
+
+def test_image_structured_representation_is_bracketed_text() -> None:
+    # STRUCTURED uses a single-line bracketed artefact format — NOT a
+    # JSON object (a JSON rep would double-stringify inside the prompt).
+    # The UUID inside the bracket is the ``artefact_uuid`` (resolvable
+    # via ``PageTable.get_by_artefact`` / ``MemoryEngine.request_full``),
+    # NOT the ``page.id`` (which carries a ``"page-"`` prefix).
+    data_url = _make_jpeg_data_url(size=128)
+    msg = HumanMessage(
+        content=[{"type": "image_url", "image_url": {"url": data_url}}]
+    )
+    pages = ingest_message(
+        msg,
+        turn_seq=0,
+        ts=1.0,
+        token_counter=HeuristicCounter(),
+        page_id="fixed-image-id",
+    )
+    # Single-image no-text case (e.2): explicit page_id is honored.
+    assert len(pages) == 1
+    page = pages[0]
+    structured = page.representations[FidelityLevel.STRUCTURED].content
+
+    # Plain str — never a JSON-serialised dict or a list of parts.
+    assert isinstance(structured, str)
+    assert not structured.startswith("{"), (
+        f"STRUCTURED regressed to JSON: {structured!r}"
+    )
+
+    # Exact bracketed shape: single line, starts/ends predictably.
+    assert "\n" not in structured
+    assert page.artefact_uuid is not None
+    assert structured.startswith(f"[image artefact uuid={page.artefact_uuid} ")
+    assert structured.endswith("kB]")
+    # Bug guard: ``page_id`` (with its ``"page-"`` prefix) must not
+    # appear inside the bracket — the bracket UUID must be the
+    # ``artefact_uuid`` that ``PageTable._by_artefact`` indexes on.
+    assert "fixed-image-id" not in structured
+
+    # Expected fields for a decoded image.
+    assert "dims=128x128" in structured
+    assert "size=1kB" in structured or " size=" in structured
+    # src tag must be space-free so the artefact stays single-tokenable.
+    src_segment = structured.split("src=", 1)[1].split(" ", 1)[0]
+    assert " " not in src_segment
+    # Data URIs get a short mime-prefix tag rather than the base64 payload.
+    assert src_segment == "data:image/jpeg"
+
+
+def test_image_structured_representation_handles_unknown_dims() -> None:
+    # Non-data URL we cannot decode (no base64 body) — STRUCTURED must
+    # emit ``dims=unknown`` / ``size=unknown`` rather than None or crash.
+    msg = HumanMessage(
+        content=[
+            {
+                "type": "image_url",
+                "image_url": {"url": "https://example.com/cat.jpg"},
+            }
+        ]
+    )
+    pages = ingest_message(
+        msg,
+        turn_seq=0,
+        ts=1.0,
+        token_counter=HeuristicCounter(),
+        page_id="unknown-dims-id",
+    )
+    assert len(pages) == 1
+    page = pages[0]
+    structured = page.representations[FidelityLevel.STRUCTURED].content
+    assert isinstance(structured, str)
+    # UUID inside the bracket is ``artefact_uuid``, not ``page_id``.
+    assert page.artefact_uuid is not None
+    assert structured.startswith(f"[image artefact uuid={page.artefact_uuid} ")
+    assert structured.endswith("=unknown]")
+    assert "unknown-dims-id" not in structured
+    assert "dims=unknown" in structured
+    assert "size=unknown" in structured
+    assert "None" not in structured
+    # src tag preserved verbatim for non-data URLs (no spaces in this fixture).
+    src_segment = structured.split("src=", 1)[1].split(" ", 1)[0]
+    assert src_segment == "https://example.com/cat.jpg"
+
+
+def test_ingest_image_pointer_contains_artefact_uuid() -> None:
+    data_url = _make_jpeg_data_url()
+    msg = HumanMessage(
+        content=[{"type": "image_url", "image_url": {"url": data_url}}]
+    )
+    pages = ingest_message(
+        msg, turn_seq=0, ts=1.0, token_counter=HeuristicCounter()
+    )
+    assert len(pages) == 1
+    page = pages[0]
+    pointer = page.representations[FidelityLevel.POINTER].content
+    assert isinstance(pointer, str)
+    assert page.artefact_uuid in pointer
+
+
+def test_ingest_image_structured_uses_artefact_uuid_not_page_id() -> None:
+    """The UUID inside the STRUCTURED bracket MUST be
+    ``page.artefact_uuid`` — the key ``PageTable._by_artefact`` indexes
+    on, which ``MemoryEngine.request_full`` /
+    ``PageTable.get_by_artefact`` resolve against. If the bracket ever
+    renders ``page.id`` (which carries a ``"page-"`` prefix), an LLM
+    that extracts the UUID from a STRUCTURED rep and hands it to
+    ``get_artefact`` hits the "not found" path even though the page is
+    live in the table.
+    """
+    data_url = _make_jpeg_data_url()
+    msg = HumanMessage(
+        content=[{"type": "image_url", "image_url": {"url": data_url}}]
+    )
+    pages = ingest_message(
+        msg, turn_seq=0, ts=1.0, token_counter=HeuristicCounter()
+    )
+    assert len(pages) == 1
+    page = pages[0]
+
+    structured = page.rep_at(FidelityLevel.STRUCTURED).content
+    assert isinstance(structured, str)
+
+    assert page.artefact_uuid is not None
+    assert page.artefact_uuid in structured, (
+        f"STRUCTURED rep must contain page.artefact_uuid "
+        f"({page.artefact_uuid!r}); got {structured!r}"
+    )
+    # ``page.id`` carries the ``"page-"`` prefix. It must not leak into
+    # the LLM-visible bracket or rehydration breaks.
+    assert page.id not in structured, (
+        f"STRUCTURED rep must NOT contain page.id ({page.id!r}) — "
+        f"UUID-agreement invariant regressed. Got {structured!r}"
+    )
+
+
+def test_ingest_image_token_estimates_monotonic() -> None:
+    # Lock in POINTER <= STRUCTURED <= COMPRESSED <= FULL. The selector
+    # relies on this invariant to reason about fidelity cost, so keep
+    # the assertion strict.
+    data_url = _make_jpeg_data_url()
+    msg = HumanMessage(
+        content=[{"type": "image_url", "image_url": {"url": data_url}}]
+    )
+    pages = ingest_message(
+        msg, turn_seq=0, ts=1.0, token_counter=HeuristicCounter()
+    )
+    assert len(pages) == 1
+    page = pages[0]
+    p, s, c, f = (
+        page.representations[FidelityLevel.POINTER].token_estimate,
+        page.representations[FidelityLevel.STRUCTURED].token_estimate,
+        page.representations[FidelityLevel.COMPRESSED].token_estimate,
+        page.representations[FidelityLevel.FULL].token_estimate,
+    )
+    assert p <= s, f"POINTER ({p}) must be <= STRUCTURED ({s})"
+    assert s <= c, f"STRUCTURED ({s}) must be <= COMPRESSED ({c})"
+    assert c <= f, f"COMPRESSED ({c}) must be <= FULL ({f})"
+
+
+def test_ingest_image_token_estimates_monotonic_unknown_dims() -> None:
+    # Same monotonicity contract on the non-data-URL fallback path,
+    # where STRUCTURED collapses to ``dims=unknown size=unknown``.
+    msg = HumanMessage(
+        content=[
+            {
+                "type": "image_url",
+                "image_url": {"url": "https://example.com/cat.jpg"},
+            }
+        ]
+    )
+    pages = ingest_message(
+        msg, turn_seq=0, ts=1.0, token_counter=HeuristicCounter()
+    )
+    assert len(pages) == 1
+    page = pages[0]
+    p, s, c, f = (
+        page.representations[FidelityLevel.POINTER].token_estimate,
+        page.representations[FidelityLevel.STRUCTURED].token_estimate,
+        page.representations[FidelityLevel.COMPRESSED].token_estimate,
+        page.representations[FidelityLevel.FULL].token_estimate,
+    )
+    assert p <= s <= c <= f
+
+
+def test_ingest_image_extracts_existing_uuid_from_preamble() -> None:
+    # Matches the McpClient convention: "... tool with UUID:=<uuid>.".
+    # This is case (e.4) → [CONV, EVIDENCE]; the EVIDENCE page is the
+    # one that carries the artefact uuid.
+    data_url = _make_jpeg_data_url()
+    preamble = (
+        "This is the artefact for the 'camera' tool with "
+        "UUID:=12345678-1234-5678-abcd-1234567890ab."
+    )
+    msg = HumanMessage(
+        content=[
+            {"type": "text", "text": preamble},
+            {"type": "image_url", "image_url": {"url": data_url}},
+        ]
+    )
+    pages = ingest_message(
+        msg, turn_seq=0, ts=1.0, token_counter=HeuristicCounter()
+    )
+    assert len(pages) == 2
+    conv, evidence = pages
+    assert conv.type is PageType.CONVERSATION
+    assert evidence.type is PageType.EVIDENCE
+    assert evidence.artefact_uuid == "12345678-1234-5678-abcd-1234567890ab"
+
+
+def test_ingest_unsupported_message_type_raises() -> None:
+    class FakeMessage:
+        content = "x"
+
+    with pytest.raises(TypeError):
+        ingest_message(
+            FakeMessage(),  # type: ignore[arg-type]
+            turn_seq=0,
+            ts=1.0,
+            token_counter=HeuristicCounter(),
+        )
+
+
+def test_thumbnail_defaults_match_plan() -> None:
+    # Locked decision: 96x96 JPEG, quality 30.
+    assert THUMBNAIL_SIZE == 96
+    assert THUMBNAIL_JPEG_QUALITY == 30
+
+
+# --- multi-image split ------------------------------------------------
+#
+# Contract: one EVIDENCE page per image part; text splits into a
+# CONVERSATION page. These tests lock in the full split matrix so a
+# future regression cannot silently drop images from multimodal
+# HumanMessages.
+
+
+def test_ingest_humanmessage_text_plus_one_image_returns_two_pages() -> None:
+    data_url = _make_jpeg_data_url(size=128)
+    msg = HumanMessage(
+        content=[
+            {"type": "text", "text": "What do you see?"},
+            {"type": "image_url", "image_url": {"url": data_url}},
+        ]
+    )
+    pages = ingest_message(
+        msg, turn_seq=7, ts=42.0, token_counter=HeuristicCounter()
+    )
+    assert len(pages) == 2
+    conv, evidence = pages
+    assert conv.type is PageType.CONVERSATION
+    assert evidence.type is PageType.EVIDENCE
+
+    # CONVERSATION FULL text contains the preamble line and the evidence
+    # page's uuid so the LLM can reference it via ``get_artefact``.
+    conv_full = conv.representations[FidelityLevel.FULL].content
+    assert isinstance(conv_full, str)
+    assert "Attached artefacts: [" in conv_full
+    assert evidence.artefact_uuid is not None
+    assert evidence.artefact_uuid in conv_full
+
+    # The user's original question survives as the first line (before
+    # the appended Attached-artefacts line).
+    user_line, sep, tail = conv_full.partition("\n\n")
+    assert sep == "\n\n"
+    assert user_line == "What do you see?"
+    assert tail.startswith("Attached artefacts: [")
+
+    # Shared provenance across all pages produced by a single call.
+    assert conv.turn_seq == evidence.turn_seq == 7
+    assert conv.ts == evidence.ts == 42.0
+
+
+def test_ingest_humanmessage_text_plus_three_images_returns_four_pages() -> None:
+    # Use visually-distinct images so each has a unique base64 payload —
+    # that lets us verify positional order via the preserved FULL
+    # rendering (which keeps the original image_part dict verbatim).
+    url_a = _make_jpeg_data_url(size=128, color=32)
+    url_b = _make_jpeg_data_url(size=128, color=96)
+    url_c = _make_jpeg_data_url(size=128, color=192)
+    msg = HumanMessage(
+        content=[
+            {"type": "text", "text": "Describe each scene."},
+            {"type": "image_url", "image_url": {"url": url_a}},
+            {"type": "image_url", "image_url": {"url": url_b}},
+            {"type": "image_url", "image_url": {"url": url_c}},
+        ]
+    )
+    pages = ingest_message(
+        msg, turn_seq=11, ts=7.0, token_counter=HeuristicCounter()
+    )
+    assert len(pages) == 4
+    assert [p.type for p in pages] == [
+        PageType.CONVERSATION,
+        PageType.EVIDENCE,
+        PageType.EVIDENCE,
+        PageType.EVIDENCE,
+    ]
+
+    # Order preservation: pages[1+i] wraps the i-th image part in content order.
+    expected_urls = [url_a, url_b, url_c]
+    for page, expected in zip(pages[1:], expected_urls):
+        full = page.representations[FidelityLevel.FULL].content
+        assert isinstance(full, list)
+        assert full[0]["image_url"]["url"] == expected
+
+    # CONVERSATION preamble lists all three uuids in the same order as
+    # the EVIDENCE pages — i.e. content-part order.
+    conv_full = pages[0].representations[FidelityLevel.FULL].content
+    assert isinstance(conv_full, str)
+    attach_line = conv_full.split("\n\n", 1)[1]
+    positions = [
+        attach_line.find(f"[{pages[i + 1].artefact_uuid}]")
+        for i in range(3)
+    ]
+    assert all(pos >= 0 for pos in positions), (
+        f"Evidence uuids missing from preamble: {attach_line!r}"
+    )
+    assert positions == sorted(positions), (
+        f"Attached-artefact order not preserved: {positions} in {attach_line!r}"
+    )
+
+    # Shared turn_seq and ts across all four pages.
+    for p in pages:
+        assert p.turn_seq == 11
+        assert p.ts == 7.0
+
+
+def test_ingest_humanmessage_two_images_no_text_returns_two_evidence_pages() -> None:
+    url_a = _make_jpeg_data_url(size=96, color=40)
+    url_b = _make_jpeg_data_url(size=96, color=200)
+    msg = HumanMessage(
+        content=[
+            {"type": "image_url", "image_url": {"url": url_a}},
+            {"type": "image_url", "image_url": {"url": url_b}},
+        ]
+    )
+    pages = ingest_message(
+        msg, turn_seq=5, ts=9.0, token_counter=HeuristicCounter()
+    )
+    assert len(pages) == 2
+    assert all(p.type is PageType.EVIDENCE for p in pages)
+    # No CONVERSATION page — case (e.3) has nothing to say.
+    assert not any(p.type is PageType.CONVERSATION for p in pages)
+
+    # Order preserved.
+    assert pages[0].representations[FidelityLevel.FULL].content[0][
+        "image_url"
+    ]["url"] == url_a
+    assert pages[1].representations[FidelityLevel.FULL].content[0][
+        "image_url"
+    ]["url"] == url_b
+
+    for p in pages:
+        assert p.turn_seq == 5
+        assert p.ts == 9.0
+
+
+def test_ingest_multimodal_message_ignores_page_id_kwarg() -> None:
+    # Multi-page result: the explicit ``page_id`` contract only applies
+    # to single-page results. We must NOT silently assign it to the
+    # first page (that would be a disambiguation trap for callers).
+    url_a = _make_jpeg_data_url(size=96, color=40)
+    url_b = _make_jpeg_data_url(size=96, color=200)
+    msg = HumanMessage(
+        content=[
+            {"type": "text", "text": "look"},
+            {"type": "image_url", "image_url": {"url": url_a}},
+            {"type": "image_url", "image_url": {"url": url_b}},
+        ]
+    )
+    pages = ingest_message(
+        msg,
+        turn_seq=0,
+        ts=1.0,
+        token_counter=HeuristicCounter(),
+        page_id="fixed-id",
+    )
+    assert len(pages) == 3
+    assert all(p.id != "fixed-id" for p in pages), (
+        f"page_id='fixed-id' must be ignored in multi-page result; "
+        f"got ids={[p.id for p in pages]}"
+    )
+
+
+def test_page_type_hint_ignored_on_multimodal_split() -> None:
+    # When a multimodal HumanMessage splits, the hint cannot apply to
+    # both the CONVERSATION and the EVIDENCE page coherently, so the
+    # split path ignores it entirely.
+    url_a = _make_jpeg_data_url(size=96)
+    msg = HumanMessage(
+        content=[
+            {"type": "text", "text": "prefer this"},
+            {"type": "image_url", "image_url": {"url": url_a}},
+        ]
+    )
+    pages = ingest_message(
+        msg,
+        turn_seq=0,
+        ts=1.0,
+        token_counter=HeuristicCounter(),
+        page_type_hint=PageType.PREFERENCE,
+    )
+    assert len(pages) == 2
+    conv, evidence = pages
+    assert conv.type is PageType.CONVERSATION, (
+        "CONV page must be CONVERSATION regardless of hint in multi-page result"
+    )
+    assert evidence.type is PageType.EVIDENCE, (
+        "EVIDENCE is structural — hint must never override it"
+    )
+
+
+# --- AI tool_calls token accounting -----------------------------------
+#
+# ``Page.as_message`` reattaches ``tool_calls`` at every fidelity
+# level to preserve LangChain AIMessage/ToolMessage pairing, so the
+# serialized JSON cost must be added to every representation's
+# ``token_estimate``. Adding the same constant to all four rungs
+# preserves the POINTER <= STRUCTURED <= COMPRESSED <= FULL invariant
+# that the selector relies on.
+
+
+_ALL_FIDELITY_LEVELS = (
+    FidelityLevel.POINTER,
+    FidelityLevel.STRUCTURED,
+    FidelityLevel.COMPRESSED,
+    FidelityLevel.FULL,
+)
+
+
+def test_ingest_ai_message_with_tool_calls_adds_payload_tokens_to_every_rep() -> None:
+    counter = HeuristicCounter()
+    tool_calls = [
+        {
+            "id": "call_x",
+            "name": "get_weather",
+            "args": {"city": "Paris", "days": 3},
+            "type": "tool_call",
+        }
+    ]
+    msg = AIMessage(content="thinking…", tool_calls=tool_calls)
+    pages = ingest_message(msg, turn_seq=0, ts=1.0, token_counter=counter)
+    assert len(pages) == 1
+    page = pages[0]
+    assert page.ai_tool_calls == tool_calls
+
+    # Twin without tool_calls: same content, so _build_text_representations
+    # produces identical content/tokens; the per-rep difference isolates
+    # exactly the tool_calls payload cost.
+    twin = AIMessage(content="thinking…")
+    twin_pages = ingest_message(twin, turn_seq=0, ts=1.0, token_counter=counter)
+    assert len(twin_pages) == 1
+    twin_page = twin_pages[0]
+    assert twin_page.ai_tool_calls is None
+
+    # Recompute the expected payload cost exactly as the ingestor does.
+    # The tool_calls list ingest_message sees is a shallow-cloned copy
+    # (via _clone_tool_calls) whose dict contents are identical to the
+    # input, so ``sort_keys=True`` yields the same serialization and
+    # thus the same token count.
+    expected_payload_json = json.dumps(
+        page.ai_tool_calls, sort_keys=True, default=str
+    )
+    expected_payload_tokens = counter.count_text(expected_payload_json)
+    assert expected_payload_tokens > 0, (
+        "fixture chosen so the payload is non-trivial"
+    )
+
+    for level in _ALL_FIDELITY_LEVELS:
+        with_tc = page.representations[level].token_estimate
+        without_tc = twin_page.representations[level].token_estimate
+        assert with_tc >= expected_payload_tokens, (
+            f"{level.name}: {with_tc} < payload {expected_payload_tokens}"
+        )
+        assert with_tc - without_tc == expected_payload_tokens, (
+            f"{level.name}: overhead delta {with_tc - without_tc} "
+            f"!= expected {expected_payload_tokens}"
+        )
+
+    # Monotonicity must still hold with the uniform overhead added.
+    p, s, c, f = (
+        page.representations[FidelityLevel.POINTER].token_estimate,
+        page.representations[FidelityLevel.STRUCTURED].token_estimate,
+        page.representations[FidelityLevel.COMPRESSED].token_estimate,
+        page.representations[FidelityLevel.FULL].token_estimate,
+    )
+    assert p <= s <= c <= f, (
+        f"Monotonicity broken with tool_calls overhead: "
+        f"POINTER={p} STRUCTURED={s} COMPRESSED={c} FULL={f}"
+    )
+
+
+def test_ingest_ai_message_without_tool_calls_has_no_tool_call_overhead() -> None:
+    # Zero-regression test for the no-tool-calls path: the per-rep
+    # token_estimate must match exactly what ``_build_text_representations``
+    # produces with no overhead added. This catches a regression where
+    # someone accidentally enters the tool_calls accounting branch for
+    # an empty/missing payload (e.g. ``json.dumps(None)`` → 1 extra
+    # token on every rep).
+    counter = HeuristicCounter()
+    content = "no tools used here, just prose."
+    msg = AIMessage(content=content)
+    pages = ingest_message(msg, turn_seq=0, ts=1.0, token_counter=counter)
+    assert len(pages) == 1
+    page = pages[0]
+    assert page.ai_tool_calls is None
+
+    # Reconstruct the expected per-rep token counts from the same helper
+    # that ``_build_single_text_page`` calls. Using the produced page's
+    # own id keeps POINTER token counts byte-identical to the ingested
+    # representation.
+    expected_reps = _build_text_representations(
+        page.role, content, page.id, counter
+    )
+    for level in _ALL_FIDELITY_LEVELS:
+        assert (
+            page.representations[level].token_estimate
+            == expected_reps[level].token_estimate
+        ), (
+            f"{level.name}: AIMessage-without-tool_calls "
+            f"({page.representations[level].token_estimate}) must equal "
+            f"unmodified _build_text_representations output "
+            f"({expected_reps[level].token_estimate}) — no phantom overhead"
+        )
+
+    # Sanity: FULL token_estimate is at least the raw content-token count
+    # (monotonicity clamps may push it slightly higher, but never lower).
+    full = page.representations[FidelityLevel.FULL].token_estimate
+    content_tokens = counter.count_text(content)
+    assert full >= content_tokens
+
+
+def test_ingest_ai_message_with_multiple_tool_calls_accounts_serialized_payload() -> None:
+    counter = HeuristicCounter()
+    tool_calls = [
+        {
+            "id": "call_1",
+            "name": "read_file",
+            "args": {"path": "/etc/hosts"},
+            "type": "tool_call",
+        },
+        {
+            "id": "call_2",
+            "name": "list_dir",
+            "args": {"path": "/tmp"},
+            "type": "tool_call",
+        },
+    ]
+    msg = AIMessage(content="reading and listing", tool_calls=tool_calls)
+    pages = ingest_message(msg, turn_seq=0, ts=1.0, token_counter=counter)
+    assert len(pages) == 1
+    page = pages[0]
+
+    # Round-trip contract: ``Page.ai_tool_calls`` preserves the exact
+    # tool_calls payload that ``as_message`` will reattach.
+    assert page.ai_tool_calls == tool_calls
+
+    expected_payload_json = json.dumps(
+        page.ai_tool_calls, sort_keys=True, default=str
+    )
+    expected_payload_tokens = counter.count_text(expected_payload_json)
+    assert expected_payload_tokens > 0
+
+    # Twin with the same content and no tool_calls gives us the
+    # baseline per-rep token cost to subtract against.
+    twin_pages = ingest_message(
+        AIMessage(content="reading and listing"),
+        turn_seq=0,
+        ts=1.0,
+        token_counter=counter,
+    )
+    assert len(twin_pages) == 1
+    twin_page = twin_pages[0]
+
+    # FULL: exact arithmetic — plain-content tokens + payload tokens.
+    assert (
+        page.representations[FidelityLevel.FULL].token_estimate
+        == twin_page.representations[FidelityLevel.FULL].token_estimate
+        + expected_payload_tokens
+    )
+
+    # POINTER: the full expected_payload is added, NOT a scaled-down
+    # fraction. This locks in the "uniform overhead on every rung"
+    # contract — the selector must see the same tool_calls cost
+    # whether it picks POINTER or FULL, because as_message reattaches
+    # the payload either way.
+    assert (
+        page.representations[FidelityLevel.POINTER].token_estimate
+        == twin_page.representations[FidelityLevel.POINTER].token_estimate
+        + expected_payload_tokens
+    )

--- a/dimos/agents/memory/test_page_table.py
+++ b/dimos/agents/memory/test_page_table.py
@@ -1,0 +1,217 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for :mod:`dimos.agents.memory.page_table`."""
+from __future__ import annotations
+
+import pytest
+
+from dimos.agents.memory.page_table import PageTable, PinRebalance
+from dimos.agents.memory.pages import FidelityLevel, Page, PageType, Representation
+
+
+def _reps(
+    *,
+    tokens: tuple[int, int, int, int] = (1, 3, 5, 10),
+) -> dict[FidelityLevel, Representation]:
+    return {
+        FidelityLevel.POINTER: Representation(FidelityLevel.POINTER, "[p]", tokens[0]),
+        FidelityLevel.STRUCTURED: Representation(FidelityLevel.STRUCTURED, "{}", tokens[1]),
+        FidelityLevel.COMPRESSED: Representation(FidelityLevel.COMPRESSED, "short", tokens[2]),
+        FidelityLevel.FULL: Representation(FidelityLevel.FULL, "the full thing", tokens[3]),
+    }
+
+
+def _page(
+    page_id: str,
+    page_type: PageType = PageType.CONVERSATION,
+    artefact_uuid: str | None = None,
+    role: str = "human",
+    turn_seq: int = 0,
+) -> Page:
+    extra: dict[str, object] = {}
+    if role == "tool":
+        extra["tool_call_id"] = f"call-{page_id}"
+    return Page(
+        id=page_id,
+        type=page_type,
+        provenance="test",
+        turn_seq=turn_seq,
+        ts=1.0 + turn_seq,
+        role=role,  # type: ignore[arg-type]
+        representations=_reps(),
+        artefact_uuid=artefact_uuid,
+        **extra,  # type: ignore[arg-type]
+    )
+
+
+# --- basic store ------------------------------------------------------
+
+
+def test_empty_table_has_len_zero() -> None:
+    t = PageTable()
+    assert len(t) == 0
+    assert t.ordered() == []
+    assert t.get("missing") is None
+    assert t.get_by_artefact("nope") is None
+
+
+def test_add_and_lookup_by_id() -> None:
+    t = PageTable()
+    p = _page("p1")
+    t.add(p)
+    assert t.get("p1") is p
+    assert len(t) == 1
+    assert t.ordered() == [p]
+
+
+def test_add_and_lookup_by_artefact() -> None:
+    t = PageTable()
+    p = _page("p1", page_type=PageType.EVIDENCE, artefact_uuid="aa-bb")
+    t.add(p)
+    assert t.get_by_artefact("aa-bb") is p
+
+
+def test_add_rejects_duplicate_id() -> None:
+    t = PageTable()
+    t.add(_page("p1"))
+    with pytest.raises(ValueError, match="already contains a page"):
+        t.add(_page("p1"))
+
+
+def test_add_rejects_duplicate_artefact_uuid() -> None:
+    t = PageTable()
+    t.add(_page("p1", page_type=PageType.EVIDENCE, artefact_uuid="u1"))
+    with pytest.raises(ValueError, match="artefact UUID"):
+        t.add(_page("p2", page_type=PageType.EVIDENCE, artefact_uuid="u1"))
+
+
+def test_ordered_returns_copy() -> None:
+    t = PageTable()
+    p = _page("p1")
+    t.add(p)
+    snapshot = t.ordered()
+    snapshot.append(_page("p2"))  # mutate snapshot
+    assert len(t) == 1
+
+
+def test_clear_resets_all_indexes() -> None:
+    t = PageTable()
+    t.add(_page("p1", page_type=PageType.EVIDENCE, artefact_uuid="u1"))
+    t.add(_page("p2"))
+    t.clear()
+    assert len(t) == 0
+    assert t.get("p1") is None
+    assert t.get_by_artefact("u1") is None
+
+
+def test_negative_pin_rejected() -> None:
+    with pytest.raises(ValueError):
+        PageTable(pin_recent_evidence=-1)
+
+
+def test_evidence_pages_filter() -> None:
+    t = PageTable()
+    t.add(_page("c1"))
+    t.add(_page("e1", page_type=PageType.EVIDENCE, artefact_uuid="u1"))
+    t.add(_page("c2"))
+    ev = t.evidence_pages()
+    assert [p.id for p in ev] == ["e1"]
+
+
+# --- pin rebalancing ---------------------------------------------------
+
+
+def test_rebalance_pins_last_n_evidence() -> None:
+    t = PageTable(pin_recent_evidence=3)
+    for i in range(5):
+        t.add(_page(f"e{i}", page_type=PageType.EVIDENCE, artefact_uuid=f"u{i}", turn_seq=i))
+
+    diff = t.rebalance_evidence_pins()
+    # Last 3 (e2, e3, e4) must be pinned_at_full.
+    assert {p.id for p in t.evidence_pages() if p.pinned_at_full} == {"e2", "e3", "e4"}
+    # None of the earlier ones must be pinned.
+    assert not any(p.pinned_at_full for p in t.evidence_pages() if p.id in {"e0", "e1"})
+
+    # First call surfaces 3 new pins, 0 unpins.
+    assert set(diff.pinned) == {"e2", "e3", "e4"}
+    assert diff.unpinned == []
+    assert diff.empty is False
+
+
+def test_rebalance_is_idempotent() -> None:
+    t = PageTable(pin_recent_evidence=2)
+    for i in range(3):
+        t.add(_page(f"e{i}", page_type=PageType.EVIDENCE, artefact_uuid=f"u{i}", turn_seq=i))
+    t.rebalance_evidence_pins()  # first call flips things
+    diff = t.rebalance_evidence_pins()
+    assert diff.empty
+    assert diff.pinned == []
+    assert diff.unpinned == []
+
+
+def test_rebalance_unpins_displaced_older_pages() -> None:
+    t = PageTable(pin_recent_evidence=2)
+    # Add 3 EVIDENCE pages, with the oldest one expected to drop out of the
+    # pin window once the 3rd arrives.
+    for i in range(3):
+        t.add(_page(f"e{i}", page_type=PageType.EVIDENCE, artefact_uuid=f"u{i}", turn_seq=i))
+
+    diff = t.rebalance_evidence_pins()
+    assert set(diff.pinned) == {"e1", "e2"}
+    assert diff.unpinned == []  # e0 was never pinned in the first place
+
+    # Now add a 4th; e1 should fall out of the window, e3 should come in.
+    t.add(_page("e3", page_type=PageType.EVIDENCE, artefact_uuid="u3", turn_seq=3))
+    diff2 = t.rebalance_evidence_pins()
+    assert set(diff2.pinned) == {"e3"}
+    assert set(diff2.unpinned) == {"e1"}
+    pinned_now = {p.id for p in t.evidence_pages() if p.pinned_at_full}
+    assert pinned_now == {"e2", "e3"}
+
+
+def test_rebalance_zero_pins_never_pins_anything() -> None:
+    t = PageTable(pin_recent_evidence=0)
+    for i in range(3):
+        t.add(_page(f"e{i}", page_type=PageType.EVIDENCE, artefact_uuid=f"u{i}", turn_seq=i))
+    diff = t.rebalance_evidence_pins()
+    assert diff.empty
+    assert not any(p.pinned_at_full for p in t.evidence_pages())
+
+
+def test_rebalance_preserves_manual_pins() -> None:
+    # REFETCH_FAULT marks a page pinned via ``mark_pinned_full`` and we
+    # must not un-pin it via a subsequent rebalance (one-way upgrade).
+    t = PageTable(pin_recent_evidence=1)
+    for i in range(3):
+        t.add(_page(f"e{i}", page_type=PageType.EVIDENCE, artefact_uuid=f"u{i}", turn_seq=i))
+    t.rebalance_evidence_pins()
+    # Manually promote the oldest page.
+    assert t.mark_pinned_full("e0") is True
+
+    diff = t.rebalance_evidence_pins()
+    # e0 stays pinned_at_full because we just promoted it.
+    assert diff.empty or "e0" not in diff.unpinned
+    e0 = t.get("e0")
+    assert e0 is not None and e0.pinned_at_full is True
+
+
+def test_mark_pinned_full_returns_false_for_missing() -> None:
+    t = PageTable()
+    assert t.mark_pinned_full("does-not-exist") is False
+
+
+def test_pin_rebalance_empty_property() -> None:
+    assert PinRebalance(pinned=[], unpinned=[]).empty is True
+    assert PinRebalance(pinned=["x"], unpinned=[]).empty is False
+    assert PinRebalance(pinned=[], unpinned=["y"]).empty is False

--- a/dimos/agents/memory/test_pages.py
+++ b/dimos/agents/memory/test_pages.py
@@ -1,0 +1,337 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for :mod:`dimos.agents.memory.pages`."""
+from __future__ import annotations
+
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+import pytest
+
+from dimos.agents.memory.pages import (
+    FidelityLevel,
+    Page,
+    PageType,
+    Representation,
+)
+
+
+def _reps(
+    *,
+    pointer_text: str = "[p1]",
+    structured_text: str = "{role:ai}",
+    compressed_text: str = "short",
+    full_text: str = "the full thing",
+    tokens: tuple[int, int, int, int] = (1, 3, 5, 10),
+) -> dict[FidelityLevel, Representation]:
+    """Helper to build a standard 4-level representation set."""
+    return {
+        FidelityLevel.POINTER: Representation(FidelityLevel.POINTER, pointer_text, tokens[0]),
+        FidelityLevel.STRUCTURED: Representation(FidelityLevel.STRUCTURED, structured_text, tokens[1]),
+        FidelityLevel.COMPRESSED: Representation(FidelityLevel.COMPRESSED, compressed_text, tokens[2]),
+        FidelityLevel.FULL: Representation(FidelityLevel.FULL, full_text, tokens[3]),
+    }
+
+
+def _page(**overrides: object) -> Page:
+    defaults: dict[str, object] = {
+        "id": "page-1",
+        "type": PageType.CONVERSATION,
+        "provenance": "user_input",
+        "turn_seq": 0,
+        "ts": 1.0,
+        "role": "human",
+        "representations": _reps(),
+    }
+    defaults.update(overrides)
+    return Page(**defaults)  # type: ignore[arg-type]
+
+
+# -- FidelityLevel ordering -----------------------------------------------
+
+
+def test_fidelity_level_ordered_int_enum() -> None:
+    assert FidelityLevel.POINTER < FidelityLevel.STRUCTURED < FidelityLevel.COMPRESSED < FidelityLevel.FULL
+    assert int(FidelityLevel.POINTER) == 0
+    assert int(FidelityLevel.FULL) == 3
+
+
+def test_fidelity_level_min_and_max() -> None:
+    levels = [FidelityLevel.POINTER, FidelityLevel.COMPRESSED, FidelityLevel.STRUCTURED]
+    assert min(levels) == FidelityLevel.POINTER
+    assert max(levels) == FidelityLevel.COMPRESSED
+
+
+# -- Representation invariants --------------------------------------------
+
+
+def test_representation_rejects_negative_tokens() -> None:
+    with pytest.raises(ValueError, match="non-negative"):
+        Representation(FidelityLevel.FULL, "hello", -1)
+
+
+def test_representation_rejects_empty_text() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        Representation(FidelityLevel.FULL, "", 0)
+
+
+def test_representation_rejects_empty_multimodal() -> None:
+    with pytest.raises(ValueError, match="multimodal"):
+        Representation(FidelityLevel.FULL, [], 0)
+
+
+def test_representation_rejects_wrong_content_type() -> None:
+    with pytest.raises(TypeError):
+        Representation(FidelityLevel.FULL, 42, 1)  # type: ignore[arg-type]
+
+
+def test_representation_accepts_multimodal_parts() -> None:
+    rep = Representation(
+        FidelityLevel.FULL,
+        [{"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,..."}}],
+        1105,
+    )
+    assert isinstance(rep.content, list)
+
+
+# -- Page invariants ------------------------------------------------------
+
+
+def test_page_requires_pointer_structured_and_compressed_or_full() -> None:
+    reps = _reps()
+    del reps[FidelityLevel.POINTER]
+    with pytest.raises(ValueError, match="POINTER"):
+        _page(representations=reps)
+
+    reps = _reps()
+    del reps[FidelityLevel.STRUCTURED]
+    with pytest.raises(ValueError, match="STRUCTURED"):
+        _page(representations=reps)
+
+    reps = _reps()
+    del reps[FidelityLevel.FULL]
+    del reps[FidelityLevel.COMPRESSED]
+    with pytest.raises(ValueError, match="COMPRESSED/FULL"):
+        _page(representations=reps)
+
+
+def test_page_representation_level_must_match_key() -> None:
+    reps = _reps()
+    # Corrupt the POINTER entry with a STRUCTURED-level value.
+    reps[FidelityLevel.POINTER] = Representation(FidelityLevel.STRUCTURED, "x", 1)
+    with pytest.raises(ValueError, match="they must match"):
+        _page(representations=reps)
+
+
+def test_page_token_estimate_must_be_monotonic() -> None:
+    with pytest.raises(ValueError, match="monotonic"):
+        _page(representations=_reps(tokens=(5, 4, 3, 2)))
+
+
+def test_page_negative_turn_seq_rejected() -> None:
+    with pytest.raises(ValueError, match="turn_seq"):
+        _page(turn_seq=-1)
+
+
+def test_page_empty_id_rejected() -> None:
+    with pytest.raises(ValueError, match="id"):
+        _page(id="")
+
+
+def test_page_rejects_pinned_at_full_without_pinned() -> None:
+    """Revert of silent auto-mutation: caller must set pinned=True explicitly."""
+    with pytest.raises(ValueError, match="pinned=True"):
+        _page(pinned_at_full=True, pinned=False, min_fidelity=FidelityLevel.FULL)
+
+
+def test_page_rejects_pinned_at_full_without_min_full() -> None:
+    """Revert of silent auto-mutation: caller must set min_fidelity=FULL explicitly."""
+    with pytest.raises(ValueError, match="min_fidelity=FidelityLevel.FULL"):
+        _page(pinned_at_full=True, pinned=True, min_fidelity=FidelityLevel.COMPRESSED)
+
+
+def test_page_accepts_pinned_at_full_with_consistent_flags() -> None:
+    """Consistent flag-triple is accepted; pinned_at_full implies pinned=True and min_fidelity=FULL."""
+    p = _page(pinned_at_full=True, pinned=True, min_fidelity=FidelityLevel.FULL)
+    assert p.pinned is True
+    assert p.pinned_at_full is True
+    assert p.min_fidelity is FidelityLevel.FULL
+
+
+def test_page_tool_role_requires_tool_call_id() -> None:
+    with pytest.raises(ValueError, match="tool_call_id"):
+        _page(role="tool")
+
+
+def test_page_tool_role_with_id_accepted() -> None:
+    p = _page(role="tool", tool_call_id="call_abc")
+    assert p.tool_call_id == "call_abc"
+
+
+def test_page_two_level_only_compressed_ok() -> None:
+    # A text page may legitimately have the same content at COMPRESSED and
+    # FULL (e.g. a short message); leaving out FULL entirely is allowed as
+    # long as COMPRESSED is present.
+    reps = _reps()
+    del reps[FidelityLevel.FULL]
+    p = _page(representations=reps)
+    assert p.max_available() == FidelityLevel.COMPRESSED
+
+
+# -- Page.rep_at fallback -------------------------------------------------
+
+
+def test_rep_at_returns_exact_level_when_present() -> None:
+    p = _page()
+    assert p.rep_at(FidelityLevel.STRUCTURED).level == FidelityLevel.STRUCTURED
+
+
+def test_rep_at_falls_back_to_highest_available_below() -> None:
+    reps = _reps()
+    del reps[FidelityLevel.COMPRESSED]
+    p = _page(representations=reps)
+    # Asking for COMPRESSED should fall back to STRUCTURED (next below).
+    assert p.rep_at(FidelityLevel.COMPRESSED).level == FidelityLevel.STRUCTURED
+
+
+def test_rep_at_falls_back_to_lowest_when_none_below() -> None:
+    reps = _reps()
+    # Only FULL is present — asking for POINTER/STRUCTURED should fall up.
+    reps_full_only: dict[FidelityLevel, Representation] = {
+        FidelityLevel.POINTER: reps[FidelityLevel.POINTER],
+        FidelityLevel.STRUCTURED: reps[FidelityLevel.STRUCTURED],
+        FidelityLevel.FULL: reps[FidelityLevel.FULL],
+    }
+    p = _page(representations=reps_full_only)
+    assert p.rep_at(FidelityLevel.COMPRESSED).level == FidelityLevel.STRUCTURED
+
+
+# -- Page.as_message preserves role + tool_call_id -----------------------
+
+
+def test_as_message_system_role() -> None:
+    p = _page(role="system", type=PageType.BOOTSTRAP)
+    msg = p.as_message(FidelityLevel.FULL)
+    assert isinstance(msg, SystemMessage)
+    assert msg.content == "the full thing"
+
+
+def test_as_message_human_role() -> None:
+    p = _page(role="human")
+    msg = p.as_message(FidelityLevel.COMPRESSED)
+    assert isinstance(msg, HumanMessage)
+    assert msg.content == "short"
+
+
+def test_as_message_ai_role_without_tool_calls() -> None:
+    p = _page(role="ai")
+    msg = p.as_message(FidelityLevel.FULL)
+    assert isinstance(msg, AIMessage)
+    assert msg.content == "the full thing"
+    assert not msg.tool_calls
+
+
+def test_as_message_ai_role_with_tool_calls_roundtrip() -> None:
+    tool_calls = [{"id": "c1", "name": "foo", "args": {"x": 1}, "type": "tool_call"}]
+    p = _page(role="ai", ai_tool_calls=tool_calls)
+    msg = p.as_message(FidelityLevel.FULL)
+    assert isinstance(msg, AIMessage)
+    assert len(msg.tool_calls) == 1
+    assert msg.tool_calls[0]["id"] == "c1"
+
+
+def test_as_message_tool_role_preserves_tool_call_id() -> None:
+    p = _page(role="tool", tool_call_id="call_xyz")
+    msg = p.as_message(FidelityLevel.STRUCTURED)
+    assert isinstance(msg, ToolMessage)
+    assert msg.tool_call_id == "call_xyz"
+
+
+def test_max_available() -> None:
+    reps = _reps()
+    del reps[FidelityLevel.FULL]
+    assert _page(representations=reps).max_available() == FidelityLevel.COMPRESSED
+    assert _page().max_available() == FidelityLevel.FULL
+
+
+# -- Restored step-2 validations -----------------------------------------
+#
+# These tests guard the invariants the ingestion / selector pipelines
+# assume. A silent regression here tends to surface later as "why is the
+# LLM hallucinating a tool-call pair?" or "why did an unknown enum sneak
+# through?" so they're cheap insurance.
+
+
+def test_representation_rejects_non_fidelity_level() -> None:
+    with pytest.raises(TypeError, match="FidelityLevel"):
+        Representation(level=1, content="x", token_estimate=1)  # type: ignore[arg-type]
+
+
+def test_page_rejects_non_page_type_type() -> None:
+    with pytest.raises(TypeError, match="PageType"):
+        _page(type="conversation")  # type: ignore[arg-type]
+
+
+def test_page_rejects_non_fidelity_min_fidelity() -> None:
+    with pytest.raises(TypeError, match="FidelityLevel"):
+        _page(min_fidelity=0)  # type: ignore[arg-type]
+
+
+def test_page_rejects_unknown_role() -> None:
+    with pytest.raises(ValueError, match="role"):
+        _page(role="assistant")  # type: ignore[arg-type]
+
+
+def test_tool_call_id_rejected_on_non_tool_role() -> None:
+    # Bidirectional invariant: only role='tool' pages may carry a
+    # tool_call_id. Setting it on human/ai/system is a caller bug and
+    # would silently misroute LangChain pairing at egress.
+    with pytest.raises(ValueError, match="tool_call_id"):
+        _page(role="human", tool_call_id="call_bogus")
+    with pytest.raises(ValueError, match="tool_call_id"):
+        _page(role="ai", tool_call_id="call_bogus")
+    with pytest.raises(ValueError, match="tool_call_id"):
+        _page(role="system", type=PageType.BOOTSTRAP, tool_call_id="call_bogus")
+
+
+def test_rep_at_never_raises_given_invariants() -> None:
+    # POINTER is required by __post_init__, so for *any* requested level
+    # there is always at least one rep <= it (POINTER == 0). This test
+    # asserts the lenient contract: rep_at must never raise on a
+    # well-formed Page, regardless of which rung is asked for or which
+    # subset of non-POINTER rungs happens to be present.
+    base = _reps()
+
+    subsets: list[dict[FidelityLevel, Representation]] = [
+        base,  # all four
+        {k: v for k, v in base.items() if k != FidelityLevel.COMPRESSED},
+        {k: v for k, v in base.items() if k != FidelityLevel.FULL},
+        # Only POINTER + STRUCTURED + (one of COMPRESSED/FULL).
+        {
+            FidelityLevel.POINTER: base[FidelityLevel.POINTER],
+            FidelityLevel.STRUCTURED: base[FidelityLevel.STRUCTURED],
+            FidelityLevel.COMPRESSED: base[FidelityLevel.COMPRESSED],
+        },
+        {
+            FidelityLevel.POINTER: base[FidelityLevel.POINTER],
+            FidelityLevel.STRUCTURED: base[FidelityLevel.STRUCTURED],
+            FidelityLevel.FULL: base[FidelityLevel.FULL],
+        },
+    ]
+
+    for reps in subsets:
+        p = _page(representations=reps)
+        for level in FidelityLevel:
+            # Must not raise, and must return a Representation whose
+            # level is actually present in the page.
+            rep = p.rep_at(level)
+            assert rep.level in reps

--- a/dimos/agents/memory/test_selector.py
+++ b/dimos/agents/memory/test_selector.py
@@ -1,0 +1,387 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for :mod:`dimos.agents.memory.selector`."""
+from __future__ import annotations
+
+import random
+
+from langchain_core.messages import AIMessage, SystemMessage, ToolMessage
+
+from dimos.agents.memory.budget import ModelBudget
+from dimos.agents.memory.pages import FidelityLevel, Page, PageType, Representation
+from dimos.agents.memory.selector import AssembledPrompt, assemble_prompt
+
+
+def _reps(tokens: tuple[int, int, int, int] = (1, 3, 5, 10)) -> dict[FidelityLevel, Representation]:
+    return {
+        FidelityLevel.POINTER: Representation(FidelityLevel.POINTER, "[p]", tokens[0]),
+        FidelityLevel.STRUCTURED: Representation(FidelityLevel.STRUCTURED, "{}", tokens[1]),
+        FidelityLevel.COMPRESSED: Representation(FidelityLevel.COMPRESSED, "short", tokens[2]),
+        FidelityLevel.FULL: Representation(FidelityLevel.FULL, "the full thing", tokens[3]),
+    }
+
+
+def _conv_page(pid: str, turn: int, tokens: tuple[int, int, int, int] = (1, 3, 5, 10)) -> Page:
+    return Page(
+        id=pid,
+        type=PageType.CONVERSATION,
+        provenance="test",
+        turn_seq=turn,
+        ts=float(turn),
+        role="human",
+        representations=_reps(tokens),
+    )
+
+
+def _bootstrap_page(pid: str, tokens: tuple[int, int, int, int] = (1, 3, 5, 100)) -> Page:
+    return Page(
+        id=pid,
+        type=PageType.BOOTSTRAP,
+        provenance="system",
+        turn_seq=0,
+        ts=0.0,
+        role="system",
+        representations=_reps(tokens),
+        pinned=True,
+        pinned_at_full=True,
+        min_fidelity=FidelityLevel.FULL,
+    )
+
+
+def _evidence_page(
+    pid: str,
+    turn: int,
+    *,
+    pinned: bool = False,
+    tokens: tuple[int, int, int, int] = (5, 30, 85, 1105),
+) -> Page:
+    return Page(
+        id=pid,
+        type=PageType.EVIDENCE,
+        provenance="tool:camera",
+        turn_seq=turn,
+        ts=float(turn),
+        role="human",
+        representations=_reps(tokens),
+        artefact_uuid=f"uuid-{pid}",
+        pinned=pinned,
+        pinned_at_full=pinned,
+        min_fidelity=FidelityLevel.FULL if pinned else FidelityLevel.POINTER,
+    )
+
+
+def _tool_pair(
+    ai_id: str,
+    tool_id: str,
+    turn: int,
+    call_id: str = "call1",
+    tokens: tuple[int, int, int, int] = (1, 3, 5, 10),
+) -> tuple[Page, Page]:
+    ai = Page(
+        id=ai_id,
+        type=PageType.CONVERSATION,
+        provenance="llm",
+        turn_seq=turn,
+        ts=float(turn),
+        role="ai",
+        representations=_reps(tokens),
+        ai_tool_calls=[{"id": call_id, "name": "f", "args": {}, "type": "tool_call"}],
+    )
+    tool = Page(
+        id=tool_id,
+        type=PageType.CONVERSATION,
+        provenance="tool_response",
+        turn_seq=turn,
+        ts=float(turn) + 0.1,
+        role="tool",
+        representations=_reps(tokens),
+        tool_call_id=call_id,
+    )
+    return ai, tool
+
+
+def _budget(context_window: int, output_reserve: int = 0, overhead: int = 0) -> ModelBudget:
+    return ModelBudget(
+        context_window=context_window,
+        output_reserve=output_reserve,
+        system_overhead=overhead,
+    )
+
+
+# --- Phase 1: floor + pins --------------------------------------------
+
+
+def test_empty_pages_returns_empty_prompt() -> None:
+    out = assemble_prompt([], budget=_budget(100))
+    assert out.messages == []
+    assert out.total_tokens == 0
+    assert not out.evicted_page_ids
+    assert not out.physical_insufficient
+
+
+def test_bootstrap_page_always_rendered_at_full() -> None:
+    b = _bootstrap_page("sys")
+    out = assemble_prompt([b], budget=_budget(1000))
+    assert out.chosen_levels["sys"] == FidelityLevel.FULL
+
+
+def test_small_case_fits_all_pages_at_full() -> None:
+    b = _bootstrap_page("sys", tokens=(1, 3, 5, 50))
+    a = _conv_page("a", 1)
+    c = _conv_page("c", 2)
+    out = assemble_prompt([b, a, c], budget=_budget(500))
+    assert out.chosen_levels == {
+        "sys": FidelityLevel.FULL,
+        "a": FidelityLevel.FULL,
+        "c": FidelityLevel.FULL,
+    }
+    assert out.evicted_page_ids == []
+    assert not out.physical_insufficient
+
+
+def test_pinned_evidence_never_evicted_even_under_pressure() -> None:
+    sys = _bootstrap_page("sys", tokens=(1, 3, 5, 50))
+    e = _evidence_page("e", 1, pinned=True)
+    # A tight budget that just barely fits sys + e at FULL.
+    budget_size = 50 + 1105 + 20  # leave small slack for overhead
+    out = assemble_prompt([sys, e], budget=_budget(budget_size))
+    assert "e" not in out.evicted_page_ids
+    assert out.chosen_levels["e"] == FidelityLevel.FULL
+    assert not out.physical_insufficient
+
+
+def test_non_pinned_pages_evicted_when_floor_overflows() -> None:
+    # 5 conversation pages, each with floor (POINTER) = 1 token, cap = 2 tokens.
+    # Expect 3 to be evicted (leave 2 at POINTER).
+    pages = [_conv_page(f"p{i}", i) for i in range(5)]
+    out = assemble_prompt(pages, budget=_budget(100, output_reserve=97, overhead=0))
+    # cap = 100 - 97 = 3 tokens.
+    # 5 * 1 = 5 at floor; must evict at least 2 to fit under 3.
+    assert len(out.evicted_page_ids) >= 2
+    # The oldest pages (low turn_seq) should be evicted first.
+    assert "p0" in out.evicted_page_ids
+    assert "p1" in out.evicted_page_ids
+
+
+def test_physical_insufficiency_flag_set_when_pins_too_big() -> None:
+    # Two pinned-at-full evidence pages at 1105 each + a tiny budget.
+    sys = _bootstrap_page("sys", tokens=(1, 3, 5, 50))
+    e1 = _evidence_page("e1", 1, pinned=True)
+    e2 = _evidence_page("e2", 2, pinned=True)
+    out = assemble_prompt(
+        [sys, e1, e2], budget=_budget(500)    )
+    assert out.physical_insufficient is True
+
+
+# --- Phase 2: greedy upgrade ------------------------------------------
+
+
+def test_phase2_upgrades_recent_pages_first() -> None:
+    # 3 pages: oldest has the cheapest FULL (10 tokens); newest most expensive (100).
+    # With a budget that can afford *some* upgrades, the newest should upgrade first
+    # because recency wins ties. But we test a weaker property here: newest is at
+    # least as high-fidelity as oldest in the final assignment.
+    p_old = _conv_page("old", 0, tokens=(1, 3, 5, 10))
+    p_mid = _conv_page("mid", 1, tokens=(1, 3, 5, 10))
+    p_new = _conv_page("new", 2, tokens=(1, 3, 5, 10))
+
+    out = assemble_prompt(
+        [p_old, p_mid, p_new], budget=_budget(50)    )
+    assert out.chosen_levels["new"] >= out.chosen_levels["old"]
+
+
+def test_phase2_never_exceeds_budget() -> None:
+    # Random mix, check upper bound is respected.
+    rng = random.Random(0)
+    pages: list[Page] = []
+    for i in range(20):
+        tokens = tuple(sorted([rng.randint(1, 5), rng.randint(6, 20), rng.randint(21, 80), rng.randint(100, 1200)]))
+        pages.append(_conv_page(f"p{i}", i, tokens=tokens))  # type: ignore[arg-type]
+    out = assemble_prompt(pages, budget=_budget(1000))
+    if not out.physical_insufficient:
+        assert out.total_tokens <= 1000
+
+
+def test_phase2_upgrades_within_single_level_step() -> None:
+    # With a very generous budget, every page goes to FULL.
+    pages = [_conv_page(f"p{i}", i) for i in range(5)]
+    out = assemble_prompt(pages, budget=_budget(10_000))
+    for p in pages:
+        assert out.chosen_levels[p.id] == FidelityLevel.FULL
+    assert out.degraded_page_ids == []
+
+
+# --- Tool-call pair integrity ----------------------------------------
+
+
+def test_tool_call_pair_never_broken_by_eviction() -> None:
+    ai, tool = _tool_pair("ai1", "tool1", turn=1)
+    # A few other evictable pages.
+    other = _conv_page("other", 0)
+    # Very small budget: must evict something.
+    out = assemble_prompt(
+        [other, ai, tool], budget=_budget(100, output_reserve=97, overhead=0)    )
+    # If the AI is in the assembled prompt, the matching tool message must be too.
+    kept = {p: lvl for p, lvl in out.chosen_levels.items()}
+    assert ("ai1" in kept) == ("tool1" in kept)
+
+
+def test_tool_call_pair_messages_have_matching_tool_call_id() -> None:
+    ai, tool = _tool_pair("ai1", "tool1", turn=1, call_id="call42")
+    out = assemble_prompt([ai, tool], budget=_budget(1000))
+    assert len(out.messages) == 2
+    rendered_ai = out.messages[0]
+    rendered_tool = out.messages[1]
+    assert isinstance(rendered_ai, AIMessage)
+    assert isinstance(rendered_tool, ToolMessage)
+    assert rendered_ai.tool_calls[0]["id"] == "call42"
+    assert rendered_tool.tool_call_id == "call42"
+
+
+def test_tool_call_pair_degrades_together_when_possible() -> None:
+    ai, tool = _tool_pair("ai1", "tool1", turn=1, tokens=(1, 2, 3, 100))
+    # Tiny budget: only room for the pair at POINTER+POINTER.
+    out = assemble_prompt(
+        [ai, tool], budget=_budget(100, output_reserve=97, overhead=0)    )
+    # Both should be at the same level.
+    if "ai1" in out.chosen_levels and "tool1" in out.chosen_levels:
+        assert out.chosen_levels["ai1"] == out.chosen_levels["tool1"]
+
+
+# --- Bootstrap is never degraded -------------------------------------
+
+
+def test_bootstrap_never_degraded_under_pressure() -> None:
+    sys = _bootstrap_page("sys", tokens=(1, 3, 5, 200))
+    # Cap is exactly the bootstrap cost -> bootstrap stays at FULL, everything else evicted.
+    a = _conv_page("a", 1)
+    b = _conv_page("b", 2)
+    cap = 200 + 10
+    out = assemble_prompt([sys, a, b], budget=_budget(cap))
+    assert out.chosen_levels["sys"] == FidelityLevel.FULL
+
+
+# --- Messages match in order ------------------------------------------
+
+
+def test_messages_preserve_ingest_order() -> None:
+    sys = _bootstrap_page("sys")
+    pages = [sys] + [_conv_page(f"p{i}", i + 1) for i in range(5)]
+    out = assemble_prompt(pages, budget=_budget(5000))
+    assert [isinstance(m, SystemMessage) for m in out.messages][0] is True
+    # Everyone in, same order.
+    assert len(out.messages) == len(pages)
+
+
+# --- Property-style: budget respected over random mixes ---------------
+
+
+# --- Per-message overhead is reserved on the budget side --------------
+
+
+def test_assemble_accounts_per_message_overhead() -> None:
+    """Phase 1 must reserve per-message ChatML overhead on the cap.
+
+    Ten conversation pages with uniform 100-token representations and a
+    1000-token ``input_budget``: content sums to exactly
+    ``input_budget``. Under the OLD (buggy) selector ``cap = input_budget``
+    so this "just fits" and no eviction happens. Under the FIXED
+    selector, ``cap = budget.effective_budget_for_messages(10) =
+    1000 - 4 * 10 = 960``, so content exceeds the cap by 40 and Phase 1
+    must either evict at least one group or flip
+    ``physical_insufficient``.
+    """
+    pages = [
+        _conv_page(f"p{i}", i, tokens=(100, 100, 100, 100))
+        for i in range(10)
+    ]
+    budget = _budget(1000)
+    # Pre-condition: default per_message_overhead=4, so
+    # effective_budget_for_messages(10) = 960.
+    assert budget.effective_budget_for_messages(10) == 960
+    out = assemble_prompt(pages, budget=budget)
+
+    assert out.evicted_page_ids or out.physical_insufficient, (
+        f"expected an eviction or physical_insufficient, got "
+        f"evicted={out.evicted_page_ids} "
+        f"physical_insufficient={out.physical_insufficient}"
+    )
+    n_surviving = 10 - len(out.evicted_page_ids)
+    effective_cap = budget.effective_budget_for_messages(n_surviving)
+    if not out.physical_insufficient:
+        assert out.total_tokens <= effective_cap, (
+            f"total_tokens={out.total_tokens} > effective_cap={effective_cap} "
+            f"for n_surviving={n_surviving}"
+        )
+
+
+def test_assemble_recomputes_cap_after_eviction() -> None:
+    """Evicting a page must free both its content AND its overhead slot.
+
+    Scenario: nine pinned-at-full evidence pages at FULL=107 (sum=963)
+    plus one non-pinned conversation page at POINTER floor=5. Content
+    totals 968. With ``input_budget=1000`` and ten pages,
+    ``effective_cap = 1000 - 40 = 960`` — content is over by 8.
+
+    Evicting the one non-pinned page drops content by 5 AND drops the
+    surviving count from 10 to 9, so the recomputed cap becomes
+    ``1000 - 36 = 964``. Post-eviction total 963 <= 964 and the prompt
+    fits. Under a selector that forgets to recompute ``cap`` after
+    eviction, the cap stays at 960 and ``total=963`` would flip
+    ``physical_insufficient=True`` even though no more non-pinned pages
+    are available to drop.
+    """
+    pinned_pages = [
+        _evidence_page(f"pin{i}", i, pinned=True, tokens=(107, 107, 107, 107))
+        for i in range(9)
+    ]
+    np_page = _conv_page("np", 10, tokens=(5, 5, 5, 5))
+    pages = pinned_pages + [np_page]
+    budget = _budget(1000)
+    out = assemble_prompt(pages, budget=budget)
+
+    assert "np" in out.evicted_page_ids
+    # Only the one non-pinned page should be evicted — the nine pinned
+    # pages survive and no extra page gets dropped just to chase the
+    # non-recomputed cap.
+    assert out.evicted_page_ids == ["np"], (
+        f"expected exactly ['np'] evicted, got {out.evicted_page_ids}"
+    )
+    assert not out.physical_insufficient, (
+        "physical_insufficient flipped True — selector likely failed to "
+        "recompute cap after eviction"
+    )
+    effective_cap = budget.effective_budget_for_messages(9)
+    assert effective_cap == 964
+    assert out.total_tokens <= effective_cap
+    # Sanity: the nine pinned pages all rendered at FULL (content 107 each).
+    assert out.total_tokens == 9 * 107
+
+
+def test_random_mixes_never_exceed_budget_when_pins_are_small() -> None:
+    rng = random.Random(42)
+    for trial in range(50):
+        n = rng.randint(1, 40)
+        pages: list[Page] = []
+        for i in range(n):
+            tokens = tuple(sorted([rng.randint(1, 4), rng.randint(5, 15), rng.randint(16, 60), rng.randint(70, 500)]))
+            pages.append(_conv_page(f"p{trial}-{i}", i, tokens=tokens))  # type: ignore[arg-type]
+        cap = rng.randint(50, 5000)
+        out: AssembledPrompt = assemble_prompt(pages, budget=_budget(cap + 0, output_reserve=0, overhead=0))
+        if out.physical_insufficient:
+            continue
+        assert out.total_tokens <= cap, (
+            f"trial {trial}: total={out.total_tokens} cap={cap} "
+            f"chosen={out.chosen_levels}"
+        )

--- a/dimos/agents/memory/test_tokens.py
+++ b/dimos/agents/memory/test_tokens.py
@@ -1,0 +1,232 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for :mod:`dimos.agents.memory.tokens`."""
+from __future__ import annotations
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+
+from dimos.agents.memory.budget import ModelBudget
+from dimos.agents.memory.tokens import (
+    IMAGE_FULL_COST,
+    IMAGE_THUMB_COST,
+    HeuristicCounter,
+    TiktokenCounter,
+    TokenCounter,
+    _sum_content_tokens,
+    count_image_part,
+)
+
+
+# --- Protocol ------------------------------------------------------------
+
+
+def test_heuristic_and_tiktoken_implement_token_counter_protocol() -> None:
+    pytest.importorskip("tiktoken")
+    assert isinstance(HeuristicCounter(), TokenCounter)
+    assert isinstance(TiktokenCounter("gpt-4o"), TokenCounter)
+
+
+# --- HeuristicCounter ----------------------------------------------------
+
+
+def test_heuristic_count_text_ceil_divides_by_four() -> None:
+    c = HeuristicCounter()
+    assert c.count_text("") == 0
+    # 1..4 chars -> 1 token, 5..8 chars -> 2 tokens, ...
+    assert c.count_text("a") == 1
+    assert c.count_text("abcd") == 1
+    assert c.count_text("abcde") == 2
+    assert c.count_text("a" * 12) == 3
+    assert c.count_text("a" * 13) == 4
+
+
+def test_heuristic_count_message_plain_text() -> None:
+    c = HeuristicCounter()
+    msg = HumanMessage(content="hello world!")  # 12 chars -> 3 tokens
+    # Content tokens only; per-message overhead lives on ``ModelBudget``.
+    assert c.count_message(msg) == 3
+
+
+def test_heuristic_count_message_with_image_part_full() -> None:
+    c = HeuristicCounter()
+    msg = HumanMessage(
+        content=[
+            {"type": "text", "text": "look"},  # 4 chars -> 1 tok
+            {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,ABC"}},
+        ]
+    )
+    expected = 1 + IMAGE_FULL_COST
+    assert c.count_message(msg) == expected
+
+
+def test_heuristic_count_message_with_image_part_low_detail() -> None:
+    c = HeuristicCounter()
+    msg = HumanMessage(
+        content=[
+            {"type": "image_url", "image_url": {"url": "...", "detail": "low"}},
+        ]
+    )
+    expected = IMAGE_THUMB_COST
+    assert c.count_message(msg) == expected
+
+
+def test_heuristic_count_message_unknown_part_priced_as_text() -> None:
+    c = HeuristicCounter()
+    msg = HumanMessage(content=[{"type": "weird", "x": "abcd"}])
+    # The stringified dict gets priced via count_text — all we care about is
+    # that the result is >= 1 token (never silently dropped).
+    assert c.count_message(msg) >= 1
+
+
+def test_heuristic_count_message_with_non_list_non_str_content() -> None:
+    c = HeuristicCounter()
+    msg = AIMessage(content="")
+    # Empty content — exactly zero tokens now that overhead has moved to
+    # ``ModelBudget``.
+    assert c.count_message(msg) == 0
+
+
+# --- count_image_part ---------------------------------------------------
+
+
+def test_count_image_part_defaults_to_full_cost() -> None:
+    assert count_image_part({"type": "image_url", "image_url": {"url": "..."}}) == IMAGE_FULL_COST
+
+
+def test_count_image_part_respects_low_detail_hint() -> None:
+    part = {"type": "image_url", "image_url": {"url": "...", "detail": "low"}}
+    assert count_image_part(part) == IMAGE_THUMB_COST
+
+
+def test_count_image_part_high_detail_hint_is_full() -> None:
+    part = {"type": "image_url", "image_url": {"url": "...", "detail": "high"}}
+    assert count_image_part(part) == IMAGE_FULL_COST
+
+
+# --- TiktokenCounter ----------------------------------------------------
+
+
+def test_tiktoken_counter_matches_tiktoken_directly() -> None:
+    tiktoken = pytest.importorskip("tiktoken")
+    c = TiktokenCounter("gpt-4o")
+    text = "The quick brown fox jumps over the lazy dog."
+    expected = len(tiktoken.encoding_for_model("gpt-4o").encode(text))
+    assert c.count_text(text) == expected
+
+
+def test_tiktoken_counter_falls_back_for_unknown_model() -> None:
+    pytest.importorskip("tiktoken")
+    c = TiktokenCounter("not-a-real-model-v99")
+    # Should not raise; should produce a positive count.
+    assert c.count_text("hello world") > 0
+
+
+def test_tiktoken_counter_empty_text_zero_tokens() -> None:
+    pytest.importorskip("tiktoken")
+    c = TiktokenCounter("gpt-4o")
+    assert c.count_text("") == 0
+
+
+def test_tiktoken_count_message_with_image_adds_fixed_cost() -> None:
+    pytest.importorskip("tiktoken")
+    c = TiktokenCounter("gpt-4o")
+    msg = HumanMessage(
+        content=[
+            {"type": "text", "text": "hi"},
+            {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,..."}},
+        ]
+    )
+    text_tokens = c.count_text("hi")
+    # Content only: text tokens + the fixed image cost. No prelude term.
+    assert c.count_message(msg) == text_tokens + IMAGE_FULL_COST
+
+
+# --- content-only contract ---------------------------------------------
+#
+# These tests lock in the content-only contract: counters measure
+# payload, :class:`~dimos.agents.memory.budget.ModelBudget` reserves
+# framing. The arithmetic on each side of the ledger must not leak into
+# the other.
+
+
+def test_heuristic_count_message_is_content_only() -> None:
+    c = HeuristicCounter()
+    parts = [
+        {"type": "text", "text": "one two three"},      # 13 chars -> 4 tok
+        {"type": "text", "text": "alpha"},              # 5  chars -> 2 tok
+        {"type": "text", "text": "abcdefghijklmnop"},   # 16 chars -> 4 tok
+    ]
+    msg = HumanMessage(content=parts)
+    n = sum(c.count_text(p["text"]) for p in parts)
+    # Exactly N — no +4 prelude.
+    assert c.count_message(msg) == n, (
+        f"HeuristicCounter.count_message should be content-only; got "
+        f"{c.count_message(msg)} vs expected {n}. If the diff is 4, the "
+        "per-message prelude snuck back in — move it to ModelBudget."
+    )
+
+
+def test_tiktoken_count_message_is_content_only() -> None:
+    pytest.importorskip("tiktoken")
+    c = TiktokenCounter("gpt-4o")
+    parts = [
+        {"type": "text", "text": "The quick brown fox"},
+        {"type": "text", "text": "jumps over the lazy dog."},
+        {"type": "text", "text": "Sphinx of black quartz, judge my vow."},
+    ]
+    msg = HumanMessage(content=parts)
+    n = sum(c.count_text(p["text"]) for p in parts)
+    assert c.count_message(msg) == n, (
+        f"TiktokenCounter.count_message should be content-only; got "
+        f"{c.count_message(msg)} vs expected {n}. If the diff is 4, the "
+        "per-message prelude snuck back in — move it to ModelBudget."
+    )
+
+
+def test_per_message_overhead_lives_on_budget_not_counter() -> None:
+    """Regression: separate the two halves of the token ledger.
+
+    Budget owns per-message framing; counters own payload. Any future
+    refactor that re-adds a prelude term inside :meth:`count_message`
+    will fail here.
+    """
+    budget = ModelBudget(
+        context_window=100_000,
+        output_reserve=1000,
+        system_overhead=500,
+        per_message_overhead=4,
+    )
+    # The budget ceiling shrinks by exactly per_message_overhead * n
+    # messages — the counter never participates in that subtraction.
+    assert budget.effective_budget_for_messages(10) == budget.input_budget - 40
+
+    # Counters return precisely _sum_content_tokens(msg.content, ...).
+    msg = HumanMessage(
+        content=[
+            {"type": "text", "text": "hello"},
+            {"type": "text", "text": "world"},
+            {"type": "image_url", "image_url": {"url": "x", "detail": "low"}},
+        ]
+    )
+    counter = HeuristicCounter()
+    assert counter.count_message(msg) == _sum_content_tokens(
+        msg.content, counter.count_text
+    )
+
+    tiktoken = pytest.importorskip("tiktoken")  # noqa: F841
+    tk_counter = TiktokenCounter("gpt-4o")
+    assert tk_counter.count_message(msg) == _sum_content_tokens(
+        msg.content, tk_counter.count_text
+    )

--- a/dimos/agents/memory/tokens.py
+++ b/dimos/agents/memory/tokens.py
@@ -1,0 +1,204 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Token counting primitives used by the memory package.
+
+Two concrete counters are shipped:
+
+* :class:`TiktokenCounter` — accurate for OpenAI models, uses ``tiktoken``.
+* :class:`HeuristicCounter` — model-agnostic fallback that estimates four
+  characters per token and adds a fixed per-image cost.
+
+Both implement the structural :class:`TokenCounter` protocol that the rest
+of the package depends on. Multimodal content parts (``image_url``) are
+priced with a constant because tiktoken cannot tokenize images.
+
+**Contract boundary with** :class:`~dimos.agents.memory.budget.ModelBudget`.
+:meth:`TokenCounter.count_message` returns **content tokens only**. The
+per-message ChatML prelude (``<|im_start|>role\\n…<|im_end|>``, commonly
+modelled as ~4 tokens/message) is owned exclusively by
+:meth:`ModelBudget.effective_budget_for_messages`, which subtracts
+``per_message_overhead * n_messages`` from the assembly ceiling. Splitting
+the two sides of the ledger prevents double-counting: counters measure
+payload, budgets reserve framing. If you find yourself tempted to re-add
+a "+ prelude" term inside a counter, the fix belongs in ``ModelBudget``
+instead.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from langchain_core.messages.base import BaseMessage
+
+__all__ = [
+    "HeuristicCounter",
+    "TiktokenCounter",
+    "TokenCounter",
+    "count_image_part",
+]
+
+# --- image token pricing ------------------------------------------------
+#
+# OpenAI prices image inputs based on detail level. The published "low
+# detail" per-image cost is 85 tokens; "high detail" is 85 + 170 * tiles,
+# which for a single 512x512 tile works out to around 1105 tokens. We use
+# those two constants as our image cost lookup; they are intentionally
+# conservative because we would rather over-estimate budget usage than
+# blow past the context window.
+
+IMAGE_FULL_COST = 1105
+"""Tokens charged for a full-fidelity image part."""
+
+IMAGE_THUMB_COST = 85
+"""Tokens charged for a thumbnail-fidelity image part (low-detail OpenAI pricing)."""
+
+
+@runtime_checkable
+class TokenCounter(Protocol):
+    """Structural protocol for token counting backends.
+
+    Implementations must be cheap to call (``O(len(text))`` at worst) —
+    :mod:`selector` calls them in tight loops when greedily upgrading page
+    fidelity.
+    """
+
+    def count_message(self, msg: BaseMessage) -> int:
+        """Return the content-token cost of a LangChain message.
+
+        **Returns content tokens only.** The per-message ChatML prelude
+        overhead is accounted for in
+        :meth:`~dimos.agents.memory.budget.ModelBudget.effective_budget_for_messages`,
+        not here. Double-counting is prevented by this separation: counters
+        measure payload, budgets reserve framing.
+
+        Concretely, an implementation should return
+        ``_sum_content_tokens(msg.content, self.count_text)`` (or its
+        backend-specific equivalent) with no additive prelude constant.
+        """
+
+    def count_text(self, text: str) -> int:
+        """Return the token cost of a plain string."""
+
+
+# --- helpers ------------------------------------------------------------
+
+
+def count_image_part(part: dict[str, Any]) -> int:
+    """Fixed-cost estimate for one ``image_url`` content part.
+
+    We infer "thumbnail vs full" from the ``detail`` hint when present
+    (``low`` -> :data:`IMAGE_THUMB_COST`) and otherwise assume FULL.
+    Callers that want exact control build representations with an explicit
+    ``token_estimate`` at ingestion time.
+    """
+    detail = part.get("image_url", {}).get("detail")
+    if detail == "low":
+        return IMAGE_THUMB_COST
+    return IMAGE_FULL_COST
+
+
+def _sum_content_tokens(
+    content: Any,
+    text_fn: "callable[[str], int]",  # noqa: UP037 (callable used as forward-ref string)
+) -> int:
+    """Sum tokens across a message ``content`` field.
+
+    ``content`` may be a plain string or a list of LangChain content parts
+    (dicts with a ``type`` discriminator). Unknown parts are treated as
+    text.
+    """
+    if isinstance(content, str):
+        return text_fn(content)
+
+    if not isinstance(content, list):
+        return text_fn(str(content))
+
+    total = 0
+    for part in content:
+        if not isinstance(part, dict):
+            total += text_fn(str(part))
+            continue
+        ptype = part.get("type")
+        if ptype == "text":
+            total += text_fn(str(part.get("text", "")))
+        elif ptype == "image_url" or ptype == "image":
+            total += count_image_part(part)
+        else:
+            # Unknown part — price conservatively as text over the whole
+            # JSON so we never silently under-count.
+            total += text_fn(str(part))
+    return total
+
+
+# --- concrete counters --------------------------------------------------
+
+
+class HeuristicCounter:
+    """Character-length fallback counter.
+
+    Approximates OpenAI's BPE at roughly 4 characters per token for English
+    prose. Fine for budgeting — the selector rounds up anyway — but should
+    not be used to drive billing.
+
+    :meth:`count_message` returns content tokens only; the ChatML prelude
+    is owned by :class:`~dimos.agents.memory.budget.ModelBudget`.
+    """
+
+    CHARS_PER_TOKEN = 4
+
+    def count_text(self, text: str) -> int:
+        if not text:
+            return 0
+        # ceil(len / 4) — any non-empty string costs at least 1 token.
+        return max(1, (len(text) + self.CHARS_PER_TOKEN - 1) // self.CHARS_PER_TOKEN)
+
+    def count_message(self, msg: BaseMessage) -> int:
+        return _sum_content_tokens(msg.content, self.count_text)
+
+
+class TiktokenCounter:
+    """tiktoken-based counter, accurate for OpenAI and many llama models.
+
+    The tiktoken encoding is resolved from the model name; unknown models
+    fall back to ``cl100k_base`` (gpt-4/gpt-3.5 encoding), which is
+    approximately right for modern decoder-only LLMs. Import of tiktoken
+    is lazy so the ``agents`` extra is not a hard dependency of the memory
+    package.
+
+    :meth:`count_message` returns content tokens only; the ChatML prelude
+    is owned by :class:`~dimos.agents.memory.budget.ModelBudget`.
+    """
+
+    def __init__(self, model: str) -> None:
+        import tiktoken
+
+        try:
+            self._encoding = tiktoken.encoding_for_model(model)
+        except KeyError:
+            self._encoding = tiktoken.get_encoding("cl100k_base")
+        self._heuristic_fallback = HeuristicCounter()
+        self.model = model
+
+    def count_text(self, text: str) -> int:
+        if not text:
+            return 0
+        try:
+            return len(self._encoding.encode(text))
+        except Exception:
+            # Some tiktoken paths reject non-UTF strings; fall back.
+            return self._heuristic_fallback.count_text(text)
+
+    def count_message(self, msg: BaseMessage) -> int:
+        return _sum_content_tokens(msg.content, self.count_text)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,7 @@ agents = [
     "bitsandbytes>=0.48.2,<1.0; sys_platform == 'linux'",
     "ollama>=0.6.0",
     "anthropic>=0.19.0",
+    "tiktoken>=0.8.0",
 
     # Audio
     "openai",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'darwin'",
@@ -1732,6 +1732,7 @@ agents = [
     { name = "openai" },
     { name = "openai-whisper" },
     { name = "sounddevice" },
+    { name = "tiktoken" },
 ]
 base = [
     { name = "anthropic" },
@@ -1759,6 +1760,7 @@ base = [
     { name = "sounddevice" },
     { name = "soundfile" },
     { name = "sse-starlette" },
+    { name = "tiktoken" },
     { name = "transformers", extra = ["torch"] },
     { name = "ultralytics" },
     { name = "uvicorn" },
@@ -1962,6 +1964,7 @@ unitree = [
     { name = "sounddevice" },
     { name = "soundfile" },
     { name = "sse-starlette" },
+    { name = "tiktoken" },
     { name = "transformers", extra = ["torch"] },
     { name = "ultralytics" },
     { name = "unitree-webrtc-connect-leshy" },
@@ -2111,6 +2114,7 @@ requires-dist = [
     { name = "terminaltexteffects", specifier = "==0.12.2" },
     { name = "terminaltexteffects", marker = "extra == 'dev'", specifier = "==0.12.2" },
     { name = "textual", specifier = "==3.7.1" },
+    { name = "tiktoken", marker = "extra == 'agents'", specifier = ">=0.8.0" },
     { name = "tiktoken", marker = "extra == 'misc'", specifier = ">=0.8.0" },
     { name = "timm", marker = "extra == 'misc'", specifier = ">=1.0.15" },
     { name = "toolz", specifier = ">=1.1.0" },
@@ -5616,6 +5620,7 @@ resolution-markers = [
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/6c/90d3f532f608a03a13c1d6c16c266ffa3828e8011b1549d3b61db2ad59f5/nvidia_cublas_cu12-12.9.1.4-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:7a950dae01add3b415a5a5cdc4ec818fb5858263e9cca59004bb99fdbbd3a5d6", size = 575006342, upload-time = "2025-06-05T20:04:16.902Z" },
+    { url = "https://files.pythonhosted.org/packages/77/3c/aa88abe01f3be3d1f8f787d1d33dc83e76fec05945f9a28fbb41cfb99cd5/nvidia_cublas_cu12-12.9.1.4-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:453611eb21a7c1f2c2156ed9f3a45b691deda0440ec550860290dc901af5b4c2", size = 581242350, upload-time = "2025-06-05T20:04:51.979Z" },
     { url = "https://files.pythonhosted.org/packages/45/a1/a17fade6567c57452cfc8f967a40d1035bb9301db52f27808167fbb2be2f/nvidia_cublas_cu12-12.9.1.4-py3-none-win_amd64.whl", hash = "sha256:1e5fee10662e6e52bd71dec533fbbd4971bb70a5f24f3bc3793e5c2e9dc640bf", size = 553153899, upload-time = "2025-06-05T20:13:35.556Z" },
 ]
 
@@ -5674,6 +5679,7 @@ resolution-markers = [
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/e0/0279bd94539fda525e0c8538db29b72a5a8495b0c12173113471d28bce78/nvidia_cuda_runtime_cu12-12.9.79-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:83469a846206f2a733db0c42e223589ab62fd2fabac4432d2f8802de4bded0a4", size = 3515012, upload-time = "2025-06-05T20:00:35.519Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/46/a92db19b8309581092a3add7e6fceb4c301a3fd233969856a8cbf042cd3c/nvidia_cuda_runtime_cu12-12.9.79-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:25bba2dfb01d48a9b59ca474a1ac43c6ebf7011f1b0b8cc44f54eb6ac48a96c3", size = 3493179, upload-time = "2025-06-05T20:00:53.735Z" },
     { url = "https://files.pythonhosted.org/packages/59/df/e7c3a360be4f7b93cee39271b792669baeb3846c58a4df6dfcf187a7ffab/nvidia_cuda_runtime_cu12-12.9.79-py3-none-win_amd64.whl", hash = "sha256:8e018af8fa02363876860388bd10ccb89eb9ab8fb0aa749aaf58430a9f7c4891", size = 3591604, upload-time = "2025-06-05T20:11:17.036Z" },
 ]
 
@@ -9930,12 +9936,19 @@ name = "triton"
 version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/ba/b1b04f4b291a3205d95ebd24465de0e5bf010a2df27a4e58a9b5f039d8f2/triton-3.6.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6c723cfb12f6842a0ae94ac307dba7e7a44741d720a40cf0e270ed4a4e3be781", size = 175972180, upload-time = "2026-01-20T16:15:53.664Z" },
     { url = "https://files.pythonhosted.org/packages/8c/f7/f1c9d3424ab199ac53c2da567b859bcddbb9c9e7154805119f8bd95ec36f/triton-3.6.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a6550fae429e0667e397e5de64b332d1e5695b73650ee75a6146e2e902770bea", size = 188105201, upload-time = "2026-01-20T16:00:29.272Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/2c/96f92f3c60387e14cc45aed49487f3486f89ea27106c1b1376913c62abe4/triton-3.6.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:49df5ef37379c0c2b5c0012286f80174fcf0e073e5ade1ca9a86c36814553651", size = 176081190, upload-time = "2026-01-20T16:16:00.523Z" },
     { url = "https://files.pythonhosted.org/packages/e0/12/b05ba554d2c623bffa59922b94b0775673de251f468a9609bc9e45de95e9/triton-3.6.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8e323d608e3a9bfcc2d9efcc90ceefb764a82b99dea12a86d643c72539ad5d3", size = 188214640, upload-time = "2026-01-20T16:00:35.869Z" },
+    { url = "https://files.pythonhosted.org/packages/17/5d/08201db32823bdf77a0e2b9039540080b2e5c23a20706ddba942924ebcd6/triton-3.6.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:374f52c11a711fd062b4bfbb201fd9ac0a5febd28a96fb41b4a0f51dde3157f4", size = 176128243, upload-time = "2026-01-20T16:16:07.857Z" },
     { url = "https://files.pythonhosted.org/packages/ab/a8/cdf8b3e4c98132f965f88c2313a4b493266832ad47fb52f23d14d4f86bb5/triton-3.6.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74caf5e34b66d9f3a429af689c1c7128daba1d8208df60e81106b115c00d6fca", size = 188266850, upload-time = "2026-01-20T16:00:43.041Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/12/34d71b350e89a204c2c7777a9bba0dcf2f19a5bfdd70b57c4dbc5ffd7154/triton-3.6.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:448e02fe6dc898e9e5aa89cf0ee5c371e99df5aa5e8ad976a80b93334f3494fd", size = 176133521, upload-time = "2026-01-20T16:16:13.321Z" },
     { url = "https://files.pythonhosted.org/packages/f9/0b/37d991d8c130ce81a8728ae3c25b6e60935838e9be1b58791f5997b24a54/triton-3.6.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10c7f76c6e72d2ef08df639e3d0d30729112f47a56b0c81672edc05ee5116ac9", size = 188289450, upload-time = "2026-01-20T16:00:49.136Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/4e/41b0c8033b503fd3cfcd12392cdd256945026a91ff02452bef40ec34bee7/triton-3.6.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1722e172d34e32abc3eb7711d0025bb69d7959ebea84e3b7f7a341cd7ed694d6", size = 176276087, upload-time = "2026-01-20T16:16:18.989Z" },
     { url = "https://files.pythonhosted.org/packages/35/f8/9c66bfc55361ec6d0e4040a0337fb5924ceb23de4648b8a81ae9d33b2b38/triton-3.6.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d002e07d7180fd65e622134fbd980c9a3d4211fb85224b56a0a0efbd422ab72f", size = 188400296, upload-time = "2026-01-20T16:00:56.042Z" },
+    { url = "https://files.pythonhosted.org/packages/49/55/5ecf0dcaa0f2fbbd4420f7ef227ee3cb172e91e5fede9d0ecaddc43363b4/triton-3.6.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef5523241e7d1abca00f1d240949eebdd7c673b005edbbce0aca95b8191f1d43", size = 176138577, upload-time = "2026-01-20T16:16:25.426Z" },
     { url = "https://files.pythonhosted.org/packages/df/3d/9e7eee57b37c80cec63322c0231bb6da3cfe535a91d7a4d64896fcb89357/triton-3.6.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a17a5d5985f0ac494ed8a8e54568f092f7057ef60e1b0fa09d3fd1512064e803", size = 188273063, upload-time = "2026-01-20T16:01:07.278Z" },
+    { url = "https://files.pythonhosted.org/packages/48/db/56ee649cab5eaff4757541325aca81f52d02d4a7cd3506776cad2451e060/triton-3.6.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b3a97e8ed304dfa9bd23bb41ca04cdf6b2e617d5e782a8653d616037a5d537d", size = 176274804, upload-time = "2026-01-20T16:16:31.528Z" },
     { url = "https://files.pythonhosted.org/packages/f6/56/6113c23ff46c00aae423333eb58b3e60bdfe9179d542781955a5e1514cb3/triton-3.6.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:46bd1c1af4b6704e554cad2eeb3b0a6513a980d470ccfa63189737340c7746a7", size = 188397994, upload-time = "2026-01-20T16:01:14.236Z" },
 ]
 


### PR DESCRIPTION
## TL;DR

Replaces the unbounded `list[BaseMessage]` history in `McpClient` with a
paged, multi-fidelity memory layer that keeps the assembled prompt inside
the active model's context window. The worker thread also recovers from
turn-level exceptions instead of dying silently, which was the original
user-visible symptom (messages piling up in the queue with `agent_idle`
stuck at `False`).

Closes #1899.

## Before / after

**Before:** every `BaseMessage` the agent saw was appended to `self._history`
and replayed in full on every turn. As the conversation grew — especially
with image artefacts — the request eventually exceeded the model's context
window. OpenAI returned `context_length_exceeded`, the exception bubbled
out of `_process_message`, the worker thread died, and every subsequent
enqueued message sat unprocessed forever.

**After:** `McpClient` owns a `MemoryEngine` that converts each inbound
message into one or more typed `Page` objects, each storing four fidelity
representations (`POINTER`, `STRUCTURED`, `COMPRESSED`, `FULL`). A
two-phase greedy selector chooses per-page fidelities to fit the active
model's token budget. Recent image artefacts are pinned at `FULL`; older
pages gracefully degrade. The worker thread wraps each turn in
`try/except`, emits a `PHYSICAL_INSUFFICIENCY` fault, and keeps draining
the queue.

## Usage

Existing callers get the new behaviour automatically with sensible defaults
(full model window, 3 recent images pinned at FULL, 4096-token output
reserve). Three new optional knobs on `McpClientConfig`:

| field                   | default | purpose                                              |
| ----------------------- | ------- | ---------------------------------------------------- |
| `token_budget`          | `None`  | Override the per-model context window.               |
| `pin_recent_evidence`   | `3`     | Keep the N most recent image artefacts at `FULL`.    |
| `output_reserve_tokens` | `4096`  | Tokens carved out of the window for the response.    |

Plus a new `faults: Out[FaultEvent]` stream on the module for
observability (eviction, fidelity-drop, rehydrate, and
physical-insufficiency events flow through it alongside `structlog`).

## Component walkthrough

Everything new lives under `dimos/agents/memory/`. Each file is a single
responsibility; the public surface is deliberately small.

| file                  | role                                                                                              |
| --------------------- | ------------------------------------------------------------------------------------------------- |
| `pages.py`            | `Page` dataclass, fidelity enum, page-type enum. Invariants enforced in `__post_init__`.          |
| `page_table.py`       | Thread-safe page store. Explicit + auto pins, recency tracking, pin-rebalance diffs.              |
| `tokens.py`           | `TokenCounter` protocol + `TiktokenCounter` (OpenAI) and `HeuristicCounter` (fallback).           |
| `budget.py`           | `ModelBudget`: per-model context window, output reserve, per-message overhead.                    |
| `faults.py`           | Structured `FaultEvent` + `FaultObserver` (routes to `structlog` and an optional `Out` stream).   |
| `ingestion.py`        | `ingest_message`: turns a `BaseMessage` into `list[Page]`, with multimodal split rules.           |
| `selector.py`         | Two-phase greedy `assemble_prompt` respecting pins and the effective token budget.                |
| `engine.py`           | `MemoryEngine` facade: ingestion + assembly + pin rebalancing + fault emission + rehydration.     |
| `artefact_tool.py`    | `build_get_artefact_tool`: LLM-callable rehydration of a degraded `EVIDENCE` page back to `FULL`. |

Integration is a single-file change in `dimos/agents/mcp/mcp_client.py`:
replace `self._history` with `self._engine`, feed `state_graph.stream` from
`engine.assemble()`, add the `get_artefact` tool to the agent's tool list,
and wrap `_process_message` in `try/except` inside `_thread_loop`.

## Testing

170 tests ship with this PR (all green):

- **168 unit tests** in `dimos/agents/memory/test_*.py` — cover fidelity
  invariants, pin policy, token accounting contracts, budget resolution,
  fault emission, multimodal split rules, selector edge cases, and the
  rehydration path.
- **2 integration tests** in
  `dimos/agents/mcp/test_mcp_client_history_compaction.py`:
  - `test_history_compaction_keeps_recent_images_at_full_under_pressure`
    drives the real `MemoryEngine` from a bypass-constructed `McpClient`
    under an 8k-token budget and verifies the effective-cap,
    recent-image-pinning, and fault-emission contracts.
  - `test_thread_loop_recovers_from_process_message_exception` is the
    regression guard for the motivating bug: makes the second of three
    turns raise and verifies all three are processed, a
    `PHYSICAL_INSUFFICIENCY` fault is emitted, and the worker exits
    cleanly.

Run them with:

~~~bash
uv run pytest dimos/agents/memory/ \
              dimos/agents/mcp/test_mcp_client_history_compaction.py
~~~

## Not included in this PR

- **Agent class:** the older `dimos.agents.agent.Agent` was removed
  upstream before this work landed. Only `McpClient` is wired up.
- **End-to-end LLM tests:** no real API calls in the test suite. The
  integration tests bypass-construct `McpClient` and drive the engine
  directly, which is fast and deterministic but does not exercise the
  full request round-trip.
- **Dynamic model window discovery:** the `ModelBudget` table is hardcoded
  for current OpenAI/Anthropic/Gemini/Ollama model names (with
  longest-prefix matching). Add new entries in `budget.py` as models ship.

## Reviewer test plan

- [ ] Read `dimos/agents/memory/engine.py` and
      `dimos/agents/memory/selector.py` — these are the two most
      architecturally load-bearing files.
- [ ] Skim `dimos/agents/memory/ingestion.py` multimodal split rules
      (the `ingest_message` docstring lists the full matrix).
- [ ] Verify the new `McpClientConfig` knobs are optional and
      default-equivalent to the old full-history behaviour for small
      conversations.
- [ ] Run the two integration tests locally to confirm thread recovery.
- [ ] Smoke-test your preferred blueprint (e.g. `unitree-go2-agentic`)
      against a long conversation with image artefacts to watch the
      fault stream in action.

## Files changed

- `dimos/agents/memory/` — 10 production files + 9 unit test files (new)
- `dimos/agents/mcp/mcp_client.py` — modified
- `dimos/agents/mcp/test_mcp_client_history_compaction.py` — new
- `AGENTS.md` — new `Context Memory` subsection
- `pyproject.toml` — `tiktoken>=0.8.0` added to the `agents` extra
- `uv.lock` — lockfile update for `tiktoken`

Total: 24 files, ~6.3k insertions / ~18 deletions across 4 commits.

## Contributor License Agreement

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).

Made with [Cursor](https://cursor.com)