### PR TITLE
Improve PR labels

### DIFF
--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -13,7 +13,7 @@ on:
     workflows: [ci]
     types: [completed]
   pull_request_target:
-    types: [synchronize]
+    types: [synchronize, converted_to_draft, ready_for_review]
 
 permissions: {}
 
@@ -32,48 +32,8 @@ jobs:
             const event = context.eventName;
             const payload = context.payload;
 
-            let prNumbers, ciOk, runHeadSha = null;
-
-            if (event === 'pull_request_target') {
-              // synchronize → new push; clear any stale label until ci re-runs.
-              prNumbers = [payload.pull_request.number];
-              ciOk = false;
-            } else {
-              const run = payload.workflow_run;
-              runHeadSha = run.head_sha;
-              const jobs = await github.paginate(
-                github.rest.actions.listJobsForWorkflowRun,
-                { owner, repo, run_id: run.id, per_page: 100 },
-              );
-              const ciComplete = jobs.find(j => j.name === 'ci-complete');
-              ciOk = ciComplete?.conclusion === 'success';
-
-              prNumbers = run.pull_requests?.map(p => p.number) ?? [];
-              if (prNumbers.length === 0) {
-                // Fork PRs: workflow_run.pull_requests is empty; resolve via head SHA.
-                const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-                  owner, repo, commit_sha: runHeadSha,
-                });
-                prNumbers = prs.filter(p => p.state === 'open').map(p => p.number);
-              }
-            }
-
-            core.info(`event=${event} prs=${prNumbers.join(',')} ciOk=${ciOk} runHeadSha=${runHeadSha}`);
-
-            for (const prNumber of prNumbers) {
-              if (runHeadSha) {
-                // workflow_run events can be delivered after a newer push;
-                // skip if the PR has moved past the SHA we evaluated.
-                const { data: pr } = await github.rest.pulls.get({
-                  owner, repo, pull_number: prNumber,
-                });
-                if (pr.head.sha !== runHeadSha) {
-                  core.info(`stale: #${prNumber} head=${pr.head.sha} run=${runHeadSha}; skipping`);
-                  continue;
-                }
-              }
-
-              if (ciOk) {
+            async function setLabel(prNumber, present) {
+              if (present) {
                 await github.rest.issues.addLabels({
                   owner, repo, issue_number: prNumber, labels: [label],
                 });
@@ -86,4 +46,59 @@ jobs:
                   if (e.status !== 404) throw e;
                 }
               }
+            }
+
+            async function ciCompleteOk(headSha) {
+              const { data } = await github.rest.actions.listWorkflowRuns({
+                owner, repo, workflow_id: 'ci.yml', head_sha: headSha, per_page: 5,
+              });
+              const run = data.workflow_runs.find(r => r.status === 'completed');
+              if (!run) return false;
+              const jobs = await github.paginate(
+                github.rest.actions.listJobsForWorkflowRun,
+                { owner, repo, run_id: run.id, per_page: 100 },
+              );
+              return jobs.find(j => j.name === 'ci-complete')?.conclusion === 'success';
+            }
+
+            if (event === 'pull_request_target') {
+              const pr = payload.pull_request;
+              const action = payload.action;
+              core.info(`event=${event} action=${action} pr=#${pr.number} draft=${pr.draft}`);
+
+              if (action === 'converted_to_draft' || action === 'synchronize') {
+                await setLabel(pr.number, false);
+              } else if (action === 'ready_for_review') {
+                const ciOk = await ciCompleteOk(pr.head.sha);
+                await setLabel(pr.number, ciOk && !pr.draft);
+              }
+              return;
+            }
+
+            // workflow_run
+            const run = payload.workflow_run;
+            const ciOk = await ciCompleteOk(run.head_sha);
+
+            let prNumbers = run.pull_requests?.map(p => p.number) ?? [];
+            if (prNumbers.length === 0) {
+              // Fork PRs: workflow_run.pull_requests is empty; resolve via head SHA.
+              const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner, repo, commit_sha: run.head_sha,
+              });
+              prNumbers = prs.filter(p => p.state === 'open').map(p => p.number);
+            }
+
+            core.info(`event=${event} prs=${prNumbers.join(',')} ciOk=${ciOk} runHeadSha=${run.head_sha}`);
+
+            for (const prNumber of prNumbers) {
+              const { data: pr } = await github.rest.pulls.get({
+                owner, repo, pull_number: prNumber,
+              });
+              // workflow_run events can be delivered after a newer push;
+              // skip if the PR has moved past the SHA we evaluated.
+              if (pr.head.sha !== run.head_sha) {
+                core.info(`stale: #${prNumber} head=${pr.head.sha} run=${run.head_sha}; skipping`);
+                continue;
+              }
+              await setLabel(prNumber, ciOk && !pr.draft);
             }

--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -32,7 +32,7 @@ jobs:
             const event = context.eventName;
             const payload = context.payload;
 
-            let prNumbers, ciOk;
+            let prNumbers, ciOk, runHeadSha = null;
 
             if (event === 'pull_request_target') {
               // synchronize → new push; clear any stale label until ci re-runs.
@@ -40,6 +40,7 @@ jobs:
               ciOk = false;
             } else {
               const run = payload.workflow_run;
+              runHeadSha = run.head_sha;
               const jobs = await github.paginate(
                 github.rest.actions.listJobsForWorkflowRun,
                 { owner, repo, run_id: run.id, per_page: 100 },
@@ -51,15 +52,27 @@ jobs:
               if (prNumbers.length === 0) {
                 // Fork PRs: workflow_run.pull_requests is empty; resolve via head SHA.
                 const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-                  owner, repo, commit_sha: run.head_sha,
+                  owner, repo, commit_sha: runHeadSha,
                 });
                 prNumbers = prs.filter(p => p.state === 'open').map(p => p.number);
               }
             }
 
-            core.info(`event=${event} prs=${prNumbers.join(',')} ciOk=${ciOk}`);
+            core.info(`event=${event} prs=${prNumbers.join(',')} ciOk=${ciOk} runHeadSha=${runHeadSha}`);
 
             for (const prNumber of prNumbers) {
+              if (runHeadSha) {
+                // workflow_run events can be delivered after a newer push;
+                // skip if the PR has moved past the SHA we evaluated.
+                const { data: pr } = await github.rest.pulls.get({
+                  owner, repo, pull_number: prNumber,
+                });
+                if (pr.head.sha !== runHeadSha) {
+                  core.info(`stale: #${prNumber} head=${pr.head.sha} run=${runHeadSha}; skipping`);
+                  continue;
+                }
+              }
+
               if (ciOk) {
                 await github.rest.issues.addLabels({
                   owner, repo, issue_number: prNumber, labels: [label],

--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -22,6 +22,8 @@ jobs:
     if: github.event_name == 'pull_request_target' || github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
+      actions: read         # For listWorkflowRuns / listJobsForWorkflowRun
+      contents: read        # For listPullRequestsAssociatedWithCommit
       pull-requests: write  # To add/remove label
     steps:
       - uses: actions/github-script@v7

--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -50,10 +50,10 @@ jobs:
 
             async function ciCompleteOk(headSha) {
               const { data } = await github.rest.actions.listWorkflowRuns({
-                owner, repo, workflow_id: 'ci.yml', head_sha: headSha, per_page: 5,
+                owner, repo, workflow_id: 'ci.yml', head_sha: headSha, per_page: 1,
               });
-              const run = data.workflow_runs.find(r => r.status === 'completed');
-              if (!run) return false;
+              const run = data.workflow_runs[0];
+              if (!run || run.status !== 'completed') return false;
               const jobs = await github.paginate(
                 github.rest.actions.listJobsForWorkflowRun,
                 { owner, repo, run_id: run.id, per_page: 100 },
@@ -62,15 +62,19 @@ jobs:
             }
 
             if (event === 'pull_request_target') {
-              const pr = payload.pull_request;
+              const prNumber = payload.pull_request.number;
               const action = payload.action;
-              core.info(`event=${event} action=${action} pr=#${pr.number} draft=${pr.draft}`);
+              core.info(`event=${event} action=${action} pr=#${prNumber}`);
 
               if (action === 'converted_to_draft' || action === 'synchronize') {
-                await setLabel(pr.number, false);
+                await setLabel(prNumber, false);
               } else if (action === 'ready_for_review') {
+                // Refetch — draft state could have flipped again between the event and now.
+                const { data: pr } = await github.rest.pulls.get({
+                  owner, repo, pull_number: prNumber,
+                });
                 const ciOk = await ciCompleteOk(pr.head.sha);
-                await setLabel(pr.number, ciOk && !pr.draft);
+                await setLabel(prNumber, ciOk && !pr.draft);
               }
               return;
             }


### PR DESCRIPTION
- Fix a race condition that could add the label just after a push (based on the status of the previous push).
- Don't add the label to draft PRs.
- Fix permission errors in some cases.