### PR TITLE
Don't require large tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -442,7 +442,7 @@ jobs:
     - docs-validate
     - tests
     - self-hosted-tests
-    - self-hosted-large-tests
+    #- self-hosted-large-tests
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Large tests need a little more testing to get them working reliably, currently the release tests seem to messing up the runner setup or something.

Will add back in when stable.