### PR TITLE
Separate base runners from large

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,7 +277,7 @@ jobs:
         # `import rclpy` / `ament_index_python` would fail. Sourcing the ROS
         # setup script and exporting PYTHONPATH/AMENT_PREFIX_PATH/etc into
         # GITHUB_ENV makes them importable from `uv run`.
-        if: contains(toJSON(matrix.runner), 'Linux')
+        if: matrix.os == 'Linux'
         shell: bash
         run: |
           source /opt/ros/humble/setup.bash
@@ -307,7 +307,7 @@ jobs:
           disable_search: true
           fail_ci_if_error: true
           files: ./coverage.xml
-          flags: SelfHosted-${{ matrix.runner[1] }}
+          flags: SelfHosted-${{ matrix.os }}
           use_oidc: true
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,7 +245,10 @@ jobs:
             container: null  # run on host — `container:` is Linux-only
             markers: "self_hosted"
             experimental: true
-    runs-on: [self-hosted, ${{ matrix.os }}, base]
+    runs-on:
+      - self-hosted
+      - ${{ matrix.os }}
+      - base
     continue-on-error: ${{ matrix.experimental }}
     permissions:
       contents: read  # For checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,7 +245,7 @@ jobs:
             container: null  # run on host — `container:` is Linux-only
             markers: "self_hosted"
             experimental: true
-    runs-on: [self-hosted, ${{ matrix.os }}, arm64]
+    runs-on: [self-hosted, ${{ matrix.os }}, base]
     continue-on-error: ${{ matrix.experimental }}
     permissions:
       contents: read  # For checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,17 +235,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: [self-hosted, Linux]
+          - os: Linux
             # GitHub Actions only honours `container:` on Linux runners.
             container:
               image: ghcr.io/dimensionalos/ros-dev:dev
             markers: "self_hosted or skipif_no_ros"
             experimental: false
-          - runner: [self-hosted, macos, arm64]
+          - os: macOS
             container: null  # run on host — `container:` is Linux-only
             markers: "self_hosted"
             experimental: true
-    runs-on: ${{ matrix.runner }}
+    runs-on: [self-hosted, ${{ matrix.os }}, arm64]
     continue-on-error: ${{ matrix.experimental }}
     permissions:
       contents: read  # For checkout


### PR DESCRIPTION
I need to separate the base runners from the large one. My large runner keeps picking up the regular tests.