### PR TITLE
lfs_push: auto-configure credential helper for lfs.dimensionalos.com

### DIFF
--- a/bin/lfs_push
+++ b/bin/lfs_push
@@ -24,6 +24,15 @@ if ! gh auth status &>/dev/null 2>&1; then
     exit 1
 fi
 
+# Credential helper scoped to our LFS server: when git-lfs gets a 401 from
+# lfs.dimensionalos.com it asks git for credentials, and this helper answers
+# with a fresh token from `gh`. Note `gh auth git-credential` can NOT be used
+# here — it only answers for github.com hosts. Scoped to this one URL, so
+# pushes to github.com (or anywhere else) are unaffected.
+git config --global --replace-all 'credential.https://lfs.dimensionalos.com.helper' \
+    '!f() { if [ "$1" = "get" ]; then echo "username=token"; echo "password=$(gh auth token)"; fi; }; f'
+echo -e "${GREEN}✓${NC} Configured LFS credential helper for lfs.dimensionalos.com"
+
 #echo -e "${GREEN}Running test data compression check...${NC}"
 
 ROOT=$(git rev-parse --show-toplevel)


### PR DESCRIPTION
## Problem

`git push` with new LFS objects prompted for a username/password (and hung in non-interactive contexts), even after the LFS server started returning a proper 401 challenge (dimensionalOS/dimensional-lfs#1).

Root cause: the recommended credential helper, `gh auth git-credential`, **only answers for github.com hosts** — for `lfs.dimensionalos.com` it exits 1 with no output, so git falls back to an interactive prompt:

```
$ printf "protocol=https\nhost=lfs.dimensionalos.com\n\n" | gh auth git-credential get
$ echo $?   # → 1, no output
```

## Fix

`bin/lfs_push` now configures (once, globally) a credential helper **scoped to exactly `https://lfs.dimensionalos.com`** that supplies a fresh `gh auth token` on each request:

- Nothing stored on disk — the token is fetched from gh's keyring per invocation, so rotation/re-login is picked up automatically.
- Scoped by URL: pushes to github.com or any other host never invoke it.
- After running `bin/lfs_push` once, plain `git push` works with LFS objects from then on (server 401 challenge → helper supplies token → giftless validates write access via GitHub API → presigned S3 upload).

## Verified

Full auth matrix tested against the live server from a wiped config: anon upload → 401 challenge, helper answers, push succeeds, objects anonymously downloadable afterwards.

