### PR TITLE
fastlio2: publish TF directly from C++

### DIFF
--- a/dimos/hardware/sensors/lidar/fastlio2/cpp/main.cpp
+++ b/dimos/hardware/sensors/lidar/fastlio2/cpp/main.cpp
@@ -36,11 +36,14 @@
 
 // dimos LCM message headers
 #include "geometry_msgs/Quaternion.hpp"
+#include "geometry_msgs/Transform.hpp"
+#include "geometry_msgs/TransformStamped.hpp"
 #include "geometry_msgs/Vector3.hpp"
 #include "nav_msgs/Odometry.hpp"
 #include "sensor_msgs/Imu.hpp"
 #include "sensor_msgs/PointCloud2.hpp"
 #include "sensor_msgs/PointField.hpp"
+#include "tf2_msgs/TFMessage.hpp"
 
 // FAST-LIO (header-only core, compiled sources linked via CMake)
 #include "fast_lio.hpp"
@@ -62,6 +65,7 @@ static FastLio* g_fastlio = nullptr;
 static std::string g_lidar_topic;
 static std::string g_odometry_topic;
 static std::string g_map_topic;
+static std::string g_tf_topic;        // shared /tf channel (optional, default /tf#tf2_msgs.TFMessage)
 static std::string g_frame_id;        // required via --frame_id
 static std::string g_child_frame_id;   // required via --child_frame_id
 static float g_frequency = 10.0f;
@@ -258,6 +262,63 @@ static void publish_odometry(const custom_messages::Odometry& odom, double times
 }
 
 // ---------------------------------------------------------------------------
+// Publish TF
+//
+// Per REP-105, an odometry source publishes the parent → child transform on
+// /tf alongside its Odometry message.  Same frame chain as publish_odometry
+// (g_frame_id → g_child_frame_id), same init_pose offset applied.
+// ---------------------------------------------------------------------------
+
+static void publish_tf(const custom_messages::Odometry& odom, double timestamp) {
+    if (!g_lcm || g_tf_topic.empty()) return;
+
+    geometry_msgs::TransformStamped t;
+    t.header = make_header(g_frame_id, timestamp);
+    t.child_frame_id = g_child_frame_id;
+
+    // Same init_pose offset publish_odometry applies (kept in lockstep so
+    // /tf and /odometry never disagree on where base_link is).
+    double px, py, pz;
+    double qx, qy, qz, qw;
+    if (has_init_pose()) {
+        quat_rotate(g_init_qx, g_init_qy, g_init_qz, g_init_qw,
+                    odom.pose.pose.position.x,
+                    odom.pose.pose.position.y,
+                    odom.pose.pose.position.z,
+                    px, py, pz);
+        px += g_init_x; py += g_init_y; pz += g_init_z;
+        quat_mul(g_init_qx, g_init_qy, g_init_qz, g_init_qw,
+                 odom.pose.pose.orientation.x,
+                 odom.pose.pose.orientation.y,
+                 odom.pose.pose.orientation.z,
+                 odom.pose.pose.orientation.w,
+                 qx, qy, qz, qw);
+    } else {
+        px = odom.pose.pose.position.x;
+        py = odom.pose.pose.position.y;
+        pz = odom.pose.pose.position.z;
+        qx = odom.pose.pose.orientation.x;
+        qy = odom.pose.pose.orientation.y;
+        qz = odom.pose.pose.orientation.z;
+        qw = odom.pose.pose.orientation.w;
+    }
+
+    t.transform.translation.x = px;
+    t.transform.translation.y = py;
+    t.transform.translation.z = pz;
+    t.transform.rotation.x = qx;
+    t.transform.rotation.y = qy;
+    t.transform.rotation.z = qz;
+    t.transform.rotation.w = qw;
+
+    tf2_msgs::TFMessage tf_msg;
+    tf_msg.transforms.push_back(t);
+    tf_msg.transforms_length = static_cast<int32_t>(tf_msg.transforms.size());
+
+    g_lcm->publish(g_tf_topic, &tf_msg);
+}
+
+// ---------------------------------------------------------------------------
 // Livox SDK callbacks
 // ---------------------------------------------------------------------------
 
@@ -379,6 +440,11 @@ int main(int argc, char** argv) {
     g_odometry_topic = mod.has("odometry") ? mod.topic("odometry") : "";
     g_map_topic = mod.has("global_map") ? mod.topic("global_map") : "";
 
+    // Shared /tf channel.  Per REP-105, fastlio (the odometry source)
+    // publishes g_frame_id → g_child_frame_id on /tf alongside Odometry.
+    // Set --tf_channel "" to disable.
+    g_tf_topic = mod.arg("tf_channel", "/tf#tf2_msgs.TFMessage");
+
     if (g_lidar_topic.empty() && g_odometry_topic.empty()) {
         fprintf(stderr, "Error: at least one of --lidar or --odometry is required\n");
         return 1;
@@ -460,6 +526,8 @@ int main(int argc, char** argv) {
                g_odometry_topic.empty() ? "(disabled)" : g_odometry_topic.c_str());
         printf("[fastlio2] global_map topic: %s\n",
                g_map_topic.empty() ? "(disabled)" : g_map_topic.c_str());
+        printf("[fastlio2] tf topic: %s\n",
+               g_tf_topic.empty() ? "(disabled)" : g_tf_topic.c_str());
         printf("[fastlio2] config: %s\n", config_path.c_str());
         printf("[fastlio2] host_ip: %s  lidar_ip: %s  frequency: %.1f Hz\n",
                host_ip.c_str(), lidar_ip.c_str(), g_frequency);
@@ -607,9 +675,13 @@ int main(int argc, char** argv) {
                 }
             }
 
-            // Publish odometry (rate-limited to odom_freq)
+            // Publish odometry + matching TF (rate-limited to odom_freq).
+            // /tf is gated on the odometry topic being enabled so the two
+            // never disagree about whether we're publishing a pose at all.
             if (!g_odometry_topic.empty() && (now - last_odom_publish >= odom_interval)) {
-                publish_odometry(fast_lio.get_odometry(), ts);
+                auto fl_odom = fast_lio.get_odometry();
+                publish_odometry(fl_odom, ts);
+                publish_tf(fl_odom, ts);
                 last_odom_publish = now;
             }
         }

--- a/dimos/hardware/sensors/lidar/fastlio2/module.py
+++ b/dimos/hardware/sensors/lidar/fastlio2/module.py
@@ -34,11 +34,9 @@ from __future__ import annotations
 import ipaddress
 from pathlib import Path
 import socket
-import time
 from typing import TYPE_CHECKING, Annotated
 
 from pydantic.experimental.pipeline import validate_as
-from reactivex.disposable import Disposable
 
 from dimos.core.core import rpc
 from dimos.core.native_module import NativeModule, NativeModuleConfig
@@ -56,9 +54,6 @@ from dimos.hardware.sensors.lidar.livox.ports import (
     SDK_PUSH_MSG_PORT,
 )
 from dimos.msgs.geometry_msgs.Pose import Pose
-from dimos.msgs.geometry_msgs.Quaternion import Quaternion
-from dimos.msgs.geometry_msgs.Transform import Transform
-from dimos.msgs.geometry_msgs.Vector3 import Vector3
 from dimos.msgs.nav_msgs.Odometry import Odometry
 from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
 from dimos.navigation.nav_stack.frames import FRAME_BODY, FRAME_ODOM
@@ -113,6 +108,11 @@ class FastLio2Config(NativeModuleConfig):
         Path, validate_as(...).transform(lambda p: p if p.is_absolute() else _CONFIG_DIR / p)
     ] = Path("mid360.yaml")
 
+    # Shared /tf channel.  The C++ binary publishes
+    # frame_id → child_frame_id (odom → base_link) on /tf alongside
+    # Odometry, per REP-105.  Set to empty string to disable.
+    tf_channel: str = "/tf#tf2_msgs.TFMessage"
+
     debug: bool = False
 
     # SDK port configuration (see livox/ports.py for defaults)
@@ -164,29 +164,6 @@ class FastLio2(NativeModule, perception.Lidar, perception.Odometry, mapping.Glob
     def start(self) -> None:
         self._validate_network()
         super().start()
-        self.register_disposable(
-            Disposable(self.odometry.transport.subscribe(self._on_odom_for_tf, self.odometry))
-        )
-
-    def _on_odom_for_tf(self, msg: Odometry) -> None:
-        self.tf.publish(
-            Transform(
-                frame_id=FRAME_ODOM,
-                child_frame_id=FRAME_BODY,
-                translation=Vector3(
-                    msg.pose.position.x,
-                    msg.pose.position.y,
-                    msg.pose.position.z,
-                ),
-                rotation=Quaternion(
-                    msg.pose.orientation.x,
-                    msg.pose.orientation.y,
-                    msg.pose.orientation.z,
-                    msg.pose.orientation.w,
-                ),
-                ts=msg.ts or time.time(),
-            )
-        )
 
     @rpc
     def stop(self) -> None:


### PR DESCRIPTION
fastlio2 wasn't broadcasting `/tf` from the C++ binary. We had a Python-side workaround in `module.py` that subscribed to our own `/odometry` and re-published each pose as a TF Transform, which adds an LCM round-trip and would double-publish once C++ broadcasts too.

Moving the broadcast into the C++ binary so it happens at the source, alongside the Odometry publish — REP-105's normal pattern for an odometry source.

## What changed
- `cpp/main.cpp` — new `--tf_channel` arg (default `/tf#tf2_msgs.TFMessage`). Adds `publish_tf()` that emits a `TFMessage` with one `TransformStamped` (`g_frame_id → g_child_frame_id`, same `init_pose` offset that `publish_odometry` applies). Called next to `publish_odometry`, rate-limited to `odom_freq`.
- `module.py` — new `tf_channel` config field. Drops the `_on_odom_for_tf` subscribe-and-republish hack + its now-unused imports.

## Needs a recompile
The Python wrapper now always passes `--tf_channel` to the binary. Old binaries don't know that flag, so deploys with this Python wrapper but an old binary will lose TF entirely (no Python fallback anymore). Rebuild via `nix build .#fastlio2_native`.

## Smoke test
```
nix build .#fastlio2_native
./result/bin/fastlio2_native \
  --odometry "/odometry#nav_msgs.Odometry" \
  --tf_channel "/tf#tf2_msgs.TFMessage" \
  --config_path ../config/mid360.yaml \
  --frame_id odom --child_frame_id base_link \
  --host_ip <host> --lidar_ip <lidar> --debug true
```
Stdout should include `[fastlio2] tf topic: /tf#tf2_msgs.TFMessage`.

Without real lidar hardware on the bench so this is checked compile + arg-parse only — on-hardware verification belongs to whoever flashes the next deploy.