### PR TITLE
fix: avoid incompatiable tar flags on mac

### DIFF
--- a/bin/lfs_push
+++ b/bin/lfs_push
@@ -15,6 +15,11 @@ NC='\033[0m' # No Color
 ROOT=$(git rev-parse --show-toplevel)
 cd $ROOT
 
+TAR_PROGRESS=()
+if tar --version 2>/dev/null | grep -q "GNU tar"; then
+    TAR_PROGRESS=(--checkpoint=1000 --checkpoint-action=dot)
+fi
+
 # Check if data/ exists
 if [ ! -d "data/" ]; then
     echo -e "${YELLOW}No data directory found, skipping compression.${NC}"
@@ -62,8 +67,7 @@ for entry_path in data/*; do
         --exclude='*.temp' \
         --exclude='.DS_Store' \
         --exclude='Thumbs.db' \
-        --checkpoint=1000 \
-        --checkpoint-action=dot \
+        "${TAR_PROGRESS[@]}" \
         -C "data/" \
         "$entry_name"
 


### PR DESCRIPTION
fix broken lfs_push on mac

description mirrored from https://github.com/dimensionalOS/dimos/issues/2144:

### Description

## System
macOS 26.1

## Robot/Sim/Hardware (including firmware version)
N/A

## Steps to reproduce
Just run `./bin/lfs_push`

## DimOS version
6e171ac4d main / last stable release: v0.0.12

## Logs / screenshots

<img width="865" height="115" alt="Image" src="https://github.com/user-attachments/assets/86ce38b4-f249-4db8-9bde-aa0ace0b3fe3" />
