### PR TITLE
Remove * from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,2 @@
-* @leshy @paul-nechifor @spomichter @mustafab0
 /.github/ @Dreamsorcerer @leshy @paul-nechifor @spomichter
 /dimos/mapping/ @leshy @arkluc @paul-nechifor @spomichter


### PR DESCRIPTION
I've not heard confirmation from Ivan, but I think this was added by mistake. This line blocks all PRs from being merged without approval from one of those 4 people.

We already have a pr-approvers team that must approve _every_ PR, regardless of files changed. So, this is basically just a duplicate.