### PR TITLE
PointCloud2 including time per point

### DIFF
--- a/dimos/msgs/sensor_msgs/PointCloud2.py
+++ b/dimos/msgs/sensor_msgs/PointCloud2.py
@@ -178,6 +178,7 @@ class PointCloud2(Timestamped):
         frame_id: str = "world",
         timestamp: float | None = None,
         intensities: np.ndarray | None = None,
+        times: np.ndarray | None = None,
     ) -> PointCloud2:
         """Create PointCloud2 from numpy array of shape (N, 3).
 
@@ -186,6 +187,8 @@ class PointCloud2(Timestamped):
             frame_id: Frame ID for the point cloud
             timestamp: Timestamp for the point cloud (defaults to current time)
             intensities: Optional Nx1 or (N,) float array of per-point intensity values
+            times: Optional Nx1 or (N,) float array of per-point times (seconds, typically
+                frame-relative to ``timestamp``). Used by motion-deskew consumers.
 
         Returns:
             PointCloud2 instance
@@ -197,6 +200,11 @@ class PointCloud2(Timestamped):
             if arr.ndim == 1:
                 arr = arr.reshape(-1, 1)
             pcd_t.point["intensities"] = o3c.Tensor(arr, dtype=o3c.float32)
+        if times is not None:
+            tarr = times.astype(np.float32)
+            if tarr.ndim == 1:
+                tarr = tarr.reshape(-1, 1)
+            pcd_t.point["t"] = o3c.Tensor(tarr, dtype=o3c.float32)
         return cls(pointcloud=pcd_t, ts=timestamp, frame_id=frame_id)
 
     @classmethod
@@ -422,6 +430,15 @@ class PointCloud2(Timestamped):
             return arr.astype(np.float32) if arr.dtype != np.float32 else arr  # type: ignore[no-any-return]
         return None
 
+    def times_f32(self) -> np.ndarray | None:
+        """Get per-point times as a flat float32 array, or ``None`` if absent.
+        """
+        self._ensure_tensor_initialized()
+        if "t" in self._pcd_tensor.point:
+            arr = self._pcd_tensor.point["t"].numpy().flatten()
+            return arr.astype(np.float32) if arr.dtype != np.float32 else arr  # type: ignore[no-any-return]
+        return None
+
     @functools.cached_property
     def axis_aligned_bounding_box(self) -> o3d.geometry.AxisAlignedBoundingBox:
         """Get axis-aligned bounding box of the point cloud."""
@@ -475,21 +492,27 @@ class PointCloud2(Timestamped):
 
         points, _ = self.as_numpy()
 
-        # Check if pointcloud has colors
+        # Check if pointcloud has colors / per-point times
         self._ensure_tensor_initialized()
         has_colors = "colors" in self._pcd_tensor.point
+        times = self.times_f32()
 
         if len(points) == 0:
             msg.height = 0
             msg.width = 0
-            msg.point_step = 16
+            msg.point_step = 20 if times is not None else 16
             msg.row_step = 0
             msg.data_length = 0
             msg.data = b""
             msg.is_dense = True
             msg.is_bigendian = False
-            msg.fields_length = 4
-            msg.fields = self._create_xyzrgb_fields() if has_colors else self._create_xyz_fields()
+            base_fields = (
+                self._create_xyzrgb_fields() if has_colors else self._create_xyz_fields()
+            )
+            if times is not None:
+                base_fields.append(self._create_time_field())
+            msg.fields = base_fields
+            msg.fields_length = len(base_fields)
             return msg.lcm_encode()  # type: ignore[no-any-return]
 
         msg.height = 1
@@ -531,6 +554,13 @@ class PointCloud2(Timestamped):
 
             point_data = np.column_stack([points, intensities]).astype(np.float32)
 
+        # Append optional per-point time at offset 16 (FLOAT32).
+        if times is not None:
+            msg.fields = [*msg.fields, self._create_time_field()]
+            msg.fields_length = len(msg.fields)
+            msg.point_step = 20
+            point_data = np.column_stack([point_data, times]).astype(np.float32)
+
         msg.row_step = msg.point_step * msg.width
         data_bytes = point_data.tobytes()
         msg.data_length = len(data_bytes)
@@ -556,7 +586,8 @@ class PointCloud2(Timestamped):
             )
 
         # Parse field offsets
-        x_offset = y_offset = z_offset = rgb_offset = intensity_offset = None
+        x_offset = y_offset = z_offset = rgb_offset = intensity_offset = t_offset = None
+        t_datatype: int | None = None
         for msgfield in msg.fields:
             if msgfield.name == "x":
                 x_offset = msgfield.offset
@@ -568,6 +599,9 @@ class PointCloud2(Timestamped):
                 rgb_offset = msgfield.offset
             elif msgfield.name == "intensity":
                 intensity_offset = msgfield.offset
+            elif msgfield.name == "t":
+                t_offset = msgfield.offset
+                t_datatype = msgfield.datatype
 
         if any(offset is None for offset in [x_offset, y_offset, z_offset]):
             raise ValueError("PointCloud2 message missing X, Y, or Z msgfields")
@@ -620,6 +654,23 @@ class PointCloud2(Timestamped):
                     intensities.reshape(-1, 1), dtype=o3c.float32
                 )
 
+        # Extract per-point time if present
+        if t_offset is not None:
+            t_wire_dtype = "<f8" if t_datatype == 8 else "<f4"
+            t_wire_size = 8 if t_datatype == 8 else 4
+            spec: list[tuple[str, str]] = []
+            if t_offset > 0:
+                spec.append(("_pre", f"V{t_offset}"))
+            spec.append(("t", t_wire_dtype))
+            post = point_step - t_offset - t_wire_size
+            if post > 0:
+                spec.append(("_post", f"V{post}"))
+            times = (
+                np.frombuffer(raw_data, dtype=np.dtype(spec), count=num_points)["t"]
+                .astype(np.float32)
+            )
+            pcd_t.point["t"] = o3c.Tensor(times.reshape(-1, 1), dtype=o3c.float32)
+
         # Extract RGB colors if present
         if rgb_offset is not None:
             dt = np.dtype(
@@ -656,6 +707,15 @@ class PointCloud2(Timestamped):
             field.count = 1
             fields.append(field)
         return fields
+
+    def _create_time_field(self) -> PointField:
+        """Create the optional per-point time (``t``) field at offset 16 (FLOAT32)."""
+        field = PointField()
+        field.name = "t"
+        field.offset = 16
+        field.datatype = 7  # FLOAT32
+        field.count = 1
+        return field
 
     def _create_xyzrgb_fields(self) -> list:  # type: ignore[type-arg]
         """Create X, Y, Z, RGB field definitions for colored pointclouds."""

--- a/dimos/msgs/sensor_msgs/test_PointCloud2.py
+++ b/dimos/msgs/sensor_msgs/test_PointCloud2.py
@@ -111,6 +111,68 @@ def test_lcm_no_intensity_round_trip() -> None:
     np.testing.assert_allclose(decoded_pts.astype(np.float32), points, atol=1e-6)
 
 
+def test_lcm_per_point_time_round_trip() -> None:
+    """Per-point time survives an lcm_encode → lcm_decode round trip alongside intensity."""
+    points = np.array(
+        [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0], [0.0, 0.0, 0.0]],
+        dtype=np.float32,
+    )
+    intensities = np.array([0.25, 1.1, 0.0, 3.0], dtype=np.float32)
+    # Seconds relative to the scan-start timestamp (small => exact in float32).
+    times = np.array([0.0, 0.03, 0.06, 0.099], dtype=np.float32)
+
+    original = PointCloud2.from_numpy(
+        points, frame_id="lidar", timestamp=42.5, intensities=intensities, times=times
+    )
+
+    # Getter works before encoding.
+    src_t = original.times_f32()
+    assert src_t is not None
+    np.testing.assert_allclose(src_t, times, rtol=0, atol=1e-7)
+
+    decoded = PointCloud2.lcm_decode(original.lcm_encode())
+
+    op, _ = original.as_numpy()
+    dp, _ = decoded.as_numpy()
+    assert len(op) == len(dp) == 4
+    np.testing.assert_allclose(op, dp, rtol=1e-6, atol=1e-6)
+
+    dec_t = decoded.times_f32()
+    assert dec_t is not None, "times_f32() returned None after decode"
+    np.testing.assert_allclose(dec_t, times, rtol=0, atol=1e-7)
+
+    dec_i = decoded.intensities_f32()
+    assert dec_i is not None
+    np.testing.assert_allclose(dec_i, intensities, rtol=0, atol=1e-7)
+
+    assert decoded.frame_id == "lidar"
+    assert decoded.ts is not None and abs(decoded.ts - 42.5) < 1e-6
+
+
+def test_lcm_no_time_round_trip() -> None:
+    """Clouds without per-point time should round-trip with times_f32() still None."""
+    points = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=np.float32)
+    original = PointCloud2.from_numpy(points, frame_id="map", timestamp=1.0)
+    assert original.times_f32() is None
+
+    decoded = PointCloud2.lcm_decode(original.lcm_encode())
+    assert decoded.times_f32() is None
+
+
+def test_lcm_empty_cloud_with_times_metadata() -> None:
+    """An empty cloud built via from_numpy(times=...) encodes/decodes cleanly."""
+    empty = PointCloud2.from_numpy(
+        np.zeros((0, 3), dtype=np.float32),
+        frame_id="lidar",
+        timestamp=7.0,
+        times=np.zeros((0,), dtype=np.float32),
+    )
+    decoded = PointCloud2.lcm_decode(empty.lcm_encode())
+    assert len(decoded) == 0
+    # Empty cloud has no per-point data on the wire, so times_f32 is None after decode.
+    assert decoded.times_f32() is None
+
+
 def test_bounding_box_intersects() -> None:
     """Test bounding_box_intersects method with various scenarios."""
     # Test 1: Overlapping boxes


### PR DESCRIPTION
## Problem

  PointCloud2 does not allow for per-point timestamps. LiDAR drivers like RoboSense E1R emit a per-point timestamp field that motion-deskew consumers (FAST-LIO) need to correct for sensor motion within a single scan. 

  ##Solution

  Add an optional times field to PointCloud2 that stores per-point times as the t channel on the underlying tensor point cloud. No behavior change when times is omitted.

  ##How to Test

  pytest dimos/msgs/sensor_msgs/test_PointCloud2.py

