### PR TITLE
fix: pass viewer websocket URL for native teleop

### DIFF
--- a/dimos/visualization/rerun/bridge.py
+++ b/dimos/visualization/rerun/bridge.py
@@ -107,6 +107,10 @@ RerunMulti: TypeAlias = "list[tuple[str, Archetype]]"
 RerunData: TypeAlias = "Archetype | RerunMulti"
 
 
+def _dimos_viewer_extra_args(server_uri: str, ws_url: str) -> list[str]:
+    return ["--connect", server_uri, f"--ws-url={ws_url}"]
+
+
 def is_rerun_multi(data: Any) -> TypeGuard[RerunMulti]:
     """Check if data is a list of (entity_path, archetype) tuples."""
     return (
@@ -342,12 +346,15 @@ class RerunBridgeModule(Module):
             try:
                 import rerun_bindings
 
+                ws_url = f"ws://{self.host}:{self.config.g.rerun_websocket_server_port}/ws"
+
                 # Use --connect so the viewer connects to the bridge's gRPC
                 # server rather than starting its own (which would conflict).
+                # Use --ws-url so keyboard teleop events flow back to Dimos.
                 rerun_bindings.spawn(
                     executable_name="dimos-viewer",
                     memory_limit=self.config.memory_limit,
-                    extra_args=["--connect", server_uri],
+                    extra_args=_dimos_viewer_extra_args(server_uri, ws_url),
                 )
                 spawned = True
             except ImportError:

--- a/dimos/visualization/rerun/test_viewer_integration.py
+++ b/dimos/visualization/rerun/test_viewer_integration.py
@@ -116,3 +116,24 @@ class TestBridgeSpawnLogic:
             "bridge.py start() has no fallback for missing dimos-viewer. "
             "Users without dimos-viewer will crash."
         )
+
+    def test_viewer_extra_args_include_grpc_and_websocket_urls(self):
+        """Native dimos-viewer launch must include the teleop WebSocket URL."""
+        from dimos.visualization.rerun.bridge import _dimos_viewer_extra_args
+
+        server_uri = "rerun+http://127.0.0.1:9877/proxy"
+        ws_url = "ws://127.0.0.1:3030/ws"
+
+        assert _dimos_viewer_extra_args(server_uri, ws_url) == [
+            "--connect",
+            server_uri,
+            f"--ws-url={ws_url}",
+        ]
+
+    def test_bridge_uses_viewer_extra_args_helper(self):
+        """Guard against regressing to gRPC-only native viewer launch."""
+        from dimos.visualization.rerun.bridge import RerunBridgeModule
+
+        src = inspect.getsource(RerunBridgeModule.start)
+        assert "_dimos_viewer_extra_args" in src
+        assert "rerun_websocket_server_port" in src


### PR DESCRIPTION
## Summary
- pass the DimOS teleop WebSocket URL when auto-launching native `dimos-viewer`
- keep the existing Rerun gRPC `--connect` argument so the viewer still attaches to the bridge server
- add viewer integration coverage for the spawned argument list

## Root Cause
The native viewer launch path only supplied the Rerun gRPC connect URL. `dimos-viewer` sends keyboard teleop and click events back to DimOS through its `--ws-url` event channel, so auto-launched viewers could show data while WASD teleop had no return path.

## Validation
- `uv run ruff check dimos/visualization/rerun/bridge.py dimos/visualization/rerun/test_viewer_integration.py`
- `uv run pytest dimos/visualization/rerun/test_websocket_server.py dimos/visualization/rerun/test_viewer_integration.py -q`
- `uv run dimos-viewer --help | rg -n "ws-url|connect"`
