### PR TITLE
update MID-360 mount pose to physically measured values on flowbase

### DIFF
--- a/dimos/control/blueprints/mobile.py
+++ b/dimos/control/blueprints/mobile.py
@@ -138,7 +138,7 @@ coordinator_flowbase_keyboard_teleop = autoconnect(
 # FlowBase + Livox MID-360 + FastLio2 SLAM + nav stack with click-to-drive in Rerun. The velocity
 # sink is ControlCoordinator + FlowBaseAdapter
 
-_flowbase_mid360_mount = Pose(0.20, -0.20, 0.10, *Quaternion.from_euler(Vector3(0, 0, 0)))
+_flowbase_mid360_mount = Pose(0.22, -0.185, 0.381, *Quaternion.from_euler(Vector3(0, 0, 0)))
 
 coordinator_flowbase_nav = (
     autoconnect(


### PR DESCRIPTION
## Summary
Update `_flowbase_mid360_mount` in `mobile.py` with physically measured values for the Livox MID-360 on FlowBase.

| Field | Old | New |
|---|---|---|
| x | 0.20 m | 0.22 m |
| y | -0.20 m | -0.185 m |
| z | 0.10 m | 0.381 m (15 in from floor) |
| rotation | identity | identity (unchanged) |

## Measurements
Tape-measured from robot rotation center to MID-360 bolt center. `y` is negative - LiDAR is on the right side of the robot (ROS convention). `z` measured to the bottom mounting surface of the sensor. Rotation stays identity - FastLio2 IMU auto-corrects for physical bracket tilt.

## Validation
Tested on FlowBase + Livox MID-360 (`coordinator-flowbase-nav`):
- Map shows room structure clearly, walls vertical, floor flat at z=0
- Click-to-drive via Rerun confirmed working - robot navigated to clicked goals successfully
