### PR TITLE
Run tests on draft

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,13 +135,9 @@ jobs:
           use_oidc: true
 
   self-hosted-tests:
-    # Skip on draft PRs and on PRs from forks — the latter would expose the
-    # self-hosted runner to untrusted code from external contributors.
+    # Skip on PRs from forks which would expose the self-hosted runner to untrusted code from external contributors.
     if: |
-      github.event_name == 'push' || (
-        github.event.pull_request.draft == false &&
-        github.event.pull_request.head.repo.full_name == github.repository
-      )
+      github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Problem

Opening as draft, then marking it ready to review results in the PR being mergeable without the tests actually running.
Sometimes we also want to test things in the CI on a draft anyway.