### PR TITLE
fix(perception): guard EdgeTAM import with actionable error for missing sam2

### DIFF
--- a/dimos/models/segmentation/edge_tam.py
+++ b/dimos/models/segmentation/edge_tam.py
@@ -57,6 +57,14 @@ class EdgeTAMProcessor(Detector):
     def __init__(
         self,
     ) -> None:
+        try:
+            import sam2  # noqa: F401
+        except ImportError:
+            raise ImportError(
+                "EdgeTAM requires the 'edgetam-dimos' package (provides sam2). "
+                "Install with: uv sync --extra misc"
+            ) from None
+
         local_config_path = Path(__file__).parent / "configs" / "edgetam.yaml"
 
         if not local_config_path.exists():


### PR DESCRIPTION
## Problem

`unitree-go2-agentic` blueprint crashes on fresh installs with a cryptic Hydra `InstantiationException`:

```
InstantiationException: Error locating target 'sam2.sam2_video_predictor.SAM2VideoPredictor'
ModuleNotFoundError: No module named 'sam2'
```

The `sam2` module is provided by the `edgetam-dimos` package, which lives in the `[misc]` optional extra. But the agentic blueprint unconditionally instantiates `SecurityModule` → `EdgeTAMProcessor`, so any `uv sync` without `--extra misc` produces an unactionable crash.

**Introduced in:** PR #1619 (`feat(security): add security demo`) which added `SecurityModule` to the `unitree_go2_spatial` blueprint without moving `edgetam-dimos` from `misc` to core dependencies.

## Solution

Add an early `try: import sam2` guard in `EdgeTAMProcessor.__init__` that raises a clear `ImportError` with install instructions before Hydra's `instantiate()` produces an opaque error.

## Breaking Changes

None

## How to Test

```bash
# Without edgetam-dimos installed:
uv sync  # no --extra misc
uv run python -c "from dimos.models.segmentation.edge_tam import EdgeTAMProcessor; EdgeTAMProcessor()"
# Should see: ImportError: EdgeTAM requires the 'edgetam-dimos' package (provides sam2). Install with: uv sync --extra misc

# With edgetam-dimos installed:
uv sync --extra misc
# Behavior unchanged (guard passes, continues to CUDA check etc.)
```

## Contributor License Agreement
- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md)