### PR TITLE
non unique TS in sqlite

### DIFF
--- a/dimos/memory2/observationstore/sqlite.py
+++ b/dimos/memory2/observationstore/sqlite.py
@@ -258,7 +258,7 @@ class SqliteObservationStore(ObservationStore[T]):
         self._conn.execute(
             f'CREATE TABLE IF NOT EXISTS "{self._name}" ('
             "    id      INTEGER PRIMARY KEY AUTOINCREMENT,"
-            "    ts      REAL    NOT NULL UNIQUE,"
+            "    ts      REAL    NOT NULL,"
             "    value   NUMERIC,"
             "    pose_x  REAL, pose_y REAL, pose_z REAL,"
             "    pose_qx REAL, pose_qy REAL, pose_qz REAL, pose_qw REAL,"

--- a/dimos/robot/unitree/go2/blueprints/smart/unitree_go2.py
+++ b/dimos/robot/unitree/go2/blueprints/smart/unitree_go2.py
@@ -85,6 +85,6 @@ unitree_go2_relocalization = autoconnect(
 ).global_config(n_workers=11)
 
 unitree_go2_memory = autoconnect(
-    unitree_go2_markers,
+    unitree_go2,
     Go2Memory.blueprint(),
 ).global_config(n_workers=12)


### PR DESCRIPTION
we gave up on sensor assigned timestamps on go2

(timestamps have different weird bugs on different firmware versions, unable to get image timestamps from the device)

so now we use time.time()

issue is that during network dropout issues and latency, we receive a bunch of messages together, and hit UNIQUE constraints in mem2 for ts.. for now unblocking this by allowing non UNIQUE ts storage, and will investigate solutions later

PS also removing markers detector from memory blueprint