### PR TITLE
feat: add Go2+Mid360 recording blueprint (issue #2202)

### DIFF
--- a/dimos/robot/all_blueprints.py
+++ b/dimos/robot/all_blueprints.py
@@ -102,6 +102,7 @@ all_blueprints = {
     "unitree-go2-fleet": "dimos.robot.unitree.go2.blueprints.basic.unitree_go2_fleet:unitree_go2_fleet",
     "unitree-go2-keyboard-teleop": "dimos.robot.unitree.go2.blueprints.basic.unitree_go2_keyboard_teleop:unitree_go2_keyboard_teleop",
     "unitree-go2-memory": "dimos.robot.unitree.go2.blueprints.smart.unitree_go2:unitree_go2_memory",
+    "unitree-go2-mid360-memory": "dimos.robot.unitree.go2.blueprints.smart.unitree_go2_mid360:unitree_go2_mid360_memory",
     "unitree-go2-ros": "dimos.robot.unitree.go2.blueprints.smart.unitree_go2_ros:unitree_go2_ros",
     "unitree-go2-security": "dimos.robot.unitree.go2.blueprints.agentic.unitree_go2_security:unitree_go2_security",
     "unitree-go2-spatial": "dimos.robot.unitree.go2.blueprints.smart.unitree_go2_spatial:unitree_go2_spatial",

--- a/dimos/robot/unitree/go2/blueprints/smart/unitree_go2_mid360.py
+++ b/dimos/robot/unitree/go2/blueprints/smart/unitree_go2_mid360.py
@@ -36,7 +36,6 @@ from typing import Any
 from reactivex.disposable import Disposable
 
 from dimos.core.coordination.blueprints import autoconnect
-from dimos.utils.logging_config import setup_logger
 from dimos.core.stream import In
 from dimos.hardware.sensors.lidar.fastlio2.module import FastLio2
 from dimos.memory2.module import Recorder, RecorderConfig
@@ -47,6 +46,7 @@ from dimos.msgs.sensor_msgs.Image import Image
 from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
 from dimos.robot.unitree.go2.blueprints.basic.unitree_go2_basic import unitree_go2_basic
 from dimos.robot.unitree.go2.connection import GO2Connection
+from dimos.utils.logging_config import setup_logger
 
 logger = setup_logger()
 
@@ -91,7 +91,9 @@ class Go2Mid360Memory(Recorder):
             )
             if frame_id == "world":
                 frame_id = default_frame_id
-            transform = self.tf.get("world", frame_id, time_point=msg_ts, time_tolerance=tf_tolerance)
+            transform = self.tf.get(
+                "world", frame_id, time_point=msg_ts, time_tolerance=tf_tolerance
+            )
             pose = transform.to_pose() if transform is not None else None
             if not pose:
                 logger.warning(

--- a/dimos/robot/unitree/go2/blueprints/smart/unitree_go2_mid360.py
+++ b/dimos/robot/unitree/go2/blueprints/smart/unitree_go2_mid360.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Go2 + Livox Mid-360 data collection blueprint.
+
+Records color_image (Go2 camera), FastLio2 lidar (Mid360), and FastLio2
+odometry to a SQLite database for offline map validation and multi-level
+path planning development (issue #2202).
+
+GO2Connection's native ``lidar`` is remapped to ``go2_lidar`` to avoid
+colliding with FastLio2's registered point cloud on the ``lidar`` topic.
+
+Usage::
+
+    dimos --dtop --robot-ip 192.168.1.73 run unitree-go2-mid360-memory
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any
+
+from reactivex.disposable import Disposable
+
+from dimos.core.coordination.blueprints import autoconnect
+from dimos.core.stream import In
+from dimos.hardware.sensors.lidar.fastlio2.module import FastLio2
+from dimos.memory2.module import Recorder, RecorderConfig
+from dimos.memory2.stream import Stream
+from dimos.msgs.nav_msgs.Odometry import Odometry
+from dimos.msgs.sensor_msgs.Image import Image
+from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
+from dimos.robot.unitree.go2.blueprints.basic.unitree_go2_basic import unitree_go2_basic
+from dimos.robot.unitree.go2.connection import GO2Connection
+
+_voxel_size = 0.05
+
+# FastLIO ports stamped by the C++ binary with hardware clock; must be
+# overridden to time.time() so they align with color_image (also time.time()).
+_FASTLIO_PORTS = frozenset({"lidar", "odometry"})
+
+
+class Go2Mid360MemoryConfig(RecorderConfig):
+    db_path: str | Path = "recording_go2_mid360.db"
+    default_frame_id: str = "base_link"
+
+
+class Go2Mid360Memory(Recorder):
+    """Records Go2 camera, native Go2 lidar, Mid-360 lidar, and FastLio2 odometry."""
+
+    color_image: In[Image]
+    go2_lidar: In[PointCloud2]
+    lidar: In[PointCloud2]
+    odometry: In[Odometry]
+    config: Go2Mid360MemoryConfig
+
+    def _port_to_stream(self, name: str, input_topic: In[Any], stream: Stream[Any]) -> None:
+        if name not in _FASTLIO_PORTS:
+            super()._port_to_stream(name, input_topic, stream)
+            return
+
+        # Force time.time() so FastLIO hardware timestamps match image timestamps.
+        default_frame_id = self.config.default_frame_id
+        tf_tolerance = self.config.tf_tolerance
+
+        def on_msg(msg: Any) -> None:
+            ts = time.time()
+            frame_id = (
+                getattr(msg, "child_frame_id", None)
+                or getattr(msg, "frame_id", None)
+                or default_frame_id
+            )
+            if frame_id == "world":
+                frame_id = default_frame_id
+            transform = self.tf.get("world", frame_id, time_point=ts, time_tolerance=tf_tolerance)
+            pose = transform.to_pose() if transform is not None else None
+            stream.append(msg, ts=ts, pose=pose)
+
+        self.register_disposable(Disposable(input_topic.subscribe(on_msg)))
+
+
+unitree_go2_mid360_memory = (
+    autoconnect(
+        unitree_go2_basic,
+        FastLio2.blueprint(
+            voxel_size=_voxel_size,
+            map_voxel_size=_voxel_size,
+            map_freq=-1,
+        ),
+        Go2Mid360Memory.blueprint(),
+    )
+    .remappings([
+        (GO2Connection, "lidar", "go2_lidar"),
+    ])
+    .global_config(n_workers=6, robot_model="unitree_go2")
+)
+
+__all__ = ["unitree_go2_mid360_memory"]

--- a/dimos/robot/unitree/go2/blueprints/smart/unitree_go2_mid360.py
+++ b/dimos/robot/unitree/go2/blueprints/smart/unitree_go2_mid360.py
@@ -29,8 +29,8 @@ Usage::
 
 from __future__ import annotations
 
-import time
 from pathlib import Path
+import time
 from typing import Any
 
 from reactivex.disposable import Disposable
@@ -102,9 +102,11 @@ unitree_go2_mid360_memory = (
         ),
         Go2Mid360Memory.blueprint(),
     )
-    .remappings([
-        (GO2Connection, "lidar", "go2_lidar"),
-    ])
+    .remappings(
+        [
+            (GO2Connection, "lidar", "go2_lidar"),
+        ]
+    )
     .global_config(n_workers=6, robot_model="unitree_go2")
 )
 

--- a/dimos/robot/unitree/go2/blueprints/smart/unitree_go2_mid360.py
+++ b/dimos/robot/unitree/go2/blueprints/smart/unitree_go2_mid360.py
@@ -36,15 +36,19 @@ from typing import Any
 from reactivex.disposable import Disposable
 
 from dimos.core.coordination.blueprints import autoconnect
+from dimos.utils.logging_config import setup_logger
 from dimos.core.stream import In
 from dimos.hardware.sensors.lidar.fastlio2.module import FastLio2
 from dimos.memory2.module import Recorder, RecorderConfig
 from dimos.memory2.stream import Stream
+from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
 from dimos.msgs.nav_msgs.Odometry import Odometry
 from dimos.msgs.sensor_msgs.Image import Image
 from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
 from dimos.robot.unitree.go2.blueprints.basic.unitree_go2_basic import unitree_go2_basic
 from dimos.robot.unitree.go2.connection import GO2Connection
+
+logger = setup_logger()
 
 _voxel_size = 0.05
 
@@ -59,12 +63,13 @@ class Go2Mid360MemoryConfig(RecorderConfig):
 
 
 class Go2Mid360Memory(Recorder):
-    """Records Go2 camera, native Go2 lidar, Mid-360 lidar, and FastLio2 odometry."""
+    """Records Go2 camera, native Go2 lidar, Mid-360 lidar, FastLio2 odometry, and Go2 leg odometry."""
 
     color_image: In[Image]
     go2_lidar: In[PointCloud2]
     lidar: In[PointCloud2]
     odometry: In[Odometry]
+    odom: In[PoseStamped]
     config: Go2Mid360MemoryConfig
 
     def _port_to_stream(self, name: str, input_topic: In[Any], stream: Stream[Any]) -> None:
@@ -78,6 +83,7 @@ class Go2Mid360Memory(Recorder):
 
         def on_msg(msg: Any) -> None:
             ts = time.time()
+            msg_ts = getattr(msg, "ts", None) or ts
             frame_id = (
                 getattr(msg, "child_frame_id", None)
                 or getattr(msg, "frame_id", None)
@@ -85,8 +91,16 @@ class Go2Mid360Memory(Recorder):
             )
             if frame_id == "world":
                 frame_id = default_frame_id
-            transform = self.tf.get("world", frame_id, time_point=ts, time_tolerance=tf_tolerance)
+            transform = self.tf.get("world", frame_id, time_point=msg_ts, time_tolerance=tf_tolerance)
             pose = transform.to_pose() if transform is not None else None
+            if not pose:
+                logger.warning(
+                    "[%s] No tf available for frame '%s' at time %s (msg ts: %s), storing without pose",
+                    name,
+                    frame_id,
+                    msg_ts,
+                    getattr(msg, "ts", None),
+                )
             stream.append(msg, ts=ts, pose=pose)
 
         self.register_disposable(Disposable(input_topic.subscribe(on_msg)))


### PR DESCRIPTION
## Problem

Issue (https://github.com/dimensionalOS/dimos/issues/2202)

Go2 + Mid-360 LiDAR data collection blueprint is missing. Needed for multi-level map validation and path planning development.

## Solution

Added `unitree_go2_mid360_memory` blueprint combining `unitree_go2_basic`, `FastLio2`, and a new `Go2Mid360Memory` recorder.

- `GO2Connection.lidar` remapped to `go2_lidar` to avoid topic collision with FastLio2
- Overrides `_port_to_stream` for FastLIO ports to force `time.time()` timestamps, aligning them with `color_image`
- Records 4 streams to SQLite: `color_image`, `go2_lidar`, `lidar`, `odometry`

## What & Why

Issue #2202 needed a blueprint to simultaneously record Go2 camera, native Go2 lidar, Mid-360 lidar (FastLio2), and odometry into SQLite for multi-level map validation and path planning development.

**Topic collision** — `GO2Connection` and `FastLio2` both publish on `lidar`. Resolved by remapping `GO2Connection.lidar → go2_lidar`.

**Timestamp misalignment** — `color_image` is stamped with `time.time()` (Python system clock). FastLio2 lidar/odometry are stamped by the C++ binary with the hardware clock, which can be seconds off from system time. The base `Recorder._port_to_stream` uses `msg.ts` for both the TF lookup and the stored timestamp — which works when everything is on the same clock, but silently stores FastLIO observations with wrong poses or no pose at all when clocks differ.

Fix: override `_port_to_stream` for FastLIO ports only. Use `msg.ts` (hardware clock) for the TF lookup so the transform query stays in the same clock domain as the published transforms. Use `time.time()` only for `stream.append(ts=...)` so the stored timestamp aligns with `color_image` in the DB. Added a warning log when pose is None so clock-offset issues are visible during recording instead of failing silently.

**5 streams recorded** to `recording_go2_mid360.db`:
| Stream | Source |
|---|---|
| `color_image` | Go2 camera |
| `go2_lidar` | Go2 native lidar |
| `lidar` | Mid-360 via FastLio2 |
| `odometry` | FastLio2 pose estimate |
| `odom` | Go2 native leg odometry |

## Contributor License Agreement

- [ ] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
