### PR TITLE
mapper memory leak fix, measurement transforms

### DIFF
--- a/dimos/mapping/voxels.py
+++ b/dimos/mapping/voxels.py
@@ -142,6 +142,14 @@ class VoxelGrid:
 
         self._voxel_hashmap.activate(new_keys)
 
+        # Return Open3D's CUDA caching pool to the driver. The ops in this
+        # method (HashMap construction, ``key_tensor()[idx]``, ``find()``)
+        # allocate per-call device buffers; Open3D's caching allocator holds
+        # them in pool indefinitely once the Python wrappers are released.
+        # Without this call, VRAM grows ~0.8 MB/call until OOM.
+        if str(self._dev).startswith("CUDA"):
+            o3c.cuda.release_cache()
+
     @simple_mcache
     def get_global_pointcloud2(self) -> PointCloud2:
         self._check_disposed()

--- a/dimos/mapping/voxels.py
+++ b/dimos/mapping/voxels.py
@@ -107,6 +107,14 @@ class VoxelGrid:
         self.get_global_pointcloud.invalidate_cache(self)
         self.get_global_pointcloud2.invalidate_cache(self)
 
+        # Return Open3D's CUDA caching pool to the driver. The ops above
+        # (HashMap construction in carving, ``key_tensor()[idx]``, ``find()``,
+        # ``activate()``) allocate per-call device buffers; Open3D's caching
+        # allocator holds them in pool indefinitely once the Python wrappers
+        # are released. Without this call, VRAM grows ~0.8 MB/call until OOM.
+        if str(self._dev).startswith("CUDA"):
+            o3c.cuda.release_cache()
+
     def _carve_and_insert(self, new_keys: o3c.Tensor) -> None:
         """Column carving: remove all existing voxels sharing (X,Y) with new_keys, then insert."""
         if new_keys.shape[0] == 0:
@@ -141,14 +149,6 @@ class VoxelGrid:
             self._voxel_hashmap.erase(to_erase)
 
         self._voxel_hashmap.activate(new_keys)
-
-        # Return Open3D's CUDA caching pool to the driver. The ops in this
-        # method (HashMap construction, ``key_tensor()[idx]``, ``find()``)
-        # allocate per-call device buffers; Open3D's caching allocator holds
-        # them in pool indefinitely once the Python wrappers are released.
-        # Without this call, VRAM grows ~0.8 MB/call until OOM.
-        if str(self._dev).startswith("CUDA"):
-            o3c.cuda.release_cache()
 
     @simple_mcache
     def get_global_pointcloud2(self) -> PointCloud2:

--- a/dimos/memory2/transform.py
+++ b/dimos/memory2/transform.py
@@ -26,6 +26,7 @@ from dimos.memory2.utils.formatting import FilterRepr
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator, Sequence
 
+    from dimos.memory2.stream import Stream
     from dimos.memory2.type.observation import Observation
 
 T = TypeVar("T")
@@ -136,19 +137,19 @@ def throttle(interval: float) -> FnIterTransformer[T, T]:
     return FnIterTransformer(_throttle)
 
 
-def measure_time(out):
-    """Returns a transformer that records per-frame downstream cost into *out*."""
+def measure_time(out: Stream[float]) -> FnIterTransformer[T, T]:
+    """Returns a transformer that records per-frame downstream cost (ms) into *out*."""
 
-    def _xf(upstream):
+    def _xf(upstream: Iterator[Observation[T]]) -> Iterator[Observation[T]]:
         for obs in upstream:
             start = time.perf_counter()
             yield obs
             out.append((time.perf_counter() - start) * 1000, ts=obs.ts)
 
-    return _xf
+    return FnIterTransformer(_xf)
 
 
-def measure_gpu_mem(out, device: int = 0):
+def measure_gpu_mem(out: Stream[float], device: int = 0) -> FnIterTransformer[T, T]:
     """Returns a transformer that records device-level GPU VRAM used (MB) per frame into *out*.
 
     Reads ``torch.cuda.mem_get_info`` *after* each yield (and ``synchronize()``
@@ -156,16 +157,20 @@ def measure_gpu_mem(out, device: int = 0):
     capturing memory used by every allocator on the device — Open3D, torch,
     other processes — not just the current process.
     """
+    import open3d.core as o3c  # type: ignore[import-untyped]
     import torch
 
-    def _xf(upstream):
+    if not o3c.cuda.is_available():
+        raise RuntimeError("measure_gpu_mem requires a CUDA-capable GPU")
+
+    def _xf(upstream: Iterator[Observation[T]]) -> Iterator[Observation[T]]:
         for obs in upstream:
             yield obs
             torch.cuda.synchronize(device)
             free, total = torch.cuda.mem_get_info(device)
             out.append((total - free) / 1_000_000, ts=obs.ts)
 
-    return _xf
+    return FnIterTransformer(_xf)
 
 
 def speed() -> FnIterTransformer[Any, float]:

--- a/dimos/memory2/transform.py
+++ b/dimos/memory2/transform.py
@@ -18,6 +18,7 @@ from abc import ABC, abstractmethod
 import collections
 import inspect
 import math
+import time
 from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar, cast
 
 from dimos.memory2.utils.formatting import FilterRepr
@@ -133,6 +134,38 @@ def throttle(interval: float) -> FnIterTransformer[T, T]:
                 yield obs
 
     return FnIterTransformer(_throttle)
+
+
+def measure_time(out):
+    """Returns a transformer that records per-frame downstream cost into *out*."""
+
+    def _xf(upstream):
+        for obs in upstream:
+            start = time.perf_counter()
+            yield obs
+            out.append((time.perf_counter() - start) * 1000, ts=obs.ts)
+
+    return _xf
+
+
+def measure_gpu_mem(out, device: int = 0):
+    """Returns a transformer that records device-level GPU VRAM used (MB) per frame into *out*.
+
+    Reads ``torch.cuda.mem_get_info`` *after* each yield (and ``synchronize()``
+    so async kernels submitted by the downstream consumer have completed),
+    capturing memory used by every allocator on the device — Open3D, torch,
+    other processes — not just the current process.
+    """
+    import torch
+
+    def _xf(upstream):
+        for obs in upstream:
+            yield obs
+            torch.cuda.synchronize(device)
+            free, total = torch.cuda.mem_get_info(device)
+            out.append((total - free) / 1_000_000, ts=obs.ts)
+
+    return _xf
 
 
 def speed() -> FnIterTransformer[Any, float]:


### PR DESCRIPTION
Noticed a memory leak on a global mapper now with large hongkong office recording:

<img width="1201" height="384" alt="2026-05-09_10-47" src="https://github.com/user-attachments/assets/5b44af92-9a3f-4b21-b4b8-1ff70aec64dd" />

Issue was o3d GPU cache release, fixed

<img width="1189" height="410" alt="2026-05-09_10-58_1" src="https://github.com/user-attachments/assets/1f178df7-4aa9-454c-b157-e15e01ff3752" />

Also introduced 2 new mem2 transforms

`measure_time`
and 
`measure_gpu_mem`