### PR TITLE
feat: xarm manipulator adapter improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ yolo11n.pt
 .envrc
 .claude
 **/CLAUDE.md
+.omo/
 .direnv/
 
 /logs
@@ -89,3 +90,4 @@ recording*.db
 
 # Rerun recordings
 *.rrd
+

--- a/dimos/control/coordinator.py
+++ b/dimos/control/coordinator.py
@@ -225,8 +225,12 @@ class ControlCoordinator(Module):
 
         try:
             if component.auto_enable:
-                if adapter.activate() is False:
-                    raise RuntimeError(f"Failed to activate hardware {component.hardware_id}")
+                activate = getattr(adapter, "activate", None)
+                if callable(activate):
+                    if activate() is False:
+                        raise RuntimeError(f"Failed to activate hardware {component.hardware_id}")
+                elif hasattr(adapter, "write_enable"):
+                    adapter.write_enable(True)
 
             self.add_hardware(adapter, component)
         except Exception:
@@ -709,8 +713,11 @@ class ControlCoordinator(Module):
 
         with self._hardware_lock:
             for hw_id, interface in self._hardware.items():
+                deactivate = getattr(interface.adapter, "deactivate", None)
+                if not callable(deactivate):
+                    continue
                 try:
-                    if interface.adapter.deactivate() is False:
+                    if deactivate() is False:
                         logger.error(f"Hardware {hw_id} deactivate returned False")
                 except Exception as e:
                     logger.error(f"Error deactivating hardware {hw_id}: {e}")

--- a/dimos/control/coordinator.py
+++ b/dimos/control/coordinator.py
@@ -225,12 +225,8 @@ class ControlCoordinator(Module):
 
         try:
             if component.auto_enable:
-                activate = getattr(adapter, "activate", None)
-                if callable(activate):
-                    if activate() is False:
-                        raise RuntimeError(f"Failed to activate hardware {component.hardware_id}")
-                elif hasattr(adapter, "write_enable"):
-                    adapter.write_enable(True)
+                if adapter.activate() is False:
+                    raise RuntimeError(f"Failed to activate hardware {component.hardware_id}")
 
             self.add_hardware(adapter, component)
         except Exception:
@@ -713,13 +709,11 @@ class ControlCoordinator(Module):
 
         with self._hardware_lock:
             for hw_id, interface in self._hardware.items():
-                deactivate = getattr(interface.adapter, "deactivate", None)
-                if callable(deactivate):
-                    try:
-                        if deactivate() is False:
-                            logger.error(f"Hardware {hw_id} deactivate returned False")
-                    except Exception as e:
-                        logger.error(f"Error deactivating hardware {hw_id}: {e}")
+                try:
+                    if interface.adapter.deactivate() is False:
+                        logger.error(f"Hardware {hw_id} deactivate returned False")
+                except Exception as e:
+                    logger.error(f"Error deactivating hardware {hw_id}: {e}")
 
         # Disconnect all hardware adapters
         with self._hardware_lock:

--- a/dimos/control/coordinator.py
+++ b/dimos/control/coordinator.py
@@ -224,8 +224,13 @@ class ControlCoordinator(Module):
             raise RuntimeError(f"Failed to connect to {component.adapter_type} adapter")
 
         try:
-            if component.auto_enable and hasattr(adapter, "write_enable"):
-                adapter.write_enable(True)
+            if component.auto_enable:
+                activate = getattr(adapter, "activate", None)
+                if callable(activate):
+                    if activate() is False:
+                        raise RuntimeError(f"Failed to activate hardware {component.hardware_id}")
+                elif hasattr(adapter, "write_enable"):
+                    adapter.write_enable(True)
 
             self.add_hardware(adapter, component)
         except Exception:
@@ -705,6 +710,16 @@ class ControlCoordinator(Module):
 
         if self._tick_loop:
             self._tick_loop.stop()
+
+        with self._hardware_lock:
+            for hw_id, interface in self._hardware.items():
+                deactivate = getattr(interface.adapter, "deactivate", None)
+                if callable(deactivate):
+                    try:
+                        if deactivate() is False:
+                            logger.error(f"Hardware {hw_id} deactivate returned False")
+                    except Exception as e:
+                        logger.error(f"Error deactivating hardware {hw_id}: {e}")
 
         # Disconnect all hardware adapters
         with self._hardware_lock:

--- a/dimos/control/test_control.py
+++ b/dimos/control/test_control.py
@@ -23,6 +23,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from dimos.control.components import HardwareComponent, HardwareType, make_joints
+from dimos.control.coordinator import ControlCoordinator
 from dimos.control.hardware_interface import ConnectedHardware
 from dimos.control.task import (
     ControlMode,
@@ -186,6 +187,47 @@ class TestConnectedHardware:
         }
         connected_hardware.write_command(commands, ControlMode.POSITION)
         mock_adapter.write_joint_positions.assert_called()
+
+
+class TestControlCoordinatorLifecycle:
+    def test_start_stop_calls_adapter_activate_and_deactivate(self):
+        from dimos.hardware.manipulators.mock.adapter import MockAdapter
+        from dimos.hardware.manipulators.registry import adapter_registry
+
+        class LifecycleAdapter(MockAdapter):
+            events: list[str] = []
+
+            def connect(self) -> bool:
+                self.events.append("connect")
+                return super().connect()
+
+            def activate(self) -> bool:
+                self.events.append("activate")
+                return self.write_enable(True)
+
+            def deactivate(self) -> bool:
+                self.events.append("deactivate")
+                return self.write_stop()
+
+            def disconnect(self) -> None:
+                self.events.append("disconnect")
+                super().disconnect()
+
+        adapter_registry.register("lifecycle_test", LifecycleAdapter)
+        component = HardwareComponent(
+            hardware_id="arm",
+            hardware_type=HardwareType.MANIPULATOR,
+            joints=make_joints("arm", 6),
+            adapter_type="lifecycle_test",
+        )
+        coordinator = ControlCoordinator(publish_joint_state=False, hardware=[component])
+
+        try:
+            coordinator.start()
+        finally:
+            coordinator.stop()
+
+        assert LifecycleAdapter.events == ["connect", "activate", "deactivate", "disconnect"]
 
 
 class TestJointTrajectoryTask:

--- a/dimos/control/test_control.py
+++ b/dimos/control/test_control.py
@@ -229,6 +229,30 @@ class TestControlCoordinatorLifecycle:
 
         assert LifecycleAdapter.events == ["connect", "activate", "deactivate", "disconnect"]
 
+    def test_start_stop_with_adapter_without_lifecycle_methods(self):
+        """Adapters without activate/deactivate (e.g. twist bases) start and stop cleanly."""
+        from dimos.control.components import make_twist_base_joints
+
+        component = HardwareComponent(
+            hardware_id="base",
+            hardware_type=HardwareType.BASE,
+            joints=make_twist_base_joints("base"),
+            adapter_type="mock_twist_base",
+        )
+        coordinator = ControlCoordinator(publish_joint_state=False, hardware=[component])
+
+        try:
+            coordinator.start()
+            adapter = coordinator._hardware["base"].adapter
+            assert not hasattr(adapter, "activate")
+            assert not hasattr(adapter, "deactivate")
+            # auto_enable falls back to write_enable(True) for adapters without activate()
+            assert adapter.read_enabled()
+        finally:
+            coordinator.stop()
+
+        assert not adapter.is_connected()
+
 
 class TestJointTrajectoryTask:
     def test_initial_state(self, trajectory_task):

--- a/dimos/hardware/manipulators/README.md
+++ b/dimos/hardware/manipulators/README.md
@@ -124,6 +124,7 @@ All adapters must implement these core methods:
 | Category | Methods |
 |----------|---------|
 | Connection | `connect()`, `disconnect()`, `is_connected()` |
+| Lifecycle | `activate()`, `deactivate()` |
 | Info | `get_info()`, `get_dof()`, `get_limits()` |
 | State | `read_joint_positions()`, `read_joint_velocities()`, `read_joint_efforts()` |
 | Motion | `write_joint_positions()`, `write_joint_velocities()`, `write_stop()` |

--- a/dimos/hardware/manipulators/mock/adapter.py
+++ b/dimos/hardware/manipulators/mock/adapter.py
@@ -81,6 +81,15 @@ class MockAdapter:
         """Check mock connection status."""
         return self._connected
 
+    def activate(self) -> bool:
+        """Simulate activation (enable servos)."""
+        return self.write_enable(True)
+
+    def deactivate(self) -> bool:
+        """Simulate deactivation (stop motion, disable servos)."""
+        self.write_stop()
+        return self.write_enable(False)
+
     def get_info(self) -> ManipulatorInfo:
         """Return mock info."""
         return ManipulatorInfo(

--- a/dimos/hardware/manipulators/sim/adapter.py
+++ b/dimos/hardware/manipulators/sim/adapter.py
@@ -119,6 +119,13 @@ class ShmMujocoAdapter:
     def is_connected(self) -> bool:
         return self._connected and self._shm is not None
 
+    def activate(self) -> bool:
+        return self.write_enable(True)
+
+    def deactivate(self) -> bool:
+        self.write_stop()
+        return self.write_enable(False)
+
     def get_info(self) -> ManipulatorInfo:
         return ManipulatorInfo(
             vendor="Simulation",

--- a/dimos/hardware/manipulators/spec.py
+++ b/dimos/hardware/manipulators/spec.py
@@ -105,6 +105,14 @@ class ManipulatorAdapter(Protocol):
         """Check if connected."""
         ...
 
+    def activate(self) -> bool:
+        """Prepare hardware for commanded motion after connect()."""
+        ...
+
+    def deactivate(self) -> bool:
+        """Gracefully stop commanded motion before disconnect()."""
+        ...
+
     def get_info(self) -> ManipulatorInfo:
         """Get manipulator info (vendor, model, DOF)."""
         ...

--- a/dimos/hardware/manipulators/xarm/adapter.py
+++ b/dimos/hardware/manipulators/xarm/adapter.py
@@ -41,8 +41,9 @@ M_TO_MM = 1000.0
 MAX_CARTESIAN_SPEED_MM = 500.0  # Max cartesian speed in mm/s
 _XARM_LIFECYCLE_SPEED_DEG = 20.0
 _XARM_LIFECYCLE_ACCEL_DEG = 500.0
-_XARM6_INITIAL_JOINTS_RAD = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-_XARM7_INITIAL_JOINTS_RAD = [0.0, 0.0, 0.0, 0.0, 0.0, -0.7, 0.0]
+_XARM6_INITIAL_JOINTS_DEG = [0.0, -40.0, -50.0, 0.0, 90.0, 0.0]
+# TODO (CC): change this once we have 7dof arm setup
+_XARM7_INITIAL_JOINTS_DEG = [0.0, 0.0, 0.0, 0.0, 0.0, math.degrees(-0.7), 0.0]
 
 # XArm mode codes
 _XARM_MODE_POSITION = 0
@@ -245,6 +246,7 @@ class XArmAdapter(ManipulatorAdapter):
         self._prepare_for_position_motion()
         if not self._move_to_initial_pose():
             return False
+        self._arm.motion_enable(enable=False)
         code: int = self._arm.set_state(4)
         return code == 0
 
@@ -252,23 +254,23 @@ class XArmAdapter(ManipulatorAdapter):
         if not self._arm:
             return False
 
-        joints = self._initial_joints()
+        joints = self._initial_joints_degrees()
         if joints is None:
             return True
 
         code: int = self._arm.set_servo_angle(
-            angle=[math.degrees(joint) for joint in joints],
+            angle=joints,
             speed=_XARM_LIFECYCLE_SPEED_DEG,
             mvacc=_XARM_LIFECYCLE_ACCEL_DEG,
             wait=True,
         )
         return code == 0
 
-    def _initial_joints(self) -> list[float] | None:
+    def _initial_joints_degrees(self) -> list[float] | None:
         if self._dof == 6:
-            return _XARM6_INITIAL_JOINTS_RAD
+            return _XARM6_INITIAL_JOINTS_DEG
         if self._dof == 7:
-            return _XARM7_INITIAL_JOINTS_RAD
+            return _XARM7_INITIAL_JOINTS_DEG
         return None
 
     def _prepare_for_position_motion(self) -> None:

--- a/dimos/hardware/manipulators/xarm/adapter.py
+++ b/dimos/hardware/manipulators/xarm/adapter.py
@@ -39,6 +39,10 @@ from dimos.hardware.manipulators.spec import (
 MM_TO_M = 0.001
 M_TO_MM = 1000.0
 MAX_CARTESIAN_SPEED_MM = 500.0  # Max cartesian speed in mm/s
+_XARM_LIFECYCLE_SPEED_DEG = 20.0
+_XARM_LIFECYCLE_ACCEL_DEG = 500.0
+_XARM6_INITIAL_JOINTS_RAD = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+_XARM7_INITIAL_JOINTS_RAD = [0.0, 0.0, 0.0, 0.0, 0.0, -0.7, 0.0]
 
 # XArm mode codes
 _XARM_MODE_POSITION = 0
@@ -222,6 +226,63 @@ class XArmAdapter(ManipulatorAdapter):
         # This only executes the last instruction, suitable for real-time control
         code: int = self._arm.set_servo_angle_j(angles, speed=100, mvacc=500)
         return code == 0
+
+    def activate(self) -> bool:
+        """Enable motion and move the arm to its initial joint pose."""
+        if not self._arm:
+            return False
+
+        self._prepare_for_position_motion()
+        if not self._move_to_initial_pose():
+            return False
+        return self.set_control_mode(ControlMode.SERVO_POSITION)
+
+    def deactivate(self) -> bool:
+        """Move the arm to its initial joint pose and enter stopped state."""
+        if not self._arm:
+            return False
+
+        self._prepare_for_position_motion()
+        if not self._move_to_initial_pose():
+            return False
+        code: int = self._arm.set_state(4)
+        return code == 0
+
+    def _move_to_initial_pose(self) -> bool:
+        if not self._arm:
+            return False
+
+        joints = self._initial_joints()
+        if joints is None:
+            return True
+
+        code: int = self._arm.set_servo_angle(
+            angle=[math.degrees(joint) for joint in joints],
+            speed=_XARM_LIFECYCLE_SPEED_DEG,
+            mvacc=_XARM_LIFECYCLE_ACCEL_DEG,
+            wait=True,
+        )
+        return code == 0
+
+    def _initial_joints(self) -> list[float] | None:
+        if self._dof == 6:
+            return _XARM6_INITIAL_JOINTS_RAD
+        if self._dof == 7:
+            return _XARM7_INITIAL_JOINTS_RAD
+        return None
+
+    def _prepare_for_position_motion(self) -> None:
+        if not self._arm:
+            return
+
+        if self._arm.warn_code != 0:
+            self._arm.clean_warn()
+        if self._arm.error_code != 0:
+            self._arm.clean_error()
+        self._arm.motion_enable(enable=True)
+        self._arm.set_mode(_XARM_MODE_POSITION)
+        self._arm.set_state(0)
+        self._control_mode = ControlMode.POSITION
 
     def write_joint_velocities(self, velocities: list[float]) -> bool:
         """Write joint velocities (rad/s -> deg/s).

--- a/dimos/robot/manipulators/xarm/blueprints.py
+++ b/dimos/robot/manipulators/xarm/blueprints.py
@@ -53,7 +53,11 @@ _xarm7_cfg = _catalog_xarm7(
 
 # XArm6 mock sim + keyboard teleop + Drake visualization
 keyboard_teleop_xarm6 = autoconnect(
-    KeyboardTeleopModule.blueprint(model_path=XARM6_FK_MODEL, ee_joint_id=_xarm6_cfg.dof),
+    KeyboardTeleopModule.blueprint(
+        model_path=XARM6_FK_MODEL,
+        ee_joint_id=_xarm6_cfg.dof,
+        joint_names=_xarm6_cfg.coordinator_joint_names,
+    ),
     ControlCoordinator.blueprint(
         tick_rate=100.0,
         publish_joint_state=True,
@@ -83,7 +87,11 @@ keyboard_teleop_xarm6 = autoconnect(
 
 # XArm7 mock sim + keyboard teleop + Drake visualization
 keyboard_teleop_xarm7 = autoconnect(
-    KeyboardTeleopModule.blueprint(model_path=XARM7_FK_MODEL, ee_joint_id=_xarm7_cfg.dof),
+    KeyboardTeleopModule.blueprint(
+        model_path=XARM7_FK_MODEL,
+        ee_joint_id=_xarm7_cfg.dof,
+        joint_names=_xarm7_cfg.coordinator_joint_names,
+    ),
     ControlCoordinator.blueprint(
         tick_rate=100.0,
         publish_joint_state=True,

--- a/dimos/teleop/keyboard/keyboard_teleop_module.py
+++ b/dimos/teleop/keyboard/keyboard_teleop_module.py
@@ -48,6 +48,9 @@ from dimos.core.module import Module, ModuleConfig
 from dimos.core.stream import In, Out
 from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
 from dimos.msgs.sensor_msgs.JointState import JointState
+from dimos.utils.logging_config import setup_logger
+
+logger = setup_logger()
 
 # Force X11 driver to avoid OpenGL threading issues
 os.environ["SDL_VIDEODRIVER"] = "x11"
@@ -136,8 +139,12 @@ class KeyboardTeleopModule(Module):
 
         initial_joints = self._read_joint_positions(self.config.initial_state_timeout)
         if initial_joints is None:
+            logger.error(
+                f"Failed to read initial joint state within "
+                f"{self.config.initial_state_timeout}s; keyboard teleop exiting"
+            )
+            self._stop_event.set()
             return
-        home_pose = JogState.from_fk(model_path, ee_joint_id, self.config.home_joints)
         current_pose = JogState.from_fk(model_path, ee_joint_id, initial_joints).copy()
 
         # Publish initial pose

--- a/dimos/teleop/keyboard/keyboard_teleop_module.py
+++ b/dimos/teleop/keyboard/keyboard_teleop_module.py
@@ -19,7 +19,7 @@ blueprints via autoconnect.
 
 Keyboard controls:
     W/S: +X/-X (forward/backward)
-    A/D: -Y/+Y (left/right)
+    A/D: +Y/-Y (left/right)
     Q/E: +Z/-Z (up/down)
     R/F: +Roll/-Roll
     T/G: +Pitch/-Pitch
@@ -45,8 +45,9 @@ from dimos.constants import DEFAULT_THREAD_JOIN_TIMEOUT
 from dimos.control.examples.cartesian_ik_jogger import JogState
 from dimos.core.core import rpc
 from dimos.core.module import Module, ModuleConfig
-from dimos.core.stream import Out
+from dimos.core.stream import In, Out
 from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
+from dimos.msgs.sensor_msgs.JointState import JointState
 
 # Force X11 driver to avoid OpenGL threading issues
 os.environ["SDL_VIDEODRIVER"] = "x11"
@@ -71,6 +72,8 @@ class KeyboardTeleopConfig(ModuleConfig):
     ee_joint_id: int = 6
     task_name: str = "cartesian_ik_arm"
     home_joints: list[float] | None = None
+    joint_names: list[str] | None = None
+    initial_state_timeout: float = 5.0
 
 
 class KeyboardTeleopModule(Module):
@@ -81,6 +84,7 @@ class KeyboardTeleopModule(Module):
 
     config: KeyboardTeleopConfig
 
+    joint_state: In[JointState]
     cartesian_command: Out[PoseStamped]
 
     _stop_event: threading.Event
@@ -107,14 +111,34 @@ class KeyboardTeleopModule(Module):
             self._thread.join(DEFAULT_THREAD_JOIN_TIMEOUT)
         super().stop()
 
+    def _read_joint_positions(self, timeout: float) -> list[float] | None:
+        try:
+            msg = self.joint_state.get_next(timeout)
+        except Exception:
+            return None
+        if not msg.position:
+            return None
+
+        if joint_names := self.config.joint_names:
+            name_to_position = dict(zip(msg.name, msg.position, strict=False))
+            if any(name not in name_to_position for name in joint_names):
+                return None
+            return [float(name_to_position[name]) for name in joint_names]
+
+        if len(msg.position) < self.config.ee_joint_id:
+            return None
+        return [float(position) for position in msg.position[: self.config.ee_joint_id]]
+
     def _pygame_loop(self) -> None:
         model_path = str(self.config.model_path)
         ee_joint_id = self.config.ee_joint_id
         task_name = self.config.task_name
 
-        # Initialize pose from forward kinematics at the robot's home configuration
+        initial_joints = self._read_joint_positions(self.config.initial_state_timeout)
+        if initial_joints is None:
+            return
         home_pose = JogState.from_fk(model_path, ee_joint_id, self.config.home_joints)
-        current_pose = home_pose.copy()
+        current_pose = JogState.from_fk(model_path, ee_joint_id, initial_joints).copy()
 
         # Publish initial pose
         self.cartesian_command.publish(current_pose.to_pose_stamped(task_name))
@@ -137,7 +161,8 @@ class KeyboardTeleopModule(Module):
                     if event.key == pygame.K_ESCAPE:
                         self._stop_event.set()
                     elif event.key == pygame.K_SPACE:
-                        current_pose = home_pose.copy()
+                        if joints := self._read_joint_positions(timeout=0.1):
+                            current_pose = JogState.from_fk(model_path, ee_joint_id, joints).copy()
 
             keys = pygame.key.get_pressed()
 
@@ -147,9 +172,9 @@ class KeyboardTeleopModule(Module):
             if keys[pygame.K_s]:
                 current_pose.x -= LINEAR_SPEED * dt
             if keys[pygame.K_a]:
-                current_pose.y -= LINEAR_SPEED * dt
-            if keys[pygame.K_d]:
                 current_pose.y += LINEAR_SPEED * dt
+            if keys[pygame.K_d]:
+                current_pose.y -= LINEAR_SPEED * dt
             if keys[pygame.K_q]:
                 current_pose.z += LINEAR_SPEED * dt
             if keys[pygame.K_e]:
@@ -201,12 +226,12 @@ class KeyboardTeleopModule(Module):
 
             controls = [
                 ("W/S", "+X/-X (forward/back)"),
-                ("A/D", "-Y/+Y (left/right)"),
+                ("A/D", "+Y/-Y (left/right)"),
                 ("Q/E", "+Z/-Z (up/down)"),
                 ("R/F", "+Roll/-Roll"),
                 ("T/G", "+Pitch/-Pitch"),
                 ("Y/H", "+Yaw/-Yaw"),
-                ("SPACE", "Reset to home"),
+                ("SPACE", "Sync to current pose"),
                 ("ESC", "Quit"),
             ]
             for key, desc in controls:

--- a/docs/capabilities/manipulation/adding_a_custom_arm.md
+++ b/docs/capabilities/manipulation/adding_a_custom_arm.md
@@ -141,6 +141,14 @@ class YourArmAdapter:
         """Check if connected."""
         return self._sdk is not None and self._sdk.is_alive()
 
+    def activate(self) -> bool:
+        """Prepare hardware for commanded motion after connect()."""
+        return self.write_enable(True)
+
+    def deactivate(self) -> bool:
+        """Gracefully stop commanded motion before disconnect()."""
+        return self.write_stop()
+
 
     def get_info(self) -> ManipulatorInfo:
         """Get manipulator info (vendor, model, DOF)."""
@@ -632,6 +640,8 @@ def mock_adapter():
     adapter.read_joint_velocities.return_value = [0.0] * 6
     adapter.read_joint_efforts.return_value = [0.0] * 6
     adapter.write_joint_positions.return_value = True
+    adapter.activate.return_value = True
+    adapter.deactivate.return_value = True
     adapter.read_enabled.return_value = True
     adapter.is_connected.return_value = True
     return adapter
@@ -674,12 +684,12 @@ positions = adapter.read_joint_positions()
 assert len(positions) == 6
 print(f"Joint positions (rad): {positions}")
 
-# Enable and move
-adapter.write_enable(True)
+# Activate and move
+adapter.activate()
 adapter.write_joint_positions([0.0] * 6)
 
 # Cleanup
-adapter.write_stop()
+adapter.deactivate()
 adapter.disconnect()
 ```
 


### PR DESCRIPTION
Closes #1183

## Solution
This PR resolves the following issues observed on teleoperating xarm:
### KeyboardTeleopModule initial position sync
Wire robot joint states to the keyboard teleop module so that it initialize target to the robot startup position. A more proper fix in my mind should be to refactor keyboard teleop module to only output relative cartesian motion and wire that to some relative cartesian task so that the teleop module is decoupled from the actual robot state.

### XArm graceful start/stop
Added two lifecycle methods in manipulator adapter `activate`/`deactivate` to execute functions required before robot starts/stop movement. The semantic is different from `connect`/`disconnect` in that sometime you might want to only pause robot commanding while still keeping the connection. Now the xarm will move to the default position on start/stop.

## How to Test
```bash
# connects to a real robot for testing
dimos --xarm6-ip=192.168.1.210 run keyboard-teleop-xarm6
```

<!-- oneliner required to run the actual feature -->
<!-- blueprint for robot changes, benchmarks for transport changes etc -->

## Contributor License Agreement

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
