### PR TITLE
ci: stop cancelling in-progress runs on new pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,8 @@ on:
   pull_request:
 
 concurrency:
-  # Cancels runs from previous pushes in a PR.
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions: {}
 


### PR DESCRIPTION
## Problem

With `cancel-in-progress: true`, any new push to a PR immediately kills the running CI workflow. This includes commits pushed by `autofix.ci` (formatting fixes), which means:

1. You push code
2. CI starts running tests
3. autofix.ci pushes a format commit 6 seconds later
4. Your entire CI run gets cancelled
5. PR shows X failures even though nothing actually failed

Example: https://github.com/dimensionalOS/dimos/actions/runs/26152674707

## Fix

Set `cancel-in-progress: false`. Existing runs complete normally. New pushes still trigger their own CI run — they just queue instead of killing the previous one.

## What is NOT affected

- **Intra-run fail-fast** (matrix job cancellation when one job fails) — this is controlled by `strategy.fail-fast` on the matrix, completely independent
- **Concurrency grouping** — still grouped per-PR, so runs are serialized (not parallel)

## Tradeoff

Slightly more runner minutes on stale commits (old run finishes even if a new commit arrives). But no more phantom failures from autofix races.