### PR TITLE
fix(ci): fix git-lfs-guard compat and add LFS pull retry

### DIFF
--- a/dimos/utils/data.py
+++ b/dimos/utils/data.py
@@ -22,6 +22,7 @@ import subprocess
 import sys
 import tarfile
 import tempfile
+import time
 
 from dimos.constants import DIMOS_PROJECT_ROOT
 from dimos.utils.logging_config import setup_logger
@@ -191,23 +192,30 @@ def _is_lfs_pointer_file(file_path: Path) -> bool:
         return False
 
 
-def _lfs_pull(file_path: Path, repo_root: Path) -> None:
-    try:
-        relative_path = file_path.relative_to(repo_root)
+def _lfs_pull(file_path: Path, repo_root: Path, *, retries: int = 2) -> None:
+    relative_path = file_path.relative_to(repo_root)
 
-        env = os.environ.copy()
-        env["GIT_LFS_FORCE_PROGRESS"] = "1"
+    env = os.environ.copy()
+    env["GIT_LFS_FORCE_PROGRESS"] = "1"
 
-        subprocess.run(
-            ["git", "lfs", "pull", "--include", str(relative_path)],
-            cwd=repo_root,
-            check=True,
-            env=env,
-        )
-    except subprocess.CalledProcessError as e:
-        raise RuntimeError(f"Failed to pull LFS file {file_path}: {e}")
+    last_err: subprocess.CalledProcessError | None = None
+    for attempt in range(1, retries + 2):  # retries + 1 total attempts
+        try:
+            subprocess.run(
+                ["git", "lfs", "pull", "--include", str(relative_path)],
+                cwd=repo_root,
+                check=True,
+                env=env,
+            )
+            return
+        except subprocess.CalledProcessError as e:
+            last_err = e
+            if attempt <= retries:
+                time.sleep(attempt)  # 1s, 2s backoff
 
-    return None
+    raise RuntimeError(
+        f"Failed to pull LFS file {file_path} after {retries + 1} attempts: {last_err}"
+    )
 
 
 def _decompress_archive(filename: str | Path) -> Path:


### PR DESCRIPTION
## Problem

`test_make_path_mask` and other LFS-dependent tests are failing intermittently on GitHub-hosted runners since PR #2287 removed `self_hosted` markers and PR #2352 switched LFS to `lfs.dimensionalos.com`.

**Root cause (two bugs):**
1. `git-lfs-guard` uses `--json` flag for `ls-files` which requires git-lfs 3.6+. On older versions this fails silently (guard warns and allows through, but the size check is bypassed)
2. `git lfs pull` against the self-hosted LFS server occasionally returns exit code 2 (transient server error), with no retry logic

## Solution

1. **Fix `git-lfs-guard`**: Replace `--json` + `jq` parsing with text `--size` output parsing that works on all git-lfs versions. Parses the standard `ls-files --size` format (`* = downloaded`, `- = pointer`, size in parentheses with unit suffix)
2. **Add retry to `_lfs_pull()`**: 3 attempts with linear backoff (1s, 2s) for transient LFS server errors

## How to Test

```bash
pytest dimos/mapping/occupancy/test_path_mask.py -v
```

CI should pass without the flaky LFS failures.

## Contributor License Agreement

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
