### PR TITLE
Reenable codecov status

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,9 +3,6 @@ codecov:
   notify:
     manual_trigger: true
 
-coverage:
-  status: false
-
 # Carry forward self-hosted, as these are not run on external PRs.
 flag_management:
   individual_flags:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,6 +3,11 @@ codecov:
   notify:
     manual_trigger: true
 
+coverage:
+  status:
+    project: true
+    patch: true
+
 # Carry forward self-hosted, as these are not run on external PRs.
 flag_management:
   individual_flags:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -17,5 +17,6 @@ flag_management:
       carryforward: true
 
 comment:
+  layout: "newheader, diff, flags, components, files, newfooter"
   require_head: false
   require_base: false

--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -1,0 +1,49 @@
+name: pr-label
+
+# `workflow_run` runs on the default branch with a write-scoped GITHUB_TOKEN,
+# so this fires for PRs from forks too (where `pull_request`'s token is read-only).
+
+on:
+  workflow_run:
+    workflows: [ci]
+    types: [completed]
+
+permissions: {}
+
+jobs:
+  ready-to-merge:
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write  # To add/remove label
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const label = 'ready-to-merge';
+            const { owner, repo } = context.repo;
+            const run = context.payload.workflow_run;
+
+            // `workflow_run.pull_requests` is empty for fork PRs; fall back to a SHA lookup.
+            let prNumber = run.pull_requests?.[0]?.number;
+            if (!prNumber) {
+              const { data } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner, repo, commit_sha: run.head_sha,
+              });
+              prNumber = data.find(pr => pr.state === 'open')?.number;
+            }
+            if (!prNumber) return;
+
+            if (run.conclusion === 'success') {
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number: prNumber, labels: [label],
+              });
+            } else {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner, repo, issue_number: prNumber, name: label,
+                });
+              } catch (e) {
+                if (e.status !== 404) throw e;
+              }
+            }

--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -1,18 +1,23 @@
 name: pr-label
 
-# `workflow_run` runs on the default branch with a write-scoped GITHUB_TOKEN,
-# so this fires for PRs from forks too (where `pull_request`'s token is read-only).
+# Adds/removes `ready-to-merge` based on the `ci-complete` check-run (which is
+# what branch protection gates on). Re-evaluates on a new push too, so a stale
+# label is cleared before the new run finishes.
+#
+# Runs on the default branch via these events, so the GITHUB_TOKEN is
+# write-scoped even for PRs from forks.
 
 on:
-  workflow_run:
-    workflows: [ci]
+  check_run:
     types: [completed]
+  pull_request_target:
+    types: [opened, reopened, synchronize]
 
 permissions: {}
 
 jobs:
   ready-to-merge:
-    if: github.event.workflow_run.event == 'pull_request'
+    if: github.event_name == 'pull_request_target' || github.event.check_run.name == 'ci-complete'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write  # To add/remove label
@@ -22,19 +27,27 @@ jobs:
           script: |
             const label = 'ready-to-merge';
             const { owner, repo } = context.repo;
-            const run = context.payload.workflow_run;
+            const payload = context.payload;
 
-            // `workflow_run.pull_requests` is empty for fork PRs; fall back to a SHA lookup.
-            let prNumber = run.pull_requests?.[0]?.number;
-            if (!prNumber) {
-              const { data } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-                owner, repo, commit_sha: run.head_sha,
+            let sha, prNumber;
+            if (context.eventName === 'pull_request_target') {
+              sha = payload.pull_request.head.sha;
+              prNumber = payload.pull_request.number;
+            } else {
+              sha = payload.check_run.head_sha;
+              const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner, repo, commit_sha: sha,
               });
-              prNumber = data.find(pr => pr.state === 'open')?.number;
+              prNumber = prs.find(p => p.state === 'open')?.number;
+              if (!prNumber) return;
             }
-            if (!prNumber) return;
 
-            if (run.conclusion === 'success') {
+            const { data: { check_runs } } = await github.rest.checks.listForRef({
+              owner, repo, ref: sha, check_name: 'ci-complete',
+            });
+            const ciOk = check_runs[0]?.conclusion === 'success';
+
+            if (ciOk) {
               await github.rest.issues.addLabels({
                 owner, repo, issue_number: prNumber, labels: [label],
               });


### PR DESCRIPTION
I think we need these status checks so people are more aware when coverage drops.

This also adds a workflow to add a label to PRs that have all _required_ checks passing, so it's easy to see which PRs are mergeable. This also means it can be used in a custom view to filter out PRs which are not ready.