### PR TITLE
Allow small LFS in tests job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,8 +186,11 @@ jobs:
       - name: Install dependency for pyaudio (macOS)
         if: matrix.os == 'macos'
         run: brew install portaudio
-      - name: Remove git LFS to avoid accidental large downloads
-        run: sudo rm -f /usr/bin/git-lfs
+      - name: Cap accidental LFS downloads at 1 MiB
+        run: |
+          sudo mv /usr/bin/git-lfs /usr/bin/git-lfs.orig
+          sudo install -m 0755 bin/git-lfs-guard /usr/bin/git-lfs
+          git config --global --unset-all filter.lfs.process || true
       - name: Set PYTHON_GIL=0 for free-threading builds
         if: ${{ endsWith(matrix.pyver, 't') }}
         run: echo "PYTHON_GIL=0" >> $GITHUB_ENV

--- a/bin/git-lfs-guard
+++ b/bin/git-lfs-guard
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Wrapper around git-lfs that caps per-invocation download size in CI.
+#
+# Installed at /usr/bin/git-lfs (real binary moved to /usr/bin/git-lfs.orig)
+# by the regular `tests:` job in .github/workflows/ci.yml. Refuses any
+# pull/fetch/checkout/smudge that would download more than
+# DIMOS_LFS_GUARD_LIMIT_BYTES (default 1 MiB) so tests can't pull big LFS
+# data on the standard runner. Tests that legitimately need the data should
+# be marked self_hosted (see dimos/conftest.py).
+#
+# Env vars:
+#   DIMOS_LFS_GUARD_REAL          path to real git-lfs (default /usr/bin/git-lfs.orig)
+#   DIMOS_LFS_GUARD_LIMIT_BYTES   per-invocation cap (default 1048576)
+
+REAL="${DIMOS_LFS_GUARD_REAL:-/usr/bin/git-lfs.orig}"
+LIMIT="${DIMOS_LFS_GUARD_LIMIT_BYTES:-$((1024*1024))}"
+
+die() {
+    cat >&2 <<EOF
+git-lfs-guard: $1
+Cap is $LIMIT bytes per git-lfs invocation in the regular tests CI job.
+If this test needs the data, mark it self_hosted so it only runs on the
+self-hosted runner:
+
+    pytestmark = pytest.mark.self_hosted   # module scope
+    @pytest.mark.self_hosted               # single test
+EOF
+    exit 1
+}
+
+case "${1:-}" in
+    smudge)
+        tmp=$(mktemp)
+        cat > "$tmp"
+        size=$(awk '/^size [0-9]+$/ {print $2; exit}' "$tmp")
+        if [[ -n "$size" && "$size" -gt "$LIMIT" ]]; then
+            rm -f "$tmp"
+            die "blocked smudge of ${size}-byte LFS object"
+        fi
+        "$REAL" "$@" < "$tmp"
+        rc=$?
+        rm -f "$tmp"
+        exit "$rc"
+        ;;
+    filter-process)
+        die "filter-process is disabled; the CI step unsets filter.lfs.process so git falls back to smudge"
+        ;;
+    pull|fetch|checkout)
+        sub="$1"; shift
+        orig_args=( "$@" )
+        ls_args=( --json --size )
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                -I|--include|-X|--exclude)
+                    if [[ $# -ge 2 ]]; then
+                        ls_args+=( "$1" "$2" )
+                        shift 2
+                    else
+                        shift
+                    fi
+                    ;;
+                --include=*|--exclude=*)
+                    ls_args+=( "$1" )
+                    shift
+                    ;;
+                *)
+                    shift
+                    ;;
+            esac
+        done
+        total=$("$REAL" ls-files "${ls_args[@]}" 2>/dev/null \
+                | jq '[.files[] | select(.downloaded == false) | .size] | add // 0' 2>/dev/null) \
+                || total=0
+        if (( total > LIMIT )); then
+            die "blocked $sub of ${total} bytes (args: ${orig_args[*]:-<none>})"
+        fi
+        exec "$REAL" "$sub" "${orig_args[@]}"
+        ;;
+    *)
+        exec "$REAL" "$@"
+        ;;
+esac

--- a/bin/git-lfs-guard
+++ b/bin/git-lfs-guard
@@ -69,8 +69,11 @@ case "${1:-}" in
             esac
         done
         total=$("$REAL" ls-files "${ls_args[@]}" 2>/dev/null \
-                | jq '[.files[] | select(.downloaded == false) | .size] | add // 0' 2>/dev/null) \
-                || total=0
+                | jq '[.files[] | select(.downloaded == false) | .size] | add // 0' 2>/dev/null)
+        if [[ $? -ne 0 || -z "$total" ]]; then
+            echo "git-lfs-guard: warning: could not determine LFS download size; allowing $sub" >&2
+            total=0
+        fi
         if (( total > LIMIT )); then
             die "blocked $sub of ${total} bytes (args: ${orig_args[*]:-<none>})"
         fi

--- a/bin/git-lfs-guard
+++ b/bin/git-lfs-guard
@@ -33,7 +33,11 @@ case "${1:-}" in
         tmp=$(mktemp)
         cat > "$tmp"
         size=$(awk '/^size [0-9]+$/ {print $2; exit}' "$tmp")
-        if [[ -n "$size" && "$size" -gt "$LIMIT" ]]; then
+        if [[ -z "$size" ]]; then
+            rm -f "$tmp"
+            die "could not parse size from LFS pointer — refusing smudge"
+        fi
+        if [[ "$size" -gt "$LIMIT" ]]; then
             rm -f "$tmp"
             die "blocked smudge of ${size}-byte LFS object"
         fi

--- a/dimos/agents/mcp/test_mcp_client.py
+++ b/dimos/agents/mcp/test_mcp_client.py
@@ -15,7 +15,6 @@
 from typing import Any
 
 from langchain_core.messages import HumanMessage
-import pytest
 
 from dimos.agents.annotation import skill
 from dimos.core.module import Module
@@ -181,7 +180,6 @@ class Visualizer(Module):
         return Image.from_file(get_data("cafe-smol.jpg")).to_rgb()
 
 
-@pytest.mark.self_hosted
 def test_image(agent_setup):
     history = agent_setup(
         blueprints=[Visualizer.blueprint()],

--- a/dimos/experimental/security_demo/test_security_module.py
+++ b/dimos/experimental/security_demo/test_security_module.py
@@ -43,7 +43,6 @@ def test_find_best_person_returns_none_for_empty_scene(security_module, yolo_det
     assert result is None
 
 
-@pytest.mark.self_hosted
 def test_patrol_step_transitions_to_following_on_detection(
     security_module, person_image, make_detection, mocker
 ):
@@ -91,7 +90,6 @@ def test_patrol_step_requests_goal_when_no_active_goal(security_module):
     assert module._has_active_goal is True
 
 
-@pytest.mark.self_hosted
 def test_follow_step_publishes_twist_when_tracking(
     security_module, person_image, make_detection, mocker
 ):
@@ -117,7 +115,6 @@ def test_follow_step_publishes_twist_when_tracking(
     assert module._state == "FOLLOWING"
 
 
-@pytest.mark.self_hosted
 def test_follow_step_transitions_to_patrolling_on_person_lost(security_module, person_image):
     module = security_module
     module._state = "FOLLOWING"

--- a/dimos/mapping/occupancy/test_extrude_occupancy.py
+++ b/dimos/mapping/occupancy/test_extrude_occupancy.py
@@ -12,13 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
-
 from dimos.mapping.occupancy.extrude_occupancy import generate_mujoco_scene
 from dimos.utils.data import get_data
 
 
-@pytest.mark.self_hosted
 def test_generate_mujoco_scene(occupancy) -> None:
     with open(get_data("expected_occupancy_scene.xml")) as f:
         expected = f.read()

--- a/dimos/mapping/occupancy/test_gradient.py
+++ b/dimos/mapping/occupancy/test_gradient.py
@@ -20,8 +20,6 @@ from dimos.mapping.occupancy.visualizations import visualize_occupancy_grid
 from dimos.msgs.sensor_msgs.Image import Image
 from dimos.utils.data import get_data
 
-pytestmark = pytest.mark.self_hosted
-
 
 @pytest.mark.parametrize("method", ["simple", "voronoi"])
 def test_gradient(occupancy, method) -> None:

--- a/dimos/mapping/occupancy/test_inflation.py
+++ b/dimos/mapping/occupancy/test_inflation.py
@@ -16,13 +16,10 @@
 
 import cv2
 import numpy as np
-import pytest
 
 from dimos.mapping.occupancy.inflation import simple_inflate
 from dimos.mapping.occupancy.visualizations import visualize_occupancy_grid
 from dimos.utils.data import get_data
-
-pytestmark = pytest.mark.self_hosted
 
 
 def test_inflation(occupancy) -> None:

--- a/dimos/mapping/occupancy/test_operations.py
+++ b/dimos/mapping/occupancy/test_operations.py
@@ -16,13 +16,10 @@
 
 import cv2
 import numpy as np
-import pytest
 
 from dimos.mapping.occupancy.operations import overlay_occupied, smooth_occupied
 from dimos.mapping.occupancy.visualizations import visualize_occupancy_grid
 from dimos.utils.data import get_data
-
-pytestmark = pytest.mark.self_hosted
 
 
 def test_smooth_occupied(occupancy) -> None:

--- a/dimos/mapping/occupancy/test_path_map.py
+++ b/dimos/mapping/occupancy/test_path_map.py
@@ -22,8 +22,6 @@ from dimos.mapping.occupancy.path_map import make_navigation_map
 from dimos.mapping.occupancy.visualizations import visualize_occupancy_grid
 from dimos.utils.data import get_data
 
-pytestmark = pytest.mark.self_hosted
-
 
 @pytest.mark.parametrize("strategy", ["simple", "mixed"])
 def test_make_navigation_map(occupancy, strategy) -> None:

--- a/dimos/mapping/occupancy/test_path_mask.py
+++ b/dimos/mapping/occupancy/test_path_mask.py
@@ -25,8 +25,6 @@ from dimos.msgs.sensor_msgs.Image import Image
 from dimos.navigation.replanning_a_star.min_cost_astar import min_cost_astar
 from dimos.utils.data import get_data
 
-pytestmark = pytest.mark.self_hosted
-
 
 @pytest.mark.parametrize(
     "pose_index,max_length,expected_image",

--- a/dimos/mapping/occupancy/test_path_resampling.py
+++ b/dimos/mapping/occupancy/test_path_resampling.py
@@ -25,8 +25,6 @@ from dimos.msgs.sensor_msgs.Image import Image
 from dimos.navigation.replanning_a_star.min_cost_astar import min_cost_astar
 from dimos.utils.data import get_data
 
-pytestmark = pytest.mark.self_hosted
-
 
 @pytest.fixture
 def costmap() -> OccupancyGrid:

--- a/dimos/mapping/occupancy/test_visualizations.py
+++ b/dimos/mapping/occupancy/test_visualizations.py
@@ -21,8 +21,6 @@ import pytest
 from dimos.mapping.occupancy.visualizations import visualize_occupancy_grid
 from dimos.utils.data import get_data
 
-pytestmark = pytest.mark.self_hosted
-
 
 @pytest.mark.parametrize("palette", ["rainbow", "turbo"])
 def test_visualize_occupancy_grid(occupancy_gradient, palette) -> None:

--- a/dimos/msgs/nav_msgs/test_OccupancyGrid.py
+++ b/dimos/msgs/nav_msgs/test_OccupancyGrid.py
@@ -170,7 +170,6 @@ def test_invalid_grid_dimensions() -> None:
         OccupancyGrid(grid=np.zeros(10), resolution=0.1)
 
 
-@pytest.mark.self_hosted
 def test_from_pointcloud() -> None:
     """Test creating OccupancyGrid from PointCloud2."""
     file_path = get_data("lcm_msgs") / "sensor_msgs/PointCloud2.pickle"

--- a/dimos/msgs/sensor_msgs/test_image.py
+++ b/dimos/msgs/sensor_msgs/test_image.py
@@ -31,7 +31,6 @@ def img():
     return Image.from_file(str(image_file_path))
 
 
-@pytest.mark.self_hosted
 def test_file_load(img: Image) -> None:
     assert isinstance(img.data, np.ndarray)
     assert img.width == 1024
@@ -46,7 +45,6 @@ def test_file_load(img: Image) -> None:
     assert img.data.flags["C_CONTIGUOUS"]
 
 
-@pytest.mark.self_hosted
 def test_lcm_encode_decode(img: Image) -> None:
     binary_msg = img.lcm_encode()
     decoded_img = Image.lcm_decode(binary_msg)
@@ -56,14 +54,12 @@ def test_lcm_encode_decode(img: Image) -> None:
     assert decoded_img == img
 
 
-@pytest.mark.self_hosted
 def test_rgb_bgr_conversion(img: Image) -> None:
     rgb = img.to_rgb()
     assert not rgb == img
     assert rgb.to_bgr() == img
 
 
-@pytest.mark.self_hosted
 def test_opencv_conversion(img: Image) -> None:
     ocv = img.to_opencv()
     decoded_img = Image.from_opencv(ocv)

--- a/dimos/navigation/patrolling/test_create_patrol_router.py
+++ b/dimos/navigation/patrolling/test_create_patrol_router.py
@@ -39,6 +39,7 @@ def big_office() -> OccupancyGrid:
     return height_cost_occupancy(cloud)
 
 
+@pytest.mark.self_hosted
 @pytest.mark.parametrize(
     "router_name, saturation", [("random", 0.20), ("coverage", 0.30), ("frontier", 0.20)]
 )

--- a/dimos/navigation/patrolling/test_create_patrol_router.py
+++ b/dimos/navigation/patrolling/test_create_patrol_router.py
@@ -39,7 +39,6 @@ def big_office() -> OccupancyGrid:
     return height_cost_occupancy(cloud)
 
 
-@pytest.mark.self_hosted
 @pytest.mark.parametrize(
     "router_name, saturation", [("random", 0.20), ("coverage", 0.30), ("frontier", 0.20)]
 )

--- a/dimos/navigation/replanning_a_star/test_goal_validator.py
+++ b/dimos/navigation/replanning_a_star/test_goal_validator.py
@@ -20,8 +20,6 @@ from dimos.msgs.nav_msgs.OccupancyGrid import CostValues, OccupancyGrid
 from dimos.navigation.replanning_a_star.goal_validator import find_safe_goal
 from dimos.utils.data import get_data
 
-pytestmark = pytest.mark.self_hosted
-
 
 @pytest.fixture
 def costmap() -> OccupancyGrid:

--- a/dimos/navigation/replanning_a_star/test_min_cost_astar.py
+++ b/dimos/navigation/replanning_a_star/test_min_cost_astar.py
@@ -26,8 +26,6 @@ from dimos.msgs.sensor_msgs.Image import Image
 from dimos.navigation.replanning_a_star.min_cost_astar import min_cost_astar
 from dimos.utils.data import get_data
 
-pytestmark = pytest.mark.self_hosted
-
 
 @pytest.fixture
 def costmap() -> PointCloud:

--- a/dimos/robot/unitree/type/test_lidar.py
+++ b/dimos/robot/unitree/type/test_lidar.py
@@ -28,9 +28,8 @@ from dimos.robot.unitree.type.lidar import (
 from dimos.types.timestamped import Timestamped
 from dimos.utils.testing.replay import SensorReplay
 
-pytestmark = pytest.mark.self_hosted
 
-
+@pytest.mark.self_hosted
 def test_init() -> None:
     lidar = SensorReplay("office_lidar")
 

--- a/dimos/robot/unitree/type/test_odometry.py
+++ b/dimos/robot/unitree/type/test_odometry.py
@@ -19,8 +19,6 @@ import pytest
 from dimos.robot.unitree.type.odometry import Odometry
 from dimos.utils.testing.replay import SensorReplay
 
-pytestmark = pytest.mark.self_hosted
-
 _EXPECTED_TOTAL_RAD = -4.05212
 
 

--- a/dimos/simulation/unity/test_unity_sim.py
+++ b/dimos/simulation/unity/test_unity_sim.py
@@ -54,8 +54,6 @@ from dimos.utils.ros1 import (
 _is_linux_x86 = platform.system() == "Linux" and platform.machine() in ("x86_64", "AMD64")
 _has_display = bool(os.environ.get("DISPLAY"))
 
-pytestmark = pytest.mark.self_hosted
-
 
 class _MockTransport:
     def __init__(self):
@@ -396,6 +394,7 @@ class TestSensorOffset:
         assert last.twist.angular.y == pytest.approx(0.0, abs=1e-6)
 
 
+@pytest.mark.self_hosted
 @pytest.mark.skipif(not _is_linux_x86, reason="Unity binary requires Linux x86_64")
 @pytest.mark.skipif(not _has_display, reason="Unity requires DISPLAY (X11)")
 class TestLiveUnity:

--- a/dimos/utils/test_data.py
+++ b/dimos/utils/test_data.py
@@ -182,7 +182,6 @@ def test_lfs_path_no_download_on_creation() -> None:
     assert cache is None
 
 
-@pytest.mark.self_hosted
 def test_lfs_path_with_real_file() -> None:
     """Test LfsPath with a real small LFS file."""
     # Use a small existing LFS file
@@ -261,7 +260,6 @@ def test_lfs_path_unload_and_reload() -> None:
     assert content_first == content_second
 
 
-@pytest.mark.self_hosted
 def test_lfs_path_operations() -> None:
     """Test various Path operations with LfsPath."""
     filename = "three_paths.png"
@@ -290,7 +288,6 @@ def test_lfs_path_operations() -> None:
     assert filename in fspath_result
 
 
-@pytest.mark.self_hosted
 def test_lfs_path_division_operator() -> None:
     """Test path division operator with LfsPath."""
     # Use a directory for testing
@@ -304,7 +301,6 @@ def test_lfs_path_division_operator() -> None:
     assert "three_paths.png" in str(result)
 
 
-@pytest.mark.self_hosted
 def test_lfs_path_multiple_instances() -> None:
     """Test that multiple LfsPath instances for same file work correctly."""
     filename = "three_paths.png"


### PR DESCRIPTION
This rejects large LFS downloads, rather than all LFS downloads.

As a result, we can pull a lot of tests back from self_hosted to the parallised tests.