### PR TITLE
Default to Zenoh transport on macOS and document replay workflow

### DIFF
--- a/dimos/agents/conftest.py
+++ b/dimos/agents/conftest.py
@@ -84,7 +84,7 @@ def agent_setup(request, mcp_url: str, lcm_url: str):
             AgentTestRunner.blueprint(messages=messages),
         )
 
-        global_config.update(viewer="none")
+        global_config.update(viewer="none", transport="lcm")  # fixture uses pLCMTransport sidecars
 
         nonlocal coordinator
         coordinator = ModuleCoordinator.build(blueprint)

--- a/dimos/agents/mcp/conftest.py
+++ b/dimos/agents/mcp/conftest.py
@@ -81,7 +81,7 @@ def agent_setup(request, mcp_url: str, lcm_url: str):
             AgentTestRunner.blueprint(messages=messages),
         )
 
-        global_config.update(viewer="none")
+        global_config.update(viewer="none", transport="lcm")  # fixture uses pLCMTransport sidecars
 
         nonlocal coordinator
         coordinator = ModuleCoordinator.build(blueprint)

--- a/dimos/constants.py
+++ b/dimos/constants.py
@@ -49,6 +49,11 @@ DEFAULT_CAPACITY_DEPTH_IMAGE = 1280 * 720 * 4
 # From https://github.com/lcm-proj/lcm.git
 LCM_MAX_CHANNEL_NAME_LENGTH = 63
 
+# First path segment of Zenoh key expressions for DimOS module streams. Used by
+# ModuleCoordinator (dimos + LCM-style "/name") and ZenohPubSub.subscribe_all
+# (wildcard f"{ZENOH_DIMOS_KEY_PREFIX}/**"). Rerun bridge strips this prefix for entity paths.
+ZENOH_DIMOS_KEY_PREFIX = "dimos"
+
 # Default timeout (seconds) for thread.join() during shutdown.
 DEFAULT_THREAD_JOIN_TIMEOUT = 2.0
 

--- a/dimos/core/coordination/module_coordinator.py
+++ b/dimos/core/coordination/module_coordinator.py
@@ -30,7 +30,13 @@ from dimos.core.coordination.worker_manager_python import WorkerManagerPython
 from dimos.core.global_config import GlobalConfig, global_config
 from dimos.core.module import ModuleBase, ModuleSpec
 from dimos.core.resource import Resource
-from dimos.core.transport import ZENOH_AVAILABLE, LCMTransport, PubSubTransport, pLCMTransport
+from dimos.core.transport import (
+    ZENOH_AVAILABLE,
+    ZENOH_INSTALL_HINT,
+    LCMTransport,
+    PubSubTransport,
+    pLCMTransport,
+)
 from dimos.spec.utils import is_spec, spec_annotation_compliance, spec_structural_compliance
 from dimos.utils.generic import short_id
 from dimos.utils.logging_config import setup_logger
@@ -547,8 +553,7 @@ def _get_transport_for(blueprint: Blueprint, name: str, stream_type: type) -> Pu
     if global_config.transport == "zenoh":
         if not ZENOH_AVAILABLE:
             raise RuntimeError(
-                "transport='zenoh' but eclipse-zenoh is not installed. "
-                "Install with: uv sync --extra zenoh"
+                "transport='zenoh' but eclipse-zenoh is not installed. " + ZENOH_INSTALL_HINT
             )
         from dimos.core.transport import ZenohTransport, pZenohTransport
 

--- a/dimos/core/coordination/module_coordinator.py
+++ b/dimos/core/coordination/module_coordinator.py
@@ -30,7 +30,7 @@ from dimos.core.coordination.worker_manager_python import WorkerManagerPython
 from dimos.core.global_config import GlobalConfig, global_config
 from dimos.core.module import ModuleBase, ModuleSpec
 from dimos.core.resource import Resource
-from dimos.core.transport import LCMTransport, PubSubTransport, ZENOH_AVAILABLE, pLCMTransport
+from dimos.core.transport import ZENOH_AVAILABLE, LCMTransport, PubSubTransport, pLCMTransport
 from dimos.spec.utils import is_spec, spec_annotation_compliance, spec_structural_compliance
 from dimos.utils.generic import short_id
 from dimos.utils.logging_config import setup_logger

--- a/dimos/core/coordination/module_coordinator.py
+++ b/dimos/core/coordination/module_coordinator.py
@@ -23,6 +23,7 @@ import sys
 import threading
 from typing import TYPE_CHECKING, Any, cast
 
+from dimos.constants import ZENOH_DIMOS_KEY_PREFIX
 from dimos.core.coordination.rpyc_server import RpycServer
 from dimos.core.coordination.worker_manager import WorkerManager
 from dimos.core.coordination.worker_manager_docker import WorkerManagerDocker
@@ -557,7 +558,7 @@ def _get_transport_for(blueprint: Blueprint, name: str, stream_type: type) -> Pu
             )
         from dimos.core.transport import ZenohTransport, pZenohTransport
 
-        zenoh_topic = f"dimos{topic}"
+        zenoh_topic = f"{ZENOH_DIMOS_KEY_PREFIX}{topic}"
         transport = (
             pZenohTransport(zenoh_topic)
             if use_pickled
@@ -634,7 +635,9 @@ def _run_configurators(blueprint: Blueprint) -> None:
     from dimos.protocol.service.system_configurator.base import configure_system
     from dimos.protocol.service.system_configurator.lcm_config import lcm_configurators
 
-    lcm_checks = lcm_configurators() if global_config.transport == "lcm" else []
+    # LCM is still used outside merged module transports (CLI side channels, agents, tests).
+    # OS multicast/buffer tuning applies whenever those paths run, not only when transport=lcm.
+    lcm_checks = lcm_configurators()
     configurators = [*lcm_checks, *blueprint.configurator_checks]
 
     try:

--- a/dimos/core/coordination/module_coordinator.py
+++ b/dimos/core/coordination/module_coordinator.py
@@ -554,7 +554,9 @@ def _get_transport_for(blueprint: Blueprint, name: str, stream_type: type) -> Pu
 
         zenoh_topic = f"dimos{topic}"
         transport = (
-            pZenohTransport(zenoh_topic) if use_pickled else ZenohTransport(zenoh_topic, stream_type)
+            pZenohTransport(zenoh_topic)
+            if use_pickled
+            else ZenohTransport(zenoh_topic, stream_type)
         )
     else:
         transport = pLCMTransport(topic) if use_pickled else LCMTransport(topic, stream_type)

--- a/dimos/core/coordination/module_coordinator.py
+++ b/dimos/core/coordination/module_coordinator.py
@@ -30,7 +30,7 @@ from dimos.core.coordination.worker_manager_python import WorkerManagerPython
 from dimos.core.global_config import GlobalConfig, global_config
 from dimos.core.module import ModuleBase, ModuleSpec
 from dimos.core.resource import Resource
-from dimos.core.transport import LCMTransport, PubSubTransport, pLCMTransport
+from dimos.core.transport import LCMTransport, PubSubTransport, ZENOH_AVAILABLE, pLCMTransport
 from dimos.spec.utils import is_spec, spec_annotation_compliance, spec_structural_compliance
 from dimos.utils.generic import short_id
 from dimos.utils.logging_config import setup_logger
@@ -543,7 +543,21 @@ def _get_transport_for(blueprint: Blueprint, name: str, stream_type: type) -> Pu
 
     use_pickled = getattr(stream_type, "lcm_encode", None) is None
     topic = f"/{name}" if _is_name_unique(blueprint, name) else f"/{short_id()}"
-    transport = pLCMTransport(topic) if use_pickled else LCMTransport(topic, stream_type)
+
+    if global_config.transport == "zenoh":
+        if not ZENOH_AVAILABLE:
+            raise RuntimeError(
+                "transport='zenoh' but eclipse-zenoh is not installed. "
+                "Install with: uv sync --extra zenoh"
+            )
+        from dimos.core.transport import ZenohTransport, pZenohTransport
+
+        zenoh_topic = f"dimos{topic}"
+        transport = (
+            pZenohTransport(zenoh_topic) if use_pickled else ZenohTransport(zenoh_topic, stream_type)
+        )
+    else:
+        transport = pLCMTransport(topic) if use_pickled else LCMTransport(topic, stream_type)
 
     return transport
 
@@ -613,7 +627,8 @@ def _run_configurators(blueprint: Blueprint) -> None:
     from dimos.protocol.service.system_configurator.base import configure_system
     from dimos.protocol.service.system_configurator.lcm_config import lcm_configurators
 
-    configurators = [*lcm_configurators(), *blueprint.configurator_checks]
+    lcm_checks = lcm_configurators() if global_config.transport == "lcm" else []
+    configurators = [*lcm_checks, *blueprint.configurator_checks]
 
     try:
         configure_system(configurators)

--- a/dimos/core/coordination/test_module_reloading.py
+++ b/dimos/core/coordination/test_module_reloading.py
@@ -94,9 +94,13 @@ def test_module_file():
 
 
 def test_module_reloading(repl, greeting, response, test_module_file):
+    # Child process must use LCM: this file spies with pLCMTransport, while the
+    # default on Darwin (when Zenoh is installed) is Zenoh.
     repl.stdin.write("""
+from dimos.core.global_config import global_config
 from dimos.core.coordination.module_coordinator import ModuleCoordinator
 from dimos.core.coordination import _test_module
+global_config.update(transport="lcm")
 mc = ModuleCoordinator.build(_test_module.AliceModule.blueprint())
 """)
     repl.stdin.flush()

--- a/dimos/core/global_config.py
+++ b/dimos/core/global_config.py
@@ -61,6 +61,7 @@ class GlobalConfig(BaseSettings):
     planner_robot_speed: float | None = None
     mcp_port: int = 9990
     build_native: bool = DEFAULT_BUILD_NATIVE
+    transport: str = "lcm"
     dtop: bool = False
     obstacle_avoidance: bool = True
     detection_model: VlModelName = "moondream"

--- a/dimos/core/global_config.py
+++ b/dimos/core/global_config.py
@@ -14,6 +14,7 @@
 
 import platform
 import re
+from typing import Literal, TypeAlias
 
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -28,12 +29,14 @@ from dimos.visualization.rerun.constants import (
     ViewerBackend,
 )
 
+TransportBackend: TypeAlias = Literal["lcm", "zenoh"]
+
 
 def _get_all_numbers(s: str) -> list[float]:
     return [float(x) for x in re.findall(r"-?\d+\.?\d*", s)]
 
 
-def _default_transport() -> str:
+def _default_transport() -> TransportBackend:
     if platform.system() == "Darwin" and ZENOH_AVAILABLE:
         return "zenoh"
     return "lcm"
@@ -70,7 +73,7 @@ class GlobalConfig(BaseSettings):
     planner_robot_speed: float | None = None
     mcp_port: int = 9990
     build_native: bool = DEFAULT_BUILD_NATIVE
-    transport: str = Field(default_factory=_default_transport)
+    transport: TransportBackend = Field(default_factory=_default_transport)
     dtop: bool = False
     obstacle_avoidance: bool = True
     detection_model: VlModelName = "moondream"
@@ -82,6 +85,7 @@ class GlobalConfig(BaseSettings):
         env_file=".env",
         env_file_encoding="utf-8",
         extra="ignore",
+        validate_assignment=True,
     )
 
     def update(self, **kwargs: object) -> None:

--- a/dimos/core/global_config.py
+++ b/dimos/core/global_config.py
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import platform
 import re
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from dimos.constants import DEFAULT_BUILD_NATIVE
+from dimos.core.transport import ZENOH_AVAILABLE
 from dimos.models.vl.types import VlModelName
 from dimos.visualization.rerun.constants import (
     RERUN_ENABLE_WEB,
@@ -28,6 +31,12 @@ from dimos.visualization.rerun.constants import (
 
 def _get_all_numbers(s: str) -> list[float]:
     return [float(x) for x in re.findall(r"-?\d+\.?\d*", s)]
+
+
+def _default_transport() -> str:
+    if platform.system() == "Darwin" and ZENOH_AVAILABLE:
+        return "zenoh"
+    return "lcm"
 
 
 class GlobalConfig(BaseSettings):
@@ -61,7 +70,7 @@ class GlobalConfig(BaseSettings):
     planner_robot_speed: float | None = None
     mcp_port: int = 9990
     build_native: bool = DEFAULT_BUILD_NATIVE
-    transport: str = "lcm"
+    transport: str = Field(default_factory=_default_transport)
     dtop: bool = False
     obstacle_avoidance: bool = True
     detection_model: VlModelName = "moondream"

--- a/dimos/core/test_utils.py
+++ b/dimos/core/test_utils.py
@@ -1,0 +1,43 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared test helpers that must remain import-safe in minimal environments."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import threading
+
+
+def retry_until(
+    event: threading.Event,
+    action: Callable[[], None],
+    timeout: float = 2.0,
+    interval: float = 0.01,
+) -> None:
+    """Retry an action until an Event fires.
+
+    Useful for async test paths where the producer may need to retry briefly
+    before the subscriber is fully ready.
+    """
+    deadline = threading.Event()
+    timer = threading.Timer(timeout, deadline.set)
+    timer.start()
+    try:
+        while not event.is_set() and not deadline.is_set():
+            action()
+            event.wait(interval)
+    finally:
+        timer.cancel()
+    assert event.is_set(), f"Timed out after {timeout}s waiting for event"

--- a/dimos/core/test_zenoh_transport.py
+++ b/dimos/core/test_zenoh_transport.py
@@ -29,9 +29,9 @@ from dimos.core.coordination.module_coordinator import _get_transport_for, _run_
 from dimos.core.global_config import GlobalConfig, global_config
 from dimos.core.module import Module
 from dimos.core.stream import In, Out
+from dimos.core.test_utils import retry_until
 from dimos.core.transport import ZENOH_AVAILABLE, LCMTransport, pLCMTransport
 from dimos.msgs.sensor_msgs.Image import Image
-from dimos.protocol.pubsub.impl.test_zenohpubsub import _retry_until
 
 
 class TypedMsg:
@@ -213,7 +213,7 @@ class TestZenohTransportWrapper:
 
         t.subscribe(cb)
         test_img = Image(np.zeros((2, 2, 3), dtype=np.uint8))
-        _retry_until(event, lambda: t.broadcast(None, test_img))
+        retry_until(event, lambda: t.broadcast(None, test_img))
         assert isinstance(received[0], Image)
         t.stop()
 
@@ -233,7 +233,7 @@ class TestZenohTransportWrapper:
             event.set()
 
         t.subscribe(cb)
-        _retry_until(event, lambda: t.broadcast(None, {"key": "value"}))
+        retry_until(event, lambda: t.broadcast(None, {"key": "value"}))
         assert received[0] == {"key": "value"}
         t.stop()
 

--- a/dimos/core/test_zenoh_transport.py
+++ b/dimos/core/test_zenoh_transport.py
@@ -30,8 +30,8 @@ from dimos.core.global_config import GlobalConfig, global_config
 from dimos.core.module import Module
 from dimos.core.stream import In, Out
 from dimos.core.transport import ZENOH_AVAILABLE, LCMTransport, pLCMTransport
-from dimos.protocol.pubsub.impl.test_zenohpubsub import wait_for_subscribers
 from dimos.msgs.sensor_msgs.Image import Image
+from dimos.protocol.pubsub.impl.test_zenohpubsub import _retry_until
 
 
 class TypedMsg:
@@ -179,7 +179,8 @@ class TestZenohTransportWrapper:
 
     def test_zenoh_transport_broadcast_and_subscribe(self) -> None:
         import threading
-        import time
+
+        import numpy as np
 
         from dimos.core.transport import ZenohTransport
 
@@ -194,20 +195,13 @@ class TestZenohTransportWrapper:
             event.set()
 
         t.subscribe(cb)
-        wait_for_subscribers()
-
-        import numpy as np
-
         test_img = Image(np.zeros((2, 2, 3), dtype=np.uint8))
-        t.broadcast(None, test_img)
-
-        assert event.wait(timeout=2.0), f"Timed out (got {len(received)} messages)"
+        _retry_until(event, lambda: t.broadcast(None, test_img))
         assert isinstance(received[0], Image)
         t.stop()
 
     def test_pzenoh_transport_broadcast_and_subscribe(self) -> None:
         import threading
-        import time
 
         from dimos.core.transport import pZenohTransport
 
@@ -222,11 +216,7 @@ class TestZenohTransportWrapper:
             event.set()
 
         t.subscribe(cb)
-        wait_for_subscribers()
-
-        t.broadcast(None, {"key": "value"})
-
-        assert event.wait(timeout=2.0), f"Timed out (got {len(received)} messages)"
+        _retry_until(event, lambda: t.broadcast(None, {"key": "value"}))
         assert received[0] == {"key": "value"}
         t.stop()
 

--- a/dimos/core/test_zenoh_transport.py
+++ b/dimos/core/test_zenoh_transport.py
@@ -1,0 +1,163 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for Zenoh transport scaffold — Phase 1.
+
+Tests the conditional logic added to support Zenoh alongside LCM:
+- GlobalConfig transport field
+- _get_transport_for() branching
+- LCM configurator gating
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dimos.core.coordination.blueprints import autoconnect
+from dimos.core.coordination.module_coordinator import _get_transport_for, _run_configurators
+from dimos.core.global_config import GlobalConfig, global_config
+from dimos.core.module import Module
+from dimos.core.stream import In, Out
+from dimos.core.transport import ZENOH_AVAILABLE, LCMTransport, pLCMTransport
+from dimos.msgs.sensor_msgs.Image import Image
+
+
+class TypedMsg:
+    """A fake typed message with lcm_encode for testing."""
+
+    @staticmethod
+    def lcm_encode() -> bytes:
+        return b""
+
+
+class UntypedMsg:
+    """A message without lcm_encode — triggers pickle transport."""
+
+    pass
+
+
+class ProducerModule(Module):
+    typed_out: Out[Image]
+    untyped_out: Out[UntypedMsg]
+
+
+class ConsumerModule(Module):
+    typed_out: In[Image]
+    untyped_out: In[UntypedMsg]
+
+
+class TestGlobalConfigTransportField:
+    def test_default_transport_is_lcm(self) -> None:
+        config = GlobalConfig()
+        assert config.transport == "lcm"
+
+    def test_transport_can_be_set_to_zenoh(self) -> None:
+        config = GlobalConfig()
+        config.update(transport="zenoh")
+        assert config.transport == "zenoh"
+
+
+class TestZenohAvailableGuard:
+    def test_zenoh_available_is_bool(self) -> None:
+        assert isinstance(ZENOH_AVAILABLE, bool)
+
+    @pytest.mark.skipif(not ZENOH_AVAILABLE, reason="zenoh not installed")
+    def test_zenoh_transport_classes_exist_when_available(self) -> None:
+        from dimos.core.transport import ZenohTransport, pZenohTransport
+
+        assert ZenohTransport is not None
+        assert pZenohTransport is not None
+
+
+class TestGetTransportForBranching:
+    """Test that _get_transport_for() returns the right transport type based on config."""
+
+    def _make_blueprint(self):  # type: ignore[no-untyped-def]
+        return autoconnect(ProducerModule.blueprint(), ConsumerModule.blueprint())
+
+    def test_lcm_transport_returned_when_transport_is_lcm(self, mocker) -> None:
+        mocker.patch.object(global_config, "transport", "lcm")
+        bp = self._make_blueprint()
+        transport = _get_transport_for(bp, "typed_out", Image)
+        assert isinstance(transport, LCMTransport)
+
+    def test_lcm_pickle_transport_returned_for_untyped_when_lcm(self, mocker) -> None:
+        mocker.patch.object(global_config, "transport", "lcm")
+        bp = self._make_blueprint()
+        transport = _get_transport_for(bp, "untyped_out", UntypedMsg)
+        assert isinstance(transport, pLCMTransport)
+
+    @pytest.mark.skipif(not ZENOH_AVAILABLE, reason="zenoh not installed")
+    def test_zenoh_transport_returned_when_transport_is_zenoh(self, mocker) -> None:
+        from dimos.core.transport import ZenohTransport
+
+        mocker.patch.object(global_config, "transport", "zenoh")
+        bp = self._make_blueprint()
+        transport = _get_transport_for(bp, "typed_out", Image)
+        assert isinstance(transport, ZenohTransport)
+
+    @pytest.mark.skipif(not ZENOH_AVAILABLE, reason="zenoh not installed")
+    def test_zenoh_pickle_transport_returned_for_untyped_when_zenoh(self, mocker) -> None:
+        from dimos.core.transport import pZenohTransport
+
+        mocker.patch.object(global_config, "transport", "zenoh")
+        bp = self._make_blueprint()
+        transport = _get_transport_for(bp, "untyped_out", UntypedMsg)
+        assert isinstance(transport, pZenohTransport)
+
+    @pytest.mark.skipif(not ZENOH_AVAILABLE, reason="zenoh not installed")
+    def test_zenoh_topic_uses_dimos_prefix(self, mocker) -> None:
+        from dimos.core.transport import pZenohTransport
+
+        mocker.patch.object(global_config, "transport", "zenoh")
+        bp = self._make_blueprint()
+        transport = _get_transport_for(bp, "untyped_out", UntypedMsg)
+        assert isinstance(transport, pZenohTransport)
+        assert "dimos/" in transport.topic
+
+    def test_zenoh_raises_when_not_available(self, mocker) -> None:
+        mocker.patch.object(global_config, "transport", "zenoh")
+        mocker.patch("dimos.core.transport.ZENOH_AVAILABLE", False)
+
+        bp = self._make_blueprint()
+        with pytest.raises(RuntimeError, match="eclipse-zenoh is not installed"):
+            _get_transport_for(bp, "typed_out", Image)
+
+
+class TestConfiguratorGating:
+    def test_lcm_configurators_run_when_transport_is_lcm(self, mocker) -> None:
+        mocker.patch.object(global_config, "transport", "lcm")
+        mock_lcm_configs = mocker.patch(
+            "dimos.protocol.service.system_configurator.lcm_config.lcm_configurators",
+            return_value=[],
+        )
+        mocker.patch("dimos.protocol.service.system_configurator.base.configure_system")
+
+        bp = autoconnect(ProducerModule.blueprint(), ConsumerModule.blueprint())
+        _run_configurators(bp)
+
+        mock_lcm_configs.assert_called_once()
+
+    def test_lcm_configurators_skipped_when_transport_is_zenoh(self, mocker) -> None:
+        mocker.patch.object(global_config, "transport", "zenoh")
+        mock_lcm_configs = mocker.patch(
+            "dimos.protocol.service.system_configurator.lcm_config.lcm_configurators",
+            return_value=[],
+        )
+        mocker.patch("dimos.protocol.service.system_configurator.base.configure_system")
+
+        bp = autoconnect(ProducerModule.blueprint(), ConsumerModule.blueprint())
+        _run_configurators(bp)
+
+        mock_lcm_configs.assert_not_called()

--- a/dimos/core/test_zenoh_transport.py
+++ b/dimos/core/test_zenoh_transport.py
@@ -30,6 +30,7 @@ from dimos.core.global_config import GlobalConfig, global_config
 from dimos.core.module import Module
 from dimos.core.stream import In, Out
 from dimos.core.transport import ZENOH_AVAILABLE, LCMTransport, pLCMTransport
+from dimos.protocol.pubsub.impl.test_zenohpubsub import wait_for_subscribers
 from dimos.msgs.sensor_msgs.Image import Image
 
 
@@ -193,7 +194,7 @@ class TestZenohTransportWrapper:
             event.set()
 
         t.subscribe(cb)
-        time.sleep(0.05)
+        wait_for_subscribers()
 
         import numpy as np
 
@@ -221,7 +222,7 @@ class TestZenohTransportWrapper:
             event.set()
 
         t.subscribe(cb)
-        time.sleep(0.05)
+        wait_for_subscribers()
 
         t.broadcast(None, {"key": "value"})
 

--- a/dimos/core/test_zenoh_transport.py
+++ b/dimos/core/test_zenoh_transport.py
@@ -161,3 +161,91 @@ class TestConfiguratorGating:
         _run_configurators(bp)
 
         mock_lcm_configs.assert_not_called()
+
+
+@pytest.mark.skipif(not ZENOH_AVAILABLE, reason="zenoh not installed")
+class TestZenohTransportWrapper:
+    """Test ZenohTransport and pZenohTransport broadcast/subscribe lifecycle."""
+
+    @pytest.fixture(autouse=True)
+    def _clean_sessions(self):
+        from dimos.protocol.service.zenohservice import _sessions
+
+        yield
+        for s in _sessions.values():
+            s.close()
+        _sessions.clear()
+
+    def test_zenoh_transport_broadcast_and_subscribe(self) -> None:
+        import threading
+        import time
+
+        from dimos.core.transport import ZenohTransport
+
+        t = ZenohTransport("dimos/test/transport", Image)
+        t.start()
+
+        received = []
+        event = threading.Event()
+
+        def cb(msg):  # type: ignore[no-untyped-def]
+            received.append(msg)
+            event.set()
+
+        t.subscribe(cb)
+        time.sleep(0.05)
+
+        import numpy as np
+
+        test_img = Image(np.zeros((2, 2, 3), dtype=np.uint8))
+        t.broadcast(None, test_img)
+
+        assert event.wait(timeout=2.0), f"Timed out (got {len(received)} messages)"
+        assert isinstance(received[0], Image)
+        t.stop()
+
+    def test_pzenoh_transport_broadcast_and_subscribe(self) -> None:
+        import threading
+        import time
+
+        from dimos.core.transport import pZenohTransport
+
+        t = pZenohTransport("dimos/test/pickle_transport")
+        t.start()
+
+        received = []
+        event = threading.Event()
+
+        def cb(msg):  # type: ignore[no-untyped-def]
+            received.append(msg)
+            event.set()
+
+        t.subscribe(cb)
+        time.sleep(0.05)
+
+        t.broadcast(None, {"key": "value"})
+
+        assert event.wait(timeout=2.0), f"Timed out (got {len(received)} messages)"
+        assert received[0] == {"key": "value"}
+        t.stop()
+
+    def test_auto_start_on_broadcast(self) -> None:
+        from dimos.core.transport import pZenohTransport
+
+        t = pZenohTransport("dimos/test/autostart")
+        # Don't call start() — broadcast should auto-start
+        t.broadcast(None, "test")
+        assert t._started
+        t.stop()
+
+    def test_stop_and_restart(self) -> None:
+        from dimos.core.transport import pZenohTransport
+
+        t = pZenohTransport("dimos/test/restart")
+        t.start()
+        assert t._started
+        t.stop()
+        assert not t._started
+        t.start()
+        assert t._started
+        t.stop()

--- a/dimos/core/test_zenoh_transport.py
+++ b/dimos/core/test_zenoh_transport.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for Zenoh transport scaffold — Phase 1.
+"""Tests for Zenoh transport scaffold
 
 Tests the conditional logic added to support Zenoh alongside LCM:
 - GlobalConfig transport field

--- a/dimos/core/test_zenoh_transport.py
+++ b/dimos/core/test_zenoh_transport.py
@@ -22,6 +22,9 @@ Tests the conditional logic added to support Zenoh alongside LCM:
 
 from __future__ import annotations
 
+from typing import cast
+
+from pydantic import ValidationError
 import pytest
 
 from dimos.core.coordination.blueprints import autoconnect
@@ -84,6 +87,15 @@ class TestGlobalConfigTransportField:
         config = GlobalConfig()
         config.update(transport="zenoh")
         assert config.transport == "zenoh"
+
+    def test_invalid_transport_is_rejected_at_init(self) -> None:
+        with pytest.raises(ValidationError, match="transport"):
+            GlobalConfig(transport=cast("object", "invalid"))
+
+    def test_invalid_transport_is_rejected_on_update(self) -> None:
+        config = GlobalConfig()
+        with pytest.raises(ValidationError, match="transport"):
+            config.update(transport=cast("object", "invalid"))
 
 
 class TestZenohAvailableGuard:

--- a/dimos/core/test_zenoh_transport.py
+++ b/dimos/core/test_zenoh_transport.py
@@ -129,7 +129,7 @@ class TestGetTransportForBranching:
 
     def test_zenoh_raises_when_not_available(self, mocker) -> None:
         mocker.patch.object(global_config, "transport", "zenoh")
-        mocker.patch("dimos.core.transport.ZENOH_AVAILABLE", False)
+        mocker.patch("dimos.core.coordination.module_coordinator.ZENOH_AVAILABLE", False)
 
         bp = self._make_blueprint()
         with pytest.raises(RuntimeError, match="eclipse-zenoh is not installed"):

--- a/dimos/core/test_zenoh_transport.py
+++ b/dimos/core/test_zenoh_transport.py
@@ -48,13 +48,13 @@ class UntypedMsg:
 
 
 class ProducerModule(Module):
-    typed_out: Out[Image]
-    untyped_out: Out[UntypedMsg]
+    typed_data: Out[TypedMsg]
+    untyped_data: Out[UntypedMsg]
 
 
 class ConsumerModule(Module):
-    typed_out: In[Image]
-    untyped_out: In[UntypedMsg]
+    typed_data: In[TypedMsg]
+    untyped_data: In[UntypedMsg]
 
 
 class TestGlobalConfigTransportField:
@@ -89,13 +89,13 @@ class TestGetTransportForBranching:
     def test_lcm_transport_returned_when_transport_is_lcm(self, mocker) -> None:
         mocker.patch.object(global_config, "transport", "lcm")
         bp = self._make_blueprint()
-        transport = _get_transport_for(bp, "typed_out", Image)
+        transport = _get_transport_for(bp, "typed_data", TypedMsg)
         assert isinstance(transport, LCMTransport)
 
     def test_lcm_pickle_transport_returned_for_untyped_when_lcm(self, mocker) -> None:
         mocker.patch.object(global_config, "transport", "lcm")
         bp = self._make_blueprint()
-        transport = _get_transport_for(bp, "untyped_out", UntypedMsg)
+        transport = _get_transport_for(bp, "untyped_data", UntypedMsg)
         assert isinstance(transport, pLCMTransport)
 
     @pytest.mark.skipif(not ZENOH_AVAILABLE, reason="zenoh not installed")
@@ -104,7 +104,7 @@ class TestGetTransportForBranching:
 
         mocker.patch.object(global_config, "transport", "zenoh")
         bp = self._make_blueprint()
-        transport = _get_transport_for(bp, "typed_out", Image)
+        transport = _get_transport_for(bp, "typed_data", TypedMsg)
         assert isinstance(transport, ZenohTransport)
 
     @pytest.mark.skipif(not ZENOH_AVAILABLE, reason="zenoh not installed")
@@ -113,7 +113,7 @@ class TestGetTransportForBranching:
 
         mocker.patch.object(global_config, "transport", "zenoh")
         bp = self._make_blueprint()
-        transport = _get_transport_for(bp, "untyped_out", UntypedMsg)
+        transport = _get_transport_for(bp, "untyped_data", UntypedMsg)
         assert isinstance(transport, pZenohTransport)
 
     @pytest.mark.skipif(not ZENOH_AVAILABLE, reason="zenoh not installed")
@@ -122,7 +122,7 @@ class TestGetTransportForBranching:
 
         mocker.patch.object(global_config, "transport", "zenoh")
         bp = self._make_blueprint()
-        transport = _get_transport_for(bp, "untyped_out", UntypedMsg)
+        transport = _get_transport_for(bp, "untyped_data", UntypedMsg)
         assert isinstance(transport, pZenohTransport)
         assert "dimos/" in transport.topic
 
@@ -132,7 +132,7 @@ class TestGetTransportForBranching:
 
         bp = self._make_blueprint()
         with pytest.raises(RuntimeError, match="eclipse-zenoh is not installed"):
-            _get_transport_for(bp, "typed_out", Image)
+            _get_transport_for(bp, "typed_data", TypedMsg)
 
 
 class TestConfiguratorGating:

--- a/dimos/core/test_zenoh_transport.py
+++ b/dimos/core/test_zenoh_transport.py
@@ -59,7 +59,24 @@ class ConsumerModule(Module):
 
 
 class TestGlobalConfigTransportField:
-    def test_default_transport_is_lcm(self) -> None:
+    def test_default_transport_is_lcm_on_linux(self, mocker) -> None:  # type: ignore[no-untyped-def]
+        mocker.patch("dimos.core.global_config.platform.system", return_value="Linux")
+        mocker.patch("dimos.core.global_config.ZENOH_AVAILABLE", True)
+
+        config = GlobalConfig()
+        assert config.transport == "lcm"
+
+    def test_default_transport_is_zenoh_on_macos_when_available(self, mocker) -> None:  # type: ignore[no-untyped-def]
+        mocker.patch("dimos.core.global_config.platform.system", return_value="Darwin")
+        mocker.patch("dimos.core.global_config.ZENOH_AVAILABLE", True)
+
+        config = GlobalConfig()
+        assert config.transport == "zenoh"
+
+    def test_default_transport_stays_lcm_on_macos_without_zenoh(self, mocker) -> None:  # type: ignore[no-untyped-def]
+        mocker.patch("dimos.core.global_config.platform.system", return_value="Darwin")
+        mocker.patch("dimos.core.global_config.ZENOH_AVAILABLE", False)
+
         config = GlobalConfig()
         assert config.transport == "lcm"
 

--- a/dimos/core/test_zenoh_transport.py
+++ b/dimos/core/test_zenoh_transport.py
@@ -17,24 +17,37 @@
 Tests the conditional logic added to support Zenoh alongside LCM:
 - GlobalConfig transport field
 - _get_transport_for() branching
-- LCM configurator gating
+- LCM system configurators always run with blueprint checks (LCM is used outside transport_map)
+
+Requires the ``zenoh`` extra (``eclipse-zenoh``): ``ZenohTransport`` is only defined
+when that dependency is installed, so this module does not load without it.
 """
 
 from __future__ import annotations
 
+import threading
 from typing import cast
 
+import numpy as np
 from pydantic import ValidationError
 import pytest
 
+from dimos.constants import ZENOH_DIMOS_KEY_PREFIX
 from dimos.core.coordination.blueprints import autoconnect
 from dimos.core.coordination.module_coordinator import _get_transport_for, _run_configurators
 from dimos.core.global_config import GlobalConfig, global_config
 from dimos.core.module import Module
 from dimos.core.stream import In, Out
 from dimos.core.test_utils import retry_until
-from dimos.core.transport import ZENOH_AVAILABLE, LCMTransport, pLCMTransport
+from dimos.core.transport import (
+    ZENOH_AVAILABLE,
+    LCMTransport,
+    ZenohTransport,
+    pLCMTransport,
+    pZenohTransport,
+)
 from dimos.msgs.sensor_msgs.Image import Image
+from dimos.protocol.service.zenohservice import close_all_zenoh_sessions
 
 
 class TypedMsg:
@@ -102,10 +115,7 @@ class TestZenohAvailableGuard:
     def test_zenoh_available_is_bool(self) -> None:
         assert isinstance(ZENOH_AVAILABLE, bool)
 
-    @pytest.mark.skipif(not ZENOH_AVAILABLE, reason="zenoh not installed")
-    def test_zenoh_transport_classes_exist_when_available(self) -> None:
-        from dimos.core.transport import ZenohTransport, pZenohTransport
-
+    def test_zenoh_transport_classes_exist(self) -> None:
         assert ZenohTransport is not None
         assert pZenohTransport is not None
 
@@ -128,33 +138,24 @@ class TestGetTransportForBranching:
         transport = _get_transport_for(bp, "untyped_data", UntypedMsg)
         assert isinstance(transport, pLCMTransport)
 
-    @pytest.mark.skipif(not ZENOH_AVAILABLE, reason="zenoh not installed")
     def test_zenoh_transport_returned_when_transport_is_zenoh(self, mocker) -> None:
-        from dimos.core.transport import ZenohTransport
-
         mocker.patch.object(global_config, "transport", "zenoh")
         bp = self._make_blueprint()
         transport = _get_transport_for(bp, "typed_data", TypedMsg)
         assert isinstance(transport, ZenohTransport)
 
-    @pytest.mark.skipif(not ZENOH_AVAILABLE, reason="zenoh not installed")
     def test_zenoh_pickle_transport_returned_for_untyped_when_zenoh(self, mocker) -> None:
-        from dimos.core.transport import pZenohTransport
-
         mocker.patch.object(global_config, "transport", "zenoh")
         bp = self._make_blueprint()
         transport = _get_transport_for(bp, "untyped_data", UntypedMsg)
         assert isinstance(transport, pZenohTransport)
 
-    @pytest.mark.skipif(not ZENOH_AVAILABLE, reason="zenoh not installed")
     def test_zenoh_topic_uses_dimos_prefix(self, mocker) -> None:
-        from dimos.core.transport import pZenohTransport
-
         mocker.patch.object(global_config, "transport", "zenoh")
         bp = self._make_blueprint()
         transport = _get_transport_for(bp, "untyped_data", UntypedMsg)
         assert isinstance(transport, pZenohTransport)
-        assert "dimos/" in transport.topic
+        assert f"{ZENOH_DIMOS_KEY_PREFIX}/" in transport.topic
 
     def test_zenoh_raises_when_not_available(self, mocker) -> None:
         mocker.patch.object(global_config, "transport", "zenoh")
@@ -179,7 +180,7 @@ class TestConfiguratorGating:
 
         mock_lcm_configs.assert_called_once()
 
-    def test_lcm_configurators_skipped_when_transport_is_zenoh(self, mocker) -> None:
+    def test_lcm_configurators_run_when_transport_is_zenoh(self, mocker) -> None:
         mocker.patch.object(global_config, "transport", "zenoh")
         mock_lcm_configs = mocker.patch(
             "dimos.protocol.service.system_configurator.lcm_config.lcm_configurators",
@@ -190,30 +191,19 @@ class TestConfiguratorGating:
         bp = autoconnect(ProducerModule.blueprint(), ConsumerModule.blueprint())
         _run_configurators(bp)
 
-        mock_lcm_configs.assert_not_called()
+        mock_lcm_configs.assert_called_once()
 
 
-@pytest.mark.skipif(not ZENOH_AVAILABLE, reason="zenoh not installed")
 class TestZenohTransportWrapper:
     """Test ZenohTransport and pZenohTransport broadcast/subscribe lifecycle."""
 
     @pytest.fixture(autouse=True)
     def _clean_sessions(self):
-        from dimos.protocol.service.zenohservice import _sessions
-
         yield
-        for s in _sessions.values():
-            s.close()
-        _sessions.clear()
+        close_all_zenoh_sessions()
 
     def test_zenoh_transport_broadcast_and_subscribe(self) -> None:
-        import threading
-
-        import numpy as np
-
-        from dimos.core.transport import ZenohTransport
-
-        t = ZenohTransport("dimos/test/transport", Image)
+        t = ZenohTransport(f"{ZENOH_DIMOS_KEY_PREFIX}/test/transport", Image)
         t.start()
 
         received = []
@@ -230,11 +220,7 @@ class TestZenohTransportWrapper:
         t.stop()
 
     def test_pzenoh_transport_broadcast_and_subscribe(self) -> None:
-        import threading
-
-        from dimos.core.transport import pZenohTransport
-
-        t = pZenohTransport("dimos/test/pickle_transport")
+        t = pZenohTransport(f"{ZENOH_DIMOS_KEY_PREFIX}/test/pickle_transport")
         t.start()
 
         received = []
@@ -250,18 +236,14 @@ class TestZenohTransportWrapper:
         t.stop()
 
     def test_auto_start_on_broadcast(self) -> None:
-        from dimos.core.transport import pZenohTransport
-
-        t = pZenohTransport("dimos/test/autostart")
+        t = pZenohTransport(f"{ZENOH_DIMOS_KEY_PREFIX}/test/autostart")
         # Don't call start() — broadcast should auto-start
         t.broadcast(None, "test")
         assert t._started
         t.stop()
 
     def test_stop_and_restart(self) -> None:
-        from dimos.core.transport import pZenohTransport
-
-        t = pZenohTransport("dimos/test/restart")
+        t = pZenohTransport(f"{ZENOH_DIMOS_KEY_PREFIX}/test/restart")
         t.start()
         assert t._started
         t.stop()

--- a/dimos/core/test_zenoh_transport.py
+++ b/dimos/core/test_zenoh_transport.py
@@ -19,8 +19,8 @@ Tests the conditional logic added to support Zenoh alongside LCM:
 - _get_transport_for() branching
 - LCM system configurators always run with blueprint checks (LCM is used outside transport_map)
 
-Requires the ``zenoh`` extra (``eclipse-zenoh``): ``ZenohTransport`` is only defined
-when that dependency is installed, so this module does not load without it.
+Requires the ``zenoh`` extra (``eclipse-zenoh``). When it is missing, pytest skips
+this module via ``importorskip`` so collection does not fail on ``ZenohTransport`` imports.
 """
 
 from __future__ import annotations
@@ -31,6 +31,8 @@ from typing import cast
 import numpy as np
 from pydantic import ValidationError
 import pytest
+
+pytest.importorskip("zenoh")
 
 from dimos.constants import ZENOH_DIMOS_KEY_PREFIX
 from dimos.core.coordination.blueprints import autoconnect

--- a/dimos/core/transport.py
+++ b/dimos/core/transport.py
@@ -419,4 +419,6 @@ if ZENOH_AVAILABLE:
             with self._start_lock:
                 if not self._started:
                     self.start()
-                return self.zenoh.subscribe(ZenohTopic(self.topic), lambda msg, topic: callback(msg))
+                return self.zenoh.subscribe(
+                    ZenohTopic(self.topic), lambda msg, topic: callback(msg)
+                )

--- a/dimos/core/transport.py
+++ b/dimos/core/transport.py
@@ -40,6 +40,14 @@ try:
 except ImportError:
     ZENOH_AVAILABLE = False
 
+# Shown when transport=zenoh but eclipse-zenoh is missing. Prefer uv pip so the
+# venv is not narrowed to base+zenoh only (uv sync --extra zenoh drops other extras).
+ZENOH_INSTALL_HINT = (
+    "Install with: uv pip install 'eclipse-zenoh>=1.0.0,<2.0' "
+    "or uv pip install -e '.[zenoh]' from the repo. "
+    "uv sync --extra zenoh limits extras to zenoh and can remove other packages."
+)
+
 from dimos.protocol.pubsub.impl.lcmpubsub import LCM, PickleLCM, Topic as LCMTopic
 from dimos.protocol.pubsub.impl.rospubsub import DimosROS, ROSTopic
 from dimos.protocol.pubsub.impl.shmpubsub import BytesSharedMemory, PickleSharedMemory

--- a/dimos/core/transport.py
+++ b/dimos/core/transport.py
@@ -338,9 +338,9 @@ if DDS_AVAILABLE:
 
 if ZENOH_AVAILABLE:
     from dimos.protocol.pubsub.impl.zenohpubsub import (
-        Zenoh,
         PickleZenoh,
         Topic as ZenohTopic,
+        Zenoh,
     )
 
     class ZenohTransport(PubSubTransport[T]):

--- a/dimos/core/transport.py
+++ b/dimos/core/transport.py
@@ -32,6 +32,13 @@ try:
 except ImportError:
     DDS_AVAILABLE = False
 
+try:
+    import zenoh as _zenoh  # noqa: F401
+
+    ZENOH_AVAILABLE = True
+except ImportError:
+    ZENOH_AVAILABLE = False
+
 from dimos.protocol.pubsub.impl.lcmpubsub import LCM, PickleLCM, Topic as LCMTopic
 from dimos.protocol.pubsub.impl.rospubsub import DimosROS, ROSTopic
 from dimos.protocol.pubsub.impl.shmpubsub import BytesSharedMemory, PickleSharedMemory
@@ -329,4 +336,87 @@ if DDS_AVAILABLE:
                 return self.dds.subscribe(self.topic, lambda msg, topic: callback(msg))
 
 
-class ZenohTransport(PubSubTransport[T]): ...
+if ZENOH_AVAILABLE:
+    from dimos.protocol.pubsub.impl.zenohpubsub import (
+        Zenoh,
+        PickleZenoh,
+        Topic as ZenohTopic,
+    )
+
+    class ZenohTransport(PubSubTransport[T]):
+        """Zenoh transport with LCM encoding for typed DimosMsg."""
+
+        _started: bool = False
+
+        def __init__(self, topic: str, type: type, **kwargs) -> None:  # type: ignore[no-untyped-def]
+            super().__init__(LCMTopic(topic, type))
+            self.zenoh = Zenoh(**kwargs)
+            self._start_lock = threading.RLock()
+
+        def __reduce__(self):  # type: ignore[no-untyped-def]
+            return (ZenohTransport, (self.topic.topic, self.topic.lcm_type))
+
+        def start(self) -> None:
+            with self._start_lock:
+                if not self._started:
+                    self.zenoh.start()
+                    self._started = True
+
+        def stop(self) -> None:
+            with self._start_lock:
+                if self._started:
+                    self.zenoh.stop()
+                    self._started = False
+
+        def broadcast(self, _, msg) -> None:  # type: ignore[no-untyped-def]
+            with self._start_lock:
+                if not self._started:
+                    self.start()
+                self.zenoh.publish(self.topic, msg)
+
+        def subscribe(
+            self, callback: Callable[[T], None], selfstream: Stream[T] | None = None
+        ) -> Callable[[], None]:
+            with self._start_lock:
+                if not self._started:
+                    self.start()
+                return self.zenoh.subscribe(self.topic, lambda msg, topic: callback(msg))
+
+    class pZenohTransport(PubSubTransport[T]):
+        """Zenoh transport with pickle encoding for arbitrary Python objects."""
+
+        _started: bool = False
+
+        def __init__(self, topic: str, **kwargs) -> None:  # type: ignore[no-untyped-def]
+            super().__init__(topic)
+            self.zenoh = PickleZenoh(**kwargs)
+            self._start_lock = threading.RLock()
+
+        def __reduce__(self):  # type: ignore[no-untyped-def]
+            return (pZenohTransport, (self.topic,))
+
+        def start(self) -> None:
+            with self._start_lock:
+                if not self._started:
+                    self.zenoh.start()
+                    self._started = True
+
+        def stop(self) -> None:
+            with self._start_lock:
+                if self._started:
+                    self.zenoh.stop()
+                    self._started = False
+
+        def broadcast(self, _, msg) -> None:  # type: ignore[no-untyped-def]
+            with self._start_lock:
+                if not self._started:
+                    self.start()
+                self.zenoh.publish(self.topic, msg)
+
+        def subscribe(
+            self, callback: Callable[[T], None], selfstream: Stream[T] | None = None
+        ) -> Callable[[], None]:
+            with self._start_lock:
+                if not self._started:
+                    self.start()
+                return self.zenoh.subscribe(self.topic, lambda msg, topic: callback(msg))

--- a/dimos/core/transport.py
+++ b/dimos/core/transport.py
@@ -389,7 +389,6 @@ if ZENOH_AVAILABLE:
 
         def __init__(self, topic: str, **kwargs) -> None:  # type: ignore[no-untyped-def]
             super().__init__(topic)
-            self._zenoh_topic = ZenohTopic(topic)
             self.zenoh = PickleZenoh(**kwargs)
             self._start_lock = threading.RLock()
 
@@ -412,7 +411,7 @@ if ZENOH_AVAILABLE:
             with self._start_lock:
                 if not self._started:
                     self.start()
-                self.zenoh.publish(self._zenoh_topic, msg)
+                self.zenoh.publish(ZenohTopic(self.topic), msg)
 
         def subscribe(
             self, callback: Callable[[T], None], selfstream: Stream[T] | None = None
@@ -420,4 +419,4 @@ if ZENOH_AVAILABLE:
             with self._start_lock:
                 if not self._started:
                     self.start()
-                return self.zenoh.subscribe(self._zenoh_topic, lambda msg, topic: callback(msg))
+                return self.zenoh.subscribe(ZenohTopic(self.topic), lambda msg, topic: callback(msg))

--- a/dimos/core/transport.py
+++ b/dimos/core/transport.py
@@ -389,6 +389,7 @@ if ZENOH_AVAILABLE:
 
         def __init__(self, topic: str, **kwargs) -> None:  # type: ignore[no-untyped-def]
             super().__init__(topic)
+            self._zenoh_topic = ZenohTopic(topic)
             self.zenoh = PickleZenoh(**kwargs)
             self._start_lock = threading.RLock()
 
@@ -411,7 +412,7 @@ if ZENOH_AVAILABLE:
             with self._start_lock:
                 if not self._started:
                     self.start()
-                self.zenoh.publish(self.topic, msg)
+                self.zenoh.publish(self._zenoh_topic, msg)
 
         def subscribe(
             self, callback: Callable[[T], None], selfstream: Stream[T] | None = None
@@ -419,4 +420,4 @@ if ZENOH_AVAILABLE:
             with self._start_lock:
                 if not self._started:
                     self.start()
-                return self.zenoh.subscribe(self.topic, lambda msg, topic: callback(msg))
+                return self.zenoh.subscribe(self._zenoh_topic, lambda msg, topic: callback(msg))

--- a/dimos/core/transport.py
+++ b/dimos/core/transport.py
@@ -19,6 +19,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     TypeVar,
+    cast,
 )
 
 from dimos.core.stream import In, Out, Stream, Transport
@@ -380,7 +381,7 @@ if ZENOH_AVAILABLE:
             with self._start_lock:
                 if not self._started:
                     self.start()
-                return self.zenoh.subscribe(self.topic, lambda msg, topic: callback(msg))
+                return self.zenoh.subscribe(self.topic, lambda msg, topic: callback(cast("T", msg)))
 
     class pZenohTransport(PubSubTransport[T]):
         """Zenoh transport with pickle encoding for arbitrary Python objects."""

--- a/dimos/protocol/pubsub/benchmark/testdata.py
+++ b/dimos/protocol/pubsub/benchmark/testdata.py
@@ -285,7 +285,7 @@ if ZENOH_AVAILABLE:
         yield zenoh_pubsub
         zenoh_pubsub.stop()
         for s in _zenoh_sessions.values():
-            s.close()
+            s.close()  # type: ignore[no-untyped-call]
         _zenoh_sessions.clear()
 
     def zenoh_msggen(size: int) -> tuple[ZenohTopic, Image]:

--- a/dimos/protocol/pubsub/benchmark/testdata.py
+++ b/dimos/protocol/pubsub/benchmark/testdata.py
@@ -275,7 +275,7 @@ except (ConnectionError, ImportError):
 from dimos.core.transport import ZENOH_AVAILABLE
 
 if ZENOH_AVAILABLE:
-    from dimos.protocol.pubsub.impl.zenohpubsub import Zenoh, Topic as ZenohTopic
+    from dimos.protocol.pubsub.impl.zenohpubsub import Topic as ZenohTopic, Zenoh
     from dimos.protocol.service.zenohservice import _sessions as _zenoh_sessions
 
     @contextmanager

--- a/dimos/protocol/pubsub/benchmark/testdata.py
+++ b/dimos/protocol/pubsub/benchmark/testdata.py
@@ -272,6 +272,33 @@ except (ConnectionError, ImportError):
     print("Redis not available")
 
 
+from dimos.core.transport import ZENOH_AVAILABLE
+
+if ZENOH_AVAILABLE:
+    from dimos.protocol.pubsub.impl.zenohpubsub import Zenoh, Topic as ZenohTopic
+    from dimos.protocol.service.zenohservice import _sessions as _zenoh_sessions
+
+    @contextmanager
+    def zenoh_pubsub_channel() -> Generator[Zenoh, None, None]:
+        zenoh_pubsub = Zenoh()
+        zenoh_pubsub.start()
+        yield zenoh_pubsub
+        zenoh_pubsub.stop()
+        for s in _zenoh_sessions.values():
+            s.close()
+        _zenoh_sessions.clear()
+
+    def zenoh_msggen(size: int) -> tuple[ZenohTopic, Image]:
+        return (ZenohTopic("dimos/benchmark/zenoh", Image), make_data_image(size))
+
+    testcases.append(
+        Case(
+            pubsub_context=zenoh_pubsub_channel,
+            msg_gen=zenoh_msggen,
+        )
+    )
+
+
 from dimos.protocol.pubsub.impl.rospubsub import (
     ROS_AVAILABLE,
     DimosROS,

--- a/dimos/protocol/pubsub/impl/test_zenohpubsub.py
+++ b/dimos/protocol/pubsub/impl/test_zenohpubsub.py
@@ -16,11 +16,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
 import threading
 
 import pytest
 
+pytest.importorskip("zenoh")
+
+from dimos.core.test_utils import retry_until
 from dimos.protocol.pubsub.impl.lcmpubsub import Topic
 from dimos.protocol.pubsub.impl.zenohpubsub import ZenohPubSubBase
 from dimos.protocol.service.zenohservice import _sessions
@@ -44,32 +46,6 @@ def pubsub():
     _sessions.clear()
 
 
-def _retry_until(
-    event: threading.Event,
-    action: Callable[[], None],
-    timeout: float = 2.0,
-    interval: float = 0.01,
-) -> None:
-    """Retry an action until an Event fires.
-
-    Zenoh's Python API does not expose a "subscriber ready" signal.
-    After declare_subscriber(), there is a brief window where published
-    messages may not be delivered (peers need to exchange interest
-    declarations). Instead of sleeping a fixed duration, we re-run
-    the action in a tight loop until the callback sets the event.
-    """
-    deadline = threading.Event()
-    timer = threading.Timer(timeout, deadline.set)
-    timer.start()
-    try:
-        while not event.is_set() and not deadline.is_set():
-            action()
-            event.wait(interval)
-    finally:
-        timer.cancel()
-    assert event.is_set(), f"Timed out after {timeout}s waiting for event"
-
-
 class TestZenohPubSubBase:
     def test_publish_and_subscribe(self, pubsub) -> None:
         received = []
@@ -81,7 +57,7 @@ class TestZenohPubSubBase:
             event.set()
 
         pubsub.subscribe(topic, callback)
-        _retry_until(event, lambda: pubsub.publish(topic, b"hello zenoh"))
+        retry_until(event, lambda: pubsub.publish(topic, b"hello zenoh"))
         assert received[0] == b"hello zenoh"
 
     def test_multiple_subscribers(self, pubsub) -> None:
@@ -101,7 +77,7 @@ class TestZenohPubSubBase:
 
         pubsub.subscribe(topic, callback_a)
         pubsub.subscribe(topic, callback_b)
-        _retry_until(both_received, lambda: pubsub.publish(topic, b"broadcast"))
+        retry_until(both_received, lambda: pubsub.publish(topic, b"broadcast"))
         assert received_a[-1:] == [b"broadcast"]
         assert received_b[-1:] == [b"broadcast"]
 
@@ -115,7 +91,7 @@ class TestZenohPubSubBase:
             event.set()
 
         unsub = pubsub.subscribe(topic, callback)
-        _retry_until(event, lambda: pubsub.publish(topic, b"before"))
+        retry_until(event, lambda: pubsub.publish(topic, b"before"))
         assert received == [b"before"]
 
         # Unsubscribe and verify no more messages arrive
@@ -156,7 +132,7 @@ class TestZenohPubSubBase:
             event.set()
 
         pubsub.subscribe_all(callback)
-        _retry_until(event, lambda: pubsub.publish(topic, b"wildcard"))
+        retry_until(event, lambda: pubsub.publish(topic, b"wildcard"))
         assert received[-1] == b"wildcard"
 
 

--- a/dimos/protocol/pubsub/impl/test_zenohpubsub.py
+++ b/dimos/protocol/pubsub/impl/test_zenohpubsub.py
@@ -16,8 +16,8 @@
 
 from __future__ import annotations
 
-import threading
 from collections.abc import Callable
+import threading
 
 import pytest
 

--- a/dimos/protocol/pubsub/impl/test_zenohpubsub.py
+++ b/dimos/protocol/pubsub/impl/test_zenohpubsub.py
@@ -155,3 +155,78 @@ class TestZenohPubSubBase:
 
         assert event.wait(timeout=2.0), "Timed out waiting for wildcard message"
         assert received[0] == b"wildcard"
+
+
+class TestTopicKeyExprConversion:
+    """Tests for _topic_to_key_expr and _key_expr_to_topic round-trip."""
+
+    def test_typed_topic_to_key_expr(self) -> None:
+        from dimos.msgs.geometry_msgs.Twist import Twist
+        from dimos.protocol.pubsub.impl.zenohpubsub import _topic_to_key_expr
+
+        topic = Topic("dimos/cmd_vel", lcm_type=Twist)
+        key = _topic_to_key_expr(topic)
+        assert key == "dimos/cmd_vel/geometry_msgs.Twist"
+
+    def test_untyped_topic_to_key_expr(self) -> None:
+        from dimos.protocol.pubsub.impl.zenohpubsub import _topic_to_key_expr
+
+        topic = Topic("dimos/data")
+        key = _topic_to_key_expr(topic)
+        assert key == "dimos/data"
+
+    def test_key_expr_to_topic_with_known_type(self) -> None:
+        from dimos.msgs.geometry_msgs.Twist import Twist
+        from dimos.protocol.pubsub.impl.zenohpubsub import _key_expr_to_topic
+
+        topic = _key_expr_to_topic("dimos/cmd_vel/geometry_msgs.Twist")
+        assert topic.topic == "dimos/cmd_vel"
+        assert topic.lcm_type is Twist
+
+    def test_key_expr_to_topic_with_unknown_type(self) -> None:
+        from dimos.protocol.pubsub.impl.zenohpubsub import _key_expr_to_topic
+
+        topic = _key_expr_to_topic("dimos/data/unknown.FooBar")
+        # Last segment doesn't resolve — entire string becomes the topic
+        assert topic.topic == "dimos/data/unknown.FooBar"
+        assert topic.lcm_type is None
+
+    def test_key_expr_to_topic_with_no_slash(self) -> None:
+        from dimos.protocol.pubsub.impl.zenohpubsub import _key_expr_to_topic
+
+        topic = _key_expr_to_topic("simple_topic")
+        assert topic.topic == "simple_topic"
+        assert topic.lcm_type is None
+
+    def test_key_expr_to_topic_uses_default_type(self) -> None:
+        from dimos.msgs.geometry_msgs.Twist import Twist
+        from dimos.protocol.pubsub.impl.zenohpubsub import _key_expr_to_topic
+
+        topic = _key_expr_to_topic("dimos/data", default_lcm_type=Twist)
+        assert topic.topic == "dimos/data"
+        assert topic.lcm_type is Twist
+
+    def test_round_trip_typed(self) -> None:
+        from dimos.msgs.sensor_msgs.Image import Image
+        from dimos.protocol.pubsub.impl.zenohpubsub import (
+            _key_expr_to_topic,
+            _topic_to_key_expr,
+        )
+
+        original = Topic("dimos/color_image", lcm_type=Image)
+        key = _topic_to_key_expr(original)
+        reconstructed = _key_expr_to_topic(key)
+        assert reconstructed.topic == original.topic
+        assert reconstructed.lcm_type is original.lcm_type
+
+    def test_round_trip_untyped(self) -> None:
+        from dimos.protocol.pubsub.impl.zenohpubsub import (
+            _key_expr_to_topic,
+            _topic_to_key_expr,
+        )
+
+        original = Topic("dimos/gps_location")
+        key = _topic_to_key_expr(original)
+        reconstructed = _key_expr_to_topic(key)
+        assert reconstructed.topic == original.topic
+        assert reconstructed.lcm_type is None

--- a/dimos/protocol/pubsub/impl/test_zenohpubsub.py
+++ b/dimos/protocol/pubsub/impl/test_zenohpubsub.py
@@ -1,0 +1,138 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ZenohPubSubBase — raw bytes pub/sub over Zenoh."""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+from dimos.protocol.pubsub.impl.lcmpubsub import Topic
+from dimos.protocol.pubsub.impl.zenohpubsub import ZenohPubSubBase
+from dimos.protocol.service.zenohservice import _sessions
+
+
+@pytest.fixture()
+def pubsub():
+    """Create and start a ZenohPubSubBase instance, clean up after."""
+    # Each test gets a fresh session to avoid thread leak detection
+    for session in _sessions.values():
+        session.close()
+    _sessions.clear()
+
+    ps = ZenohPubSubBase()
+    ps.start()
+    yield ps
+    ps.stop()
+    # Close sessions so Zenoh's internal threads are joined
+    for session in _sessions.values():
+        session.close()
+    _sessions.clear()
+
+
+class TestZenohPubSubBase:
+    def test_publish_and_subscribe(self, pubsub) -> None:
+        received = []
+        event = threading.Event()
+        topic = Topic("dimos/test/basic")
+
+        def callback(msg: bytes, t: Topic) -> None:
+            received.append(msg)
+            event.set()
+
+        pubsub.subscribe(topic, callback)
+        time.sleep(0.05)  # let subscriber register
+        pubsub.publish(topic, b"hello zenoh")
+
+        assert event.wait(timeout=2.0), f"Timed out waiting for message (got {len(received)})"
+        assert received[0] == b"hello zenoh"
+
+    def test_multiple_subscribers(self, pubsub) -> None:
+        received_a: list[bytes] = []
+        received_b: list[bytes] = []
+        event = threading.Event()
+        topic = Topic("dimos/test/multi")
+
+        def callback_a(msg: bytes, t: Topic) -> None:
+            received_a.append(msg)
+            if received_a and received_b:
+                event.set()
+
+        def callback_b(msg: bytes, t: Topic) -> None:
+            received_b.append(msg)
+            if received_a and received_b:
+                event.set()
+
+        pubsub.subscribe(topic, callback_a)
+        pubsub.subscribe(topic, callback_b)
+        time.sleep(0.05)
+        pubsub.publish(topic, b"broadcast")
+
+        assert event.wait(timeout=2.0), "Timed out waiting for both subscribers"
+        assert received_a == [b"broadcast"]
+        assert received_b == [b"broadcast"]
+
+    def test_unsubscribe(self, pubsub) -> None:
+        received: list[bytes] = []
+        topic = Topic("dimos/test/unsub")
+
+        def callback(msg: bytes, t: Topic) -> None:
+            received.append(msg)
+
+        unsub = pubsub.subscribe(topic, callback)
+        time.sleep(0.05)
+        pubsub.publish(topic, b"before")
+        time.sleep(0.1)
+        unsub()
+        time.sleep(0.05)
+        pubsub.publish(topic, b"after")
+        time.sleep(0.1)
+
+        assert received == [b"before"]
+
+    def test_unsubscribe_is_idempotent(self, pubsub) -> None:
+        topic = Topic("dimos/test/idempotent")
+        unsub = pubsub.subscribe(topic, lambda msg, t: None)
+        unsub()
+        unsub()  # should not raise
+
+    def test_publish_before_subscriber_does_not_error(self, pubsub) -> None:
+        topic = Topic("dimos/test/no_sub")
+        pubsub.publish(topic, b"orphan message")  # should not raise
+
+    def test_stop_cleans_up_publishers_and_subscribers(self, pubsub) -> None:
+        topic = Topic("dimos/test/cleanup")
+        pubsub.subscribe(topic, lambda msg, t: None)
+        pubsub.publish(topic, b"test")
+        pubsub.stop()
+        assert len(pubsub._publishers) == 0
+        assert len(pubsub._subscribers) == 0
+
+    def test_subscribe_all(self, pubsub) -> None:
+        received: list[bytes] = []
+        event = threading.Event()
+
+        def callback(msg: bytes, t: Topic) -> None:
+            received.append(msg)
+            event.set()
+
+        pubsub.subscribe_all(callback)
+        time.sleep(0.05)
+        pubsub.publish(Topic("dimos/test/any/topic"), b"wildcard")
+
+        assert event.wait(timeout=2.0), "Timed out waiting for wildcard message"
+        assert received[0] == b"wildcard"

--- a/dimos/protocol/pubsub/impl/test_zenohpubsub.py
+++ b/dimos/protocol/pubsub/impl/test_zenohpubsub.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import threading
-import time
 
 import pytest
 
@@ -44,6 +43,27 @@ def pubsub():
     _sessions.clear()
 
 
+def wait_for_delivery() -> None:
+    """Wait for published messages to be delivered to subscribers."""
+    import time
+
+    time.sleep(0.1)
+
+
+def wait_for_subscribers() -> None:
+    """Wait for Zenoh subscriber declarations to propagate.
+
+    Zenoh's Python API does not expose a "subscriber ready" signal or
+    callback. After declare_subscriber(), there is a brief window where
+    messages published to the same key expression may not be delivered.
+    This is a known limitation of the peer discovery protocol — peers
+    need time to exchange interest declarations over the network.
+    """
+    import time
+
+    time.sleep(0.05)
+
+
 class TestZenohPubSubBase:
     def test_publish_and_subscribe(self, pubsub) -> None:
         received = []
@@ -55,7 +75,7 @@ class TestZenohPubSubBase:
             event.set()
 
         pubsub.subscribe(topic, callback)
-        time.sleep(0.05)  # let subscriber register
+        wait_for_subscribers()
         pubsub.publish(topic, b"hello zenoh")
 
         assert event.wait(timeout=2.0), f"Timed out waiting for message (got {len(received)})"
@@ -79,7 +99,7 @@ class TestZenohPubSubBase:
 
         pubsub.subscribe(topic, callback_a)
         pubsub.subscribe(topic, callback_b)
-        time.sleep(0.05)
+        wait_for_subscribers()
         pubsub.publish(topic, b"broadcast")
 
         assert event.wait(timeout=2.0), "Timed out waiting for both subscribers"
@@ -94,13 +114,13 @@ class TestZenohPubSubBase:
             received.append(msg)
 
         unsub = pubsub.subscribe(topic, callback)
-        time.sleep(0.05)
+        wait_for_subscribers()
         pubsub.publish(topic, b"before")
-        time.sleep(0.1)
+        wait_for_delivery()
         unsub()
-        time.sleep(0.05)
+        wait_for_subscribers()
         pubsub.publish(topic, b"after")
-        time.sleep(0.1)
+        wait_for_delivery()
 
         assert received == [b"before"]
 
@@ -131,7 +151,7 @@ class TestZenohPubSubBase:
             event.set()
 
         pubsub.subscribe_all(callback)
-        time.sleep(0.05)
+        wait_for_subscribers()
         pubsub.publish(Topic("dimos/test/any/topic"), b"wildcard")
 
         assert event.wait(timeout=2.0), "Timed out waiting for wildcard message"

--- a/dimos/protocol/pubsub/impl/test_zenohpubsub.py
+++ b/dimos/protocol/pubsub/impl/test_zenohpubsub.py
@@ -84,18 +84,17 @@ class TestZenohPubSubBase:
     def test_multiple_subscribers(self, pubsub) -> None:
         received_a: list[bytes] = []
         received_b: list[bytes] = []
+        countdown = threading.Barrier(2, action=lambda: event.set())
         event = threading.Event()
         topic = Topic("dimos/test/multi")
 
         def callback_a(msg: bytes, t: Topic) -> None:
             received_a.append(msg)
-            if received_a and received_b:
-                event.set()
+            countdown.wait()
 
         def callback_b(msg: bytes, t: Topic) -> None:
             received_b.append(msg)
-            if received_a and received_b:
-                event.set()
+            countdown.wait()
 
         pubsub.subscribe(topic, callback_a)
         pubsub.subscribe(topic, callback_b)

--- a/dimos/protocol/pubsub/impl/test_zenohpubsub.py
+++ b/dimos/protocol/pubsub/impl/test_zenohpubsub.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import threading
+from collections.abc import Callable
 
 import pytest
 
@@ -43,25 +44,30 @@ def pubsub():
     _sessions.clear()
 
 
-def wait_for_delivery() -> None:
-    """Wait for published messages to be delivered to subscribers."""
-    import time
+def _retry_until(
+    event: threading.Event,
+    action: Callable[[], None],
+    timeout: float = 2.0,
+    interval: float = 0.01,
+) -> None:
+    """Retry an action until an Event fires.
 
-    time.sleep(0.1)
-
-
-def wait_for_subscribers() -> None:
-    """Wait for Zenoh subscriber declarations to propagate.
-
-    Zenoh's Python API does not expose a "subscriber ready" signal or
-    callback. After declare_subscriber(), there is a brief window where
-    messages published to the same key expression may not be delivered.
-    This is a known limitation of the peer discovery protocol — peers
-    need time to exchange interest declarations over the network.
+    Zenoh's Python API does not expose a "subscriber ready" signal.
+    After declare_subscriber(), there is a brief window where published
+    messages may not be delivered (peers need to exchange interest
+    declarations). Instead of sleeping a fixed duration, we re-run
+    the action in a tight loop until the callback sets the event.
     """
-    import time
-
-    time.sleep(0.05)
+    deadline = threading.Event()
+    timer = threading.Timer(timeout, deadline.set)
+    timer.start()
+    try:
+        while not event.is_set() and not deadline.is_set():
+            action()
+            event.wait(interval)
+    finally:
+        timer.cancel()
+    assert event.is_set(), f"Timed out after {timeout}s waiting for event"
 
 
 class TestZenohPubSubBase:
@@ -75,17 +81,14 @@ class TestZenohPubSubBase:
             event.set()
 
         pubsub.subscribe(topic, callback)
-        wait_for_subscribers()
-        pubsub.publish(topic, b"hello zenoh")
-
-        assert event.wait(timeout=2.0), f"Timed out waiting for message (got {len(received)})"
+        _retry_until(event, lambda: pubsub.publish(topic, b"hello zenoh"))
         assert received[0] == b"hello zenoh"
 
     def test_multiple_subscribers(self, pubsub) -> None:
         received_a: list[bytes] = []
         received_b: list[bytes] = []
-        countdown = threading.Barrier(2, action=lambda: event.set())
-        event = threading.Event()
+        both_received = threading.Event()
+        countdown = threading.Barrier(2, action=both_received.set)
         topic = Topic("dimos/test/multi")
 
         def callback_a(msg: bytes, t: Topic) -> None:
@@ -98,30 +101,32 @@ class TestZenohPubSubBase:
 
         pubsub.subscribe(topic, callback_a)
         pubsub.subscribe(topic, callback_b)
-        wait_for_subscribers()
-        pubsub.publish(topic, b"broadcast")
-
-        assert event.wait(timeout=2.0), "Timed out waiting for both subscribers"
-        assert received_a == [b"broadcast"]
-        assert received_b == [b"broadcast"]
+        _retry_until(both_received, lambda: pubsub.publish(topic, b"broadcast"))
+        assert received_a[-1:] == [b"broadcast"]
+        assert received_b[-1:] == [b"broadcast"]
 
     def test_unsubscribe(self, pubsub) -> None:
         received: list[bytes] = []
+        event = threading.Event()
         topic = Topic("dimos/test/unsub")
 
         def callback(msg: bytes, t: Topic) -> None:
             received.append(msg)
+            event.set()
 
         unsub = pubsub.subscribe(topic, callback)
-        wait_for_subscribers()
-        pubsub.publish(topic, b"before")
-        wait_for_delivery()
-        unsub()
-        wait_for_subscribers()
-        pubsub.publish(topic, b"after")
-        wait_for_delivery()
-
+        _retry_until(event, lambda: pubsub.publish(topic, b"before"))
         assert received == [b"before"]
+
+        # Unsubscribe and verify no more messages arrive
+        unsub()
+        received.clear()
+        event.clear()
+        pubsub.publish(topic, b"after")
+
+        # We can't prove a negative with an event, so use a short timeout
+        assert not event.wait(timeout=0.2), "Received message after unsubscribe"
+        assert received == []
 
     def test_unsubscribe_is_idempotent(self, pubsub) -> None:
         topic = Topic("dimos/test/idempotent")
@@ -144,17 +149,15 @@ class TestZenohPubSubBase:
     def test_subscribe_all(self, pubsub) -> None:
         received: list[bytes] = []
         event = threading.Event()
+        topic = Topic("dimos/test/any/topic")
 
         def callback(msg: bytes, t: Topic) -> None:
             received.append(msg)
             event.set()
 
         pubsub.subscribe_all(callback)
-        wait_for_subscribers()
-        pubsub.publish(Topic("dimos/test/any/topic"), b"wildcard")
-
-        assert event.wait(timeout=2.0), "Timed out waiting for wildcard message"
-        assert received[0] == b"wildcard"
+        _retry_until(event, lambda: pubsub.publish(topic, b"wildcard"))
+        assert received[-1] == b"wildcard"
 
 
 class TestTopicKeyExprConversion:

--- a/dimos/protocol/pubsub/impl/test_zenohpubsub.py
+++ b/dimos/protocol/pubsub/impl/test_zenohpubsub.py
@@ -25,25 +25,20 @@ pytest.importorskip("zenoh")
 from dimos.core.test_utils import retry_until
 from dimos.protocol.pubsub.impl.lcmpubsub import Topic
 from dimos.protocol.pubsub.impl.zenohpubsub import ZenohPubSubBase
-from dimos.protocol.service.zenohservice import _sessions
+from dimos.protocol.service.zenohservice import close_all_zenoh_sessions
 
 
 @pytest.fixture()
 def pubsub():
     """Create and start a ZenohPubSubBase instance, clean up after."""
     # Each test gets a fresh session to avoid thread leak detection
-    for session in _sessions.values():
-        session.close()
-    _sessions.clear()
+    close_all_zenoh_sessions()
 
     ps = ZenohPubSubBase()
     ps.start()
     yield ps
     ps.stop()
-    # Close sessions so Zenoh's internal threads are joined
-    for session in _sessions.values():
-        session.close()
-    _sessions.clear()
+    close_all_zenoh_sessions()
 
 
 class TestZenohPubSubBase:

--- a/dimos/protocol/pubsub/impl/zenohpubsub.py
+++ b/dimos/protocol/pubsub/impl/zenohpubsub.py
@@ -12,38 +12,130 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Zenoh PubSub implementation — stub for Phase 1 scaffolding.
+"""Zenoh PubSub implementation.
 
-This module will be implemented in Phase 2. The stub exists so that
-transport.py can import from it when ZENOH_AVAILABLE is True.
+Provides raw bytes pub/sub over Zenoh (ZenohPubSubBase) and
+encoder-composed variants (Zenoh, PickleZenoh).
 """
 
 from __future__ import annotations
 
+from collections.abc import Callable
+import threading
+from typing import TYPE_CHECKING, Any
+
+from dimos.protocol.pubsub.encoders import LCMEncoderMixin, PickleEncoderMixin
 from dimos.protocol.pubsub.impl.lcmpubsub import Topic
+from dimos.protocol.pubsub.spec import AllPubSub
+from dimos.protocol.service.zenohservice import ZenohService
+from dimos.utils.logging_config import setup_logger
 
-# Phase 2 will implement these:
-# - ZenohPubSubBase(ZenohService, AllPubSub[Topic, bytes])
-# - Zenoh(LCMEncoderMixin, ZenohPubSubBase)
-# - PickleZenoh(PickleEncoderMixin, ZenohPubSubBase)
+if TYPE_CHECKING:
+    import zenoh
 
-
-class Zenoh:
-    """Stub — LCM-encoded Zenoh PubSub. Implemented in Phase 2."""
-
-    def __init__(self, **kwargs):  # type: ignore[no-untyped-def]
-        raise NotImplementedError("Zenoh transport not yet implemented")
+logger = setup_logger()
 
 
-class PickleZenoh:
-    """Stub — Pickle-encoded Zenoh PubSub. Implemented in Phase 2."""
+class ZenohPubSubBase(ZenohService, AllPubSub[Topic, bytes]):
+    """Raw bytes pub/sub over Zenoh.
 
-    def __init__(self, **kwargs):  # type: ignore[no-untyped-def]
-        raise NotImplementedError("PickleZenoh transport not yet implemented")
+    Publishers are cached per-topic to avoid re-declaring on every publish.
+    Subscribers are tracked for cleanup on stop().
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._publishers: dict[str, zenoh.Publisher] = {}
+        self._publisher_lock = threading.Lock()
+        self._subscribers: list[zenoh.Subscriber] = []
+        self._subscriber_lock = threading.Lock()
+
+    def _get_publisher(self, key_expr: str) -> zenoh.Publisher:
+        """Get or create a Publisher for the given key expression."""
+        with self._publisher_lock:
+            if key_expr not in self._publishers:
+                self._publishers[key_expr] = self.session.declare_publisher(key_expr)
+            return self._publishers[key_expr]
+
+    def publish(self, topic: Topic, message: bytes) -> None:
+        """Publish bytes to a Zenoh key expression."""
+        key_expr = topic.topic if isinstance(topic.topic, str) else topic.pattern
+        try:
+            publisher = self._get_publisher(key_expr)
+            publisher.put(message)
+        except Exception:
+            logger.error(f"Error publishing to {key_expr}", exc_info=True)
+
+    def subscribe(
+        self, topic: Topic, callback: Callable[[bytes, Topic], None]
+    ) -> Callable[[], None]:
+        """Subscribe to a Zenoh key expression.
+
+        Returns an unsubscribe callable.
+        """
+        key_expr = topic.topic if isinstance(topic.topic, str) else topic.pattern
+
+        def on_sample(sample: zenoh.Sample) -> None:
+            callback(sample.payload.to_bytes(), topic)
+
+        sub = self.session.declare_subscriber(key_expr, on_sample)
+        with self._subscriber_lock:
+            self._subscribers.append(sub)
+
+        undeclared = False
+
+        def unsubscribe() -> None:
+            nonlocal undeclared
+            if undeclared:
+                return
+            undeclared = True
+            sub.undeclare()
+            with self._subscriber_lock:
+                try:
+                    self._subscribers.remove(sub)
+                except ValueError:
+                    pass
+
+        return unsubscribe
+
+    def subscribe_all(self, callback: Callable[[bytes, Topic], Any]) -> Callable[[], None]:
+        """Subscribe to all dimos key expressions via wildcard."""
+        return self.subscribe(Topic("dimos/**"), callback)
+
+    def stop(self) -> None:
+        """Clean up publishers and subscribers."""
+        with self._subscriber_lock:
+            for subscriber in self._subscribers:
+                subscriber.undeclare()
+            self._subscribers.clear()
+        with self._publisher_lock:
+            for publisher in self._publishers.values():
+                publisher.undeclare()
+            self._publishers.clear()
+        super().stop()
+
+
+class Zenoh(  # type: ignore[misc]
+    LCMEncoderMixin,  # type: ignore[type-arg]
+    ZenohPubSubBase,
+):
+    """Zenoh pub/sub with LCM encoding for typed DimosMsg."""
+
+    ...
+
+
+class PickleZenoh(  # type: ignore[misc]
+    PickleEncoderMixin,  # type: ignore[type-arg]
+    ZenohPubSubBase,
+):
+    """Zenoh pub/sub with pickle encoding for arbitrary Python objects."""
+
+    ...
 
 
 __all__ = [
     "PickleZenoh",
     "Topic",
     "Zenoh",
+    "ZenohPubSubBase",
 ]

--- a/dimos/protocol/pubsub/impl/zenohpubsub.py
+++ b/dimos/protocol/pubsub/impl/zenohpubsub.py
@@ -36,6 +36,37 @@ if TYPE_CHECKING:
 logger = setup_logger()
 
 
+def _topic_to_key_expr(topic: Topic) -> str:
+    """Convert a Topic to a Zenoh key expression.
+
+    Embeds the lcm_type in the key using '/' instead of '#' (which is
+    forbidden in Zenoh key expressions). This mirrors how LCM channels
+    carry type info in the channel name for subscribe_all decoding.
+    """
+    base = topic.topic if isinstance(topic.topic, str) else topic.pattern
+    if topic.lcm_type is not None:
+        return f"{base}/{topic.lcm_type.msg_name}"
+    return base
+
+
+def _key_expr_to_topic(key_expr: str, default_lcm_type: type | None = None) -> Topic:
+    """Reconstruct a Topic from a Zenoh key expression.
+
+    Parses the type suffix (last segment after the base path) using
+    the same resolver as LCM's Topic.from_channel_str.
+    """
+    from dimos.msgs.helpers import resolve_msg_type
+
+    # Try to resolve the last segment as a message type
+    parts = key_expr.rsplit("/", 1)
+    if len(parts) == 2:
+        base, maybe_type = parts
+        lcm_type = resolve_msg_type(maybe_type)
+        if lcm_type is not None:
+            return Topic(topic=base, lcm_type=lcm_type)
+    return Topic(topic=key_expr, lcm_type=default_lcm_type)
+
+
 class ZenohPubSubBase(ZenohService, AllPubSub[Topic, bytes]):
     """Raw bytes pub/sub over Zenoh.
 
@@ -65,7 +96,7 @@ class ZenohPubSubBase(ZenohService, AllPubSub[Topic, bytes]):
         reliability protocol (RELIABLE mode retransmits at each hop) — these
         do not surface as exceptions from put().
         """
-        key_expr = topic.topic if isinstance(topic.topic, str) else topic.pattern
+        key_expr = _topic_to_key_expr(topic)
         try:
             publisher = self._get_publisher(key_expr)
             publisher.put(message)
@@ -79,7 +110,7 @@ class ZenohPubSubBase(ZenohService, AllPubSub[Topic, bytes]):
 
         Returns an unsubscribe callable.
         """
-        key_expr = topic.topic if isinstance(topic.topic, str) else topic.pattern
+        key_expr = _topic_to_key_expr(topic)
 
         def on_sample(sample: zenoh.Sample) -> None:
             try:
@@ -87,7 +118,10 @@ class ZenohPubSubBase(ZenohService, AllPubSub[Topic, bytes]):
             except Exception:
                 logger.error(f"Error reading payload from {key_expr}", exc_info=True)
                 return
-            callback(data, topic)
+            # Reconstruct topic with type info from the key expression
+            # (needed for subscribe_all where the subscription topic has no lcm_type)
+            recv_topic = _key_expr_to_topic(str(sample.key_expr), topic.lcm_type)
+            callback(data, recv_topic)
 
         sub = self.session.declare_subscriber(key_expr, on_sample)
         with self._subscriber_lock:

--- a/dimos/protocol/pubsub/impl/zenohpubsub.py
+++ b/dimos/protocol/pubsub/impl/zenohpubsub.py
@@ -1,0 +1,49 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Zenoh PubSub implementation — stub for Phase 1 scaffolding.
+
+This module will be implemented in Phase 2. The stub exists so that
+transport.py can import from it when ZENOH_AVAILABLE is True.
+"""
+
+from __future__ import annotations
+
+from dimos.protocol.pubsub.impl.lcmpubsub import Topic
+
+# Phase 2 will implement these:
+# - ZenohPubSubBase(ZenohService, AllPubSub[Topic, bytes])
+# - Zenoh(LCMEncoderMixin, ZenohPubSubBase)
+# - PickleZenoh(PickleEncoderMixin, ZenohPubSubBase)
+
+
+class Zenoh:
+    """Stub — LCM-encoded Zenoh PubSub. Implemented in Phase 2."""
+
+    def __init__(self, **kwargs):  # type: ignore[no-untyped-def]
+        raise NotImplementedError("Zenoh transport not yet implemented")
+
+
+class PickleZenoh:
+    """Stub — Pickle-encoded Zenoh PubSub. Implemented in Phase 2."""
+
+    def __init__(self, **kwargs):  # type: ignore[no-untyped-def]
+        raise NotImplementedError("PickleZenoh transport not yet implemented")
+
+
+__all__ = [
+    "PickleZenoh",
+    "Topic",
+    "Zenoh",
+]

--- a/dimos/protocol/pubsub/impl/zenohpubsub.py
+++ b/dimos/protocol/pubsub/impl/zenohpubsub.py
@@ -42,6 +42,16 @@ def _topic_to_key_expr(topic: Topic) -> str:
     Embeds the lcm_type in the key using '/' instead of '#' (which is
     forbidden in Zenoh key expressions). This mirrors how LCM channels
     carry type info in the channel name for subscribe_all decoding.
+
+    Examples:
+        Topic("dimos/cmd_vel", Twist) → "dimos/cmd_vel/geometry_msgs.Twist"
+        Topic("dimos/data")           → "dimos/data"
+
+    Known limitation: the type name becomes a path segment. If a topic
+    name itself looks like a type name (e.g., "dimos/geometry_msgs.Twist"),
+    _key_expr_to_topic may misparse it on the receiving end. In practice
+    this doesn't happen because topic names come from stream names (e.g.,
+    "cmd_vel", "lidar"), not from type names.
     """
     base = topic.topic if isinstance(topic.topic, str) else topic.pattern
     if topic.lcm_type is not None:
@@ -52,8 +62,18 @@ def _topic_to_key_expr(topic: Topic) -> str:
 def _key_expr_to_topic(key_expr: str, default_lcm_type: type | None = None) -> Topic:
     """Reconstruct a Topic from a Zenoh key expression.
 
-    Parses the type suffix (last segment after the base path) using
-    the same resolver as LCM's Topic.from_channel_str.
+    Parses the last '/' segment and attempts to resolve it as a DimosMsg
+    type via resolve_msg_type(). If resolution succeeds, the segment is
+    treated as the type suffix and the remainder as the base topic.
+
+    Examples:
+        "dimos/cmd_vel/geometry_msgs.Twist" → Topic("dimos/cmd_vel", Twist)
+        "dimos/data"                        → Topic("dimos/data", default_lcm_type)
+        "dimos/data/unknown.Foo"            → Topic("dimos/data/unknown.Foo", default_lcm_type)
+
+    Known limitation: if a topic's base path ends with a segment that
+    happens to match a registered DimosMsg type name, this function will
+    incorrectly split it. See _topic_to_key_expr docstring for details.
     """
     from dimos.msgs.helpers import resolve_msg_type
 

--- a/dimos/protocol/pubsub/impl/zenohpubsub.py
+++ b/dimos/protocol/pubsub/impl/zenohpubsub.py
@@ -101,11 +101,9 @@ class ZenohPubSubBase(ZenohService, AllPubSub[Topic, bytes]):
                 return
             undeclared = True
             with self._subscriber_lock:
-                try:
-                    self._subscribers.remove(sub)
-                except ValueError:
-                    # Already removed by stop() — stop() owns the undeclare
-                    return
+                if sub not in self._subscribers:
+                    return  # Already removed by stop() — stop() owns the undeclare
+                self._subscribers.remove(sub)
             sub.undeclare()
 
         return unsubscribe

--- a/dimos/protocol/pubsub/impl/zenohpubsub.py
+++ b/dimos/protocol/pubsub/impl/zenohpubsub.py
@@ -98,7 +98,7 @@ class ZenohPubSubBase(ZenohService, AllPubSub[Topic, bytes]):
         super().__init__(**kwargs)
         self._publishers: dict[str, zenoh.Publisher] = {}
         self._publisher_lock = threading.Lock()
-        self._subscribers: list[zenoh.Subscriber] = []
+        self._subscribers: list[zenoh.Subscriber[Any]] = []
         self._subscriber_lock = threading.Lock()
 
     def _get_publisher(self, key_expr: str) -> zenoh.Publisher:
@@ -158,7 +158,7 @@ class ZenohPubSubBase(ZenohService, AllPubSub[Topic, bytes]):
                 if sub not in self._subscribers:
                     return  # Already removed by stop() — stop() owns the undeclare
                 self._subscribers.remove(sub)
-            sub.undeclare()
+            sub.undeclare()  # type: ignore[no-untyped-call]
 
         return unsubscribe
 
@@ -170,11 +170,11 @@ class ZenohPubSubBase(ZenohService, AllPubSub[Topic, bytes]):
         """Clean up publishers and subscribers."""
         with self._subscriber_lock:
             for subscriber in self._subscribers:
-                subscriber.undeclare()
+                subscriber.undeclare()  # type: ignore[no-untyped-call]
             self._subscribers.clear()
         with self._publisher_lock:
             for publisher in self._publishers.values():
-                publisher.undeclare()
+                publisher.undeclare()  # type: ignore[no-untyped-call]
             self._publishers.clear()
         super().stop()
 

--- a/dimos/protocol/pubsub/impl/zenohpubsub.py
+++ b/dimos/protocol/pubsub/impl/zenohpubsub.py
@@ -58,7 +58,13 @@ class ZenohPubSubBase(ZenohService, AllPubSub[Topic, bytes]):
             return self._publishers[key_expr]
 
     def publish(self, topic: Topic, message: bytes) -> None:
-        """Publish bytes to a Zenoh key expression."""
+        """Publish bytes to a Zenoh key expression.
+
+        Transport-level errors (session closed, invalid key expression) are
+        logged but not raised. Delivery guarantees are handled by Zenoh's
+        reliability protocol (RELIABLE mode retransmits at each hop) — these
+        do not surface as exceptions from put().
+        """
         key_expr = topic.topic if isinstance(topic.topic, str) else topic.pattern
         try:
             publisher = self._get_publisher(key_expr)

--- a/dimos/protocol/pubsub/impl/zenohpubsub.py
+++ b/dimos/protocol/pubsub/impl/zenohpubsub.py
@@ -82,7 +82,12 @@ class ZenohPubSubBase(ZenohService, AllPubSub[Topic, bytes]):
         key_expr = topic.topic if isinstance(topic.topic, str) else topic.pattern
 
         def on_sample(sample: zenoh.Sample) -> None:
-            callback(sample.payload.to_bytes(), topic)
+            try:
+                data = sample.payload.to_bytes()
+            except Exception:
+                logger.error(f"Error reading payload from {key_expr}", exc_info=True)
+                return
+            callback(data, topic)
 
         sub = self.session.declare_subscriber(key_expr, on_sample)
         with self._subscriber_lock:
@@ -95,12 +100,13 @@ class ZenohPubSubBase(ZenohService, AllPubSub[Topic, bytes]):
             if undeclared:
                 return
             undeclared = True
-            sub.undeclare()
             with self._subscriber_lock:
                 try:
                     self._subscribers.remove(sub)
                 except ValueError:
-                    pass
+                    # Already removed by stop() — stop() owns the undeclare
+                    return
+            sub.undeclare()
 
         return unsubscribe
 

--- a/dimos/protocol/pubsub/impl/zenohpubsub.py
+++ b/dimos/protocol/pubsub/impl/zenohpubsub.py
@@ -24,6 +24,7 @@ from collections.abc import Callable
 import threading
 from typing import TYPE_CHECKING, Any
 
+from dimos.constants import ZENOH_DIMOS_KEY_PREFIX
 from dimos.protocol.pubsub.encoders import LCMEncoderMixin, PickleEncoderMixin
 from dimos.protocol.pubsub.impl.lcmpubsub import Topic
 from dimos.protocol.pubsub.spec import AllPubSub
@@ -151,10 +152,10 @@ class ZenohPubSubBase(ZenohService, AllPubSub[Topic, bytes]):
 
         def unsubscribe() -> None:
             nonlocal undeclared
-            if undeclared:
-                return
-            undeclared = True
             with self._subscriber_lock:
+                if undeclared:
+                    return
+                undeclared = True
                 if sub not in self._subscribers:
                     return  # Already removed by stop() — stop() owns the undeclare
                 self._subscribers.remove(sub)
@@ -164,7 +165,7 @@ class ZenohPubSubBase(ZenohService, AllPubSub[Topic, bytes]):
 
     def subscribe_all(self, callback: Callable[[bytes, Topic], Any]) -> Callable[[], None]:
         """Subscribe to all dimos key expressions via wildcard."""
-        return self.subscribe(Topic("dimos/**"), callback)
+        return self.subscribe(Topic(f"{ZENOH_DIMOS_KEY_PREFIX}/**"), callback)
 
     def stop(self) -> None:
         """Clean up publishers and subscribers."""

--- a/dimos/protocol/pubsub/test_spec.py
+++ b/dimos/protocol/pubsub/test_spec.py
@@ -145,6 +145,49 @@ testdata.append(
 )
 
 
+from dimos.core.transport import ZENOH_AVAILABLE
+
+if ZENOH_AVAILABLE:
+    from dimos.protocol.pubsub.impl.zenohpubsub import Zenoh, PickleZenoh
+    from dimos.protocol.service.zenohservice import _sessions as _zenoh_sessions
+
+    @contextmanager
+    def zenoh_lcm_context() -> Generator[Zenoh, None, None]:
+        zenoh_pubsub = Zenoh()
+        zenoh_pubsub.start()
+        yield zenoh_pubsub
+        zenoh_pubsub.stop()
+        for s in _zenoh_sessions.values():
+            s.close()
+        _zenoh_sessions.clear()
+
+    testdata.append(
+        (
+            zenoh_lcm_context,
+            Topic(topic="dimos/test/spec", lcm_type=Vector3),
+            [Vector3(1, 2, 3), Vector3(4, 5, 6), Vector3(7, 8, 9)],
+        )
+    )
+
+    @contextmanager
+    def zenoh_pickle_context() -> Generator[PickleZenoh, None, None]:
+        zenoh_pubsub = PickleZenoh()
+        zenoh_pubsub.start()
+        yield zenoh_pubsub
+        zenoh_pubsub.stop()
+        for s in _zenoh_sessions.values():
+            s.close()
+        _zenoh_sessions.clear()
+
+    testdata.append(
+        (
+            zenoh_pickle_context,
+            Topic("dimos/test/spec/pickle"),
+            [{"key": "value1"}, {"key": "value2"}, {"key": "value3"}],
+        )
+    )
+
+
 @pytest.mark.parametrize("pubsub_context, topic, values", testdata)
 def test_store(pubsub_context: Callable[[], Any], topic: Any, values: list[Any]) -> None:
     with pubsub_context() as x:

--- a/dimos/protocol/pubsub/test_spec.py
+++ b/dimos/protocol/pubsub/test_spec.py
@@ -148,7 +148,7 @@ testdata.append(
 from dimos.core.transport import ZENOH_AVAILABLE
 
 if ZENOH_AVAILABLE:
-    from dimos.protocol.pubsub.impl.zenohpubsub import Zenoh, PickleZenoh
+    from dimos.protocol.pubsub.impl.zenohpubsub import PickleZenoh, Zenoh
     from dimos.protocol.service.zenohservice import _sessions as _zenoh_sessions
 
     @contextmanager

--- a/dimos/protocol/service/test_zenohservice.py
+++ b/dimos/protocol/service/test_zenohservice.py
@@ -1,0 +1,82 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ZenohService — singleton session management."""
+
+from __future__ import annotations
+
+import pytest
+
+from dimos.protocol.service.zenohservice import ZenohConfig, ZenohService, _sessions
+
+
+@pytest.fixture(autouse=True)
+def _clear_sessions():
+    """Clear the global session cache before each test."""
+    yield
+    # Close and remove all sessions after each test
+    for session in _sessions.values():
+        session.close()
+    _sessions.clear()
+
+
+class TestZenohConfig:
+    def test_default_mode_is_peer(self) -> None:
+        config = ZenohConfig()
+        assert config.mode == "peer"
+
+    def test_session_key_is_stable(self) -> None:
+        config = ZenohConfig()
+        assert config.session_key == config.session_key
+
+    def test_different_modes_produce_different_keys(self) -> None:
+        peer = ZenohConfig(mode="peer")
+        client = ZenohConfig(mode="client")
+        assert peer.session_key != client.session_key
+
+
+class TestZenohService:
+    def test_start_creates_session(self) -> None:
+        svc = ZenohService()
+        svc.start()
+        assert svc.session is not None
+
+    def test_two_services_share_session(self) -> None:
+        svc1 = ZenohService()
+        svc2 = ZenohService()
+        svc1.start()
+        svc2.start()
+        assert svc1.session is svc2.session
+
+    def test_stop_does_not_close_shared_session(self) -> None:
+        svc1 = ZenohService()
+        svc2 = ZenohService()
+        svc1.start()
+        svc2.start()
+        svc1.stop()
+        # svc2's session should still be valid
+        assert svc2.session is not None
+
+    def test_session_before_start_raises(self) -> None:
+        svc = ZenohService()
+        with pytest.raises(RuntimeError, match="not initialized"):
+            _ = svc.session
+
+    def test_start_is_idempotent(self) -> None:
+        svc = ZenohService()
+        svc.start()
+        session1 = svc.session
+        svc.start()
+        session2 = svc.session
+        assert session1 is session2

--- a/dimos/protocol/service/test_zenohservice.py
+++ b/dimos/protocol/service/test_zenohservice.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 import pytest
 
+pytest.importorskip("zenoh")
+
 from dimos.protocol.service.zenohservice import ZenohConfig, ZenohService, _sessions
 
 

--- a/dimos/protocol/service/test_zenohservice.py
+++ b/dimos/protocol/service/test_zenohservice.py
@@ -20,17 +20,14 @@ import pytest
 
 pytest.importorskip("zenoh")
 
-from dimos.protocol.service.zenohservice import ZenohConfig, ZenohService, _sessions
+from dimos.protocol.service.zenohservice import ZenohConfig, ZenohService, close_all_zenoh_sessions
 
 
 @pytest.fixture(autouse=True)
 def _clear_sessions():
     """Clear the global session cache before each test."""
     yield
-    # Close and remove all sessions after each test
-    for session in _sessions.values():
-        session.close()
-    _sessions.clear()
+    close_all_zenoh_sessions()
 
 
 class TestZenohConfig:

--- a/dimos/protocol/service/zenohservice.py
+++ b/dimos/protocol/service/zenohservice.py
@@ -62,7 +62,7 @@ class ZenohService(Service[ZenohConfig]):
                 if self.config.listen:
                     config.insert_json5("listen/endpoints", json.dumps(self.config.listen))
                 _sessions[key] = zenoh.open(config)
-                logger.info(f"Zenoh session opened in {self.config.mode} mode")
+                logger.debug(f"Zenoh session opened in {self.config.mode} mode")
         super().start()
 
     def stop(self) -> None:

--- a/dimos/protocol/service/zenohservice.py
+++ b/dimos/protocol/service/zenohservice.py
@@ -23,6 +23,8 @@ from typing import Any
 import zenoh
 
 from dimos.protocol.service.spec import BaseConfig, Service
+
+zenoh.init_log_from_env_or("warn")
 from dimos.utils.logging_config import setup_logger
 
 logger = setup_logger()

--- a/dimos/protocol/service/zenohservice.py
+++ b/dimos/protocol/service/zenohservice.py
@@ -1,0 +1,84 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Zenoh session management — singleton pattern following DDSService."""
+
+from __future__ import annotations
+
+import json
+import threading
+from typing import Any
+
+import zenoh
+
+from dimos.protocol.service.spec import BaseConfig, Service
+from dimos.utils.logging_config import setup_logger
+
+logger = setup_logger()
+
+_sessions: dict[str, zenoh.Session] = {}
+_sessions_lock = threading.Lock()
+
+
+class ZenohConfig(BaseConfig):
+    """Configuration for Zenoh service."""
+
+    mode: str = "peer"
+    connect: list[str] = []
+    listen: list[str] = []
+
+    @property
+    def session_key(self) -> str:
+        """Produce a hashable key for singleton session lookup."""
+        return f"{self.mode}|{json.dumps(sorted(self.connect))}|{json.dumps(sorted(self.listen))}"
+
+
+class ZenohService(Service[ZenohConfig]):
+    default_config = ZenohConfig
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+
+    def start(self) -> None:
+        """Start the Zenoh service — opens a session if one doesn't exist for this config."""
+        key = self.config.session_key
+        with _sessions_lock:
+            if key not in _sessions:
+                config = zenoh.Config()
+                config.insert_json5("mode", json.dumps(self.config.mode))
+                if self.config.connect:
+                    config.insert_json5("connect/endpoints", json.dumps(self.config.connect))
+                if self.config.listen:
+                    config.insert_json5("listen/endpoints", json.dumps(self.config.listen))
+                _sessions[key] = zenoh.open(config)
+                logger.info(f"Zenoh session opened in {self.config.mode} mode")
+        super().start()
+
+    def stop(self) -> None:
+        """Stop the Zenoh service — does NOT close the shared session."""
+        super().stop()
+
+    @property
+    def session(self) -> zenoh.Session:
+        """Get the Zenoh Session instance for this service's config."""
+        key = self.config.session_key
+        if key not in _sessions:
+            raise RuntimeError("Zenoh session not initialized — call start() first")
+        return _sessions[key]
+
+
+__all__ = [
+    "ZenohConfig",
+    "ZenohService",
+]

--- a/dimos/protocol/service/zenohservice.py
+++ b/dimos/protocol/service/zenohservice.py
@@ -46,8 +46,8 @@ class ZenohConfig(BaseConfig):
         return f"{self.mode}|{json.dumps(sorted(self.connect))}|{json.dumps(sorted(self.listen))}"
 
 
-class ZenohService(Service[ZenohConfig]):
-    default_config = ZenohConfig
+class ZenohService(Service):
+    config: ZenohConfig
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)

--- a/dimos/protocol/service/zenohservice.py
+++ b/dimos/protocol/service/zenohservice.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import atexit
 import json
 import threading
 from typing import Any
@@ -31,6 +32,25 @@ logger = setup_logger()
 
 _sessions: dict[str, zenoh.Session] = {}
 _sessions_lock = threading.Lock()
+
+
+def close_all_zenoh_sessions() -> None:
+    """Close and clear every cached session in this process.
+
+    Safe to call when no live publishers or subscribers still reference the
+    sessions (call after module ``stop()``). Idempotent if the cache is empty.
+    """
+    with _sessions_lock:
+        to_close = list(_sessions.values())
+        _sessions.clear()
+    for session in to_close:
+        try:
+            session.close()  # type: ignore[no-untyped-call]
+        except Exception:
+            logger.error("Error closing Zenoh session", exc_info=True)
+
+
+atexit.register(close_all_zenoh_sessions)
 
 
 class ZenohConfig(BaseConfig):
@@ -83,4 +103,5 @@ class ZenohService(Service):
 __all__ = [
     "ZenohConfig",
     "ZenohService",
+    "close_all_zenoh_sessions",
 ]

--- a/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_basic.py
+++ b/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_basic.py
@@ -34,9 +34,18 @@ _mac_transports: dict[tuple[str, type], pSHMTransport[Image]] = {
     ),
 }
 
-_transports_base = (
-    autoconnect() if platform.system() == "Linux" else autoconnect().transports(_mac_transports)
-)
+
+def _platform_transports() -> Any:
+    """Darwin: pSHM for color_image only under LCM; under Zenoh use coordinator defaults."""
+    if platform.system() == "Linux":
+        return autoconnect()
+    if global_config.transport == "lcm":
+        return autoconnect().transports(_mac_transports)
+    # under Zenoh, do not override color_image to pSHM.
+    return autoconnect()
+
+
+_transports_base = _platform_transports()
 
 
 def _convert_camera_info(camera_info: Any) -> Any:

--- a/dimos/visualization/rerun/bridge.py
+++ b/dimos/visualization/rerun/bridge.py
@@ -166,7 +166,12 @@ def _default_blueprint() -> Blueprint:
 
 
 def _default_pubsubs(config: Any = None) -> list[SubscribeAllCapable[Any, Any]]:
-    """Select the pubsub backend based on the active transport."""
+    """Select the pubsub backend based on the active transport.
+
+    When transport is Zenoh, we listen on BOTH Zenoh and LCM because
+    TF (transform frames) is currently hardcoded to LCM in the Module
+    base class. Without LCM, the robot pose won't update in the viewer.
+    """
     transport = getattr(config, "transport", None) or global_config.transport
     if transport == "zenoh":
         from dimos.core.transport import ZENOH_AVAILABLE
@@ -174,7 +179,7 @@ def _default_pubsubs(config: Any = None) -> list[SubscribeAllCapable[Any, Any]]:
         if ZENOH_AVAILABLE:
             from dimos.protocol.pubsub.impl.zenohpubsub import Zenoh
 
-            return [Zenoh()]
+            return [Zenoh(), LCM()]
     return [LCM()]
 
 

--- a/dimos/visualization/rerun/bridge.py
+++ b/dimos/visualization/rerun/bridge.py
@@ -171,15 +171,23 @@ def _default_pubsubs(config: Any = None) -> list[SubscribeAllCapable[Any, Any]]:
     When transport is Zenoh, we listen on BOTH Zenoh and LCM because
     TF (transform frames) is currently hardcoded to LCM in the Module
     base class. Without LCM, the robot pose won't update in the viewer.
+
+    If transport is zenoh but eclipse-zenoh is not installed, raises
+    ``RuntimeError`` (same message as stream transport selection) instead of
+    falling back to LCM only.
     """
     transport = getattr(config, "transport", None) or global_config.transport
     if transport == "zenoh":
         from dimos.core.transport import ZENOH_AVAILABLE
 
-        if ZENOH_AVAILABLE:
-            from dimos.protocol.pubsub.impl.zenohpubsub import Zenoh
+        if not ZENOH_AVAILABLE:
+            raise RuntimeError(
+                "transport='zenoh' but eclipse-zenoh is not installed. "
+                "Install with: uv sync --extra zenoh"
+            )
+        from dimos.protocol.pubsub.impl.zenohpubsub import Zenoh
 
-            return [Zenoh(), LCM()]
+        return [Zenoh(), LCM()]
     return [LCM()]
 
 

--- a/dimos/visualization/rerun/bridge.py
+++ b/dimos/visualization/rerun/bridge.py
@@ -191,12 +191,32 @@ def _default_pubsubs(config: Any = None) -> list[SubscribeAllCapable[Any, Any]]:
     return [LCM()]
 
 
+def _resolve_pubsubs(config: Any) -> list[SubscribeAllCapable[Any, Any]]:
+    """Return explicit pubsubs when truly overridden, else transport defaults.
+
+    Older blueprints commonly passed ``pubsubs=[LCM()]`` as the effective
+    default. Preserve the newer transport-driven behavior for that legacy
+    value, but honor explicit non-default overrides such as custom backends.
+    """
+    fields_set: set[str] = cast("set[str]", getattr(config, "model_fields_set", set()))
+    pubsubs = cast(
+        "list[SubscribeAllCapable[Any, Any]] | None",
+        getattr(config, "pubsubs", None),
+    )
+    if "pubsubs" in fields_set and pubsubs is not None:
+        is_legacy_default = len(pubsubs) == 1 and isinstance(pubsubs[0], LCM)
+        if not is_legacy_default:
+            return pubsubs
+    return _default_pubsubs(getattr(config, "g", config))
+
+
 class Config(ModuleConfig):
     """Configuration for RerunBridgeModule.
 
-    The pubsubs field is accepted for backwards compatibility (existing blueprints
-    pass it), but ignored at start() — the actual pubsub backend is resolved
-    lazily from global_config.transport.
+    The pubsubs field is accepted for backwards compatibility. The legacy
+    ``[LCM()]`` value is treated as the old default and replaced by the
+    transport-driven runtime default. Explicit non-default overrides are still
+    honored.
     """
 
     pubsubs: list[SubscribeAllCapable[Any, Any]] = field(default_factory=lambda: [LCM()])
@@ -439,7 +459,7 @@ class RerunBridgeModule(Module):
         # Resolve pubsubs lazily — the module-level global_config singleton in worker
         # processes doesn't have CLI overrides. Use self.config.g which is the parent's
         # updated config, passed via the worker kwargs.
-        pubsubs = _default_pubsubs(self.config.g)
+        pubsubs = _resolve_pubsubs(self.config)
 
         for pubsub in pubsubs:
             logger.info(f"bridge listening on {pubsub.__class__.__name__}")

--- a/dimos/visualization/rerun/bridge.py
+++ b/dimos/visualization/rerun/bridge.py
@@ -178,12 +178,11 @@ def _default_pubsubs(config: Any = None) -> list[SubscribeAllCapable[Any, Any]]:
     """
     transport = getattr(config, "transport", None) or global_config.transport
     if transport == "zenoh":
-        from dimos.core.transport import ZENOH_AVAILABLE
+        from dimos.core.transport import ZENOH_AVAILABLE, ZENOH_INSTALL_HINT
 
         if not ZENOH_AVAILABLE:
             raise RuntimeError(
-                "transport='zenoh' but eclipse-zenoh is not installed. "
-                "Install with: uv sync --extra zenoh"
+                "transport='zenoh' but eclipse-zenoh is not installed. " + ZENOH_INSTALL_HINT
             )
         from dimos.protocol.pubsub.impl.zenohpubsub import Zenoh
 

--- a/dimos/visualization/rerun/bridge.py
+++ b/dimos/visualization/rerun/bridge.py
@@ -181,8 +181,12 @@ def _default_pubsubs(config: Any = None) -> list[SubscribeAllCapable[Any, Any]]:
 class Config(ModuleConfig):
     """Configuration for RerunBridgeModule.
 
-    Pubsub backend is resolved lazily at start() from global_config.transport.
+    The pubsubs field is accepted for backwards compatibility (existing blueprints
+    pass it), but ignored at start() — the actual pubsub backend is resolved
+    lazily from global_config.transport.
     """
+
+    pubsubs: list[SubscribeAllCapable[Any, Any]] = field(default_factory=lambda: [LCM()])
 
     visual_override: dict[Glob | str, Callable[[Any], Archetype] | None] = field(
         default_factory=dict

--- a/dimos/visualization/rerun/bridge.py
+++ b/dimos/visualization/rerun/bridge.py
@@ -42,7 +42,9 @@ from rerun.blueprint import Blueprint
 from toolz import pipe  # type: ignore[import-untyped]
 
 from dimos.core.core import rpc
+from dimos.core.global_config import global_config
 from dimos.core.module import Module, ModuleConfig
+from dimos.msgs.sensor_msgs.PointCloud2 import register_colormap_annotation
 from dimos.protocol.pubsub.impl.lcmpubsub import LCM
 from dimos.protocol.pubsub.patterns import Glob, pattern_matches
 from dimos.protocol.pubsub.spec import SubscribeAllCapable
@@ -163,6 +165,19 @@ def _default_blueprint() -> Blueprint:
     )
 
 
+def _default_pubsubs(config: Any = None) -> list[SubscribeAllCapable[Any, Any]]:
+    """Select the pubsub backend based on the active transport."""
+    transport = getattr(config, "transport", None) or global_config.transport
+    if transport == "zenoh":
+        from dimos.core.transport import ZENOH_AVAILABLE
+
+        if ZENOH_AVAILABLE:
+            from dimos.protocol.pubsub.impl.zenohpubsub import Zenoh
+
+            return [Zenoh()]
+    return [LCM()]
+
+
 class Config(ModuleConfig):
     pubsubs: list[SubscribeAllCapable[Any, Any]] = field(default_factory=lambda: [LCM()])
 
@@ -269,7 +284,15 @@ class RerunBridgeModule(Module):
             return self.config.topic_to_entity(topic)
 
         topic_str = getattr(topic, "name", None) or str(topic)
-        topic_str = topic_str.split("#")[0]  # strip LCM topic suffix
+        # Strip type suffix: LCM uses '#type', Zenoh embeds type as '/type' in key expr
+        # but _key_expr_to_topic already parsed it into topic.topic, so use that.
+        raw = getattr(topic, "topic", topic_str)
+        if isinstance(raw, str):
+            topic_str = raw
+        topic_str = topic_str.split("#")[0]
+        # Strip Zenoh key prefix (dimos/) to match LCM entity paths
+        if topic_str.startswith("dimos/"):
+            topic_str = "/" + topic_str.removeprefix("dimos/")
         return f"{self.config.entity_prefix}{topic_str}"
 
     def _on_message(self, msg: Any, topic: Any) -> None:
@@ -390,14 +413,22 @@ class RerunBridgeModule(Module):
         if self.config.blueprint:
             rr.send_blueprint(_with_graph_tab(self.config.blueprint()))
 
-        for pubsub in self.config.pubsubs:
+        # Register colormap for viewer-side color resolution (PointCloud2 class_ids)
+        register_colormap_annotation("turbo")
+
+        # Resolve pubsubs lazily — the module-level global_config singleton in worker
+        # processes doesn't have CLI overrides. Use self.config.g which is the parent's
+        # updated config, passed via the worker kwargs.
+        pubsubs = _default_pubsubs(self.config.g)
+
+        for pubsub in pubsubs:
             logger.info(f"bridge listening on {pubsub.__class__.__name__}")
             if hasattr(pubsub, "start"):
                 pubsub.start()
             unsub = pubsub.subscribe_all(self._on_message)
             self.register_disposable(Disposable(unsub))
 
-        for pubsub in self.config.pubsubs:
+        for pubsub in pubsubs:
             if hasattr(pubsub, "stop"):
                 self.register_disposable(Disposable(pubsub.stop))  # type: ignore[union-attr]
 

--- a/dimos/visualization/rerun/bridge.py
+++ b/dimos/visualization/rerun/bridge.py
@@ -41,6 +41,7 @@ import rerun.blueprint as rrb
 from rerun.blueprint import Blueprint
 from toolz import pipe  # type: ignore[import-untyped]
 
+from dimos.constants import ZENOH_DIMOS_KEY_PREFIX
 from dimos.core.core import rpc
 from dimos.core.global_config import global_config
 from dimos.core.module import Module, ModuleConfig
@@ -329,9 +330,10 @@ class RerunBridgeModule(Module):
         if isinstance(raw, str):
             topic_str = raw
         topic_str = topic_str.split("#")[0]
-        # Strip Zenoh key prefix (dimos/) to match LCM entity paths
-        if topic_str.startswith("dimos/"):
-            topic_str = "/" + topic_str.removeprefix("dimos/")
+        # Strip Zenoh key root to match LCM-style entity paths.
+        _prefix = f"{ZENOH_DIMOS_KEY_PREFIX}/"
+        if topic_str.startswith(_prefix):
+            topic_str = "/" + topic_str.removeprefix(_prefix)
         return f"{self.config.entity_prefix}{topic_str}"
 
     def _on_message(self, msg: Any, topic: Any) -> None:

--- a/dimos/visualization/rerun/bridge.py
+++ b/dimos/visualization/rerun/bridge.py
@@ -179,7 +179,10 @@ def _default_pubsubs(config: Any = None) -> list[SubscribeAllCapable[Any, Any]]:
 
 
 class Config(ModuleConfig):
-    pubsubs: list[SubscribeAllCapable[Any, Any]] = field(default_factory=lambda: [LCM()])
+    """Configuration for RerunBridgeModule.
+
+    Pubsub backend is resolved lazily at start() from global_config.transport.
+    """
 
     visual_override: dict[Glob | str, Callable[[Any], Archetype] | None] = field(
         default_factory=dict
@@ -554,7 +557,6 @@ def run_bridge(
         memory_limit=memory_limit,
         rerun_open=rerun_open,
         rerun_web=rerun_web,
-        pubsubs=[LCM()],
     )
     bridge.start()
 

--- a/dimos/visualization/rerun/test_viewer_integration.py
+++ b/dimos/visualization/rerun/test_viewer_integration.py
@@ -27,6 +27,10 @@ pushing an update that breaks the spawn interface.
 import inspect
 import shutil
 
+from dimos.core.global_config import GlobalConfig
+from dimos.protocol.pubsub.impl.lcmpubsub import LCM
+from dimos.visualization.rerun.bridge import Config, _resolve_pubsubs
+
 
 class TestViewerBinaryInstallation:
     """Verify dimos-viewer binary is installed and functional."""
@@ -116,3 +120,24 @@ class TestBridgeSpawnLogic:
             "bridge.py start() has no fallback for missing dimos-viewer. "
             "Users without dimos-viewer will crash."
         )
+
+
+class ExplicitPubSubOverride:
+    def subscribe_all(self, callback):  # type: ignore[no-untyped-def]
+        return lambda: None
+
+
+class TestBridgePubsubResolution:
+    def test_legacy_lcm_pubsubs_defers_to_transport_default(self):
+        config = Config(pubsubs=[LCM()], g=GlobalConfig(transport="lcm"))
+        pubsubs = _resolve_pubsubs(config)
+
+        assert len(pubsubs) == 1
+        assert isinstance(pubsubs[0], LCM)
+
+    def test_explicit_custom_pubsubs_override_is_honored(self):
+        custom = ExplicitPubSubOverride()
+        config = Config(pubsubs=[custom], g=GlobalConfig(transport="lcm"))
+        pubsubs = _resolve_pubsubs(config)
+
+        assert pubsubs == [custom]

--- a/dimos/visualization/rerun/test_viewer_integration.py
+++ b/dimos/visualization/rerun/test_viewer_integration.py
@@ -27,9 +27,11 @@ pushing an update that breaks the spawn interface.
 import inspect
 import shutil
 
+import rerun_bindings
+
 from dimos.core.global_config import GlobalConfig
 from dimos.protocol.pubsub.impl.lcmpubsub import LCM
-from dimos.visualization.rerun.bridge import Config, _resolve_pubsubs
+from dimos.visualization.rerun.bridge import Config, RerunBridgeModule, _resolve_pubsubs
 
 
 class TestViewerBinaryInstallation:
@@ -62,8 +64,6 @@ class TestRerunBindingsInterface:
         stock rerun. If rerun-sdk removes this parameter, our integration
         breaks silently (falls back to stock rerun).
         """
-        import rerun_bindings
-
         sig = inspect.signature(rerun_bindings.spawn)
         assert "executable_name" in sig.parameters, (
             "rerun_bindings.spawn() no longer accepts 'executable_name'. "
@@ -73,15 +73,11 @@ class TestRerunBindingsInterface:
 
     def test_spawn_accepts_port(self):
         """rerun_bindings.spawn must accept port kwarg."""
-        import rerun_bindings
-
         sig = inspect.signature(rerun_bindings.spawn)
         assert "port" in sig.parameters, "rerun_bindings.spawn() no longer accepts 'port'. "
 
     def test_spawn_accepts_expected_params(self):
         """All spawn params used by bridge.py must be available."""
-        import rerun_bindings
-
         sig = inspect.signature(rerun_bindings.spawn)
         required = {"port", "executable_name"}
         missing = required - set(sig.parameters.keys())
@@ -96,8 +92,6 @@ class TestBridgeSpawnLogic:
 
     def test_bridge_references_dimos_viewer(self):
         """bridge.py must attempt to spawn dimos-viewer."""
-        from dimos.visualization.rerun.bridge import RerunBridgeModule
-
         src = inspect.getsource(RerunBridgeModule.start)
         assert "dimos-viewer" in src, (
             "bridge.py start() does not reference 'dimos-viewer'. "
@@ -106,15 +100,11 @@ class TestBridgeSpawnLogic:
 
     def test_bridge_uses_rerun_bindings(self):
         """bridge.py must use rerun_bindings (not subprocess) for spawn."""
-        from dimos.visualization.rerun.bridge import RerunBridgeModule
-
         src = inspect.getsource(RerunBridgeModule.start)
         assert "rerun_bindings" in src, "bridge.py start() does not use rerun_bindings. "
 
     def test_bridge_has_fallback(self):
         """bridge.py must fall back to stock rerun if dimos-viewer unavailable."""
-        from dimos.visualization.rerun.bridge import RerunBridgeModule
-
         src = inspect.getsource(RerunBridgeModule.start)
         assert "ImportError" in src or "except" in src, (
             "bridge.py start() has no fallback for missing dimos-viewer. "

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -38,7 +38,7 @@ Self-hosted tests are marked with `@pytest.mark.self_hosted` (they need LFS, ROS
 ### Default suite
 
 ```bash
-./bin/pytest-fast
+CI=1 ./bin/pytest-fast
 ```
 
 This is the same as:
@@ -51,11 +51,15 @@ The default `addopts` in `pyproject.toml` includes a `-m` filter that excludes `
 
 ### Self-hosted tests
 
+For non-interactive runs, especially on macOS, prefer `CI=1`. This skips system configurator prompts and avoids test runs trying to change local multicast or sysctl state.
+
 ```bash
-./bin/pytest-slow
+CI=1 ./bin/pytest-slow
 ```
 
 (Shortcut for `pytest -m 'not (tool or mujoco)' dimos` — runs the default suite *and* self-hosted tests, but not `tool` or `mujoco`.)
+
+This includes slow agent and MCP-style integration tests in addition to slower transport and module tests. If one of those paths is broken, a failure can take close to a minute to surface because the harness waits for the agent flow to finish before timing out.
 
 When writing or debugging a specific self-hosted test, override `-m` yourself to run it:
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -54,7 +54,7 @@ The default `addopts` in `pyproject.toml` includes a `-m` filter that excludes `
 For non-interactive runs, especially on macOS, prefer `CI=1`. This skips system configurator prompts and avoids test runs trying to change local multicast or sysctl state.
 
 ```bash
-CI=1 ./bin/pytest-slow
+./bin/pytest-slow
 ```
 
 (Shortcut for `pytest -m 'not (tool or mujoco)' dimos` — runs the default suite *and* self-hosted tests, but not `tool` or `mujoco`.)

--- a/docs/installation/osx.md
+++ b/docs/installation/osx.md
@@ -48,14 +48,14 @@ LCM over UDP can be unreliable on macOS for large or high-rate replay workloads.
 
 See the [Zenoh quickstart](/docs/usage/transports/index.md#zenoh-quickstart) for install, Linux versus macOS defaults, and `DIMOS_TRANSPORT`.
 
-```sh
+```sh skip
 dimos --dtop --replay --replay-db=go2_bigoffice run unitree-go2
 ```
 
 If you are developing on the repository, prefer syncing the full environment with the checked-in lockfile:
 
-```sh
+```sh skip
 uv sync --all-extras --no-extra dds --no-extra cuda --frozen
 ```
 
-Do not rely on `uv sync --extra zenoh` in an existing full development environment. That can re-resolve the environment in a way that removes unrelated packages you already had installed.
+Do not rely on `` `uv sync --extra zenoh` `` in an existing full development environment. That can re-resolve the environment in a way that removes unrelated packages you already had installed.

--- a/docs/installation/osx.md
+++ b/docs/installation/osx.md
@@ -41,3 +41,19 @@ uv run mypy dimos
 # tests (around a minute to run)
 uv run pytest --numprocesses=auto dimos
 ```
+
+## Transport note for macOS
+
+LCM over UDP can be unreliable on macOS for large or high-rate replay workloads. If you are running heavy replay traffic, prefer Zenoh:
+
+```sh
+dimos --transport=zenoh --dtop --replay --replay-dir=unitree_go2_bigoffice run unitree-go2
+```
+
+If you are developing on the repository, prefer syncing the full environment with the checked-in lockfile:
+
+```sh
+uv sync --all-extras --no-extra dds --no-extra cuda --frozen
+```
+
+Do not rely on `uv sync --extra zenoh` in an existing full development environment. That can re-resolve the environment in a way that removes unrelated packages you already had installed.

--- a/docs/installation/osx.md
+++ b/docs/installation/osx.md
@@ -44,10 +44,12 @@ uv run pytest --numprocesses=auto dimos
 
 ## Transport note for macOS
 
-LCM over UDP can be unreliable on macOS for large or high-rate replay workloads. If you are running heavy replay traffic, prefer Zenoh:
+LCM over UDP can be unreliable on macOS for large or high-rate replay workloads. When the optional **Zenoh** bindings are installed, DimOS already defaults the global stream transport to **Zenoh** on macOS, so you usually do not need `--transport=zenoh`. Use `--transport=lcm` if you need to force the legacy multicast path.
+
+See the [Zenoh quickstart](/docs/usage/transports/index.md#zenoh-quickstart) for install, Linux versus macOS defaults, and `DIMOS_TRANSPORT`.
 
 ```sh
-dimos --transport=zenoh --dtop --replay --replay-dir=unitree_go2_bigoffice run unitree-go2
+dimos --dtop --replay --replay-db=go2_bigoffice run unitree-go2
 ```
 
 If you are developing on the repository, prefer syncing the full environment with the checked-in lockfile:

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -84,8 +84,8 @@ dimos run unitree-go2-agentic --daemon
 # Replay with Rerun viewer
 dimos --replay --viewer rerun run unitree-go2
 
-# Replay Big Office data explicitly over Zenoh
-dimos --transport=zenoh --dtop --replay --replay-dir=unitree_go2_bigoffice run unitree-go2
+# Replay Big Office (on Linux use --transport=zenoh; on macOS Zenoh is default when installed)
+dimos --transport=zenoh --dtop --replay --replay-db=go2_bigoffice run unitree-go2
 
 # Real robot
 dimos run unitree-go2-agentic --robot-ip 192.168.123.161

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -25,6 +25,7 @@ dimos [GLOBAL OPTIONS] COMMAND [ARGS]
 | `--memory-limit` | TEXT | `auto` | Rerun viewer memory limit |
 | `--mcp-port` | INT | `9990` | MCP server port |
 | `--mcp-host` | TEXT | `127.0.0.1` | MCP server bind address |
+| `--transport` | `lcm\|zenoh` | platform-dependent | Stream transport backend. Defaults to `zenoh` on macOS when Zenoh is installed, otherwise `lcm`. |
 | `--dtop` / `--no-dtop` | bool | `False` | Enable live resource monitor overlay |
 | `--obstacle-avoidance` / `--no-obstacle-avoidance` | bool | `True` | Enable obstacle avoidance |
 | `--detection-model` | `qwen\|moondream` | `moondream` | Vision model for object detection |
@@ -83,6 +84,9 @@ dimos run unitree-go2-agentic --daemon
 # Replay with Rerun viewer
 dimos --replay --viewer rerun run unitree-go2
 
+# Replay Big Office data explicitly over Zenoh
+dimos --transport=zenoh --dtop --replay --replay-dir=unitree_go2_bigoffice run unitree-go2
+
 # Real robot
 dimos run unitree-go2-agentic --robot-ip 192.168.123.161
 
@@ -92,6 +96,8 @@ dimos run unitree-go2 keyboard-teleop
 # Disable specific modules
 dimos run unitree-go2-agentic --disable OsmSkill WebInput
 ```
+
+On macOS, heavy replay workloads can be unreliable over LCM UDP. If Zenoh is installed, the default transport resolves to `zenoh`; you can still force either path explicitly with `--transport=lcm` or `--transport=zenoh`.
 
 When `--daemon` is used, the process:
 1. Builds and starts all modules (foreground — you see errors)

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -199,6 +199,19 @@ Print resolved GlobalConfig values and their sources.
 dimos show-config
 ```
 
+### `dimos topic echo` and `dimos topic send`
+
+Subscribe to or publish on a channel by name, for quick debugging.
+
+```bash
+dimos topic echo /some_topic [MsgType]
+dimos topic send /some_topic '<python expression>'
+```
+
+**Zenoh and `--transport`:** These commands are **LCM-only**. They do not use the `dimos` global `--transport` flag and never open a Zenoh subscriber or publisher. Implementation uses `LCMTransport`, `pLCMTransport`, or raw LCM subscribe via `LCMPubSubBase` (see `dimos/robot/cli/topic.py`).
+
+If DimOS is running with `--transport=zenoh`, module streams use Zenoh (key expressions such as `dimos/...` on the Zenoh session), not the LCM UDP multicast bus. In that common case, `dimos topic echo` will **not** show the same traffic as the running stack. Use `--transport=lcm` when you need to snoop on the wire with these commands, use `lcmspy`, or use Zenoh-specific tooling against the stack's Zenoh keys.
+
 ---
 
 ## Agent & MCP Commands

--- a/docs/usage/transports/index.md
+++ b/docs/usage/transports/index.md
@@ -48,6 +48,54 @@ On macOS, large replay workloads can be unreliable over LCM UDP. If Zenoh is ins
 
 ---
 
+## Zenoh quickstart
+
+Zenoh comes from the **`zenoh`** optional extra (`eclipse-zenoh`).
+
+Repo devs who run `uv sync --all-extras --no-extra dds` (`uv sync --all-extras --no-extra dds --no-extra cuda` on mac) (see [Developing on DimOS](/docs/installation/osx.md#developing-on-dimos)) already pull in **`zenoh`** among the extras, so no extra step.
+
+Otherwise add only the Zenoh wheel (same constraint as the `zenoh` extra in `pyproject.toml`; does not edit `pyproject.toml`):
+
+```bash
+uv pip install 'eclipse-zenoh>=1.0.0,<2.0'
+```
+
+From a checkout, install the project editable with the optional group:
+
+```bash
+uv pip install -e ".[zenoh]"
+```
+
+Only use `uv sync --extra zenoh` when you intend to **sync the environment to default plus the `zenoh` extra only**; that can **uninstall** packages from other extras you used before. See the [macOS install page](/docs/installation/osx.md) if you rely on a wide optional set.
+
+**Default global stream transport** (only applies when you do not pass `--transport` or set `DIMOS_TRANSPORT`):
+
+| Situation | Default |
+|-----------|---------|
+| macOS and the `eclipse-zenoh` package is importable | `zenoh` |
+| Any other platform, or Zenoh not installed | `lcm` |
+
+**Two ways to override for one run or for your shell:**
+
+1. **CLI:** `dimos --transport=zenoh ...` or `dimos --transport=lcm ...` (see [CLI](/docs/usage/cli.md) for precedence with `.env` and blueprints).
+2. **Environment:** `DIMOS_TRANSPORT=zenoh` or `DIMOS_TRANSPORT=lcm`.
+
+Typical **replay on macOS** when Zenoh is installed (default is already Zenoh, so no transport flag is required):
+
+```bash
+dimos --dtop --replay --replay-db=go2_bigoffice run unitree-go2
+```
+
+The same workload on **Linux** (default remains `lcm` until you opt in):
+
+```bash
+dimos --transport=zenoh --dtop --replay --replay-db=go2_bigoffice run unitree-go2
+```
+
+Architecture notes (Rerun bridge, TF still on LCM) live under [Zenoh](#zenoh) in PubSub transports below.
+
+---
+
 ## Benchmarks
 
 Quick view on performance of our pubsub backends:
@@ -338,11 +386,7 @@ Use Zenoh when:
 * you are replaying large or high-rate data and want a more reliable network path
 * you want to keep the DimOS typed stream model while changing the transport backend
 
-At the stream level, the transport wrappers are `ZenohTransport` and `pZenohTransport`. At the CLI level, the usual entry point is:
-
-```bash
-dimos --transport=zenoh --dtop --replay --replay-dir=unitree_go2_bigoffice run unitree-go2
-```
+At the stream level, the transport wrappers are `ZenohTransport` and `pZenohTransport`. Install, defaults, and CLI versus environment overrides are in the [Zenoh quickstart](#zenoh-quickstart) above.
 
 The Rerun bridge also follows the global transport. When `transport=zenoh`, the bridge listens on Zenoh and on LCM for TF data.
 

--- a/docs/usage/transports/index.md
+++ b/docs/usage/transports/index.md
@@ -52,7 +52,7 @@ On macOS, large replay workloads can be unreliable over LCM UDP. If Zenoh is ins
 
 Zenoh comes from the **`zenoh`** optional extra (`eclipse-zenoh`).
 
-Repo devs who run `uv sync --all-extras --no-extra dds` (`uv sync --all-extras --no-extra dds --no-extra cuda` on mac) (see [Developing on DimOS](/docs/installation/osx.md#developing-on-dimos)) already pull in **`zenoh`** among the extras, so no extra step.
+Repo devs who run `uv sync --all-extras --no-extra dds` (on macOS also `--no-extra cuda`; see [Developing on DimOS](/docs/installation/osx.md#developing-on-dimos) for optional `--frozen` with the checked-in lockfile) already pull in **`zenoh`** among the extras, so no extra step.
 
 Otherwise add only the Zenoh wheel (same constraint as the `zenoh` extra in `pyproject.toml`; does not edit `pyproject.toml`):
 
@@ -66,7 +66,7 @@ From a checkout, install the project editable with the optional group:
 uv pip install -e ".[zenoh]"
 ```
 
-Only use `uv sync --extra zenoh` when you intend to **sync the environment to default plus the `zenoh` extra only**; that can **uninstall** packages from other extras you used before. See the [macOS install page](/docs/installation/osx.md) if you rely on a wide optional set.
+Only use `` `uv sync --extra zenoh` `` when you intend to **sync the environment to default plus the `zenoh` extra only**; that can **uninstall** packages from other extras you used before. See the [macOS install page](/docs/installation/osx.md) if you rely on a wide optional set.
 
 **Default global stream transport** (only applies when you do not pass `--transport` or set `DIMOS_TRANSPORT`):
 

--- a/docs/usage/transports/index.md
+++ b/docs/usage/transports/index.md
@@ -29,6 +29,25 @@ So: treat the API as uniform, but pick a backend whose semantics match the task.
 
 ---
 
+## Choosing a backend
+
+For most users, the important choice is between `lcm`, `zenoh`, and shared memory overrides:
+
+* `lcm`: current legacy default on most platforms. Fast and simple, but UDP multicast is best-effort.
+* `zenoh`: network transport with reliable delivery semantics and the same typed message model through `LCMEncoderMixin`.
+* shared memory (`pSHMTransport`, etc.): best for large local streams on a single machine.
+
+At the CLI level, you can select the stream transport globally with:
+
+```bash
+dimos --transport=lcm run unitree-go2
+dimos --transport=zenoh run unitree-go2
+```
+
+On macOS, large replay workloads can be unreliable over LCM UDP. If Zenoh is installed, DimOS defaults the global stream transport to `zenoh`; otherwise it falls back to `lcm`.
+
+---
+
 ## Benchmarks
 
 Quick view on performance of our pubsub backends:
@@ -309,6 +328,24 @@ lcm.stop()
 Received velocity: x=1.0, y=0.0, z=0.5
 ```
 
+### Zenoh
+
+Zenoh provides network pubsub without relying on UDP multicast for the user-facing stream transport. In DimOS it carries the same typed messages by encoding them with `LCMEncoderMixin`, so existing `dimos.msgs.*` types still work.
+
+Use Zenoh when:
+
+* you want a transport that behaves better than UDP multicast on macOS
+* you are replaying large or high-rate data and want a more reliable network path
+* you want to keep the DimOS typed stream model while changing the transport backend
+
+At the stream level, the transport wrappers are `ZenohTransport` and `pZenohTransport`. At the CLI level, the usual entry point is:
+
+```bash
+dimos --transport=zenoh --dtop --replay --replay-dir=unitree_go2_bigoffice run unitree-go2
+```
+
+The Rerun bridge also follows the global transport. When `transport=zenoh`, the bridge listens on Zenoh and on LCM for TF data.
+
 ### Shared memory (IPC)
 
 Shared memory is highest performance, but only works on the **same machine**.
@@ -480,6 +517,7 @@ python -m pytest -svm tool -k "not bytes" dimos/protocol/pubsub/benchmark/test_b
 | `Memory`       | Testing only, single process        | No            | No      | Minimal reference impl               |
 | `SharedMemory` | Multi-process on same machine       | Yes           | No      | Highest throughput (IPC)             |
 | `LCM`          | Robot LAN broadcast (UDP multicast) | Yes           | Yes     | Best-effort; can drop packets on LAN |
+| `Zenoh`        | Reliable network stream transport   | Yes           | Yes     | Recommended on macOS for heavy replay |
 | `Redis`        | Network pubsub via Redis server     | Yes           | Yes     | Central broker; adds hop             |
 | `ROS`          | ROS 2 topic communication           | Yes           | Yes     | Integrates with RViz/ROS tools       |
 | `DDS`          | Cyclone DDS without ROS (WIP)       | Yes           | Yes     | WIP                                  |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -406,7 +406,7 @@ tests = [
 
     # Deps the lint job swaps for stubs (`stubs/<pkg>/` or `types-*`):
     # the real packages are needed at test time, stubs cover mypy.
-    "dimos[apriltag,psql,drone,cpu]",
+    "dimos[apriltag,psql,drone,cpu,zenoh]",
     "mujoco>=3.3.4",
     "pygame>=2.6.1",
     "python-can>=4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -574,6 +574,8 @@ module = [
     "unitree_webrtc_connect.*",
     "websocket",
     "xarm.*",
+    "zenoh",
+    "zenoh.*",
     "ament_index_python.*",
 ]
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -316,6 +316,11 @@ dds = [
     "cyclonedds>=0.10.5",
 ]
 
+zenoh = [
+    "dimos[dev]",
+    "eclipse-zenoh>=1.0.0,<2.0",
+]
+
 # Minimal dependencies for Docker modules that communicate with the DimOS host
 docker = [
     "dimos-lcm",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -352,7 +352,7 @@ apriltag = [
 ]
 
 all = [
-    "dimos[agents,apriltag,base,cpu,cuda,docker,drone,manipulation,misc,perception,psql,sim,unitree,visualization,web]",
+    "dimos[agents,apriltag,base,cpu,cuda,docker,drone,manipulation,misc,perception,psql,sim,unitree,visualization,web,zenoh]",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -317,7 +317,6 @@ dds = [
 ]
 
 zenoh = [
-    "dimos[dev]",
     "eclipse-zenoh>=1.0.0,<2.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -6279,7 +6279,6 @@ resolution-markers = [
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/6c/90d3f532f608a03a13c1d6c16c266ffa3828e8011b1549d3b61db2ad59f5/nvidia_cublas_cu12-12.9.1.4-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:7a950dae01add3b415a5a5cdc4ec818fb5858263e9cca59004bb99fdbbd3a5d6", size = 575006342, upload-time = "2025-06-05T20:04:16.902Z" },
-    { url = "https://files.pythonhosted.org/packages/77/3c/aa88abe01f3be3d1f8f787d1d33dc83e76fec05945f9a28fbb41cfb99cd5/nvidia_cublas_cu12-12.9.1.4-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:453611eb21a7c1f2c2156ed9f3a45b691deda0440ec550860290dc901af5b4c2", size = 581242350, upload-time = "2025-06-05T20:04:51.979Z" },
     { url = "https://files.pythonhosted.org/packages/45/a1/a17fade6567c57452cfc8f967a40d1035bb9301db52f27808167fbb2be2f/nvidia_cublas_cu12-12.9.1.4-py3-none-win_amd64.whl", hash = "sha256:1e5fee10662e6e52bd71dec533fbbd4971bb70a5f24f3bc3793e5c2e9dc640bf", size = 553153899, upload-time = "2025-06-05T20:13:35.556Z" },
 ]
 
@@ -6342,7 +6341,6 @@ resolution-markers = [
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/e0/0279bd94539fda525e0c8538db29b72a5a8495b0c12173113471d28bce78/nvidia_cuda_runtime_cu12-12.9.79-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:83469a846206f2a733db0c42e223589ab62fd2fabac4432d2f8802de4bded0a4", size = 3515012, upload-time = "2025-06-05T20:00:35.519Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/46/a92db19b8309581092a3add7e6fceb4c301a3fd233969856a8cbf042cd3c/nvidia_cuda_runtime_cu12-12.9.79-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:25bba2dfb01d48a9b59ca474a1ac43c6ebf7011f1b0b8cc44f54eb6ac48a96c3", size = 3493179, upload-time = "2025-06-05T20:00:53.735Z" },
     { url = "https://files.pythonhosted.org/packages/59/df/e7c3a360be4f7b93cee39271b792669baeb3846c58a4df6dfcf187a7ffab/nvidia_cuda_runtime_cu12-12.9.79-py3-none-win_amd64.whl", hash = "sha256:8e018af8fa02363876860388bd10ccb89eb9ab8fb0aa749aaf58430a9f7c4891", size = 3591604, upload-time = "2025-06-05T20:11:17.036Z" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -2368,15 +2368,9 @@ requires-dist = [
     { name = "cupy-cuda12x", marker = "platform_machine == 'x86_64' and extra == 'cuda'", specifier = "==13.6.0" },
     { name = "cyclonedds", marker = "extra == 'dds'", specifier = ">=0.10.5" },
     { name = "cyclonedds", marker = "extra == 'unitree-dds'", specifier = ">=0.10.5" },
-<<<<<<< HEAD
-    { name = "dimos", extras = ["agents", "apriltag", "base", "cpu", "cuda", "docker", "drone", "manipulation", "misc", "perception", "psql", "sim", "unitree", "visualization", "web"], marker = "extra == 'all'" },
+    { name = "dimos", extras = ["agents", "apriltag", "base", "cpu", "cuda", "docker", "drone", "manipulation", "misc", "perception", "psql", "sim", "unitree", "visualization", "web", "zenoh"], marker = "extra == 'all'" },
     { name = "dimos", extras = ["agents", "web", "perception", "visualization"], marker = "extra == 'base'" },
     { name = "dimos", extras = ["base", "mapping"], marker = "extra == 'unitree'" },
-=======
-    { name = "dimos", extras = ["agents", "base", "cpu", "cuda", "dev", "docker", "drone", "manipulation", "misc", "perception", "psql", "sim", "unitree", "visualization", "web", "zenoh"], marker = "extra == 'all'" },
-    { name = "dimos", extras = ["agents", "web", "visualization"], marker = "extra == 'base'" },
-    { name = "dimos", extras = ["base"], marker = "extra == 'unitree'" },
->>>>>>> 63cb098e7 (Include zenoh to --extra all)
     { name = "dimos", extras = ["unitree"], marker = "extra == 'unitree-dds'" },
     { name = "dimos-lcm" },
     { name = "dimos-lcm", marker = "extra == 'docker'" },

--- a/uv.lock
+++ b/uv.lock
@@ -2206,6 +2206,9 @@ web = [
     { name = "sse-starlette" },
     { name = "uvicorn" },
 ]
+zenoh = [
+    { name = "eclipse-zenoh" },
+]
 
 [package.dev-dependencies]
 autofix = [
@@ -2378,6 +2381,7 @@ requires-dist = [
     { name = "dimos-viewer", marker = "extra == 'visualization'", specifier = "==0.32.0a1" },
     { name = "drake", marker = "platform_machine != 'aarch64' and sys_platform == 'darwin' and extra == 'manipulation'", specifier = "==1.45.0" },
     { name = "drake", marker = "platform_machine != 'aarch64' and sys_platform != 'darwin' and extra == 'manipulation'", specifier = ">=1.40.0" },
+    { name = "eclipse-zenoh", marker = "extra == 'zenoh'", specifier = ">=1.0.0,<2.0" },
     { name = "edgetam-dimos", marker = "extra == 'misc'" },
     { name = "einops", marker = "extra == 'misc'", specifier = "==0.8.1" },
     { name = "empy", marker = "extra == 'misc'", specifier = "==3.3.4" },
@@ -2495,7 +2499,7 @@ requires-dist = [
     { name = "xformers", marker = "platform_machine == 'x86_64' and extra == 'cuda'", specifier = ">=0.0.20" },
     { name = "yapf", marker = "extra == 'misc'", specifier = "==0.40.2" },
 ]
-provides-extras = ["misc", "visualization", "agents", "web", "perception", "unitree", "unitree-dds", "manipulation", "cpu", "cuda", "psql", "sim", "mapping", "drone", "dds", "docker", "base", "apriltag", "all"]
+provides-extras = ["misc", "visualization", "agents", "web", "perception", "unitree", "unitree-dds", "manipulation", "cpu", "cuda", "psql", "sim", "mapping", "drone", "dds", "zenoh", "docker", "base", "apriltag", "all"]
 
 [package.metadata.requires-dev]
 autofix = [{ name = "ruff", specifier = "==0.14.3" }]
@@ -2811,6 +2815,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9d/a4/e44218c2b394e31a6dd0d6b095c4e1f32d0be54c2a4b250032d717647bab/durationpy-0.10.tar.gz", hash = "sha256:1fa6893409a6e739c9c72334fc65cca1f355dbdd93405d30f726deb5bde42fba", size = 3335, upload-time = "2025-05-17T13:52:37.26Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/0d/9feae160378a3553fa9a339b0e9c1a048e147a4127210e286ef18b730f03/durationpy-0.10-py3-none-any.whl", hash = "sha256:3b41e1b601234296b4fb368338fdcd3e13e0b4fb5b67345948f4f2bf9868b286", size = 3922, upload-time = "2025-05-17T13:52:36.463Z" },
+]
+
+[[package]]
+name = "eclipse-zenoh"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/42/c8502d0e77f74b9cf4c192a01e620b3d15273d371464485796807d202d9d/eclipse_zenoh-1.9.0.tar.gz", hash = "sha256:b0477ab431132ebfe1096eccac13ea0066d50d1528d726c8872c00e0345070d1", size = 164557, upload-time = "2026-04-10T13:23:35.883Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/3b/22b9104b0a022bd2b1627b4866876831585eda2eacb9ca1f3b4b8e847945/eclipse_zenoh-1.9.0-cp39-abi3-linux_armv6l.whl", hash = "sha256:15b6f37c407617ea4de32d32835cbcab4d1a116b892477490fc6c10a7d27c73b", size = 10664168, upload-time = "2026-04-10T13:23:15.008Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c5/ee0815c7ec49c5a29307cd935478305159bb3f0b2489f8c54fc6db3fdf36/eclipse_zenoh-1.9.0-cp39-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:6f66059b12e1ec53c70bc25192b0e74502751759064726dbb153ed6dd8f4dc8b", size = 19942168, upload-time = "2026-04-10T13:23:17.785Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/6a/42b83b4e8c262ebbb3bcae702394478326c807f54b3162130b0a603e1a01/eclipse_zenoh-1.9.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:180dd2a6da3b86b52e87f5e470a1f8a86db03c519978b22ffb1dc7c11f98ef3b", size = 10225694, upload-time = "2026-04-10T13:23:20.244Z" },
+    { url = "https://files.pythonhosted.org/packages/27/57/28e66893801b63df36fea355a64b6fc22637e1148a952ee11e3039ae955e/eclipse_zenoh-1.9.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:949d82851bc9e3ad646fd1307ee544ed23359dcfd18d4065075fc592f6ab6fa7", size = 10517069, upload-time = "2026-04-10T13:23:23.053Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/2f/be614f1f7f4e046da2764cd36227d19db3655839219744ce7a12e6e2dae6/eclipse_zenoh-1.9.0-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3a1fe847225cda21e3e74677cfd4ddfd2e72600d5a56968d4229d981c67f78d4", size = 11580068, upload-time = "2026-04-10T13:23:25.594Z" },
+    { url = "https://files.pythonhosted.org/packages/58/1b/2a074d4f4595bd37c3d12f1b2ad49bceef5c8cd0962cbfd97d1d39f32e1f/eclipse_zenoh-1.9.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:43299593891cfd648bca4b2aa00f3dca916508a49a0c9e6960902e6e867b247e", size = 10537556, upload-time = "2026-04-10T13:23:28.414Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/33/c3116f1bf7647ee0ea8972efbe0fe5710ae75ea7226440a8fda7f04a4cbc/eclipse_zenoh-1.9.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:8c139a43706c8ff3c94fa625008af8667687c161a8395ad1fa3faff29c16fae4", size = 10721249, upload-time = "2026-04-10T13:23:30.843Z" },
+    { url = "https://files.pythonhosted.org/packages/26/16/a94c4f37e3a088faadf4b5fbc64e5f69dea1023dc7efc49b3be0e0ecc953/eclipse_zenoh-1.9.0-cp39-abi3-win_amd64.whl", hash = "sha256:5dfb352eca4585b85edbbc84c6db58906008e202823ca280496c0b867f9719f0", size = 9124510, upload-time = "2026-04-10T13:23:34.119Z" },
 ]
 
 [[package]]
@@ -6280,6 +6300,7 @@ resolution-markers = [
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/6c/90d3f532f608a03a13c1d6c16c266ffa3828e8011b1549d3b61db2ad59f5/nvidia_cublas_cu12-12.9.1.4-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:7a950dae01add3b415a5a5cdc4ec818fb5858263e9cca59004bb99fdbbd3a5d6", size = 575006342, upload-time = "2025-06-05T20:04:16.902Z" },
+    { url = "https://files.pythonhosted.org/packages/77/3c/aa88abe01f3be3d1f8f787d1d33dc83e76fec05945f9a28fbb41cfb99cd5/nvidia_cublas_cu12-12.9.1.4-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:453611eb21a7c1f2c2156ed9f3a45b691deda0440ec550860290dc901af5b4c2", size = 581242350, upload-time = "2025-06-05T20:04:51.979Z" },
     { url = "https://files.pythonhosted.org/packages/45/a1/a17fade6567c57452cfc8f967a40d1035bb9301db52f27808167fbb2be2f/nvidia_cublas_cu12-12.9.1.4-py3-none-win_amd64.whl", hash = "sha256:1e5fee10662e6e52bd71dec533fbbd4971bb70a5f24f3bc3793e5c2e9dc640bf", size = 553153899, upload-time = "2025-06-05T20:13:35.556Z" },
 ]
 
@@ -6342,6 +6363,7 @@ resolution-markers = [
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/e0/0279bd94539fda525e0c8538db29b72a5a8495b0c12173113471d28bce78/nvidia_cuda_runtime_cu12-12.9.79-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:83469a846206f2a733db0c42e223589ab62fd2fabac4432d2f8802de4bded0a4", size = 3515012, upload-time = "2025-06-05T20:00:35.519Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/46/a92db19b8309581092a3add7e6fceb4c301a3fd233969856a8cbf042cd3c/nvidia_cuda_runtime_cu12-12.9.79-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:25bba2dfb01d48a9b59ca474a1ac43c6ebf7011f1b0b8cc44f54eb6ac48a96c3", size = 3493179, upload-time = "2025-06-05T20:00:53.735Z" },
     { url = "https://files.pythonhosted.org/packages/59/df/e7c3a360be4f7b93cee39271b792669baeb3846c58a4df6dfcf187a7ffab/nvidia_cuda_runtime_cu12-12.9.79-py3-none-win_amd64.whl", hash = "sha256:8e018af8fa02363876860388bd10ccb89eb9ab8fb0aa749aaf58430a9f7c4891", size = 3591604, upload-time = "2025-06-05T20:11:17.036Z" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1906,6 +1906,7 @@ all = [
     { name = "dimos-viewer" },
     { name = "drake", version = "1.45.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and sys_platform == 'darwin'" },
     { name = "drake", version = "1.49.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and sys_platform != 'darwin'" },
+    { name = "eclipse-zenoh" },
     { name = "edgetam-dimos" },
     { name = "einops" },
     { name = "empy" },
@@ -2367,9 +2368,15 @@ requires-dist = [
     { name = "cupy-cuda12x", marker = "platform_machine == 'x86_64' and extra == 'cuda'", specifier = "==13.6.0" },
     { name = "cyclonedds", marker = "extra == 'dds'", specifier = ">=0.10.5" },
     { name = "cyclonedds", marker = "extra == 'unitree-dds'", specifier = ">=0.10.5" },
+<<<<<<< HEAD
     { name = "dimos", extras = ["agents", "apriltag", "base", "cpu", "cuda", "docker", "drone", "manipulation", "misc", "perception", "psql", "sim", "unitree", "visualization", "web"], marker = "extra == 'all'" },
     { name = "dimos", extras = ["agents", "web", "perception", "visualization"], marker = "extra == 'base'" },
     { name = "dimos", extras = ["base", "mapping"], marker = "extra == 'unitree'" },
+=======
+    { name = "dimos", extras = ["agents", "base", "cpu", "cuda", "dev", "docker", "drone", "manipulation", "misc", "perception", "psql", "sim", "unitree", "visualization", "web", "zenoh"], marker = "extra == 'all'" },
+    { name = "dimos", extras = ["agents", "web", "visualization"], marker = "extra == 'base'" },
+    { name = "dimos", extras = ["base"], marker = "extra == 'unitree'" },
+>>>>>>> 63cb098e7 (Include zenoh to --extra all)
     { name = "dimos", extras = ["unitree"], marker = "extra == 'unitree-dds'" },
     { name = "dimos-lcm" },
     { name = "dimos-lcm", marker = "extra == 'docker'" },

--- a/uv.lock
+++ b/uv.lock
@@ -2275,7 +2275,7 @@ project-deps = [
 ]
 tests = [
     { name = "coverage" },
-    { name = "dimos", extra = ["apriltag", "cpu", "drone", "psql", "visualization", "web"] },
+    { name = "dimos", extra = ["apriltag", "cpu", "drone", "psql", "visualization", "web", "zenoh"] },
     { name = "gdown" },
     { name = "googlemaps" },
     { name = "hydra-core" },
@@ -2316,7 +2316,7 @@ tests = [
 ]
 tests-self-hosted = [
     { name = "coverage" },
-    { name = "dimos", extra = ["agents", "apriltag", "cpu", "drone", "manipulation", "misc", "perception", "psql", "sim", "unitree", "visualization", "web"] },
+    { name = "dimos", extra = ["agents", "apriltag", "cpu", "drone", "manipulation", "misc", "perception", "psql", "sim", "unitree", "visualization", "web", "zenoh"] },
     { name = "gdown" },
     { name = "googlemaps" },
     { name = "hydra-core" },
@@ -2563,7 +2563,7 @@ project-deps = [
 ]
 tests = [
     { name = "coverage", specifier = ">=7.0" },
-    { name = "dimos", extras = ["apriltag", "psql", "drone", "cpu"] },
+    { name = "dimos", extras = ["apriltag", "psql", "drone", "cpu", "zenoh"] },
     { name = "dimos", extras = ["web", "visualization"] },
     { name = "gdown", specifier = "==6.0.0" },
     { name = "googlemaps", specifier = ">=4.10.0" },
@@ -2606,7 +2606,7 @@ tests = [
 tests-self-hosted = [
     { name = "coverage", specifier = ">=7.0" },
     { name = "dimos", extras = ["agents", "perception", "manipulation", "sim", "unitree", "misc"] },
-    { name = "dimos", extras = ["apriltag", "psql", "drone", "cpu"] },
+    { name = "dimos", extras = ["apriltag", "psql", "drone", "cpu", "zenoh"] },
     { name = "dimos", extras = ["web", "visualization"] },
     { name = "gdown", specifier = "==6.0.0" },
     { name = "googlemaps", specifier = ">=4.10.0" },


### PR DESCRIPTION
Supersedes #1906 so self-hosted CI can run. Prior review discussion is preserved there.
---
Supersedes #1787.

This PR carries forward the Zenoh transport integration from #1787 and wraps it into a merge-ready branch that fixes the remaining macOS Big Office replay gap.

## Validation

Typical **replay on macOS** when Zenoh is installed (default is already Zenoh, so no transport flag is required):

```bash
dimos --dtop --replay run unitree-go2
```

The same workload on **Linux** (default remains `lcm` until you opt in):

```bash
dimos --transport=zenoh --dtop run unitree-go2
```

## Notes

- this PR is intended as the wrapped successor to #1787, not a separate redesign
- Linux behavior remains unchanged by default: explicit Zenoh still works, and the default transport remains LCM