### PR TITLE
docs: update transforms 3D-viz instructions for rerun

### DIFF
--- a/docs/usage/transforms.md
+++ b/docs/usage/transforms.md
@@ -377,7 +377,13 @@ Transform tree:
 ```
 
 
-You can also run `foxglove-studio-bridge` in the next terminal (binary provided by DimOS and should be in your Python env) and `foxglove-studio` to view these transforms in 3D. (TODO we need to update this for rerun)
+You can also visualize these transforms in 3D with Rerun. In a separate terminal, *before* running the example, start the standalone bridge:
+
+```bash
+dimos rerun-bridge
+```
+
+This opens the Rerun viewer and subscribes to the LCM bus, so every transform broadcast by `self.tf.publish()` is rendered under the `world/tf/<child_frame_id>` entity path in the 3D view. Start the bridge first — the example runs only briefly, and the TF buffer is short-lived, so a late-started viewer will miss the transforms.
 
 ![transforms](assets/transforms.png)
 


### PR DESCRIPTION

## Problem

`docs/usage/transforms.md` carried an inline `(TODO we need to update this for rerun)`. The 3D-visualization instructions still told readers to use `foxglove-studio-bridge` / `foxglove-studio`, but Rerun is now the default viewer backend. No tracked issue — this resolves the in-doc TODO directly.

## Solution

Replaced the Foxglove instructions with the direct Rerun equivalent, `dimos rerun-bridge`. This works end-to-end with no other changes: `TFMessage.to_rerun()` maps each transform to the `world/tf/<child_frame_id>` entity path, and the default Rerun blueprint roots its `Spatial3DView` at `world`, so the example's transform tree renders automatically. Added a note to start the bridge before the example (it runs briefly; TF buffer is short-lived). Scoped to the TODO line; the existing screenshot asset is left untouched.

## How to Test

In one terminal: `dimos rerun-bridge`; then run the multi-module example from the doc — the `world/tf/*` frames render in the Rerun 3D view.

## Contributor License Agreement

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).