### PR TITLE
Don't skip CI on md files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,7 @@ name: ci
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - '**.md'
   pull_request:
-    paths-ignore:
-      - '**.md'
 
 concurrency:
   # Cancels runs from previous pushes in a PR.


### PR DESCRIPTION
At the very least, we need to run codeblocks and get the ci-complete status to pass when md files are changed.

I think it's easiest currently to just run the full workflow, as it doesn't take that long. Maybe in future we'll adapt this to only run specific steps depending on the files changed.