### PR TITLE
feat(mcp): parallel tool dispatch with per-lane locks

### DIFF
--- a/dimos/agents/annotation.py
+++ b/dimos/agents/annotation.py
@@ -66,7 +66,17 @@ def _stamp_and_log(func_name: str, result: Any, elapsed_ms: float) -> Any:
     return result
 
 
-def skill(func: F) -> F:
+def skill(func: F | None = None, *, lane: str | None = None) -> F | Callable[[F], F]:
+    """Mark a method as an agent-callable skill, optionally assigned to a lane."""
+    if func is None:
+        def decorator(f: F) -> F:
+            return _make_skill(f, lane=lane)
+        return decorator  # type: ignore[return-value]
+
+    return _make_skill(func, lane=lane)
+
+
+def _make_skill(func: F, *, lane: str | None) -> F:
     if inspect.iscoroutinefunction(func):
 
         @functools.wraps(func)
@@ -108,4 +118,5 @@ def skill(func: F) -> F:
 
     wrapped = rpc(context_wrapper)
     wrapped.__skill__ = True  # type: ignore[attr-defined]
+    wrapped.__skill_lane__ = lane  # type: ignore[attr-defined]
     return cast("F", wrapped)

--- a/dimos/agents/mcp/mcp_client.py
+++ b/dimos/agents/mcp/mcp_client.py
@@ -143,6 +143,9 @@ class McpClient(Module):
 
         raw_tools = result.get("tools", [])
         self._tool_registry = {t["name"]: t for t in raw_tools}
+        for t in raw_tools:
+            if lane := t.get("lane"):
+                self._lane_locks.setdefault(lane, threading.Lock())
         tools = [self._mcp_tool_to_langchain(t) for t in raw_tools]
 
         if not tools:
@@ -170,7 +173,7 @@ class McpClient(Module):
     def _invoke_tool(self, name: str, kwargs: dict[str, Any]) -> dict[str, Any]:
         lane = self._tool_registry.get(name, {}).get("lane")
         if lane:
-            with self._lane_locks.setdefault(lane, threading.Lock()):
+            with self._lane_locks[lane]:
                 return self._mcp_tool_call(name, kwargs)
         return self._mcp_tool_call(name, kwargs)
 

--- a/dimos/agents/mcp/mcp_client.py
+++ b/dimos/agents/mcp/mcp_client.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 from collections.abc import Callable
 from queue import Empty, Queue
+import threading
 from threading import Event, RLock, Thread
 import time
 from typing import Any
@@ -58,6 +60,7 @@ class McpClient(Module):
     _state_graph: CompiledStateGraph[Any, Any, Any, Any] | None
     _message_queue: Queue[BaseMessage]
     _tool_registry: dict[str, dict[str, Any]]
+    _lane_locks: dict[str, threading.Lock]
     _history: list[BaseMessage]
     _thread: Thread
     _stop_event: Event
@@ -71,6 +74,7 @@ class McpClient(Module):
         self._state_graph = None
         self._message_queue = Queue()
         self._tool_registry = {}
+        self._lane_locks = {}
         self._history = []
         self._thread = Thread(
             target=self._thread_loop,
@@ -163,13 +167,21 @@ class McpClient(Module):
 
         return self._mcp_request("tools/list")
 
+    def _invoke_tool(self, name: str, kwargs: dict[str, Any]) -> dict[str, Any]:
+        lane = self._tool_registry.get(name, {}).get("lane")
+        if lane:
+            with self._lane_locks.setdefault(lane, threading.Lock()):
+                return self._mcp_tool_call(name, kwargs)
+        return self._mcp_tool_call(name, kwargs)
+
     def _mcp_tool_to_langchain(self, mcp_tool: dict[str, Any]) -> StructuredTool:
         name = mcp_tool["name"]
         description = mcp_tool.get("description", "")
         input_schema = mcp_tool.get("inputSchema", {"type": "object", "properties": {}})
 
-        def call_tool(**kwargs: Any) -> str:
-            result = self._mcp_tool_call(name, kwargs)
+        async def call_tool(**kwargs: Any) -> str:
+            result = await asyncio.to_thread(self._invoke_tool, name, kwargs)
+
             content = result.get("content", [])
             parts = [c.get("text", "") for c in content if c.get("type") == "text"]
             text = "\n".join(parts)
@@ -188,7 +200,7 @@ class McpClient(Module):
         return StructuredTool(
             name=name,
             description=description,
-            func=call_tool,
+            coroutine=call_tool,
             args_schema=input_schema,
         )
 
@@ -285,7 +297,7 @@ class McpClient(Module):
                     tool_args[key] = continuation_context[context_key]
 
         try:
-            result = self._mcp_tool_call(tool_name, tool_args)
+            result = self._invoke_tool(tool_name, tool_args)
             content = result.get("content", [])
             parts = [c.get("text", "") for c in content if c.get("type") == "text"]
             text = "\n".join(parts)
@@ -323,13 +335,17 @@ class McpClient(Module):
         pretty_print_langchain_message(message)
         self.agent.publish(message)
 
-        for update in state_graph.stream({"messages": self._history}, stream_mode="updates"):
-            for node_output in update.values():
-                for msg in node_output.get("messages", []):
-                    self._history.append(msg)
-                    pretty_print_langchain_message(msg)
-                    self.agent.publish(msg)
+        async def run() -> None:
+            async for update in state_graph.astream(
+                {"messages": self._history}, stream_mode="updates"
+            ):
+                for node_output in update.values():
+                    for msg in node_output.get("messages", []):
+                        self._history.append(msg)
+                        pretty_print_langchain_message(msg)
+                        self.agent.publish(msg)
 
+        asyncio.run(run())
         if self._message_queue.empty():
             self.agent_idle.publish(True)
 

--- a/dimos/agents/mcp/mcp_server.py
+++ b/dimos/agents/mcp/mcp_server.py
@@ -89,6 +89,8 @@ def _handle_tools_list(req_id: Any, skills: list[SkillInfo]) -> dict[str, Any]:
         tool: dict[str, Any] = {"name": s.func_name, "inputSchema": schema}
         if description:
             tool["description"] = description
+        if s.lane is not None:
+            tool["lane"] = s.lane
         tools.append(tool)
 
     return _jsonrpc_result(req_id, {"tools": tools})

--- a/dimos/agents/mcp/test_mcp_client_unit.py
+++ b/dimos/agents/mcp/test_mcp_client_unit.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import asyncio
 import json
 from queue import Empty, Queue
+import threading
 import time
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -258,6 +259,7 @@ def test_same_lane_tools_execute_serially(mcp_client: McpClient) -> None:
         "a": {"name": "a", "lane": "motion"},
         "b": {"name": "b", "lane": "motion"},
     }
+    mcp_client._lane_locks = {"motion": threading.Lock()}
     tool_a = mcp_client._mcp_tool_to_langchain(
         {
             "name": "a",
@@ -276,7 +278,6 @@ def test_same_lane_tools_execute_serially(mcp_client: McpClient) -> None:
     )
 
     async def run() -> None:
-        mcp_client._lane_locks.clear()
         await asyncio.gather(tool_a.coroutine(), tool_b.coroutine())  # type: ignore[misc]
 
     asyncio.run(run())
@@ -301,6 +302,7 @@ def test_different_lane_tools_run_in_parallel(mcp_client: McpClient) -> None:
         "cam": {"name": "cam", "lane": "camera"},
         "nav": {"name": "nav", "lane": "motion"},
     }
+    mcp_client._lane_locks = {"camera": threading.Lock(), "motion": threading.Lock()}
     tool_cam = mcp_client._mcp_tool_to_langchain(
         {
             "name": "cam",
@@ -319,7 +321,6 @@ def test_different_lane_tools_run_in_parallel(mcp_client: McpClient) -> None:
     )
 
     async def run() -> None:
-        mcp_client._lane_locks.clear()
         await asyncio.gather(tool_cam.coroutine(), tool_nav.coroutine())  # type: ignore[misc]
 
     asyncio.run(run())

--- a/dimos/agents/mcp/test_mcp_client_unit.py
+++ b/dimos/agents/mcp/test_mcp_client_unit.py
@@ -13,8 +13,11 @@
 # limitations under the License.
 from __future__ import annotations
 
+import asyncio
 import json
 from queue import Empty, Queue
+import time
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 from langchain_core.messages import HumanMessage
@@ -53,6 +56,7 @@ def _mock_post(url: str, **kwargs: object) -> MagicMock:
                         },
                         "required": ["x", "y"],
                     },
+                    "lane": "motion",
                 },
                 {
                     "name": "greet",
@@ -105,9 +109,17 @@ def mcp_client() -> McpClient:
 
     client._http_client = mock_http
     client._seq_ids = SequentialIds()
+    client._lane_locks = {}
     client.config = MagicMock()
     client.config.mcp_server_url = "http://localhost:9990/mcp"
     return client
+
+
+def test_lane_stored_in_tool_registry(mcp_client: McpClient) -> None:
+    mcp_client._fetch_tools()
+
+    assert mcp_client._tool_registry["add"].get("lane") == "motion"
+    assert mcp_client._tool_registry["greet"].get("lane") is None
 
 
 def test_fetch_tools_from_mcp_server(mcp_client: McpClient) -> None:
@@ -123,8 +135,8 @@ def test_tool_invocation_via_mcp(mcp_client: McpClient) -> None:
     add_tool = next(t for t in tools if t.name == "add")
     greet_tool = next(t for t in tools if t.name == "greet")
 
-    assert add_tool.func(x=2, y=3) == "5"
-    assert greet_tool.func(name="Alice") == "Hello, Alice!"
+    assert asyncio.run(add_tool.coroutine(x=2, y=3)) == "5"  # type: ignore[arg-type, misc]
+    assert asyncio.run(greet_tool.coroutine(name="Alice")) == "Hello, Alice!"  # type: ignore[arg-type, misc]
 
 
 def test_mcp_request_error_propagation(mcp_client: McpClient) -> None:
@@ -229,3 +241,89 @@ def test_mcp_tool_call_sends_progress_token(mcp_client: McpClient) -> None:
     assert isinstance(meta, dict)
     token = meta["progressToken"]
     assert isinstance(token, str) and len(token) > 0
+
+
+def test_same_lane_tools_execute_serially(mcp_client: McpClient) -> None:
+    """Tools sharing a lane never overlap — the second waits for the first."""
+    events: list[str] = []
+
+    def slow_call(name: str, kwargs: dict[str, Any]) -> dict[str, Any]:
+        events.append(f"{name}:start")
+        time.sleep(0.05)
+        events.append(f"{name}:end")
+        return {"content": [{"type": "text", "text": "ok"}]}
+
+    mcp_client._mcp_tool_call = slow_call  # type: ignore[assignment]
+    mcp_client._tool_registry = {
+        "a": {"name": "a", "lane": "motion"},
+        "b": {"name": "b", "lane": "motion"},
+    }
+    tool_a = mcp_client._mcp_tool_to_langchain(
+        {
+            "name": "a",
+            "description": "",
+            "inputSchema": {"type": "object", "properties": {}},
+            "lane": "motion",
+        }
+    )
+    tool_b = mcp_client._mcp_tool_to_langchain(
+        {
+            "name": "b",
+            "description": "",
+            "inputSchema": {"type": "object", "properties": {}},
+            "lane": "motion",
+        }
+    )
+
+    async def run() -> None:
+        mcp_client._lane_locks.clear()
+        await asyncio.gather(tool_a.coroutine(), tool_b.coroutine())  # type: ignore[misc]
+
+    asyncio.run(run())
+
+    a_start, a_end = events.index("a:start"), events.index("a:end")
+    b_start, b_end = events.index("b:start"), events.index("b:end")
+    assert a_end < b_start or b_end < a_start
+
+
+def test_different_lane_tools_run_in_parallel(mcp_client: McpClient) -> None:
+    """Tools in different lanes overlap — neither waits for the other."""
+    timestamps: dict[str, float] = {}
+
+    def slow_call(name: str, kwargs: dict[str, Any]) -> dict[str, Any]:
+        timestamps[f"{name}:start"] = time.monotonic()
+        time.sleep(0.05)
+        timestamps[f"{name}:end"] = time.monotonic()
+        return {"content": [{"type": "text", "text": "ok"}]}
+
+    mcp_client._mcp_tool_call = slow_call  # type: ignore[assignment]
+    mcp_client._tool_registry = {
+        "cam": {"name": "cam", "lane": "camera"},
+        "nav": {"name": "nav", "lane": "motion"},
+    }
+    tool_cam = mcp_client._mcp_tool_to_langchain(
+        {
+            "name": "cam",
+            "description": "",
+            "inputSchema": {"type": "object", "properties": {}},
+            "lane": "camera",
+        }
+    )
+    tool_nav = mcp_client._mcp_tool_to_langchain(
+        {
+            "name": "nav",
+            "description": "",
+            "inputSchema": {"type": "object", "properties": {}},
+            "lane": "motion",
+        }
+    )
+
+    async def run() -> None:
+        mcp_client._lane_locks.clear()
+        await asyncio.gather(tool_cam.coroutine(), tool_nav.coroutine())  # type: ignore[misc]
+
+    asyncio.run(run())
+
+    # Intervals overlap: each tool starts before the other finishes
+    assert timestamps["cam:start"] < timestamps["nav:end"]
+    assert timestamps["nav:start"] < timestamps["cam:end"]

--- a/dimos/agents/mcp/test_mcp_server.py
+++ b/dimos/agents/mcp/test_mcp_server.py
@@ -68,6 +68,23 @@ def test_mcp_module_request_flow() -> None:
     rpc_calls["add"].assert_called_once_with(x=2, y=3)
 
 
+def test_tools_list_includes_lane_when_set() -> None:
+    """Lane is included in the tools/list response for annotated skills and
+    omitted entirely for skills without a lane."""
+    schema = json.dumps({"type": "object", "properties": {}})
+    skills = [
+        SkillInfo(class_name="TestSkills", func_name="move", args_schema=schema, lane="motion"),
+        SkillInfo(class_name="TestSkills", func_name="query", args_schema=schema),
+    ]
+    rpc_calls = _make_rpc_calls(skills, {})
+
+    response = asyncio.run(handle_request({"method": "tools/list", "id": 1}, skills, rpc_calls))
+    tools = {t["name"]: t for t in response["result"]["tools"]}
+
+    assert tools["move"]["lane"] == "motion"
+    assert "lane" not in tools["query"]
+
+
 def test_mcp_module_injects_progress_token_as_mcp_context() -> None:
     """When the client sends `_meta.progressToken`, the RPC call receives it as
     an `_mcp_context` kwarg so the `@skill` wrapper can stash it in the

--- a/dimos/core/module.py
+++ b/dimos/core/module.py
@@ -69,6 +69,7 @@ class SkillInfo:
     class_name: str
     func_name: str
     args_schema: str
+    lane: str | None = None
 
 
 def get_loop() -> tuple[asyncio.AbstractEventLoop, threading.Thread | None]:
@@ -428,7 +429,10 @@ class ModuleBase(Configurable, CompositeResource):
                 schema = json.dumps(tool(attr).args_schema.model_json_schema())
                 skills.append(
                     SkillInfo(
-                        class_name=self.__class__.__name__, func_name=name, args_schema=schema
+                        class_name=self.__class__.__name__,
+                        func_name=name,
+                        args_schema=schema,
+                        lane=getattr(attr, "__skill_lane__", None),
                     )
                 )
         return skills

--- a/docs/capabilities/agents/readme.md
+++ b/docs/capabilities/agents/readme.md
@@ -40,6 +40,18 @@ class MySkillContainer(Module):
 - Docstrings become the tool description the LLM sees. Write them clearly so the agent has sufficent context.
 - The function must return a string or image which with be used by the agent to decide what to do next.
 
+Skills in different modules can run in parallel when the agent calls them in the same turn. Use `lane=` to serialize skills that must not overlap (e.g. motion commands):
+
+```python
+@skill(lane="motion")
+def move_forward(self) -> str: ...
+
+@skill(lane="motion")
+def turn_left(self) -> str: ...  # will not run at the same time as move_forward
+```
+
+See [Lanes](../usage/blueprints.md#lanes) for details.
+
 ### Built-in Skills
 
 | Skill | Module | Description |

--- a/docs/usage/blueprints.md
+++ b/docs/usage/blueprints.md
@@ -374,6 +374,31 @@ class SomeSkill(Module):
         return "result"
 ```
 
+### Lanes
+
+By default, when the agent decides to call multiple independent skills in a single turn, they execute in parallel. Skills that must not overlap — for example, motion commands that would conflict if sent simultaneously — can be assigned to a **lane**:
+
+```python
+class MotionSkills(Module):
+
+    @skill(lane="motion")
+    def move_forward(self) -> str:
+        """Move the robot forward."""
+        ...
+
+    @skill(lane="motion")
+    def turn_left(self) -> str:
+        """Turn the robot left."""
+        ...
+
+    @skill
+    def take_photo(self) -> str:
+        """Take a picture."""
+        ...
+```
+
+Skills sharing a lane execute one at a time. Skills in different lanes, or with no lane, run concurrently. In the example above, `move_forward` and `turn_left` will never overlap, but either can run at the same time as `take_photo`.
+
 ## Building
 
 All you have to do to build a blueprint is call:


### PR DESCRIPTION
## Problem

Tool calls dispatched by the LLM always execute sequentially even when they are fully independent. On a robot, this means "take a photo" must wait for "move forward" to complete before starting — even though the two have nothing to do with each other. At the same time, some tools genuinely must not overlap: two concurrent motion commands can produce conflicting actuator inputs.

Closes DIM-2204

## Solution

Adds a lane parameter to the @skill decorator:

```
  @skill(lane="motion")
  def move_forward(self): ...
  
  @skill(lane="motion")
  def turn_left(self): ...   # locked with move_forward

  @skill    
  def take_photo(self): ...  # runs freely in parallel with anything
```

The lane travels through the full stack:
  
  @skill(lane=...) → __skill_lane__ on the function
  → `SkillInfo.lane`
  → `McpServer` tools/list response ({"lane": "motion"})
  → `McpClient._tool_registry`
  → `call_tool()` acquires `threading.Lock` per lane at execution time

  On the client side, two changes enable parallel dispatch:

1. `call_tool` now uses `asyncio.to_thread` to run the blocking HTTP call off the event loop, so multiple tool calls can be in-flight simultaneously. Tools in the same lane acquire a shared `threading.Lock` before proceeding; tools in different lanes or with no lane run concurrently without waiting.
2. `_process_message` switches from `state_graph.stream()` to `asyncio.run(state_graph.astream())`. This is what actually enables LangGraph to dispatch all pending tool calls as concurrent async tasks in a single agent turn.

The MCP server handles concurrent requests natively via FastAPI's async request handler and `run_in_executor`, so no server-side changes were needed.

  ---
### Backwards Compatibility
  
Existing @skill methods with no lane argument are unaffected — they continue to work exactly as before. The only behavioral change is that the agent now dispatches independent tools concurrently within a single turn instead of sequentially.
  
For modules where multiple skills have implicit ordering dependencies (e.g. a write_state skill that must complete before read_state), concurrent dispatch could produce unexpected results if the LLM happens to call both in the same turn.

The fix is to assign them to a shared lane:
```
  @skill(lane="state")
  def write_state(self, value: str) -> str: ...

  @skill(lane="state")
  def read_state(self) -> str: ...
```
  In practice, LLMs generally reason through dependent tool chains step-by-step and won't call both in a single turn — but for safety-critical sequences, adding a lane is recommended and needs to be well documented. See Next Steps for a `default_skill_lane config` that avoids annotating every method individually.

---

## How to Test

 Run the unit tests — the timing in the two new tests directly proves the behavior:
  
  `uv run pytest dimos/agents/mcp/test_mcp_client_unit.py dimos/agents/mcp/test_mcp_server.py -v`

  - `test_same_lane_tools_execute_serially` completes in ~0.11s (two 0.05s sleeps run back-to-back)
  - `test_different_lane_tools_run_in_parallel` completes in ~0.05s (both sleeps run simultaneously)
  - `test_lane_stored_in_tool_registry` verifies lane propagates end-to-end from tools/list into the client registry
  - `test_tools_list_includes_lane_when_set` verifies the server includes/omits lane correctly

The existing integration tests (`test_can_call_tool`, `test_multiple_tool_calls_with_multiple_messages`) cover backwards compatibility — they pass unchanged through the stream → astream migration.

---
### Next Steps
  
`default_skill_lane` module config: For modules where every skill belongs to the same lane (e.g. a `MotionModule` where every method is a motion command), it is verbose to annotate each method with `@skill(lane="motion")`. A `default_skill_lane: str | None = None` field on `ModuleConfig` would let a module declare a lane that applies to all its unannotated skills, with an explicit `@skill(lane=...)` overriding it per method. 

Implementation is two changes: add the field to `ModuleConfig`, and fall back to it in `get_skills()` when `__skill_lane__` is None.

## Contributor License Agreement

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
