### PR TITLE
Fix/python memoryleak replay

### DIFF
--- a/dimos/mapping/voxels.py
+++ b/dimos/mapping/voxels.py
@@ -240,7 +240,6 @@ class VoxelGridMapperConfig(ModuleConfig):
     device: str = "CUDA:0"
     carve_columns: bool = True
     frame_id: str = "world"
-    emit_every: int = 10
 
 
 class VoxelGridMapper(StreamModule[PointCloud2, PointCloud2]):

--- a/dimos/mapping/voxels.py
+++ b/dimos/mapping/voxels.py
@@ -240,6 +240,7 @@ class VoxelGridMapperConfig(ModuleConfig):
     device: str = "CUDA:0"
     carve_columns: bool = True
     frame_id: str = "world"
+    emit_every: int = 10
 
 
 class VoxelGridMapper(StreamModule[PointCloud2, PointCloud2]):

--- a/dimos/utils/testing/replay.py
+++ b/dimos/utils/testing/replay.py
@@ -28,8 +28,8 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterator
 from pathlib import Path
-import time
 import threading
+import time
 from typing import Any, Generic, TypeVar, cast
 
 import reactivex as rx

--- a/dimos/utils/testing/replay.py
+++ b/dimos/utils/testing/replay.py
@@ -34,9 +34,8 @@ from typing import Any, Generic, TypeVar, cast
 
 import reactivex as rx
 from reactivex.abc import DisposableBase, ObserverBase, SchedulerBase
-from reactivex.disposable import Disposable, MultipleAssignmentDisposable
+from reactivex.disposable import Disposable
 from reactivex.observable import Observable
-from reactivex.scheduler import TimeoutScheduler
 
 from dimos.memory.timeseries.legacy import LegacyPickleStore
 from dimos.memory2.store.sqlite import SqliteStore
@@ -88,22 +87,21 @@ def timed_playback(
 ) -> Observable[T]:
     """Replay a ``(ts, data)`` iterator as an Observable at real-time speed.
 
-    Anchors on the first timestamp and runs a single background thread that
-    sleeps between emissions.
+    Anchors on the first timestamp and runs a dedicated worker thread that
+    sleeps between emissions. The thread is joined on dispose (unlike
+    ``TimeoutScheduler``) so test thread-leak checks do not see a stray worker.
     When ``detect_loop`` is set, a backwards-going timestamp re-anchors — use
     this when the source iterator loops.
     """
 
     def subscribe(
         observer: ObserverBase[T],
-        scheduler: SchedulerBase | None = None,
+        _scheduler: SchedulerBase | None = None,
     ) -> DisposableBase:
-        sched = scheduler or TimeoutScheduler()
-        disp = MultipleAssignmentDisposable()
         cancel_event = threading.Event()
         is_disposed = False
 
-        def loop_action(_scheduler: SchedulerBase, _state: object) -> None:
+        def loop_action() -> None:
             iterator = source()
             try:
                 first_ts, first_data = next(iterator)
@@ -151,13 +149,18 @@ def timed_playback(
             if not is_disposed:
                 observer.on_completed()
 
-        disp.disposable = sched.schedule(loop_action)
+        worker = threading.Thread(
+            target=loop_action,
+            name="timed_playback",
+            daemon=False,
+        )
+        worker.start()
 
         def dispose() -> None:
             nonlocal is_disposed
             is_disposed = True
             cancel_event.set()
-            disp.dispose()
+            worker.join(timeout=60.0)
 
         return Disposable(dispose)
 

--- a/dimos/utils/testing/replay.py
+++ b/dimos/utils/testing/replay.py
@@ -29,11 +29,12 @@ from __future__ import annotations
 from collections.abc import Callable, Iterator
 from pathlib import Path
 import time
+import threading
 from typing import Any, Generic, TypeVar, cast
 
 import reactivex as rx
 from reactivex.abc import DisposableBase, ObserverBase, SchedulerBase
-from reactivex.disposable import CompositeDisposable, Disposable
+from reactivex.disposable import Disposable, MultipleAssignmentDisposable
 from reactivex.observable import Observable
 from reactivex.scheduler import TimeoutScheduler
 
@@ -87,16 +88,10 @@ def timed_playback(
 ) -> Observable[T]:
     """Replay a ``(ts, data)`` iterator as an Observable at real-time speed.
 
-    Anchors on the first timestamp and schedules subsequent emissions with
-    ``scheduler.schedule_relative`` at ``anchor + (ts - first_ts) / speed``.
+    Anchors on the first timestamp and runs a single background thread that
+    sleeps between emissions.
     When ``detect_loop`` is set, a backwards-going timestamp re-anchors — use
     this when the source iterator loops.
-
-    ``source`` is a factory: called fresh on each subscription so the same
-    Observable can be re-subscribed without iterator collisions.
-
-    Pending timers are tracked on a CompositeDisposable and cancelled on
-    subscription dispose.
     """
 
     def subscribe(
@@ -104,68 +99,64 @@ def timed_playback(
         scheduler: SchedulerBase | None = None,
     ) -> DisposableBase:
         sched = scheduler or TimeoutScheduler()
-        disp = CompositeDisposable()
+        disp = MultipleAssignmentDisposable()
+        cancel_event = threading.Event()
         is_disposed = False
-        iterator = source()
 
-        try:
-            first_ts, first_data = next(iterator)
-        except StopIteration:
-            observer.on_completed()
-            return Disposable()
-
-        start_local_time = time.time()
-        start_replay_time = first_ts
-
-        observer.on_next(first_data)
-
-        try:
-            next_message: tuple[float, T] | None = next(iterator)
-        except StopIteration:
-            observer.on_completed()
-            return disp
-
-        prev_ts = first_ts
-
-        def schedule_emission(message: tuple[float, T]) -> None:
-            nonlocal next_message, start_local_time, start_replay_time, prev_ts
+        def loop_action(_scheduler: SchedulerBase, _state: object) -> None:
+            iterator = source()
+            try:
+                first_ts, first_data = next(iterator)
+            except StopIteration:
+                observer.on_completed()
+                return
 
             if is_disposed:
                 return
 
-            ts, data = message
+            start_local_time = time.time()
+            start_replay_time = first_ts
+            observer.on_next(first_data)
 
-            if detect_loop and ts < prev_ts:
-                start_local_time = time.time()
-                start_replay_time = ts
-            prev_ts = ts
+            prev_ts = first_ts
 
-            try:
-                next_message = next(iterator)
-            except StopIteration:
-                next_message = None
-
-            target_time = start_local_time + (ts - start_replay_time) / speed
-            delay = max(0.0, target_time - time.time())
-
-            def emit(_scheduler: SchedulerBase, _state: object) -> DisposableBase | None:
+            for ts, data in iterator:
                 if is_disposed:
-                    return None
+                    return
+
+                if detect_loop and ts < prev_ts:
+                    start_local_time = time.time()
+                    start_replay_time = ts
+                prev_ts = ts
+
+                target_time = start_local_time + (ts - start_replay_time) / speed
+                delay = target_time - time.time()
+
+                if delay < -0.2:
+                    # We fell significantly behind (e.g. queue blocking, computation heavy).
+                    # Re-anchor time to prevent a "death spiral" where we blast 100% CPU
+                    # to emit stale frames as fast as possible, which chokes queues.
+                    start_local_time = time.time()
+                    start_replay_time = ts
+                    delay = 0.0
+
+                if delay > 0:
+                    cancel_event.wait(delay)
+
+                if is_disposed:
+                    return
+
                 observer.on_next(data)
-                if next_message is not None:
-                    schedule_emission(next_message)
-                else:
-                    observer.on_completed()
-                return None
 
-            disp.add(sched.schedule_relative(delay, emit))
+            if not is_disposed:
+                observer.on_completed()
 
-        if next_message is not None:
-            schedule_emission(next_message)
+        disp.disposable = sched.schedule(loop_action)
 
         def dispose() -> None:
             nonlocal is_disposed
             is_disposed = True
+            cancel_event.set()
             disp.dispose()
 
         return Disposable(dispose)

--- a/dimos/utils/testing/replay.py
+++ b/dimos/utils/testing/replay.py
@@ -102,52 +102,55 @@ def timed_playback(
         is_disposed = False
 
         def loop_action() -> None:
-            iterator = source()
             try:
-                first_ts, first_data = next(iterator)
-            except StopIteration:
-                observer.on_completed()
-                return
-
-            if is_disposed:
-                return
-
-            start_local_time = time.time()
-            start_replay_time = first_ts
-            observer.on_next(first_data)
-
-            prev_ts = first_ts
-
-            for ts, data in iterator:
-                if is_disposed:
+                iterator = source()
+                try:
+                    first_ts, first_data = next(iterator)
+                except StopIteration:
+                    observer.on_completed()
                     return
-
-                if detect_loop and ts < prev_ts:
-                    start_local_time = time.time()
-                    start_replay_time = ts
-                prev_ts = ts
-
-                target_time = start_local_time + (ts - start_replay_time) / speed
-                delay = target_time - time.time()
-
-                if delay < -0.2:
-                    # We fell significantly behind (e.g. queue blocking, computation heavy).
-                    # Re-anchor time to prevent a "death spiral" where we blast 100% CPU
-                    # to emit stale frames as fast as possible, which chokes queues.
-                    start_local_time = time.time()
-                    start_replay_time = ts
-                    delay = 0.0
-
-                if delay > 0:
-                    cancel_event.wait(delay)
 
                 if is_disposed:
                     return
 
-                observer.on_next(data)
+                start_local_time = time.time()
+                start_replay_time = first_ts
+                observer.on_next(first_data)
 
-            if not is_disposed:
-                observer.on_completed()
+                prev_ts = first_ts
+
+                for ts, data in iterator:
+                    if is_disposed:
+                        return
+
+                    if detect_loop and ts < prev_ts:
+                        start_local_time = time.time()
+                        start_replay_time = ts
+                    prev_ts = ts
+
+                    target_time = start_local_time + (ts - start_replay_time) / speed
+                    delay = target_time - time.time()
+
+                    if delay < -0.2:
+                        # We fell significantly behind (e.g. queue blocking, computation heavy).
+                        # Re-anchor time to prevent a "death spiral" where we blast 100% CPU
+                        # to emit stale frames as fast as possible, which chokes queues.
+                        start_local_time = time.time()
+                        start_replay_time = ts
+                        delay = 0.0
+
+                    if delay > 0:
+                        cancel_event.wait(delay)
+
+                    if is_disposed:
+                        return
+
+                    observer.on_next(data)
+
+                if not is_disposed:
+                    observer.on_completed()
+            except Exception as exc:
+                observer.on_error(exc)
 
         worker = threading.Thread(
             target=loop_action,


### PR DESCRIPTION
## Problem

### Running `dimos --dtop --replay run unitree-go2` causes one of the Python processes to grow in memory. Even if the dimos-viewer was closed midway the replay that would not change anything and the memory would still grow.

The problem was discussed by @leshy  and @aclauer .

Previously, the code was doing this:

delay = target_time - current_time
If delay is negative,  emit the frame immediately to catch up.
This meant that if the playback fell behind by 0.5 seconds, it would try to emit 500 milliseconds worth of video, lidar, and odometry frames instantly to catch up.


## Solution


Re-Anchoring on Delay: Added a death spiral breaker logic. If the stream detects that it has fallen behind by more than 0.2 seconds (200 milliseconds), instead of trying to catch up with an instantaneous stream of frames, it re-anchors the time to the current frame (start_local_time = time.time()). 

Precise Blocking Sleep: Replaced the manual chunked time.sleep() loop with threading.Event().wait(delay). This provides single-call sleep mechanism that has practically zero drift, completely preventing the systematic time accumulation over long playbacks, while still allowing instant cancellation if you stop the replay.

