### PR TITLE
Add lcmflow: animated LCM packet highway TUI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,7 +225,7 @@ Every `GlobalConfig` field is a CLI flag: `--robot-ip`, `--simulation/--no-simul
 | `dimos log [-f] [-n N] [--json] [-r <run-id>]` | View per-run logs |
 | `dimos mcp list-tools / call / status / modules` | MCP tools (requires McpServer in blueprint) |
 | `dimos agent-send "<text>"` | Send text to the running agent via LCM |
-| `dimos lcmspy / agentspy / humancli / top` | Debug/diagnostic tools |
+| `dimos lcmspy / lcmflow / agentspy / humancli / top` | Debug/diagnostic tools (`lcmflow` = animated packet highway) |
 | `dimos topic echo <topic> / send <topic> <expr>` | LCM topic pub/sub |
 | `dimos rerun-bridge` | Launch Rerun visualization standalone |
 

--- a/dimos/robot/cli/dimos.py
+++ b/dimos/robot/cli/dimos.py
@@ -625,6 +625,15 @@ def lcmspy(ctx: typer.Context) -> None:
 
 
 @main.command(context_settings={"allow_extra_args": True, "ignore_unknown_options": True})
+def lcmflow(ctx: typer.Context) -> None:
+    """LCM packet highway — animated real-time view of LCM traffic."""
+    from dimos.utils.cli.lcmflow.run_lcmflow import main as lcmflow_main
+
+    sys.argv = ["lcmflow", *ctx.args]
+    lcmflow_main()
+
+
+@main.command(context_settings={"allow_extra_args": True, "ignore_unknown_options": True})
 def agentspy(ctx: typer.Context) -> None:
     """Agent spy tool for monitoring agents."""
     from dimos.utils.cli.agentspy.agentspy import main as agentspy_main

--- a/dimos/utils/cli/lcmflow/demo_lcmflow.py
+++ b/dimos/utils/cli/lcmflow/demo_lcmflow.py
@@ -1,0 +1,62 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Headless screenshot harness for lcmflow with synthetic traffic.
+
+Usage: python demo_lcmflow.py [out.svg] [seconds]
+Renders the app off-screen, injects fake robot-ish packet streams,
+and writes an SVG screenshot (convert with cairosvg for PNG).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import random
+import sys
+
+from dimos.utils.cli.lcmflow.run_lcmflow import LCMFlowApp
+
+STREAMS = [
+    # channel, avg bytes, hz
+    ("/color_image#sensor_msgs.Image", 2_764_800, 12.8),
+    ("/lidar#sensor_msgs.PointCloud2", 320_000, 7.0),
+    ("/global_map#sensor_msgs.PointCloud2", 800_000, 1.4),
+    ("/global_costmap#nav_msgs.OccupancyGrid", 60_000, 1.4),
+    ("/tf#tf2_msgs.TFMessage", 300, 17.0),
+    ("/odom#geometry_msgs.PoseStamped", 88, 17.0),
+    ("/cmd_vel#geometry_msgs.Twist", 60, 50.0),
+    ("/camera_info#sensor_msgs.CameraInfo", 360, 1.0),
+]
+
+
+async def screenshot(path: str, seconds: float) -> None:
+    app = LCMFlowApp()
+    async with app.run_test(size=(170, 34)) as pilot:
+        elapsed = 0.0
+        step = 0.05
+        while elapsed < seconds:
+            for channel, size, hz in STREAMS:
+                if random.random() < hz * step:
+                    jitter = max(20, int(random.gauss(size, size * 0.1)))
+                    app.highway.spy.msg(channel, b"\0" * jitter)
+            await pilot.pause(step)
+            elapsed += step
+        app.save_screenshot(path)
+
+
+if __name__ == "__main__":
+    out = sys.argv[1] if len(sys.argv) > 1 else "lcmflow.svg"
+    secs = float(sys.argv[2]) if len(sys.argv) > 2 else 4.0
+    asyncio.run(screenshot(out, secs))
+    print(f"wrote {out}")

--- a/dimos/utils/cli/lcmflow/lcmflow.py
+++ b/dimos/utils/cli/lcmflow/lcmflow.py
@@ -1,0 +1,289 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""lcmflow — model layer for the LCM packet-highway visualization.
+
+Every LCM packet becomes a *vehicle* driving down a per-topic *lane*.
+Packet size picks the vehicle class: tiny telemetry messages (cmd_vel,
+tf) are fast little dots, raw images and point clouds are long, slower
+trucks. Packets that arrive faster than the lane can fit them merge into
+a single vehicle with a passenger count (``xN``).
+
+The model is deliberately renderer-agnostic so the Textual TUI and any
+future web frontend share the same physics.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+import math
+import time
+from typing import Any
+
+from dimos.utils.cli import theme
+from dimos.utils.cli.lcmspy.lcmspy import LCMSpy, LCMSpyConfig, Topic as SpyTopic
+
+# Cells per second a speed-1.0 vehicle covers. Frequency shows up as
+# vehicle density, size as vehicle length and a small speed handicap.
+BASE_SPEED = 24.0
+
+# Free cells required behind the previous vehicle before a new one may
+# spawn; arrivals during that window coalesce into the previous vehicle.
+SPAWN_GAP = 2
+
+TRAIL_LEN = 3
+
+
+@dataclass(frozen=True)
+class SizeClass:
+    """A vehicle class for a packet-size band."""
+
+    name: str
+    max_bytes: int  # inclusive upper bound for this class
+    length: int  # body length in cells
+    speed: float  # multiplier on BASE_SPEED
+
+
+# Ordered smallest to largest. Calibrated against typical robot streams:
+# Twist/tf ~100 B, odom/camera_info ~1 KiB, laser scans ~10 KiB,
+# costmaps/JPEG ~100 KiB, raw images and point clouds 0.5 MiB+.
+SIZE_CLASSES: tuple[SizeClass, ...] = (
+    SizeClass("nano", 256, 1, 1.5),
+    SizeClass("small", 2_048, 2, 1.25),
+    SizeClass("medium", 32_768, 4, 1.0),
+    SizeClass("large", 524_288, 7, 0.8),
+    SizeClass("mega", 2**63 - 1, 11, 0.65),
+)
+
+
+def size_class(n_bytes: int) -> SizeClass:
+    """Pick the vehicle class for a packet of *n_bytes*."""
+    for cls in SIZE_CLASSES:
+        if n_bytes <= cls.max_bytes:
+            return cls
+    return SIZE_CLASSES[-1]
+
+
+# Colors keyed by LCM message type name (the part after the last '.'
+# in a '/topic#pkg.Type' channel), falling back to package, falling
+# back to a stable hash into the palette.
+TYPE_COLORS: dict[str, str] = {
+    "Image": theme.YELLOW,
+    "CompressedImage": theme.BRIGHT_YELLOW,
+    "CameraInfo": theme.BRIGHT_YELLOW,
+    "PointCloud2": theme.PURPLE,
+    "LaserScan": theme.BRIGHT_PURPLE,
+    "OccupancyGrid": theme.BLUE,
+    "Path": theme.BRIGHT_BLUE,
+    "Odometry": theme.CYAN,
+    "TFMessage": theme.AGENT,
+}
+
+PKG_COLORS: dict[str, str] = {
+    "sensor_msgs": theme.YELLOW,
+    "geometry_msgs": theme.CYAN,
+    "nav_msgs": theme.BLUE,
+    "tf2_msgs": theme.AGENT,
+    "vision_msgs": theme.BRIGHT_PURPLE,
+    "std_msgs": theme.WHITE,
+}
+
+FALLBACK_PALETTE: tuple[str, ...] = (
+    theme.CYAN,
+    theme.YELLOW,
+    theme.BLUE,
+    theme.PURPLE,
+    theme.AGENT,
+    theme.BRIGHT_YELLOW,
+    theme.BRIGHT_BLUE,
+    theme.BRIGHT_PURPLE,
+)
+
+
+def split_channel(channel: str) -> tuple[str, str]:
+    """Split an LCM channel into (topic, type) at the '#' marker.
+
+    '/odom#geometry_msgs.PoseStamped' -> ('/odom', 'geometry_msgs.PoseStamped')
+    """
+    if "#" in channel:
+        topic, _, type_name = channel.partition("#")
+        return topic, type_name
+    return channel, ""
+
+
+def color_for_channel(channel: str) -> str:
+    """Stable display color for an LCM channel."""
+    _, type_name = split_channel(channel)
+    if type_name:
+        msg_name = type_name.rsplit(".", 1)[-1]
+        if msg_name in TYPE_COLORS:
+            return TYPE_COLORS[msg_name]
+        pkg = type_name.split(".", 1)[0]
+        if pkg in PKG_COLORS:
+            return PKG_COLORS[pkg]
+    if channel.startswith("/rpc"):
+        return theme.BRIGHT_BLUE
+    # Stable (non-salted) hash so colors survive restarts.
+    digest = sum(channel.encode())
+    return FALLBACK_PALETTE[digest % len(FALLBACK_PALETTE)]
+
+
+@dataclass
+class Vehicle:
+    """One packet (or a coalesced burst of packets) on the road."""
+
+    t0: float  # lane-clock time the vehicle spawned
+    cls: SizeClass
+    n_bytes: int
+    count: int = 1
+
+    @property
+    def speed(self) -> float:
+        return BASE_SPEED * self.cls.speed
+
+    @property
+    def length(self) -> int:
+        # Coalesced bursts stretch a little so dense streams read as
+        # convoys rather than a single flickering car.
+        stretch = min(4, int(math.log2(self.count)) if self.count > 1 else 0)
+        return self.cls.length + stretch
+
+    def head(self, now: float) -> float:
+        """Head (front bumper) position in cells at lane-clock *now*."""
+        return (now - self.t0) * self.speed
+
+    def absorb(self, n_bytes: int) -> None:
+        """Merge a packet that arrived before this vehicle cleared the on-ramp."""
+        self.count += 1
+        self.n_bytes += n_bytes
+        cls = size_class(n_bytes)
+        if cls.length > self.cls.length:
+            self.cls = cls
+
+
+@dataclass
+class Lane:
+    """A single topic's lane: live vehicles plus spawn bookkeeping."""
+
+    channel: str
+    color: str = ""
+    vehicles: deque[Vehicle] = field(default_factory=deque)
+    topic: str = field(init=False, default="")
+    type_name: str = field(init=False, default="")
+
+    def __post_init__(self) -> None:
+        if not self.color:
+            self.color = color_for_channel(self.channel)
+        self.topic, self.type_name = split_channel(self.channel)
+
+    def spawn(self, n_bytes: int, now: float) -> Vehicle:
+        """Add a packet at lane-clock *now*, coalescing into the newest
+        vehicle if it has not yet cleared the on-ramp."""
+        last = self.vehicles[-1] if self.vehicles else None
+        if last is not None and last.head(now) < last.length + SPAWN_GAP:
+            last.absorb(n_bytes)
+            return last
+        vehicle = Vehicle(t0=now, cls=size_class(n_bytes), n_bytes=n_bytes)
+        self.vehicles.append(vehicle)
+        return vehicle
+
+    def prune(self, now: float, road_width: int) -> None:
+        """Drop vehicles whose tail (and trail) left the visible road."""
+        while self.vehicles:
+            v = self.vehicles[0]
+            if v.head(now) - v.length - TRAIL_LEN > road_width:
+                self.vehicles.popleft()
+            else:
+                break
+
+
+class PacketSpyConfig(LCMSpyConfig):
+    max_pending_packets: int = 100_000
+
+
+class PacketSpy(LCMSpy):
+    """LCMSpy that additionally queues every packet arrival for the renderer.
+
+    The LCM handle thread appends; the UI thread drains via
+    :meth:`drain`. ``deque`` keeps that lock-free and bounded.
+    """
+
+    config: PacketSpyConfig
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.pending: deque[tuple[str, int]] = deque(maxlen=self.config.max_pending_packets)
+
+    def msg(self, topic, data) -> None:  # type: ignore[no-untyped-def, override]
+        super().msg(topic, data)
+        self.pending.append((topic, len(data)))
+
+    def topics(self) -> dict[str, SpyTopic]:
+        """Typed accessor for the per-channel statistics."""
+        return self.topic  # type: ignore[return-value]
+
+    def drain(self) -> list[tuple[str, int]]:
+        """Return and clear all packets queued since the last drain."""
+        drained: list[tuple[str, int]] = []
+        while True:
+            try:
+                drained.append(self.pending.popleft())
+            except IndexError:
+                return drained
+
+
+class Highway:
+    """All lanes plus the animation clock (pausable)."""
+
+    def __init__(self, spy: PacketSpy | None = None) -> None:
+        self.spy = spy if spy is not None else PacketSpy()
+        self.lanes: dict[str, Lane] = {}
+        self.paused = False
+        self._clock = 0.0
+        self._last_tick = time.monotonic()
+
+    def start(self) -> None:
+        self.spy.start()
+
+    def stop(self) -> None:
+        self.spy.stop()
+
+    @property
+    def clock(self) -> float:
+        return self._clock
+
+    def toggle_pause(self) -> None:
+        self.paused = not self.paused
+
+    def tick(self, road_width: int) -> None:
+        """Advance the clock, spawn queued packets, prune off-road vehicles."""
+        now = time.monotonic()
+        dt = now - self._last_tick
+        self._last_tick = now
+        if not self.paused:
+            self._clock += dt
+
+        packets = self.spy.drain()
+        if self.paused:
+            return
+        for channel, n_bytes in packets:
+            lane = self.lanes.get(channel)
+            if lane is None:
+                lane = Lane(channel)
+                self.lanes[channel] = lane
+            lane.spawn(n_bytes, self._clock)
+
+        for lane in self.lanes.values():
+            lane.prune(self._clock, road_width)

--- a/dimos/utils/cli/lcmflow/run_lcmflow.py
+++ b/dimos/utils/cli/lcmflow/run_lcmflow.py
@@ -1,0 +1,339 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""lcmflow — a real-time LCM packet highway.
+
+Each topic is a lane; every packet drives across it as a vehicle.
+Small fast packets (cmd_vel, tf) are zippy dots, images and point
+clouds are long slow trucks. Run alongside any DimOS stack:
+
+    lcmflow            # native TUI
+    lcmflow web        # serve the TUI in a browser
+    dimos lcmflow      # same, via the dimos CLI
+"""
+
+from __future__ import annotations
+
+from rich.segment import Segment
+from rich.style import Style
+from textual.app import App, ComposeResult
+from textual.binding import Binding
+from textual.color import Color
+from textual.geometry import Size
+from textual.scroll_view import ScrollView
+from textual.strip import Strip
+from textual.widgets import Static
+
+from dimos.utils.cli import theme
+from dimos.utils.cli.lcmflow.lcmflow import TRAIL_LEN, Highway, Lane
+
+FPS = 20.0
+LABEL_W = 38  # left column: topic names + stats
+ROWS_PER_LANE = 2  # vehicle row + separator/stats row
+
+BG = Color.parse(theme.BACKGROUND)
+ROAD_DOT_STYLE = Style(color=Color.parse(theme.DIM).blend(BG, 0.55).hex, bgcolor=theme.BACKGROUND)
+SEPARATOR_STYLE = Style(color=Color.parse(theme.DIM).blend(BG, 0.35).hex, bgcolor=theme.BACKGROUND)
+BLANK_STYLE = Style(bgcolor=theme.BACKGROUND)
+
+BODY_CHAR = "▰"
+HEAD_CHAR = "▶"
+NANO_CHAR = "●"
+TRAIL_CHARS = ("╸", "╌", "·")  # brightest first, fading behind the vehicle
+
+
+def freq_gradient(freq: float, max_freq: float = 30.0) -> str:
+    """Cyan (idle) to yellow (hot) for frequency readouts."""
+    ratio = min(freq / max_freq, 1.0)
+    return Color.parse(theme.CYAN).blend(Color.parse(theme.YELLOW), ratio).hex
+
+
+class HighwayView(ScrollView):
+    """Scrollable, line-rendered view of all lanes."""
+
+    can_focus = True
+
+    def __init__(self, highway: Highway) -> None:
+        super().__init__()
+        self.highway = highway
+        self.order: list[str] = []  # lane display order (arrival)
+        self.sort_mode = "arrival"  # arrival | traffic | name
+        self._lanes_view: list[Lane] = []  # sorted snapshot, rebuilt per tick
+
+    def on_mount(self) -> None:
+        self.set_interval(1 / FPS, self.tick)
+
+    def tick(self) -> None:
+        road_width = max(40, self.size.width - LABEL_W)
+        self.highway.tick(road_width)
+        for channel in self.highway.lanes:
+            if channel not in self.order:
+                self.order.append(channel)
+        self._lanes_view = self._sorted_lanes()
+        self.virtual_size = Size(self.size.width, len(self.order) * ROWS_PER_LANE)
+        self.refresh()
+
+    def cycle_sort(self) -> str:
+        modes = ["arrival", "traffic", "name"]
+        self.sort_mode = modes[(modes.index(self.sort_mode) + 1) % len(modes)]
+        return self.sort_mode
+
+    def _sorted_lanes(self) -> list[Lane]:
+        lanes = [self.highway.lanes[c] for c in self.order if c in self.highway.lanes]
+        if self.sort_mode == "traffic":
+            spy_topics = self.highway.spy.topics()
+            lanes.sort(
+                key=lambda lane: spy_topics[lane.channel].total_traffic()
+                if lane.channel in spy_topics
+                else 0,
+                reverse=True,
+            )
+        elif self.sort_mode == "name":
+            lanes.sort(key=lambda lane: lane.topic)
+        return lanes
+
+    def render_line(self, y: int) -> Strip:
+        y += int(self.scroll_offset.y)
+        lanes = self._lanes_view
+        lane_idx, row = divmod(y, ROWS_PER_LANE)
+        if lane_idx >= len(lanes):
+            return Strip([Segment(" " * self.size.width, BLANK_STYLE)])
+        lane = lanes[lane_idx]
+        road_width = max(40, self.size.width - LABEL_W)
+        if row == 0:
+            segments = self._label_segments(lane) + self._road_segments(lane, road_width)
+        else:
+            segments = self._stats_segments(lane) + self._separator_segments(road_width)
+        return Strip(segments, self.size.width)
+
+    def _label_segments(self, lane: Lane) -> list[Segment]:
+        """Topic name, with the message type in the lane color."""
+        topic = lane.topic
+        msg_name = lane.type_name.rsplit(".", 1)[-1] if lane.type_name else ""
+        room = LABEL_W - 2  # leading space + trailing space
+        if msg_name and len(topic) + 1 + len(msg_name) > room:
+            topic = topic[: max(1, room - len(msg_name) - 2)] + "…"
+        text = f" {topic}"
+        segments = [Segment(text, Style(color=theme.BRIGHT_WHITE, bgcolor=theme.BACKGROUND))]
+        used = len(text)
+        if msg_name:
+            type_text = f"·{msg_name}"[: max(0, LABEL_W - used - 1)]
+            segments.append(
+                Segment(
+                    type_text,
+                    Style(
+                        color=Color.parse(lane.color).blend(BG, 0.25).hex, bgcolor=theme.BACKGROUND
+                    ),
+                )
+            )
+            used += len(type_text)
+        segments.append(Segment(" " * max(0, LABEL_W - used), BLANK_STYLE))
+        return segments
+
+    def _stats_segments(self, lane: Lane) -> list[Segment]:
+        spy_topic = self.highway.spy.topics().get(lane.channel)
+        if spy_topic is None:
+            return [Segment(" " * LABEL_W, BLANK_STYLE)]
+        freq = spy_topic.freq(5.0)
+        parts = [
+            ("   ", BLANK_STYLE),
+            (f"{freq:6.1f} Hz ", Style(color=freq_gradient(freq), bgcolor=theme.BACKGROUND)),
+            (
+                f"{spy_topic.kbps_hr(5.0):>12} ",
+                Style(color=theme.WHITE, bgcolor=theme.BACKGROUND, dim=True),
+            ),
+            (
+                f"Σ{spy_topic.total_traffic_hr():>10}",
+                Style(color=theme.DIM, bgcolor=theme.BACKGROUND),
+            ),
+        ]
+        segments: list[Segment] = []
+        used = 0
+        for text, style in parts:
+            text = text[: max(0, LABEL_W - used)]
+            if text:
+                segments.append(Segment(text, style))
+                used += len(text)
+        segments.append(Segment(" " * max(0, LABEL_W - used), BLANK_STYLE))
+        return segments
+
+    def _road_segments(self, lane: Lane, road_width: int) -> list[Segment]:
+        """Render the vehicles of one lane into styled segments."""
+        chars = [" "] * road_width
+        styles: list[Style] = [BLANK_STYLE] * road_width
+        # Faint distance markers so empty road still reads as a road.
+        for x in range(0, road_width, 8):
+            chars[x] = "·"
+            styles[x] = ROAD_DOT_STYLE
+
+        now = self.highway.clock
+        color = Color.parse(lane.color)
+        body_style = Style(color=lane.color, bgcolor=theme.BACKGROUND, bold=True)
+        head_style = Style(
+            color=color.blend(Color.parse(theme.BRIGHT_WHITE), 0.65).hex,
+            bgcolor=theme.BACKGROUND,
+            bold=True,
+        )
+        trail_styles = [
+            Style(color=color.blend(BG, 1 - alpha).hex, bgcolor=theme.BACKGROUND)
+            for alpha in (0.55, 0.3, 0.15)
+        ]
+
+        for vehicle in lane.vehicles:
+            head = int(vehicle.head(now))
+            length = vehicle.length
+            tail = head - length + 1
+            if tail >= road_width or head < -TRAIL_LEN:
+                continue
+            # Fading trail behind the tail.
+            for i in range(TRAIL_LEN):
+                x = tail - 1 - i
+                if 0 <= x < road_width:
+                    chars[x] = TRAIL_CHARS[i]
+                    styles[x] = trail_styles[i]
+            # Body.
+            for x in range(max(0, tail), min(road_width, head + 1)):
+                chars[x] = BODY_CHAR if length > 1 else NANO_CHAR
+                styles[x] = body_style
+            # Bright nose on anything truck-sized.
+            if length >= 3 and 0 <= head < road_width:
+                chars[head] = HEAD_CHAR
+                styles[head] = head_style
+            # Passenger count for coalesced bursts, etched into the body.
+            if vehicle.count > 1 and length >= 4:
+                badge = f"×{min(vehicle.count, 999)}"  # noqa: RUF001 — intentional UI glyph
+                badge_style = Style(color=theme.BACKGROUND, bgcolor=lane.color, bold=True)
+                start = tail + max(0, (length - 1 - len(badge)) // 2)
+                if start >= 0 and start + len(badge) < head:
+                    for i, ch in enumerate(badge):
+                        if 0 <= start + i < road_width:
+                            chars[start + i] = ch
+                            styles[start + i] = badge_style
+
+        # Group identical styles into few segments.
+        segments: list[Segment] = []
+        run_start = 0
+        for x in range(1, road_width + 1):
+            if x == road_width or styles[x] is not styles[run_start]:
+                segments.append(Segment("".join(chars[run_start:x]), styles[run_start]))
+                run_start = x
+        return segments
+
+    def _separator_segments(self, road_width: int) -> list[Segment]:
+        pattern = ("╌" * 5 + "   ") * (road_width // 8 + 1)
+        return [Segment(pattern[:road_width], SEPARATOR_STYLE)]
+
+
+class HeaderBar(Static):
+    """One-line global stats strip."""
+
+    def __init__(self, view: HighwayView) -> None:
+        super().__init__()
+        self.view = view
+
+    def on_mount(self) -> None:
+        self.set_interval(0.5, self.refresh_stats)
+        self.refresh_stats()
+
+    def refresh_stats(self) -> None:
+        highway = self.view.highway
+        spy = highway.spy
+        n_topics = len(highway.lanes)
+        state = "  ⏸ PAUSED" if highway.paused else ""
+        self.update(
+            f"[bold {theme.CYAN}]◢◤ LCM FLOW[/]"
+            f"[{theme.DIM}] · packet highway[/]"
+            f"[bold {theme.YELLOW}]{state}[/]"
+            f"   [{theme.WHITE}]{n_topics} lanes[/]"
+            f"   [{freq_gradient(spy.freq(5.0), 100)}]{spy.freq(5.0):.1f} Hz[/]"
+            f"   [{theme.WHITE}]{spy.kbps_hr(5.0)}[/]"
+            f"   [{theme.DIM}]Σ {spy.total_traffic_hr()}[/]"
+            f"   [{theme.DIM}]sort: {self.view.sort_mode}[/]"
+        )
+
+
+class LCMFlowApp(App):  # type: ignore[type-arg]
+    """Real-time LCM packet highway visualization."""
+
+    CSS = f"""
+    Screen {{
+        layout: vertical;
+        background: {theme.BACKGROUND};
+    }}
+    HeaderBar {{
+        height: 2;
+        padding: 0 1;
+        background: {theme.BACKGROUND};
+        border-bottom: solid {theme.BORDER};
+    }}
+    HighwayView {{
+        background: {theme.BACKGROUND};
+        scrollbar-size: 1 1;
+    }}
+    Footer {{
+        background: {theme.BACKGROUND};
+    }}
+    """
+
+    BINDINGS = [
+        Binding("q", "quit", "quit"),
+        Binding("ctrl+c", "quit", show=False),
+        Binding("space", "pause", "pause"),
+        Binding("s", "sort", "sort"),
+    ]
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Warn about missing system config before entering TUI raw mode.
+        from dimos.protocol.service.lcmservice import autoconf
+
+        autoconf(check_only=True)
+
+        self.highway = Highway()
+        self.highway.start()
+        self.view = HighwayView(self.highway)
+
+    def compose(self) -> ComposeResult:
+        from textual.widgets import Footer
+
+        yield HeaderBar(self.view)
+        yield self.view
+        yield Footer()
+
+    async def on_unmount(self) -> None:
+        self.highway.stop()
+
+    def action_pause(self) -> None:
+        self.highway.toggle_pause()
+
+    def action_sort(self) -> None:
+        self.view.cycle_sort()
+
+
+def main() -> None:
+    import sys
+
+    if len(sys.argv) > 1 and sys.argv[1] == "web":
+        import os
+
+        from textual_serve.server import Server  # type: ignore[import-not-found]
+
+        server = Server(f"python {os.path.abspath(__file__)}")
+        server.serve()
+    else:
+        LCMFlowApp().run()
+
+
+if __name__ == "__main__":
+    main()

--- a/dimos/utils/cli/lcmflow/test_lcmflow.py
+++ b/dimos/utils/cli/lcmflow/test_lcmflow.py
@@ -1,0 +1,142 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dimos.utils.cli import theme
+from dimos.utils.cli.lcmflow.lcmflow import (
+    BASE_SPEED,
+    SIZE_CLASSES,
+    SPAWN_GAP,
+    Highway,
+    Lane,
+    PacketSpy,
+    color_for_channel,
+    size_class,
+    split_channel,
+)
+
+
+def test_size_classes_ordered() -> None:
+    bounds = [cls.max_bytes for cls in SIZE_CLASSES]
+    assert bounds == sorted(bounds)
+    lengths = [cls.length for cls in SIZE_CLASSES]
+    assert lengths == sorted(lengths)
+    # Bigger packets are slower.
+    speeds = [cls.speed for cls in SIZE_CLASSES]
+    assert speeds == sorted(speeds, reverse=True)
+
+
+def test_size_class_selection() -> None:
+    assert size_class(60).name == "nano"  # Twist
+    assert size_class(1_000).name == "small"  # odom
+    assert size_class(10_000).name == "medium"  # laser scan
+    assert size_class(100_000).name == "large"  # costmap
+    assert size_class(2_764_800).name == "mega"  # raw image
+    assert size_class(2**40).name == "mega"
+
+
+def test_split_channel() -> None:
+    assert split_channel("/odom#geometry_msgs.PoseStamped") == (
+        "/odom",
+        "geometry_msgs.PoseStamped",
+    )
+    assert split_channel("/plain") == ("/plain", "")
+
+
+def test_color_for_channel() -> None:
+    assert color_for_channel("/color_image#sensor_msgs.Image") == theme.YELLOW
+    assert color_for_channel("/lidar#sensor_msgs.PointCloud2") == theme.PURPLE
+    assert color_for_channel("/cmd_vel#geometry_msgs.Twist") == theme.CYAN
+    assert color_for_channel("/rpc/foo") == theme.BRIGHT_BLUE
+    # Unknown channels get a stable palette color.
+    assert color_for_channel("/mystery") == color_for_channel("/mystery")
+
+
+def test_vehicle_position_and_speed() -> None:
+    lane = Lane("/cmd_vel#geometry_msgs.Twist")
+    vehicle = lane.spawn(60, now=0.0)
+    speed = BASE_SPEED * vehicle.cls.speed
+    assert vehicle.head(0.0) == 0.0
+    assert vehicle.head(1.0) == speed
+    # Nano packets outrun mega packets.
+    mega = Lane("/img#sensor_msgs.Image").spawn(2_000_000, now=0.0)
+    assert vehicle.head(1.0) > mega.head(1.0)
+
+
+def test_lane_coalescing() -> None:
+    lane = Lane("/tf#tf2_msgs.TFMessage")
+    v1 = lane.spawn(300, now=0.0)
+    # Arrives before v1 cleared the on-ramp: coalesce.
+    v2 = lane.spawn(300, now=0.001)
+    assert v2 is v1
+    assert v1.count == 2
+    assert v1.n_bytes == 600
+    # Arrives after v1 cleared (length + gap cells): new vehicle.
+    clear_time = (v1.length + SPAWN_GAP + 1) / v1.speed
+    v3 = lane.spawn(300, now=clear_time)
+    assert v3 is not v1
+    assert len(lane.vehicles) == 2
+
+
+def test_coalesced_burst_upgrades_class() -> None:
+    lane = Lane("/mixed")
+    v = lane.spawn(100, now=0.0)
+    assert v.cls.name == "nano"
+    lane.spawn(1_000_000, now=0.001)
+    assert v.cls.name == "mega"
+
+
+def test_coalesced_burst_stretches() -> None:
+    lane = Lane("/tf#tf2_msgs.TFMessage")
+    v = lane.spawn(300, now=0.0)
+    base_length = v.length
+    for _ in range(7):
+        lane.spawn(300, now=0.001)
+    assert v.count == 8
+    assert base_length < v.length <= v.cls.length + 4
+
+
+def test_lane_prune() -> None:
+    lane = Lane("/odom#nav_msgs.Odometry")
+    lane.spawn(500, now=0.0)
+    lane.prune(now=0.1, road_width=100)
+    assert len(lane.vehicles) == 1
+    lane.prune(now=1_000.0, road_width=100)
+    assert len(lane.vehicles) == 0
+
+
+def test_packet_spy_drain() -> None:
+    spy = PacketSpy()
+    spy.msg("/a", b"xx")
+    spy.msg("/b", b"yyyy")
+    drained = spy.drain()
+    assert drained == [("/a", 2), ("/b", 4)]
+    assert spy.drain() == []
+    # Stats side stays intact (LCMSpy behavior).
+    assert spy.topic["/a"].total_traffic() == 2
+
+
+def test_highway_tick_spawns_and_pauses() -> None:
+    highway = Highway()
+    highway.spy.msg("/a#std_msgs.String", b"x" * 100)
+    highway.tick(road_width=100)
+    assert "/a#std_msgs.String" in highway.lanes
+    assert len(highway.lanes["/a#std_msgs.String"].vehicles) == 1
+
+    clock_before = highway.clock
+    highway.toggle_pause()
+    highway.spy.msg("/a#std_msgs.String", b"x" * 100)
+    highway.tick(road_width=100)
+    # Paused: clock frozen, packets dropped, no new vehicles.
+    assert highway.clock == clock_before
+    assert len(highway.lanes["/a#std_msgs.String"].vehicles) == 1

--- a/dimos/utils/cli/lcmspy/lcmspy.py
+++ b/dimos/utils/cli/lcmspy/lcmspy.py
@@ -128,7 +128,6 @@ class LCMSpy(LCMService, Topic):
 
         with self._topic_lock:
             if topic not in self.topic:  # type: ignore[operator]
-                print(self.config)
                 self.topic[topic] = self.topic_class(  # type: ignore[assignment, call-arg]
                     topic,
                     history_window=self.config.topic_history_window,

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -295,6 +295,20 @@ Monitor LCM messages in real time.
 lcmspy
 ```
 
+### `lcmflow`
+
+Animated "packet highway" view of LCM traffic. Each topic is a lane;
+every packet drives across it as a vehicle — small fast packets
+(`cmd_vel`, `tf`) are quick dots, large packets (images, point clouds)
+are long slow trucks. Bursts faster than the lane can fit merge into a
+single vehicle with a `×N` count. Keys: `space` pause, `s` cycle sort
+(arrival/traffic/name), `q` quit.
+
+```bash
+lcmflow        # native TUI
+lcmflow web    # serve the same TUI in a browser
+```
+
 ### `agentspy`
 
 Monitor agent messages and tool calls.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,7 @@ dependencies = [
 
 [project.scripts]
 lcmspy = "dimos.utils.cli.lcmspy.run_lcmspy:main"
+lcmflow = "dimos.utils.cli.lcmflow.run_lcmflow:main"
 agentspy = "dimos.utils.cli.agentspy.agentspy:main"
 humancli = "dimos.utils.cli.human.humanclianim:main"
 dimos = "dimos.robot.cli.dimos:cli_main"


### PR DESCRIPTION
## What

`lcmflow` — a real-time animated visualization of LCM traffic, sibling to `lcmspy`. Each topic is a lane on a highway; every packet drives across it as a vehicle:

- **Packet size picks the vehicle class**: tiny telemetry (`cmd_vel`, `tf`, ≤256 B) are fast 1-cell dots; raw images and point clouds (>512 KiB) are 11-cell trucks at 0.65× speed. Five log-scale bands in between.
- **Bursts coalesce**: packets arriving faster than a lane can fit merge into one vehicle with a `×N` count badge (e.g. a 14 Hz raw image stream shows as `×15` convoys). Lossless — stats always reflect true packet counts/bytes.
- **Color by message type** (`Image`=yellow, `PointCloud2`=purple, `OccupancyGrid`=blue, `TFMessage`=green, …), stable hash fallback for unknown types.
- Per-lane Hz / bandwidth / total stats, global header stats, fading trails, scrollable lanes, DimOS tcss theme.
- Keys: `space` pause, `s` cycle sort (arrival/traffic/name), `q` quit. `lcmflow web` serves the TUI in a browser via textual-serve (same as lcmspy).

## How

- `dimos/utils/cli/lcmflow/lcmflow.py`: renderer-agnostic model — `PacketSpy(LCMSpy)` collector with a thread-safe packet queue, `Lane`/`Vehicle` physics with on-ramp coalescing. Reuses lcmspy's `Topic` sliding-window stats.
- `dimos/utils/cli/lcmflow/run_lcmflow.py`: Textual app using the line API (`render_line`/`Strip`) at 20 fps.
- Entry points: `lcmflow` console script + `dimos lcmflow` subcommand; docs in `docs/usage/cli.md` and AGENTS.md.
- Drive-by fix: removed a stray `print(self.config)` debug line in `lcmspy.py` that fired on every new topic and corrupted TUI output.

## Testing

- 11 unit tests (`test_lcmflow.py`): size classing, coalescing, class upgrade, convoy stretch, pruning, drain, pause semantics. All lcmspy tests still pass.
- mypy + ruff clean.
- Live-tested against `dimos --replay run unitree-go2`: 7 lanes at ~42 MiB/s, verified in a real xterm and via headless Textual screenshots.
