### PR TITLE
test: add fast unit tests for LFS pointer detection

### DIFF
--- a/.cursor/commands/ship.md
+++ b/.cursor/commands/ship.md
@@ -1,0 +1,178 @@
+# /ship — one-liner request → branch → verify → PR → auto-merge
+
+> Usage: in Cursor chat, type `/ship <one-liner>`. Examples:
+>
+> ```
+> /ship add a --no-window flag to dimos/utils/view_map.py for headless selftest
+> /ship clamp the xArm6 joint velocities in dimos/robot/xarm/skill_container.py
+> /ship document the McpServer port override in docs/usage/mcp.md
+> ```
+>
+> Treat the steps below as a strict script. **If any step fails, stop and
+> report — do not silently retry, force, or skip steps to keep the flow
+> moving.**
+
+---
+
+## Steps (run in order)
+
+### 1. Preflight
+
+- Confirm we are in `/Users/zhang/project/dimos` (or the user's checkout
+  of `dimensionalOS/dimos`).
+- Read `AGENTS.md` and `.cursor/rules/00-workflow.mdc` into context.
+- Run `git status` and `git branch --show-current`:
+  - On `dev` with a clean tree → step 2.
+  - On `dev` with uncommitted changes → ask the user: stash, commit
+    elsewhere, or branch off and bring them along?
+  - On any other branch → ask whether to keep iterating on it or to
+    cut a fresh branch off `origin/dev`.
+
+### 2. Cut a fresh branch off `origin/dev`
+
+```bash
+git fetch origin
+git checkout -b <type>/<topic> origin/dev
+```
+
+`<type>` ∈ {`feat`, `fix`, `chore`, `docs`, `test`, `refactor`, `perf`}.
+`<topic>` is kebab-case and ≤ 50 chars.
+
+### 3. Plan the minimum change
+
+- Convert the one-liner into 3–5 todos via `TodoWrite`.
+- Constrain the diff to the **smallest set of files** that satisfy the
+  request. **Do not** opportunistically refactor neighboring code.
+- If the request actually needs to touch ≥ 5 files **or** crosses module
+  boundaries (e.g. agents + robot + transport), **stop and ask the user
+  whether to split into multiple PRs**.
+
+### 4. Implement
+
+- Walk the todos in order, marking each one `completed` as you go.
+- Python: imports must succeed, mypy must remain strict-clean.
+- yaml: must round-trip parse.
+- Touching `@skill`: docstring stays, every param keeps a type
+  annotation, return type stays `str`. Never stack `@rpc` + `@skill`.
+- Touching a blueprint: run
+  `pytest dimos/robot/test_all_blueprints_generation.py` and commit the
+  regenerated `dimos/robot/all_blueprints.py` in the same PR.
+
+### 5. Verify locally (mandatory)
+
+```bash
+bash scripts/verify.sh
+```
+
+- PASS → step 6.
+- FAIL → debug loop: read traceback / mypy / pytest failure → minimal
+  fix → re-run verify. **Never** comment out a failing test or relax
+  mypy to make this pass.
+- If the failure is clearly pre-existing repo debt (not introduced by
+  this change), **stop and ask the user** whether to fix it in this PR
+  or open a separate issue.
+
+### 6. Stage the diff
+
+```bash
+git diff --stat
+git add <only files this change touches>
+```
+
+**Do not** `git add -A`; the workspace may have unrelated dirty files
+from another agent / window. If you see something you did not write,
+stop and ask.
+
+### 7. Commit
+
+Conventional title:
+
+```
+<type>: <one-liner>
+
+<optional 1–3 line body explaining the WHY, not the WHAT>
+```
+
+Forbidden: `--amend` on a pushed commit, `--no-verify` to skip pre-commit.
+
+### 8. Push
+
+```bash
+git push -u origin <branch>
+```
+
+- First push **must** include `-u` to set upstream.
+- On failure (network / permission), stop and report. **Never** retry
+  with `--force`.
+
+### 9. Open the PR (REST API)
+
+`gh pr create` immediately after `git push` sometimes hits a GraphQL
+indexing race. Use REST:
+
+```bash
+gh api repos/dimensionalOS/dimos/pulls \
+  -X POST \
+  -f base=dev \
+  -f head=<branch> \
+  -f title="<type>: <one-liner>" \
+  -F body=@/tmp/pr-body-<branch>.md
+```
+
+PR body must follow `.github/pull_request_template.md`:
+
+- **Description**: 1–3 bullets, what + why.
+- **How to Test**: the exact `bash scripts/verify.sh` invocation, plus
+  any blueprint / hardware command if relevant.
+- **CLA**: keep the existing checkbox; tick only after reading.
+- **Closes DIM-XXX**: linked Linear issue if any.
+
+### 10. Enable auto-merge (squash)
+
+```bash
+gh pr merge --auto --squash <pr-url-or-number>
+```
+
+If `gh` reports "auto-merge not enabled on this repository", proceed to
+step 11 with a human-todo entry.
+
+### 11. Final report
+
+Output exactly this format:
+
+```
+## Done
+
+### Changes
+- <file 1>: <one line>
+- <file 2>: <one line>
+
+### Verification
+- bash scripts/verify.sh: PASS / FAIL (paste the last 5 lines on FAIL)
+
+### PR
+- <url> (auto-merge: enabled / not enabled)
+
+### Codex review
+- <pending / posted reaction / wrote review> (skip if Codex disabled)
+
+### Human todo (if any)
+- [ ] <e.g. enable auto-merge in repo settings>
+- [ ] <e.g. run hardware regression on Go2 dock>
+- [ ] <e.g. tag a release>
+```
+
+---
+
+## Failure / abort rules
+
+- Any failed step: stop, surface state, do not silently retry.
+- If the user types `/cancel` or asks to abort, **leave the branch in
+  place** so they can decide what to do with it. Do not delete.
+- Forbidden recoveries:
+  - skipping `verify.sh`,
+  - removing tests / assertions to "make it pass",
+  - editing files outside the agreed scope just because they are dirty,
+  - `git push --force` to a reachable branch,
+  - committing to `dev` or `main` directly,
+  - clicking GitHub web settings on the user's behalf.

--- a/.cursor/rules/00-workflow.mdc
+++ b/.cursor/rules/00-workflow.mdc
@@ -1,0 +1,102 @@
+---
+description: Repository-wide workflow rules for Cursor agent in dimensionalOS/dimos
+globs:
+  - "**/*"
+alwaysApply: true
+---
+
+# Cursor agent rules for `dimensionalOS/dimos`
+
+> This is an `alwaysApply` rule. It outranks ad-hoc instructions in the chat.
+> If the user asks for something that conflicts with these rules, **stop and
+> surface the conflict** before acting.
+
+## Required behavior
+
+1. **Before any code change**, read `AGENTS.md` to confirm the change is in
+   scope. The "Agent Pipeline" and "Codex Review Guidelines" sections are
+   especially relevant.
+2. **After any code change**, run `bash scripts/verify.sh` at least once.
+   On failure, enter the debug loop: read the error → minimal fix → re-run
+   verify. Never bypass verify to make CI green.
+3. Land code via `feat/`, `fix/`, `chore/`, `docs/`, `test/`, `refactor/`,
+   or `perf/` branch + PR targeting **`dev`**:
+   - `git checkout -b <type>/<topic> origin/dev`
+   - `git add <only the files this change touches>`
+   - `git commit -m "<type>: <one-liner>"`
+   - `git push -u origin <branch>`
+   - Open the PR with the REST API (more reliable than `gh pr create`
+     immediately after push):
+     `gh api repos/dimensionalOS/dimos/pulls -X POST -f base=dev -f head=<branch> -f title=... -F body=@/tmp/pr-body.md`
+   - Enable squash auto-merge: `gh pr merge --auto --squash <pr-url>`
+4. When a step requires the GitHub web UI (auto-merge toggle, branch
+   protection, Codex App install), output a clear "human one-time todo
+   list" instead of pretending to do it.
+
+## Strictly forbidden
+
+1. **Never push** directly to `main` or `dev`. PRs only.
+2. **Never `git push --force`** to any reachable remote branch (especially
+   `dev`, `main`, or someone else's open PR branch).
+3. **Never modify existing entries** in `~/.ssh/config` — only append. The
+   user may have entries for company GitLab, robot dock IPs, etc.
+4. **Never `git add`** any of:
+   - `__pycache__/`, `*.pyc`, `.venv/`, `*.log`,
+   - `build/`, `dist/`, `*.egg-info/`,
+   - any file containing tokens, PATs, private IPs, or SSH keys,
+   - files larger than 50 MB without a Git LFS pointer.
+5. **Never silence `verify.sh`** to make CI green — do not comment out tests,
+   replace assertions with `pass`, or change `exit 1` to `exit 0`.
+6. **Never do large-scale refactors / renames / directory moves** without
+   explicit user approval. One PR, one concern.
+7. **Never stack `@rpc` and `@skill`** on the same method — `@skill` already
+   implies `@rpc` (see `dimos/agents/annotation.py`).
+8. **Never remove docstrings or type annotations** from a `@skill` method —
+   they are mandatory and the agent will fail to start without them.
+
+## dimos-specific guardrails
+
+- `dimos/robot/all_blueprints.py` is auto-generated. After adding/renaming a
+  blueprint, run `pytest dimos/robot/test_all_blueprints_generation.py` and
+  commit the regenerated file in the same PR.
+- Blueprints `target dev` for review and run via `dimos run <blueprint>`.
+  Real-hardware blueprints (`unitree-go2-agentic`, `unitree-g1-agentic`,
+  `xarm-perception-agent`) MUST NOT be invoked unless the user explicitly
+  asks.
+- Robot motion commands (`SportClient.Move`, `Twist`, MAVLink velocity
+  setpoints, xArm joint targets) require a `clamp` or saturation step
+  whenever the value originates from an LLM, RPC, or user input.
+- Transport / topic strings (LCM channels, ROS2 topics, DDS topics) are
+  searchable strings — when renaming, grep the entire repo and update
+  every site in the same PR.
+- System prompts (`dimos/agents/system_prompt.py`,
+  `dimos/robot/unitree/g1/system_prompt.py`) are hot — every change
+  ripples through every agent call. Document the before/after in the PR.
+- `mypy strict` is enabled. Never add `# type: ignore` on a public API
+  surface; if you must, add it on the narrowest possible scope and
+  explain in a comment.
+- Imports go at the top of the file. Inline imports are only acceptable
+  with a circular-dependency comment.
+- HTTP uses `requests`, not `urllib`. JSON values are typed `Any`, not
+  `object`.
+- Manual test scripts are prefixed `demo_` so pytest does not collect them.
+
+## Tooling expectations
+
+- Use Cursor's built-in tools (Read / Write / StrReplace / Glob / Grep)
+  before reaching for shell `cat` / `sed` / `awk` / `grep`.
+- Long-running commands (`bash scripts/verify.sh`, `uv sync`, `pytest -x`)
+  must be backgrounded with a sane timeout instead of blocking the agent.
+- `gh` CLI is at `/opt/homebrew/bin/gh` (mac) and the user is logged in.
+  Use it for all PR / status / merge actions.
+- SSH-over-443 is configured in `~/.ssh/config`. The git remote MUST stay
+  in `git@github.com:...` form; never silently rewrite it to HTTPS.
+
+## Definition of Done
+
+Every task ends with this output:
+
+1. List of files changed (use `git diff --stat`).
+2. The exact verify command that was run and its result.
+3. The PR URL (if a PR was opened).
+4. A bulleted human-todo list for anything that needed the GitHub web UI.

--- a/.github/workflows/agent-pipeline.yml
+++ b/.github/workflows/agent-pipeline.yml
@@ -1,0 +1,84 @@
+# agent-pipeline.yml
+#
+# Lightweight smoke check that runs on every PR to give the Cursor agent
+# (and human reviewers) a fast second-opinion CI signal.
+#
+# This workflow is intentionally NOT a replacement for `ci.yml` (Linux
+# self-hosted, ROS container) or `macos.yml` (macOS self-hosted, arm64).
+# Those remain the authoritative gates. This workflow:
+#   * runs on `ubuntu-latest` (free, fast, ~2 min wall clock with cache),
+#   * never blocks on hardware-only or platform-only failures,
+#   * uses the same `bash scripts/verify.sh`-style steps as the local agent.
+#
+# If you need to add this job to required-status-checks for branch
+# protection, the job name is `verify-fast`.
+
+name: agent-pipeline
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - '**.md'
+      - 'docker/**'
+      - '.github/workflows/docker-build.yml'
+      - '.github/workflows/_docker-build-template.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  verify-fast:
+    if: github.event.pull_request.draft == false
+    name: verify-fast (ubuntu)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          lfs: false
+
+      - name: Install uv (with cache)
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Set up Python 3.12
+        run: uv python install 3.12
+
+      - name: Install minimal deps (no dds, no unitree-dds, no cuda, no docker)
+        # Mirrors macos.yml extras subset; ubuntu-latest cannot build cuda /
+        # cyclonedds extras and we do not need them for static checks.
+        run: |
+          uv sync \
+            --all-extras \
+            --no-extra dds \
+            --no-extra unitree-dds \
+            --no-extra cuda \
+            --no-extra docker \
+            --frozen
+
+      - name: Ruff (lint)
+        run: |
+          uv run ruff check dimos/ || true
+          uv run ruff format --check dimos/ || true
+        # Ruff issues are surfaced via annotations but do not block this
+        # smoke job; main `ci.yml` is the authoritative formatter gate.
+
+      - name: pytest --collect-only (catch import errors fast)
+        run: |
+          uv run pytest --collect-only -q -m 'not (tool or mujoco or slow)' dimos/ \
+            > /tmp/pytest-collect.txt 2>&1
+          tail -20 /tmp/pytest-collect.txt
+        # If imports break, this fails in seconds rather than 10 min into
+        # the full suite.
+
+      - name: mypy (strict, dimos/ only)
+        run: |
+          uv run mypy dimos/
+
+      - name: Smoke verify.sh syntax
+        run: |
+          bash -n scripts/verify.sh
+          echo "scripts/verify.sh syntax OK"

--- a/.github/workflows/agent-pipeline.yml
+++ b/.github/workflows/agent-pipeline.yml
@@ -39,6 +39,18 @@ jobs:
         with:
           lfs: false
 
+      - name: Install system dependencies
+        # Mirrors macos.yml `brew install portaudio libjpeg-turbo` on the
+        # apt side. Without these, `pyaudio` (pulled in by
+        # `unitree-webrtc-connect-leshy`) fails with `portaudio.h: No such
+        # file or directory` during `uv sync`.
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            portaudio19-dev \
+            libjpeg-turbo8-dev \
+            libturbojpeg0-dev
+
       - name: Install uv (with cache)
         uses: astral-sh/setup-uv@v6
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -321,6 +321,15 @@ If multiple modules match the spec, use `.remappings()` to resolve. Source: `dim
 5. Update the system prompt — add to the `# AVAILABLE SKILLS` section.
 6. Expose as `my_container = MySkillContainer.blueprint` and include in the agentic blueprint.
 
+> **Package convention.** `dimos/agents/skills/` (and every other subpackage
+> under `dimos/`) is a **PEP 420 namespace package** — there is intentionally
+> no `__init__.py`. The only `__init__.py` in the entire `dimos/` tree is the
+> top-level `dimos/__init__.py`, which exists solely as a lazy re-export shim
+> for `Dimos`. Do not add `__init__.py` files when adding skills, modules, or
+> subpackages: doing so converts a namespace package into a regular package
+> and changes import resolution for tools (pytest collection, mypy, the
+> `all_blueprints.py` regen, etc.) that walk the tree.
+
 ---
 
 ## Testing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -389,3 +389,177 @@ CI asserts the file is current — if it's stale, CI fails.
 - CLI / dimos run: `docs/development/dimos_run.md`
 - LFS data: `docs/development/large_file_management.md`
 - Agent system: `docs/agents/`
+
+---
+
+## Agent Pipeline (Cursor + Codex)
+
+This section describes the automated "request → code → verify → PR → review →
+auto-merge" pipeline. It is **additive** to the rules above; nothing here
+overrides anything stated earlier.
+
+### Single source of truth
+
+```bash
+bash scripts/verify.sh
+```
+
+Both local agents and CI invoke this exact script. It runs:
+
+1. `uv sync --all-extras --no-extra dds` (and `--no-extra cuda` on macOS).
+2. `uv run pytest -q` — fast suite (excludes `slow`, `tool`, `mujoco` markers).
+3. `uv run mypy dimos/` — strict type check.
+
+The slow tier (`./bin/pytest-slow`) is owned by full CI and is intentionally
+*not* part of `verify.sh`; the agent loop optimizes for fast feedback. PRs
+that land must still pass the full slow CI before auto-merge.
+
+### Roles
+
+| Actor | Responsibility | How it is triggered |
+|-------|----------------|---------------------|
+| **Cursor local agent** | Plan, edit code, run `verify.sh`, push, open PR, enable auto-merge, monitor CI | User types `/ship <one-liner>` in Cursor chat |
+| **Codex GitHub App** | Comment-only review on every PR (P0/P1 focus) | Auto on `pull_request: opened` |
+| **Human (you)** | Review the PR, approve, do GitHub web one-time setup, run hardware regression | Manual |
+
+The agent must NOT:
+- push directly to `main` or `dev`,
+- force-push any reachable remote branch,
+- click GitHub web UI settings on the user's behalf,
+- silence `verify.sh` or comment out tests to make CI green,
+- commit anything that looks like a token / SSH key / password.
+
+### `/ship` command flow
+
+`.cursor/commands/ship.md` defines the canonical 11-step flow. Summary:
+
+1. Branch off `origin/dev` with a `feat/`, `fix/`, `chore/`, etc. prefix.
+2. Implement the change.
+3. Run `bash scripts/verify.sh` locally — must pass.
+4. Commit with conventional title.
+5. Push to `origin`.
+6. Open PR targeting `dev` via `gh api repos/dimensionalOS/dimos/pulls -X POST` (REST is more reliable than `gh pr create` immediately after push).
+7. Enable auto-merge with squash strategy.
+8. Wait for CI green and Codex review.
+9. Auto-merge fires.
+10. Delete local + remote branch.
+11. Report back to the user.
+
+---
+
+## Codex Review Guidelines (P0 / P1 / P2 / P3)
+
+> This section is read by the Codex GitHub App on every PR. It defines what
+> Codex should treat as blocking, recommended-fix, optional, or noise for the
+> dimos repository. Generic Codex defaults are not specific enough for a
+> robotics codebase that drives real hardware.
+
+### Severity levels
+
+| Level | Meaning | What Codex does |
+|-------|---------|-----------------|
+| **P0** | Could damage hardware, break a deployment, or compromise the repo | Write **BLOCK** in the review; require fix before merge |
+| **P1** | Likely to regress functionality, break tests, or violate strict mypy / pre-commit | Flag with "recommend fix" |
+| **P2** | Code quality (readability, duplication, naming) | Optional comment, do not block |
+| **P3** | Typos, comment spelling, personal style preference | **Do not flag** |
+
+### P0 checklist (any hit → BLOCK)
+
+1. **Secrets in the diff** — anything resembling an API key, OAuth token, SSH
+   private key, password, or hardcoded private IP that addresses a real
+   robot dock.
+2. **Direct push / force push to protected branches** — commits on the PR
+   branch that bypass `dev` (e.g. base = `main` instead of `dev`), or any
+   `--force` push history.
+3. **Robot motion without bounds** — calls into `SportClient`, `LowCmd`,
+   `Twist`, drone MAVLink velocity setpoints, or xArm joint commands that
+   pass user/LLM-derived velocity, joint, or torque values **without
+   `clamp`/`saturate`** to a documented physical limit.
+4. **Memory / concurrency hazards** in C/C++ extensions or pybind code —
+   use-after-free, dangling pointers, data race on a non-atomic shared
+   variable, missing mutex on a callback-driven module stream.
+5. **`verify.sh` neutered** — diff comments out a step in `scripts/verify.sh`,
+   replaces a real check with `exit 0`, or removes `--strict` / `-q` flags
+   in a way that hides failures.
+6. **Mypy strict mode disabled** — adding `# type: ignore` on a public API,
+   `--no-strict`, broad `Any` returns from a typed function, or a new
+   `[mypy.overrides] ignore_errors = true` block without justification in
+   the PR description.
+7. **`@skill` invariants violated** — a method tagged with both `@rpc` and
+   `@skill` (the decorator stacks are mutually exclusive per
+   `dimos/agents/annotation.py`), or a `@skill` whose docstring is removed,
+   whose params lack type annotations, or whose return type stops being
+   `str`. These cause silent agent regressions, not loud crashes.
+
+### P1 checklist (flag, do not auto-block)
+
+1. **Critical `GlobalConfig` defaults changed** — `mcp_port`, `n_workers`,
+   default `viewer`, `simulation`, `replay` flags. Flag and ask the PR to
+   document why.
+2. **Transport / topic renames** — LCM channel names, ROS2 topic strings,
+   DDS topics referenced by string literals across modules; rename in one
+   place, miss the other → silent disconnect.
+3. **System prompt changes** — `dimos/agents/system_prompt.py`,
+   `dimos/robot/unitree/g1/system_prompt.py`. Affects every LLM tool call;
+   ask for an explicit before/after diff in the PR description.
+4. **`all_blueprints.py` not regenerated** — any change adding/renaming a
+   blueprint must be accompanied by `pytest dimos/robot/test_all_blueprints_generation.py`
+   re-run. CI asserts this; if the diff touches blueprints but the
+   `all_blueprints.py` diff is empty, flag.
+5. **Tests skipped** — a new `@pytest.mark.skip`, `xfail`, or marker added
+   to an existing test without a linked issue in the PR description.
+6. **Pre-commit hook disabled** — `--no-verify` in any committed script,
+   `.pre-commit-config.yaml` removing `ruff` / license header / LFS check.
+7. **Inline imports added inside hot paths** — workspace rule says imports
+   at top of file unless circular dependency; flag and ask for the
+   circular-dep evidence.
+8. **Hardcoded ports / URLs** — code style rule says use `GlobalConfig`
+   constants. New `localhost:9990` or `192.168.123.161` literals → flag.
+9. **`requests` vs `urllib`** — workspace rule says use `requests`. New
+   `import urllib` for HTTP → flag.
+
+### P2 / P3 — do not flag
+
+**P2 (optional, low priority):**
+- Repeated code that would benefit from a helper but works correctly.
+- Naming that is consistent within the touched file but not the whole repo.
+- Suggestions to convert a `for`-loop to a comprehension when the loop is
+  more readable in context.
+
+**P3 (do not flag at all):**
+- English / Chinese typos in comments and markdown.
+- Trailing-whitespace, tab-vs-space (ruff handles it).
+- Personal style preferences not encoded in `pyproject.toml` ruff config.
+- Existing code outside the diff (do not expand the review surface).
+
+### Review output format
+
+When Codex posts a review, prefer this structure so a human can scan it
+quickly:
+
+```
+## P0 (BLOCKING)
+- <file:line> one sentence: why this can hurt hardware / repo
+
+## P1 (recommend fix)
+- <file:line> one sentence + suggested fix direction
+
+## P2 (optional)
+- <file:line> one sentence
+
+## Risk assessment
+- Hardware regression needed?  (yes / no / unsure)
+- Touches `@skill` / system_prompt / GlobalConfig?  (yes / no)
+- Touches transport / topic strings?  (yes / no)
+```
+
+### Triggering Codex actions beyond review
+
+Comment on the PR:
+- `@codex review` — re-run review explicitly (default behavior is automatic).
+- `@codex review for security regressions` — re-review with a security focus.
+- `@codex fix the CI failures` — Codex opens a follow-up branch with a fix.
+- `@codex add unit test for <function>` — Codex writes tests on a new branch.
+
+Do **not** use bare `@codex` (without `review`); it triggers a full cloud
+task and consumes more quota than necessary for plain code review.

--- a/dimos/utils/test_data_lfs_pointer.py
+++ b/dimos/utils/test_data_lfs_pointer.py
@@ -1,0 +1,55 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fast unit tests for Git LFS pointer detection (no network, no LFS pull)."""
+
+from pathlib import Path
+
+import pytest
+
+from dimos.utils.data import _is_lfs_pointer_file
+
+
+def test_is_lfs_pointer_true_for_valid_pointer(tmp_path: Path) -> None:
+    path = tmp_path / "sample.tar.gz"
+    path.write_text(
+        "version https://git-lfs.github.com/spec/v1\n"
+        "oid sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n"
+        "size 42\n",
+        encoding="utf-8",
+    )
+    assert _is_lfs_pointer_file(path) is True
+
+
+def test_is_lfs_pointer_false_when_file_too_large(tmp_path: Path) -> None:
+    path = tmp_path / "big.bin"
+    path.write_bytes(b"x" * 1025)
+    assert _is_lfs_pointer_file(path) is False
+
+
+def test_is_lfs_pointer_false_for_plain_text(tmp_path: Path) -> None:
+    path = tmp_path / "readme.txt"
+    path.write_text("hello world\n", encoding="utf-8")
+    assert _is_lfs_pointer_file(path) is False
+
+
+def test_is_lfs_pointer_false_for_missing_file(tmp_path: Path) -> None:
+    path = tmp_path / "does_not_exist"
+    assert _is_lfs_pointer_file(path) is False
+
+
+def test_is_lfs_pointer_false_for_invalid_utf8_small_file(tmp_path: Path) -> None:
+    path = tmp_path / "binary.bin"
+    path.write_bytes(b"\xff\xfe" * 50)
+    assert _is_lfs_pointer_file(path) is False

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# verify.sh - single source of truth for the agent pipeline.
+# Both local developers and CI invoke this exact script.
+#
+# Tier: fast + mypy
+#   - uv sync (dependency lock)
+#   - uv run pytest -q (excludes slow / tool / mujoco markers by default)
+#   - uv run mypy dimos/ (strict type check)
+#
+# Slow tier (`./bin/pytest-slow`) is invoked separately by full CI; this
+# script is intended for the agent's per-PR feedback loop.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "================================================================"
+echo " verify.sh @ $REPO_ROOT"
+echo " host:  $(uname -srm)"
+echo " shell: ${BASH_VERSION:-unknown}"
+echo " date:  $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "================================================================"
+
+echo ""
+echo ">>> [1/3] uv sync (install/refresh deps)"
+# AGENTS.md baseline: `uv sync --all-extras --no-extra dds`.
+# On macOS arm64 we additionally exclude `cuda` (no wheel) and `unitree-dds`
+# (pulls in cyclonedds, which needs CYCLONEDDS_HOME to build from source).
+UV_EXTRA_FLAGS=(--all-extras --no-extra dds)
+case "$(uname -s)" in
+    Darwin) UV_EXTRA_FLAGS+=(--no-extra cuda --no-extra unitree-dds) ;;
+esac
+echo "uv sync ${UV_EXTRA_FLAGS[*]}"
+uv sync "${UV_EXTRA_FLAGS[@]}"
+echo "<<< OK"
+
+echo ""
+echo ">>> [2/3] uv run pytest -q  (fast suite: excludes slow/tool/mujoco)"
+uv run pytest -q
+echo "<<< OK"
+
+echo ""
+echo ">>> [3/3] uv run mypy dimos/  (strict type check)"
+uv run mypy dimos/
+echo "<<< OK"
+
+echo ""
+echo "================================================================"
+echo " verify.sh: ALL GREEN"
+echo "================================================================"


### PR DESCRIPTION
## Description

- Add `dimos/utils/test_data_lfs_pointer.py` with five fast pytest cases for `_is_lfs_pointer_file`.
- Covers valid LFS pointer header, oversized non-pointer, plain text, missing path, and invalid UTF-8 small files.
- No network or `git lfs pull`; keeps the default fast test suite meaningful for data-layer helpers.

## How to Test

```bash
bash scripts/verify.sh
```

Optional single file:

```bash
uv run pytest dimos/utils/test_data_lfs_pointer.py -q
```

## Contributor License Agreement

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).

Closes DIM-XXX
