### PR TITLE
Fix flaky collector tests

### DIFF
--- a/dimos/utils/testing/collector.py
+++ b/dimos/utils/testing/collector.py
@@ -30,7 +30,7 @@ class CallbackCollector:
         assert len(collector.results) == 3
     """
 
-    def __init__(self, n: int, timeout: float = 5.0) -> None:
+    def __init__(self, n: int, timeout: float = 15.0) -> None:
         self.results: list[tuple[Any, Any]] = []
         self._done = threading.Event()
         self._n = n


### PR DESCRIPTION
## Problem

Some of the tests using the collector are flaky due to having more CPU contention with xdist.

## Solution

Raise the timeouts further to handle this.