### PR TITLE
Upgrade ROS image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,27 @@ env:
   UV_NO_SYNC: "1"
 
 jobs:
+  compute-ros-pin:
+    # Extracts the ros-dev image digest pinned in docker/ros-dev-pin/Dockerfile
+    # so downstream jobs can reference it from their `container:` field.
+    # That will be updated by Dependabot, and keep CI tests stable.
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read  # For checkout
+    outputs:
+      digest: ${{ steps.read.outputs.digest }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - id: read
+        run: |
+          DIGEST=$(grep -oE 'sha256:[a-f0-9]{64}' docker/ros-dev-pin/Dockerfile)
+          if [ -z "$DIGEST" ]; then
+            echo "::error::No sha256 digest found in docker/ros-dev-pin/Dockerfile"
+            exit 1
+          fi
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+
   lint:
     timeout-minutes: 10
     runs-on: ubuntu-latest
@@ -230,6 +251,7 @@ jobs:
     # Skip on PRs from forks which would expose the self-hosted runner to untrusted code from external contributors.
     if: |
       github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    needs: compute-ros-pin
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -242,7 +264,7 @@ jobs:
           - os: Linux
             # GitHub Actions only honours `container:` on Linux runners.
             container:
-              image: ghcr.io/dimensionalos/ros-dev:dev
+              image: ghcr.io/dimensionalos/ros-dev@${{ needs.compute-ros-pin.outputs.digest }}
             markers: "self_hosted or skipif_no_ros"
             experimental: false
           - os: macOS

--- a/docker/ros-dev-pin/Dockerfile
+++ b/docker/ros-dev-pin/Dockerfile
@@ -15,4 +15,4 @@
 # IMPORTANT: do NOT remove the `:latest` tag from the FROM line — Dependabot
 # uses it to anchor which channel to track. With digest-only, it has nothing
 # to follow and stops updating.
-FROM ghcr.io/dimensionalos/ros-dev:latest@sha256:7e3e6b664489be902be3fa6ecd1a7295bd89583f0272a8b61db557acff664d07
+FROM ghcr.io/dimensionalos/ros-dev:latest@sha256:a3a27c793caca2486ec8c781a2a238067d08c7188c740ff8dda65cd18e27866c

--- a/docker/ros-dev-pin/Dockerfile
+++ b/docker/ros-dev-pin/Dockerfile
@@ -8,10 +8,6 @@
 # release.yml greps the digest out of this file and feeds it to consuming jobs'
 # `container:` fields.
 #
-# To seed / refresh manually:
-#   docker pull ghcr.io/dimensionalos/ros-dev:latest
-#   docker inspect --format='{{index .RepoDigests 0}}' ghcr.io/dimensionalos/ros-dev:latest
-#
 # IMPORTANT: do NOT remove the `:latest` tag from the FROM line — Dependabot
 # uses it to anchor which channel to track. With digest-only, it has nothing
 # to follow and stops updating.

--- a/docker/ros-dev-pin/Dockerfile
+++ b/docker/ros-dev-pin/Dockerfile
@@ -1,0 +1,18 @@
+# Digest pin for ghcr.io/dimensionalos/ros-dev:latest consumed by every CI
+# and release job that uses the ros-dev container. This Dockerfile is NEVER
+# BUILT. It exists solely as a target for Dependabot's `docker` ecosystem,
+# which scans FROM directives and opens PRs to bump the @sha256:... digest
+# when the `:latest` tag moves (rebuilt from main by docker-build.yml).
+#
+# The `compute-pin` job in .github/workflows/ci.yml and .github/workflows/
+# release.yml greps the digest out of this file and feeds it to consuming jobs'
+# `container:` fields.
+#
+# To seed / refresh manually:
+#   docker pull ghcr.io/dimensionalos/ros-dev:latest
+#   docker inspect --format='{{index .RepoDigests 0}}' ghcr.io/dimensionalos/ros-dev:latest
+#
+# IMPORTANT: do NOT remove the `:latest` tag from the FROM line — Dependabot
+# uses it to anchor which channel to track. With digest-only, it has nothing
+# to follow and stops updating.
+FROM ghcr.io/dimensionalos/ros-dev:latest@sha256:7e3e6b664489be902be3fa6ecd1a7295bd89583f0272a8b61db557acff664d07

--- a/docker/ros/Dockerfile
+++ b/docker/ros/Dockerfile
@@ -1,4 +1,4 @@
-ARG FROM_IMAGE=ubuntu:22.04
+ARG FROM_IMAGE=ubuntu:24.04
 FROM ${FROM_IMAGE}
 
 # Avoid prompts from apt
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y locales && \
 ENV LANG=en_US.UTF-8
 
 # Set ROS distro
-ENV ROS_DISTRO=humble
+ENV ROS_DISTRO=jazzy
 
 # Install basic requirements
 RUN apt-get update && apt-get install -y \
@@ -68,9 +68,6 @@ RUN apt-get update && apt-get install -y \
     ros-${ROS_DISTRO}-slam-toolbox \
     ros-${ROS_DISTRO}-foxglove-bridge \
     python3-rosdep \
-    python3-rosinstall \
-    python3-rosinstall-generator \
-    python3-wstool \
     python3-colcon-common-extensions \
     python3-vcstool \
     build-essential \


### PR DESCRIPTION
## Problem

ROS tests are being skipped due to unmet dependencies. The current ROS image requires Python 3.10 but other dependencies (onnxruntime) no longer support 3.10.

## Solution

- Update ROS image.
- Pin ROS image so changes in the image don't break CI implicitly. Dependabot can automatically update and keep any breakages kept within those PRs, to be fixed later.