### PR TITLE
Disable GIL in astar module

### DIFF
--- a/dimos/navigation/replanning_a_star/min_cost_astar_cpp.cpp
+++ b/dimos/navigation/replanning_a_star/min_cost_astar_cpp.cpp
@@ -242,7 +242,11 @@ std::vector<std::pair<int, int>> min_cost_astar_cpp(
     return {};
 }
 
-PYBIND11_MODULE(min_cost_astar_ext, m) {
+// Free-threaded build opt-in: this module has no shared mutable state — DX/DY/MOVE_COSTS are
+// constexpr, and every container (open_set, closed_set, parents, cost_score, dist_score) is
+// constructed inside min_cost_astar_cpp() and lives only on the calling thread's stack frame.
+// No GIL needed for safety. (pybind11 2.13+)
+PYBIND11_MODULE(min_cost_astar_ext, m, py::mod_gil_not_used()) {
     m.doc() = "C++ implementation of A* pathfinding for costmap grids";
 
     m.def("min_cost_astar_cpp", &min_cost_astar_cpp,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,7 @@
 [build-system]
-requires = ["setuptools>=70", "wheel", "pybind11>=2.12"]
+# Upper-pin to keep release-time build inputs reproducible. pybind11>=2.13 is required for
+# the py::mod_gil_not_used() marker on free-threaded wheels.
+requires = ["setuptools>=70,<82", "wheel", "pybind11>=2.13,<3"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]


### PR DESCRIPTION
In free-threaded builds, this should allow the GIL to remain disabled and improve threading performance.