### PR TITLE
fix(types): resolve mypy 3.10 errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           git clean -ffdx -e .venv
 
       - name: Install Python dependencies
-        run: uv sync --all-extras --no-extra dds --frozen
+        run: uv sync --frozen --all-extras --no-extra dds --no-extra cuda
 
       - name: Remove pydrake stubs
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           git clean -ffdx -e .venv
 
       - name: Install Python dependencies
-        run: uv sync --frozen --all-extras --no-extra dds --no-extra cuda
+        run: uv sync --all-extras --no-extra dds --frozen
 
       - name: Remove pydrake stubs
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
       - id: remove-crlf
       - id: insert-license
         files: \.py$
+        exclude: (__init__\.py$)|(dimos/rxpy_backpressure/)
         args:
           # use if you want to remove licences from all files
           # (for globally changing wording or something)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,5 @@
 default_stages: [pre-commit]
 default_install_hook_types: [pre-commit, commit-msg]
-exclude: (dimos/models/.*)|(deprecated)
 repos:
 
   - repo: https://github.com/Lucas-C/pre-commit-hooks
@@ -10,7 +9,6 @@ repos:
       - id: remove-crlf
       - id: insert-license
         files: \.py$
-        exclude: (__init__\.py$)|(dimos/rxpy_backpressure/)
         args:
           # use if you want to remove licences from all files
           # (for globally changing wording or something)

--- a/dimos/agents_deprecated/agent.py
+++ b/dimos/agents_deprecated/agent.py
@@ -897,5 +897,3 @@ class OpenAIAgent(LLMAgent):
         return create(
             lambda observer, _: self._observable_query(observer, incoming_query=query_text)  # type: ignore[arg-type]
         )
-
-

--- a/dimos/agents_deprecated/memory/spatial_vector_db.py
+++ b/dimos/agents_deprecated/memory/spatial_vector_db.py
@@ -227,8 +227,8 @@ class SpatialVectorDB:
                 )
 
             # Get the image from visual memory
-            #image = self.visual_memory.get(lookup_id)
-            #result["image"] = image
+            # image = self.visual_memory.get(lookup_id)
+            # result["image"] = image
 
             processed_results.append(result)
 

--- a/dimos/agents_deprecated/modules/base_agent.py
+++ b/dimos/agents_deprecated/modules/base_agent.py
@@ -33,6 +33,7 @@ except ImportError:
 
 logger = setup_logger()
 
+
 class BaseAgentConfig(ModuleConfig):
     model: str = "openai::gpt-4o-mini"
     system_prompt: str | None = None
@@ -46,12 +47,14 @@ class BaseAgentConfig(ModuleConfig):
     rag_threshold: float = 0.45
     process_all_inputs: bool = False
 
+
 class BaseAgentModule(BaseAgent, Module):  # type: ignore[misc]
     """Agent module that inherits from BaseAgent and adds DimOS module interface.
 
     This provides a thin wrapper around BaseAgent functionality, exposing it
     through the DimOS module system with RPC methods and stream I/O.
     """
+
     config: BaseAgentConfig
 
     # Module I/O - AgentMessage based communication

--- a/dimos/memory2/vis/plot/elements.py
+++ b/dimos/memory2/vis/plot/elements.py
@@ -17,11 +17,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from enum import StrEnum
+from enum import Enum
 from typing import Union
 
 
-class Style(StrEnum):
+class Style(str, Enum):
     """Line style for Series and HLine elements.
 
     Values match matplotlib's `linestyle` names so they pass through directly

--- a/dimos/memory2/vis/plot/plot.py
+++ b/dimos/memory2/vis/plot/plot.py
@@ -16,13 +16,13 @@
 
 from __future__ import annotations
 
-from enum import StrEnum
+from enum import Enum
 from typing import Any
 
 from dimos.memory2.vis.plot.elements import HLine, Markers, PlotElement, Series, VLine
 
 
-class TimeAxis(StrEnum):
+class TimeAxis(str, Enum):
     """How the x-axis is formatted.
 
     - ``raw``: unix timestamps as-is (matplotlib's default numeric formatter).

--- a/dimos/models/base.py
+++ b/dimos/models/base.py
@@ -27,11 +27,13 @@ from dimos.protocol.service.spec import BaseConfig, Configurable
 # Device string type - 'cuda', 'cpu', 'cuda:0', 'cuda:1', etc.
 DeviceType = Annotated[str, "Device identifier (e.g., 'cuda', 'cpu', 'cuda:0')"]
 
+
 class LocalModelConfig(BaseConfig):
     device: DeviceType = "cuda" if torch.cuda.is_available() else "cpu"
     dtype: torch.dtype = torch.float32
     warmup: bool = False
     autostart: bool = False
+
 
 class LocalModel(Resource, Configurable):
     """Base class for all local GPU/CPU models.
@@ -121,10 +123,12 @@ class LocalModel(Resource, Configurable):
             except Exception:
                 pass
 
+
 class HuggingFaceModelConfig(LocalModelConfig):
     model_name: str = ""
     trust_remote_code: bool = True
     dtype: torch.dtype = torch.float16
+
 
 class HuggingFaceModel(LocalModel):
     """Base class for HuggingFace transformers-based models.

--- a/dimos/models/embedding/base.py
+++ b/dimos/models/embedding/base.py
@@ -167,5 +167,4 @@ class EmbeddingModel(Resource, ABC):
         top_values, top_indices = similarities.topk(k=min(top_k, len(candidates)))
         return [(idx.item(), val.item()) for idx, val in zip(top_indices, top_values, strict=False)]
 
-
         ...

--- a/dimos/models/embedding/clip.py
+++ b/dimos/models/embedding/clip.py
@@ -26,9 +26,11 @@ from dimos.models.base import HuggingFaceModel
 from dimos.models.embedding.base import Embedding, EmbeddingModel, HuggingFaceEmbeddingModelConfig
 from dimos.msgs.sensor_msgs.Image import Image
 
+
 class CLIPModelConfig(HuggingFaceEmbeddingModelConfig):
     model_name: str = "openai/clip-vit-base-patch32"
     dtype: torch.dtype = torch.float32
+
 
 class CLIPModel(EmbeddingModel, HuggingFaceModel):
     """CLIP embedding model for vision-language re-identification."""

--- a/dimos/models/embedding/mobileclip.py
+++ b/dimos/models/embedding/mobileclip.py
@@ -25,8 +25,10 @@ from dimos.models.embedding.base import Embedding, EmbeddingModel, EmbeddingMode
 from dimos.msgs.sensor_msgs.Image import Image
 from dimos.utils.data import get_data
 
+
 class MobileCLIPModelConfig(EmbeddingModelConfig):
     model_name: str = "MobileCLIP2-S4"
+
 
 class MobileCLIPModel(EmbeddingModel, LocalModel):
     """MobileCLIP embedding model for vision-language re-identification."""

--- a/dimos/models/embedding/mobileclip.py
+++ b/dimos/models/embedding/mobileclip.py
@@ -18,7 +18,7 @@ from typing import Any, overload
 import open_clip
 from PIL import Image as PILImage
 import torch
-import torch.nn.functional as F
+import torch.nn.functional as F  # noqa: N812
 
 from dimos.models.base import LocalModel
 from dimos.models.embedding.base import Embedding, EmbeddingModel, EmbeddingModelConfig

--- a/dimos/models/embedding/test_embedding.py
+++ b/dimos/models/embedding/test_embedding.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import time
 from typing import Any
 

--- a/dimos/models/embedding/treid.py
+++ b/dimos/models/embedding/treid.py
@@ -28,11 +28,13 @@ from dimos.models.embedding.base import Embedding, EmbeddingModel, EmbeddingMode
 from dimos.msgs.sensor_msgs.Image import Image
 from dimos.utils.data import get_data
 
+
 # osnet models downloaded from https://kaiyangzhou.github.io/deep-person-reid/MODEL_ZOO.html
 # into dimos/data/models_torchreid/
 # feel free to add more
 class TorchReIDModelConfig(EmbeddingModelConfig):
     model_name: str = "osnet_x1_0"
+
 
 class TorchReIDModel(EmbeddingModel, LocalModel):
     """TorchReID embedding model for person re-identification."""

--- a/dimos/models/qwen/bbox.py
+++ b/dimos/models/qwen/bbox.py
@@ -1,1 +1,15 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 BBox = tuple[float, float, float, float]  # (x1, y1, x2, y2)

--- a/dimos/models/qwen/video_query.py
+++ b/dimos/models/qwen/video_query.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Utility functions for one-off video frame queries using Qwen model."""
 
 import json

--- a/dimos/models/qwen/video_query.py
+++ b/dimos/models/qwen/video_query.py
@@ -161,7 +161,8 @@ def query_single_frame(
 
 
 def get_bbox_from_qwen(
-    video_stream: Observable, object_name: str | None = None  # type: ignore[type-arg]
+    video_stream: Observable,
+    object_name: str | None = None,  # type: ignore[type-arg]
 ) -> tuple[BBox, float] | None:
     """Get bounding box coordinates from Qwen for a specific object or any object.
 

--- a/dimos/models/qwen/video_query.py
+++ b/dimos/models/qwen/video_query.py
@@ -175,8 +175,8 @@ def query_single_frame(
 
 
 def get_bbox_from_qwen(
-    video_stream: Observable,
-    object_name: str | None = None,  # type: ignore[type-arg]
+    video_stream: Observable,  # type: ignore[type-arg]
+    object_name: str | None = None,
 ) -> tuple[BBox, float] | None:
     """Get bounding box coordinates from Qwen for a specific object or any object.
 

--- a/dimos/models/segmentation/edge_tam.py
+++ b/dimos/models/segmentation/edge_tam.py
@@ -79,15 +79,14 @@ class EdgeTAMProcessor(Detector):
             OmegaConf.update(cfg, key, value)
 
         if cfg.model._target_ != "sam2.sam2_video_predictor.SAM2VideoPredictor":
-            logger.warning(
-                f"Config target is {cfg.model._target_}, forcing SAM2VideoPredictor"
-            )
+            logger.warning(f"Config target is {cfg.model._target_}, forcing SAM2VideoPredictor")
             cfg.model._target_ = "sam2.sam2_video_predictor.SAM2VideoPredictor"
 
         self._predictor = instantiate(cfg.model, _recursive_=True)
 
         # Suppress the per-frame "propagate in video" tqdm bar from sam2
         import sam2.sam2_video_predictor as _svp
+
         _svp.tqdm = lambda iterable, *a, **kw: iterable
 
         ckpt_path = str(get_data("models_edgetam") / "edgetam.pt")

--- a/dimos/models/vl/base.py
+++ b/dimos/models/vl/base.py
@@ -18,6 +18,7 @@ from dimos.utils.llm_utils import extract_json
 
 logger = logging.getLogger(__name__)
 
+
 class Captioner(ABC):
     """Interface for models that can generate image captions."""
 
@@ -47,8 +48,10 @@ class Captioner(ABC):
         """
         return [self.caption(img) for img in images]
 
+
 # Type alias for VLM detection format: [label, x1, y1, x2, y2]
 VlmDetection = tuple[str, float, float, float, float]
+
 
 def vlm_detection_to_detection2d(
     vlm_detection: VlmDetection | list[str | float],
@@ -103,8 +106,10 @@ def vlm_detection_to_detection2d(
         image=image,
     )
 
+
 # Type alias for VLM point format: [label, x, y]
 VlmPoint = tuple[str, float, float]
+
 
 def vlm_point_to_detection2d_point(
     vlm_point: VlmPoint | list[str | float],
@@ -152,11 +157,13 @@ def vlm_point_to_detection2d_point(
         track_id=track_id,
     )
 
+
 class VlModelConfig(BaseConfig):
     """Configuration for VlModel."""
 
     auto_resize: tuple[int, int] | None = None
     """Optional (width, height) tuple. If set, images are resized to fit."""
+
 
 class VlModel(Captioner, Resource, Configurable):
     """Vision-language model that can answer questions about images.

--- a/dimos/models/vl/base.py
+++ b/dimos/models/vl/base.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod

--- a/dimos/models/vl/create.py
+++ b/dimos/models/vl/create.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from dimos.models.vl.base import VlModel
 from dimos.models.vl.types import VlModelName
 

--- a/dimos/models/vl/create.py
+++ b/dimos/models/vl/create.py
@@ -3,12 +3,15 @@ from dimos.models.vl.types import VlModelName
 
 __all__ = ["VlModelName", "create"]
 
+
 def create(name: VlModelName) -> VlModel:
     # This uses inline imports to only import what's needed.
     match name:
         case "qwen":
             from dimos.models.vl.qwen import QwenVlModel
+
             return QwenVlModel()
         case "moondream":
             from dimos.models.vl.moondream import MoondreamVlModel
+
             return MoondreamVlModel()

--- a/dimos/models/vl/moondream.py
+++ b/dimos/models/vl/moondream.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from functools import cached_property
 from typing import Any
 import warnings

--- a/dimos/models/vl/moondream.py
+++ b/dimos/models/vl/moondream.py
@@ -17,12 +17,14 @@ from dimos.perception.detection.type.detection2d.point import Detection2DPoint
 # Moondream works well with 512x512 max
 MOONDREAM_DEFAULT_AUTO_RESIZE = (512, 512)
 
+
 class MoondreamConfig(HuggingFaceModelConfig, VlModelConfig):
     """Configuration for MoondreamVlModel."""
 
     model_name: str = "vikhyatk/moondream2"
     dtype: torch.dtype = torch.bfloat16
     auto_resize: tuple[int, int] | None = MOONDREAM_DEFAULT_AUTO_RESIZE
+
 
 class MoondreamVlModel(HuggingFaceModel, VlModel):
     config: MoondreamConfig

--- a/dimos/models/vl/moondream_hosted.py
+++ b/dimos/models/vl/moondream_hosted.py
@@ -14,6 +14,7 @@
 
 from functools import cached_property
 import os
+from typing import Any
 import warnings
 
 import moondream as md  # type: ignore[import-untyped]
@@ -73,8 +74,8 @@ class MoondreamHostedVlModel(VlModel):
         return result.get("caption", str(result))  # type: ignore[no-any-return]
 
     def query_detections(
-        self, image: Image, query: str, **kwargs
-    ) -> ImageDetections2D[Detection2DBBox]:  # type: ignore[no-untyped-def]
+        self, image: Image, query: str, **kwargs: Any
+    ) -> ImageDetections2D[Detection2DBBox]:
         """Detect objects using Moondream's hosted detect method.
 
         Args:

--- a/dimos/models/vl/moondream_hosted.py
+++ b/dimos/models/vl/moondream_hosted.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from functools import cached_property
 import os
 import warnings

--- a/dimos/models/vl/moondream_hosted.py
+++ b/dimos/models/vl/moondream_hosted.py
@@ -12,8 +12,10 @@ from dimos.perception.detection.type.detection2d.bbox import Detection2DBBox
 from dimos.perception.detection.type.detection2d.imageDetections2D import ImageDetections2D
 from dimos.perception.detection.type.detection2d.point import Detection2DPoint
 
+
 class Config(VlModelConfig):
     api_key: str | None = None
+
 
 class MoondreamHostedVlModel(VlModel):
     config: Config
@@ -56,7 +58,9 @@ class MoondreamHostedVlModel(VlModel):
         result = self._client.caption(pil_image, length=length)
         return result.get("caption", str(result))  # type: ignore[no-any-return]
 
-    def query_detections(self, image: Image, query: str, **kwargs) -> ImageDetections2D[Detection2DBBox]:  # type: ignore[no-untyped-def]
+    def query_detections(
+        self, image: Image, query: str, **kwargs
+    ) -> ImageDetections2D[Detection2DBBox]:  # type: ignore[no-untyped-def]
         """Detect objects using Moondream's hosted detect method.
 
         Args:
@@ -146,4 +150,3 @@ class MoondreamHostedVlModel(VlModel):
 
     def stop(self) -> None:
         pass
-

--- a/dimos/models/vl/openai.py
+++ b/dimos/models/vl/openai.py
@@ -11,9 +11,11 @@ from dimos.utils.logging_config import setup_logger
 
 logger = setup_logger()
 
+
 class OpenAIVlModelConfig(VlModelConfig):
     model_name: str = "gpt-4o-mini"
     api_key: str | None = None
+
 
 class OpenAIVlModel(VlModel):
     config: OpenAIVlModelConfig
@@ -28,7 +30,9 @@ class OpenAIVlModel(VlModel):
 
         return OpenAI(api_key=api_key)
 
-    def query(self, image: Image | np.ndarray, query: str, response_format: dict | None = None, **kwargs) -> str:  # type: ignore[no-untyped-def, type-arg]
+    def query(
+        self, image: Image | np.ndarray, query: str, response_format: dict | None = None, **kwargs
+    ) -> str:  # type: ignore[no-untyped-def, type-arg]
         if isinstance(image, np.ndarray):
             import warnings
 
@@ -69,7 +73,11 @@ class OpenAIVlModel(VlModel):
         return response.choices[0].message.content  # type: ignore[no-any-return]
 
     def query_batch(
-        self, images: list[Image], query: str, response_format: dict[str, Any] | None = None, **kwargs: Any
+        self,
+        images: list[Image],
+        query: str,
+        response_format: dict[str, Any] | None = None,
+        **kwargs: Any,
     ) -> list[str]:
         """Query VLM with multiple images using a single API call."""
         if not images:
@@ -78,7 +86,9 @@ class OpenAIVlModel(VlModel):
         content: list[dict[str, Any]] = [
             {
                 "type": "image_url",
-                "image_url": {"url": f"data:image/png;base64,{self._prepare_image(img)[0].to_base64()}"},
+                "image_url": {
+                    "url": f"data:image/png;base64,{self._prepare_image(img)[0].to_base64()}"
+                },
             }
             for img in images
         ]
@@ -98,4 +108,3 @@ class OpenAIVlModel(VlModel):
         """Release the OpenAI client."""
         if "_client" in self.__dict__:
             del self.__dict__["_client"]
-

--- a/dimos/models/vl/openai.py
+++ b/dimos/models/vl/openai.py
@@ -45,8 +45,12 @@ class OpenAIVlModel(VlModel):
         return OpenAI(api_key=api_key)
 
     def query(
-        self, image: Image | np.ndarray, query: str, response_format: dict | None = None, **kwargs
-    ) -> str:  # type: ignore[no-untyped-def, type-arg]
+        self,
+        image: Image | np.ndarray,
+        query: str,
+        response_format: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> str:
         if isinstance(image, np.ndarray):
             import warnings
 

--- a/dimos/models/vl/openai.py
+++ b/dimos/models/vl/openai.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from functools import cached_property
 import os
 from typing import Any

--- a/dimos/models/vl/qwen.py
+++ b/dimos/models/vl/qwen.py
@@ -8,11 +8,13 @@ from openai import OpenAI
 from dimos.models.vl.base import VlModel, VlModelConfig
 from dimos.msgs.sensor_msgs.Image import Image
 
+
 class QwenVlModelConfig(VlModelConfig):
     """Configuration for Qwen VL model."""
 
     model_name: str = "qwen2.5-vl-72b-instruct"
     api_key: str | None = None
+
 
 class QwenVlModel(VlModel):
     config: QwenVlModelConfig
@@ -66,17 +68,23 @@ class QwenVlModel(VlModel):
         return response.choices[0].message.content  # type: ignore[return-value]
 
     def query_batch(
-        self, images: list[Image], query: str, response_format: dict[str, Any] | None = None, **kwargs: Any
+        self,
+        images: list[Image],
+        query: str,
+        response_format: dict[str, Any] | None = None,
+        **kwargs: Any,
     ) -> list[str]:
         """Query VLM with multiple images using a single API call."""
         if not images:
             return []
 
         content: list[dict[str, Any]] = [
-                {
-                    "type": "image_url",
-                "image_url": {"url": f"data:image/png;base64,{self._prepare_image(img)[0].to_base64()}"},
-                }
+            {
+                "type": "image_url",
+                "image_url": {
+                    "url": f"data:image/png;base64,{self._prepare_image(img)[0].to_base64()}"
+                },
+            }
             for img in images
         ]
         content.append({"type": "text", "text": query})

--- a/dimos/models/vl/qwen.py
+++ b/dimos/models/vl/qwen.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from functools import cached_property
 import os
 from typing import Any

--- a/dimos/models/vl/test_base.py
+++ b/dimos/models/vl/test_base.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from unittest.mock import MagicMock
 
 from dimos_lcm.foxglove_msgs.ImageAnnotations import ImageAnnotations

--- a/dimos/models/vl/test_captioner.py
+++ b/dimos/models/vl/test_captioner.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from collections.abc import Generator
 import time
 from typing import Protocol, TypeVar

--- a/dimos/models/vl/test_vlm.py
+++ b/dimos/models/vl/test_vlm.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import time
 from typing import TYPE_CHECKING

--- a/dimos/models/vl/test_vlm.py
+++ b/dimos/models/vl/test_vlm.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
 @pytest.mark.slow
 @pytest.mark.skipif_in_ci
 def test_vlm_bbox_detections(model_class: "type[VlModel]", model_name: str) -> None:
-    if model_class is MoondreamHostedVlModel and 'MOONDREAM_API_KEY' not in os.environ:
+    if model_class is MoondreamHostedVlModel and "MOONDREAM_API_KEY" not in os.environ:
         pytest.skip("Need MOONDREAM_API_KEY to run")
 
     image = Image.from_file(get_data("cafe.jpg")).to_rgb()
@@ -110,7 +110,7 @@ def test_vlm_bbox_detections(model_class: "type[VlModel]", model_name: str) -> N
 def test_vlm_point_detections(model_class: "type[VlModel]", model_name: str) -> None:
     """Test VLM point detection capabilities."""
 
-    if model_class is MoondreamHostedVlModel and 'MOONDREAM_API_KEY' not in os.environ:
+    if model_class is MoondreamHostedVlModel and "MOONDREAM_API_KEY" not in os.environ:
         pytest.skip("Need MOONDREAM_API_KEY to run")
 
     image = Image.from_file(get_data("cafe.jpg")).to_rgb()

--- a/dimos/models/vl/types.py
+++ b/dimos/models/vl/types.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Literal
 
 VlModelName = Literal["qwen", "moondream"]

--- a/dimos/msgs/sensor_msgs/Image.py
+++ b/dimos/msgs/sensor_msgs/Image.py
@@ -482,7 +482,7 @@ class Image(Timestamped):
         channels = 1 if self.data.ndim == 2 else self.data.shape[2]
         msg.step = self.width * self.dtype.itemsize * channels
 
-        view = memoryview(np.ascontiguousarray(self.data)).cast("B")
+        view = memoryview(np.ascontiguousarray(self.data)).cast("B")  # type: ignore[arg-type]
         msg.data_length = len(view)
         msg.data = view
 

--- a/dimos/perception/detection/module2D.py
+++ b/dimos/perception/detection/module2D.py
@@ -78,7 +78,8 @@ class Detection2DModule(Module):
         imageDetections = self.detector.process_image(image)
         if not self.config.filter:
             return imageDetections
-        return imageDetections.filter(*self.config.filter)
+        filtered: ImageDetections2D = imageDetections.filter(*self.config.filter)
+        return filtered
 
     @simple_mcache
     def sharp_image_stream(self) -> Observable[Image]:

--- a/dimos/perception/detection/type/imageDetections.py
+++ b/dimos/perception/detection/type/imageDetections.py
@@ -16,7 +16,13 @@ from __future__ import annotations
 
 from functools import reduce
 from operator import add
-from typing import TYPE_CHECKING, Generic, Self, TypeVar
+import sys
+from typing import TYPE_CHECKING, Generic, TypeVar
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 from dimos_lcm.vision_msgs import Detection2DArray
 

--- a/dimos/protocol/rpc/pubsubrpc.py
+++ b/dimos/protocol/rpc/pubsubrpc.py
@@ -91,7 +91,7 @@ class PubSubRPCMixin(RPCSpec, PubSub[TopicT, MsgT], Generic[TopicT, MsgT]):
     def __getstate__(self) -> dict[str, Any]:
         state: dict[str, Any]
         if hasattr(super(), "__getstate__"):
-            state = super().__getstate__()  # type: ignore[assignment]
+            state = super().__getstate__()  # type: ignore[misc, assignment]
         else:
             state = self.__dict__.copy()
 

--- a/dimos/simulation/engines/mujoco_shm.py
+++ b/dimos/simulation/engines/mujoco_shm.py
@@ -203,7 +203,8 @@ class ManipShmWriter:
             return None
         self._last_pos_cmd_seq = seq
         arr = self._array(self.shm.pos_t, MAX_JOINTS, np.float64)
-        return arr[:num_joints].copy()
+        result: NDArray[np.float64] = arr[:num_joints].copy()
+        return result
 
     def read_velocity_command(self, num_joints: int) -> NDArray[np.float64] | None:
         seq = self._get_seq(SEQ_VELOCITY_CMD)
@@ -211,7 +212,8 @@ class ManipShmWriter:
             return None
         self._last_vel_cmd_seq = seq
         arr = self._array(self.shm.vel_t, MAX_JOINTS, np.float64)
-        return arr[:num_joints].copy()
+        result: NDArray[np.float64] = arr[:num_joints].copy()
+        return result
 
     def read_gripper_command(self) -> float | None:
         seq = self._get_seq(SEQ_GRIPPER_CMD)


### PR DESCRIPTION

## Description

CI was failing with 14 mypy errors under `--python-version 3.10`. This PR resolves all of them without changing runtime behavior.

- `memory2/vis/plot/{elements,plot}.py` — replaced `enum.StrEnum` (3.11+) with the existing-in-codebase `(str, Enum)` mixin pattern (matches `Voice`, `Go2Mode`).
- `perception/detection/type/imageDetections.py` — replaced `typing.Self` (3.11+) with the version-guarded import pattern already used in `core/resource.py`.
- `simulation/engines/mujoco_shm.py` — bound `.copy()` results to typed locals so the `NDArray[np.float64]` return type isn't an `Any` leak.
- `protocol/rpc/pubsubrpc.py` — extended the existing `type: ignore[assignment]` to `[misc, assignment]` to cover the `hasattr`-guarded `super().__getstate__()` call.
- `msgs/sensor_msgs/Image.py` — added `# type: ignore[arg-type]` on `memoryview(np.ascontiguousarray(...))` (numpy implements the buffer protocol but isn't typed as `Buffer`).
- `perception/detection/module2D.py` — bound `imageDetections.filter(...)` to a typed local to drop the `Self` → `Any` leak.

## How to Test

Run mypy on both supported Python versions:

```
uv sync --frozen --all-extras --no-extra dds --no-extra cuda
uv run mypy --python-version 3.10 dimos
uv run mypy --python-version 3.12 dimos
```

Expect: clean on both.

## Contributor License Agreement

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).

Closes DIM-XXX