### PR TITLE
Native modules should build during build step

### DIFF
--- a/dimos/core/native_module.py
+++ b/dimos/core/native_module.py
@@ -180,6 +180,11 @@ class NativeModule(Module):
             self.config.executable = str(Path(self.config.cwd) / self.config.executable)
 
     @rpc
+    def build(self) -> None:
+        super().build()
+        self._maybe_build()
+
+    @rpc
     def start(self) -> None:
         super().start()
         if self._process is not None and self._process.poll() is None:
@@ -189,8 +194,6 @@ class NativeModule(Module):
                 pid=self._process.pid,
             )
             return
-
-        self._maybe_build()
 
         topics = self._collect_topics()
 


### PR DESCRIPTION
## Problem

Replay modules (all non-native modules) don't wait for native modules to build before they start replaying.

## Solution

Have native modules build at build stage instead of start

## How to Test

On a fresh G1

```
uv run dimos run --rerun-host 0.0.0.0 unitree-g1-nav-onboard
```

## Contributor License Agreement

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
