### PR TITLE
md-babel: cache Hugging Face models to stop 429 flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,26 @@ jobs:
           node-version: 'lts/*'
       - name: Install Python dependencies
         run: uv sync --group tests --frozen
+      - name: Cache Hugging Face models
+        id: hf-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface
+          # The docs determine which models get downloaded, so any docs
+          # change may introduce a new model: go online and re-save the
+          # cache then. restore-keys still seeds the new cache with the
+          # previously cached models, so only genuinely new models are
+          # downloaded (huggingface_hub falls back to cached files when
+          # revalidation is rate-limited).
+          key: hf-models-${{ hashFiles('docs/**/*.md') }}
+          restore-keys: |
+            hf-models-
+      - name: Run Hugging Face offline on exact cache hit
+        # Zero huggingface.co requests when every model is already cached;
+        # anonymous requests from shared GitHub runner IPs get rate-limited
+        # (HTTP 429), which was flaking this job.
+        if: steps.hf-cache.outputs.cache-hit == 'true'
+        run: echo "HF_HUB_OFFLINE=1" >> "$GITHUB_ENV"
       - name: Execute documentation code blocks
         run: ./bin/run-doc-codeblocks --ci --no-cache
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,24 +138,43 @@ jobs:
           node-version: 'lts/*'
       - name: Install Python dependencies
         run: uv sync --group tests --frozen
-      - name: Cache Hugging Face models
+      - name: Restore Hugging Face model cache
         id: hf-cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: ~/.cache/huggingface
           # The docs determine which models get downloaded, so any docs
           # change may introduce a new model: go online and re-save the
           # cache then. restore-keys still seeds the new cache with the
           # previously cached models, so only genuinely new models are
-          # downloaded (huggingface_hub falls back to cached files when
-          # revalidation is rate-limited).
+          # downloaded.
           key: hf-models-${{ hashFiles('docs/**/*.md') }}
           restore-keys: |
             hf-models-
+      - name: Prefetch Hugging Face models
+        if: steps.hf-cache.outputs.cache-hit != 'true'
+        # Anonymous downloads from shared GitHub runner IPs get rate-limited
+        # by huggingface.co (HTTP 429), so retry with backoff. Models already
+        # in the restored cache are not re-downloaded.
+        run: |
+          for i in 1 2 3 4 5; do
+            uv run python -c "from transformers import CLIPModel, CLIPProcessor; m = 'openai/clip-vit-base-patch32'; CLIPModel.from_pretrained(m); CLIPProcessor.from_pretrained(m)" && exit 0
+            echo "Hugging Face download failed (likely rate-limited); retry $i in $((i * 30))s"
+            sleep $((i * 30))
+          done
+          echo "::error::Could not download Hugging Face models after 5 attempts"
+          exit 1
+      - name: Save Hugging Face model cache
+        # Save right after the download (not in a post step) so a failure in
+        # the doc blocks below doesn't throw away the downloaded models.
+        if: steps.hf-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/huggingface
+          key: hf-models-${{ hashFiles('docs/**/*.md') }}
       - name: Run Hugging Face offline on exact cache hit
-        # Zero huggingface.co requests when every model is already cached;
-        # anonymous requests from shared GitHub runner IPs get rate-limited
-        # (HTTP 429), which was flaking this job.
+        # Zero huggingface.co requests when every model is already cached:
+        # immune to rate limiting.
         if: steps.hf-cache.outputs.cache-hit == 'true'
         run: echo "HF_HUB_OFFLINE=1" >> "$GITHUB_ENV"
       - name: Execute documentation code blocks


### PR DESCRIPTION
## Problem

The md-babel job randomly fails with ([example](https://github.com/dimensionalOS/dimos/actions/runs/27073589816/job/79906991136)):

```
huggingface_hub.errors.HfHubHTTPError: 429 Client Error: Too Many Requests for url:
https://huggingface.co/openai/clip-vit-base-patch32/resolve/main/preprocessor_config.json
```

`docs/capabilities/memory/index.md` instantiates `dimos.models.embedding.clip.CLIPModel`, which downloads `openai/clip-vit-base-patch32` (~600 MB) from huggingface.co **on every CI run, anonymously** — no HF cache, no token. GitHub-hosted runners share egress IPs across all of GitHub, and Hugging Face rate-limits anonymous traffic per IP, so the job is a coin flip. (Right now the throttling is severe enough that even this PR's first cold-cache run got 429'd on the initial download.)

## Fix

- **Restore** `~/.cache/huggingface` (`actions/cache/restore`), keyed on `hashFiles('docs/**/*.md')` with a `hf-models-` restore-key.
- **Exact hit** (any PR not touching docs — the steady state): `HF_HUB_OFFLINE=1` → zero huggingface.co requests → rate limiting is impossible.
- **Miss**: explicit prefetch step downloads the model with backoff (5 attempts, 30–150 s) to punch through transient 429s, then **saves the cache immediately** (`actions/cache/save`) — not in a post step — so one successful download seeds the cache permanently even if the doc blocks themselves later fail.

Side benefit: drops a ~600 MB download from every steady-state run.

If 429s ever outlast the retry budget on cold-cache runs, the escalation is an org `HF_TOKEN` secret (authenticated requests get much higher rate limits).