### PR TITLE
Added missing **kwargs to DroneTrackingModule and OsmSkill __init__

### DIFF
--- a/dimos/agents/skills/osm.py
+++ b/dimos/agents/skills/osm.py
@@ -14,6 +14,7 @@
 
 
 from typing import Any
+
 from reactivex.disposable import Disposable
 
 from dimos.agents.annotation import skill

--- a/dimos/agents/skills/osm.py
+++ b/dimos/agents/skills/osm.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+from typing import Any
 from reactivex.disposable import Disposable
 
 from dimos.agents.annotation import skill
@@ -33,8 +34,8 @@ class OsmSkill(Module):
 
     gps_location: In[LatLon]
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, **kwargs:Any) -> None:
+        super().__init__(**kwargs)
         self._latest_location = None
         self._current_location_map = CurrentLocationMap(QwenVlModel())
 

--- a/dimos/agents/skills/osm.py
+++ b/dimos/agents/skills/osm.py
@@ -34,7 +34,7 @@ class OsmSkill(Module):
 
     gps_location: In[LatLon]
 
-    def __init__(self, **kwargs:Any) -> None:
+    def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self._latest_location = None
         self._current_location_map = CurrentLocationMap(QwenVlModel())

--- a/dimos/robot/drone/drone_tracking_module.py
+++ b/dimos/robot/drone/drone_tracking_module.py
@@ -64,6 +64,7 @@ class DroneTrackingModule(Module):
         x_pid_params: PIDParams | None = None,
         y_pid_params: PIDParams | None = None,
         z_pid_params: PIDParams | None = None,
+        **kwargs: Any,
     ) -> None:
         """Initialize the drone tracking module.
 
@@ -76,7 +77,7 @@ class DroneTrackingModule(Module):
                           If None, uses preset based on outdoor flag.
             z_pid_params: Optional PID parameters for altitude control.
         """
-        super().__init__()
+        super().__init__(**kwargs)
 
         default_params = OUTDOOR_PID_PARAMS if outdoor else INDOOR_PID_PARAMS
         x_pid_params = x_pid_params if x_pid_params is not None else default_params


### PR DESCRIPTION
Fixed drone-agentic blueprint failing to start due to missing **kwargs in DroneTrackingModule and OsmSkill __init__ methods.

Both modules defined __init__ without **kwargs, causing autoconnect() to fail when passing graph wiring arguments at deploy time.

Fixed: TypeError: DroneTrackingModule.__init__() got an unexpected keyword argument 'g'
Fixed: TypeError: OsmSkill.__init__() got an unexpected keyword argument 'g'