### PR TITLE
Skill Error codes for pick and place manipulation

### DIFF
--- a/dimos/agents/skill_result.py
+++ b/dimos/agents/skill_result.py
@@ -1,0 +1,124 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Structured return type for ``@skill`` methods.
+
+Skills historically returned free-form strings, which forced agents to parse
+prose to tell success from failure. ``SkillResult`` carries a typed
+``error_code`` that any caller (LLM agent, RPC client, tests) can branch on.
+
+The MCP server's ``agent_encode`` hook (``dimos/agents/mcp/mcp_server.py``)
+auto-detects the method on this class and forwards its output as the JSON-RPC
+``content`` field, so no MCP changes are required.
+
+Domain-specific failure codes live with their domain
+(e.g. ``dimos.manipulation.skill_errors.ManipulationError``); only codes any
+domain might emit live in ``CommonSkillError`` here.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from enum import Enum, auto
+import json
+import time
+from typing import Any
+
+from dimos.utils.logging_config import setup_logger
+
+logger = setup_logger()
+
+
+class CommonSkillError(Enum):
+    """Failure modes any skill domain might emit."""
+
+    ROBOT_NOT_FOUND = auto()
+    INVALID_INPUT = auto()
+    INVALID_STATE = auto()
+    NOT_CONFIGURED = auto()
+    EXECUTION_FAILED = auto()
+    EXECUTION_TIMEOUT = auto()
+
+
+@dataclass
+class SkillResult:
+    """Structured outcome of a ``@skill`` call.
+
+    ``error_code`` accepts any ``Enum`` so each domain can supply its own
+    code namespace (manipulation, locomotion, perception, ...). The wire
+    representation uses ``Enum.name``, which is supported by all enums.
+    """
+
+    success: bool
+    message: str = ""
+    error_code: Enum | None = None
+    duration_ms: float = 0.0
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def is_success(self) -> bool:
+        return self.success
+
+    @classmethod
+    def ok(cls, message: str = "", **metadata: Any) -> SkillResult:
+        return cls(success=True, message=message, metadata=dict(metadata))
+
+    @classmethod
+    def fail(cls, error_code: Enum, message: str = "") -> SkillResult:
+        return cls(success=False, error_code=error_code, message=message)
+
+    def agent_encode(self) -> list[dict[str, Any]]:
+        payload: dict[str, Any] = {
+            "success": self.success,
+            "message": self.message,
+            "error_code": self.error_code.name if self.error_code is not None else None,
+            "duration_ms": round(self.duration_ms, 1),
+        }
+        if self.metadata:
+            payload["metadata"] = self.metadata
+        return [{"type": "text", "text": json.dumps(payload)}]
+
+    def __str__(self) -> str:
+        if self.success:
+            return f"OK: {self.message}" if self.message else "OK"
+        code = self.error_code.name if self.error_code is not None else "ERROR"
+        return f"{code}: {self.message}" if self.message else code
+
+
+@contextmanager
+def skill_timing(name: str | None = None) -> Iterator[Callable[[SkillResult], SkillResult]]:
+    """Stamp a ``SkillResult`` with the elapsed wall time at exit, and log it.
+
+    If ``name`` is supplied, a structured ``logger.info`` line is emitted on
+    every ``stamp(...)`` call (i.e. every skill return point) with the skill
+    name, the outcome code, and the elapsed duration. Pass the skill's own
+    method name so the log is greppable.
+
+    Usage::
+
+        with skill_timing("set_gripper") as stamp:
+            ...
+            return stamp(SkillResult.ok("done"))
+    """
+    t0 = time.monotonic()
+
+    def stamp(result: SkillResult) -> SkillResult:
+        result.duration_ms = (time.monotonic() - t0) * 1000.0
+        if name is not None:
+            code = result.error_code.name if result.error_code is not None else "OK"
+            logger.info(f"SKILL {name} result={code} duration_ms={result.duration_ms:.1f}")
+        return result
+
+    yield stamp

--- a/dimos/agents/test_skill_result.py
+++ b/dimos/agents/test_skill_result.py
@@ -1,0 +1,158 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for SkillResult, the agent_encode wire contract, and skill_timing."""
+
+from __future__ import annotations
+
+from enum import Enum, auto
+import json
+import time
+
+from dimos.agents.skill_result import CommonSkillError, SkillResult, skill_timing
+
+
+class _DomainError(Enum):
+    """Stand-in for a domain-specific error namespace (e.g. `ManipulationError`).
+
+    Used to verify ``SkillResult`` is not coupled to ``CommonSkillError``.
+    """
+
+    SOMETHING_BROKE = auto()
+
+
+class TestFactories:
+    def test_ok_factory_packs_kwargs_into_metadata(self):
+        """`ok(message, **kwargs)` routes kwargs to the metadata dict — non-obvious."""
+        result = SkillResult.ok("done", planning_ms=12.3, attempts=2)
+        assert result.metadata == {"planning_ms": 12.3, "attempts": 2}
+
+    def test_fail_accepts_arbitrary_enum(self):
+        """`error_code` is typed `Enum`, not `CommonSkillError`, so domains can BYO."""
+        result = SkillResult.fail(_DomainError.SOMETHING_BROKE, "boom")
+        assert result.error_code is _DomainError.SOMETHING_BROKE
+        assert not result.is_success()
+
+
+class TestAgentEncode:
+    """Pins the wire contract used by the MCP server's ``agent_encode`` hook."""
+
+    def test_success_payload_shape(self):
+        result = SkillResult.ok("picked")
+        result.duration_ms = 123.456
+
+        encoded = result.agent_encode()
+        assert isinstance(encoded, list)
+        assert encoded[0]["type"] == "text"
+
+        payload = json.loads(encoded[0]["text"])
+        assert payload == {
+            "success": True,
+            "message": "picked",
+            "error_code": None,
+            "duration_ms": 123.5,
+        }
+
+    def test_failure_serializes_enum_via_name_cross_domain(self):
+        """Failure encodes ``error_code.name`` (not ``.value``) and accepts foreign enums."""
+        result = SkillResult.fail(_DomainError.SOMETHING_BROKE, "x")
+
+        payload = json.loads(result.agent_encode()[0]["text"])
+        assert payload["success"] is False
+        assert payload["error_code"] == "SOMETHING_BROKE"
+        assert payload["message"] == "x"
+
+    def test_metadata_included_when_present(self):
+        result = SkillResult.ok("done", attempts=3)
+        payload = json.loads(result.agent_encode()[0]["text"])
+        assert payload["metadata"] == {"attempts": 3}
+
+    def test_metadata_omitted_when_empty(self):
+        """Empty metadata is dropped from the wire to keep the payload small."""
+        result = SkillResult.ok("done")
+        payload = json.loads(result.agent_encode()[0]["text"])
+        assert "metadata" not in payload
+
+
+class TestSkillTiming:
+    def test_duration_reflects_real_elapsed_time(self):
+        """`skill_timing` measures wall time — not just stamps a fixed value."""
+        sleep_ms = 50
+
+        with skill_timing() as stamp:
+            time.sleep(sleep_ms / 1000.0)
+            result = stamp(SkillResult.ok())
+
+        # Lower bound: sleep guarantees at least sleep_ms elapsed.
+        # Upper bound is intentionally loose to avoid CI flakiness.
+        assert result.duration_ms >= sleep_ms
+        assert result.duration_ms < sleep_ms * 10  # sanity: not absurdly large
+
+
+class _ListHandler:
+    """Captures ``logger.info`` calls.
+
+    The dimos logger sets ``propagate=False``, so pytest's ``caplog`` fixture
+    can't see its records via the root logger. Instead we monkeypatch the
+    logger's ``info`` method with this collector.
+    """
+
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    def __call__(self, msg: str, *args, **kwargs) -> None:
+        self.messages.append(msg if not args else msg % args)
+
+
+def _patch_logger(monkeypatch) -> _ListHandler:
+    from dimos.agents import skill_result as sr
+
+    handler = _ListHandler()
+    monkeypatch.setattr(sr.logger, "info", handler)
+    return handler
+
+
+class TestSkillTimingLogging:
+    def test_no_log_when_name_omitted(self, monkeypatch):
+        """Anonymous timing stays quiet — preserves the original opt-in API."""
+        handler = _patch_logger(monkeypatch)
+        with skill_timing() as stamp:
+            stamp(SkillResult.ok())
+        assert handler.messages == []
+
+    def test_log_format_on_success(self, monkeypatch):
+        """Successful stamp emits `SKILL <name> result=OK duration_ms=<n.n>`."""
+        handler = _patch_logger(monkeypatch)
+        with skill_timing("set_gripper") as stamp:
+            stamp(SkillResult.ok("done"))
+        assert len(handler.messages) == 1
+        msg = handler.messages[0]
+        assert msg.startswith("SKILL set_gripper result=OK duration_ms=")
+
+    def test_log_format_on_failure(self, monkeypatch):
+        """Failure stamp emits the error_code's name (not OK, not a string repr)."""
+        handler = _patch_logger(monkeypatch)
+        with skill_timing("pick") as stamp:
+            stamp(SkillResult.fail(CommonSkillError.ROBOT_NOT_FOUND, "x"))
+        assert len(handler.messages) == 1
+        msg = handler.messages[0]
+        assert msg.startswith("SKILL pick result=ROBOT_NOT_FOUND duration_ms=")
+
+    def test_each_stamp_call_logs_separately(self, monkeypatch):
+        """One log line per return point — important for skills that branch."""
+        handler = _patch_logger(monkeypatch)
+        with skill_timing("move_to_pose") as stamp:
+            stamp(SkillResult.ok("first"))
+            stamp(SkillResult.fail(CommonSkillError.EXECUTION_FAILED, "second"))
+        assert len(handler.messages) == 2

--- a/dimos/manipulation/blueprints.py
+++ b/dimos/manipulation/blueprints.py
@@ -99,6 +99,7 @@ _xarm7_cfg = _catalog_xarm7(
     name="arm",
     adapter_type="xarm" if global_config.xarm7_ip else "mock",
     address=global_config.xarm7_ip,
+    add_gripper=True,
 )
 
 xarm7_planner_coordinator = autoconnect(

--- a/dimos/manipulation/manipulation_module.py
+++ b/dimos/manipulation/manipulation_module.py
@@ -32,6 +32,7 @@ from typing import TYPE_CHECKING, Any, TypeAlias
 from pydantic import Field
 
 from dimos.agents.annotation import skill
+from dimos.agents.skill_result import CommonSkillError, SkillResult, skill_timing
 from dimos.constants import DEFAULT_THREAD_JOIN_TIMEOUT
 from dimos.core.core import rpc
 from dimos.core.module import Module, ModuleConfig
@@ -45,6 +46,7 @@ from dimos.manipulation.planning.spec.protocols import KinematicsSpec, PlannerSp
 from dimos.manipulation.planning.trajectory_generator.joint_trajectory_generator import (
     JointTrajectoryGenerator,
 )
+from dimos.manipulation.skill_errors import ManipulationError
 from dimos.msgs.geometry_msgs.Pose import Pose
 from dimos.msgs.geometry_msgs.Quaternion import Quaternion
 from dimos.msgs.geometry_msgs.Vector3 import Vector3
@@ -354,17 +356,23 @@ class ManipulationModule(Module):
 
     @rpc
     @skill
-    def reset(self) -> str:
+    def reset(self) -> SkillResult:
         """Reset the robot module to IDLE state, clearing any fault.
 
         Use this after an error or fault to allow new commands.
         Cannot reset while a motion is executing — cancel first.
         """
-        if self._state == ManipulationState.EXECUTING:
-            return "Error: Cannot reset while executing — cancel the motion first"
-        self._state = ManipulationState.IDLE
-        self._error_message = ""
-        return "Reset to IDLE — ready for new commands"
+        with skill_timing("reset") as stamp:
+            if self._state == ManipulationState.EXECUTING:
+                return stamp(
+                    SkillResult.fail(
+                        CommonSkillError.INVALID_STATE,
+                        "Cannot reset while executing — cancel the motion first",
+                    )
+                )
+            self._state = ManipulationState.IDLE
+            self._error_message = ""
+            return stamp(SkillResult.ok("Reset to IDLE — ready for new commands"))
 
     @rpc
     def get_current_joints(self, robot_name: RobotName | None = None) -> list[float] | None:
@@ -884,38 +892,47 @@ class ManipulationModule(Module):
         return float(result) if result is not None else None
 
     @skill
-    def set_gripper(self, position: float, robot_name: str | None = None) -> str:
+    def set_gripper(self, position: float, robot_name: str | None = None) -> SkillResult:
         """Set gripper to a specific opening in meters.
 
         Args:
             position: Gripper opening in meters (0.0 = closed, 0.85 = fully open).
             robot_name: Robot to control (only needed for multi-arm setups).
         """
-        if self._set_gripper_position(position, robot_name):
-            return f"Gripper set to {position:.3f}m"
-        return "Error: Failed to set gripper position"
+        with skill_timing("set_gripper") as stamp:
+            if self._set_gripper_position(position, robot_name):
+                return stamp(SkillResult.ok(f"Gripper set to {position:.3f}m"))
+            return stamp(
+                SkillResult.fail(ManipulationError.GRIPPER_FAILED, "Failed to set gripper position")
+            )
 
     @skill
-    def open_gripper(self, robot_name: str | None = None) -> str:
+    def open_gripper(self, robot_name: str | None = None) -> SkillResult:
         """Open the robot gripper fully.
 
         Args:
             robot_name: Robot to control (only needed for multi-arm setups).
         """
-        if self._set_gripper_position(0.85, robot_name):
-            return "Gripper opened"
-        return "Error: Failed to open gripper"
+        with skill_timing("open_gripper") as stamp:
+            if self._set_gripper_position(0.85, robot_name):
+                return stamp(SkillResult.ok("Gripper opened"))
+            return stamp(
+                SkillResult.fail(ManipulationError.GRIPPER_FAILED, "Failed to open gripper")
+            )
 
     @skill
-    def close_gripper(self, robot_name: str | None = None) -> str:
+    def close_gripper(self, robot_name: str | None = None) -> SkillResult:
         """Close the robot gripper fully.
 
         Args:
             robot_name: Robot to control (only needed for multi-arm setups).
         """
-        if self._set_gripper_position(0.0, robot_name):
-            return "Gripper closed"
-        return "Error: Failed to close gripper"
+        with skill_timing("close_gripper") as stamp:
+            if self._set_gripper_position(0.0, robot_name):
+                return stamp(SkillResult.ok("Gripper closed"))
+            return stamp(
+                SkillResult.fail(ManipulationError.GRIPPER_FAILED, "Failed to close gripper")
+            )
 
     def _wait_for_trajectory_completion(
         self, robot_name: RobotName | None = None, timeout: float = 60.0, poll_interval: float = 0.2
@@ -978,28 +995,26 @@ class ManipulationModule(Module):
         logger.warning(f"Trajectory execution timed out after {timeout}s")
         return False
 
-    def _lift_if_low(self, robot_name: RobotName | None = None, min_z: float = 0.05) -> str | None:
-        """If the end-effector is below *min_z*, plan and execute a short lift.
-
-        Returns None on success (or if already above threshold), error string on failure.
-        """
+    def _lift_if_low(self, robot_name: RobotName | None = None, min_z: float = 0.05) -> SkillResult:
+        """If the end-effector is below *min_z*, plan and execute a short lift."""
         ee = self.get_ee_pose(robot_name)
         if ee is None or ee.position.z >= min_z:
-            return None
+            return SkillResult.ok()
 
         lift_z = min_z + 0.05
         logger.info(f"EE z={ee.position.z:.3f} < {min_z}, lifting to z={lift_z:.3f}")
         lift_pose = Pose(Vector3(ee.position.x, ee.position.y, lift_z), ee.orientation)
         if not self.plan_to_pose(lift_pose, robot_name):
-            return f"Error: Failed to plan lift from z={ee.position.z:.3f}"
+            return SkillResult.fail(
+                ManipulationError.PLANNING_FAILED,
+                f"Failed to plan lift from z={ee.position.z:.3f}",
+            )
         return self._preview_execute_wait(robot_name)
 
     def _preview_execute_wait(
         self, robot_name: RobotName | None = None, preview_duration: float = 0.5
-    ) -> str | None:
+    ) -> SkillResult:
         """Preview planned path, execute, and wait for completion.
-
-        Returns None on success, or an error string on failure.
 
         Args:
             robot_name: Robot to operate on
@@ -1010,44 +1025,49 @@ class ManipulationModule(Module):
 
         logger.info("Executing trajectory...")
         if not self.execute(robot_name):
-            return "Error: Trajectory execution failed"
+            return SkillResult.fail(
+                CommonSkillError.EXECUTION_FAILED, "Trajectory execution failed"
+            )
 
         if not self._wait_for_trajectory_completion(robot_name):
-            return "Error: Trajectory execution timed out"
+            return SkillResult.fail(
+                CommonSkillError.EXECUTION_TIMEOUT, "Trajectory execution timed out"
+            )
 
-        return None
+        return SkillResult.ok()
 
     @skill
-    def get_robot_state(self, robot_name: str | None = None) -> str:
+    def get_robot_state(self, robot_name: str | None = None) -> SkillResult:
         """Get current robot state: joint positions, end-effector pose, and gripper.
 
         Args:
             robot_name: Robot to query (only needed for multi-arm setups).
         """
-        lines: list[str] = []
+        with skill_timing("get_robot_state") as stamp:
+            lines: list[str] = []
 
-        joints = self.get_current_joints(robot_name)
-        if joints is not None:
-            lines.append(f"Joints: [{', '.join(f'{j:.3f}' for j in joints)}]")
-        else:
-            lines.append("Joints: unavailable (no state received)")
+            joints = self.get_current_joints(robot_name)
+            if joints is not None:
+                lines.append(f"Joints: [{', '.join(f'{j:.3f}' for j in joints)}]")
+            else:
+                lines.append("Joints: unavailable (no state received)")
 
-        ee_pose = self.get_ee_pose(robot_name)
-        if ee_pose is not None:
-            p = ee_pose.position
-            lines.append(f"EE pose: ({p.x:.4f}, {p.y:.4f}, {p.z:.4f})")
-        else:
-            lines.append("EE pose: unavailable")
+            ee_pose = self.get_ee_pose(robot_name)
+            if ee_pose is not None:
+                p = ee_pose.position
+                lines.append(f"EE pose: ({p.x:.4f}, {p.y:.4f}, {p.z:.4f})")
+            else:
+                lines.append("EE pose: unavailable")
 
-        gripper_pos = self.get_gripper(robot_name)
-        if gripper_pos is not None:
-            lines.append(f"Gripper: {gripper_pos:.3f}m")
-        else:
-            lines.append("Gripper: not configured")
+            gripper_pos = self.get_gripper(robot_name)
+            if gripper_pos is not None:
+                lines.append(f"Gripper: {gripper_pos:.3f}m")
+            else:
+                lines.append("Gripper: not configured")
 
-        lines.append(f"State: {self.get_state()}")
+            lines.append(f"State: {self.get_state()}")
 
-        return "\n".join(lines)
+            return stamp(SkillResult.ok("\n".join(lines)))
 
     @skill
     def move_to_pose(
@@ -1059,7 +1079,7 @@ class ManipulationModule(Module):
         pitch: float | None = None,
         yaw: float | None = None,
         robot_name: str | None = None,
-    ) -> str:
+    ) -> SkillResult:
         """Move the robot end-effector to a target pose.
 
         Plans a collision-free trajectory and executes it.
@@ -1074,52 +1094,60 @@ class ManipulationModule(Module):
             yaw: Target yaw in radians (omit to keep current orientation).
             robot_name: Robot to move (only needed for multi-arm setups).
         """
-        logger.info(f"Planning motion to ({x:.3f}, {y:.3f}, {z:.3f})...")
+        with skill_timing("move_to_pose") as stamp:
+            logger.info(f"Planning motion to ({x:.3f}, {y:.3f}, {z:.3f})...")
 
-        # If no orientation specified, preserve the current EE orientation.
-        # If partially specified, fill unspecified angles from current orientation.
-        if roll is None and pitch is None and yaw is None:
-            current_pose = self.get_ee_pose(robot_name)
-            if current_pose is not None:
-                orientation = current_pose.orientation
+            # If no orientation specified, preserve the current EE orientation.
+            # If partially specified, fill unspecified angles from current orientation.
+            if roll is None and pitch is None and yaw is None:
+                current_pose = self.get_ee_pose(robot_name)
+                if current_pose is not None:
+                    orientation = current_pose.orientation
+                else:
+                    orientation = Quaternion(0, 0, 0, 1)  # identity fallback
             else:
-                orientation = Quaternion(0, 0, 0, 1)  # identity fallback
-        else:
-            current_pose = self.get_ee_pose(robot_name)
-            if current_pose is not None:
-                current_euler = current_pose.orientation.to_euler()
-                orientation = Quaternion.from_euler(
-                    Vector3(
-                        roll if roll is not None else current_euler.x,
-                        pitch if pitch is not None else current_euler.y,
-                        yaw if yaw is not None else current_euler.z,
+                current_pose = self.get_ee_pose(robot_name)
+                if current_pose is not None:
+                    current_euler = current_pose.orientation.to_euler()
+                    orientation = Quaternion.from_euler(
+                        Vector3(
+                            roll if roll is not None else current_euler.x,
+                            pitch if pitch is not None else current_euler.y,
+                            yaw if yaw is not None else current_euler.z,
+                        )
+                    )
+                else:
+                    orientation = Quaternion.from_euler(
+                        Vector3(roll or 0.0, pitch or 0.0, yaw or 0.0)
+                    )
+
+            pose = Pose(Vector3(x, y, z), orientation)
+
+            # If EE is low, lift up first to clear obstacles
+            lift = self._lift_if_low(robot_name)
+            if not lift.is_success():
+                return stamp(lift)
+
+            if not self.plan_to_pose(pose, robot_name):
+                return stamp(
+                    SkillResult.fail(
+                        ManipulationError.PLANNING_FAILED,
+                        f"Pose ({x:.3f}, {y:.3f}, {z:.3f}) may be unreachable or in collision",
                     )
                 )
-            else:
-                orientation = Quaternion.from_euler(Vector3(roll or 0.0, pitch or 0.0, yaw or 0.0))
 
-        pose = Pose(Vector3(x, y, z), orientation)
+            exec_result = self._preview_execute_wait(robot_name)
+            if not exec_result.is_success():
+                return stamp(exec_result)
 
-        # If EE is low, lift up first to clear obstacles
-        err = self._lift_if_low(robot_name)
-        if err:
-            return err
-
-        if not self.plan_to_pose(pose, robot_name):
-            return f"Error: Planning failed — pose ({x:.3f}, {y:.3f}, {z:.3f}) may be unreachable or in collision"
-
-        err = self._preview_execute_wait(robot_name)
-        if err:
-            return err
-
-        return f"Reached target pose ({x:.3f}, {y:.3f}, {z:.3f})"
+            return stamp(SkillResult.ok(f"Reached target pose ({x:.3f}, {y:.3f}, {z:.3f})"))
 
     @skill
     def move_to_joints(
         self,
         joints: str,
         robot_name: str | None = None,
-    ) -> str:
+    ) -> SkillResult:
         """Move the robot to a target joint configuration.
 
         Plans a collision-free trajectory and executes it.
@@ -1128,29 +1156,42 @@ class ManipulationModule(Module):
             joints: Comma-separated joint positions in radians, e.g. "0.1, -0.5, 1.2, 0.0, 0.3, -0.1".
             robot_name: Robot to move (only needed for multi-arm setups).
         """
-        try:
-            joint_values = [float(j.strip()) for j in joints.split(",")]
-        except ValueError:
-            return f"Error: Invalid joints format '{joints}'. Expected comma-separated floats."
+        with skill_timing("move_to_joints") as stamp:
+            try:
+                joint_values = [float(j.strip()) for j in joints.split(",")]
+            except ValueError:
+                return stamp(
+                    SkillResult.fail(
+                        CommonSkillError.INVALID_INPUT,
+                        f"Invalid joints format '{joints}'. Expected comma-separated floats.",
+                    )
+                )
 
-        robot = self._get_robot(robot_name)
-        if robot is None:
-            return "Error: Robot not found"
-        rname, _, config, _ = robot
-        goal = JointState(name=config.joint_names, position=joint_values)
+            robot = self._get_robot(robot_name)
+            if robot is None:
+                return stamp(SkillResult.fail(CommonSkillError.ROBOT_NOT_FOUND, "Robot not found"))
+            rname, _, config, _ = robot
+            goal = JointState(name=config.joint_names, position=joint_values)
 
-        logger.info(f"Planning motion to joints [{', '.join(f'{j:.3f}' for j in joint_values)}]...")
-        if not self.plan_to_joints(goal, rname):
-            return "Error: Planning failed — joint configuration may be unreachable or in collision"
+            logger.info(
+                f"Planning motion to joints [{', '.join(f'{j:.3f}' for j in joint_values)}]..."
+            )
+            if not self.plan_to_joints(goal, rname):
+                return stamp(
+                    SkillResult.fail(
+                        ManipulationError.PLANNING_FAILED,
+                        "Joint configuration may be unreachable or in collision",
+                    )
+                )
 
-        err = self._preview_execute_wait(robot_name)
-        if err:
-            return err
+            exec_result = self._preview_execute_wait(robot_name)
+            if not exec_result.is_success():
+                return stamp(exec_result)
 
-        return "Reached target joint configuration"
+            return stamp(SkillResult.ok("Reached target joint configuration"))
 
     @skill
-    def go_home(self, robot_name: str | None = None) -> str:
+    def go_home(self, robot_name: str | None = None) -> SkillResult:
         """Move the robot to its home/observe joint configuration.
 
         Opens the gripper and moves to the predefined home position.
@@ -1158,31 +1199,41 @@ class ManipulationModule(Module):
         Args:
             robot_name: Robot to move (only needed for multi-arm setups).
         """
-        robot = self._get_robot(robot_name)
-        if robot is None:
-            return "Error: Robot not found"
-        rname, _, config, _ = robot
+        with skill_timing("go_home") as stamp:
+            robot = self._get_robot(robot_name)
+            if robot is None:
+                return stamp(SkillResult.fail(CommonSkillError.ROBOT_NOT_FOUND, "Robot not found"))
+            rname, _, config, _ = robot
 
-        if config.home_joints is None:
-            return "Error: No home_joints configured for this robot"
+            if config.home_joints is None:
+                return stamp(
+                    SkillResult.fail(
+                        CommonSkillError.NOT_CONFIGURED,
+                        "No home_joints configured for this robot",
+                    )
+                )
 
-        logger.info("Opening gripper...")
-        self._set_gripper_position(0.85, rname)
-        time.sleep(0.5)
+            logger.info("Opening gripper...")
+            self._set_gripper_position(0.85, rname)
+            time.sleep(0.5)
 
-        goal = JointState(name=config.joint_names, position=config.home_joints)
-        logger.info("Planning motion to home position...")
-        if not self.plan_to_joints(goal, rname):
-            return "Error: Failed to plan path to home position"
+            goal = JointState(name=config.joint_names, position=config.home_joints)
+            logger.info("Planning motion to home position...")
+            if not self.plan_to_joints(goal, rname):
+                return stamp(
+                    SkillResult.fail(
+                        ManipulationError.PLANNING_FAILED, "Failed to plan path to home position"
+                    )
+                )
 
-        err = self._preview_execute_wait(robot_name)
-        if err:
-            return err
+            exec_result = self._preview_execute_wait(robot_name)
+            if not exec_result.is_success():
+                return stamp(exec_result)
 
-        return "Reached home position"
+            return stamp(SkillResult.ok("Reached home position"))
 
     @skill
-    def go_init(self, robot_name: str | None = None) -> str:
+    def go_init(self, robot_name: str | None = None) -> SkillResult:
         """Move the robot to its init position (captured at startup or set manually).
 
         The init position is the joint configuration the robot was in when the
@@ -1191,51 +1242,61 @@ class ManipulationModule(Module):
         Args:
             robot_name: Robot to move (only needed for multi-arm setups).
         """
-        robot = self._get_robot(robot_name)
-        if robot is None:
-            return "Error: Robot not found"
-        rname, robot_id, _, _ = robot
+        with skill_timing("go_init") as stamp:
+            robot = self._get_robot(robot_name)
+            if robot is None:
+                return stamp(SkillResult.fail(CommonSkillError.ROBOT_NOT_FOUND, "Robot not found"))
+            rname, robot_id, _, _ = robot
 
-        init = self._init_joints.get(rname)
-        if init is None:
-            return "Error: No init joints captured — robot may not have reported joint state yet"
-
-        # Lift if EE is low before moving to init
-        err = self._lift_if_low(robot_name)
-        if err:
-            return err
-
-        # Move through a safe waypoint: 10cm above and 5cm in front of init pose.
-        # This avoids direct paths through the workspace that could collide with objects.
-        if self._world_monitor is not None:
-            init_ee = self._world_monitor.get_ee_pose(robot_id, joint_state=init)
-            if init_ee is not None:
-                wp = Pose(
-                    Vector3(
-                        init_ee.position.x + 0.05,
-                        init_ee.position.y,
-                        init_ee.position.z + 0.10,
-                    ),
-                    init_ee.orientation,
+            init = self._init_joints.get(rname)
+            if init is None:
+                return stamp(
+                    SkillResult.fail(
+                        CommonSkillError.NOT_CONFIGURED,
+                        "No init joints captured — robot may not have reported joint state yet",
+                    )
                 )
-                if self.plan_to_pose(wp, robot_name):
-                    err = self._preview_execute_wait(robot_name)
-                    if err:
-                        return err
-                else:
-                    logger.warning("Safe waypoint unreachable, going directly to init")
 
-        logger.info(
-            f"Planning motion to init position [{', '.join(f'{j:.3f}' for j in init.position)}]..."
-        )
-        if not self.plan_to_joints(init, robot_name):
-            return "Error: Failed to plan path to init position"
+            # Lift if EE is low before moving to init
+            lift = self._lift_if_low(robot_name)
+            if not lift.is_success():
+                return stamp(lift)
 
-        err = self._preview_execute_wait(robot_name)
-        if err:
-            return err
+            # Move through a safe waypoint: 10cm above and 5cm in front of init pose.
+            # This avoids direct paths through the workspace that could collide with objects.
+            if self._world_monitor is not None:
+                init_ee = self._world_monitor.get_ee_pose(robot_id, joint_state=init)
+                if init_ee is not None:
+                    wp = Pose(
+                        Vector3(
+                            init_ee.position.x + 0.05,
+                            init_ee.position.y,
+                            init_ee.position.z + 0.10,
+                        ),
+                        init_ee.orientation,
+                    )
+                    if self.plan_to_pose(wp, robot_name):
+                        wp_result = self._preview_execute_wait(robot_name)
+                        if not wp_result.is_success():
+                            return stamp(wp_result)
+                    else:
+                        logger.warning("Safe waypoint unreachable, going directly to init")
 
-        return "Reached init position"
+            logger.info(
+                f"Planning motion to init position [{', '.join(f'{j:.3f}' for j in init.position)}]..."
+            )
+            if not self.plan_to_joints(init, robot_name):
+                return stamp(
+                    SkillResult.fail(
+                        ManipulationError.PLANNING_FAILED, "Failed to plan path to init position"
+                    )
+                )
+
+            exec_result = self._preview_execute_wait(robot_name)
+            if not exec_result.is_success():
+                return stamp(exec_result)
+
+            return stamp(SkillResult.ok("Reached init position"))
 
     @rpc
     def stop(self) -> None:

--- a/dimos/manipulation/pick_and_place_module.py
+++ b/dimos/manipulation/pick_and_place_module.py
@@ -28,6 +28,7 @@ import time
 from typing import TYPE_CHECKING, Any
 
 from dimos.agents.annotation import skill
+from dimos.agents.skill_result import CommonSkillError, SkillResult, skill_timing
 from dimos.constants import DIMOS_PROJECT_ROOT
 from dimos.core.core import rpc
 from dimos.core.docker_module import DockerModuleProxy as DockerRunner
@@ -37,6 +38,7 @@ from dimos.manipulation.manipulation_module import (
     ManipulationModule,
     ManipulationModuleConfig,
 )
+from dimos.manipulation.skill_errors import ManipulationError
 from dimos.msgs.geometry_msgs.Pose import Pose
 from dimos.msgs.geometry_msgs.Quaternion import Quaternion
 from dimos.msgs.geometry_msgs.Vector3 import Vector3
@@ -152,17 +154,25 @@ class PickAndPlaceModule(ManipulationModule):
         return result
 
     @skill
-    def clear_perception_obstacles(self) -> str:
+    def clear_perception_obstacles(self) -> SkillResult:
         """Clear all perception obstacles from the planning world.
 
         Use this when the planner reports COLLISION_AT_START — detected objects
         may overlap the robot's current position and block planning.
         """
-        if self._world_monitor is None:
-            return "No world monitor available"
-        count = self._world_monitor.clear_perception_obstacles()
-        self._detection_snapshot = []
-        return f"Cleared {count} perception obstacle(s) from planning world"
+        with skill_timing("clear_perception_obstacles") as stamp:
+            if self._world_monitor is None:
+                return stamp(
+                    SkillResult.fail(
+                        ManipulationError.WORLD_MONITOR_UNAVAILABLE,
+                        "No world monitor available",
+                    )
+                )
+            count = self._world_monitor.clear_perception_obstacles()
+            self._detection_snapshot = []
+            return stamp(
+                SkillResult.ok(f"Cleared {count} perception obstacle(s) from planning world")
+            )
 
     @rpc
     def get_perception_status(self) -> dict[str, int]:
@@ -410,7 +420,7 @@ class PickAndPlaceModule(ManipulationModule):
         return det.center.x, det.center.y, det.center.z
 
     @skill
-    def get_scene_info(self, robot_name: str | None = None) -> str:
+    def get_scene_info(self, robot_name: str | None = None) -> SkillResult:
         """Get current robot state, detected objects, and scene information.
 
         Returns a summary of the robot's joint positions, end-effector pose,
@@ -419,56 +429,58 @@ class PickAndPlaceModule(ManipulationModule):
         Args:
             robot_name: Robot to query (only needed for multi-arm setups).
         """
-        lines: list[str] = []
+        with skill_timing("get_scene_info") as stamp:
+            lines: list[str] = []
 
-        # Robot state
-        joints = self.get_current_joints(robot_name)
-        if joints is not None:
-            lines.append(f"Joints: [{', '.join(f'{j:.3f}' for j in joints)}]")
-        else:
-            lines.append("Joints: unavailable (no state received)")
+            # Robot state
+            joints = self.get_current_joints(robot_name)
+            if joints is not None:
+                lines.append(f"Joints: [{', '.join(f'{j:.3f}' for j in joints)}]")
+            else:
+                lines.append("Joints: unavailable (no state received)")
 
-        ee_pose = self.get_ee_pose(robot_name)
-        if ee_pose is not None:
-            p = ee_pose.position
-            lines.append(f"EE pose: ({p.x:.4f}, {p.y:.4f}, {p.z:.4f})")
-        else:
-            lines.append("EE pose: unavailable")
+            ee_pose = self.get_ee_pose(robot_name)
+            if ee_pose is not None:
+                p = ee_pose.position
+                lines.append(f"EE pose: ({p.x:.4f}, {p.y:.4f}, {p.z:.4f})")
+            else:
+                lines.append("EE pose: unavailable")
 
-        # Gripper
-        gripper_pos = self.get_gripper(robot_name)
-        if gripper_pos is not None:
-            lines.append(f"Gripper: {gripper_pos:.3f}m")
-        else:
-            lines.append("Gripper: not configured")
+            # Gripper
+            gripper_pos = self.get_gripper(robot_name)
+            if gripper_pos is not None:
+                lines.append(f"Gripper: {gripper_pos:.3f}m")
+            else:
+                lines.append("Gripper: not configured")
 
-        # Perception
-        perception = self.get_perception_status()
-        lines.append(
-            f"Perception: {perception.get('cached', 0)} cached, {perception.get('added', 0)} obstacles added"
-        )
+            # Perception
+            perception = self.get_perception_status()
+            lines.append(
+                f"Perception: {perception.get('cached', 0)} cached, "
+                f"{perception.get('added', 0)} obstacles added"
+            )
 
-        detections = self._detection_snapshot
-        if detections:
-            lines.append(f"Detected objects ({len(detections)}):")
-            for det in detections:
-                c = det.center
-                lines.append(f"  - {det.name}: ({c.x:.3f}, {c.y:.3f}, {c.z:.3f})")
-        else:
-            lines.append("Detected objects: none")
+            detections = self._detection_snapshot
+            if detections:
+                lines.append(f"Detected objects ({len(detections)}):")
+                for det in detections:
+                    c = det.center
+                    lines.append(f"  - {det.name}: ({c.x:.3f}, {c.y:.3f}, {c.z:.3f})")
+            else:
+                lines.append("Detected objects: none")
 
-        # Visualization
-        url = self.get_visualization_url()
-        if url:
-            lines.append(f"Visualization: {url}")
+            # Visualization
+            url = self.get_visualization_url()
+            if url:
+                lines.append(f"Visualization: {url}")
 
-        # State
-        lines.append(f"State: {self.get_state()}")
+            # State
+            lines.append(f"State: {self.get_state()}")
 
-        return "\n".join(lines)
+            return stamp(SkillResult.ok("\n".join(lines)))
 
     @skill
-    def look(self, robot_name: str | None = None) -> str:
+    def look(self, robot_name: str | None = None) -> SkillResult:
         """Quick check of what objects are visible from the current camera position.
 
         Does NOT move the arm. Returns objects currently detected in the camera view.
@@ -476,30 +488,36 @@ class PickAndPlaceModule(ManipulationModule):
         Args:
             robot_name: Robot context (only needed for multi-arm setups).
         """
-        obstacles = self.refresh_obstacles(0.0)
+        with skill_timing("look") as stamp:
+            obstacles = self.refresh_obstacles(0.0)
 
-        detections = self._detection_snapshot
-        if not detections:
-            return "No objects visible from current position"
+            detections = self._detection_snapshot
+            if not detections:
+                return stamp(
+                    SkillResult.fail(
+                        ManipulationError.NO_OBJECTS_VISIBLE,
+                        "No objects visible from current position",
+                    )
+                )
 
-        lines = [f"Currently see {len(detections)} object(s):"]
-        for det in detections:
-            c = det.center
-            lines.append(
-                f"  - {det.name} [id={det.object_id[:8]}]: ({c.x:.3f}, {c.y:.3f}, {c.z:.3f})"
-            )
+            lines = [f"Currently see {len(detections)} object(s):"]
+            for det in detections:
+                c = det.center
+                lines.append(
+                    f"  - {det.name} [id={det.object_id[:8]}]: ({c.x:.3f}, {c.y:.3f}, {c.z:.3f})"
+                )
 
-        if obstacles:
-            lines.append(f"\n{len(obstacles)} obstacle(s) added to planning world")
+            if obstacles:
+                lines.append(f"\n{len(obstacles)} obstacle(s) added to planning world")
 
-        return "\n".join(lines)
+            return stamp(SkillResult.ok("\n".join(lines)))
 
     @skill
     def scan_objects(
         self,
         min_duration: float = 0.0,
         robot_name: str | None = None,
-    ) -> str:
+    ) -> SkillResult:
         """Scan for objects — moves to init position first for a clear camera view, \
 then refreshes perception obstacles.
 
@@ -509,28 +527,34 @@ then refreshes perception obstacles.
             min_duration: Minimum time an object must be seen to be included.
             robot_name: Robot context (only needed for multi-arm setups).
         """
-        # Go to init for a clear camera view
-        init_result = self.go_init(robot_name)
-        if init_result.startswith("Error:"):
-            return f"Failed to reach init position: {init_result}"
+        with skill_timing("scan_objects") as stamp:
+            # Go to init for a clear camera view
+            init_result = self.go_init(robot_name)
+            if not init_result.is_success():
+                return stamp(init_result)
 
-        obstacles = self.refresh_obstacles(min_duration)
+            obstacles = self.refresh_obstacles(min_duration)
 
-        detections = self._detection_snapshot
-        if not detections:
-            return "No objects detected in scene"
+            detections = self._detection_snapshot
+            if not detections:
+                return stamp(
+                    SkillResult.fail(
+                        ManipulationError.NO_OBJECTS_VISIBLE, "No objects detected in scene"
+                    )
+                )
 
-        lines = [f"Detected {len(detections)} object(s):"]
-        for det in detections:
-            c = det.center
-            lines.append(
-                f"  - {det.name}: ({c.x:.3f}, {c.y:.3f}, {c.z:.3f}) [{det.detections_count} views]"
-            )
+            lines = [f"Detected {len(detections)} object(s):"]
+            for det in detections:
+                c = det.center
+                lines.append(
+                    f"  - {det.name}: ({c.x:.3f}, {c.y:.3f}, {c.z:.3f}) "
+                    f"[{det.detections_count} views]"
+                )
 
-        if obstacles:
-            lines.append(f"\n{len(obstacles)} obstacle(s) added to planning world")
+            if obstacles:
+                lines.append(f"\n{len(obstacles)} obstacle(s) added to planning world")
 
-        return "\n".join(lines)
+            return stamp(SkillResult.ok("\n".join(lines)))
 
     @skill
     def pick(
@@ -538,7 +562,7 @@ then refreshes perception obstacles.
         object_name: str,
         object_id: str | None = None,
         robot_name: str | None = None,
-    ) -> str:
+    ) -> SkillResult:
         """Pick up an object by name using grasp planning and motion execution.
 
         Generates grasp poses, plans collision-free approach/grasp/retract motions,
@@ -549,74 +573,95 @@ then refreshes perception obstacles.
             object_id: Optional unique object ID from perception for precise identification.
             robot_name: Robot to use (only needed for multi-arm setups).
         """
-        robot = self._get_robot(robot_name)
-        if robot is None:
-            return "Error: Robot not found"
-        rname, _, config, _ = robot
-        pre_grasp_offset = config.pre_grasp_offset
+        with skill_timing("pick") as stamp:
+            robot = self._get_robot(robot_name)
+            if robot is None:
+                return stamp(SkillResult.fail(CommonSkillError.ROBOT_NOT_FOUND, "Robot not found"))
+            rname, _, config, _ = robot
+            pre_grasp_offset = config.pre_grasp_offset
 
-        # 1. Generate grasps (uses already-cached detections — call scan_objects first)
-        logger.info(f"Generating grasp poses for '{object_name}'...")
-        grasp_poses = self._generate_grasps_for_pick(object_name, object_id)
-        if not grasp_poses:
-            return f"Error: No grasp poses found for '{object_name}'. Object may not be detected."
+            # 1. Generate grasps (uses already-cached detections — call scan_objects first)
+            logger.info(f"Generating grasp poses for '{object_name}'...")
+            grasp_poses = self._generate_grasps_for_pick(object_name, object_id)
+            if not grasp_poses:
+                return stamp(
+                    SkillResult.fail(
+                        ManipulationError.GRASP_GENERATION_FAILED,
+                        f"No grasp poses found for '{object_name}'. Object may not be detected.",
+                    )
+                )
 
-        # Lift if EE is low before approaching
-        err = self._lift_if_low(rname)
-        if err:
-            return err
+            # Lift if EE is low before approaching
+            lift = self._lift_if_low(rname)
+            if not lift.is_success():
+                return stamp(lift)
 
-        # 2. Try each grasp candidate
-        max_attempts = min(len(grasp_poses), 5)
-        for i, grasp_pose in enumerate(grasp_poses[:max_attempts]):
-            # Reduce pre-grasp height for far objects (arm can't reach high + far)
-            gp = grasp_pose.position
-            xy_dist = (gp.x**2 + gp.y**2) ** 0.5
-            offset = pre_grasp_offset if xy_dist < _FAR_REACH_XY_THRESHOLD else 0.05
-            pre_grasp_pose = self._compute_pre_grasp_pose(grasp_pose, offset)
+            # 2. Try each grasp candidate
+            max_attempts = min(len(grasp_poses), 5)
+            for i, grasp_pose in enumerate(grasp_poses[:max_attempts]):
+                # Reduce pre-grasp height for far objects (arm can't reach high + far)
+                gp = grasp_pose.position
+                xy_dist = (gp.x**2 + gp.y**2) ** 0.5
+                offset = pre_grasp_offset if xy_dist < _FAR_REACH_XY_THRESHOLD else 0.05
+                pre_grasp_pose = self._compute_pre_grasp_pose(grasp_pose, offset)
 
-            logger.info(f"Planning approach to pre-grasp (attempt {i + 1}/{max_attempts})...")
-            if not self.plan_to_pose(pre_grasp_pose, rname):
-                logger.info(f"Grasp candidate {i + 1} approach planning failed, trying next")
-                continue  # Try next candidate
+                logger.info(f"Planning approach to pre-grasp (attempt {i + 1}/{max_attempts})...")
+                if not self.plan_to_pose(pre_grasp_pose, rname):
+                    logger.info(f"Grasp candidate {i + 1} approach planning failed, trying next")
+                    continue  # Try next candidate
 
-            # 3. Open gripper before approach
-            logger.info("Opening gripper...")
-            self._set_gripper_position(0.85, rname)
-            time.sleep(0.5)
+                # 3. Open gripper before approach
+                logger.info("Opening gripper...")
+                self._set_gripper_position(0.85, rname)
+                time.sleep(0.5)
 
-            # 4. Execute approach to pre-grasp
-            err = self._preview_execute_wait(rname)
-            if err:
-                return err
+                # 4. Execute approach to pre-grasp
+                exec_result = self._preview_execute_wait(rname)
+                if not exec_result.is_success():
+                    return stamp(exec_result)
 
-            # 5. Move to grasp pose
-            logger.info("Moving to grasp position...")
-            if not self.plan_to_pose(grasp_pose, rname):
-                return "Error: Grasp pose planning failed"
-            err = self._preview_execute_wait(rname)
-            if err:
-                return err
+                # 5. Move to grasp pose
+                logger.info("Moving to grasp position...")
+                if not self.plan_to_pose(grasp_pose, rname):
+                    return stamp(
+                        SkillResult.fail(
+                            ManipulationError.PLANNING_FAILED, "Grasp pose planning failed"
+                        )
+                    )
+                exec_result = self._preview_execute_wait(rname)
+                if not exec_result.is_success():
+                    return stamp(exec_result)
 
-            # 6. Close gripper
-            logger.info("Closing gripper...")
-            self._set_gripper_position(0.0, rname)
-            time.sleep(1.5)  # Wait for gripper to close
+                # 6. Close gripper
+                logger.info("Closing gripper...")
+                self._set_gripper_position(0.0, rname)
+                time.sleep(1.5)  # Wait for gripper to close
 
-            # 7. Retract to pre-grasp
-            logger.info("Retracting with object...")
-            if not self.plan_to_pose(pre_grasp_pose, rname):
-                return "Error: Retract planning failed"
-            err = self._preview_execute_wait(rname)
-            if err:
-                return err
+                # 7. Retract to pre-grasp
+                logger.info("Retracting with object...")
+                if not self.plan_to_pose(pre_grasp_pose, rname):
+                    return stamp(
+                        SkillResult.fail(
+                            ManipulationError.PLANNING_FAILED, "Retract planning failed"
+                        )
+                    )
+                exec_result = self._preview_execute_wait(rname)
+                if not exec_result.is_success():
+                    return stamp(exec_result)
 
-            # Store pick pose so place_back() can return with same orientation
-            self._last_pick_pose = grasp_pose
+                # Store pick pose so place_back() can return with same orientation
+                self._last_pick_pose = grasp_pose
 
-            return f"Pick complete — grasped '{object_name}' successfully"
+                return stamp(
+                    SkillResult.ok(f"Pick complete — grasped '{object_name}' successfully")
+                )
 
-        return f"Error: All {max_attempts} grasp attempts failed for '{object_name}'"
+            return stamp(
+                SkillResult.fail(
+                    ManipulationError.GRASP_ATTEMPTS_EXHAUSTED,
+                    f"All {max_attempts} grasp attempts failed for '{object_name}'",
+                )
+            )
 
     @skill
     def place(
@@ -625,7 +670,7 @@ then refreshes perception obstacles.
         y: float,
         z: float,
         robot_name: str | None = None,
-    ) -> str:
+    ) -> SkillResult:
         """Place a held object at the specified position.
 
         Plans and executes an approach, lowers to the target, releases the gripper,
@@ -637,9 +682,10 @@ then refreshes perception obstacles.
             z: Target Z position in meters.
             robot_name: Robot to use (only needed for multi-arm setups).
         """
-        xy_dist = (x**2 + y**2) ** 0.5
-        orientation = self._grasp_orientation(x, y, xy_dist)
-        return self._place_with_orientation(x, y, z, orientation, robot_name)
+        with skill_timing("place") as stamp:
+            xy_dist = (x**2 + y**2) ** 0.5
+            orientation = self._grasp_orientation(x, y, xy_dist)
+            return stamp(self._place_with_orientation(x, y, z, orientation, robot_name))
 
     def _place_with_orientation(
         self,
@@ -648,11 +694,11 @@ then refreshes perception obstacles.
         z: float,
         orientation: Quaternion,
         robot_name: str | None = None,
-    ) -> str:
+    ) -> SkillResult:
         """Internal place with explicit orientation."""
         robot = self._get_robot(robot_name)
         if robot is None:
-            return "Error: Robot not found"
+            return SkillResult.fail(CommonSkillError.ROBOT_NOT_FOUND, "Robot not found")
         rname, _, config, _ = robot
         pre_place_offset = config.pre_grasp_offset
 
@@ -665,26 +711,28 @@ then refreshes perception obstacles.
         pre_place_pose = self._compute_pre_grasp_pose(place_pose, pre_place_offset)
 
         # Lift if EE is low before approaching
-        err = self._lift_if_low(rname)
-        if err:
-            return err
+        lift = self._lift_if_low(rname)
+        if not lift.is_success():
+            return lift
 
         # 1. Move to pre-place
         logger.info(f"Planning approach to place position ({x:.3f}, {y:.3f}, {z:.3f})...")
         if not self.plan_to_pose(pre_place_pose, rname):
-            return "Error: Pre-place approach planning failed"
+            return SkillResult.fail(
+                ManipulationError.PLANNING_FAILED, "Pre-place approach planning failed"
+            )
 
-        err = self._preview_execute_wait(rname)
-        if err:
-            return err
+        exec_result = self._preview_execute_wait(rname)
+        if not exec_result.is_success():
+            return exec_result
 
         # 2. Lower to place position
         logger.info("Lowering to place position...")
         if not self.plan_to_pose(place_pose, rname):
-            return "Error: Place pose planning failed"
-        err = self._preview_execute_wait(rname)
-        if err:
-            return err
+            return SkillResult.fail(ManipulationError.PLANNING_FAILED, "Place pose planning failed")
+        exec_result = self._preview_execute_wait(rname)
+        if not exec_result.is_success():
+            return exec_result
 
         # 3. Release
         logger.info("Releasing object...")
@@ -694,15 +742,15 @@ then refreshes perception obstacles.
         # 4. Retract
         logger.info("Retracting...")
         if not self.plan_to_pose(pre_place_pose, rname):
-            return "Error: Retract planning failed"
-        err = self._preview_execute_wait(rname)
-        if err:
-            return err
+            return SkillResult.fail(ManipulationError.PLANNING_FAILED, "Retract planning failed")
+        exec_result = self._preview_execute_wait(rname)
+        if not exec_result.is_success():
+            return exec_result
 
-        return f"Place complete — object released at ({x:.3f}, {y:.3f}, {z:.3f})"
+        return SkillResult.ok(f"Place complete — object released at ({x:.3f}, {y:.3f}, {z:.3f})")
 
     @skill
-    def place_back(self, robot_name: str | None = None) -> str:
+    def place_back(self, robot_name: str | None = None) -> SkillResult:
         """Place the held object back at its original pick position.
 
         Uses the position stored from the last successful pick operation.
@@ -710,13 +758,19 @@ then refreshes perception obstacles.
         Args:
             robot_name: Robot to use (only needed for multi-arm setups).
         """
-        if self._last_pick_pose is None:
-            return "Error: No previous pick position stored — run pick() first"
+        with skill_timing("place_back") as stamp:
+            if self._last_pick_pose is None:
+                return stamp(
+                    SkillResult.fail(
+                        ManipulationError.NO_PRIOR_POSE,
+                        "No previous pick position stored — run pick() first",
+                    )
+                )
 
-        p = self._last_pick_pose.position
-        o = self._last_pick_pose.orientation
-        logger.info(f"Placing back at original position ({p.x:.3f}, {p.y:.3f}, {p.z:.3f})...")
-        return self._place_with_orientation(p.x, p.y, p.z, o, robot_name)
+            p = self._last_pick_pose.position
+            o = self._last_pick_pose.orientation
+            logger.info(f"Placing back at original position ({p.x:.3f}, {p.y:.3f}, {p.z:.3f})...")
+            return stamp(self._place_with_orientation(p.x, p.y, p.z, o, robot_name))
 
     @skill
     def drop_on(
@@ -724,7 +778,7 @@ then refreshes perception obstacles.
         target_object_name: str,
         z_offset: float = 0.1,
         robot_name: str | None = None,
-    ) -> str:
+    ) -> SkillResult:
         """Drop a held object on top of a detected object.
 
         Resolves the target object's position with occlusion correction and
@@ -735,15 +789,22 @@ then refreshes perception obstacles.
             z_offset: Height above the target object's center to release (meters).
             robot_name: Robot to use (only needed for multi-arm setups).
         """
-        pos = self._resolve_object_position(target_object_name)
-        if pos is None:
-            return f"Error: Target object '{target_object_name}' not found in detections"
-        x, y, z = pos
-        z += z_offset
-        logger.info(
-            f"Dropping on '{target_object_name}' at corrected position ({x:.3f}, {y:.3f}, {z:.3f})"
-        )
-        return self.place(x, y, z, robot_name)
+        with skill_timing("drop_on") as stamp:
+            pos = self._resolve_object_position(target_object_name)
+            if pos is None:
+                return stamp(
+                    SkillResult.fail(
+                        ManipulationError.OBJECT_NOT_DETECTED,
+                        f"Target object '{target_object_name}' not found in detections",
+                    )
+                )
+            x, y, z = pos
+            z += z_offset
+            logger.info(
+                f"Dropping on '{target_object_name}' at corrected position "
+                f"({x:.3f}, {y:.3f}, {z:.3f})"
+            )
+            return stamp(self.place(x, y, z, robot_name))
 
     @skill
     def pick_and_place(
@@ -754,7 +815,7 @@ then refreshes perception obstacles.
         place_z: float,
         object_id: str | None = None,
         robot_name: str | None = None,
-    ) -> str:
+    ) -> SkillResult:
         """Pick up an object and place it at a target location.
 
         Combines the pick and place skills into a single end-to-end operation.
@@ -767,17 +828,19 @@ then refreshes perception obstacles.
             object_id: Optional unique object ID from perception.
             robot_name: Robot to use (only needed for multi-arm setups).
         """
-        logger.info(
-            f"Starting pick and place: pick '{object_name}' → place at ({place_x:.3f}, {place_y:.3f}, {place_z:.3f})"
-        )
+        with skill_timing("pick_and_place") as stamp:
+            logger.info(
+                f"Starting pick and place: pick '{object_name}' → place at "
+                f"({place_x:.3f}, {place_y:.3f}, {place_z:.3f})"
+            )
 
-        # Pick phase
-        result = self.pick(object_name, object_id, robot_name)
-        if result.startswith("Error:"):
-            return result
+            # Pick phase
+            pick_result = self.pick(object_name, object_id, robot_name)
+            if not pick_result.is_success():
+                return stamp(pick_result)
 
-        # Place phase
-        return self.place(place_x, place_y, place_z, robot_name)
+            # Place phase
+            return stamp(self.place(place_x, place_y, place_z, robot_name))
 
     @rpc
     def stop(self) -> None:

--- a/dimos/manipulation/skill_errors.py
+++ b/dimos/manipulation/skill_errors.py
@@ -1,0 +1,37 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Manipulation-domain failure codes for ``SkillResult``.
+
+Cross-domain codes (``ROBOT_NOT_FOUND``, ``INVALID_INPUT``, ``EXECUTION_FAILED``,
+``EXECUTION_TIMEOUT``, ...) live in ``dimos.agents.skill_result.CommonSkillError``.
+This module owns codes that are specific to manipulation skills.
+"""
+
+from enum import Enum, auto
+
+
+class ManipulationError(Enum):
+    """Manipulation-specific skill failure modes."""
+
+    NO_PRIOR_POSE = auto()
+    OBJECT_NOT_DETECTED = auto()
+    NO_OBJECTS_VISIBLE = auto()
+    IK_FAILED = auto()
+    PLANNING_FAILED = auto()
+    COLLISION_AT_START = auto()
+    GRASP_GENERATION_FAILED = auto()
+    GRASP_ATTEMPTS_EXHAUSTED = auto()
+    GRIPPER_FAILED = auto()
+    WORLD_MONITOR_UNAVAILABLE = auto()

--- a/dimos/manipulation/test_manipulation_unit.py
+++ b/dimos/manipulation/test_manipulation_unit.py
@@ -119,18 +119,21 @@ class TestStateMachine:
 
     def test_reset_not_during_execution(self):
         """Reset works in any state except EXECUTING."""
+        from dimos.agents.skill_result import CommonSkillError
+
         module = _make_module()
 
         module._state = ManipulationState.FAULT
         module._error_message = "Error"
         result = module.reset()
-        assert "IDLE" in result
+        assert result.is_success()
         assert module._state == ManipulationState.IDLE
         assert module._error_message == ""
 
         module._state = ManipulationState.EXECUTING
         result = module.reset()
-        assert "Error" in result
+        assert not result.is_success()
+        assert result.error_code is CommonSkillError.INVALID_STATE
 
     def test_fail_sets_fault_state(self):
         """_fail helper sets FAULT state and message."""

--- a/dimos/manipulation/test_pick_and_place_unit.py
+++ b/dimos/manipulation/test_pick_and_place_unit.py
@@ -152,8 +152,11 @@ class TestPlaceBack:
     """Test place_back guard logic."""
 
     def test_place_back_no_pick_pose_errors(self, module):
+        from dimos.manipulation.skill_errors import ManipulationError
+
         module._last_pick_pose = None
 
         result = module.place_back()
-        assert "Error" in result
-        assert "pick" in result.lower()
+        assert not result.is_success()
+        assert result.error_code is ManipulationError.NO_PRIOR_POSE
+        assert "pick" in result.message.lower()


### PR DESCRIPTION
## Problem

Manipulation skills return prose like `"Error: Robot not found"`. The agent has to parse strings to know what failed — blocks structured retries. Phase 1 of the pick-and-place reliability plan.

## Solution

Skills now return a `SkillResult` dataclass with `success`, `message`, `error_code`, `duration_ms`. Error codes are domain enums (`CommonSkillError`, `ManipulationError`). MCP auto-detects the new `agent_encode()` method, so the LLM sees structured JSON. Every return logs `SKILL <name> result=<code> duration_ms=<n>` server-side. All 18 manipulation skills migrated. Drive-by: enabled gripper on `xarm7-planner-coordinator`.

## Breaking Changes

Skills return `SkillResult` instead of `str`. Replace `"Error:" in result` with `result.is_success()` / `result.error_code`.

## How to Test

1. `uv run pytest dimos/agents/test_skill_result.py dimos/manipulation/`
2. dimos run xarm7-planner-coordinator`, then `python -i -m dimos.manipulation.planning.examples.manipulation_client`
3. `_client.set_gripper(0.85)` returns a `SkillResult` dataclass; logs show `SKILL set_gripper result=OK ...`

closes DIM-786