### PR TITLE
Second attempt to fix flaky collector tests

### DIFF
--- a/dimos/protocol/pubsub/impl/test_lcmpubsub.py
+++ b/dimos/protocol/pubsub/impl/test_lcmpubsub.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from collections.abc import Iterator
-import time
 from typing import Any
 
 import pytest
@@ -34,7 +33,6 @@ from dimos.utils.testing.collector import CallbackCollector
 def lcm_pub_sub_base(lcm_url: str) -> Iterator[LCMPubSubBase]:
     lcm = LCMPubSubBase(url=lcm_url)
     lcm.start()
-    time.sleep(0.05)  # let the handler thread enter the LCM loop
     yield lcm
     lcm.stop()
 
@@ -43,7 +41,6 @@ def lcm_pub_sub_base(lcm_url: str) -> Iterator[LCMPubSubBase]:
 def pickle_lcm(lcm_url: str) -> Iterator[PickleLCM]:
     lcm = PickleLCM(url=lcm_url)
     lcm.start()
-    time.sleep(0.05)  # let the handler thread enter the LCM loop
     yield lcm
     lcm.stop()
 
@@ -52,7 +49,6 @@ def pickle_lcm(lcm_url: str) -> Iterator[PickleLCM]:
 def lcm(lcm_url: str) -> Iterator[LCM]:
     lcm = LCM(url=lcm_url)
     lcm.start()
-    time.sleep(0.05)  # let the handler thread enter the LCM loop
     yield lcm
     lcm.stop()
 

--- a/dimos/protocol/service/lcmservice.py
+++ b/dimos/protocol/service/lcmservice.py
@@ -63,6 +63,7 @@ class LCMService(Service):
     config: LCMConfig
     l: lcm_mod.LCM | None
     _stop_event: threading.Event
+    _loop_running: threading.Event
     _l_lock: threading.Lock
     _thread: threading.Thread | None
     _call_thread_pool: ThreadPoolExecutor | None = None
@@ -79,6 +80,7 @@ class LCMService(Service):
 
         self._l_lock = threading.Lock()
         self._stop_event = threading.Event()
+        self._loop_running = threading.Event()
         self._thread = None
 
     def __getstate__(self):  # type: ignore[no-untyped-def]
@@ -87,6 +89,7 @@ class LCMService(Service):
         # Remove unpicklable attributes
         state.pop("l", None)
         state.pop("_stop_event", None)
+        state.pop("_loop_running", None)
         state.pop("_thread", None)
         state.pop("_l_lock", None)
         state.pop("_call_thread_pool", None)
@@ -99,6 +102,7 @@ class LCMService(Service):
         # Reinitialize runtime attributes
         self.l = None
         self._stop_event = threading.Event()
+        self._loop_running = threading.Event()
         self._thread = None
         self._l_lock = threading.Lock()
         self._call_thread_pool = None
@@ -113,12 +117,16 @@ class LCMService(Service):
                 self.l = lcm_mod.LCM(self.config.url) if self.config.url else lcm_mod.LCM()
 
         self._stop_event.clear()
+        self._loop_running.clear()
         self._thread = threading.Thread(target=self._lcm_loop)
         self._thread.daemon = True
         self._thread.start()
+        if not self._loop_running.wait(timeout=5.0):
+            raise RuntimeError("LCM handler thread failed to start within 5s")
 
     def _lcm_loop(self) -> None:
         """LCM message handling loop."""
+        primed = False
         while not self._stop_event.is_set():
             try:
                 with self._l_lock:
@@ -128,6 +136,11 @@ class LCMService(Service):
             except Exception as e:
                 stack_trace = traceback.format_exc()
                 print(f"Error in LCM handling: {e}\n{stack_trace}")
+            if not primed:
+                # Signal start() only after one full poll cycle, so callers
+                # don't race the first handle_timeout dispatch.
+                primed = True
+                self._loop_running.set()
 
     def stop(self) -> None:
         """Stop the LCM loop."""

--- a/dimos/utils/testing/collector.py
+++ b/dimos/utils/testing/collector.py
@@ -30,7 +30,7 @@ class CallbackCollector:
         assert len(collector.results) == 3
     """
 
-    def __init__(self, n: int, timeout: float = 15.0) -> None:
+    def __init__(self, n: int, timeout: float = 5.0) -> None:
         self.results: list[tuple[Any, Any]] = []
         self._done = threading.Event()
         self._n = n


### PR DESCRIPTION
Second attempt at resolving flaky collector tests.

The increased timeout didn't help, so it may be that a race is happening and the message is getting missed.

Solution here is to wait until the poll loop is actually processing to ensure that messages will definitely be received. The original code already slept for 50ms unconditionally, this now waits for a single loop iteration which will wait upto 50ms, so this shouldn't be any slower than before, except when needed.