### PR TITLE
Mustafa/fix/issue 2182 keyboard teleop lfs path

### DIFF
--- a/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_webrtc_keyboard_teleop.py
+++ b/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_webrtc_keyboard_teleop.py
@@ -28,9 +28,13 @@ from dimos.robot.unitree.go2.blueprints.basic.unitree_go2_coordinator import (
 )
 from dimos.robot.unitree.keyboard_teleop import KeyboardTeleop
 
+# publish_only_when_active: teleop stays silent while no movement key is
+# held (one zero Twist on release, then nothing) so it does not flood
+# /cmd_vel and can coexist with a co-publisher such as the Go2
+# characterization / benchmark tools.
 unitree_go2_webrtc_keyboard_teleop = autoconnect(
     unitree_go2_coordinator,
-    KeyboardTeleop.blueprint(),
+    KeyboardTeleop.blueprint(publish_only_when_active=True),
 )
 
 __all__ = ["unitree_go2_webrtc_keyboard_teleop"]

--- a/dimos/robot/unitree/keyboard_teleop.py
+++ b/dimos/robot/unitree/keyboard_teleop.py
@@ -64,6 +64,7 @@ class KeyboardTeleop(Module):
         angular_speed: float = DEFAULT_ANGULAR_SPEED,
         boost_multiplier: float = DEFAULT_BOOST_MULTIPLIER,
         slow_multiplier: float = DEFAULT_SLOW_MULTIPLIER,
+        publish_only_when_active: bool = False,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -72,6 +73,12 @@ class KeyboardTeleop(Module):
         self.angular_speed = angular_speed
         self.boost_multiplier = boost_multiplier
         self.slow_multiplier = slow_multiplier
+        # When True, only publish while a movement key is held; on
+        # release publish a single zero Twist (stop) then go silent.
+        # Lets the teleop coexist with another /cmd_vel publisher
+        # (e.g. the SI / benchmark tools) instead of flooding zeros.
+        self.publish_only_when_active = publish_only_when_active
+        self._was_active = False
 
     @rpc
     def start(self) -> None:
@@ -164,7 +171,16 @@ class KeyboardTeleop(Module):
             twist.linear.y *= speed_multiplier
             twist.angular.z *= speed_multiplier
 
-            self.cmd_vel.publish(twist)
+            if self.publish_only_when_active:
+                active = twist.linear.x != 0 or twist.linear.y != 0 or twist.angular.z != 0
+                # Publish while active; publish exactly one zero on the
+                # active->idle transition (clean stop); then stay silent
+                # so a co-publisher owns /cmd_vel.
+                if active or self._was_active:
+                    self.cmd_vel.publish(twist)
+                self._was_active = active
+            else:
+                self.cmd_vel.publish(twist)
 
             self._update_display(twist)
 

--- a/dimos/teleop/keyboard/keyboard_teleop_module.py
+++ b/dimos/teleop/keyboard/keyboard_teleop_module.py
@@ -29,6 +29,7 @@ Keyboard controls:
 """
 
 import os
+from pathlib import Path
 import threading
 import time
 from typing import Any
@@ -65,7 +66,8 @@ def _clamp(value: float, min_val: float, max_val: float) -> float:
 
 
 class KeyboardTeleopConfig(ModuleConfig):
-    model_path: str = ""
+    # Accept str or Path-like (incl. LfsPath, which lazy-resolves on str()).
+    model_path: str | Path = ""
     ee_joint_id: int = 6
     task_name: str = "cartesian_ik_arm"
 


### PR DESCRIPTION
## Problem

`KeyboardTeleopConfig.model_path` was typed as `str`, so passing the `LfsPath`/`Path` values that all manipulator blueprints use crashed at startup with a pydantic `string_type` error. Separately, the Go2 webrtc keyboard teleop publishes a zero `Twist` every tick, flooding `/cmd_vel` and preventing co-publishers (e.g. the characterization tools) from owning the topic.

Issue: #2182
closes DIM-933

---

## Solution

Widen `KeyboardTeleopConfig.model_path` to `str | Path` so `LfsPath` validates. Add a `publish_only_when_active` flag to `dimos/robot/unitree/keyboard_teleop.py` — publishes while a movement key is held, emits exactly one zero `Twist` on release, then stays silent. Opt the Go2 webrtc blueprint in.

---

## Breaking Changes

None

---

## How to Test

1. Run `keyboard_teleop_xarm6` and confirm it starts without `ValidationError`.
2. Launch `unitree-go2-webrtc-keyboard-teleop`; hold W and verify Twists publish.
3. Release W; confirm one zero Twist publishes, then `/cmd_vel` goes silent.
