### PR TITLE
docs(development): add developer guide index and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,17 +306,17 @@ if __name__ == "__main__":
 
 # Development
 
-## Develop on DimOS
-
 ```sh skip
 export GIT_LFS_SKIP_SMUDGE=1
 git clone https://github.com/dimensionalOS/dimos.git
 cd dimos
-
-# Run the default test suite (uv run syncs deps on demand; --all-groups
-# only needed for self-hosted tests / mypy — see docs/development/testing.md)
-uv run pytest --numprocesses=auto dimos
+uv sync --all-extras --no-extra dds
+source .venv/bin/activate
+pre-commit install
+pytest --numprocesses=auto dimos
 ```
+
+> **Full developer guide:** [docs/development/index.md](docs/development/index.md) — environment setup, linting, type checking, project structure, and more.
 
 
 ## Multi Language Support

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -1,0 +1,107 @@
+# Development Guide
+
+This guide gets you from clone to running tests. For CLI usage, see [docs/usage/cli.md](/docs/usage/cli.md).
+
+## Setup
+
+### Clone
+
+```bash
+# Skip LFS data on clone (downloads on demand later)
+export GIT_LFS_SKIP_SMUDGE=1
+git clone https://github.com/dimensionalOS/dimos.git
+cd dimos
+```
+
+### Install Dependencies
+
+```bash
+# Create the virtualenv and install all dev dependencies
+uv sync --all-extras --no-extra dds
+source .venv/bin/activate
+```
+
+### Pre-commit Hooks
+
+```bash
+pre-commit install
+```
+
+This enables automatic checks on every commit: formatting (ruff), linting (ruff), license headers, trailing whitespace, JSON/TOML/YAML validation, editorconfig, LFS guards, and more.
+
+> **Tip:** Pre-commit auto-fixes most formatting issues. If it modifies files, re-stage them and commit again.
+
+## Linting & Type Checking
+
+```bash
+# Format
+ruff format dimos/
+
+# Lint (with auto-fix)
+ruff check --fix dimos/
+
+# Type check (strict mode, Python 3.12)
+mypy dimos/
+```
+
+Ruff config lives in `pyproject.toml` under `[tool.ruff]`. Mypy config is under `[tool.mypy]`.
+
+## Testing
+
+Run the fast test suite:
+
+```bash
+pytest --numprocesses=auto dimos
+```
+
+Or equivalently:
+
+```bash
+./bin/pytest-fast
+```
+
+Run slow tests (integration-level, before opening a PR):
+
+```bash
+./bin/pytest-slow
+```
+
+See [testing.md](/docs/development/testing.md) for markers, fixtures, mocking patterns, and advanced test configuration.
+
+## Project Structure
+
+```
+dimos/              Main package
+├── core/           Module system, streams, blueprints, transports
+├── agents/         Agent framework (MCP client/server, skills)
+├── robot/          Hardware drivers (Unitree, drone, arms)
+├── navigation/     SLAM, planners, costmaps
+├── perception/     Detectors, VLMs, depth, audio
+├── memory/         Spatial and temporal memory
+├── manipulation/   Arm control, grasping
+├── simulation/     MuJoCo integration
+├── msgs/           Message type definitions
+└── skills/         Agent skill implementations
+docs/               Documentation
+├── usage/          User-facing docs (modules, blueprints, CLI, transports)
+├── development/    Contributor docs (this guide, testing, profiling)
+├── platforms/      Hardware platform guides
+├── capabilities/   Feature guides (navigation, agents, manipulation)
+└── installation/   System setup guides
+blueprints/         Blueprint runfiles
+bin/                Dev scripts (pytest shortcuts, hooks)
+data/               LFS-managed datasets
+stubs/              Mypy type stubs for untyped dependencies
+```
+
+## Further Reading
+
+| Topic | Link |
+|-------|------|
+| Testing | [testing.md](/docs/development/testing.md) |
+| Docker images | [docker.md](/docs/development/docker.md) |
+| LFS data loading | [large_file_management.md](/docs/development/large_file_management.md) |
+| Profiling | [profiling_dimos.md](/docs/development/profiling_dimos.md) |
+| Writing docs | [writing_docs.md](/docs/development/writing_docs.md) |
+| Conventions | [conventions.md](/docs/development/conventions.md) |
+| Grid testing | [grid_testing.md](/docs/development/grid_testing.md) |


### PR DESCRIPTION
## Problem
Closes DIM-894

New contributors landing on `docs/development/` find a raw file list with no guidance on where to start. The README Development section has a 3-line snippet with no mention of pre-commit, linting, type checking, or project layout.

## Solution

- **New `docs/development/index.md`** — entry point covering clone, dependency install, pre-commit setup, linting (`ruff`), type checking (`mypy`), testing, project structure overview, and links to all existing dev docs.
- **Updated `README.md` Development section** — replaced the minimal snippet with the full setup sequence (clone → sync → activate → pre-commit → test) and added a link to the full guide.
- No CLI docs (already in `docs/usage/cli.md`), no CONTRIBUTING.md (separate concern).

## Breaking Changes
None

## How to Test
```bash
git fetch origin && git checkout docs/dim-894-developer-guide
# Verify index.md renders properly
cat docs/development/index.md
# Verify README Development section links correctly
grep -A10 '# Development' README.md
# Verify all links in index.md point to existing files
for f in testing.md docker.md large_file_management.md profiling_dimos.md writing_docs.md conventions.md grid_testing.md; do
  ls docs/development/$f
done
```

## Contributor License Agreement
- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md)