### PR TITLE
removed security demo which requires cuda

### DIFF
--- a/dimos/robot/unitree/go2/blueprints/smart/unitree_go2_spatial.py
+++ b/dimos/robot/unitree/go2/blueprints/smart/unitree_go2_spatial.py
@@ -14,17 +14,14 @@
 # limitations under the License.
 
 from dimos.core.coordination.blueprints import autoconnect
-from dimos.experimental.security_demo.security_module import SecurityModule
 from dimos.perception.perceive_loop_skill import PerceiveLoopSkill
 from dimos.perception.spatial_perception import SpatialMemory
 from dimos.robot.unitree.go2.blueprints.smart.unitree_go2 import unitree_go2
-from dimos.robot.unitree.go2.connection import GO2Connection
 
 unitree_go2_spatial = autoconnect(
     unitree_go2,
     SpatialMemory.blueprint(),
     PerceiveLoopSkill.blueprint(),
-    SecurityModule.blueprint(camera_info=GO2Connection.camera_info_static),
 ).global_config(n_workers=8)
 
 __all__ = ["unitree_go2_spatial"]


### PR DESCRIPTION
## Problem

Unitree go2 agentic has been broken on all CUDA machines due to SecurityModule related demo 

Closes DIM-XXX

## Solution

<!-- What you changed and why this approach -->
<!-- Key design decisions / tradeoffs -->
<!-- Keep it high-signal; deep planning belongs in the issue. -->

## How to Test

`uv run dimos --replay run unitree-go2-agentic` on macos
<!-- oneliner required to run the actual feature -->
<!-- blueprint for robot changes, benchmarks for transport changes etc -->

## Contributor License Agreement

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
