### PR TITLE
Update docs to --all-groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,8 +316,8 @@ export GIT_LFS_SKIP_SMUDGE=1
 git clone https://github.com/dimensionalOS/dimos.git
 cd dimos
 
-# Run the default test suite (uv run syncs deps on demand; --all-extras
-# only needed for the self-hosted tests — see docs/development/testing.md)
+# Run the default test suite (uv run syncs deps on demand; --all-groups
+# only needed for self-hosted tests / mypy — see docs/development/testing.md)
 uv run pytest --numprocesses=auto dimos
 ```
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -5,7 +5,7 @@
 Self-hosted tests need the heavy optional extras (LFS data, perception models, simulation, hardware SDKs, …). Sync them explicitly before running:
 
 ```bash
-uv sync --all-extras              # everything the resolver supports for your platform
+uv sync --all-groups              # all dependency groups (tests-self-hosted, lint, …)
 uv sync --group tests-self-hosted # just what CI installs on the self-hosted runner
 ```
 

--- a/docs/installation/osx.md
+++ b/docs/installation/osx.md
@@ -31,9 +31,9 @@ export GIT_LFS_SKIP_SMUDGE=1
 git clone https://github.com/dimensionalOS/dimos.git
 cd dimos
 
-# `uv run` syncs the project deps + `tests` group on demand — enough for
-# the default test suite and mypy. For self-hosted tests, sync the extras
-# explicitly (see docs/development/testing.md).
+# Install all dependency groups (tests, lint, …) so mypy + pytest are
+# both available. For self-hosted tests, see docs/development/testing.md.
+uv sync --all-groups
 
 # type check
 uv run mypy dimos

--- a/docs/installation/ubuntu.md
+++ b/docs/installation/ubuntu.md
@@ -29,9 +29,9 @@ export GIT_LFS_SKIP_SMUDGE=1
 git clone https://github.com/dimensionalOS/dimos.git
 cd dimos
 
-# `uv run` syncs the project deps + `tests` group on demand — enough for
-# the default test suite and mypy. For self-hosted tests, sync the extras
-# explicitly (see docs/development/testing.md).
+# Install all dependency groups (tests, lint, …) so mypy + pytest are
+# both available. For self-hosted tests, see docs/development/testing.md.
+uv sync --all-groups
 
 # type check
 uv run mypy dimos


### PR DESCRIPTION
Having moved development dependencies from the extras into groups, developers will now need to install the groups.