### PR TITLE
feat: add unitree-go2-rage blueprint with Rerun viewer support

### DIFF
--- a/dimos/robot/all_blueprints.py
+++ b/dimos/robot/all_blueprints.py
@@ -104,6 +104,7 @@ all_blueprints = {
     "unitree-go2-keyboard-teleop": "dimos.robot.unitree.go2.blueprints.basic.unitree_go2_keyboard_teleop:unitree_go2_keyboard_teleop",
     "unitree-go2-markers": "dimos.robot.unitree.go2.blueprints.smart.unitree_go2:unitree_go2_markers",
     "unitree-go2-memory": "dimos.robot.unitree.go2.blueprints.smart.unitree_go2:unitree_go2_memory",
+    "unitree-go2-rage": "dimos.robot.unitree.go2.blueprints.smart.unitree_go2:unitree_go2_rage",
     "unitree-go2-relocalization": "dimos.robot.unitree.go2.blueprints.smart.unitree_go2:unitree_go2_relocalization",
     "unitree-go2-ros": "dimos.robot.unitree.go2.blueprints.smart.unitree_go2_ros:unitree_go2_ros",
     "unitree-go2-security": "dimos.robot.unitree.go2.blueprints.agentic.unitree_go2_security:unitree_go2_security",

--- a/dimos/robot/unitree/go2/blueprints/smart/unitree_go2.py
+++ b/dimos/robot/unitree/go2/blueprints/smart/unitree_go2.py
@@ -32,6 +32,7 @@ from dimos.navigation.patrolling.module import PatrollingModule
 from dimos.navigation.replanning_a_star.module import ReplanningAStarPlanner
 from dimos.perception.fiducial.marker_tf_module import MarkerTfModule
 from dimos.robot.unitree.go2.blueprints.basic.unitree_go2_basic import unitree_go2_basic
+from dimos.robot.unitree.go2.connection import GO2Connection
 
 unitree_go2 = autoconnect(
     unitree_go2_basic,
@@ -42,6 +43,11 @@ unitree_go2 = autoconnect(
     PatrollingModule.blueprint(),
     MovementManager.blueprint(),
 ).global_config(n_workers=10, robot_model="unitree_go2")
+
+unitree_go2_rage = autoconnect(
+    unitree_go2,
+    GO2Connection.blueprint(mode="rage"),
+).global_config(obstacle_avoidance=True)
 
 
 class Go2MemoryConfig(RecorderConfig):


### PR DESCRIPTION
The existing rage keyboard teleop blueprint uses pygame which crashes on macOS due to X11/threading restrictions. This adds a unitree-go2-rage blueprint that composes from the full unitree-go2 stack (Rerun viewer, nav, mapping) with GO2Connection mode="rage" to enable FsmRageMode.

Run with: dimos run unitree-go2-rage

## Problem

<!-- What feature are you adding, or what is broken/missing/sub-optimal? -->
<!-- Context, symptoms, motivation. Link the issue. -->

Closes DIM-XXX

## Solution

<!-- What you changed and why this approach -->
<!-- Key design decisions / tradeoffs -->
<!-- Keep it high-signal; deep planning belongs in the issue. -->

## How to Test

<!-- oneliner required to run the actual feature -->
<!-- blueprint for robot changes, benchmarks for transport changes etc -->

## Contributor License Agreement

- [ ] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
