### PR TITLE
feat: leveled logging for native modules

### DIFF
--- a/dimos/core/native_module.py
+++ b/dimos/core/native_module.py
@@ -89,6 +89,19 @@ class LogFormat(enum.Enum):
     JSON = "json"
 
 
+_NATIVE_TO_PYTHON_LEVELS = {
+    "trace": "debug",
+    "debug": "debug",
+    "info": "info",
+    "warn": "warning",
+    "warning": "warning",
+    "err": "error",
+    "error": "error",
+    "fatal": "critical",
+    "critical": "critical",
+}
+
+
 class NativeModuleConfig(ModuleConfig):
     """Configuration for a native (C/C++) subprocess module."""
 
@@ -344,7 +357,7 @@ class NativeModule(Module):
     ) -> None:
         if stream is None:
             return
-        log_fn = getattr(logger, level)
+        default_log_fn = getattr(logger, level)
         for raw in stream:
             line = raw.decode("utf-8", errors="replace").rstrip()
             if not line:
@@ -352,12 +365,21 @@ class NativeModule(Module):
             if self.config.log_format == LogFormat.JSON:
                 try:
                     data = json.loads(line)
-                    event = data.pop("event", line)
-                    log_fn(event, module=self._module_label, pid=pid, **data)
+                    fields = data.pop("fields", None)
+                    if fields:
+                        data.update(fields)
+                    message = data.pop("message", None) or line
+                    msg_level = data.pop("level", None)
+                    method = (
+                        _NATIVE_TO_PYTHON_LEVELS.get(msg_level.lower(), level)
+                        if msg_level
+                        else level
+                    )
+                    getattr(logger, method)(message, module=self._module_label, pid=pid, **data)
                     continue
-                except (json.JSONDecodeError, TypeError):
+                except (json.JSONDecodeError, TypeError, AttributeError):
                     pass
-            log_fn(line, module=self._module_label, pid=pid)
+            default_log_fn(line, module=self._module_label, pid=pid)
         stream.close()
 
     def _maybe_build(self) -> None:

--- a/dimos/core/native_module.py
+++ b/dimos/core/native_module.py
@@ -89,7 +89,7 @@ class LogFormat(enum.Enum):
     JSON = "json"
 
 
-# convert most native namings to Python levels
+# convert to Python levels
 _NATIVE_TO_PYTHON_LEVELS = {
     "trace": "debug",
     "debug": "debug",
@@ -102,7 +102,7 @@ _NATIVE_TO_PYTHON_LEVELS = {
     "critical": "critical",
 }
 
-# set Rust level to match Python level
+# convert to Rust levels
 _PYTHON_TO_RUST_LEVELS = {
     "DEBUG": "debug",
     "INFO": "info",

--- a/dimos/core/native_module.py
+++ b/dimos/core/native_module.py
@@ -111,7 +111,7 @@ class NativeModuleConfig(ModuleConfig):
     extra_args: list[str] = Field(default_factory=list)
     extra_env: dict[str, str] = Field(default_factory=dict)
     shutdown_timeout: float = DEFAULT_THREAD_JOIN_TIMEOUT
-    log_format: LogFormat = LogFormat.TEXT
+    log_format: LogFormat = LogFormat.JSON
     auto_build: bool = False
 
     # New version of Native Modules read json configs from stdin

--- a/dimos/core/native_module.py
+++ b/dimos/core/native_module.py
@@ -89,7 +89,7 @@ class LogFormat(enum.Enum):
     JSON = "json"
 
 
-# to convert most native namings to Python levels
+# convert most native namings to Python levels
 _NATIVE_TO_PYTHON_LEVELS = {
     "trace": "debug",
     "debug": "debug",
@@ -102,7 +102,7 @@ _NATIVE_TO_PYTHON_LEVELS = {
     "critical": "critical",
 }
 
-# to set Rust level to match Python level
+# set Rust level to match Python level
 _PYTHON_TO_RUST_LEVELS = {
     "DEBUG": "debug",
     "INFO": "info",

--- a/dimos/core/native_module.py
+++ b/dimos/core/native_module.py
@@ -89,6 +89,7 @@ class LogFormat(enum.Enum):
     JSON = "json"
 
 
+# to convert most native namings to Python levels
 _NATIVE_TO_PYTHON_LEVELS = {
     "trace": "debug",
     "debug": "debug",
@@ -99,6 +100,15 @@ _NATIVE_TO_PYTHON_LEVELS = {
     "error": "error",
     "fatal": "critical",
     "critical": "critical",
+}
+
+# to set Rust level to match Python level
+_PYTHON_TO_RUST_LEVELS = {
+    "DEBUG": "debug",
+    "INFO": "info",
+    "WARNING": "warn",
+    "ERROR": "error",
+    "CRITICAL": "error",
 }
 
 
@@ -217,6 +227,11 @@ class NativeModule(Module):
         cmd.extend(self.config.extra_args)
 
         env = {**os.environ, **self.config.extra_env}
+
+        # set Rust logging to match Python level
+        env["RUST_LOG"] = _PYTHON_TO_RUST_LEVELS.get(
+            os.environ.get("DIMOS_LOG_LEVEL", "").upper(), "info"
+        )
         cwd = self.config.cwd or str(Path(self.config.executable).resolve().parent)
 
         logger.info(

--- a/dimos/core/test_native_module.py
+++ b/dimos/core/test_native_module.py
@@ -18,17 +18,21 @@ Every test launches the real native_echo.py subprocess via ModuleCoordinator.bui
 The echo script writes received CLI args to a temp file for assertions.
 """
 
+from io import BytesIO
 import json
 from pathlib import Path
 import time
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 
+from dimos.core import native_module as native_module_mod
 from dimos.core.coordination.blueprints import autoconnect
 from dimos.core.coordination.module_coordinator import ModuleCoordinator
 from dimos.core.core import rpc
 from dimos.core.module import Module
-from dimos.core.native_module import NativeModule, NativeModuleConfig
+from dimos.core.native_module import LogFormat, NativeModule, NativeModuleConfig
 from dimos.core.stream import In, Out
 from dimos.core.transport import LCMTransport
 from dimos.msgs.geometry_msgs.Twist import Twist
@@ -193,3 +197,104 @@ def test_autoconnect(args_file: str) -> None:
         "output_file": args_file,
         "some_param": "2.5",
     }
+
+
+def _capture_logs(
+    log_format: LogFormat,
+    payload: bytes,
+    default_level: str = "info",
+) -> list[tuple[str, str, dict]]:
+    calls: list[tuple[str, str, dict]] = []
+
+    class FakeLogger:
+        def __getattr__(self, name: str):
+            def _record(message: str, **kwargs: object) -> None:
+                calls.append((name, message, kwargs))
+
+            return _record
+
+    fixture = SimpleNamespace(
+        config=SimpleNamespace(log_format=log_format),
+        _module_label="test",
+    )
+    with patch.object(native_module_mod, "logger", FakeLogger()):
+        NativeModule._read_log_stream(
+            fixture,  # type: ignore[arg-type]
+            BytesIO(payload),
+            default_level,
+            pid=123,
+        )
+    return calls
+
+
+def test_text_mode_uses_stream_default_level() -> None:
+    calls = _capture_logs(LogFormat.TEXT, b"hello\n", "info")
+    assert calls == [("info", "hello", {"module": "test", "pid": 123})]
+
+
+def test_empty_lines_skipped() -> None:
+    calls = _capture_logs(LogFormat.TEXT, b"\n\nhello\n\n", "info")
+    assert len(calls) == 1
+    assert calls[0][1] == "hello"
+
+
+def test_json_mode_honors_level_field() -> None:
+    calls = _capture_logs(
+        LogFormat.JSON,
+        b'{"level": "error", "message": "boom"}\n',
+        "info",
+    )
+    assert len(calls) == 1
+    assert calls[0][0] == "error"
+    assert calls[0][1] == "boom"
+
+
+def test_json_mode_level_alias_is_case_insensitive() -> None:
+    calls = _capture_logs(
+        LogFormat.JSON,
+        b'{"level": "WARN", "message": "watch out"}\n',
+        "info",
+    )
+    assert calls[0][0] == "warning"
+
+
+def test_json_mode_reads_tracing_subscriber_fields_message() -> None:
+    calls = _capture_logs(
+        LogFormat.JSON,
+        b'{"level": "INFO", "fields": {"message": "started", "device": "/dev/foo"}}\n',
+        "info",
+    )
+    assert len(calls) == 1
+    method, message, kwargs = calls[0]
+    assert method == "info"
+    assert message == "started"
+    assert kwargs["device"] == "/dev/foo"
+
+
+def test_json_mode_unrecognized_level_falls_back_to_stream_default() -> None:
+    calls = _capture_logs(
+        LogFormat.JSON,
+        b'{"level": "weird", "message": "hi"}\n',
+        "warning",
+    )
+    assert calls[0][0] == "warning"
+
+
+def test_json_mode_missing_level_falls_back_to_stream_default() -> None:
+    calls = _capture_logs(
+        LogFormat.JSON,
+        b'{"message": "no level here"}\n',
+        "warning",
+    )
+    assert calls[0][0] == "warning"
+    assert calls[0][1] == "no level here"
+
+
+def test_json_mode_malformed_falls_back_to_plain_text() -> None:
+    calls = _capture_logs(
+        LogFormat.JSON,
+        b"not json at all\n",
+        "info",
+    )
+    assert calls[0][0] == "info"
+    assert calls[0][1] == "not json at all"

--- a/dimos/mapping/ray_tracing/rust/Cargo.lock
+++ b/dimos/mapping/ray_tracing/rust/Cargo.lock
@@ -16,6 +16,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,6 +61,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -103,6 +114,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "lcm-msgs"
 version = "0.1.0"
 source = "git+https://github.com/dimensionalOS/dimos-lcm.git?branch=rust-codegen#e7c9428b7201cdfeadecd181c77c9e2d60a14503"
@@ -115,6 +132,21 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "memchr"
@@ -130,6 +162,15 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
  "windows-sys 0.61.2",
 ]
 
@@ -168,6 +209,23 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "serde"
@@ -213,6 +271,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,6 +288,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
@@ -254,6 +327,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,10 +363,90 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/dimos/mapping/ray_tracing/rust/Cargo.lock
+++ b/dimos/mapping/ray_tracing/rust/Cargo.lock
@@ -83,6 +83,7 @@ dependencies = [
  "lcm-msgs",
  "serde",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/dimos/mapping/ray_tracing/rust/Cargo.toml
+++ b/dimos/mapping/ray_tracing/rust/Cargo.toml
@@ -15,6 +15,7 @@ lcm-msgs = { git = "https://github.com/dimensionalOS/dimos-lcm.git", branch = "r
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal"] }
 serde = { version = "1", features = ["derive"] }
 ahash = "0.8"
+tracing = "0.1"
 
 [profile.release]
 lto = "thin"

--- a/dimos/mapping/ray_tracing/rust/src/main.rs
+++ b/dimos/mapping/ray_tracing/rust/src/main.rs
@@ -1,8 +1,10 @@
 // Copyright 2026 Dimensional Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::time::Duration;
+
 use ahash::{AHashMap, AHashSet};
-use dimos_module::{run, Input, LcmTransport, Module, Output};
+use dimos_module::{error_throttled, run, warn_throttled, Input, LcmTransport, Module, Output};
 use lcm_msgs::nav_msgs::Odometry;
 use lcm_msgs::sensor_msgs::{PointCloud2, PointField};
 use lcm_msgs::std_msgs::{Header, Time};
@@ -111,7 +113,11 @@ impl RayTracingVoxelMap {
         let points = match extract_xyz(&msg) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("voxel_ray_tracing: bad cloud, dropped: {e}");
+                warn_throttled!(
+                    Duration::from_secs(1),
+                    error = %e,
+                    "Failed to get lidar points, dropped a cloud.",
+                );
                 return;
             }
         };
@@ -137,7 +143,11 @@ impl RayTracingVoxelMap {
             msg.header.stamp,
         );
         if let Err(e) = self.global_map.publish(&cloud).await {
-            eprintln!("voxel_ray_tracing: publish failed: {e}");
+            error_throttled!(
+                Duration::from_secs(1),
+                error = %e,
+                "Updated voxel map failed to publish",
+            );
         }
     }
 }

--- a/examples/native-modules/rust/Cargo.lock
+++ b/examples/native-modules/rust/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13,6 +22,12 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "dimos-lcm"
@@ -33,6 +48,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -52,6 +69,7 @@ dependencies = [
  "lcm-msgs",
  "serde",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -61,7 +79,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -69,6 +87,12 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lcm-msgs"
@@ -83,6 +107,21 @@ name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "memchr"
@@ -100,6 +139,21 @@ dependencies = [
  "wasi",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "pin-project-lite"
@@ -124,6 +178,23 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "serde"
@@ -169,6 +240,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,6 +257,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
@@ -210,6 +296,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,10 +332,90 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "wasi"

--- a/examples/native-modules/rust/Cargo.toml
+++ b/examples/native-modules/rust/Cargo.toml
@@ -16,3 +16,4 @@ dimos-module = { path = "../../../native/rust/dimos-module" }
 lcm-msgs = { git = "https://github.com/dimensionalOS/dimos-lcm.git", branch = "rust-codegen" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 serde = { version = "1", features = ["derive"] }
+tracing = "0.1"

--- a/examples/native-modules/rust/src/native_ping.rs
+++ b/examples/native-modules/rust/src/native_ping.rs
@@ -39,9 +39,10 @@ impl Ping {
     }
 
     async fn handle_confirm(&mut self, echo: Twist) {
-        println!(
-            "ping: echo received (seq={}, sample_config={})",
-            echo.linear.x as u64, echo.angular.z as i64,
+        tracing::info!(
+            seq = echo.linear.x as u64,
+            sample_config = echo.angular.z as i64,
+            "echo received",
         );
     }
 }

--- a/native/rust/Cargo.lock
+++ b/native/rust/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13,6 +22,12 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "dimos-lcm"
@@ -34,6 +49,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -52,7 +69,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -60,6 +77,12 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lcm-msgs"
@@ -74,6 +97,21 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "memchr"
@@ -91,6 +129,21 @@ dependencies = [
  "wasi",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "pin-project-lite"
@@ -115,6 +168,23 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "serde"
@@ -160,6 +230,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,6 +247,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
@@ -201,6 +286,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,10 +322,90 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "wasi"

--- a/native/rust/Cargo.lock
+++ b/native/rust/Cargo.lock
@@ -51,6 +51,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "tracing-test",
 ]
 
 [[package]]
@@ -393,6 +394,27 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "tracing-test"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a4c448db514d4f24c5ddb9f73f2ee71bfb24c526cf0c570ba142d1119e0051"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/native/rust/dimos-module/Cargo.toml
+++ b/native/rust/dimos-module/Cargo.toml
@@ -16,3 +16,4 @@ tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
 
 [dev-dependencies]
 lcm-msgs = { git = "https://github.com/dimensionalOS/dimos-lcm.git", branch = "rust-codegen" }
+tracing-test = "0.2"

--- a/native/rust/dimos-module/Cargo.toml
+++ b/native/rust/dimos-module/Cargo.toml
@@ -11,6 +11,8 @@ dimos-module-macros = { version = "=0.1.0", path = "../dimos-module-macros" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time", "signal", "io-std", "io-util"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
 
 [dev-dependencies]
 lcm-msgs = { git = "https://github.com/dimensionalOS/dimos-lcm.git", branch = "rust-codegen" }

--- a/native/rust/dimos-module/src/lib.rs
+++ b/native/rust/dimos-module/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod lcm;
+pub mod log;
 pub mod module;
 pub mod transport;
 

--- a/native/rust/dimos-module/src/log.rs
+++ b/native/rust/dimos-module/src/log.rs
@@ -1,0 +1,77 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::OnceLock;
+use std::time::Instant;
+
+pub fn process_uptime_ns() -> u64 {
+    static START: OnceLock<Instant> = OnceLock::new();
+    START.get_or_init(Instant::now).elapsed().as_nanos() as u64
+}
+
+#[inline]
+#[doc(hidden)]
+pub fn check_and_record(last_ns: &AtomicU64, interval_ns: u64) -> bool {
+    let now_ns = process_uptime_ns().max(1);
+    let last = last_ns.load(Ordering::Relaxed);
+    (last == 0 || now_ns.saturating_sub(last) >= interval_ns)
+        && last_ns
+            .compare_exchange(last, now_ns, Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok()
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! log_throttled {
+    ($level:expr, $interval:expr, $($arg:tt)*) => {{
+        if ::tracing::enabled!($level) {
+            static LAST_NS: ::std::sync::atomic::AtomicU64 =
+                ::std::sync::atomic::AtomicU64::new(0);
+            if $crate::log::check_and_record(&LAST_NS, $interval.as_nanos() as u64) {
+                ::tracing::event!($level, $($arg)*);
+            }
+        }
+    }};
+}
+
+#[macro_export]
+macro_rules! trace_throttled {
+    ($($arg:tt)*) => { $crate::log_throttled!(::tracing::Level::TRACE, $($arg)*) };
+}
+
+#[macro_export]
+macro_rules! debug_throttled {
+    ($($arg:tt)*) => { $crate::log_throttled!(::tracing::Level::DEBUG, $($arg)*) };
+}
+
+#[macro_export]
+macro_rules! info_throttled {
+    ($($arg:tt)*) => { $crate::log_throttled!(::tracing::Level::INFO, $($arg)*) };
+}
+
+#[macro_export]
+macro_rules! warn_throttled {
+    ($($arg:tt)*) => { $crate::log_throttled!(::tracing::Level::WARN, $($arg)*) };
+}
+
+#[macro_export]
+macro_rules! error_throttled {
+    ($($arg:tt)*) => { $crate::log_throttled!(::tracing::Level::ERROR, $($arg)*) };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::check_and_record;
+    use std::sync::atomic::AtomicU64;
+    use std::time::Duration;
+
+    #[test]
+    fn throttles_within_interval_then_fires_after() {
+        let counter = AtomicU64::new(0);
+        let interval_ns = Duration::from_millis(50).as_nanos() as u64;
+        assert!(check_and_record(&counter, interval_ns));
+        assert!(!check_and_record(&counter, interval_ns));
+
+        // after waiting for > interval we should fire again
+        std::thread::sleep(Duration::from_millis(75));
+        assert!(check_and_record(&counter, interval_ns));
+    }
+}

--- a/native/rust/dimos-module/src/module.rs
+++ b/native/rust/dimos-module/src/module.rs
@@ -6,10 +6,21 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::sync::mpsc;
+use tracing::{error, info, warn};
+use tracing_subscriber::EnvFilter;
 
 use serde::de::DeserializeOwned;
 
 use crate::transport::Transport;
+
+fn init_tracing() {
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    let _ = tracing_subscriber::fmt()
+        .json()
+        .with_writer(std::io::stderr)
+        .with_env_filter(filter)
+        .try_init();
+}
 
 const INPUT_CHANNEL_CAPACITY: usize = 1024;
 const PUBLISH_CHANNEL_CAPACITY: usize = 1024;
@@ -45,15 +56,17 @@ impl<T: Send + 'static> Route for TypedRoute<T> {
                         .unwrap_or(true)
                     {
                         *last = Some(now);
-                        eprintln!(
-                            "dimos_module: input '{}' dropped {} message(s) — handler can't keep up (queue cap = {})",
-                            self.topic, n, INPUT_CHANNEL_CAPACITY,
+                        warn!(
+                            topic = %self.topic,
+                            dropped = n,
+                            queue_cap = INPUT_CHANNEL_CAPACITY,
+                            "input queue full — handler can't keep up",
                         );
                     }
                 }
                 Err(mpsc::error::TrySendError::Closed(_)) => {}
             },
-            Err(e) => eprintln!("dimos_module: decode error on {}: {e}", self.topic),
+            Err(e) => error!(topic = %self.topic, error = %e, "decode error"),
         }
     }
 }
@@ -207,7 +220,7 @@ pub(crate) fn spawn_pubsub_tasks<T: Transport>(
                         }
                     }
                 }
-                Err(e) => eprintln!("dimos_module: recv error: {e}"),
+                Err(e) => error!(error = %e, "recv error"),
             }
         }
     });
@@ -216,7 +229,7 @@ pub(crate) fn spawn_pubsub_tasks<T: Transport>(
     let pub_handle = tokio::spawn(async move {
         while let Some((topic, data)) = publish_rx.recv().await {
             if let Err(e) = pub_transport.publish(&topic, &data).await {
-                eprintln!("dimos_module: publish error on {topic}: {e}");
+                error!(topic = %topic, error = %e, "publish error");
             }
         }
     });
@@ -226,9 +239,9 @@ pub(crate) fn spawn_pubsub_tasks<T: Transport>(
 
 fn propagate_task_failure(name: &str, res: Result<(), tokio::task::JoinError>) {
     match res {
-        Ok(()) => eprintln!("dimos_module: {name} task exited unexpectedly"),
+        Ok(()) => error!(task = name, "task exited unexpectedly"),
         Err(e) => {
-            eprintln!("dimos_module: {name} task panicked, propagating");
+            error!(task = name, "task panicked, propagating");
             std::panic::resume_unwind(e.into_panic());
         }
     }
@@ -239,6 +252,8 @@ where
     M: Module,
     T: Transport,
 {
+    init_tracing();
+
     let mut line = String::new();
     BufReader::new(tokio::io::stdin())
         .read_line(&mut line)
@@ -249,11 +264,10 @@ where
         .ok()
         .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
         .unwrap_or_else(|| "unknown".to_string());
-    eprintln!("[{exe}] topics received:");
     for (port, topic) in &topics {
-        eprintln!("  {port} -> {topic}");
+        info!(exe = %exe, port = %port, topic = %topic, "topic mapping");
     }
-    eprintln!("[{exe}] config: {config:?}");
+    info!(exe = %exe, config = ?config, "config loaded");
 
     let (publish_tx, publish_rx) = mpsc::channel::<(String, Vec<u8>)>(PUBLISH_CHANNEL_CAPACITY);
     let mut builder = Builder::new(topics, publish_tx);

--- a/native/rust/dimos-module/src/module.rs
+++ b/native/rust/dimos-module/src/module.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::sync::mpsc;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 use tracing_subscriber::EnvFilter;
 
 use serde::de::DeserializeOwned;
@@ -36,6 +36,7 @@ struct TypedRoute<T: Send + 'static> {
     decode: fn(&[u8]) -> io::Result<T>,
     sender: mpsc::Sender<T>,
     drop_count: AtomicU64,
+    last_log_ns: AtomicU64,
 }
 
 impl<T: Send + 'static> Route for TypedRoute<T> {
@@ -44,14 +45,20 @@ impl<T: Send + 'static> Route for TypedRoute<T> {
             Ok(msg) => match self.sender.try_send(msg) {
                 Ok(()) => {}
                 Err(mpsc::error::TrySendError::Full(_)) => {
+                    // throttle the warning logging per route
+                    // we can't use warn_throttled! because this code is shared across all route instances
                     let n = self.drop_count.fetch_add(1, Ordering::Relaxed) + 1;
-                    crate::warn_throttled!(
-                        Duration::from_secs(1),
-                        topic = %self.topic,
-                        dropped = n,
-                        queue_cap = INPUT_CHANNEL_CAPACITY,
-                        "Dispatcher could not send message because handler was full.",
-                    );
+                    if crate::log::check_and_record(
+                        &self.last_log_ns,
+                        Duration::from_secs(1).as_nanos() as u64,
+                    ) {
+                        warn!(
+                            topic = %self.topic,
+                            dropped = n,
+                            queue_cap = INPUT_CHANNEL_CAPACITY,
+                            "Dispatcher could not send message because handler was full.",
+                        );
+                    }
                 }
                 Err(mpsc::error::TrySendError::Closed(_)) => {}
             },
@@ -174,6 +181,7 @@ impl Builder {
                 decode,
                 sender: tx,
                 drop_count: AtomicU64::new(0),
+                last_log_ns: AtomicU64::new(0),
             }));
         Input {
             topic,
@@ -600,6 +608,7 @@ mod tests {
             decode: |b| Ok(b.to_vec()),
             sender: tx,
             drop_count: AtomicU64::new(0),
+            last_log_ns: AtomicU64::new(0),
         };
         route.try_dispatch(&[1u8]); // fill queue
         route.try_dispatch(&[1u8]); // now we warn

--- a/native/rust/dimos-module/src/module.rs
+++ b/native/rust/dimos-module/src/module.rs
@@ -2,11 +2,11 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::io;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
+use std::sync::Arc;
+use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::sync::mpsc;
-use tracing::{error, info, warn};
+use tracing::{error, info};
 use tracing_subscriber::EnvFilter;
 
 use serde::de::DeserializeOwned;
@@ -24,8 +24,6 @@ fn init_tracing() {
 
 const INPUT_CHANNEL_CAPACITY: usize = 1024;
 const PUBLISH_CHANNEL_CAPACITY: usize = 1024;
-/// Maximum drop-warning log lines per second per route.
-const MAX_ERROR_LOG_RATE: u32 = 1;
 
 // Each input() call produces a TypedRoute that decodes its message type
 // and forwards it to the right Input's mpsc channel.
@@ -38,7 +36,6 @@ struct TypedRoute<T: Send + 'static> {
     decode: fn(&[u8]) -> io::Result<T>,
     sender: mpsc::Sender<T>,
     drop_count: AtomicU64,
-    last_log: Mutex<Option<Instant>>,
 }
 
 impl<T: Send + 'static> Route for TypedRoute<T> {
@@ -48,21 +45,13 @@ impl<T: Send + 'static> Route for TypedRoute<T> {
                 Ok(()) => {}
                 Err(mpsc::error::TrySendError::Full(_)) => {
                     let n = self.drop_count.fetch_add(1, Ordering::Relaxed) + 1;
-                    let interval = Duration::from_secs(1) / MAX_ERROR_LOG_RATE;
-                    let mut last = self.last_log.lock().unwrap();
-                    let now = Instant::now();
-                    if last
-                        .map(|t| now.duration_since(t) >= interval)
-                        .unwrap_or(true)
-                    {
-                        *last = Some(now);
-                        warn!(
-                            topic = %self.topic,
-                            dropped = n,
-                            queue_cap = INPUT_CHANNEL_CAPACITY,
-                            "input queue full — handler can't keep up",
-                        );
-                    }
+                    crate::warn_throttled!(
+                        Duration::from_secs(1),
+                        topic = %self.topic,
+                        dropped = n,
+                        queue_cap = INPUT_CHANNEL_CAPACITY,
+                        "Dispatcher could not send message because handler was full.",
+                    );
                 }
                 Err(mpsc::error::TrySendError::Closed(_)) => {}
             },
@@ -185,7 +174,6 @@ impl Builder {
                 decode,
                 sender: tx,
                 drop_count: AtomicU64::new(0),
-                last_log: Mutex::new(None),
             }));
         Input {
             topic,
@@ -604,22 +592,18 @@ mod tests {
     }
 
     #[test]
-    fn typed_route_logs_error_on_drop() {
+    #[tracing_test::traced_test]
+    fn typed_route_warns_and_counts_on_drop() {
         let (tx, _rx) = mpsc::channel::<Vec<u8>>(1);
         let route = TypedRoute {
             topic: "/test".to_string(),
             decode: |b| Ok(b.to_vec()),
             sender: tx,
             drop_count: AtomicU64::new(0),
-            last_log: Mutex::new(None),
         };
-        // Fill the queue, then force a drop.
-        route.try_dispatch(&[1u8]);
-        route.try_dispatch(&[1u8]);
+        route.try_dispatch(&[1u8]); // fill queue
+        route.try_dispatch(&[1u8]); // now we warn
         assert_eq!(route.drop_count.load(Ordering::Relaxed), 1);
-        assert!(
-            route.last_log.lock().unwrap().is_some(),
-            "drop must trigger a log",
-        );
+        assert!(logs_contain("handler was full"));
     }
 }

--- a/uv.lock
+++ b/uv.lock
@@ -44,8 +44,8 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-dimos-viewer = "2026-05-23T00:00:00Z"
-md-babel-py = "2026-05-17T00:00:00Z"
+dimos-viewer = "2026-05-23T07:00:00Z"
+md-babel-py = "2026-05-17T07:00:00Z"
 
 [manifest]
 overrides = [


### PR DESCRIPTION
## Problem

Logging levels from native modules wasn't respected, only behavior was stdout -> "info" and stderr -> "warn". Also Rust modules were using println! and eprintln!.

Closes DIM-936

## Solution

- On Python native module side, read "level" from json log message. Map that string to python logging levels.
- Switch Rust logging to use tracing crate. Set RUST_LOG to match dimos log level env var.
- Add Rust macro for throttled versions of tracing macros (I'm thinking of publishing this on crates.io in the future fyi).
- Fix core Rust test for dropping to actually check logs

## How to Test

`uv run pytest dimos/core/test_native_module.py` python unit tests
`cd native/rust && cargo test -p dimos-module` rust unit tests
`cd examples/native-modules/rust && cargo build --release && uv run python3 ../rust_ping_pong.py` rust with `DIMOS_LOG_LEVEL=INFO` and 'DIMOS_LOG_LEVEL=ERROR` to verify info logs turn off.

## Contributor License Agreement

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
