### PR TITLE
docs: mark non-executable code blocks as skip

### DIFF
--- a/docs/capabilities/navigation/nav_stack.md
+++ b/docs/capabilities/navigation/nav_stack.md
@@ -33,7 +33,7 @@ The stack produces:
 
 All configuration goes through `create_nav_stack()` keyword arguments. Top-level switches plus per-module config dicts:
 
-```python
+```python skip
 create_nav_stack(
     planner="simple",              # "far" (default) or "simple" (A*)
     use_tare=False,                # Add TARE frontier exploration
@@ -71,7 +71,7 @@ create_nav_stack(
 
 Keep `obstacle_height_threshold` aligned between TerrainAnalysis and LocalPlanner — if TerrainAnalysis flags something but LocalPlanner's threshold is higher, the planner will drive through it.
 
-```python
+```python skip
 create_nav_stack(
     terrain_analysis={"obstacle_height_threshold": 0.1},
     local_planner={"obstacle_height_threshold": 0.1},
@@ -82,7 +82,7 @@ create_nav_stack(
 
 Capped at two levels: LocalPlanner caps how fast it will *plan*, PathFollower caps how fast it will *execute*.
 
-```python
+```python skip
 create_nav_stack(
     local_planner={"max_speed": 1.5, "autonomy_speed": 1.0},
     path_follower={"max_speed": 1.5, "autonomy_speed": 1.0},
@@ -167,7 +167,7 @@ Following the CMU autonomy convention, odometry splits into two paths: **local**
 
 If you have a Livox Mid-360 lidar and a module that consumes `cmd_vel: In[Twist]`, compose three blueprints with `autoconnect`:
 
-```python
+```python skip
 from dimos.core.coordination.blueprints import autoconnect
 from dimos.hardware.sensors.lidar.fastlio2.module import FastLio2
 from dimos.msgs.geometry_msgs.Pose import Pose
@@ -201,7 +201,7 @@ my_robot_nav = (
 
 Just needs `cmd_vel: In[Twist]` and a subscription that drives the hardware:
 
-```python
+```python skip
 from dimos.core.core import rpc
 from dimos.core.module import Module, ModuleConfig
 from dimos.core.stream import In
@@ -235,7 +235,7 @@ class MyRobotControl(Module):
 
 Add a Rerun bridge:
 
-```python
+```python skip
 from dimos.navigation.nav_stack.main import nav_stack_rerun_config
 from dimos.visualization.rerun.bridge import RerunBridgeModule
 

--- a/docs/capabilities/navigation/readme.md
+++ b/docs/capabilities/navigation/readme.md
@@ -1,5 +1,4 @@
 # Navigation
-
 Note: in the future these will be merged into one system.
 
 ## Nav Stack

--- a/docs/platforms/humanoid/g1/index.md
+++ b/docs/platforms/humanoid/g1/index.md
@@ -78,7 +78,7 @@ Note: this button combination may vary based on the model of the G1
 
 In the ssh terminal `ssh -L 3030:localhost:3030 unitree@192.168.123.164`
 
-```sh
+```sh skip
 source .venv/bin/activate
 uv run dimos --rerun-host 0.0.0.0 run unitree-g1-nav-onboard
 # should print out something like:
@@ -98,7 +98,7 @@ uv run dimos --rerun-host 0.0.0.0 run unitree-g1-nav-onboard
 
 On your laptop:
 
-```sh
+```sh skip
 # install uv
 curl -LsSf https://astral.sh/uv/install.sh | sh
 uv venv --python "3.12"

--- a/docs/usage/visualization.md
+++ b/docs/usage/visualization.md
@@ -71,7 +71,7 @@ dimos --rerun-web --rerun-open native run unitree-go2
 
 To enable visualization in your own blueprint, use `vis_module`:
 
-```python
+```python skip
 from dimos.core.coordination.blueprints import autoconnect
 from dimos.hardware.sensors.camera.module import CameraModule
 from dimos.visualization.vis_module import vis_module
@@ -127,7 +127,7 @@ voxel_mapper(voxel_size=0.1),   # 10cm voxels
 
 If you want to log data to Rerun directly from inside a module (e.g. for debugging or one-off visualizations), use `rerun_init` instead of calling `rr.init()` yourself. It handles colormap registration and can optionally start a gRPC server so a viewer can connect.
 
-```python
+```python skip
 import rerun as rr
 from dimos.visualization.rerun.init import rerun_init
 


### PR DESCRIPTION
## Summary

Three docs were failing the `doc-codeblocks` CI job because they contain illustrative code blocks that can't be executed in CI:

Net diff: 10 lines, each just appends ` skip` to a fence opener.
