### PR TITLE
fix: watchdog for pytest

### DIFF
--- a/dimos/conftest.py
+++ b/dimos/conftest.py
@@ -19,6 +19,7 @@ import os
 import platform
 import tempfile
 import threading
+import uuid
 
 # With pytest-xdist, pick a per-worker bucket and pin env vars *before*
 # any dimos module is imported, so parallel workers don't share LCM bus,
@@ -42,6 +43,11 @@ if _worker:
     os.environ["MCP_PORT"] = str(20000 + _BUCKET)
     os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp(prefix=f"dimos-test-state-{_worker}-")
 
+# Tag every pytest descendant so a sidecar watchdog can sweep strays (dimsim, rerun, etc).
+DIMOS_PYTEST_RUN_ID_ENV = "DIMOS_PYTEST_RUN_ID"
+if not _worker:
+    os.environ[DIMOS_PYTEST_RUN_ID_ENV] = f"pytest-{uuid.uuid4().hex[:16]}"
+
 # Raise the open-file limit. Each LCM transport opens at least one
 # multicast socket; with pytest-xdist workers running many in parallel,
 # the macOS default soft cap (~256) gets exhausted and tests fail with
@@ -61,6 +67,7 @@ from dotenv import load_dotenv
 import pytest
 
 from dimos.core.coordination.module_coordinator import ModuleCoordinator
+from dimos.core.coordination.process_lifecycle import spawn_watchdog
 
 load_dotenv()
 
@@ -95,6 +102,13 @@ def pytest_configure(config):
 
     if config.pluginmanager.hasplugin("_cov"):
         os.environ["COVERAGE_PROCESS_START"] = str(config.rootpath / "pyproject.toml")
+
+    # Only spawn on the controller, without doing it on xdist workers.
+    if not hasattr(config, "workerinput"):
+        spawn_watchdog(
+            os.environ[DIMOS_PYTEST_RUN_ID_ENV],
+            env_var=DIMOS_PYTEST_RUN_ID_ENV,
+        )
 
 
 @pytest.fixture(scope="session")

--- a/dimos/core/coordination/process_lifecycle.py
+++ b/dimos/core/coordination/process_lifecycle.py
@@ -14,9 +14,11 @@
 
 """Process-lifecycle utilities: tag descendants by run id, sweep strays.
 
-Every descendant of a `dimos run` invocation inherits `DIMOS_RUN_ID` in
-its environment. kill_run_processes scans the system via psutil and
-terminates any process whose environment matches a given run id.
+Every descendant of a `dimos run` invocation inherits a tag env var
+(default `DIMOS_RUN_ID`) in its environment. kill_run_processes scans the
+system via psutil and terminates any process whose environment matches a
+given run id. The tag env var is configurable so other entry points (e.g.
+the pytest harness) can reuse the same sweep with their own tag.
 
 spawn_watchdog launches a small sidecar process that watches the main
 PID; when main dies for any reason (including SIGKILL) the sidecar invokes
@@ -40,8 +42,10 @@ logger = setup_logger()
 DIMOS_RUN_ID_ENV = "DIMOS_RUN_ID"
 
 
-def _iter_matching_processes(run_id: str, exclude_pids: frozenset[int]) -> list[psutil.Process]:
-    """Return live processes whose environment contains DIMOS_RUN_ID=run_id."""
+def _iter_matching_processes(
+    run_id: str, exclude_pids: frozenset[int], *, env_var: str = DIMOS_RUN_ID_ENV
+) -> list[psutil.Process]:
+    """Return live processes whose environment contains env_var=run_id."""
     matches: list[psutil.Process] = []
     for proc in psutil.process_iter(attrs=["pid"]):
         pid = proc.info["pid"]
@@ -54,7 +58,7 @@ def _iter_matching_processes(run_id: str, exclude_pids: frozenset[int]) -> list[
         except OSError:
             # /proc entry may transiently fail on slow systems.
             continue
-        if env.get(DIMOS_RUN_ID_ENV) == run_id:
+        if env.get(env_var) == run_id:
             matches.append(proc)
     return matches
 
@@ -65,10 +69,11 @@ def kill_run_processes(
     exclude_pids: Iterable[int] = (),
     term_timeout: float = 2.0,
     kill_timeout: float = 1.0,
+    env_var: str = DIMOS_RUN_ID_ENV,
 ) -> int:
-    """Terminate every process tagged with `DIMOS_RUN_ID == run_id`."""
+    """Terminate every process tagged with `env_var == run_id`."""
     excluded = frozenset({os.getpid(), *exclude_pids})
-    targets = _iter_matching_processes(run_id, excluded)
+    targets = _iter_matching_processes(run_id, excluded, env_var=env_var)
     if not targets:
         return 0
 
@@ -91,10 +96,20 @@ def kill_run_processes(
 
 
 def spawn_watchdog(
-    run_id: str, log_dir: str | os.PathLike[str] | None = None
+    run_id: str,
+    log_dir: str | os.PathLike[str] | None = None,
+    *,
+    env_var: str = DIMOS_RUN_ID_ENV,
 ) -> subprocess.Popen[bytes]:
-    """Launch a sidecar that kills run processes if main dies abruptly."""
-    env = {k: v for k, v in os.environ.items() if k != DIMOS_RUN_ID_ENV}
+    """Launch a sidecar that kills run processes if main dies abruptly.
+
+    The sidecar sweeps processes tagged with ``env_var``; that var is stripped
+    from the sidecar's own env (so it never sweeps itself) and its name is
+    passed through ``DIMOS_WATCHDOG_TARGET_ENV`` so the sidecar knows which tag
+    to match.
+    """
+    env = {k: v for k, v in os.environ.items() if k != env_var}
+    env["DIMOS_WATCHDOG_TARGET_ENV"] = env_var
     if log_dir is not None:
         env["DIMOS_RUN_LOG_DIR"] = str(log_dir)
 

--- a/dimos/core/coordination/test_process_lifecycle.py
+++ b/dimos/core/coordination/test_process_lifecycle.py
@@ -47,11 +47,16 @@ def run_id() -> str:
 
 @pytest.fixture
 def spawn_tagged():
-    """Factory that spawns subprocesses tagged with DIMOS_RUN_ID; auto-cleans."""
+    """Factory that spawns subprocesses tagged with an env var; auto-cleans."""
     procs: list[subprocess.Popen[bytes]] = []
 
-    def _spawn(rid: str, code: str = "import time; time.sleep(60)") -> subprocess.Popen[bytes]:
-        env = {**os.environ, DIMOS_RUN_ID_ENV: rid}
+    def _spawn(
+        rid: str,
+        code: str = "import time; time.sleep(60)",
+        *,
+        env_var: str = DIMOS_RUN_ID_ENV,
+    ) -> subprocess.Popen[bytes]:
+        env = {**os.environ, env_var: rid}
         proc = subprocess.Popen(
             [sys.executable, "-c", code],
             env=env,
@@ -84,6 +89,19 @@ def test_kill_run_processes_kills_only_matching_run_id(spawn_tagged, run_id):
     assert _wait_gone(a1)
     assert _wait_gone(a2)
     # The other child must still be alive.
+    assert b.poll() is None
+
+
+def test_kill_run_processes_matches_custom_env_var(spawn_tagged, run_id):
+    # `a` is tagged with a custom var, `b` with the default DIMOS_RUN_ID.
+    # Sweeping on the custom var must hit `a` and leave `b` (whose custom var
+    # is the ambient pytest tag, not run_id) alone.
+    a = spawn_tagged(run_id, env_var="DIMOS_PYTEST_RUN_ID")
+    b = spawn_tagged(run_id)
+
+    killed = kill_run_processes(run_id, env_var="DIMOS_PYTEST_RUN_ID")
+    assert killed == 1
+    assert _wait_gone(a)
     assert b.poll() is None
 
 
@@ -184,4 +202,21 @@ def test_spawn_watchdog_strips_run_id_env(mocker: MockerFixture, run_id: str) ->
 
     kwargs = popen_mock.call_args.kwargs
     assert DIMOS_RUN_ID_ENV not in kwargs["env"]
+    assert kwargs["env"]["DIMOS_WATCHDOG_TARGET_ENV"] == DIMOS_RUN_ID_ENV
     assert kwargs["start_new_session"] is True
+
+
+def test_spawn_watchdog_custom_env_var(mocker: MockerFixture, run_id: str) -> None:
+    # With a custom tag var, the sidecar gets that var stripped from its own
+    # env and its name forwarded via DIMOS_WATCHDOG_TARGET_ENV; the default
+    # run-id var is left untouched.
+    custom = "DIMOS_PYTEST_RUN_ID"
+    mocker.patch.dict(os.environ, {custom: run_id, DIMOS_RUN_ID_ENV: "other"})
+    popen_mock = mocker.patch("dimos.core.coordination.process_lifecycle.subprocess.Popen")
+    popen_mock.return_value = mocker.MagicMock(pid=12345)
+    spawn_watchdog(run_id, env_var=custom)
+
+    kwargs = popen_mock.call_args.kwargs
+    assert custom not in kwargs["env"]
+    assert kwargs["env"]["DIMOS_WATCHDOG_TARGET_ENV"] == custom
+    assert kwargs["env"][DIMOS_RUN_ID_ENV] == "other"

--- a/dimos/core/coordination/watchdog_main.py
+++ b/dimos/core/coordination/watchdog_main.py
@@ -16,10 +16,12 @@
 
 from __future__ import annotations
 
+import os
 import sys
 import time
 
 from dimos.core.coordination.process_lifecycle import (
+    DIMOS_RUN_ID_ENV,
     kill_run_processes,
     wait_for_pid_exit,
 )
@@ -40,12 +42,13 @@ def main(argv: list[str]) -> int:
 
     main_pid = int(argv[1])
     run_id = argv[2]
+    env_var = os.environ.get("DIMOS_WATCHDOG_TARGET_ENV", DIMOS_RUN_ID_ENV)
 
     wait_for_pid_exit(main_pid)
 
     time.sleep(_GRACE_PERIOD_SECONDS)
 
-    kill_run_processes(run_id)
+    kill_run_processes(run_id, env_var=env_var)
 
     return 0
 


### PR DESCRIPTION
## Problem

`pytest` sometimes leaves `dimsim` or `rerun` processes around.

Closes DIM-976

## Solution

Add a watchdog process which terminates everything.

## Contributor License Agreement

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
