### PR TITLE
go2 lidar timestamps bugfix

### DIFF
--- a/dimos/robot/unitree/connection.py
+++ b/dimos/robot/unitree/connection.py
@@ -41,7 +41,11 @@ from dimos.msgs.geometry_msgs.Transform import Transform
 from dimos.msgs.geometry_msgs.Twist import Twist
 from dimos.msgs.sensor_msgs.Image import Image, ImageFormat
 from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
-from dimos.robot.unitree.type.lidar import RawLidarMsg, pointcloud2_from_webrtc_lidar
+from dimos.robot.unitree.type.lidar import (
+    RawLidarMsg,
+    pointcloud2_from_webrtc_lidar,
+    repair_stale_ts,
+)
 from dimos.robot.unitree.type.lowstate import LowStateMsg
 from dimos.robot.unitree.type.odometry import Odometry
 from dimos.utils.decorators.decorators import simple_mcache
@@ -248,7 +252,12 @@ class UnitreeWebRTCConnection(Resource):
 
     @simple_mcache
     def lidar_stream(self) -> Observable[PointCloud2]:
-        return backpressure(self.raw_lidar_stream().pipe(ops.map(pointcloud2_from_webrtc_lidar)))
+        return backpressure(
+            self.raw_lidar_stream().pipe(
+                ops.map(pointcloud2_from_webrtc_lidar),
+                repair_stale_ts(),
+            )
+        )
 
     @simple_mcache
     def tf_stream(self) -> Observable[Transform]:

--- a/dimos/robot/unitree/type/lidar.py
+++ b/dimos/robot/unitree/type/lidar.py
@@ -14,13 +14,19 @@
 
 """Unitree WebRTC lidar message parsing utilities."""
 
-import time
-from typing import TypedDict
+from collections.abc import Callable
+import logging
+from typing import TypedDict, TypeVar
 
 import numpy as np
 import open3d as o3d  # type: ignore[import-untyped]
+from reactivex import operators as ops
+from reactivex.observable import Observable
 
 from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
+from dimos.types.timestamped import Timestamped
+
+logger = logging.getLogger(__name__)
 
 # Backwards compatibility alias for pickled data
 LidarMessage = PointCloud2
@@ -55,10 +61,12 @@ def pointcloud2_from_webrtc_lidar(raw_message: RawLidarMsg, ts: float | None = N
 
     Args:
         raw_message: Raw lidar message from Unitree WebRTC API
-        ts: Optional timestamp override. If None, uses current time.
+        ts: Optional timestamp override. If None, uses the sensor stamp from
+            ``raw_message["data"]["stamp"]``.
 
-    Returns:
-        PointCloud2 message with the lidar points
+    The sensor stamp is authoritative when valid but Unitree's publisher
+    occasionally re-emits a stale value on fresh scans — see
+    :func:`repair_stale_ts` for the downstream repair.
     """
     data = raw_message["data"]
     points = data["data"]["points"]
@@ -68,7 +76,32 @@ def pointcloud2_from_webrtc_lidar(raw_message: RawLidarMsg, ts: float | None = N
 
     return PointCloud2(
         pointcloud=pointcloud,
-        # webrtc stamp is broken (e.g., "stamp": 1.758148e+09), use current time
-        ts=ts if ts is not None else time.time(),
+        ts=ts if ts is not None else data["stamp"],
         frame_id="world",
     )
+
+
+T = TypeVar("T", bound=Timestamped)
+
+
+def repair_stale_ts(default_period: float = 0.130) -> Callable[[Observable[T]], Observable[T]]:
+    """Repair Unitree's stale-stamp bug by forward-extrapolating non-monotonic stamps.
+
+    Unitree's WebRTC publisher occasionally emits the same stale ``stamp`` on
+    fresh scans (8 frames over 600s in the HK office recording, all sharing
+    one stamp predating recording start). This pipeable operator detects a
+    non-monotonic stamp and rewrites it to ``prev_good.ts + default_period``.
+    Zero latency — emits each item immediately. Successive bad frames each
+    advance by another ``default_period``.
+    """
+    prev_good: list[float | None] = [None]
+
+    def _repair(item: T) -> T:
+        if prev_good[0] is not None and item.ts <= prev_good[0]:
+            old = item.ts
+            item.ts = prev_good[0] + default_period
+            logger.warning("repair_stale_ts: stale stamp %.6f → %.6f", old, item.ts)
+        prev_good[0] = item.ts
+        return item
+
+    return ops.map(_repair)

--- a/dimos/robot/unitree/type/lidar.py
+++ b/dimos/robot/unitree/type/lidar.py
@@ -15,7 +15,6 @@
 """Unitree WebRTC lidar message parsing utilities."""
 
 from collections.abc import Callable
-import logging
 from typing import TypedDict, TypeVar
 
 import numpy as np
@@ -25,8 +24,9 @@ from reactivex.observable import Observable
 
 from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
 from dimos.types.timestamped import Timestamped
+from dimos.utils.logging_config import setup_logger
 
-logger = logging.getLogger(__name__)
+logger = setup_logger()
 
 # Backwards compatibility alias for pickled data
 LidarMessage = PointCloud2

--- a/dimos/robot/unitree/type/test_lidar.py
+++ b/dimos/robot/unitree/type/test_lidar.py
@@ -16,8 +16,15 @@
 import itertools
 from typing import cast
 
+import reactivex as rx
+
 from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
-from dimos.robot.unitree.type.lidar import RawLidarMsg, pointcloud2_from_webrtc_lidar
+from dimos.robot.unitree.type.lidar import (
+    RawLidarMsg,
+    pointcloud2_from_webrtc_lidar,
+    repair_stale_ts,
+)
+from dimos.types.timestamped import Timestamped
 from dimos.utils.testing.replay import SensorReplay
 
 
@@ -28,3 +35,32 @@ def test_init() -> None:
         assert isinstance(raw_frame, dict)
         frame = pointcloud2_from_webrtc_lidar(cast("RawLidarMsg", raw_frame))
         assert isinstance(frame, PointCloud2)
+
+
+def test_repair_stale_ts_extrapolates_non_monotonic_stamp() -> None:
+    # input: two healthy frames, one stale, one healthy
+    raw = [Timestamped(0.000), Timestamped(0.130), Timestamped(-6.354), Timestamped(0.260)]
+    out: list[float] = []
+    rx.from_iterable(raw).pipe(repair_stale_ts(default_period=0.130)).subscribe(
+        on_next=lambda item: out.append(item.ts)
+    )
+    assert out == [0.000, 0.130, 0.260, 0.390]
+
+
+def test_repair_stale_ts_passes_monotonic_unchanged() -> None:
+    raw = [Timestamped(0.0), Timestamped(0.130), Timestamped(0.260)]
+    out: list[float] = []
+    rx.from_iterable(raw).pipe(repair_stale_ts()).subscribe(
+        on_next=lambda item: out.append(item.ts)
+    )
+    assert out == [0.0, 0.130, 0.260]
+
+
+def test_repair_stale_ts_handles_consecutive_bad_frames() -> None:
+    # two stale-stamp frames in a row → each forward-extrapolated by default_period
+    raw = [Timestamped(0.0), Timestamped(-6.354), Timestamped(-6.354), Timestamped(0.500)]
+    out: list[float] = []
+    rx.from_iterable(raw).pipe(repair_stale_ts(default_period=0.130)).subscribe(
+        on_next=lambda item: out.append(item.ts)
+    )
+    assert out == [0.0, 0.130, 0.260, 0.500]


### PR DESCRIPTION
GO2 webrtc stream has a bug with bizzare timestamps occasionally attached to lidar frames

<img width="1188" height="412" alt="2026-05-06_16-03" src="https://github.com/user-attachments/assets/38714464-ac58-46d7-8b18-b6ab35fe6e98" />

this very simple hack corrects timestamps that are non monotonic because we know the expected lidar frequency