### PR TITLE
docs: fill TF/Rerun section in visualization.md

### DIFF
--- a/docs/usage/visualization.md
+++ b/docs/usage/visualization.md
@@ -139,6 +139,17 @@ rerun_init(
 
 When a `RerunBridgeModule` is already part of your blueprint, you typically don't need `start_grpc` — just call `rerun_init()` and log directly with `rr.log()`. The data will appear in the existing viewer.
 
-## How to use Rerun on `dev` (and the TF/entity nuances)
+## TF Frames in Rerun
 
-Rerun on `dev` is **module-driven**: modules decide what to log, and `Blueprint.build()` sets up the shared viewer + default layout.
+When a module calls `self.tf.publish(...)`, the resulting `TFMessage` is converted to a Rerun `Transform3D` and logged at the entity path `world/tf/<child_frame_id>`. The default `Spatial3DView` is rooted at `world`, so frames appear in the 3D scene with no extra logging code. The conversion lives in `TFMessage.to_rerun()` ([`dimos/msgs/tf2_msgs/TFMessage.py`](/dimos/msgs/tf2_msgs/TFMessage.py#L126)) and runs inside whichever Rerun bridge is active.
+
+> Note: every transform is flattened under `world/tf/` regardless of TF tree depth. Rerun's native convention is hierarchical (each path segment is a frame), but the dimos bridge does not yet reconstruct full ancestry — see the `TODO` in [`dimos/visualization/rerun/bridge.py`](/dimos/visualization/rerun/bridge.py#L79).
+
+### Two ways to run the bridge
+
+| Path | Use |
+|------|-----|
+| **In-blueprint** | Include `RerunBridgeModule` in your composition. All shipped agentic blueprints do this. |
+| **Standalone** | Run `dimos rerun-bridge` in a separate terminal — it subscribes to LCM and picks up any blueprint already running on the host. Useful as a sidecar viewer for debugging. |
+
+The standalone bridge subscribes to LCM at startup, so transforms published before it comes up are missed (the TF buffer is short and Rerun does not backfill). Start `dimos rerun-bridge` first when using it as a sidecar.


### PR DESCRIPTION
## Problem

`docs/usage/visualization.md` has a stub section "How to use Rerun on `dev` (and the TF/entity nuances)" with a one-line intro and no body. Readers landing there from `transforms.md` (which now links here after #2122) find nothing concrete about how dimos renders TF frames in Rerun, what entity path conventions are used, or how to run the bridge.

This also tidies the section heading: the `dev` reference is stale (per AGENTS.md, `main` is now the unstable development branch).

## Solution

Replace the stub with focused content covering:

- The entity path convention `world/tf/<child_frame_id>` and where the conversion happens (`TFMessage.to_rerun()`).
- A note that transforms are currently flattened under `world/tf/` rather than nested per Rerun's native convention, linking to the in-source TODO in `dimos/visualization/rerun/bridge.py`.
- A small table contrasting the two ways to run the bridge (in-blueprint `RerunBridgeModule` vs. standalone `dimos rerun-bridge`).
- A start-order note for the standalone bridge (subscribes at startup; TF buffer is short).

Retitled to "TF Frames in Rerun" to drop the stale `dev` reference and reflect actual scope.

## How to Test

Locally verified: ran the multi-module example from `docs/usage/transforms.md` (with `time.sleep(2.5)` bumped to 60 so the modules stay alive) in one terminal, and `dimos rerun-bridge --rerun-open web` in another. The viewer's entity tree showed exactly:

```
world
└── tf
    ├── base_link
    ├── camera_link
    └── camera_optical
```

## Contributor License Agreement

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).