### PR TITLE
HK village recordings for loop closure, relocalization evals

### DIFF
--- a/data/.lfs/hk_village1.db.tar.gz
+++ b/data/.lfs/hk_village1.db.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b22392beae1b055743a00090317dc4191d4e7cef6d1f2114fdde19e1b35597ab
+size 207852261

--- a/data/.lfs/hk_village2.db.tar.gz
+++ b/data/.lfs/hk_village2.db.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58acf7449bb1e9a0258f842113781ab7cabdd2a3ac4a49db0a574b701df21c50
+size 164625597

--- a/data/.lfs/hk_village3.db.tar.gz
+++ b/data/.lfs/hk_village3.db.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d575b524bf95a0f5c505d31d4b5eaac00a00457d8b82bb49a3b849bc37d51ff7
+size 132125897

--- a/data/.lfs/hk_village4.db.tar.gz
+++ b/data/.lfs/hk_village4.db.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f63d0c2f642e4b2463ae9ed7a1c3faa81d978907e105b798b50af7b76c045ed
+size 287082427

--- a/data/.lfs/hk_village5.db.tar.gz
+++ b/data/.lfs/hk_village5.db.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a9970fae362220d1e2d67ccb81ea0ec25610db2d2a53409b00fe8635d590940
+size 173241480

--- a/data/.lfs/hk_village6.db.tar.gz
+++ b/data/.lfs/hk_village6.db.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9637f2c78025d2eec238396a3697334a35350dae42c59346b0f7fc748743c63c
+size 227454066


### PR DESCRIPTION
These recordings need some simple repairs (Posestamped missing from observation, to be reconstructed from odom)

EDIT - was a replay bug, after this is merged odom is ok here https://github.com/dimensionalOS/dimos/pull/2210


Stare at some tags

<img width="1388" height="816" alt="2026-05-22_02-08" src="https://github.com/user-attachments/assets/b536c3e7-8958-4930-b270-8cbd742003d4" />

Run around the village

<img width="1298" height="818" alt="2026-05-22_02-08_1" src="https://github.com/user-attachments/assets/61bf9520-6f7d-4169-a6a4-1e43ea478c56" />
