### PR TITLE
Tweak no sync in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,16 @@ concurrency:
 
 permissions: {}
 
+env:
+  # Disable default package installs. Each job should explicitly install a group.
+  UV_NO_SYNC: "1"
+
 jobs:
   lint:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     permissions:
       contents: read  # For checkout
-    env:
-      UV_NO_SYNC: "1"  # Disable installing default packages on `uv run`
 
     steps:
       - name: Checkout
@@ -111,6 +113,8 @@ jobs:
       - name: Set PYTHON_GIL=0 for free-threading builds
         if: ${{ endsWith(matrix.pyver, 't') }}
         run: echo "PYTHON_GIL=0" >> $GITHUB_ENV
+      - name: Install dependencies
+        run: uv sync --group tests --frozen
       - name: Run tests
         run: uv run pytest --numprocesses=3 --cov=dimos/ --junitxml=junit.xml -m 'not (tool or self_hosted or mujoco)'
       - name: Re-run the failing tests with maximum verbosity
@@ -146,7 +150,6 @@ jobs:
         github.event.pull_request.head.repo.full_name == github.repository
       )
     env:
-      UV_NO_SYNC: "1"  # Disable installing default packages on `uv run`
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       ALIBABA_API_KEY: ${{ secrets.ALIBABA_API_KEY }}


### PR DESCRIPTION
Thought about this overnight, and I think this will be more robust to future changes if we ensure the uv installs are always explicit.