### PR TITLE
feat(modules): allow for dedicated workers

### DIFF
--- a/dimos/core/coordination/python_worker.py
+++ b/dimos/core/coordination/python_worker.py
@@ -177,6 +177,7 @@ class PythonWorker:
         self._process: Any = None
         self._conn: Connection | None = None
         self._worker_id: int = _worker_ids.next()
+        self.dedicated: bool = False
 
     @property
     def module_count(self) -> int:

--- a/dimos/core/coordination/test_worker.py
+++ b/dimos/core/coordination/test_worker.py
@@ -81,6 +81,22 @@ class ThirdModule(Module):
         return self.multiplier
 
 
+class HeavyModule(Module):
+    dedicated_worker = True
+
+    @rpc
+    def start(self) -> None:
+        pass
+
+
+class AnotherHeavyModule(Module):
+    dedicated_worker = True
+
+    @rpc
+    def start(self) -> None:
+        pass
+
+
 @pytest.fixture
 def create_worker_manager():
     manager = None
@@ -304,3 +320,39 @@ def test_load_balancing_distributes_modules(manager_and_modules):
     # Each worker should have 2 modules (even distribution)
     counts = [w.module_count for w in manager._workers]
     assert counts == [2, 2]
+
+
+@pytest.mark.skipif_macos_bug
+def test_dedicated_worker_gets_own_process(manager_and_modules):
+    manager, modules = manager_and_modules(n_workers=2)
+
+    heavy = manager.deploy(HeavyModule, global_config, {})
+    modules.append(heavy)
+    heavy.start()
+
+    for _ in range(3):
+        m = manager.deploy(SimpleModule, global_config, {})
+        modules.append(m)
+        m.start()
+
+    counts = sorted(w.module_count for w in manager._workers)
+    # One worker hosts only the dedicated module; the other hosts the 3 light ones.
+    assert counts == [1, 3]
+    assert sum(1 for w in manager._workers if w.dedicated) == 1
+
+
+@pytest.mark.skipif_macos_bug
+def test_dedicated_workers_trigger_autoscale(manager_and_modules):
+    manager, modules = manager_and_modules(n_workers=2)
+
+    heavy1 = manager.deploy(HeavyModule, global_config, {})
+    modules.append(heavy1)
+    heavy1.start()
+    heavy2 = manager.deploy(AnotherHeavyModule, global_config, {})
+    modules.append(heavy2)
+    heavy2.start()
+
+    # 2 dedicated modules require >= 4 total workers so non-dedicated workers
+    # at least match the dedicated count.
+    assert len(manager._workers) == 4
+    assert sum(1 for w in manager._workers if w.dedicated) == 2

--- a/dimos/core/coordination/worker_manager_python.py
+++ b/dimos/core/coordination/worker_manager_python.py
@@ -70,9 +70,6 @@ class WorkerManagerPython:
         self._n_workers += n
         logger.info("Added workers to pool.", added=n, total=self._n_workers)
 
-    def _select_worker(self) -> PythonWorker:
-        return min(self._workers, key=lambda w: w.module_count)
-
     def deploy(
         self,
         module_class: type[ModuleBase],
@@ -85,7 +82,8 @@ class WorkerManagerPython:
         if not self._started:
             self.start()
 
-        worker = self._select_worker()
+        self._ensure_capacity_for_dedicated([(module_class, global_config, kwargs)])
+        worker = self._select_worker(dedicated=module_class.dedicated_worker)
         actor = worker.deploy_module(module_class, global_config, kwargs=kwargs)
         return RPCClient(actor, module_class)
 
@@ -110,6 +108,8 @@ class WorkerManagerPython:
         worker.start_process()
         self._workers.append(worker)
         self._n_workers += 1
+        if module_class.dedicated_worker:
+            worker.dedicated = True
         actor = worker.deploy_module(module_class, global_config, kwargs=kwargs)
         return RPCClient(actor, module_class)
 
@@ -148,22 +148,32 @@ class WorkerManagerPython:
         if not self._started:
             self.start()
 
+        self._ensure_capacity_for_dedicated(specs)
+
         # Pre-assign workers sequentially (so least-loaded accounting is
         # correct), then deploy concurrently via threads. The per-worker lock
         # serializes deploys that land on the same worker process.
-        assignments: list[tuple[PythonWorker, type[ModuleBase], GlobalConfig, dict[str, Any]]] = []
-        for module_class, global_config, kwargs in specs:
-            worker = self._select_worker()
+        # Process dedicated specs first so they claim empty workers before
+        # non-dedicated specs land on them; preserve input order in output.
+        workers_by_index: dict[int, PythonWorker] = {}
+        order = sorted(range(len(specs)), key=lambda i: not specs[i][0].dedicated_worker)
+        for i in order:
+            module_class, _, kwargs = specs[i]
+            worker = self._select_worker(dedicated=module_class.dedicated_worker)
             worker.reserve_slot()
             kwargs.update(blueprint_args.get(module_class.name, {}))
-            assignments.append((worker, module_class, global_config, kwargs))
+            workers_by_index[i] = worker
+
+        assignments = [(workers_by_index[i], specs[i]) for i in range(len(specs))]
+
+        def _deploy(item: tuple[PythonWorker, ModuleSpec]) -> ModuleProxyProtocol:
+            worker, (module_class, global_config, kwargs) = item
+            return RPCClient(
+                worker.deploy_module(module_class, global_config, kwargs), module_class
+            )
 
         try:
-            # item: (worker, module_class, global_config, kwargs)
-            return safe_thread_map(
-                assignments,
-                lambda item: RPCClient(item[0].deploy_module(item[1], item[2], item[3]), item[1]),
-            )
+            return safe_thread_map(assignments, _deploy)
         except:
             self.stop()
             raise
@@ -206,3 +216,43 @@ class WorkerManagerPython:
         self._workers.clear()
 
         logger.info("All workers shut down")
+
+    def _select_worker(self, dedicated: bool = False) -> PythonWorker:
+        """Pick a worker for a new module and mark it dedicated if needed."""
+        if dedicated:
+            for w in self._workers:
+                if not w.dedicated and w.module_count == 0:
+                    w.dedicated = True
+                    return w
+            self.add_workers(1)
+            w = self._workers[-1]
+            w.dedicated = True
+            return w
+
+        candidates = [w for w in self._workers if not w.dedicated]
+        if not candidates:
+            self.add_workers(1)
+            return self._workers[-1]
+        return min(candidates, key=lambda w: w.module_count)
+
+    def _ensure_capacity_for_dedicated(self, specs: Iterable[ModuleSpec]) -> None:
+        """Grow the pool so non-dedicated workers >= dedicated workers.
+
+        If the total number of dedicated modules (already deployed + about to be)
+        exceeds half the worker pool, scale up to `2 * total_dedicated` workers.
+        """
+        new_dedicated = sum(1 for spec in specs if spec[0].dedicated_worker)
+        already_dedicated = sum(1 for w in self._workers if w.dedicated)
+        total_dedicated = already_dedicated + new_dedicated
+        if total_dedicated == 0:
+            return
+        total_workers = len(self._workers)
+        if total_dedicated * 2 > total_workers:
+            n_to_add = total_dedicated * 2 - total_workers
+            logger.warning(
+                "Auto-scaling worker pool for dedicated modules.",
+                dedicated=total_dedicated,
+                before=total_workers,
+                added=n_to_add,
+            )
+            self.add_workers(n_to_add)

--- a/dimos/core/module.py
+++ b/dimos/core/module.py
@@ -112,6 +112,11 @@ class ModuleBase(Configurable, CompositeResource):
     # handle; the coordinator routes modules accordingly.
     deployment: ClassVar[Deployment] = "python"
 
+    # When True, this module must be the only one running on its worker
+    # process. Used for heavy modules that would otherwise contend with
+    # each other for CPU and the GIL.
+    dedicated_worker: ClassVar[bool] = False
+
     _rpc: RPCSpec | None = None
     _tf: TFSpec | None = None
     _loop: asyncio.AbstractEventLoop | None = None

--- a/dimos/core/resource_monitor/monitor.py
+++ b/dimos/core/resource_monitor/monitor.py
@@ -46,6 +46,9 @@ class WorkerInfo(Protocol):
     @property
     def module_names(self) -> list[str]: ...
 
+    @property
+    def dedicated(self) -> bool: ...
+
 
 @runtime_checkable
 class WorkerSource(Protocol):
@@ -117,7 +120,11 @@ class StatsMonitor(Resource):
                 ps_dict["cpu_percent"] += sum(c.cpu_percent for c in children)
                 worker_stats.append(
                     WorkerStats(
-                        **ps_dict, worker_id=w.worker_id, modules=w.module_names, children=children
+                        **ps_dict,
+                        worker_id=w.worker_id,
+                        modules=w.module_names,
+                        dedicated=w.dedicated,
+                        children=children,
                     )
                 )
             else:
@@ -127,6 +134,7 @@ class StatsMonitor(Resource):
                         alive=False,
                         worker_id=w.worker_id,
                         modules=w.module_names,
+                        dedicated=w.dedicated,
                     )
                 )
 

--- a/dimos/core/resource_monitor/stats.py
+++ b/dimos/core/resource_monitor/stats.py
@@ -164,4 +164,5 @@ class WorkerStats(ProcessStats):
 
     worker_id: int = -1
     modules: list[str] = field(default_factory=list)
+    dedicated: bool = False
     children: list[ChildProcessStats] = field(default_factory=list)

--- a/dimos/core/tests/test_parallel_deploy_cleanup.py
+++ b/dimos/core/tests/test_parallel_deploy_cleanup.py
@@ -175,6 +175,7 @@ class TestWorkerManagerPartialFailure:
         mock_workers = [MagicMock(name=f"Worker{i}") for i in range(2)]
         for w in mock_workers:
             w.module_count = 0
+            w.dedicated = False
             w.reserve_slot = MagicMock(
                 side_effect=lambda w=w: setattr(w, "module_count", w.module_count + 1)
             )
@@ -190,9 +191,9 @@ class TestWorkerManagerPartialFailure:
         for w in mock_workers:
             w.deploy_module = fake_deploy_module
 
-        FakeA = type("A", (), {"name": "A"})
-        FakeB = type("B", (), {"name": "B"})
-        FakeC = type("C", (), {"name": "C"})
+        FakeA = type("A", (), {"name": "A", "dedicated_worker": False})
+        FakeB = type("B", (), {"name": "B", "dedicated_worker": False})
+        FakeC = type("C", (), {"name": "C", "dedicated_worker": False})
 
         with patch("dimos.core.coordination.worker_manager_python.RPCClient"):
             with pytest.raises(ExceptionGroup, match="safe_thread_map failed"):

--- a/dimos/perception/spatial_perception.py
+++ b/dimos/perception/spatial_perception.py
@@ -79,6 +79,7 @@ class SpatialMemory(Module):
     """
 
     config: SpatialConfig
+    dedicated_worker = True
 
     # LCM inputs
     color_image: In[Image]

--- a/dimos/robot/drone/connection_module.py
+++ b/dimos/robot/drone/connection_module.py
@@ -52,6 +52,8 @@ class Config(ModuleConfig):
 class DroneConnectionModule(Module):
     """Module that handles drone sensor data and movement commands."""
 
+    dedicated_worker = True
+
     config: Config
 
     # Inputs

--- a/dimos/robot/unitree/b1/connection.py
+++ b/dimos/robot/unitree/b1/connection.py
@@ -64,6 +64,8 @@ class B1ConnectionModule(Module):
     internally converts to B1Command format, and sends UDP packets at 50Hz.
     """
 
+    dedicated_worker = True
+
     config: B1ConnectionConfig
 
     # LCM ports (inter-module communication)

--- a/dimos/robot/unitree/go2/connection.py
+++ b/dimos/robot/unitree/go2/connection.py
@@ -192,6 +192,8 @@ _Config = TypeVar("_Config", bound=ConnectionConfig, default=ConnectionConfig)
 
 
 class GO2Connection(Module, Camera, Pointcloud):
+    dedicated_worker = True
+
     config: ConnectionConfig
     cmd_vel: In[Twist]
     pointcloud: Out[PointCloud2]

--- a/dimos/utils/cli/dtop.py
+++ b/dimos/utils/cli/dtop.py
@@ -313,7 +313,8 @@ class ResourceSpyApp(App[None]):
             wid = w.get("worker_id", "?")
             role_style = theme.BRIGHT_GREEN if alive else theme.BRIGHT_RED
             modules = ", ".join(w.get("modules", [])) or ""
-            entries.append((f"worker {wid}", role_style, w, modules, str(w.get("pid", ""))))
+            label = f"worker {wid} (dedicated)" if w.get("dedicated") else f"worker {wid}"
+            entries.append((label, role_style, w, modules, str(w.get("pid", ""))))
 
         # Per-metric max for relative coloring
         ranges = _compute_ranges([d for _, _, d, _, _ in entries])
@@ -466,6 +467,7 @@ _PREVIEW_DATA: dict[str, Any] = {
         {
             "worker_id": 1,
             "alive": False,
+            "dedicated": True,
             "modules": ["vision"],
             "cpu_percent": 87.0,
             "pss": 536_870_912,
@@ -505,7 +507,12 @@ def _preview() -> None:
     for w in data["workers"]:
         rs = theme.BRIGHT_GREEN if w.get("alive") else theme.BRIGHT_RED
         mods = ", ".join(w.get("modules", []))
-        entries.append((f"worker {w['worker_id']}", rs, w, mods, str(w.get("pid", ""))))
+        label = (
+            f"worker {w['worker_id']} (dedicated)"
+            if w.get("dedicated")
+            else f"worker {w['worker_id']}"
+        )
+        entries.append((label, rs, w, mods, str(w.get("pid", ""))))
 
     ranges = _compute_ranges([d for _, _, d, _, _ in entries])
 

--- a/dimos/visualization/rerun/bridge.py
+++ b/dimos/visualization/rerun/bridge.py
@@ -202,6 +202,7 @@ class RerunBridgeModule(Module):
     """
 
     config: Config
+    dedicated_worker = True
     _last_log: dict[str, float]
 
     # TODO this doesn't belong here, either hardcode it or put it to rerun bridge config

--- a/docs/usage/modules.md
+++ b/docs/usage/modules.md
@@ -160,6 +160,20 @@ For this, we use `dimos.core` and DimOS transport protocols.
 
 Defining message exchange protocols and message types also gives us the ability to write models in faster languages.
 
+### Dedicated workers
+
+By default the coordinator assigns modules to worker processes by least-load, so multiple modules share a worker. Heavy modules (robot connections, voxel mappers) should run alone so they don't contend with anything else for CPU or the GIL. Set `dedicated_worker = True` on the class and the coordinator will give that module a worker process to itself.
+
+```python
+from dimos.core.module import Module
+
+
+class HeavyModule(Module):
+    dedicated_worker = True
+```
+
+If declaring dedicated modules would push the pool past half-dedicated, the coordinator auto-grows it so non-dedicated workers always at least match the dedicated count.
+
 ## Restarting a module
 
 While iterating on a module it's often convenient to edit its source file


### PR DESCRIPTION
## Problem

We sometimes have modules which take a lot of resourced allocated to the same worker.

Closes DIM-934

## Solution

* Add `dedicated_worker` field to modules. Such modules are allocated to an exclusive worker.

## Contributor License Agreement

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
