### PR TITLE
Hackathon: WorldForge Go2 Trace Judge

### DIFF
--- a/hackathon/worldforge_go2_trace_judge/README.md
+++ b/hackathon/worldforge_go2_trace_judge/README.md
@@ -1,0 +1,87 @@
+# WorldForge Go2 Trace Judge
+
+Hackathon submission from Omar Espejel, Abdel, and Ciro.
+
+## Summary
+
+WorldForge Go2 Trace Judge is an inspectable decision layer for Unitree Go2
+autonomy. It turns robot-view observations into candidate actions, scores those
+candidates, selects one action, and writes the evidence trail as replayable JSON.
+
+The core loop is:
+
+```text
+observation + goal + candidate action -> score -> selected action -> evidence
+```
+
+This submission keeps DimOS as the robot/runtime layer and uses WorldForge-style
+traces as the scoring, comparison, dataset, and evidence layer around Go2
+actions.
+
+## Links
+
+- Project repo: https://github.com/omarespejel/worldforge-go2-trace-judge
+- WorldForge: https://github.com/AbdelStark/worldforge
+- Hugging Face dataset: https://huggingface.co/datasets/espejelomar/worldforge-go2-dimos-replay-world-pairs
+- Hugging Face model: https://huggingface.co/espejelomar/go2-dimos-replay-latent-dynamics
+- Decision trace examples: https://github.com/omarespejel/worldforge-go2-trace-judge/tree/main/docs/decision_trace_examples
+- Final demo video: pending final voiceover upload
+
+## What We Built
+
+- Real Unitree Go2 venue captures and robot-view traces.
+- Label-preserving counterfactual candidate scenes for cube/marker navigation.
+- WorldForge-style trace artifacts:
+  - `score_info.json`
+  - `candidate_scores.json`
+  - `selected_action.json`
+  - `outcome_after_execution.json`
+  - `run_manifest.json`
+- A micro world scorer for action ranking from trace features.
+- A DimOS replay-derived Hugging Face dataset of action-conditioned Go2
+  current/future frame pairs.
+- A small frozen-DINOv2 residual latent dynamics head trained on those replay
+  pairs.
+
+## Why It Fits DimOS
+
+DimOS already exposes the robot runtime: streams, replay data, blueprints,
+camera frames, odometry, and Go2 control skills. This project adds a thin
+decision-evidence layer on top:
+
+```text
+DimOS observes and executes
+WorldForge-style scorer compares candidate actions
+trace files explain and replay the decision
+```
+
+That boundary lets DimOS remain the hardware/control system while making robot
+decisions auditable and model-ready.
+
+## Repro
+
+Clone the project repo and run:
+
+```bash
+make check
+make dimos-replay-stretch
+make final-video
+```
+
+The DimOS replay target downloads public replay archives into an ignored local
+cache, derives current/future Go2 frame pairs, trains a small latent dynamics
+head, and exports Hugging Face-ready dataset/model folders.
+
+If memory is tight, run the DimOS side with the venue-recommended memory limit,
+for example:
+
+```bash
+dimos --memory-limit 1GB --replay run unitree-go2-agentic
+```
+
+## Submission Note
+
+This PR intentionally does not vendor the whole external project into DimOS.
+The full source, generated artifacts, Hugging Face links, and final video live in
+the project repo. The demo video link will be added here and in the PR body as
+soon as the final voiceover export is ready.

--- a/hackathon/worldforge_go2_trace_judge/README.md
+++ b/hackathon/worldforge_go2_trace_judge/README.md
@@ -25,6 +25,7 @@ actions.
 - Hugging Face dataset: https://huggingface.co/datasets/espejelomar/worldforge-go2-dimos-replay-world-pairs
 - Hugging Face model: https://huggingface.co/espejelomar/go2-dimos-replay-latent-dynamics
 - Decision trace examples: https://github.com/omarespejel/worldforge-go2-trace-judge/tree/main/docs/decision_trace_examples
+- Replay-MPC demo: https://github.com/omarespejel/worldforge-go2-trace-judge/tree/main/artifacts/replay_mpc_demo
 - Final demo video: pending final voiceover upload
 
 ## What We Built
@@ -38,10 +39,12 @@ actions.
   - `outcome_after_execution.json`
   - `run_manifest.json`
 - A micro world scorer for action ranking from trace features.
-- A DimOS replay-derived Hugging Face dataset of action-conditioned Go2
-  current/future frame pairs.
+- A DimOS replay-derived Hugging Face dataset of 2,557 action-conditioned Go2
+  current/future frame pairs from six usable public replay DBs.
 - A small frozen-DINOv2 residual latent dynamics head trained on those replay
   pairs.
+- A no-robot replay-MPC demo: real DimOS replay frame, six candidate egomotion
+  futures, selected action, and WorldForge-style trace JSON.
 
 ## Why It Fits DimOS
 
@@ -71,6 +74,15 @@ make final-video
 The DimOS replay target downloads public replay archives into an ignored local
 cache, derives current/future Go2 frame pairs, trains a small latent dynamics
 head, and exports Hugging Face-ready dataset/model folders.
+
+Current replay-world-model outputs:
+
+```text
+pairs: 2557
+validation lift vs no-motion baseline: +0.0507 cosine
+test lift vs no-motion baseline: +0.0182 cosine
+replay-MPC selected demo margin: +0.0170 over best counterfactual
+```
 
 If memory is tight, run the DimOS side with the venue-recommended memory limit,
 for example:

--- a/hackathon/worldforge_go2_trace_judge/README.md
+++ b/hackathon/worldforge_go2_trace_judge/README.md
@@ -2,55 +2,97 @@
 
 Hackathon submission from Omar Espejel, Abdel, and Ciro.
 
-## Summary
+## If You Only Have 60 Seconds
 
-WorldForge Go2 Trace Judge is an inspectable decision layer for Unitree Go2
-autonomy. It turns robot-view observations into candidate actions, scores those
-candidates, selects one action, and writes the evidence trail as replayable JSON.
+1. Watch the main demo:
+   https://github.com/omarespejel/worldforge-go2-trace-judge/blob/main/artifacts/showcase/final_hackathon_video.mp4
+2. Watch the short decision-to-simulation clip:
+   https://github.com/omarespejel/worldforge-go2-trace-judge/blob/main/artifacts/showcase/sim_decision_trace_video.mp4
+3. Inspect one evidence trace:
+   https://github.com/omarespejel/worldforge-go2-trace-judge/tree/main/artifacts/replay_mpc_arena/decision_traces/decision_001
+4. Open the release bundle:
+   https://github.com/omarespejel/worldforge-go2-trace-judge/releases/tag/v0.2-replay-mpc-arena-2026-05-28
 
-The core loop is:
+## One Sentence
+
+WorldForge Go2 Trace Judge makes Go2 autonomy inspectable: it compares candidate
+robot actions, scores their predicted futures, selects one action, and writes a
+replayable evidence trail.
 
 ```text
-observation + goal + candidate action -> score -> selected action -> evidence
+robot observation + goal + candidate action
+-> score
+-> selected action
+-> evidence trace
+-> DimOS execution or simulation handoff
 ```
 
-This submission keeps DimOS as the robot/runtime layer and uses WorldForge-style
-traces as the scoring, comparison, dataset, and evidence layer around Go2
-actions.
+## What Matters
 
-## Links
-
-- Project repo: https://github.com/omarespejel/worldforge-go2-trace-judge
-- WorldForge: https://github.com/AbdelStark/worldforge
-- Hugging Face dataset: https://huggingface.co/datasets/espejelomar/worldforge-go2-dimos-replay-world-pairs
-- Hugging Face model: https://huggingface.co/espejelomar/go2-dimos-replay-latent-dynamics
-- Decision trace examples: https://github.com/omarespejel/worldforge-go2-trace-judge/tree/main/docs/decision_trace_examples
-- Replay-MPC demo: https://github.com/omarespejel/worldforge-go2-trace-judge/tree/main/artifacts/replay_mpc_demo
-- Final demo video: pending final voiceover upload
+- DimOS remains the robot runtime: camera, odometry, replay, simulation, MCP,
+  and execution.
+- WorldForge-style code acts as the decision and evidence layer around DimOS.
+- The project creates one of the first open Go2 replay datasets shaped for
+  world-model/action-scoring research.
+- Every demo decision has auditable JSON: what was seen, what was scored, what
+  was selected, and what happened afterward.
 
 ## What We Built
 
 - Real Unitree Go2 venue captures and robot-view traces.
 - Label-preserving counterfactual candidate scenes for cube/marker navigation.
-- WorldForge-style trace artifacts:
+- WorldForge-style decision artifacts:
   - `score_info.json`
   - `candidate_scores.json`
   - `selected_action.json`
   - `outcome_after_execution.json`
   - `run_manifest.json`
-- A micro world scorer for action ranking from trace features.
-- A DimOS replay-derived Hugging Face dataset of 2,557 action-conditioned Go2
+- A DimOS replay-derived Hugging Face dataset with 2,557 action-conditioned Go2
   current/future frame pairs from six usable public replay DBs.
-- A small frozen-DINOv2 residual latent dynamics head trained on those replay
-  pairs.
-- A no-robot replay-MPC demo: real DimOS replay frame, six candidate egomotion
-  futures, selected action, and WorldForge-style trace JSON.
+- A small frozen-DINOv2 latent dynamics head:
+  `DINOv2(current_frame) + egomotion_delta -> future DINOv2 latent`.
+- Replay-MPC Arena: 12 selected held-out replay decisions with per-decision
+  candidate scores and trace files.
+- DimOS MCP/MuJoCo proof that a selected movement can be handed to the simulated
+  Go2 runtime.
 
-## Why It Fits DimOS
+## Reviewer Map
 
-DimOS already exposes the robot runtime: streams, replay data, blueprints,
-camera frames, odometry, and Go2 control skills. This project adds a thin
-decision-evidence layer on top:
+| Question | Open This |
+| --- | --- |
+| What is the demo? | https://github.com/omarespejel/worldforge-go2-trace-judge/blob/main/artifacts/showcase/final_hackathon_video.mp4 |
+| Does the decision loop reach simulation? | https://github.com/omarespejel/worldforge-go2-trace-judge/blob/main/artifacts/showcase/sim_decision_trace_video.mp4 |
+| Where are the score traces? | https://github.com/omarespejel/worldforge-go2-trace-judge/tree/main/artifacts/replay_mpc_arena/decision_traces |
+| Where is the dataset? | https://huggingface.co/datasets/espejelomar/worldforge-go2-dimos-replay-world-pairs |
+| Where is the model? | https://huggingface.co/espejelomar/go2-dimos-replay-latent-dynamics |
+| Where is the full source? | https://github.com/omarespejel/worldforge-go2-trace-judge |
+| Where is the release bundle? | https://github.com/omarespejel/worldforge-go2-trace-judge/releases/tag/v0.2-replay-mpc-arena-2026-05-28 |
+
+## Current Results
+
+```text
+DimOS replay pairs: 2,557
+usable replay sources: 6
+validation lift vs no-motion baseline: +0.0507 cosine
+test lift vs no-motion baseline: +0.0182 cosine
+Replay-MPC Arena: 12 selected held-out decisions with JSON evidence
+main video: 58 seconds
+decision-to-simulation clip: 23 seconds
+```
+
+The Replay-MPC Arena number is demo evidence over selected held-out examples,
+not a broad autonomy accuracy claim.
+
+## Why This Fits DimOS
+
+DimOS is already the right place for robot runtime concerns:
+
+```text
+streams, replay data, blueprints, simulation, camera frames,
+odometry, MCP tools, and Go2 control skills
+```
+
+This project adds a thin layer above that runtime:
 
 ```text
 DimOS observes and executes
@@ -58,42 +100,44 @@ WorldForge-style scorer compares candidate actions
 trace files explain and replay the decision
 ```
 
-That boundary lets DimOS remain the hardware/control system while making robot
-decisions auditable and model-ready.
+That boundary keeps physical execution host-owned while making decisions easier
+to inspect, debug, compare, and train from.
 
-## Repro
-
-Clone the project repo and run:
+## Reproduce From The External Project
 
 ```bash
+git clone https://github.com/omarespejel/worldforge-go2-trace-judge.git
+cd worldforge-go2-trace-judge
+
 make check
-make dimos-replay-stretch
+make replay-mpc-arena
 make final-video
+python3 scripts/build_sim_decision_video.py
 ```
 
-The DimOS replay target downloads public replay archives into an ignored local
-cache, derives current/future Go2 frame pairs, trains a small latent dynamics
-head, and exports Hugging Face-ready dataset/model folders.
+The replay dataset/model artifacts are also published on Hugging Face:
 
-Current replay-world-model outputs:
+- Dataset: https://huggingface.co/datasets/espejelomar/worldforge-go2-dimos-replay-world-pairs
+- Model: https://huggingface.co/espejelomar/go2-dimos-replay-latent-dynamics
+
+## Scope Boundary
+
+This PR does not vendor the full external project into DimOS and does not modify
+DimOS runtime code. It is a hackathon submission pointer with the full source,
+artifacts, dataset, model, and videos hosted externally.
+
+Accurate claim:
 
 ```text
-pairs: 2557
-validation lift vs no-motion baseline: +0.0507 cosine
-test lift vs no-motion baseline: +0.0182 cosine
-replay-MPC selected demo margin: +0.0170 over best counterfactual
+small action-conditioned latent world model + WorldForge-style decision traces
+around DimOS/Go2 replay and simulation
 ```
 
-If memory is tight, run the DimOS side with the venue-recommended memory limit,
-for example:
+Avoided claims:
 
-```bash
-dimos --memory-limit 1GB --replay run unitree-go2-agentic
+```text
+Go2 foundation model
+trained V-JEPA
+safety-certified controller
+solved autonomous navigation
 ```
-
-## Submission Note
-
-This PR intentionally does not vendor the whole external project into DimOS.
-The full source, generated artifacts, Hugging Face links, and final video live in
-the project repo. The demo video link will be added here and in the PR body as
-soon as the final voiceover export is ready.


### PR DESCRIPTION
## What to review first

**Watch the voiced demo (browser playback):** https://share.descript.com/view/ClQV2Me2GTQ  
**GitHub MP4 backup:** https://github.com/omarespejel/worldforge-go2-trace-judge/blob/main/artifacts/showcase/final_voiced_demo.mp4  
**Dataset:** https://huggingface.co/datasets/espejelomar/worldforge-go2-dimos-replay-world-pairs  
**Model:** https://huggingface.co/espejelomar/go2-dimos-replay-latent-dynamics  
**One trace:** https://github.com/omarespejel/worldforge-go2-trace-judge/tree/main/artifacts/replay_mpc_arena/decision_traces/decision_001  
**Full repo:** https://github.com/omarespejel/worldforge-go2-trace-judge


## Team

- Omar Espejel — AI at Starknet Foundation; previously AI engineering at Hugging Face.
- Abdel — Applied AI at StarkWare; WorldForge lead.
- Ciro — Engineer at Harvard Publishing.

Direct release MP4: https://github.com/omarespejel/worldforge-go2-trace-judge/releases/download/v0.2-replay-mpc-arena-2026-05-28/final_voiced_demo.mp4

## Short version

We built a decision layer around DimOS/Go2.

Instead of only showing a robot moving, the project shows the decision behind the movement:

```text
robot view + goal + candidate action
-> predicted future score
-> selected action
-> replayable evidence trace
```

DimOS stays the robot runtime. WorldForge-style traces sit above it as the scoring and evidence layer.

## What is new

- Real Go2 venue captures and robot-view traces.
- An open Hugging Face DimOS/Go2 replay dataset: 2,557 current/future frame pairs from six usable public replay sources.
- A small action-conditioned latent world model: `DINOv2(current_frame) + egomotion_delta -> future DINOv2 latent`.
- Replay-MPC Arena: held-out replay scenes where candidate futures are scored and written as JSON traces.
- A short DimOS/MuJoCo handoff proof showing a selected movement reaching the simulation runtime.

## Why it matters for DimOS

DimOS already gives us the runtime: robot streams, replay, simulation, MCP, and control skills.

This project adds the missing review surface:

```text
what did the robot see?
what actions did it compare?
why did one action win?
what trace proves it?
```

That makes robot autonomy easier to debug, compare, and improve.

## Extra links

- Decision-to-simulation clip: https://github.com/omarespejel/worldforge-go2-trace-judge/blob/main/artifacts/showcase/sim_decision_trace_video.mp4
- Replay-MPC Arena: https://github.com/omarespejel/worldforge-go2-trace-judge/tree/main/artifacts/replay_mpc_arena
- Release bundle: https://github.com/omarespejel/worldforge-go2-trace-judge/releases/tag/v0.2-replay-mpc-arena-2026-05-28
- WorldForge: https://github.com/AbdelStark/worldforge

## Boundary

This PR is intentionally just a hackathon pointer inside DimOS. It does not vendor the external project and does not change DimOS runtime code.

Accurate claim: small action-conditioned latent world model + WorldForge-style decision traces around DimOS/Go2 replay and simulation.

Not claiming: a Go2 foundation model, trained V-JEPA, safety-certified control, or solved autonomous navigation.

