### PR TITLE
feat: calculate global map voxel normals

### DIFF
--- a/dimos/mapping/ray_tracing/module.py
+++ b/dimos/mapping/ray_tracing/module.py
@@ -46,6 +46,9 @@ class RayTracingVoxelMapConfig(NativeModuleConfig):
     # Spare a clearing miss when |ray dot surface normal| is below this.
     # Larger spares steeper grazes, protecting floors, treads and landings.
     graze_cos: float = 0.7
+    # Only spare a voxel whose neighborhood was hit within this many frames.
+    # A voxel that goes stale clears despite its normal. Large disables it.
+    recency_window: int = 15
 
 
 class RayTracingVoxelMap(NativeModule, mapping.GlobalPointcloud):

--- a/dimos/mapping/ray_tracing/module.py
+++ b/dimos/mapping/ray_tracing/module.py
@@ -43,6 +43,9 @@ class RayTracingVoxelMapConfig(NativeModuleConfig):
     # Bounds for the health of voxels. Positive health means voxel is occupied.
     min_health: int = -2
     max_health: int = 1
+    # Spare a clearing miss when |ray dot surface normal| is below this.
+    # Larger spares steeper grazes, protecting floors, treads and landings.
+    graze_cos: float = 0.7
 
 
 class RayTracingVoxelMap(NativeModule, mapping.GlobalPointcloud):

--- a/dimos/mapping/ray_tracing/module.py
+++ b/dimos/mapping/ray_tracing/module.py
@@ -44,10 +44,8 @@ class RayTracingVoxelMapConfig(NativeModuleConfig):
     min_health: int = -2
     max_health: int = 1
     # Spare a clearing miss when |ray dot surface normal| is below this.
-    # Larger spares steeper grazes, protecting floors, treads and landings.
     graze_cos: float = 0.7
     # Only spare a voxel whose neighborhood was hit within this many frames.
-    # A voxel that goes stale clears despite its normal. Large disables it.
     recency_window: int = 15
 
 

--- a/dimos/mapping/ray_tracing/rust/Cargo.lock
+++ b/dimos/mapping/ray_tracing/rust/Cargo.lock
@@ -25,10 +25,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"
@@ -123,6 +138,7 @@ dependencies = [
  "ahash",
  "dimos-module",
  "lcm-msgs",
+ "nalgebra",
  "numpy",
  "pyo3",
  "serde",
@@ -179,6 +195,30 @@ dependencies = [
  "r-efi",
  "wasip2",
 ]
+
+[[package]]
+name = "glam"
+version = "0.30.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19fc433e8437a212d1b6f1e68c7824af3aed907da60afa994e7f542d18d12aa9"
+
+[[package]]
+name = "glam"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556f6b2ea90b8d15a74e0e7bb41671c9bdf38cd9f78c284d750b9ce58a2b5be7"
+
+[[package]]
+name = "glam"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f70749695b063ecbf6b62949ccccde2e733ec3ecbbd71d467dca4e5c6c97cca0"
+
+[[package]]
+name = "glam"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "898f5a568a84989b6c0f8caa50a93074b97dbdc58fc6d9543157bb4562758933"
 
 [[package]]
 name = "heck"
@@ -388,6 +428,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "nalgebra"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc43a60c217b0c6ff46e47f26911015ad8d2e5a8be1af668c67e370d99a4346"
+dependencies = [
+ "approx",
+ "glam 0.30.10",
+ "glam 0.31.1",
+ "glam 0.32.1",
+ "glam 0.33.1",
+ "matrixmultiply",
+ "nalgebra-macros",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "simba",
+ "typenum",
+]
+
+[[package]]
+name = "nalgebra-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "973e7178a678cfd059ccec50887658d482ce16b0aa9da3888ddeab5cd5eb4889"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ndarray"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,6 +483,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -426,6 +507,17 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -652,6 +744,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "safe_arch"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7caad094bd561859bcd467734a720c3c1f5d1f338995351fefe2190c45efed"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,6 +812,18 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "simba"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f45c644a9f3a386f9288625d9f0c1e999e1acf07a37df35d0516c7f199d9cb2"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "wide",
 ]
 
 [[package]]
@@ -906,6 +1019,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -990,6 +1109,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wide"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfdfe6a32973f2d1b268b8895845a8a96cac2f0191e72c27cc929036060dbf89"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/dimos/mapping/ray_tracing/rust/Cargo.lock
+++ b/dimos/mapping/ray_tracing/rust/Cargo.lock
@@ -142,7 +142,6 @@ dependencies = [
  "numpy",
  "pyo3",
  "serde",
- "svg",
  "tokio",
  "tracing",
  "validator",
@@ -863,12 +862,6 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "svg"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94afda9cd163c04f6bee8b4bf2501c91548deae308373c436f36aeff3cf3c4a3"
 
 [[package]]
 name = "syn"

--- a/dimos/mapping/ray_tracing/rust/Cargo.lock
+++ b/dimos/mapping/ray_tracing/rust/Cargo.lock
@@ -126,6 +126,7 @@ dependencies = [
  "numpy",
  "pyo3",
  "serde",
+ "svg",
  "tokio",
  "tracing",
  "validator",
@@ -749,6 +750,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "svg"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94afda9cd163c04f6bee8b4bf2501c91548deae308373c436f36aeff3cf3c4a3"
 
 [[package]]
 name = "syn"

--- a/dimos/mapping/ray_tracing/rust/Cargo.toml
+++ b/dimos/mapping/ray_tracing/rust/Cargo.toml
@@ -29,3 +29,6 @@ validator = { version = "0.20", features = ["derive"] }
 [profile.release]
 lto = "thin"
 codegen-units = 1
+
+[dev-dependencies]
+svg = "0.18.0"

--- a/dimos/mapping/ray_tracing/rust/Cargo.toml
+++ b/dimos/mapping/ray_tracing/rust/Cargo.toml
@@ -25,6 +25,7 @@ tracing = "0.1"
 pyo3 = { version = "0.25", features = ["extension-module", "abi3-py310"] }
 numpy = "0.25"
 validator = { version = "0.20", features = ["derive"] }
+nalgebra = "0.35.0"
 
 [profile.release]
 lto = "thin"

--- a/dimos/mapping/ray_tracing/rust/Cargo.toml
+++ b/dimos/mapping/ray_tracing/rust/Cargo.toml
@@ -30,6 +30,3 @@ nalgebra = "0.35.0"
 [profile.release]
 lto = "thin"
 codegen-units = 1
-
-[dev-dependencies]
-svg = "0.18.0"

--- a/dimos/mapping/ray_tracing/rust/src/main.rs
+++ b/dimos/mapping/ray_tracing/rust/src/main.rs
@@ -212,7 +212,7 @@ fn build_pointclouds(
 
     // add live voxels to both if they aren't already there
     for &(kx, ky, kz) in live {
-        if matches!(map.voxels.get(&(kx, ky, kz)), Some(h) if *h > 0) {
+        if matches!(map.voxels.get(&(kx, ky, kz)), Some(c) if c.health > 0) {
             continue;
         }
         let x = kx as f32 * voxel_size + half;
@@ -280,6 +280,7 @@ async fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use dimos_voxel_ray_tracing::voxel_ray_tracer::Voxel;
 
     fn cloud_points(c: &PointCloud2) -> AHashSet<(u32, u32, u32)> {
         let mut out = AHashSet::new();
@@ -305,7 +306,7 @@ mod tests {
     #[test]
     fn local_map_includes_voxel_inside_cylinder() {
         let mut map = VoxelMap::default();
-        map.voxels.insert((0, 0, 0), 1);
+        map.voxels.insert((0, 0, 0), Voxel::with_health(1));
         let live: AHashSet<VoxelKey> = AHashSet::new();
         let cylinder = LocalBounds {
             origin_x: 0.0,
@@ -323,7 +324,7 @@ mod tests {
     #[test]
     fn local_map_excludes_voxel_outside_radius() {
         let mut map = VoxelMap::default();
-        map.voxels.insert((5, 0, 0), 1);
+        map.voxels.insert((5, 0, 0), Voxel::with_health(1));
         let live: AHashSet<VoxelKey> = AHashSet::new();
         let cylinder = LocalBounds {
             origin_x: 0.0,
@@ -342,7 +343,7 @@ mod tests {
     #[test]
     fn local_map_excludes_voxel_outside_z_range() {
         let mut map = VoxelMap::default();
-        map.voxels.insert((0, 0, 5), 1);
+        map.voxels.insert((0, 0, 5), Voxel::with_health(1));
         let live: AHashSet<VoxelKey> = AHashSet::new();
         let cylinder = LocalBounds {
             origin_x: 0.0,

--- a/dimos/mapping/ray_tracing/rust/src/python.rs
+++ b/dimos/mapping/ray_tracing/rust/src/python.rs
@@ -7,7 +7,9 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use validator::Validate;
 
-use crate::voxel_ray_tracer::{iter_global_points, update_map, Config, LocalBounds, VoxelMap};
+use crate::voxel_ray_tracer::{
+    iter_global_normals, iter_global_points, update_map, Config, LocalBounds, VoxelMap,
+};
 
 #[pyclass]
 pub struct VoxelRayMapper {
@@ -106,6 +108,36 @@ impl VoxelRayMapper {
         Array2::from_shape_vec((n, 3), positions)
             .expect("3 elements pushed per voxel")
             .into_pyarray(py)
+    }
+
+    /// Healthy voxel centers and their unit surface normals, both (M, 3) float32
+    /// in matching order. The normal is the zero vector where the voxel has no
+    /// confident planar normal.
+    fn global_map_normals<'py>(
+        &self,
+        py: Python<'py>,
+    ) -> (Bound<'py, PyArray2<f32>>, Bound<'py, PyArray2<f32>>) {
+        let voxel_size = self.config.voxel_size;
+        let map = &self.map;
+        let (positions, normals): (Vec<f32>, Vec<f32>) = py.allow_threads(|| {
+            let mut positions: Vec<f32> = Vec::with_capacity(map.voxels.len() * 3);
+            let mut normals: Vec<f32> = Vec::with_capacity(map.voxels.len() * 3);
+            for ((x, y, z), n) in iter_global_normals(map, voxel_size) {
+                positions.push(x);
+                positions.push(y);
+                positions.push(z);
+                normals.extend_from_slice(&n);
+            }
+            (positions, normals)
+        });
+        let m = positions.len() / 3;
+        let positions = Array2::from_shape_vec((m, 3), positions)
+            .expect("3 elements pushed per voxel")
+            .into_pyarray(py);
+        let normals = Array2::from_shape_vec((m, 3), normals)
+            .expect("3 elements pushed per voxel")
+            .into_pyarray(py);
+        (positions, normals)
     }
 
     fn local_map<'py>(

--- a/dimos/mapping/ray_tracing/rust/src/python.rs
+++ b/dimos/mapping/ray_tracing/rust/src/python.rs
@@ -29,7 +29,9 @@ impl VoxelRayMapper {
         grace_depth = 0.2,
         min_health = -2,
         max_health = 1,
+        graze_cos = 0.7,
     ))]
+    #[allow(clippy::too_many_arguments)]
     fn new(
         voxel_size: f32,
         max_range: f32,
@@ -38,6 +40,7 @@ impl VoxelRayMapper {
         grace_depth: f32,
         min_health: i32,
         max_health: i32,
+        graze_cos: f32,
     ) -> PyResult<Self> {
         let config = Config {
             voxel_size,
@@ -47,6 +50,7 @@ impl VoxelRayMapper {
             grace_depth,
             min_health,
             max_health,
+            graze_cos,
         };
         config
             .validate()

--- a/dimos/mapping/ray_tracing/rust/src/python.rs
+++ b/dimos/mapping/ray_tracing/rust/src/python.rs
@@ -30,6 +30,7 @@ impl VoxelRayMapper {
         min_health = -2,
         max_health = 1,
         graze_cos = 0.7,
+        recency_window = 15,
     ))]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -41,6 +42,7 @@ impl VoxelRayMapper {
         min_health: i32,
         max_health: i32,
         graze_cos: f32,
+        recency_window: u32,
     ) -> PyResult<Self> {
         let config = Config {
             voxel_size,
@@ -51,6 +53,7 @@ impl VoxelRayMapper {
             min_health,
             max_health,
             graze_cos,
+            recency_window,
         };
         config
             .validate()

--- a/dimos/mapping/ray_tracing/rust/src/python.rs
+++ b/dimos/mapping/ray_tracing/rust/src/python.rs
@@ -117,9 +117,8 @@ impl VoxelRayMapper {
             .into_pyarray(py)
     }
 
-    /// Healthy voxel centers and their unit surface normals, both (M, 3) float32
-    /// in matching order. The normal is the zero vector where the voxel has no
-    /// confident planar normal.
+    /// Healthy voxel centers and their surface normals, both (M, 3) float32 in
+    /// matching order. The normal is the zero vector where there is no plane.
     fn global_map_normals<'py>(
         &self,
         py: Python<'py>,

--- a/dimos/mapping/ray_tracing/rust/src/voxel_ray_tracer.rs
+++ b/dimos/mapping/ray_tracing/rust/src/voxel_ray_tracer.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use ahash::{AHashMap, AHashSet};
+use nalgebra::{Matrix3, Vector3};
 use serde::Deserialize;
 use validator::{Validate, ValidationError};
 
@@ -36,12 +37,117 @@ fn validate_health_range(cfg: &Config) -> Result<(), ValidationError> {
 
 #[derive(Default)]
 pub struct VoxelMap {
-    pub voxels: AHashMap<VoxelKey, VoxelHealth>,
+    pub voxels: AHashMap<VoxelKey, Voxel>,
 }
 
 impl VoxelMap {
     pub fn healthy_count(&self) -> usize {
-        self.voxels.values().filter(|h| **h > 0).count()
+        self.voxels.values().filter(|c| c.health > 0).count()
+    }
+
+    /// Fold a return into its voxel's covariance, relative to the voxel center.
+    fn accumulate(&mut self, point: (f32, f32, f32), voxel_size: f32) {
+        let key = world_to_voxel(point.0, point.1, point.2, 1.0 / voxel_size);
+        let center = Vector3::new(
+            (key.0 as f32 + 0.5) * voxel_size,
+            (key.1 as f32 + 0.5) * voxel_size,
+            (key.2 as f32 + 0.5) * voxel_size,
+        );
+        self.voxels
+            .entry(key)
+            .or_default()
+            .observe(Vector3::new(point.0, point.1, point.2) - center);
+    }
+
+    #[cfg(test)]
+    fn set(&mut self, key: VoxelKey, health: VoxelHealth) {
+        self.voxels.insert(key, Voxel::with_health(health));
+    }
+
+    #[cfg(test)]
+    fn health(&self, key: VoxelKey) -> Option<VoxelHealth> {
+        self.voxels.get(&key).map(|c| c.health)
+    }
+}
+
+/// Minimum points before a voxel's surface normal is trusted.
+const NORMAL_MIN_POINTS: u32 = 6;
+/// A voxel is planar when its smallest covariance eigenvalue is below this
+/// fraction of the next-smallest.
+const NORMAL_PLANAR_RATIO: f32 = 0.15;
+/// Spare a clearing miss when |ray · normal| is below this (grazing incidence).
+const GRAZE_COS: f32 = 0.5;
+
+/// One voxel: occupancy health plus a running point covariance used to estimate
+/// the local surface normal. Points are accumulated relative to the voxel center
+/// to keep the moments small and f32-stable. The covariance lives and dies with
+/// the voxel entry.
+#[derive(Clone)]
+pub struct Voxel {
+    pub health: VoxelHealth,
+    num_pts: u32,
+    sum: Vector3<f32>,
+    m2: Matrix3<f32>,
+}
+
+impl Default for Voxel {
+    fn default() -> Self {
+        Self {
+            health: 0,
+            num_pts: 0,
+            sum: Vector3::zeros(),
+            m2: Matrix3::zeros(),
+        }
+    }
+}
+
+impl Voxel {
+    pub fn with_health(health: VoxelHealth) -> Self {
+        Self {
+            health,
+            ..Default::default()
+        }
+    }
+
+    fn observe(&mut self, q: Vector3<f32>) {
+        self.num_pts += 1;
+        self.sum += q;
+        self.m2 += q * q.transpose();
+    }
+
+    /// Unit surface normal if the voxel holds enough confidently-planar points,
+    /// else None (too sparse, or an edge/corner where the normal is ill-defined).
+    fn planar_normal(&self) -> Option<Vector3<f32>> {
+        if self.num_pts < NORMAL_MIN_POINTS {
+            return None;
+        }
+        let n = self.num_pts as f32;
+        let mean = self.sum / n;
+        let cov = self.m2 / n - mean * mean.transpose();
+        let eig = cov.symmetric_eigen();
+        let i0 = (0usize..3).min_by(|&a, &b| eig.eigenvalues[a].total_cmp(&eig.eigenvalues[b]))?;
+        let e0 = eig.eigenvalues[i0].max(0.0);
+        let e1 = (0usize..3)
+            .filter(|&i| i != i0)
+            .map(|i| eig.eigenvalues[i].max(0.0))
+            .fold(f32::INFINITY, f32::min);
+        if e0 > NORMAL_PLANAR_RATIO * e1.max(1e-9) {
+            return None;
+        }
+        Some(eig.eigenvectors.column(i0).into_owned())
+    }
+}
+
+/// Whether to spare an occupied voxel from a clearing miss: spare if a grazing
+/// ray skims its surface, or if it is a confident edge/corner. Voxels with too
+/// few points (no normal yet) are not spared, preserving the unguarded behavior.
+fn should_spare(voxels: &AHashMap<VoxelKey, Voxel>, key: VoxelKey, ray_unit: Vector3<f32>) -> bool {
+    let Some(c) = voxels.get(&key) else {
+        return false;
+    };
+    match c.planar_normal() {
+        Some(n) => ray_unit.dot(&n).abs() < GRAZE_COS,
+        None => c.num_pts >= NORMAL_MIN_POINTS,
     }
 }
 
@@ -71,7 +177,7 @@ pub fn iter_global_points(
     let half = voxel_size * 0.5;
     map.voxels
         .iter()
-        .filter(|(_, &h)| h > 0)
+        .filter(|(_, c)| c.health > 0)
         .map(move |(&(kx, ky, kz), _)| {
             (
                 kx as f32 * voxel_size + half,
@@ -134,15 +240,23 @@ pub fn update_map(
 
     // add new hits
     for v in &hits {
-        let h = map.voxels.entry(*v).or_insert(cfg.min_health);
-        *h = (*h + 1).min(cfg.max_health);
+        let c = map.voxels.entry(*v).or_insert_with(|| Voxel {
+            health: cfg.min_health,
+            ..Default::default()
+        });
+        c.health = (c.health + 1).min(cfg.max_health);
     }
 
-    // each miss is only checked once
+    // accumulate each return into its voxel's covariance
+    for &p in points {
+        map.accumulate(p, cfg.voxel_size);
+    }
+
+    // each miss is only checked once; removal drops the covariance with it
     for v in misses.difference(&hits) {
-        if let Some(h) = map.voxels.get_mut(v) {
-            *h -= 1;
-            if *h <= cfg.min_health {
+        if let Some(c) = map.voxels.get_mut(v) {
+            c.health -= 1;
+            if c.health <= cfg.min_health {
                 map.voxels.remove(v);
             }
         }
@@ -165,7 +279,7 @@ fn world_to_voxel(x: f32, y: f32, z: f32, inv: f32) -> VoxelKey {
 #[allow(clippy::too_many_arguments)]
 fn find_misses_along_ray(
     misses: &mut AHashSet<VoxelKey>,
-    map_voxels: &AHashMap<VoxelKey, VoxelHealth>,
+    map_voxels: &AHashMap<VoxelKey, Voxel>,
     origin: (f32, f32, f32),
     end: (f32, f32, f32),
     voxel_size: f32,
@@ -232,6 +346,7 @@ fn find_misses_along_ray(
 
     let ray_len = (dx * dx + dy * dy + dz * dz).sqrt();
     let t_max = 1.0 + shadow_depth / ray_len.max(f32::EPSILON);
+    let ray_unit = Vector3::new(dx, dy, dz) / ray_len.max(f32::EPSILON);
 
     let mut past_endpoint = false;
     loop {
@@ -288,7 +403,7 @@ fn find_misses_along_ray(
             continue;
         }
 
-        if map_voxels.contains_key(&(x, y, z)) {
+        if map_voxels.contains_key(&(x, y, z)) && !should_spare(map_voxels, (x, y, z), ray_unit) {
             misses.insert((x, y, z));
         }
     }
@@ -330,9 +445,9 @@ mod tests {
         ]
         .into_iter()
         .collect();
-        let mut map_voxels: AHashMap<VoxelKey, VoxelHealth> = AHashMap::new();
+        let mut map_voxels: AHashMap<VoxelKey, Voxel> = AHashMap::new();
         for v in &expected {
-            map_voxels.insert(*v, 1);
+            map_voxels.insert(*v, Voxel::with_health(1));
         }
 
         let mut misses: AHashSet<VoxelKey> = AHashSet::new();
@@ -373,9 +488,9 @@ mod tests {
         ]
         .into_iter()
         .collect();
-        let mut map_voxels: AHashMap<VoxelKey, VoxelHealth> = AHashMap::new();
+        let mut map_voxels: AHashMap<VoxelKey, Voxel> = AHashMap::new();
         for v in &walked {
-            map_voxels.insert(*v, 1);
+            map_voxels.insert(*v, Voxel::with_health(1));
         }
 
         let mut misses: AHashSet<VoxelKey> = AHashSet::new();
@@ -411,8 +526,8 @@ mod tests {
             &[(5.5, 0.5, 0.5), (0.5, 5.5, 0.5)],
             &cfg,
         );
-        assert_eq!(map.voxels.get(&(5, 0, 0)), Some(&1));
-        assert_eq!(map.voxels.get(&(0, 5, 0)), Some(&1));
+        assert_eq!(map.health((5, 0, 0)), Some(1));
+        assert_eq!(map.health((0, 5, 0)), Some(1));
         assert_eq!(map.voxels.len(), 2);
     }
 
@@ -420,42 +535,42 @@ mod tests {
     fn voxels_on_ray_are_removed() {
         let cfg = basic_config();
         let mut map = VoxelMap::default();
-        map.voxels.insert((3, 0, 0), 1);
+        map.set((3, 0, 0), 1);
         update_map(&mut map, (0.0, 0.0, 0.0), &[(5.5, 0.5, 0.5)], &cfg);
         // make sure the initial point got cleared by the new update
         assert!(!map.voxels.contains_key(&(3, 0, 0)));
-        assert_eq!(map.voxels.get(&(5, 0, 0)), Some(&1));
+        assert_eq!(map.health((5, 0, 0)), Some(1));
     }
 
     #[test]
     fn voxels_not_on_ray_survive() {
         let cfg = basic_config();
         let mut map = VoxelMap::default();
-        map.voxels.insert((3, 5, 0), 1);
+        map.set((3, 5, 0), 1);
         update_map(&mut map, (0.0, 0.0, 0.0), &[(5.5, 0.5, 0.5)], &cfg);
-        assert_eq!(map.voxels.get(&(3, 5, 0)), Some(&1));
-        assert_eq!(map.voxels.get(&(5, 0, 0)), Some(&1));
+        assert_eq!(map.health((3, 5, 0)), Some(1));
+        assert_eq!(map.health((5, 0, 0)), Some(1));
     }
 
     #[test]
     fn voxels_within_shadow_region_are_removed() {
         let cfg = basic_config();
         let mut map = VoxelMap::default();
-        map.voxels.insert((6, 0, 0), 1);
+        map.set((6, 0, 0), 1);
         update_map(&mut map, (0.0, 0.0, 0.0), &[(5.5, 0.5, 0.5)], &cfg);
         // point within the shadow is no longer included, new point is included
         assert!(!map.voxels.contains_key(&(6, 0, 0)));
-        assert_eq!(map.voxels.get(&(5, 0, 0)), Some(&1));
+        assert_eq!(map.health((5, 0, 0)), Some(1));
     }
 
     #[test]
     fn voxels_beyond_shadow_region_survive() {
         let cfg = basic_config();
         let mut map = VoxelMap::default();
-        map.voxels.insert((8, 0, 0), 1);
+        map.set((8, 0, 0), 1);
         update_map(&mut map, (0.0, 0.0, 0.0), &[(5.5, 0.5, 0.5)], &cfg);
-        assert_eq!(map.voxels.get(&(8, 0, 0)), Some(&1));
-        assert_eq!(map.voxels.get(&(5, 0, 0)), Some(&1));
+        assert_eq!(map.health((8, 0, 0)), Some(1));
+        assert_eq!(map.health((5, 0, 0)), Some(1));
     }
 
     #[test]
@@ -468,8 +583,8 @@ mod tests {
             &[(3.5, 0.5, 0.5), (5.5, 0.5, 0.5)],
             &cfg,
         );
-        assert_eq!(map.voxels.get(&(3, 0, 0)), Some(&1));
-        assert_eq!(map.voxels.get(&(5, 0, 0)), Some(&1));
+        assert_eq!(map.health((3, 0, 0)), Some(1));
+        assert_eq!(map.health((5, 0, 0)), Some(1));
     }
 
     #[test]
@@ -479,9 +594,9 @@ mod tests {
             ..basic_config()
         };
         let mut map = VoxelMap::default();
-        map.voxels.insert((3, 0, 0), 1);
+        map.set((3, 0, 0), 1);
         update_map(&mut map, (0.0, 0.0, 0.0), &[(5.5, 0.5, 0.5)], &cfg);
-        assert_eq!(map.voxels.get(&(3, 0, 0)), Some(&1));
+        assert_eq!(map.health((3, 0, 0)), Some(1));
     }
 
     #[test]
@@ -492,10 +607,10 @@ mod tests {
         };
         let mut map = VoxelMap::default();
         update_map(&mut map, (0.0, 0.0, 0.0), &[(5.5, 0.5, 0.5)], &cfg);
-        assert_eq!(map.voxels.get(&(5, 0, 0)), Some(&0));
+        assert_eq!(map.health((5, 0, 0)), Some(0));
 
         update_map(&mut map, (0.0, 0.0, 0.0), &[(5.5, 0.5, 0.5)], &cfg);
-        assert_eq!(map.voxels.get(&(5, 0, 0)), Some(&1));
+        assert_eq!(map.health((5, 0, 0)), Some(1));
     }
 
     /// Test how bad the planar ray clipping is.
@@ -531,7 +646,7 @@ mod tests {
             for i in 0..n_ground {
                 let x = (i as f32) * voxel_size + voxel_size * 0.5;
                 let key = world_to_voxel(x, 0.0, 0.0, inv);
-                map.voxels.insert(key, cfg.max_health);
+                map.set(key, cfg.max_health);
             }
             let n_before = map.voxels.len();
 
@@ -575,7 +690,7 @@ mod tests {
         shadow_depth: f32,
         grace_depth: f32,
     ) {
-        use svg::node::element::{Circle, Line, Rectangle};
+        use svg::node::element::{Circle, Definitions, Line, Marker, Path, Rectangle};
         use svg::Document;
 
         let inv = 1.0 / voxel_size;
@@ -608,6 +723,23 @@ mod tests {
                     .set("width", w)
                     .set("height", h)
                     .set("fill", "white"),
+            )
+            .add(
+                Definitions::new().add(
+                    Marker::new()
+                        .set("id", "nrm")
+                        .set("viewBox", "0 0 10 10")
+                        .set("refX", 9)
+                        .set("refY", 5)
+                        .set("markerWidth", 5)
+                        .set("markerHeight", 5)
+                        .set("orient", "auto")
+                        .add(
+                            Path::new()
+                                .set("d", "M0,0 L10,5 L0,10 z")
+                                .set("fill", "#7b2cbf"),
+                        ),
+                ),
             );
 
         for xi in xmin..=xmax + 1 {
@@ -648,6 +780,37 @@ mod tests {
                     .set("height", s)
                     .set("fill", fill)
                     .set("stroke", "black"),
+            );
+        }
+
+        // Per-voxel surface normal, projected into the x-z plane and oriented
+        // toward the sensor. Voxels with no confident planar normal get none.
+        for &v in stairs {
+            let Some(normal) = map.voxels.get(&v).and_then(Voxel::planar_normal) else {
+                continue;
+            };
+            let (mut nx, mut nz) = (normal[0], normal[2]);
+            let mag = (nx * nx + nz * nz).sqrt();
+            if mag < 1e-3 {
+                continue;
+            }
+            nx /= mag;
+            nz /= mag;
+            let (cx, cz) = (v.0 as f32 + 0.5, v.2 as f32 + 0.5);
+            if nx * (origin.0 * inv - cx) + nz * (origin.2 * inv - cz) < 0.0 {
+                nx = -nx;
+                nz = -nz;
+            }
+            let len = 0.6;
+            doc = doc.add(
+                Line::new()
+                    .set("x1", sx(cx))
+                    .set("y1", sz(cz))
+                    .set("x2", sx(cx + nx * len))
+                    .set("y2", sz(cz + nz * len))
+                    .set("stroke", "#7b2cbf")
+                    .set("stroke-width", 3)
+                    .set("marker-end", "url(#nrm)"),
             );
         }
 
@@ -762,26 +925,30 @@ mod tests {
             segments.push((false, zt, rx, rx + run));
         }
 
-        // Dense surface samples: the true lidar-visible geometry. Voxelize them
-        // to build the occupancy the clearing pass operates on.
+        // Dense surface samples: the true lidar-visible geometry. Each segment
+        // is swept across a band of y as well so the per-voxel covariance is a
+        // genuine 2d patch (planar), not a degenerate line in the x-z slice.
         let mut lidar: Vec<(f32, f32, f32)> = Vec::new();
         let ds = voxel_size / 6.0;
+        let ny = 5;
         for &(vertical, fixed, lo, hi) in &segments {
             let n = ((hi - lo) / ds).round().max(1.0) as i32;
             for i in 0..=n {
                 let t = lo + (hi - lo) * (i as f32 / n as f32);
-                lidar.push(if vertical {
-                    (fixed, half, t)
-                } else {
-                    (t, half, fixed)
-                });
+                for j in 0..ny {
+                    let yy = voxel_size * (0.15 + 0.7 * j as f32 / (ny - 1) as f32);
+                    lidar.push(if vertical {
+                        (fixed, yy, t)
+                    } else {
+                        (t, yy, fixed)
+                    });
+                }
             }
         }
 
         let mut map = VoxelMap::default();
-        for &(x, y, z) in &lidar {
-            map.voxels
-                .insert(world_to_voxel(x, y, z, inv), cfg.max_health);
+        for &p in &lidar {
+            map.accumulate(p, voxel_size);
         }
         let mut all_stairs: Vec<VoxelKey> = lidar
             .iter()
@@ -789,6 +956,9 @@ mod tests {
             .collect();
         all_stairs.sort();
         all_stairs.dedup();
+        for &k in &all_stairs {
+            map.voxels.get_mut(&k).unwrap().health = cfg.max_health;
+        }
 
         // Sensor at the foot of the stairs, 0.2 m off the ground.
         let origin = (half, half, base_z + 0.23);
@@ -874,10 +1044,10 @@ mod tests {
         let mut map = VoxelMap::default();
         update_map(&mut map, (0.0, 0.0, 0.0), &[(3.5, 0.5, 0.5)], &cfg);
         update_map(&mut map, (0.0, 0.0, 0.0), &[(3.5, 0.5, 0.5)], &cfg);
-        assert_eq!(map.voxels.get(&(3, 0, 0)), Some(&2));
+        assert_eq!(map.health((3, 0, 0)), Some(2));
 
         update_map(&mut map, (0.0, 0.0, 0.0), &[(5.5, 0.5, 0.5)], &cfg);
-        assert_eq!(map.voxels.get(&(3, 0, 0)), Some(&1));
+        assert_eq!(map.health((3, 0, 0)), Some(1));
 
         update_map(&mut map, (0.0, 0.0, 0.0), &[(5.5, 0.5, 0.5)], &cfg);
         assert!(!map.voxels.contains_key(&(3, 0, 0)));

--- a/dimos/mapping/ray_tracing/rust/src/voxel_ray_tracer.rs
+++ b/dimos/mapping/ray_tracing/rust/src/voxel_ray_tracer.rs
@@ -560,6 +560,311 @@ mod tests {
         );
     }
 
+    /// Write an SVG of the x-z plane: kept voxels blue, cleared voxels red,
+    /// ray-hit voxels green, the dense true-surface points, each ray from the
+    /// sensor to its surface hit, and the sensor.
+    #[allow(clippy::too_many_arguments)]
+    fn write_stair_svg(
+        path: &std::path::Path,
+        stairs: &[VoxelKey],
+        map: &VoxelMap,
+        lidar_points: &[(f32, f32, f32)],
+        origin: (f32, f32, f32),
+        hits: &[(f32, f32, f32)],
+        voxel_size: f32,
+        shadow_depth: f32,
+        grace_depth: f32,
+    ) {
+        use svg::node::element::{Circle, Line, Rectangle};
+        use svg::Document;
+
+        let inv = 1.0 / voxel_size;
+        let origin_v = world_to_voxel(origin.0, origin.1, origin.2, inv);
+        let hit_voxels: AHashSet<VoxelKey> = hits
+            .iter()
+            .map(|&(x, y, z)| world_to_voxel(x, y, z, inv))
+            .collect();
+
+        let mut keys: Vec<VoxelKey> = stairs.to_vec();
+        keys.push(origin_v);
+        keys.extend(hit_voxels.iter().copied());
+        let xmin = keys.iter().map(|k| k.0).min().unwrap() - 2;
+        let xmax = keys.iter().map(|k| k.0).max().unwrap() + 2;
+        let zmin = keys.iter().map(|k| k.2).min().unwrap() - 2;
+        let zmax = keys.iter().map(|k| k.2).max().unwrap() + 2;
+
+        let s = 70.0_f32;
+        let w = (xmax - xmin + 1) as f32 * s;
+        let h = (zmax - zmin + 1) as f32 * s;
+        let sx = |xi: f32| (xi - xmin as f32) * s;
+        let sz = |zi: f32| (zmax as f32 + 1.0 - zi) * s;
+
+        let mut doc = Document::new()
+            .set("viewBox", (0.0, 0.0, w, h))
+            .set("width", w)
+            .set("height", h)
+            .add(
+                Rectangle::new()
+                    .set("width", w)
+                    .set("height", h)
+                    .set("fill", "white"),
+            );
+
+        for xi in xmin..=xmax + 1 {
+            let x = sx(xi as f32);
+            doc = doc.add(
+                Line::new()
+                    .set("x1", x)
+                    .set("y1", 0)
+                    .set("x2", x)
+                    .set("y2", h)
+                    .set("stroke", "#eee"),
+            );
+        }
+        for zi in zmin..=zmax + 1 {
+            let y = sz(zi as f32);
+            doc = doc.add(
+                Line::new()
+                    .set("x1", 0)
+                    .set("y1", y)
+                    .set("x2", w)
+                    .set("y2", y)
+                    .set("stroke", "#eee"),
+            );
+        }
+        for &v in stairs {
+            let fill = if hit_voxels.contains(&v) {
+                "#2ca02c"
+            } else if map.voxels.contains_key(&v) {
+                "#4a78b0"
+            } else {
+                "#d62728"
+            };
+            doc = doc.add(
+                Rectangle::new()
+                    .set("x", sx(v.0 as f32))
+                    .set("y", sz((v.2 + 1) as f32))
+                    .set("width", s)
+                    .set("height", s)
+                    .set("fill", fill)
+                    .set("stroke", "black"),
+            );
+        }
+
+        for &(px, _, pz) in lidar_points {
+            doc = doc.add(
+                Circle::new()
+                    .set("cx", sx(px * inv))
+                    .set("cy", sz(pz * inv))
+                    .set("r", 2.0)
+                    .set("fill", "#111")
+                    .set("fill-opacity", 0.85),
+            );
+        }
+
+        let oc = (origin.0 * inv, origin.2 * inv);
+        let shadow_idx = shadow_depth * inv;
+        let grace_px = grace_depth * inv * s;
+        for &(hx, _, hz) in hits {
+            let hc = (hx * inv, hz * inv);
+            let dir = (hc.0 - oc.0, hc.1 - oc.1);
+            let dlen = (dir.0 * dir.0 + dir.1 * dir.1).sqrt().max(f32::EPSILON);
+            let sh = (
+                hc.0 + dir.0 / dlen * shadow_idx,
+                hc.1 + dir.1 / dlen * shadow_idx,
+            );
+            doc = doc
+                .add(
+                    Line::new()
+                        .set("x1", sx(oc.0))
+                        .set("y1", sz(oc.1))
+                        .set("x2", sx(hc.0))
+                        .set("y2", sz(hc.1))
+                        .set("stroke", "orange")
+                        .set("stroke-width", 2),
+                )
+                .add(
+                    Line::new()
+                        .set("x1", sx(hc.0))
+                        .set("y1", sz(hc.1))
+                        .set("x2", sx(sh.0))
+                        .set("y2", sz(sh.1))
+                        .set("stroke", "purple")
+                        .set("stroke-width", 2)
+                        .set("stroke-dasharray", "5"),
+                )
+                .add(
+                    Circle::new()
+                        .set("cx", sx(hc.0))
+                        .set("cy", sz(hc.1))
+                        .set("r", grace_px)
+                        .set("fill", "none")
+                        .set("stroke", "green")
+                        .set("stroke-dasharray", "4"),
+                )
+                .add(
+                    Circle::new()
+                        .set("cx", sx(hc.0))
+                        .set("cy", sz(hc.1))
+                        .set("r", 4)
+                        .set("fill", "darkgreen"),
+                );
+        }
+        doc = doc.add(
+            Circle::new()
+                .set("cx", sx(oc.0))
+                .set("cy", sz(oc.1))
+                .set("r", 6)
+                .set("fill", "darkorange"),
+        );
+
+        svg::save(path, &doc).expect("write stair_clip.svg");
+    }
+
+    /// A fan of lidar rays from a sensor at the foot of a staircase. Each ray
+    /// direction is intersected with the true continuous surface to find its
+    /// hit point, then the whole frame is fed to the mapper. Rays that reach an
+    /// upper step graze the voxels of the lower steps they pass over, and the
+    /// thin-ray DDA clears that real geometry. A correct clearing pass must
+    /// leave every stair voxel intact.
+    ///
+    /// Run it with `cargo test stair_clipping_ray_fan -- --nocapture`.
+    #[test]
+    fn stair_clipping_ray_fan() {
+        let voxel_size = 0.1_f32;
+        let inv = 1.0 / voxel_size;
+        let half = voxel_size * 0.5;
+        let cfg = Config {
+            voxel_size,
+            max_range: 50.0,
+            ray_subsample: 1,
+            shadow_depth: 0.2,
+            grace_depth: 0.2,
+            min_health: 0,
+            max_health: 1,
+        };
+
+        // True continuous staircase in the x-z plane (single y row): household
+        // slope, run = 0.3 m, rise = 0.2 m. Each step is a vertical riser face
+        // and a horizontal tread top, stored as axis-aligned segments
+        // (vertical?, fixed, lo, hi) in world meters.
+        const N: i32 = 5;
+        let run = 3.0 * voxel_size;
+        let rise = 2.0 * voxel_size;
+        let first_riser_x = 3.0 * voxel_size + half;
+        let base_z = half;
+        let mut segments: Vec<(bool, f32, f32, f32)> = Vec::new();
+        for k in 1..=N {
+            let rx = first_riser_x + (k - 1) as f32 * run;
+            let zb = base_z + (k - 1) as f32 * rise;
+            let zt = base_z + k as f32 * rise;
+            segments.push((true, rx, zb, zt));
+            segments.push((false, zt, rx, rx + run));
+        }
+
+        // Dense surface samples: the true lidar-visible geometry. Voxelize them
+        // to build the occupancy the clearing pass operates on.
+        let mut lidar: Vec<(f32, f32, f32)> = Vec::new();
+        let ds = voxel_size / 6.0;
+        for &(vertical, fixed, lo, hi) in &segments {
+            let n = ((hi - lo) / ds).round().max(1.0) as i32;
+            for i in 0..=n {
+                let t = lo + (hi - lo) * (i as f32 / n as f32);
+                lidar.push(if vertical {
+                    (fixed, half, t)
+                } else {
+                    (t, half, fixed)
+                });
+            }
+        }
+
+        let mut map = VoxelMap::default();
+        for &(x, y, z) in &lidar {
+            map.voxels
+                .insert(world_to_voxel(x, y, z, inv), cfg.max_health);
+        }
+        let mut all_stairs: Vec<VoxelKey> = lidar
+            .iter()
+            .map(|&(x, y, z)| world_to_voxel(x, y, z, inv))
+            .collect();
+        all_stairs.sort();
+        all_stairs.dedup();
+
+        // Sensor at the foot of the stairs, 0.2 m off the ground.
+        let origin = (half, half, base_z + 0.23);
+
+        // Five rays evenly spaced in elevation, sweeping the staircase. Each
+        // ray's hit is the nearest forward intersection with a surface segment.
+        const N_RAYS: usize = 6;
+        let (lo_deg, hi_deg) = (0.0_f32, 27.0_f32);
+        let mut hits: Vec<(f32, f32, f32)> = Vec::new();
+        for i in 0..N_RAYS {
+            let frac = i as f32 / (N_RAYS - 1) as f32;
+            let theta = (lo_deg + (hi_deg - lo_deg) * frac).to_radians();
+            let d = (theta.cos(), theta.sin());
+            let mut best: Option<(f32, (f32, f32))> = None;
+            for &(vertical, fixed, lo, hi) in &segments {
+                let hit = if vertical {
+                    if d.0.abs() < 1e-9 {
+                        continue;
+                    }
+                    let t = (fixed - origin.0) / d.0;
+                    let z = origin.2 + t * d.1;
+                    (t > 1e-4 && z >= lo && z <= hi).then_some((t, (fixed, z)))
+                } else {
+                    if d.1.abs() < 1e-9 {
+                        continue;
+                    }
+                    let t = (fixed - origin.2) / d.1;
+                    let x = origin.0 + t * d.0;
+                    (t > 1e-4 && x >= lo && x <= hi).then_some((t, (x, fixed)))
+                };
+                if let Some(cand) = hit {
+                    if best.is_none_or(|b| cand.0 < b.0) {
+                        best = Some(cand);
+                    }
+                }
+            }
+            if let Some((_, (hx, hz))) = best {
+                hits.push((hx, half, hz));
+            }
+        }
+
+        update_map(&mut map, origin, &hits, &cfg);
+
+        let svg_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("stair_clip.svg");
+        write_stair_svg(
+            &svg_path,
+            &all_stairs,
+            &map,
+            &lidar,
+            origin,
+            &hits,
+            voxel_size,
+            cfg.shadow_depth,
+            cfg.grace_depth,
+        );
+        eprintln!("wrote {}", svg_path.display());
+
+        // No real stair voxel may be cleared: every ray that grazes a step's
+        // voxels en route to its true hit must leave them intact.
+        let cleared: Vec<VoxelKey> = all_stairs
+            .iter()
+            .copied()
+            .filter(|v| !map.voxels.contains_key(v))
+            .collect();
+        eprintln!(
+            "{} rays hit, cleared {} stair voxel(s): {cleared:?}",
+            hits.len(),
+            cleared.len()
+        );
+        assert!(
+            cleared.is_empty(),
+            "ray fan cleared {} real stair voxel(s): {cleared:?}",
+            cleared.len()
+        );
+    }
+
     #[test]
     fn two_misses_needed_when_max_health_is_two() {
         let cfg = Config {

--- a/dimos/mapping/ray_tracing/rust/src/voxel_ray_tracer.rs
+++ b/dimos/mapping/ray_tracing/rust/src/voxel_ray_tracer.rs
@@ -26,12 +26,13 @@ pub struct Config {
     pub min_health: i32,
     #[validate(range(min = 1))]
     pub max_health: i32,
-    /// Spare a clearing miss when |ray dot normal| is below this. Higher
-    /// protects steeper grazing surfaces like floors and treads.
+    /// Don't clear a miss when abs of ray dot normal is below this, clear it when above.
+    /// Higher value means points are only cleared with direct hits. Low values means
+    /// even slight grazes will clear points.
     #[validate(range(min = 0.0, max = 1.0))]
     pub graze_cos: f32,
     /// Only spare a voxel whose neighborhood was hit within this many frames.
-    /// A stale voxel clears despite its normal. Large disables it.
+    /// A stale voxel can be cleared, even if it's a grazing hit. Large disables it.
     pub recency_window: u32,
 }
 
@@ -53,7 +54,7 @@ impl VoxelMap {
         self.voxels.values().filter(|c| c.health > 0).count()
     }
 
-    /// Fold a return into its voxel's covariance, relative to the voxel center.
+    /// Update or add voxel on a hit. Updates covariance and hit count for normal calculation.
     fn accumulate(&mut self, point: (f32, f32, f32), voxel_size: f32) {
         let key = world_to_voxel(point.0, point.1, point.2, 1.0 / voxel_size);
         let center = Vector3::new(
@@ -61,6 +62,8 @@ impl VoxelMap {
             (key.1 as f32 + 0.5) * voxel_size,
             (key.2 as f32 + 0.5) * voxel_size,
         );
+
+        // update or add voxel with new info
         self.voxels
             .entry(key)
             .or_default()
@@ -92,22 +95,26 @@ impl VoxelMap {
     }
 }
 
+/// Number of required points to assign a normal
 const NORMAL_MIN_POINTS: u32 = 3;
+/// Consider points within this voxel radius when calculating normal
 const NORMAL_NEIGHBOR_RADIUS: i32 = 1;
 const NORMAL_REWEIGHT_ITERS: u32 = 3;
 /// Neighbor weight falloff with plane distance, as a fraction of voxel size.
 const NORMAL_PLANE_SIGMA_FRAC: f32 = 0.5;
-/// Lowest retained point-mass fraction that still counts as a real plane.
+/// Fraction of points that must be kept after the IRLS to count as a real plane
 const NORMAL_MIN_SUPPORT: f32 = 0.5;
 
-/// Occupancy health, a running point covariance, and the cached normal fit from
-/// the voxel's pooled neighborhood. Points accumulate relative to the voxel
-/// center for f32 stability.
+/// Voxel stats, such as health, accumulate hit count, running covariance, and cached normal.
+/// Normal is determined from all points in a neighborhood of voxel.
 #[derive(Clone)]
 pub struct Voxel {
     pub health: VoxelHealth,
+    /// Number of accumulated hits in this voxel
     num_pts: u32,
+    /// Sum of all hit points within voxel
     sum: Vector3<f32>,
+    /// Covariance of accumulated hits
     m2: Matrix3<f32>,
     normal: Option<Vector3<f32>>,
     last_hit: u32,
@@ -137,6 +144,7 @@ impl Voxel {
         }
     }
 
+    /// Update accumulation info on this voxel so we can calculate the normal
     fn observe(&mut self, q: Vector3<f32>) {
         self.num_pts += 1;
         self.sum += q;
@@ -160,8 +168,7 @@ impl Voxel {
     }
 }
 
-/// The surface normal of a covariance, or None unless planarity dominates the
-/// linear and scatter dimensionality features. An edge or blob has no normal.
+/// The surface normal of a covariance, or None unless there is a strong planarity feature. Lines and scattered blobs shouldn't get a normal.
 fn fit_normal(cov: Matrix3<f32>) -> Option<Vector3<f32>> {
     let eig = cov.symmetric_eigen();
     let mut idx = [0usize, 1, 2];
@@ -182,17 +189,18 @@ fn fit_normal(cov: Matrix3<f32>) -> Option<Vector3<f32>> {
     Some(eig.eigenvectors.column(idx[0]).into_owned())
 }
 
-/// Moments of one neighbor voxel, shifted into the target voxel's local frame.
+/// Moments of one neighbor voxel.
 struct Neighbor {
+    /// Number of points, zeroth moment
     n: f32,
+    /// Sum of points, first moment
     s: Vector3<f32>,
+    /// Sum of outer prods, second moment
     t: Matrix3<f32>,
     centroid: Vector3<f32>,
 }
 
-/// Fit a voxel's normal from its neighborhood, reweighting out neighbors whose
-/// centroid lies off the tentative plane so a flat tread is not polluted by an
-/// adjacent riser.
+/// Find voxel's normal from its neighborhood.
 fn pooled_normal(
     voxels: &AHashMap<VoxelKey, Voxel>,
     key: VoxelKey,
@@ -261,7 +269,7 @@ fn pooled_normal(
             *w = (-(dist * dist) / two_sig2).exp();
         }
     }
-    // Reject a plane the reweighting fabricated by discarding most of the mass.
+    // get rid of planes if we had to discard too many points to get a plane
     let kept: f32 = nbs.iter().zip(&weights).map(|(nb, &w)| w * nb.n).sum();
     if kept < NORMAL_MIN_SUPPORT * n_raw as f32 {
         return None;
@@ -323,9 +331,8 @@ fn refresh_voxels(
     }
 }
 
-/// Spare a clearing miss only when a grazing ray skims a planar surface whose
-/// neighborhood was hit recently. A stale voxel is left to the health hysteresis,
-/// and so is anything without a trustworthy normal.
+/// Spare a clearing miss only when a grazing ray skims a recently hit planar
+/// surface. Stale or voxels with no normal are left to the health checks.
 fn should_spare(
     voxels: &AHashMap<VoxelKey, Voxel>,
     key: VoxelKey,
@@ -381,8 +388,8 @@ pub fn iter_global_points(
         })
 }
 
-/// Healthy voxel centers paired with their surface normal, in matching order.
-/// The normal is the zero vector where the voxel has no planar normal.
+/// Healthy voxel centers paired with their surface normal.
+/// If no normal, it's just the null vector
 pub fn iter_global_normals(
     map: &VoxelMap,
     voxel_size: f32,
@@ -859,38 +866,14 @@ mod tests {
                 "{range:>6.1}  {n_before:>20}  {clipped:>7}  {pct:>10.1}\n"
             ));
             total_clipped += clipped;
-
-            // Emit one x-z picture so the floor and its normals are visible.
-            // Window the floor to a little past the hit so the image stays readable.
-            if (range - 8.0).abs() < 1e-3 {
-                let floor: Vec<VoxelKey> = center_row
-                    .iter()
-                    .copied()
-                    .filter(|k| (k.0 as f32) * voxel_size <= range + 1.5)
-                    .collect();
-                let svg = std::env::temp_dir().join("ground_clip.svg");
-                write_stair_svg(
-                    &svg,
-                    &floor,
-                    &map,
-                    &points,
-                    origin,
-                    &points,
-                    voxel_size,
-                    cfg.shadow_depth,
-                    cfg.grace_depth,
-                );
-            }
         }
-        eprint!("{table}");
         assert!(
             total_clipped == 0,
             "planar grace regressed, ground voxels clipped:\n{table}"
         );
     }
 
-    /// Dense surface samples for axis-aligned segments, swept across a y band so
-    /// each patch is a genuine 2d surface rather than a degenerate line.
+    /// Sample axis-aligned segments across a y band so each patch is a 2d surface.
     fn sample_segments(
         segments: &[(bool, f32, f32, f32)],
         voxel_size: f32,
@@ -975,213 +958,6 @@ mod tests {
         best.map(|(_, p)| p)
     }
 
-    /// Write an SVG of the x-z plane for visual inspection.
-    #[allow(clippy::too_many_arguments)]
-    fn write_stair_svg(
-        path: &std::path::Path,
-        stairs: &[VoxelKey],
-        map: &VoxelMap,
-        lidar_points: &[(f32, f32, f32)],
-        origin: (f32, f32, f32),
-        hits: &[(f32, f32, f32)],
-        voxel_size: f32,
-        shadow_depth: f32,
-        grace_depth: f32,
-    ) {
-        use svg::node::element::{Circle, Definitions, Line, Marker, Path, Rectangle};
-        use svg::Document;
-
-        let inv = 1.0 / voxel_size;
-        let origin_v = world_to_voxel(origin.0, origin.1, origin.2, inv);
-        let hit_voxels: AHashSet<VoxelKey> = hits
-            .iter()
-            .map(|&(x, y, z)| world_to_voxel(x, y, z, inv))
-            .collect();
-
-        let mut keys: Vec<VoxelKey> = stairs.to_vec();
-        keys.push(origin_v);
-        keys.extend(hit_voxels.iter().copied());
-        let xmin = keys.iter().map(|k| k.0).min().unwrap() - 2;
-        let xmax = keys.iter().map(|k| k.0).max().unwrap() + 2;
-        let zmin = keys.iter().map(|k| k.2).min().unwrap() - 2;
-        let zmax = keys.iter().map(|k| k.2).max().unwrap() + 2;
-
-        let s = 70.0_f32;
-        let w = (xmax - xmin + 1) as f32 * s;
-        let h = (zmax - zmin + 1) as f32 * s;
-        let sx = |xi: f32| (xi - xmin as f32) * s;
-        let sz = |zi: f32| (zmax as f32 + 1.0 - zi) * s;
-
-        let mut doc = Document::new()
-            .set("viewBox", (0.0, 0.0, w, h))
-            .set("width", w)
-            .set("height", h)
-            .add(
-                Rectangle::new()
-                    .set("width", w)
-                    .set("height", h)
-                    .set("fill", "white"),
-            )
-            .add(
-                Definitions::new().add(
-                    Marker::new()
-                        .set("id", "nrm")
-                        .set("viewBox", "0 0 10 10")
-                        .set("refX", 9)
-                        .set("refY", 5)
-                        .set("markerWidth", 5)
-                        .set("markerHeight", 5)
-                        .set("orient", "auto")
-                        .add(
-                            Path::new()
-                                .set("d", "M0,0 L10,5 L0,10 z")
-                                .set("fill", "#7b2cbf"),
-                        ),
-                ),
-            );
-
-        for xi in xmin..=xmax + 1 {
-            let x = sx(xi as f32);
-            doc = doc.add(
-                Line::new()
-                    .set("x1", x)
-                    .set("y1", 0)
-                    .set("x2", x)
-                    .set("y2", h)
-                    .set("stroke", "#eee"),
-            );
-        }
-        for zi in zmin..=zmax + 1 {
-            let y = sz(zi as f32);
-            doc = doc.add(
-                Line::new()
-                    .set("x1", 0)
-                    .set("y1", y)
-                    .set("x2", w)
-                    .set("y2", y)
-                    .set("stroke", "#eee"),
-            );
-        }
-        for &v in stairs {
-            let fill = if hit_voxels.contains(&v) {
-                "#2ca02c"
-            } else if map.voxels.contains_key(&v) {
-                "#4a78b0"
-            } else {
-                "#d62728"
-            };
-            doc = doc.add(
-                Rectangle::new()
-                    .set("x", sx(v.0 as f32))
-                    .set("y", sz((v.2 + 1) as f32))
-                    .set("width", s)
-                    .set("height", s)
-                    .set("fill", fill)
-                    .set("stroke", "black"),
-            );
-        }
-
-        // Per-voxel surface normal, projected into the x-z plane and oriented
-        // toward the sensor. Voxels with no confident planar normal get none.
-        for &v in stairs {
-            let Some(normal) = map.voxels.get(&v).and_then(Voxel::planar_normal) else {
-                continue;
-            };
-            let (mut nx, mut nz) = (normal[0], normal[2]);
-            let mag = (nx * nx + nz * nz).sqrt();
-            if mag < 1e-3 {
-                continue;
-            }
-            nx /= mag;
-            nz /= mag;
-            let (cx, cz) = (v.0 as f32 + 0.5, v.2 as f32 + 0.5);
-            if nx * (origin.0 * inv - cx) + nz * (origin.2 * inv - cz) < 0.0 {
-                nx = -nx;
-                nz = -nz;
-            }
-            let len = 0.6;
-            doc = doc.add(
-                Line::new()
-                    .set("x1", sx(cx))
-                    .set("y1", sz(cz))
-                    .set("x2", sx(cx + nx * len))
-                    .set("y2", sz(cz + nz * len))
-                    .set("stroke", "#7b2cbf")
-                    .set("stroke-width", 3)
-                    .set("marker-end", "url(#nrm)"),
-            );
-        }
-
-        for &(px, _, pz) in lidar_points {
-            doc = doc.add(
-                Circle::new()
-                    .set("cx", sx(px * inv))
-                    .set("cy", sz(pz * inv))
-                    .set("r", 2.0)
-                    .set("fill", "#111")
-                    .set("fill-opacity", 0.85),
-            );
-        }
-
-        let oc = (origin.0 * inv, origin.2 * inv);
-        let shadow_idx = shadow_depth * inv;
-        let grace_px = grace_depth * inv * s;
-        for &(hx, _, hz) in hits {
-            let hc = (hx * inv, hz * inv);
-            let dir = (hc.0 - oc.0, hc.1 - oc.1);
-            let dlen = (dir.0 * dir.0 + dir.1 * dir.1).sqrt().max(f32::EPSILON);
-            let sh = (
-                hc.0 + dir.0 / dlen * shadow_idx,
-                hc.1 + dir.1 / dlen * shadow_idx,
-            );
-            doc = doc
-                .add(
-                    Line::new()
-                        .set("x1", sx(oc.0))
-                        .set("y1", sz(oc.1))
-                        .set("x2", sx(hc.0))
-                        .set("y2", sz(hc.1))
-                        .set("stroke", "orange")
-                        .set("stroke-width", 2),
-                )
-                .add(
-                    Line::new()
-                        .set("x1", sx(hc.0))
-                        .set("y1", sz(hc.1))
-                        .set("x2", sx(sh.0))
-                        .set("y2", sz(sh.1))
-                        .set("stroke", "purple")
-                        .set("stroke-width", 2)
-                        .set("stroke-dasharray", "5"),
-                )
-                .add(
-                    Circle::new()
-                        .set("cx", sx(hc.0))
-                        .set("cy", sz(hc.1))
-                        .set("r", grace_px)
-                        .set("fill", "none")
-                        .set("stroke", "green")
-                        .set("stroke-dasharray", "4"),
-                )
-                .add(
-                    Circle::new()
-                        .set("cx", sx(hc.0))
-                        .set("cy", sz(hc.1))
-                        .set("r", 4)
-                        .set("fill", "darkgreen"),
-                );
-        }
-        doc = doc.add(
-            Circle::new()
-                .set("cx", sx(oc.0))
-                .set("cy", sz(oc.1))
-                .set("r", 6)
-                .set("fill", "darkorange"),
-        );
-
-        svg::save(path, &doc).expect("write stair_clip.svg");
-    }
-
     /// A ray fan from the foot of a staircase grazes lower steps en route to
     /// upper ones. The grazing gate must leave every planar surface voxel intact.
     #[test]
@@ -1218,19 +994,16 @@ mod tests {
         let lidar = sample_segments(&segments, voxel_size);
         let (mut map, all_stairs) = build_surface(&lidar, voxel_size, cfg.max_health);
 
-        // The grazing gate must spare every voxel that has a normal. Only the
-        // tread/riser junctions, which have no plane, may clear.
+        // Voxels with a normal must be spared. Only edge voxels with no plane may clear.
         let planar: Vec<VoxelKey> = all_stairs
             .iter()
             .copied()
             .filter(|k| map.voxels.get(k).and_then(Voxel::planar_normal).is_some())
             .collect();
 
-        // Sensor at the foot of the stairs, 0.23 m off the ground.
         let origin = (half, half, base_z + 0.23);
 
-        // Six rays evenly spaced in elevation, sweeping the staircase. Each
-        // ray's hit is the nearest forward intersection with a surface segment.
+        // A ray fan sweeping up the staircase.
         const N_RAYS: usize = 6;
         let (lo_deg, hi_deg) = (0.0_f32, 27.0_f32);
         let mut hits: Vec<(f32, f32, f32)> = Vec::new();
@@ -1244,21 +1017,6 @@ mod tests {
 
         update_map(&mut map, origin, &hits, &cfg);
 
-        let svg_path = std::env::temp_dir().join("stair_clip.svg");
-        write_stair_svg(
-            &svg_path,
-            &all_stairs,
-            &map,
-            &lidar,
-            origin,
-            &hits,
-            voxel_size,
-            cfg.shadow_depth,
-            cfg.grace_depth,
-        );
-
-        // The grazing gate must spare every planar surface voxel: a ray skimming
-        // a tread or riser en route to a higher step may not erode it.
         let cleared_planar: Vec<VoxelKey> = planar
             .iter()
             .copied()
@@ -1289,7 +1047,7 @@ mod tests {
             recency_window: 60,
         };
 
-        // Flat floor (horizontal, row 0) from the sensor out to a vertical wall.
+        // Flat floor from the sensor out to a vertical wall.
         let floor_z = half;
         let x_wall = 25.0 * voxel_size + half;
         let segments = vec![
@@ -1304,10 +1062,8 @@ mod tests {
         const SENSOR_HEIGHT: f32 = 0.3;
         let origin = (half, half, floor_z + SENSOR_HEIGHT);
 
-        // Floor voxels captured before any clearing.
         let floor: Vec<VoxelKey> = all_surf.iter().copied().filter(|k| k.2 == 0).collect();
 
-        // Fan sweeping from steep-down at the near floor up to the wall.
         const N_RAYS: usize = 16;
         let (lo_deg, hi_deg) = (-35.0_f32, 18.0_f32);
         let mut hits: Vec<(f32, f32, f32)> = Vec::new();
@@ -1321,19 +1077,6 @@ mod tests {
 
         update_map(&mut map, origin, &hits, &cfg);
 
-        let svg_path = std::env::temp_dir().join("floor_clip.svg");
-        write_stair_svg(
-            &svg_path,
-            &all_surf,
-            &map,
-            &lidar,
-            origin,
-            &hits,
-            voxel_size,
-            cfg.shadow_depth,
-            cfg.grace_depth,
-        );
-
         let cleared: Vec<VoxelKey> = floor
             .iter()
             .copied()
@@ -1346,8 +1089,7 @@ mod tests {
         );
     }
 
-    /// Robot just below a landing, seeing over its edge. The landing must survive:
-    /// rays hit it directly and the normal gate spares the grazed voxels.
+    /// A landing seen edge-on from just below must survive the grazing rays.
     #[test]
     fn landing_grazed_from_below() {
         let voxel_size = 0.1_f32;
@@ -1364,8 +1106,7 @@ mod tests {
             recency_window: 60,
         };
 
-        // Staircase, then the top tread extended into a long flat landing and a
-        // back wall for the grazing rays to terminate on.
+        // Staircase topped by a flat landing and a back wall.
         const N: i32 = 5;
         let run = 3.0 * voxel_size;
         let rise = 2.0 * voxel_size;
@@ -1389,9 +1130,6 @@ mod tests {
         let lidar = sample_segments(&segments, voxel_size);
         let landing_row = (z_top / voxel_size).floor() as i32;
 
-        // Robot on the step just below the landing, sensor 0.3 m up: it can just
-        // see over the landing edge, so its downward fan grazes that edge at the
-        // slope angle and skims the surface beyond toward the back wall.
         let step_below_x = first_riser_x + (N - 2) as f32 * run + run * 0.5;
         let origin = (step_below_x, half, z_top - rise + 0.3);
         const N_RAYS: usize = 16;
@@ -1407,14 +1145,7 @@ mod tests {
 
         let (mut map, surf) = build_surface(&lidar, voxel_size, 1);
         update_map(&mut map, origin, &hits, &cfg(0.7));
-        let svg = std::env::temp_dir().join("landing_clip.svg");
-        write_stair_svg(
-            &svg, &surf, &map, &lidar, origin, &hits, voxel_size, 0.2, 0.2,
-        );
 
-        // When the robot can see the landing, it hits the surface directly and
-        // grazing rays skim the planar top, so the normal gate spares those
-        // voxels. The landing must survive this view.
         let cleared: Vec<VoxelKey> = surf
             .iter()
             .copied()
@@ -1422,7 +1153,7 @@ mod tests {
             .collect();
         assert!(
             cleared.is_empty(),
-            "landing must survive when the robot can see over it; cleared {cleared:?}"
+            "landing must survive when the robot can see over it, cleared {cleared:?}"
         );
     }
 
@@ -1462,9 +1193,7 @@ mod tests {
 
     #[test]
     fn line_like_patch_has_no_normal() {
-        // Wide in y, ~zero in x, tiny z noise: a grazing scan-line across a flat
-        // floor. Its smallest eigenvector is horizontal, so trusting it as a normal
-        // would clear the floor. A line is not planar, so it must yield no normal.
+        // A scan-line is not planar, so it gets no normal.
         let mut v = Voxel::default();
         for j in 0..20 {
             let y = 0.08 * (j as f32 / 19.0 - 0.5);
@@ -1477,9 +1206,7 @@ mod tests {
         );
     }
 
-    /// A grazing ray over a flat floor is spared while the floor is fresh, but
-    /// once it goes stale (recency_window passed without a hit) the same ray
-    /// clears it despite the normal. Only the window differs between the runs.
+    /// A grazing ray spares a fresh floor but clears it once stale.
     #[test]
     fn stale_planar_voxel_loses_its_spare() {
         let voxel_size = 0.1_f32;

--- a/dimos/mapping/ray_tracing/rust/src/voxel_ray_tracer.rs
+++ b/dimos/mapping/ray_tracing/rust/src/voxel_ray_tracer.rs
@@ -156,7 +156,7 @@ impl Voxel {
 }
 
 /// The surface normal of a covariance, or None unless planarity dominates the
-/// linear and scatter dimensionality features (an edge or blob has no normal).
+/// linear and scatter dimensionality features. An edge or blob has no normal.
 fn fit_normal(cov: Matrix3<f32>) -> Option<Vector3<f32>> {
     let eig = cov.symmetric_eigen();
     let mut idx = [0usize, 1, 2];
@@ -1239,7 +1239,6 @@ mod tests {
             cfg.shadow_depth,
             cfg.grace_depth,
         );
-        eprintln!("wrote {}", svg_path.display());
 
         // The grazing gate must spare every planar surface voxel: a ray skimming
         // a tread or riser en route to a higher step may not erode it.
@@ -1248,16 +1247,6 @@ mod tests {
             .copied()
             .filter(|v| !map.voxels.contains_key(v))
             .collect();
-        let cleared_total = all_stairs
-            .iter()
-            .filter(|v| !map.voxels.contains_key(v))
-            .count();
-        eprintln!(
-            "{} rays hit; {} junction voxel(s) cleared, {} planar surface voxel(s) cleared",
-            hits.len(),
-            cleared_total - cleared_planar.len(),
-            cleared_planar.len()
-        );
         assert!(
             cleared_planar.is_empty(),
             "grazing rays eroded {} planar surface voxel(s): {cleared_planar:?}",
@@ -1298,15 +1287,8 @@ mod tests {
         const SENSOR_HEIGHT: f32 = 0.3;
         let origin = (half, half, floor_z + SENSOR_HEIGHT);
 
-        // Floor voxels and their normals, sampled before any clearing.
+        // Floor voxels captured before any clearing.
         let floor: Vec<VoxelKey> = all_surf.iter().copied().filter(|k| k.2 == 0).collect();
-        for &k in floor.iter().step_by(floor.len().max(6) / 6) {
-            let normal = map.voxels.get(&k).and_then(Voxel::planar_normal);
-            eprintln!(
-                "  floor {k:?} normal {:?}",
-                normal.map(|n| [n[0], n[1], n[2]])
-            );
-        }
 
         // Fan sweeping from steep-down at the near floor up to the wall.
         const N_RAYS: usize = 16;
@@ -1334,19 +1316,12 @@ mod tests {
             cfg.shadow_depth,
             cfg.grace_depth,
         );
-        eprintln!("wrote {}", svg_path.display());
 
         let cleared: Vec<VoxelKey> = floor
             .iter()
             .copied()
             .filter(|v| !map.voxels.contains_key(v))
             .collect();
-        eprintln!(
-            "{} rays hit, {} floor voxels, cleared {}: {cleared:?}",
-            hits.len(),
-            floor.len(),
-            cleared.len()
-        );
         assert!(
             cleared.is_empty(),
             "ray fan cleared {} floor voxel(s): {cleared:?}",
@@ -1418,18 +1393,15 @@ mod tests {
         write_stair_svg(
             &svg, &surf, &map, &lidar, origin, &hits, voxel_size, 0.2, 0.2,
         );
-        eprintln!("wrote {}", svg.display());
 
         // When the robot can see the landing, it hits the surface directly and
         // the grazed voxels share the hit's z-row, so the z-slab guard protects
-        // them. The landing must survive this view. (Real-data landing loss is a
-        // multi-frame occlusion effect, not a single grazing frame.)
+        // them. The landing must survive this view.
         let cleared: Vec<VoxelKey> = surf
             .iter()
             .copied()
             .filter(|k| k.2 == landing_row && !map.voxels.contains_key(k))
             .collect();
-        eprintln!("landing voxels cleared: {} {cleared:?}", cleared.len());
         assert!(
             cleared.is_empty(),
             "landing must survive when the robot can see over it; cleared {cleared:?}"

--- a/dimos/mapping/ray_tracing/rust/src/voxel_ray_tracer.rs
+++ b/dimos/mapping/ray_tracing/rust/src/voxel_ray_tracer.rs
@@ -31,10 +31,18 @@ pub struct Config {
     #[validate(range(min = 0.0, max = 1.0))]
     #[serde(default = "default_graze_cos")]
     pub graze_cos: f32,
+    /// Only spare a voxel whose neighborhood was hit within this many frames.
+    /// A stale voxel clears despite its normal. Large disables it.
+    #[serde(default = "default_recency_window")]
+    pub recency_window: u32,
 }
 
 fn default_graze_cos() -> f32 {
     0.7
+}
+
+fn default_recency_window() -> u32 {
+    15
 }
 
 fn validate_health_range(cfg: &Config) -> Result<(), ValidationError> {
@@ -47,6 +55,7 @@ fn validate_health_range(cfg: &Config) -> Result<(), ValidationError> {
 #[derive(Default)]
 pub struct VoxelMap {
     pub voxels: AHashMap<VoxelKey, Voxel>,
+    frame: u32,
 }
 
 impl VoxelMap {
@@ -111,6 +120,9 @@ pub struct Voxel {
     sum: Vector3<f32>,
     m2: Matrix3<f32>,
     normal: Option<Vector3<f32>>,
+    last_hit: u32,
+    // Most recent frame any voxel in this one's neighborhood was hit.
+    recency: u32,
 }
 
 impl Default for Voxel {
@@ -121,6 +133,8 @@ impl Default for Voxel {
             sum: Vector3::zeros(),
             m2: Matrix3::zeros(),
             normal: None,
+            last_hit: 0,
+            recency: 0,
         }
     }
 }
@@ -264,8 +278,25 @@ fn pooled_normal(
     fit_normal(cov)
 }
 
-/// Refit the cached normal of every voxel whose neighborhood changed this frame.
-fn refresh_normals(
+/// Most recent frame any voxel in the neighborhood was hit.
+fn neighborhood_recency(voxels: &AHashMap<VoxelKey, Voxel>, key: VoxelKey) -> u32 {
+    let r = NORMAL_NEIGHBOR_RADIUS;
+    let mut best = 0;
+    for dx in -r..=r {
+        for dy in -r..=r {
+            for dz in -r..=r {
+                if let Some(v) = voxels.get(&(key.0 + dx, key.1 + dy, key.2 + dz)) {
+                    best = best.max(v.last_hit);
+                }
+            }
+        }
+    }
+    best
+}
+
+/// Refit the cached normal and neighborhood recency of every voxel whose
+/// neighborhood changed this frame.
+fn refresh_voxels(
     map: &mut VoxelMap,
     hits: &AHashSet<VoxelKey>,
     removed: &[VoxelKey],
@@ -282,31 +313,43 @@ fn refresh_normals(
             }
         }
     }
-    let updates: Vec<(VoxelKey, Option<Vector3<f32>>)> = dirty
+    let updates: Vec<(VoxelKey, Option<Vector3<f32>>, u32)> = dirty
         .iter()
         .filter(|k| map.voxels.contains_key(k))
-        .map(|&k| (k, pooled_normal(&map.voxels, k, voxel_size)))
+        .map(|&k| {
+            (
+                k,
+                pooled_normal(&map.voxels, k, voxel_size),
+                neighborhood_recency(&map.voxels, k),
+            )
+        })
         .collect();
-    for (k, n) in updates {
+    for (k, n, rec) in updates {
         if let Some(c) = map.voxels.get_mut(&k) {
             c.normal = n;
+            c.recency = rec;
         }
     }
 }
 
-/// Spare a clearing miss only when a grazing ray skims a planar surface.
-/// Anything without a trustworthy normal is left to the health hysteresis.
+/// Spare a clearing miss only when a grazing ray skims a planar surface whose
+/// neighborhood was hit recently. A stale voxel is left to the health hysteresis,
+/// and so is anything without a trustworthy normal.
 fn should_spare(
     voxels: &AHashMap<VoxelKey, Voxel>,
     key: VoxelKey,
     ray_unit: Vector3<f32>,
     graze_cos: f32,
+    frame: u32,
+    recency_window: u32,
 ) -> bool {
     let Some(c) = voxels.get(&key) else {
         return false;
     };
     match c.normal {
-        Some(n) => ray_unit.dot(&n).abs() < graze_cos,
+        Some(n) => {
+            frame.saturating_sub(c.recency) <= recency_window && ray_unit.dot(&n).abs() < graze_cos
+        }
         None => false,
     }
 }
@@ -390,6 +433,8 @@ pub fn update_map(
         f32::INFINITY
     };
 
+    map.frame += 1;
+    let frame = map.frame;
     let hits = live_voxels(points, cfg.voxel_size);
 
     let mut misses: AHashSet<VoxelKey> = AHashSet::new();
@@ -415,6 +460,8 @@ pub fn update_map(
             cfg.shadow_depth,
             cfg.grace_depth,
             cfg.graze_cos,
+            frame,
+            cfg.recency_window,
             origin_voxel,
             endpoint,
         );
@@ -427,6 +474,7 @@ pub fn update_map(
             ..Default::default()
         });
         c.health = (c.health + 1).min(cfg.max_health);
+        c.last_hit = frame;
     }
 
     // accumulate each return into its voxel's covariance
@@ -446,8 +494,8 @@ pub fn update_map(
         }
     }
 
-    // refresh cached normals wherever the neighborhood changed this frame
-    refresh_normals(map, &hits, &removed, cfg.voxel_size);
+    // refresh cached normals and recency wherever the neighborhood changed
+    refresh_voxels(map, &hits, &removed, cfg.voxel_size);
 
     hits
 }
@@ -473,6 +521,8 @@ fn find_misses_along_ray(
     shadow_depth: f32,
     grace_depth: f32,
     graze_cos: f32,
+    frame: u32,
+    recency_window: u32,
     origin_voxel: VoxelKey,
     endpoint: VoxelKey,
 ) {
@@ -586,7 +636,14 @@ fn find_misses_along_ray(
         }
 
         if map_voxels.contains_key(&(x, y, z))
-            && !should_spare(map_voxels, (x, y, z), ray_unit, graze_cos)
+            && !should_spare(
+                map_voxels,
+                (x, y, z),
+                ray_unit,
+                graze_cos,
+                frame,
+                recency_window,
+            )
         {
             misses.insert((x, y, z));
         }
@@ -607,6 +664,7 @@ mod tests {
             min_health: 0,
             max_health: 1,
             graze_cos: 0.5,
+            recency_window: 60,
         }
     }
 
@@ -645,6 +703,8 @@ mod tests {
             shadow_depth,
             0.0,
             0.5,
+            1,
+            60,
             origin_voxel,
             endpoint,
         );
@@ -763,6 +823,7 @@ mod tests {
             min_health: 0,
             max_health: 1,
             graze_cos: 0.5,
+            recency_window: 60,
         };
         // A real floor is a 2d plane, not a wire. Build it from accumulated
         // returns over a y band so the centerline voxels the ray walks have a
@@ -1148,6 +1209,7 @@ mod tests {
             min_health: 0,
             max_health: 1,
             graze_cos: 0.5,
+            recency_window: 60,
         };
 
         // True continuous staircase in the x-z plane (single y row): household
@@ -1240,6 +1302,7 @@ mod tests {
             min_health: 0,
             max_health: 1,
             graze_cos: 0.5,
+            recency_window: 60,
         };
 
         // Flat floor (horizontal, row 0) from the sensor out to a vertical wall.
@@ -1253,8 +1316,7 @@ mod tests {
         let lidar = sample_segments(&segments, voxel_size);
         let (mut map, all_surf) = build_surface(&lidar, voxel_size, cfg.max_health);
 
-        // Sensor above the floor. Drop this toward 0 to disable the z-slab guard
-        // (origin and floor in the same z-row) and stress the normal gate.
+        // Sensor above the floor, so grazing rays skim it on the way to the wall.
         const SENSOR_HEIGHT: f32 = 0.3;
         let origin = (half, half, floor_z + SENSOR_HEIGHT);
 
@@ -1301,7 +1363,7 @@ mod tests {
     }
 
     /// Robot just below a landing, seeing over its edge. The landing must survive:
-    /// rays hit it directly and the z-slab guard protects the grazed voxels.
+    /// rays hit it directly and the normal gate spares the grazed voxels.
     #[test]
     fn landing_grazed_from_below() {
         let voxel_size = 0.1_f32;
@@ -1315,6 +1377,7 @@ mod tests {
             min_health: 0,
             max_health: 1,
             graze_cos,
+            recency_window: 60,
         };
 
         // Staircase, then the top tread extended into a long flat landing and a
@@ -1366,8 +1429,8 @@ mod tests {
         );
 
         // When the robot can see the landing, it hits the surface directly and
-        // the grazed voxels share the hit's z-row, so the z-slab guard protects
-        // them. The landing must survive this view.
+        // grazing rays skim the planar top, so the normal gate spares those
+        // voxels. The landing must survive this view.
         let cleared: Vec<VoxelKey> = surf
             .iter()
             .copied()
@@ -1428,5 +1491,49 @@ mod tests {
             v.self_normal().is_none(),
             "a scan-line has no trustworthy normal"
         );
+    }
+
+    /// A grazing ray over a flat floor is spared while the floor is fresh, but
+    /// once it goes stale (recency_window passed without a hit) the same ray
+    /// clears it despite the normal. Only the window differs between the runs.
+    #[test]
+    fn stale_planar_voxel_loses_its_spare() {
+        let voxel_size = 0.1_f32;
+        let y_half = 0.3_f32;
+        let ds = voxel_size / 3.0;
+        let nx = (20.0 / ds).ceil() as i32;
+        let ny = (2.0 * y_half / ds).ceil() as i32;
+        let floor_z = voxel_size * 0.5;
+        let floor: Vec<(f32, f32, f32)> = (0..=nx)
+            .flat_map(|i| (0..=ny).map(move |j| (i as f32 * ds, -y_half + j as f32 * ds, floor_z)))
+            .collect();
+        let origin = (0.0_f32, 0.0_f32, 0.35_f32);
+        let ray = vec![(8.0_f32, 0.0, 0.0)];
+
+        let clipped = |recency_window| {
+            let cfg = Config {
+                voxel_size,
+                max_range: 50.0,
+                ray_subsample: 1,
+                shadow_depth: 0.2,
+                grace_depth: 0.2,
+                min_health: 0,
+                max_health: 1,
+                graze_cos: 0.5,
+                recency_window,
+            };
+            let (mut map, _) = build_surface(&floor, voxel_size, cfg.max_health);
+            let row: Vec<VoxelKey> = map
+                .voxels
+                .keys()
+                .copied()
+                .filter(|k| k.1 == 0 && k.2 == 0)
+                .collect();
+            update_map(&mut map, origin, &ray, &cfg);
+            row.iter().filter(|k| !map.voxels.contains_key(k)).count()
+        };
+
+        assert_eq!(clipped(60), 0, "a fresh floor keeps its grazing spare");
+        assert!(clipped(0) > 0, "a stale floor loses its spare and clips");
     }
 }

--- a/dimos/mapping/ray_tracing/rust/src/voxel_ray_tracer.rs
+++ b/dimos/mapping/ray_tracing/rust/src/voxel_ray_tracer.rs
@@ -71,7 +71,7 @@ impl VoxelMap {
 }
 
 /// Minimum points before a voxel's surface normal is trusted.
-const NORMAL_MIN_POINTS: u32 = 6;
+const NORMAL_MIN_POINTS: u32 = 3;
 /// A voxel is planar when its smallest covariance eigenvalue is below this
 /// fraction of the next-smallest.
 const NORMAL_PLANAR_RATIO: f32 = 0.15;
@@ -184,6 +184,27 @@ pub fn iter_global_points(
                 ky as f32 * voxel_size + half,
                 kz as f32 * voxel_size + half,
             )
+        })
+}
+
+/// Healthy voxel centers paired with their estimated surface normal. The normal
+/// is the zero vector where the voxel has no confident planar normal.
+pub fn iter_global_normals(
+    map: &VoxelMap,
+    voxel_size: f32,
+) -> impl Iterator<Item = ((f32, f32, f32), [f32; 3])> + '_ {
+    let half = voxel_size * 0.5;
+    map.voxels
+        .iter()
+        .filter(|(_, c)| c.health > 0)
+        .map(move |(&(kx, ky, kz), c)| {
+            let pos = (
+                kx as f32 * voxel_size + half,
+                ky as f32 * voxel_size + half,
+                kz as f32 * voxel_size + half,
+            );
+            let normal = c.planar_normal().map_or([0.0; 3], |n| [n[0], n[1], n[2]]);
+            (pos, normal)
         })
 }
 

--- a/dimos/mapping/ray_tracing/rust/src/voxel_ray_tracer.rs
+++ b/dimos/mapping/ray_tracing/rust/src/voxel_ray_tracer.rs
@@ -26,6 +26,17 @@ pub struct Config {
     pub min_health: i32,
     #[validate(range(min = 1))]
     pub max_health: i32,
+    /// Spare a clearing miss when |ray · surface normal| is below this. Larger
+    /// spares steeper grazes: 0.5 clears anything hit past 30 deg off the
+    /// surface, 0.7 past ~45 deg. Raise it to stop grazing rays eroding floors,
+    /// treads and landings (whose slope can exceed 30 deg).
+    #[validate(range(min = 0.0, max = 1.0))]
+    #[serde(default = "default_graze_cos")]
+    pub graze_cos: f32,
+}
+
+fn default_graze_cos() -> f32 {
+    0.7
 }
 
 fn validate_health_range(cfg: &Config) -> Result<(), ValidationError> {
@@ -75,8 +86,9 @@ const NORMAL_MIN_POINTS: u32 = 3;
 /// A voxel is planar when its smallest covariance eigenvalue is below this
 /// fraction of the next-smallest.
 const NORMAL_PLANAR_RATIO: f32 = 0.15;
-/// Spare a clearing miss when |ray · normal| is below this (grazing incidence).
-const GRAZE_COS: f32 = 0.5;
+/// A patch is a line with no defined normal when its middle eigenvalue is below
+/// this fraction of the largest (e.g. a single grazing scan-line on a floor).
+const NORMAL_LINE_RATIO: f32 = 0.15;
 
 /// One voxel: occupancy health plus a running point covariance used to estimate
 /// the local surface normal. Points are accumulated relative to the voxel center
@@ -125,28 +137,41 @@ impl Voxel {
         let mean = self.sum / n;
         let cov = self.m2 / n - mean * mean.transpose();
         let eig = cov.symmetric_eigen();
-        let i0 = (0usize..3).min_by(|&a, &b| eig.eigenvalues[a].total_cmp(&eig.eigenvalues[b]))?;
-        let e0 = eig.eigenvalues[i0].max(0.0);
-        let e1 = (0usize..3)
-            .filter(|&i| i != i0)
-            .map(|i| eig.eigenvalues[i].max(0.0))
-            .fold(f32::INFINITY, f32::min);
-        if e0 > NORMAL_PLANAR_RATIO * e1.max(1e-9) {
+        let mut idx = [0usize, 1, 2];
+        idx.sort_by(|&a, &b| eig.eigenvalues[a].total_cmp(&eig.eigenvalues[b]));
+        let e0 = eig.eigenvalues[idx[0]].max(0.0);
+        let e1 = eig.eigenvalues[idx[1]].max(0.0);
+        let e2 = eig.eigenvalues[idx[2]].max(0.0);
+        if e2 < 1e-12 {
             return None;
         }
-        Some(eig.eigenvectors.column(i0).into_owned())
+        // Reject a line: both in-plane directions must carry real spread, or the
+        // normal is undefined (e.g. a single grazing scan-line across a floor).
+        if e1 < NORMAL_LINE_RATIO * e2 {
+            return None;
+        }
+        // Reject a patch that is not flat enough.
+        if e0 > NORMAL_PLANAR_RATIO * e1 {
+            return None;
+        }
+        Some(eig.eigenvectors.column(idx[0]).into_owned())
     }
 }
 
 /// Whether to spare an occupied voxel from a clearing miss: spare if a grazing
 /// ray skims its surface, or if it is a confident edge/corner. Voxels with too
 /// few points (no normal yet) are not spared, preserving the unguarded behavior.
-fn should_spare(voxels: &AHashMap<VoxelKey, Voxel>, key: VoxelKey, ray_unit: Vector3<f32>) -> bool {
+fn should_spare(
+    voxels: &AHashMap<VoxelKey, Voxel>,
+    key: VoxelKey,
+    ray_unit: Vector3<f32>,
+    graze_cos: f32,
+) -> bool {
     let Some(c) = voxels.get(&key) else {
         return false;
     };
     match c.planar_normal() {
-        Some(n) => ray_unit.dot(&n).abs() < GRAZE_COS,
+        Some(n) => ray_unit.dot(&n).abs() < graze_cos,
         None => c.num_pts >= NORMAL_MIN_POINTS,
     }
 }
@@ -254,6 +279,7 @@ pub fn update_map(
             cfg.voxel_size,
             cfg.shadow_depth,
             cfg.grace_depth,
+            cfg.graze_cos,
             origin_voxel,
             endpoint,
         );
@@ -306,6 +332,7 @@ fn find_misses_along_ray(
     voxel_size: f32,
     shadow_depth: f32,
     grace_depth: f32,
+    graze_cos: f32,
     origin_voxel: VoxelKey,
     endpoint: VoxelKey,
 ) {
@@ -424,7 +451,9 @@ fn find_misses_along_ray(
             continue;
         }
 
-        if map_voxels.contains_key(&(x, y, z)) && !should_spare(map_voxels, (x, y, z), ray_unit) {
+        if map_voxels.contains_key(&(x, y, z))
+            && !should_spare(map_voxels, (x, y, z), ray_unit, graze_cos)
+        {
             misses.insert((x, y, z));
         }
     }
@@ -443,6 +472,7 @@ mod tests {
             grace_depth: 0.0,
             min_health: 0,
             max_health: 1,
+            graze_cos: 0.5,
         }
     }
 
@@ -480,6 +510,7 @@ mod tests {
             voxel_size,
             shadow_depth,
             0.0,
+            0.5,
             origin_voxel,
             endpoint,
         );
@@ -523,6 +554,7 @@ mod tests {
             voxel_size,
             shadow_depth,
             0.0,
+            0.5,
             origin_voxel,
             endpoint,
         );
@@ -648,6 +680,7 @@ mod tests {
             grace_depth: 0.2,
             min_health: 0,
             max_health: 1,
+            graze_cos: 0.5,
         };
         let inv = 1.0 / voxel_size;
 
@@ -694,6 +727,90 @@ mod tests {
             total_clipped == 0,
             "planar grace regressed, ground voxels clipped:\n{table}"
         );
+    }
+
+    /// Dense surface samples for axis-aligned segments (vertical?, fixed, lo,
+    /// hi), swept across a y band so the per-voxel covariance is a genuine 2d
+    /// patch rather than a degenerate line in the x-z slice.
+    fn sample_segments(
+        segments: &[(bool, f32, f32, f32)],
+        voxel_size: f32,
+    ) -> Vec<(f32, f32, f32)> {
+        let ds = voxel_size / 6.0;
+        let ny = 5;
+        let mut pts = Vec::new();
+        for &(vertical, fixed, lo, hi) in segments {
+            let n = ((hi - lo) / ds).round().max(1.0) as i32;
+            for i in 0..=n {
+                let t = lo + (hi - lo) * (i as f32 / n as f32);
+                for j in 0..ny {
+                    let yy = voxel_size * (0.15 + 0.7 * j as f32 / (ny - 1) as f32);
+                    pts.push(if vertical {
+                        (fixed, yy, t)
+                    } else {
+                        (t, yy, fixed)
+                    });
+                }
+            }
+        }
+        pts
+    }
+
+    /// Build a map by accumulating sampled returns and marking each touched
+    /// voxel occupied. Returns the map and the sorted unique voxel keys.
+    fn build_surface(
+        lidar: &[(f32, f32, f32)],
+        voxel_size: f32,
+        health: VoxelHealth,
+    ) -> (VoxelMap, Vec<VoxelKey>) {
+        let inv = 1.0 / voxel_size;
+        let mut map = VoxelMap::default();
+        for &p in lidar {
+            map.accumulate(p, voxel_size);
+        }
+        let mut keys: Vec<VoxelKey> = lidar
+            .iter()
+            .map(|&(x, y, z)| world_to_voxel(x, y, z, inv))
+            .collect();
+        keys.sort();
+        keys.dedup();
+        for &k in &keys {
+            map.voxels.get_mut(&k).unwrap().health = health;
+        }
+        (map, keys)
+    }
+
+    /// Nearest forward intersection (t > 0) of a ray with the segments, as an
+    /// x-z point.
+    fn nearest_hit(
+        origin: (f32, f32, f32),
+        d: (f32, f32),
+        segments: &[(bool, f32, f32, f32)],
+    ) -> Option<(f32, f32)> {
+        let mut best: Option<(f32, (f32, f32))> = None;
+        for &(vertical, fixed, lo, hi) in segments {
+            let hit = if vertical {
+                if d.0.abs() < 1e-9 {
+                    continue;
+                }
+                let t = (fixed - origin.0) / d.0;
+                let z = origin.2 + t * d.1;
+                (t > 1e-4 && z >= lo && z <= hi).then_some((t, (fixed, z)))
+            } else {
+                if d.1.abs() < 1e-9 {
+                    continue;
+                }
+                let t = (fixed - origin.2) / d.1;
+                let x = origin.0 + t * d.0;
+                (t > 1e-4 && x >= lo && x <= hi).then_some((t, (x, fixed)))
+            };
+            if let Some(cand) = hit {
+                if best.is_none_or(|b| cand.0 < b.0) {
+                    best = Some(cand);
+                }
+            }
+        }
+        best.map(|(_, p)| p)
     }
 
     /// Write an SVG of the x-z plane: kept voxels blue, cleared voxels red,
@@ -916,7 +1033,6 @@ mod tests {
     #[test]
     fn stair_clipping_ray_fan() {
         let voxel_size = 0.1_f32;
-        let inv = 1.0 / voxel_size;
         let half = voxel_size * 0.5;
         let cfg = Config {
             voxel_size,
@@ -926,6 +1042,7 @@ mod tests {
             grace_depth: 0.2,
             min_health: 0,
             max_health: 1,
+            graze_cos: 0.5,
         };
 
         // True continuous staircase in the x-z plane (single y row): household
@@ -946,45 +1063,13 @@ mod tests {
             segments.push((false, zt, rx, rx + run));
         }
 
-        // Dense surface samples: the true lidar-visible geometry. Each segment
-        // is swept across a band of y as well so the per-voxel covariance is a
-        // genuine 2d patch (planar), not a degenerate line in the x-z slice.
-        let mut lidar: Vec<(f32, f32, f32)> = Vec::new();
-        let ds = voxel_size / 6.0;
-        let ny = 5;
-        for &(vertical, fixed, lo, hi) in &segments {
-            let n = ((hi - lo) / ds).round().max(1.0) as i32;
-            for i in 0..=n {
-                let t = lo + (hi - lo) * (i as f32 / n as f32);
-                for j in 0..ny {
-                    let yy = voxel_size * (0.15 + 0.7 * j as f32 / (ny - 1) as f32);
-                    lidar.push(if vertical {
-                        (fixed, yy, t)
-                    } else {
-                        (t, yy, fixed)
-                    });
-                }
-            }
-        }
+        let lidar = sample_segments(&segments, voxel_size);
+        let (mut map, all_stairs) = build_surface(&lidar, voxel_size, cfg.max_health);
 
-        let mut map = VoxelMap::default();
-        for &p in &lidar {
-            map.accumulate(p, voxel_size);
-        }
-        let mut all_stairs: Vec<VoxelKey> = lidar
-            .iter()
-            .map(|&(x, y, z)| world_to_voxel(x, y, z, inv))
-            .collect();
-        all_stairs.sort();
-        all_stairs.dedup();
-        for &k in &all_stairs {
-            map.voxels.get_mut(&k).unwrap().health = cfg.max_health;
-        }
-
-        // Sensor at the foot of the stairs, 0.2 m off the ground.
+        // Sensor at the foot of the stairs, 0.23 m off the ground.
         let origin = (half, half, base_z + 0.23);
 
-        // Five rays evenly spaced in elevation, sweeping the staircase. Each
+        // Six rays evenly spaced in elevation, sweeping the staircase. Each
         // ray's hit is the nearest forward intersection with a surface segment.
         const N_RAYS: usize = 6;
         let (lo_deg, hi_deg) = (0.0_f32, 27.0_f32);
@@ -992,31 +1077,7 @@ mod tests {
         for i in 0..N_RAYS {
             let frac = i as f32 / (N_RAYS - 1) as f32;
             let theta = (lo_deg + (hi_deg - lo_deg) * frac).to_radians();
-            let d = (theta.cos(), theta.sin());
-            let mut best: Option<(f32, (f32, f32))> = None;
-            for &(vertical, fixed, lo, hi) in &segments {
-                let hit = if vertical {
-                    if d.0.abs() < 1e-9 {
-                        continue;
-                    }
-                    let t = (fixed - origin.0) / d.0;
-                    let z = origin.2 + t * d.1;
-                    (t > 1e-4 && z >= lo && z <= hi).then_some((t, (fixed, z)))
-                } else {
-                    if d.1.abs() < 1e-9 {
-                        continue;
-                    }
-                    let t = (fixed - origin.2) / d.1;
-                    let x = origin.0 + t * d.0;
-                    (t > 1e-4 && x >= lo && x <= hi).then_some((t, (x, fixed)))
-                };
-                if let Some(cand) = hit {
-                    if best.is_none_or(|b| cand.0 < b.0) {
-                        best = Some(cand);
-                    }
-                }
-            }
-            if let Some((_, (hx, hz))) = best {
+            if let Some((hx, hz)) = nearest_hit(origin, (theta.cos(), theta.sin()), &segments) {
                 hits.push((hx, half, hz));
             }
         }
@@ -1056,6 +1117,187 @@ mod tests {
         );
     }
 
+    /// A flat landing floor with a wall at the far end, scanned by a fan of rays
+    /// from a sensor above the floor. Reports which floor voxels get cleared and
+    /// prints a sample of floor-voxel normals. Tune SENSOR_HEIGHT / shadow_depth
+    /// / NORMAL_MIN_POINTS to probe what erodes the floor.
+    ///
+    /// Run it with `cargo test landing_floor_ray_fan -- --nocapture`.
+    #[test]
+    fn landing_floor_ray_fan() {
+        let voxel_size = 0.1_f32;
+        let half = voxel_size * 0.5;
+        let cfg = Config {
+            voxel_size,
+            max_range: 50.0,
+            ray_subsample: 1,
+            shadow_depth: 0.2,
+            grace_depth: 0.2,
+            min_health: 0,
+            max_health: 1,
+            graze_cos: 0.5,
+        };
+
+        // Flat floor (horizontal, row 0) from the sensor out to a vertical wall.
+        let floor_z = half;
+        let x_wall = 25.0 * voxel_size + half;
+        let segments = vec![
+            (false, floor_z, half, x_wall),         // floor
+            (true, x_wall, floor_z, floor_z + 1.0), // wall
+        ];
+
+        let lidar = sample_segments(&segments, voxel_size);
+        let (mut map, all_surf) = build_surface(&lidar, voxel_size, cfg.max_health);
+
+        // Sensor above the floor. Drop this toward 0 to disable the z-slab guard
+        // (origin and floor in the same z-row) and stress the normal gate.
+        const SENSOR_HEIGHT: f32 = 0.3;
+        let origin = (half, half, floor_z + SENSOR_HEIGHT);
+
+        // Floor voxels and their normals, sampled before any clearing.
+        let floor: Vec<VoxelKey> = all_surf.iter().copied().filter(|k| k.2 == 0).collect();
+        for &k in floor.iter().step_by(floor.len().max(6) / 6) {
+            let normal = map.voxels.get(&k).and_then(Voxel::planar_normal);
+            eprintln!(
+                "  floor {k:?} normal {:?}",
+                normal.map(|n| [n[0], n[1], n[2]])
+            );
+        }
+
+        // Fan sweeping from steep-down at the near floor up to the wall.
+        const N_RAYS: usize = 16;
+        let (lo_deg, hi_deg) = (-35.0_f32, 18.0_f32);
+        let mut hits: Vec<(f32, f32, f32)> = Vec::new();
+        for i in 0..N_RAYS {
+            let frac = i as f32 / (N_RAYS - 1) as f32;
+            let theta = (lo_deg + (hi_deg - lo_deg) * frac).to_radians();
+            if let Some((hx, hz)) = nearest_hit(origin, (theta.cos(), theta.sin()), &segments) {
+                hits.push((hx, half, hz));
+            }
+        }
+
+        update_map(&mut map, origin, &hits, &cfg);
+
+        let svg_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("floor_clip.svg");
+        write_stair_svg(
+            &svg_path,
+            &all_surf,
+            &map,
+            &lidar,
+            origin,
+            &hits,
+            voxel_size,
+            cfg.shadow_depth,
+            cfg.grace_depth,
+        );
+        eprintln!("wrote {}", svg_path.display());
+
+        let cleared: Vec<VoxelKey> = floor
+            .iter()
+            .copied()
+            .filter(|v| !map.voxels.contains_key(v))
+            .collect();
+        eprintln!(
+            "{} rays hit, {} floor voxels, cleared {}: {cleared:?}",
+            hits.len(),
+            floor.len(),
+            cleared.len()
+        );
+        assert!(
+            cleared.is_empty(),
+            "ray fan cleared {} floor voxel(s): {cleared:?}",
+            cleared.len()
+        );
+    }
+
+    /// Robot on the step just below a landing, sensor at head height, so it can
+    /// just see over the landing. A single frame does NOT erode it: the rays hit
+    /// the surface directly and the grazed voxels share the hit's z-row, so the
+    /// z-slab guard protects them. This regression guard documents that the
+    /// realistic single-frame view is safe; real-data landing loss is a
+    /// multi-frame occlusion effect, reproduced elsewhere.
+    ///
+    /// Run it with `cargo test landing_grazed_from_below -- --nocapture`.
+    #[test]
+    fn landing_grazed_from_below() {
+        let voxel_size = 0.1_f32;
+        let half = voxel_size * 0.5;
+        let cfg = |graze_cos| Config {
+            voxel_size,
+            max_range: 50.0,
+            ray_subsample: 1,
+            shadow_depth: 0.2,
+            grace_depth: 0.2,
+            min_health: 0,
+            max_health: 1,
+            graze_cos,
+        };
+
+        // Staircase, then the top tread extended into a long flat landing and a
+        // back wall for the grazing rays to terminate on.
+        const N: i32 = 5;
+        let run = 3.0 * voxel_size;
+        let rise = 2.0 * voxel_size;
+        let first_riser_x = 3.0 * voxel_size + half;
+        let base_z = half;
+        let mut segments: Vec<(bool, f32, f32, f32)> = Vec::new();
+        for k in 1..=N {
+            let rx = first_riser_x + (k - 1) as f32 * run;
+            let zb = base_z + (k - 1) as f32 * rise;
+            let zt = base_z + k as f32 * rise;
+            segments.push((true, rx, zb, zt));
+            if k < N {
+                segments.push((false, zt, rx, rx + run));
+            }
+        }
+        let z_top = base_z + N as f32 * rise;
+        let landing_x0 = first_riser_x + (N - 1) as f32 * run;
+        segments.push((false, z_top, landing_x0, landing_x0 + 1.0));
+        segments.push((true, landing_x0 + 1.0, z_top, z_top + 1.0));
+
+        let lidar = sample_segments(&segments, voxel_size);
+        let landing_row = (z_top / voxel_size).floor() as i32;
+
+        // Robot on the step just below the landing, sensor 0.3 m up: it can just
+        // see over the landing edge, so its downward fan grazes that edge at the
+        // slope angle and skims the surface beyond toward the back wall.
+        let step_below_x = first_riser_x + (N - 2) as f32 * run + run * 0.5;
+        let origin = (step_below_x, half, z_top - rise + 0.3);
+        const N_RAYS: usize = 16;
+        let (lo_deg, hi_deg) = (-38.0_f32, -2.0_f32);
+        let mut hits: Vec<(f32, f32, f32)> = Vec::new();
+        for i in 0..N_RAYS {
+            let frac = i as f32 / (N_RAYS - 1) as f32;
+            let theta = (lo_deg + (hi_deg - lo_deg) * frac).to_radians();
+            if let Some((hx, hz)) = nearest_hit(origin, (theta.cos(), theta.sin()), &segments) {
+                hits.push((hx, half, hz));
+            }
+        }
+
+        let (mut map, surf) = build_surface(&lidar, voxel_size, 1);
+        update_map(&mut map, origin, &hits, &cfg(0.7));
+        let svg = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("landing_clip.svg");
+        write_stair_svg(
+            &svg, &surf, &map, &lidar, origin, &hits, voxel_size, 0.2, 0.2,
+        );
+        eprintln!("wrote {}", svg.display());
+
+        // When the robot can see the landing, it hits the surface directly and
+        // the grazed voxels share the hit's z-row, so the z-slab guard protects
+        // them. The landing must survive this view. (Real-data landing loss is a
+        // multi-frame occlusion effect, not a single grazing frame.)
+        let cleared: Vec<VoxelKey> = surf
+            .iter()
+            .copied()
+            .filter(|k| k.2 == landing_row && !map.voxels.contains_key(k))
+            .collect();
+        eprintln!("landing voxels cleared: {} {cleared:?}", cleared.len());
+        assert!(
+            cleared.is_empty(),
+            "landing must survive when the robot can see over it; cleared {cleared:?}"
+        );
+    }
+
     #[test]
     fn two_misses_needed_when_max_health_is_two() {
         let cfg = Config {
@@ -1072,6 +1314,37 @@ mod tests {
 
         update_map(&mut map, (0.0, 0.0, 0.0), &[(5.5, 0.5, 0.5)], &cfg);
         assert!(!map.voxels.contains_key(&(3, 0, 0)));
+    }
+
+    #[test]
+    fn planar_patch_yields_vertical_normal() {
+        let mut v = Voxel::default();
+        for i in 0..8 {
+            for j in 0..8 {
+                let x = 0.09 * (i as f32 / 7.0 - 0.5);
+                let y = 0.09 * (j as f32 / 7.0 - 0.5);
+                v.observe(Vector3::new(x, y, 0.0));
+            }
+        }
+        let n = v.planar_normal().expect("a 2d patch has a normal");
+        assert!(n[2].abs() > 0.99, "expected ~vertical normal, got {n:?}");
+    }
+
+    #[test]
+    fn line_like_patch_has_no_normal() {
+        // Wide in y, ~zero in x, tiny z noise: a grazing scan-line across a flat
+        // floor. Its smallest eigenvector is horizontal, so trusting it would
+        // clear the floor; the line guard must reject it.
+        let mut v = Voxel::default();
+        for j in 0..20 {
+            let y = 0.08 * (j as f32 / 19.0 - 0.5);
+            let z = 0.003 * ((j % 3) - 1) as f32;
+            v.observe(Vector3::new(0.0, y, z));
+        }
+        assert!(
+            v.planar_normal().is_none(),
+            "a line-like patch must not yield a normal"
+        );
     }
 
     #[test]

--- a/dimos/mapping/ray_tracing/rust/src/voxel_ray_tracer.rs
+++ b/dimos/mapping/ray_tracing/rust/src/voxel_ray_tracer.rs
@@ -158,9 +158,10 @@ impl Voxel {
     }
 }
 
-/// Whether to spare an occupied voxel from a clearing miss: spare if a grazing
-/// ray skims its surface, or if it is a confident edge/corner. Voxels with too
-/// few points (no normal yet) are not spared, preserving the unguarded behavior.
+/// Whether to spare an occupied voxel from a clearing miss. The only reason to
+/// spare is a grazing ray skimming a real planar surface, which a near-tangent
+/// ray would otherwise erode. Everything else is left to the health hysteresis,
+/// which alone decides persistence.
 fn should_spare(
     voxels: &AHashMap<VoxelKey, Voxel>,
     key: VoxelKey,
@@ -172,7 +173,7 @@ fn should_spare(
     };
     match c.planar_normal() {
         Some(n) => ray_unit.dot(&n).abs() < graze_cos,
-        None => c.num_pts >= NORMAL_MIN_POINTS,
+        None => false,
     }
 }
 

--- a/dimos/mapping/ray_tracing/rust/src/voxel_ray_tracer.rs
+++ b/dimos/mapping/ray_tracing/rust/src/voxel_ray_tracer.rs
@@ -29,20 +29,10 @@ pub struct Config {
     /// Spare a clearing miss when |ray dot normal| is below this. Higher
     /// protects steeper grazing surfaces like floors and treads.
     #[validate(range(min = 0.0, max = 1.0))]
-    #[serde(default = "default_graze_cos")]
     pub graze_cos: f32,
     /// Only spare a voxel whose neighborhood was hit within this many frames.
     /// A stale voxel clears despite its normal. Large disables it.
-    #[serde(default = "default_recency_window")]
     pub recency_window: u32,
-}
-
-fn default_graze_cos() -> f32 {
-    0.7
-}
-
-fn default_recency_window() -> u32 {
-    15
 }
 
 fn validate_health_range(cfg: &Config) -> Result<(), ValidationError> {
@@ -153,6 +143,7 @@ impl Voxel {
         self.m2 += q * q.transpose();
     }
 
+    #[cfg(test)]
     fn planar_normal(&self) -> Option<Vector3<f32>> {
         self.normal
     }
@@ -390,8 +381,8 @@ pub fn iter_global_points(
         })
 }
 
-/// Healthy voxel centers paired with their estimated surface normal. The normal
-/// is the zero vector where the voxel has no confident planar normal.
+/// Healthy voxel centers paired with their surface normal, in matching order.
+/// The normal is the zero vector where the voxel has no planar normal.
 pub fn iter_global_normals(
     map: &VoxelMap,
     voxel_size: f32,
@@ -406,7 +397,7 @@ pub fn iter_global_normals(
                 ky as f32 * voxel_size + half,
                 kz as f32 * voxel_size + half,
             );
-            let normal = c.planar_normal().map_or([0.0; 3], |n| [n[0], n[1], n[2]]);
+            let normal = c.normal.map_or([0.0; 3], |n| [n[0], n[1], n[2]]);
             (pos, normal)
         })
 }
@@ -482,7 +473,7 @@ pub fn update_map(
         map.accumulate(p, cfg.voxel_size);
     }
 
-    // each miss is only checked once; removal drops the covariance with it
+    // each miss is only checked once. removal drops the covariance with it
     let mut removed: Vec<VoxelKey> = Vec::new();
     for v in misses.difference(&hits) {
         if let Some(c) = map.voxels.get_mut(v) {
@@ -825,9 +816,7 @@ mod tests {
             graze_cos: 0.5,
             recency_window: 60,
         };
-        // A real floor is a 2d plane, not a wire. Build it from accumulated
-        // returns over a y band so the centerline voxels the ray walks have a
-        // full planar neighborhood and earn a trustworthy vertical normal.
+        // Build the floor over a y band so it is a 2d plane, not a wire.
         let max_x = 25.0_f32;
         let y_half = 0.3_f32;
         let ds = voxel_size / 3.0;
@@ -879,7 +868,7 @@ mod tests {
                     .copied()
                     .filter(|k| (k.0 as f32) * voxel_size <= range + 1.5)
                     .collect();
-                let svg = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("ground_clip.svg");
+                let svg = std::env::temp_dir().join("ground_clip.svg");
                 write_stair_svg(
                     &svg,
                     &floor,
@@ -907,8 +896,7 @@ mod tests {
         voxel_size: f32,
     ) -> Vec<(f32, f32, f32)> {
         let ds = voxel_size / 6.0;
-        // A real step spans many voxels across its width; sample the full width so
-        // treads have two in-plane directions and nosings a dominant edge along y.
+        // Sample the full step width so treads keep two in-plane directions.
         let width = 3.0 * voxel_size;
         let ny = 19;
         let mut pts = Vec::new();
@@ -1212,10 +1200,7 @@ mod tests {
             recency_window: 60,
         };
 
-        // True continuous staircase in the x-z plane (single y row): household
-        // slope, run = 0.3 m, rise = 0.2 m. Each step is a vertical riser face
-        // and a horizontal tread top, stored as axis-aligned segments
-        // (vertical?, fixed, lo, hi) in world meters.
+        // Staircase
         const N: i32 = 5;
         let run = 3.0 * voxel_size;
         let rise = 2.0 * voxel_size;
@@ -1233,9 +1218,8 @@ mod tests {
         let lidar = sample_segments(&segments, voxel_size);
         let (mut map, all_stairs) = build_surface(&lidar, voxel_size, cfg.max_health);
 
-        // Voxels with a trustworthy normal before the clearing pass. The grazing
-        // gate must spare every one of these; the only voxels it may clear are
-        // the tread/riser junctions, which have no plane and rely on health.
+        // The grazing gate must spare every voxel that has a normal. Only the
+        // tread/riser junctions, which have no plane, may clear.
         let planar: Vec<VoxelKey> = all_stairs
             .iter()
             .copied()
@@ -1260,7 +1244,7 @@ mod tests {
 
         update_map(&mut map, origin, &hits, &cfg);
 
-        let svg_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("stair_clip.svg");
+        let svg_path = std::env::temp_dir().join("stair_clip.svg");
         write_stair_svg(
             &svg_path,
             &all_stairs,
@@ -1337,7 +1321,7 @@ mod tests {
 
         update_map(&mut map, origin, &hits, &cfg);
 
-        let svg_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("floor_clip.svg");
+        let svg_path = std::env::temp_dir().join("floor_clip.svg");
         write_stair_svg(
             &svg_path,
             &all_surf,
@@ -1423,7 +1407,7 @@ mod tests {
 
         let (mut map, surf) = build_surface(&lidar, voxel_size, 1);
         update_map(&mut map, origin, &hits, &cfg(0.7));
-        let svg = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("landing_clip.svg");
+        let svg = std::env::temp_dir().join("landing_clip.svg");
         write_stair_svg(
             &svg, &surf, &map, &lidar, origin, &hits, voxel_size, 0.2, 0.2,
         );

--- a/dimos/mapping/ray_tracing/rust/src/voxel_ray_tracer.rs
+++ b/dimos/mapping/ray_tracing/rust/src/voxel_ray_tracer.rs
@@ -567,12 +567,6 @@ fn find_misses_along_ray(
             continue;
         }
 
-        // don't remove points in the same xy plane as the hit, unless the plane only walks that plane
-        // we do this to preserve floors, which is more important than some missed points
-        if origin_voxel.2 != endpoint.2 && z == endpoint.2 {
-            continue;
-        }
-
         let cx = x as f32 * voxel_size + half;
         let cy = y as f32 * voxel_size + half;
         let cz = z as f32 * voxel_size + half;
@@ -617,7 +611,7 @@ mod tests {
     }
 
     #[test]
-    fn find_misses_along_ray_hits_correct_voxels_1() {
+    fn find_misses_along_ray_hits_correct_voxels() {
         let voxel_size = 1.0;
         let shadow_depth = 2.0;
         let origin = (0.5, 0.5, 0.5);
@@ -655,57 +649,6 @@ mod tests {
             endpoint,
         );
 
-        assert_eq!(misses, expected);
-    }
-
-    #[test]
-    fn find_misses_along_ray_hits_correct_voxels_2() {
-        let voxel_size = 1.0;
-        let shadow_depth = 2.0;
-        let origin = (0.5, 0.5, 0.5);
-        let end = (3.5, 2.5, 1.5);
-        let inv = 1.0 / voxel_size;
-        let origin_voxel = world_to_voxel(origin.0, origin.1, origin.2, inv);
-        let endpoint = world_to_voxel(end.0, end.1, end.2, inv);
-
-        let walked: AHashSet<VoxelKey> = [
-            (1, 0, 0),
-            (1, 1, 0),
-            (1, 1, 1),
-            (2, 1, 1),
-            (2, 2, 1),
-            (4, 2, 1),
-            (4, 3, 1),
-            (4, 3, 2),
-        ]
-        .into_iter()
-        .collect();
-        let mut map_voxels: AHashMap<VoxelKey, Voxel> = AHashMap::new();
-        for v in &walked {
-            map_voxels.insert(*v, Voxel::with_health(1));
-        }
-
-        let mut misses: AHashSet<VoxelKey> = AHashSet::new();
-        find_misses_along_ray(
-            &mut misses,
-            &map_voxels,
-            origin,
-            end,
-            voxel_size,
-            shadow_depth,
-            0.0,
-            0.5,
-            origin_voxel,
-            endpoint,
-        );
-
-        // z-slab protection skips voxels in the endpoint's z-slab when the
-        // ray crosses z-slabs. Endpoint is at z=1 here.
-        let expected: AHashSet<VoxelKey> = walked
-            .iter()
-            .filter(|v| v.2 != endpoint.2)
-            .copied()
-            .collect();
         assert_eq!(misses, expected);
     }
 
@@ -821,11 +764,18 @@ mod tests {
             max_health: 1,
             graze_cos: 0.5,
         };
-        let inv = 1.0 / voxel_size;
-
-        // Cover the full range we will probe, plus a little for shadow.
+        // A real floor is a 2d plane, not a wire. Build it from accumulated
+        // returns over a y band so the centerline voxels the ray walks have a
+        // full planar neighborhood and earn a trustworthy vertical normal.
         let max_x = 25.0_f32;
-        let n_ground = (max_x / voxel_size).ceil() as i32;
+        let y_half = 0.3_f32;
+        let ds = voxel_size / 3.0;
+        let nx = (max_x / ds).ceil() as i32;
+        let ny = (2.0 * y_half / ds).ceil() as i32;
+        let floor_z = voxel_size * 0.5;
+        let floor_points: Vec<(f32, f32, f32)> = (0..=nx)
+            .flat_map(|i| (0..=ny).map(move |j| (i as f32 * ds, -y_half + j as f32 * ds, floor_z)))
+            .collect();
 
         let ranges: Vec<f32> = (1..=20).map(|i| i as f32).collect();
         let mut table = format!(
@@ -835,24 +785,23 @@ mod tests {
         );
         let mut total_clipped = 0usize;
         for &range in &ranges {
-            let mut map = VoxelMap::default();
-            for i in 0..n_ground {
-                let x = (i as f32) * voxel_size + voxel_size * 0.5;
-                let key = world_to_voxel(x, 0.0, 0.0, inv);
-                map.set(key, cfg.max_health);
-            }
-            let n_before = map.voxels.len();
+            let (mut map, _) = build_surface(&floor_points, voxel_size, cfg.max_health);
+            // The ray walks the y=0, z=0 row, so only that row is ever at risk.
+            let center_row: Vec<VoxelKey> = map
+                .voxels
+                .keys()
+                .copied()
+                .filter(|k| k.1 == 0 && k.2 == 0)
+                .collect();
+            let n_before = center_row.len();
 
             let origin = (0.0_f32, 0.0_f32, lidar_height);
             let points = vec![(range, 0.0_f32, 0.0_f32)];
             update_map(&mut map, origin, &points, &cfg);
 
-            let n_after_ground: usize = (0..n_ground)
-                .filter(|i| {
-                    let x = (*i as f32) * voxel_size + voxel_size * 0.5;
-                    let key = world_to_voxel(x, 0.0, 0.0, inv);
-                    map.voxels.contains_key(&key)
-                })
+            let n_after_ground = center_row
+                .iter()
+                .filter(|k| map.voxels.contains_key(k))
                 .count();
             let clipped = n_before - n_after_ground;
             let pct = 100.0 * clipped as f32 / n_before as f32;
@@ -860,6 +809,28 @@ mod tests {
                 "{range:>6.1}  {n_before:>20}  {clipped:>7}  {pct:>10.1}\n"
             ));
             total_clipped += clipped;
+
+            // Emit one x-z picture so the floor and its normals are visible.
+            // Window the floor to a little past the hit so the image stays readable.
+            if (range - 8.0).abs() < 1e-3 {
+                let floor: Vec<VoxelKey> = center_row
+                    .iter()
+                    .copied()
+                    .filter(|k| (k.0 as f32) * voxel_size <= range + 1.5)
+                    .collect();
+                let svg = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("ground_clip.svg");
+                write_stair_svg(
+                    &svg,
+                    &floor,
+                    &map,
+                    &points,
+                    origin,
+                    &points,
+                    voxel_size,
+                    cfg.shadow_depth,
+                    cfg.grace_depth,
+                );
+            }
         }
         eprint!("{table}");
         assert!(

--- a/dimos/mapping/ray_tracing/rust/src/voxel_ray_tracer.rs
+++ b/dimos/mapping/ray_tracing/rust/src/voxel_ray_tracer.rs
@@ -26,10 +26,8 @@ pub struct Config {
     pub min_health: i32,
     #[validate(range(min = 1))]
     pub max_health: i32,
-    /// Spare a clearing miss when |ray · surface normal| is below this. Larger
-    /// spares steeper grazes: 0.5 clears anything hit past 30 deg off the
-    /// surface, 0.7 past ~45 deg. Raise it to stop grazing rays eroding floors,
-    /// treads and landings (whose slope can exceed 30 deg).
+    /// Spare a clearing miss when |ray dot normal| is below this. Higher
+    /// protects steeper grazing surfaces like floors and treads.
     #[validate(range(min = 0.0, max = 1.0))]
     #[serde(default = "default_graze_cos")]
     pub graze_cos: f32,
@@ -79,27 +77,40 @@ impl VoxelMap {
     fn health(&self, key: VoxelKey) -> Option<VoxelHealth> {
         self.voxels.get(&key).map(|c| c.health)
     }
+
+    /// Fit every occupied voxel's normal from its pooled neighborhood.
+    #[cfg(test)]
+    fn recompute_all_normals(&mut self, voxel_size: f32) {
+        let updates: Vec<(VoxelKey, Option<Vector3<f32>>)> = self
+            .voxels
+            .keys()
+            .copied()
+            .map(|k| (k, pooled_normal(&self.voxels, k, voxel_size)))
+            .collect();
+        for (k, n) in updates {
+            self.voxels.get_mut(&k).unwrap().normal = n;
+        }
+    }
 }
 
-/// Minimum points before a voxel's surface normal is trusted.
 const NORMAL_MIN_POINTS: u32 = 3;
-/// A voxel is planar when its smallest covariance eigenvalue is below this
-/// fraction of the next-smallest.
-const NORMAL_PLANAR_RATIO: f32 = 0.15;
-/// A patch is a line with no defined normal when its middle eigenvalue is below
-/// this fraction of the largest (e.g. a single grazing scan-line on a floor).
-const NORMAL_LINE_RATIO: f32 = 0.15;
+const NORMAL_NEIGHBOR_RADIUS: i32 = 1;
+const NORMAL_REWEIGHT_ITERS: u32 = 3;
+/// Neighbor weight falloff with plane distance, as a fraction of voxel size.
+const NORMAL_PLANE_SIGMA_FRAC: f32 = 0.5;
+/// Lowest retained point-mass fraction that still counts as a real plane.
+const NORMAL_MIN_SUPPORT: f32 = 0.5;
 
-/// One voxel: occupancy health plus a running point covariance used to estimate
-/// the local surface normal. Points are accumulated relative to the voxel center
-/// to keep the moments small and f32-stable. The covariance lives and dies with
-/// the voxel entry.
+/// Occupancy health, a running point covariance, and the cached normal fit from
+/// the voxel's pooled neighborhood. Points accumulate relative to the voxel
+/// center for f32 stability.
 #[derive(Clone)]
 pub struct Voxel {
     pub health: VoxelHealth,
     num_pts: u32,
     sum: Vector3<f32>,
     m2: Matrix3<f32>,
+    normal: Option<Vector3<f32>>,
 }
 
 impl Default for Voxel {
@@ -109,6 +120,7 @@ impl Default for Voxel {
             num_pts: 0,
             sum: Vector3::zeros(),
             m2: Matrix3::zeros(),
+            normal: None,
         }
     }
 }
@@ -127,41 +139,163 @@ impl Voxel {
         self.m2 += q * q.transpose();
     }
 
-    /// Unit surface normal if the voxel holds enough confidently-planar points,
-    /// else None (too sparse, or an edge/corner where the normal is ill-defined).
     fn planar_normal(&self) -> Option<Vector3<f32>> {
+        self.normal
+    }
+
+    /// Fit a normal from this voxel's own points alone, ignoring neighbors.
+    #[cfg(test)]
+    fn self_normal(&self) -> Option<Vector3<f32>> {
         if self.num_pts < NORMAL_MIN_POINTS {
             return None;
         }
         let n = self.num_pts as f32;
         let mean = self.sum / n;
-        let cov = self.m2 / n - mean * mean.transpose();
-        let eig = cov.symmetric_eigen();
-        let mut idx = [0usize, 1, 2];
-        idx.sort_by(|&a, &b| eig.eigenvalues[a].total_cmp(&eig.eigenvalues[b]));
-        let e0 = eig.eigenvalues[idx[0]].max(0.0);
-        let e1 = eig.eigenvalues[idx[1]].max(0.0);
-        let e2 = eig.eigenvalues[idx[2]].max(0.0);
-        if e2 < 1e-12 {
-            return None;
-        }
-        // Reject a line: both in-plane directions must carry real spread, or the
-        // normal is undefined (e.g. a single grazing scan-line across a floor).
-        if e1 < NORMAL_LINE_RATIO * e2 {
-            return None;
-        }
-        // Reject a patch that is not flat enough.
-        if e0 > NORMAL_PLANAR_RATIO * e1 {
-            return None;
-        }
-        Some(eig.eigenvectors.column(idx[0]).into_owned())
+        fit_normal(self.m2 / n - mean * mean.transpose())
     }
 }
 
-/// Whether to spare an occupied voxel from a clearing miss. The only reason to
-/// spare is a grazing ray skimming a real planar surface, which a near-tangent
-/// ray would otherwise erode. Everything else is left to the health hysteresis,
-/// which alone decides persistence.
+/// The surface normal of a covariance, or None unless planarity dominates the
+/// linear and scatter dimensionality features (an edge or blob has no normal).
+fn fit_normal(cov: Matrix3<f32>) -> Option<Vector3<f32>> {
+    let eig = cov.symmetric_eigen();
+    let mut idx = [0usize, 1, 2];
+    idx.sort_by(|&a, &b| eig.eigenvalues[a].total_cmp(&eig.eigenvalues[b]));
+    let e2 = eig.eigenvalues[idx[2]].max(0.0);
+    if e2 < 1e-12 {
+        return None;
+    }
+    let l0 = eig.eigenvalues[idx[0]].max(0.0).sqrt();
+    let l1 = eig.eigenvalues[idx[1]].max(0.0).sqrt();
+    let l2 = e2.sqrt();
+    let linearity = (l2 - l1) / l2;
+    let planarity = (l1 - l0) / l2;
+    let scattering = l0 / l2;
+    if planarity < linearity || planarity < scattering {
+        return None;
+    }
+    Some(eig.eigenvectors.column(idx[0]).into_owned())
+}
+
+/// Moments of one neighbor voxel, shifted into the target voxel's local frame.
+struct Neighbor {
+    n: f32,
+    s: Vector3<f32>,
+    t: Matrix3<f32>,
+    centroid: Vector3<f32>,
+}
+
+/// Fit a voxel's normal from its neighborhood, reweighting out neighbors whose
+/// centroid lies off the tentative plane so a flat tread is not polluted by an
+/// adjacent riser.
+fn pooled_normal(
+    voxels: &AHashMap<VoxelKey, Voxel>,
+    key: VoxelKey,
+    voxel_size: f32,
+) -> Option<Vector3<f32>> {
+    let r = NORMAL_NEIGHBOR_RADIUS;
+    let mut nbs: Vec<Neighbor> = Vec::new();
+    let mut n_raw: u32 = 0;
+    for dx in -r..=r {
+        for dy in -r..=r {
+            for dz in -r..=r {
+                let nk = (key.0 + dx, key.1 + dy, key.2 + dz);
+                let Some(v) = voxels.get(&nk) else {
+                    continue;
+                };
+                if v.num_pts == 0 {
+                    continue;
+                }
+                let ni = v.num_pts as f32;
+                // Shift this voxel's center-relative moments to the target center.
+                let d = Vector3::new(dx as f32, dy as f32, dz as f32) * voxel_size;
+                let s = v.sum + d * ni;
+                let t =
+                    v.m2 + v.sum * d.transpose() + d * v.sum.transpose() + d * d.transpose() * ni;
+                n_raw += v.num_pts;
+                nbs.push(Neighbor {
+                    n: ni,
+                    s,
+                    t,
+                    centroid: s / ni,
+                });
+            }
+        }
+    }
+    if n_raw < NORMAL_MIN_POINTS {
+        return None;
+    }
+
+    let sigma = NORMAL_PLANE_SIGMA_FRAC * voxel_size;
+    let two_sig2 = 2.0 * sigma * sigma;
+    let mut weights = vec![1.0_f32; nbs.len()];
+    let mut cov = Matrix3::zeros();
+    for _ in 0..NORMAL_REWEIGHT_ITERS {
+        let (mut wn, mut s, mut t) = (0.0_f32, Vector3::zeros(), Matrix3::zeros());
+        for (nb, &w) in nbs.iter().zip(&weights) {
+            wn += w * nb.n;
+            s += nb.s * w;
+            t += nb.t * w;
+        }
+        if wn < 1e-6 {
+            break;
+        }
+        let mean = s / wn;
+        cov = t / wn - mean * mean.transpose();
+        let eig = cov.symmetric_eigen();
+        let smallest = eig
+            .eigenvalues
+            .iter()
+            .enumerate()
+            .min_by(|a, b| a.1.total_cmp(b.1))
+            .map(|(i, _)| i)
+            .unwrap();
+        let normal = eig.eigenvectors.column(smallest).into_owned();
+        for (nb, w) in nbs.iter().zip(&mut weights) {
+            let dist = normal.dot(&(nb.centroid - mean)).abs();
+            *w = (-(dist * dist) / two_sig2).exp();
+        }
+    }
+    // Reject a plane the reweighting fabricated by discarding most of the mass.
+    let kept: f32 = nbs.iter().zip(&weights).map(|(nb, &w)| w * nb.n).sum();
+    if kept < NORMAL_MIN_SUPPORT * n_raw as f32 {
+        return None;
+    }
+    fit_normal(cov)
+}
+
+/// Refit the cached normal of every voxel whose neighborhood changed this frame.
+fn refresh_normals(
+    map: &mut VoxelMap,
+    hits: &AHashSet<VoxelKey>,
+    removed: &[VoxelKey],
+    voxel_size: f32,
+) {
+    let r = NORMAL_NEIGHBOR_RADIUS;
+    let mut dirty: AHashSet<VoxelKey> = AHashSet::new();
+    for &c in hits.iter().chain(removed.iter()) {
+        for dx in -r..=r {
+            for dy in -r..=r {
+                for dz in -r..=r {
+                    dirty.insert((c.0 + dx, c.1 + dy, c.2 + dz));
+                }
+            }
+        }
+    }
+    let updates: Vec<(VoxelKey, Option<Vector3<f32>>)> = dirty
+        .iter()
+        .filter(|k| map.voxels.contains_key(k))
+        .map(|&k| (k, pooled_normal(&map.voxels, k, voxel_size)))
+        .collect();
+    for (k, n) in updates {
+        if let Some(c) = map.voxels.get_mut(&k) {
+            c.normal = n;
+        }
+    }
+}
+
+/// Spare a clearing miss only when a grazing ray skims a planar surface.
+/// Anything without a trustworthy normal is left to the health hysteresis.
 fn should_spare(
     voxels: &AHashMap<VoxelKey, Voxel>,
     key: VoxelKey,
@@ -171,7 +305,7 @@ fn should_spare(
     let Some(c) = voxels.get(&key) else {
         return false;
     };
-    match c.planar_normal() {
+    match c.normal {
         Some(n) => ray_unit.dot(&n).abs() < graze_cos,
         None => false,
     }
@@ -301,14 +435,19 @@ pub fn update_map(
     }
 
     // each miss is only checked once; removal drops the covariance with it
+    let mut removed: Vec<VoxelKey> = Vec::new();
     for v in misses.difference(&hits) {
         if let Some(c) = map.voxels.get_mut(v) {
             c.health -= 1;
             if c.health <= cfg.min_health {
                 map.voxels.remove(v);
+                removed.push(*v);
             }
         }
     }
+
+    // refresh cached normals wherever the neighborhood changed this frame
+    refresh_normals(map, &hits, &removed, cfg.voxel_size);
 
     hits
 }
@@ -667,8 +806,7 @@ mod tests {
         assert_eq!(map.health((5, 0, 0)), Some(1));
     }
 
-    /// Test how bad the planar ray clipping is.
-    /// For example, points on floors can be counted as misses because they are close to the same ray as the hit.
+    /// A grazing ray along a floor must not clip floor voxels near its hit.
     #[test]
     fn ground_clipping_single_ray() {
         let voxel_size = 0.1_f32;
@@ -730,22 +868,24 @@ mod tests {
         );
     }
 
-    /// Dense surface samples for axis-aligned segments (vertical?, fixed, lo,
-    /// hi), swept across a y band so the per-voxel covariance is a genuine 2d
-    /// patch rather than a degenerate line in the x-z slice.
+    /// Dense surface samples for axis-aligned segments, swept across a y band so
+    /// each patch is a genuine 2d surface rather than a degenerate line.
     fn sample_segments(
         segments: &[(bool, f32, f32, f32)],
         voxel_size: f32,
     ) -> Vec<(f32, f32, f32)> {
         let ds = voxel_size / 6.0;
-        let ny = 5;
+        // A real step spans many voxels across its width; sample the full width so
+        // treads have two in-plane directions and nosings a dominant edge along y.
+        let width = 3.0 * voxel_size;
+        let ny = 19;
         let mut pts = Vec::new();
         for &(vertical, fixed, lo, hi) in segments {
             let n = ((hi - lo) / ds).round().max(1.0) as i32;
             for i in 0..=n {
                 let t = lo + (hi - lo) * (i as f32 / n as f32);
                 for j in 0..ny {
-                    let yy = voxel_size * (0.15 + 0.7 * j as f32 / (ny - 1) as f32);
+                    let yy = width * (j as f32 / (ny - 1) as f32);
                     pts.push(if vertical {
                         (fixed, yy, t)
                     } else {
@@ -778,6 +918,7 @@ mod tests {
         for &k in &keys {
             map.voxels.get_mut(&k).unwrap().health = health;
         }
+        map.recompute_all_normals(voxel_size);
         (map, keys)
     }
 
@@ -814,9 +955,7 @@ mod tests {
         best.map(|(_, p)| p)
     }
 
-    /// Write an SVG of the x-z plane: kept voxels blue, cleared voxels red,
-    /// ray-hit voxels green, the dense true-surface points, each ray from the
-    /// sensor to its surface hit, and the sensor.
+    /// Write an SVG of the x-z plane for visual inspection.
     #[allow(clippy::too_many_arguments)]
     fn write_stair_svg(
         path: &std::path::Path,
@@ -1023,14 +1162,8 @@ mod tests {
         svg::save(path, &doc).expect("write stair_clip.svg");
     }
 
-    /// A fan of lidar rays from a sensor at the foot of a staircase. Each ray
-    /// direction is intersected with the true continuous surface to find its
-    /// hit point, then the whole frame is fed to the mapper. Rays that reach an
-    /// upper step graze the voxels of the lower steps they pass over, and the
-    /// thin-ray DDA clears that real geometry. A correct clearing pass must
-    /// leave every stair voxel intact.
-    ///
-    /// Run it with `cargo test stair_clipping_ray_fan -- --nocapture`.
+    /// A ray fan from the foot of a staircase grazes lower steps en route to
+    /// upper ones. The grazing gate must leave every planar surface voxel intact.
     #[test]
     fn stair_clipping_ray_fan() {
         let voxel_size = 0.1_f32;
@@ -1067,6 +1200,15 @@ mod tests {
         let lidar = sample_segments(&segments, voxel_size);
         let (mut map, all_stairs) = build_surface(&lidar, voxel_size, cfg.max_health);
 
+        // Voxels with a trustworthy normal before the clearing pass. The grazing
+        // gate must spare every one of these; the only voxels it may clear are
+        // the tread/riser junctions, which have no plane and rely on health.
+        let planar: Vec<VoxelKey> = all_stairs
+            .iter()
+            .copied()
+            .filter(|k| map.voxels.get(k).and_then(Voxel::planar_normal).is_some())
+            .collect();
+
         // Sensor at the foot of the stairs, 0.23 m off the ground.
         let origin = (half, half, base_z + 0.23);
 
@@ -1099,31 +1241,32 @@ mod tests {
         );
         eprintln!("wrote {}", svg_path.display());
 
-        // No real stair voxel may be cleared: every ray that grazes a step's
-        // voxels en route to its true hit must leave them intact.
-        let cleared: Vec<VoxelKey> = all_stairs
+        // The grazing gate must spare every planar surface voxel: a ray skimming
+        // a tread or riser en route to a higher step may not erode it.
+        let cleared_planar: Vec<VoxelKey> = planar
             .iter()
             .copied()
             .filter(|v| !map.voxels.contains_key(v))
             .collect();
+        let cleared_total = all_stairs
+            .iter()
+            .filter(|v| !map.voxels.contains_key(v))
+            .count();
         eprintln!(
-            "{} rays hit, cleared {} stair voxel(s): {cleared:?}",
+            "{} rays hit; {} junction voxel(s) cleared, {} planar surface voxel(s) cleared",
             hits.len(),
-            cleared.len()
+            cleared_total - cleared_planar.len(),
+            cleared_planar.len()
         );
         assert!(
-            cleared.is_empty(),
-            "ray fan cleared {} real stair voxel(s): {cleared:?}",
-            cleared.len()
+            cleared_planar.is_empty(),
+            "grazing rays eroded {} planar surface voxel(s): {cleared_planar:?}",
+            cleared_planar.len()
         );
     }
 
-    /// A flat landing floor with a wall at the far end, scanned by a fan of rays
-    /// from a sensor above the floor. Reports which floor voxels get cleared and
-    /// prints a sample of floor-voxel normals. Tune SENSOR_HEIGHT / shadow_depth
-    /// / NORMAL_MIN_POINTS to probe what erodes the floor.
-    ///
-    /// Run it with `cargo test landing_floor_ray_fan -- --nocapture`.
+    /// A flat landing floor with a far wall, scanned by a downward ray fan. The
+    /// grazing gate must not erode the floor.
     #[test]
     fn landing_floor_ray_fan() {
         let voxel_size = 0.1_f32;
@@ -1211,14 +1354,8 @@ mod tests {
         );
     }
 
-    /// Robot on the step just below a landing, sensor at head height, so it can
-    /// just see over the landing. A single frame does NOT erode it: the rays hit
-    /// the surface directly and the grazed voxels share the hit's z-row, so the
-    /// z-slab guard protects them. This regression guard documents that the
-    /// realistic single-frame view is safe; real-data landing loss is a
-    /// multi-frame occlusion effect, reproduced elsewhere.
-    ///
-    /// Run it with `cargo test landing_grazed_from_below -- --nocapture`.
+    /// Robot just below a landing, seeing over its edge. The landing must survive:
+    /// rays hit it directly and the z-slab guard protects the grazed voxels.
     #[test]
     fn landing_grazed_from_below() {
         let voxel_size = 0.1_f32;
@@ -1327,15 +1464,17 @@ mod tests {
                 v.observe(Vector3::new(x, y, 0.0));
             }
         }
-        let n = v.planar_normal().expect("a 2d patch has a normal");
+        let n = v
+            .self_normal()
+            .expect("a flat 2d patch must yield a normal");
         assert!(n[2].abs() > 0.99, "expected ~vertical normal, got {n:?}");
     }
 
     #[test]
     fn line_like_patch_has_no_normal() {
         // Wide in y, ~zero in x, tiny z noise: a grazing scan-line across a flat
-        // floor. Its smallest eigenvector is horizontal, so trusting it would
-        // clear the floor; the line guard must reject it.
+        // floor. Its smallest eigenvector is horizontal, so trusting it as a normal
+        // would clear the floor. A line is not planar, so it must yield no normal.
         let mut v = Voxel::default();
         for j in 0..20 {
             let y = 0.08 * (j as f32 / 19.0 - 0.5);
@@ -1343,32 +1482,8 @@ mod tests {
             v.observe(Vector3::new(0.0, y, z));
         }
         assert!(
-            v.planar_normal().is_none(),
-            "a line-like patch must not yield a normal"
+            v.self_normal().is_none(),
+            "a scan-line has no trustworthy normal"
         );
-    }
-
-    #[test]
-    fn validate_rejects_zero_voxel_size() {
-        let cfg = Config {
-            voxel_size: 0.0,
-            ..basic_config()
-        };
-        assert!(cfg.validate().is_err());
-    }
-
-    #[test]
-    fn validate_rejects_min_health_geq_max_health() {
-        let cfg = Config {
-            min_health: 5,
-            max_health: 1,
-            ..basic_config()
-        };
-        assert!(cfg.validate().is_err());
-    }
-
-    #[test]
-    fn validate_accepts_basic_config() {
-        assert!(basic_config().validate().is_ok());
     }
 }

--- a/dimos/mapping/ray_tracing/rust/src/voxel_ray_tracer.rs
+++ b/dimos/mapping/ray_tracing/rust/src/voxel_ray_tracer.rs
@@ -27,8 +27,7 @@ pub struct Config {
     #[validate(range(min = 1))]
     pub max_health: i32,
     /// Don't clear a miss when abs of ray dot normal is below this, clear it when above.
-    /// Higher value means points are only cleared with direct hits. Low values means
-    /// even slight grazes will clear points.
+    /// Higher clears only on direct hits, lower clears on slight grazes too.
     #[validate(range(min = 0.0, max = 1.0))]
     pub graze_cos: f32,
     /// Only spare a voxel whose neighborhood was hit within this many frames.
@@ -54,7 +53,7 @@ impl VoxelMap {
         self.voxels.values().filter(|c| c.health > 0).count()
     }
 
-    /// Update or add voxel on a hit. Updates covariance and hit count for normal calculation.
+    /// Add a return to its voxel's accumulated moments.
     fn accumulate(&mut self, point: (f32, f32, f32), voxel_size: f32) {
         let key = world_to_voxel(point.0, point.1, point.2, 1.0 / voxel_size);
         let center = Vector3::new(
@@ -62,8 +61,6 @@ impl VoxelMap {
             (key.1 as f32 + 0.5) * voxel_size,
             (key.2 as f32 + 0.5) * voxel_size,
         );
-
-        // update or add voxel with new info
         self.voxels
             .entry(key)
             .or_default()
@@ -95,9 +92,7 @@ impl VoxelMap {
     }
 }
 
-/// Number of required points to assign a normal
 const NORMAL_MIN_POINTS: u32 = 3;
-/// Consider points within this voxel radius when calculating normal
 const NORMAL_NEIGHBOR_RADIUS: i32 = 1;
 const NORMAL_REWEIGHT_ITERS: u32 = 3;
 /// Neighbor weight falloff with plane distance, as a fraction of voxel size.
@@ -105,16 +100,13 @@ const NORMAL_PLANE_SIGMA_FRAC: f32 = 0.5;
 /// Fraction of points that must be kept after the IRLS to count as a real plane
 const NORMAL_MIN_SUPPORT: f32 = 0.5;
 
-/// Voxel stats, such as health, accumulate hit count, running covariance, and cached normal.
-/// Normal is determined from all points in a neighborhood of voxel.
+/// Occupancy health, accumulated point moments about the voxel center, and the
+/// normal fit from the voxel's neighborhood.
 #[derive(Clone)]
 pub struct Voxel {
     pub health: VoxelHealth,
-    /// Number of accumulated hits in this voxel
     num_pts: u32,
-    /// Sum of all hit points within voxel
     sum: Vector3<f32>,
-    /// Covariance of accumulated hits
     m2: Matrix3<f32>,
     normal: Option<Vector3<f32>>,
     last_hit: u32,
@@ -144,7 +136,7 @@ impl Voxel {
         }
     }
 
-    /// Update accumulation info on this voxel so we can calculate the normal
+    /// Fold a centered point into the running moments.
     fn observe(&mut self, q: Vector3<f32>) {
         self.num_pts += 1;
         self.sum += q;
@@ -168,7 +160,7 @@ impl Voxel {
     }
 }
 
-/// The surface normal of a covariance, or None unless there is a strong planarity feature. Lines and scattered blobs shouldn't get a normal.
+/// The surface normal of a covariance, or None unless it is clearly planar.
 fn fit_normal(cov: Matrix3<f32>) -> Option<Vector3<f32>> {
     let eig = cov.symmetric_eigen();
     let mut idx = [0usize, 1, 2];
@@ -189,13 +181,10 @@ fn fit_normal(cov: Matrix3<f32>) -> Option<Vector3<f32>> {
     Some(eig.eigenvectors.column(idx[0]).into_owned())
 }
 
-/// Moments of one neighbor voxel.
+/// Moments of one neighbor voxel: count, sum, sum of outer products, centroid.
 struct Neighbor {
-    /// Number of points, zeroth moment
     n: f32,
-    /// Sum of points, first moment
     s: Vector3<f32>,
-    /// Sum of outer prods, second moment
     t: Matrix3<f32>,
     centroid: Vector3<f32>,
 }
@@ -475,12 +464,10 @@ pub fn update_map(
         c.last_hit = frame;
     }
 
-    // accumulate each return into its voxel's covariance
     for &p in points {
         map.accumulate(p, cfg.voxel_size);
     }
 
-    // each miss is only checked once. removal drops the covariance with it
     let mut removed: Vec<VoxelKey> = Vec::new();
     for v in misses.difference(&hits) {
         if let Some(c) = map.voxels.get_mut(v) {

--- a/dimos/mapping/ray_tracing/test_voxel_map.py
+++ b/dimos/mapping/ray_tracing/test_voxel_map.py
@@ -85,3 +85,18 @@ def test_clear_resets_map() -> None:
     mapper.clear()
     assert mapper.voxel_count() == 0
     assert len(mapper) == 0
+
+
+def test_global_map_normals_matches_global_map() -> None:
+    mapper = make_mapper()
+    mapper.add_frame(np.array([[5.5, 0.5, 0.5]], dtype=np.float32), ORIGIN)
+
+    centers, normals = mapper.global_map_normals()
+    assert centers.shape == normals.shape == (mapper.voxel_count(), 3)
+    assert centers.dtype == normals.dtype == np.float32
+    np.testing.assert_allclose(centers, mapper.global_map())
+
+
+def test_global_map_normals_empty_map() -> None:
+    centers, normals = make_mapper().global_map_normals()
+    assert centers.shape == normals.shape == (0, 3)

--- a/dimos/mapping/ray_tracing/transformer.py
+++ b/dimos/mapping/ray_tracing/transformer.py
@@ -39,6 +39,7 @@ class RayTraceMap(Transformer[PointCloud2, PointCloud2]):
         max_range: float = 30.0,
         emit_every: int = 1,
         emit_normals: bool = False,
+        emit_raw: bool = False,
         **mapper_kwargs: Any,
     ) -> None:
         if emit_every < 0:
@@ -47,6 +48,7 @@ class RayTraceMap(Transformer[PointCloud2, PointCloud2]):
         self.max_range = max_range
         self.emit_every = emit_every
         self.emit_normals = emit_normals
+        self.emit_raw = emit_raw
         self._mapper_kwargs = mapper_kwargs
 
     def _make_obs(
@@ -61,6 +63,8 @@ class RayTraceMap(Transformer[PointCloud2, PointCloud2]):
             tags["voxel_normals"] = normals
         else:
             positions = mapper.global_map()
+        if self.emit_raw:
+            tags["raw_points"] = last_obs.data.points_f32()
         pcd = o3d.t.geometry.PointCloud()
         pcd.point["positions"] = o3c.Tensor.from_numpy(positions)
         cloud = PointCloud2(pointcloud=pcd, frame_id="world", ts=last_obs.ts)

--- a/dimos/mapping/ray_tracing/transformer.py
+++ b/dimos/mapping/ray_tracing/transformer.py
@@ -38,6 +38,7 @@ class RayTraceMap(Transformer[PointCloud2, PointCloud2]):
         voxel_size: float = 0.1,
         max_range: float = 30.0,
         emit_every: int = 1,
+        emit_normals: bool = False,
         **mapper_kwargs: Any,
     ) -> None:
         if emit_every < 0:
@@ -45,6 +46,7 @@ class RayTraceMap(Transformer[PointCloud2, PointCloud2]):
         self.voxel_size = voxel_size
         self.max_range = max_range
         self.emit_every = emit_every
+        self.emit_normals = emit_normals
         self._mapper_kwargs = mapper_kwargs
 
     def _make_obs(
@@ -53,14 +55,16 @@ class RayTraceMap(Transformer[PointCloud2, PointCloud2]):
         last_obs: Observation[PointCloud2],
         count: int,
     ) -> Observation[PointCloud2]:
-        positions = mapper.global_map()
+        tags = {**last_obs.tags, "frame_count": count}
+        if self.emit_normals:
+            positions, normals = mapper.global_map_normals()
+            tags["voxel_normals"] = normals
+        else:
+            positions = mapper.global_map()
         pcd = o3d.t.geometry.PointCloud()
         pcd.point["positions"] = o3c.Tensor.from_numpy(positions)
         cloud = PointCloud2(pointcloud=pcd, frame_id="world", ts=last_obs.ts)
-        return last_obs.derive(
-            data=cloud,
-            tags={**last_obs.tags, "frame_count": count},
-        )
+        return last_obs.derive(data=cloud, tags=tags)
 
     def __call__(
         self,

--- a/dimos/mapping/ray_tracing/transformer.py
+++ b/dimos/mapping/ray_tracing/transformer.py
@@ -38,8 +38,6 @@ class RayTraceMap(Transformer[PointCloud2, PointCloud2]):
         voxel_size: float = 0.1,
         max_range: float = 30.0,
         emit_every: int = 1,
-        emit_normals: bool = False,
-        emit_raw: bool = False,
         **mapper_kwargs: Any,
     ) -> None:
         if emit_every < 0:
@@ -47,8 +45,6 @@ class RayTraceMap(Transformer[PointCloud2, PointCloud2]):
         self.voxel_size = voxel_size
         self.max_range = max_range
         self.emit_every = emit_every
-        self.emit_normals = emit_normals
-        self.emit_raw = emit_raw
         self._mapper_kwargs = mapper_kwargs
 
     def _make_obs(
@@ -58,13 +54,7 @@ class RayTraceMap(Transformer[PointCloud2, PointCloud2]):
         count: int,
     ) -> Observation[PointCloud2]:
         tags = {**last_obs.tags, "frame_count": count}
-        if self.emit_normals:
-            positions, normals = mapper.global_map_normals()
-            tags["voxel_normals"] = normals
-        else:
-            positions = mapper.global_map()
-        if self.emit_raw:
-            tags["raw_points"] = last_obs.data.points_f32()
+        positions = mapper.global_map()
         pcd = o3d.t.geometry.PointCloud()
         pcd.point["positions"] = o3c.Tensor.from_numpy(positions)
         cloud = PointCloud2(pointcloud=pcd, frame_id="world", ts=last_obs.ts)

--- a/dimos/mapping/ray_tracing/utils/raytrace_rrd.py
+++ b/dimos/mapping/ray_tracing/utils/raytrace_rrd.py
@@ -12,36 +12,41 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Render a ray-traced voxel map from a recorded lidar stream into rerun.
+"""Replay a lidar+odometry .db through several voxel-mapper variants at once.
 
-Lidar and odometry are aligned by timestamp so each frame carries the robot
-pose used as the ray-cast origin. The robot pose axis and trajectory are
-logged alongside the map.
+Each variant's global map is logged to its own rerun entity (world/maps/<name>),
+so they overlay in one view and can be toggled on and off independently. Lidar
+and odometry are aligned by timestamp so each frame carries the robot pose used
+as the ray-cast origin.
 
 Usage:
     uv run python -m dimos.mapping.ray_tracing.utils.raytrace_rrd go2_mid360_stairs
-    uv run python -m dimos.mapping.ray_tracing.utils.raytrace_rrd go2_mid360_stairs --out map.rrd && rerun map.rrd
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 
-import numpy as np
 import rerun as rr
 import typer
 
-from dimos.mapping.ray_tracing.transformer import RayTraceMap
+from dimos.mapping.ray_tracing.voxel_map import VoxelRayMapper
 from dimos.memory2.store.sqlite import SqliteStore
 from dimos.memory2.transform import FnTransformer
 from dimos.memory2.type.observation import Observation
 from dimos.msgs.nav_msgs.Odometry import Odometry
-from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2, register_colormap_annotation
+from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
 from dimos.utils.data import resolve_named_path
 
 TIMELINE = "ts"
 
 PairObs = Observation[tuple[Observation[PointCloud2], Observation[Odometry]]]
+
+COLORS = {
+    "naive": [90, 200, 90],
+    "no_normal_gate": [235, 120, 60],
+    "normal_gate": [70, 170, 235],
+}
 
 
 def _attach_pose_from_odom(pair_obs: PairObs) -> Observation[PointCloud2]:
@@ -64,44 +69,14 @@ def main(
     out: Path | None = typer.Option(
         None, "--out", help="Output .rrd path. If omitted, spawn rerun live."
     ),
-    lidar_stream: str = typer.Option(
-        "fastlio_lidar", "--lidar-stream", help="Lidar stream name in the recording"
-    ),
-    odom_stream: str = typer.Option(
-        "fastlio_odometry", "--odom-stream", help="Odometry stream name in the recording"
-    ),
+    lidar_stream: str = typer.Option("fastlio_lidar", "--lidar-stream"),
+    odom_stream: str = typer.Option("fastlio_odometry", "--odom-stream"),
     align_tol: float = typer.Option(0.05, "--align-tol", help="Lidar/odom alignment tolerance (s)"),
-    voxel_size: float = typer.Option(0.1, "--voxel-size", help="Raycaster voxel edge length (m)"),
-    max_range: float = typer.Option(
-        30.0, "--max-range", help="Max ray cast distance (m); 0 = no limit"
-    ),
-    ray_subsample: int = typer.Option(1, "--ray-subsample", help="Keep every Nth ray for clearing"),
-    shadow_depth: float = typer.Option(
-        0.2, "--shadow-depth", help="Ray extension past endpoint (m)"
-    ),
-    grace_depth: float = typer.Option(
-        0.2, "--grace-depth", help="Spare voxels within this dist of endpoint (m)"
-    ),
-    min_health: int = typer.Option(-2, "--min-health", help="Voxel removal threshold"),
-    max_health: int = typer.Option(1, "--max-health", help="Voxel saturation cap"),
-    graze_cos: float = typer.Option(
-        0.7,
-        "--graze-cos",
-        help="Spare a clearing miss when |ray.normal| < this; raise to clear fewer",
-    ),
-    emit_every: int = typer.Option(1, "--emit-every", help="Yield the current map every N frames"),
-    render_voxel: float = typer.Option(
-        0.05, "--render-voxel", help="Voxel size for rerun rendering (m)"
-    ),
-    normals: bool = typer.Option(
-        True, "--normals/--no-normals", help="Draw a surface-normal arrow on each voxel"
-    ),
-    normal_scale: float = typer.Option(
-        0.1, "--normal-scale", help="Length of the normal arrows (m)"
-    ),
-    raw: bool = typer.Option(
-        True, "--raw/--no-raw", help="Log the raw unvoxelized sensor point cloud"
-    ),
+    voxel_size: float = typer.Option(0.1, "--voxel-size", help="Voxel edge length (m)"),
+    max_range: float = typer.Option(30.0, "--max-range", help="Max ray cast distance (m)"),
+    emit_every: int = typer.Option(1, "--emit-every", help="Log the maps every N frames"),
+    render_voxel: float = typer.Option(0.05, "--render-voxel", help="Voxel render size (m)"),
+    raw: bool = typer.Option(True, "--raw/--no-raw", help="Also log the raw sensor cloud"),
 ) -> None:
     db_path = resolve_named_path(dataset, ".db")
 
@@ -110,7 +85,6 @@ def main(
         rr.save(str(out))
     else:
         rr.spawn()
-    register_colormap_annotation("turbo")
 
     rr.log(
         "world/robot/axes",
@@ -121,83 +95,64 @@ def main(
         static=True,
     )
 
+    # Naive accumulates every voxel and never clears; the other two are identical
+    # except for the normal gate (graze_cos 0 disables it, 0.7 is the default).
+    mappers = {
+        "naive": VoxelRayMapper(
+            voxel_size=voxel_size,
+            max_range=max_range,
+            shadow_depth=0.0,
+            grace_depth=max_range,
+            min_health=0,
+        ),
+        "no_normal_gate": VoxelRayMapper(voxel_size=voxel_size, max_range=max_range, graze_cos=0.0),
+        "normal_gate": VoxelRayMapper(voxel_size=voxel_size, max_range=max_range, graze_cos=0.7),
+    }
+
     store = SqliteStore(path=str(db_path))
     with store:
         lidar = store.stream(lidar_stream, PointCloud2).order_by("ts")
         odom = store.stream(odom_stream, Odometry).order_by("ts")
-
         pose_tagged = lidar.align(odom, tolerance=align_tol).transform(
             FnTransformer(_attach_pose_from_odom)
         )
-        pipeline = pose_tagged.transform(
-            RayTraceMap(
-                voxel_size=voxel_size,
-                max_range=max_range,
-                ray_subsample=ray_subsample,
-                shadow_depth=shadow_depth,
-                grace_depth=grace_depth,
-                min_health=min_health,
-                max_health=max_health,
-                graze_cos=graze_cos,
-                emit_every=emit_every,
-                emit_normals=normals,
-                emit_raw=raw,
-            )
-        )
 
         trajectory: list[tuple[float, float, float]] = []
-        for obs in pipeline:
+        count = 0
+        for obs in pose_tagged:
+            if obs.pose_tuple is None:
+                continue
+            x, y, z, qx, qy, qz, qw = obs.pose_tuple
+            pts = obs.data.points_f32()
+            for mapper in mappers.values():
+                mapper.add_frame(pts, (x, y, z))
+            count += 1
+
+            if count % emit_every != 0:
+                continue
+
             rr.set_time(TIMELINE, timestamp=obs.ts)
-            rr.log("world/raytrace_map", obs.data.to_rerun(voxel_size=render_voxel))
-
-            raw_points = obs.tags.get("raw_points")
-            if raw_points is not None:
+            for name, mapper in mappers.items():
                 rr.log(
-                    "world/raw_points",
-                    rr.Points3D(raw_points, colors=[[150, 150, 150]], radii=0.01),
+                    f"world/maps/{name}",
+                    rr.Points3D(mapper.global_map(), colors=[COLORS[name]], radii=render_voxel / 2),
                 )
-
-            voxel_normals = obs.tags.get("voxel_normals")
-            if voxel_normals is not None:
-                centers = obs.data.points_f32()
-                keep = np.any(voxel_normals != 0.0, axis=1)
-                origins = centers[keep]
-                vectors = voxel_normals[keep]
-                # PCA normals are sign-ambiguous; orient them toward the robot.
-                if obs.pose_tuple is not None:
-                    to_robot = np.asarray(obs.pose_tuple[:3], np.float32) - origins
-                    flip = np.sum(vectors * to_robot, axis=1) < 0
-                    vectors = np.where(flip[:, None], -vectors, vectors)
-                rr.log(
-                    "world/raytrace_map/normals",
-                    rr.Arrows3D(
-                        origins=origins,
-                        vectors=vectors * normal_scale,
-                        colors=[[123, 44, 191]],
-                    ),
-                )
-
-            if obs.pose_tuple is not None:
-                x, y, z, qx, qy, qz, qw = obs.pose_tuple
-                rr.log(
-                    "world/robot",
-                    rr.Transform3D(
-                        translation=[x, y, z], quaternion=rr.Quaternion(xyzw=[qx, qy, qz, qw])
-                    ),
-                )
-                trajectory.append((x, y, z))
-                if len(trajectory) >= 2:
-                    rr.log(
-                        "world/robot_path",
-                        rr.LineStrips3D([trajectory], colors=[[255, 165, 0]]),
-                    )
-
-            print(f"frame_count={obs.tags['frame_count']}", end="\r", flush=True)
+            if raw:
+                rr.log("world/raw_points", rr.Points3D(pts, colors=[[90, 90, 90]], radii=0.01))
+            rr.log(
+                "world/robot",
+                rr.Transform3D(
+                    translation=[x, y, z], quaternion=rr.Quaternion(xyzw=[qx, qy, qz, qw])
+                ),
+            )
+            trajectory.append((x, y, z))
+            if len(trajectory) >= 2:
+                rr.log("world/robot_path", rr.LineStrips3D([trajectory], colors=[[255, 165, 0]]))
+            print(f"frame={count}", end="\r", flush=True)
         print()
 
     if out is not None:
-        print(f"wrote {out}")
-        print(f"open with: rerun {out}")
+        print(f"wrote {out}\nopen with: rerun {out}")
 
 
 if __name__ == "__main__":

--- a/dimos/mapping/ray_tracing/utils/raytrace_rrd.py
+++ b/dimos/mapping/ray_tracing/utils/raytrace_rrd.py
@@ -46,7 +46,11 @@ COLORS = {
     "naive": [90, 200, 90],
     "no_normal_gate": [235, 120, 60],
     "normal_gate": [70, 170, 235],
+    "no_recency": [200, 80, 200],
 }
+
+# A window large enough to never expire, i.e. recency gating off.
+RECENCY_OFF = 1_000_000_000
 
 
 def _attach_pose_from_odom(pair_obs: PairObs) -> Observation[PointCloud2]:
@@ -95,8 +99,9 @@ def main(
         static=True,
     )
 
-    # Naive accumulates every voxel and never clears; the other two are identical
-    # except for the normal gate (graze_cos 0 disables it, 0.7 is the default).
+    # naive accumulates every voxel and never clears. The rest are defaults except:
+    # no_normal_gate turns the normal gate off; no_recency keeps the gate but never
+    # lets a spare expire (recency off); normal_gate is the full default behavior.
     mappers = {
         "naive": VoxelRayMapper(
             voxel_size=voxel_size,
@@ -106,7 +111,10 @@ def main(
             min_health=0,
         ),
         "no_normal_gate": VoxelRayMapper(voxel_size=voxel_size, max_range=max_range, graze_cos=0.0),
-        "normal_gate": VoxelRayMapper(voxel_size=voxel_size, max_range=max_range, graze_cos=0.7),
+        "no_recency": VoxelRayMapper(
+            voxel_size=voxel_size, max_range=max_range, recency_window=RECENCY_OFF
+        ),
+        "normal_gate": VoxelRayMapper(voxel_size=voxel_size, max_range=max_range),
     }
 
     store = SqliteStore(path=str(db_path))

--- a/dimos/mapping/ray_tracing/utils/raytrace_rrd.py
+++ b/dimos/mapping/ray_tracing/utils/raytrace_rrd.py
@@ -84,6 +84,11 @@ def main(
     ),
     min_health: int = typer.Option(-2, "--min-health", help="Voxel removal threshold"),
     max_health: int = typer.Option(1, "--max-health", help="Voxel saturation cap"),
+    graze_cos: float = typer.Option(
+        0.7,
+        "--graze-cos",
+        help="Spare a clearing miss when |ray.normal| < this; raise to clear fewer",
+    ),
     emit_every: int = typer.Option(1, "--emit-every", help="Yield the current map every N frames"),
     render_voxel: float = typer.Option(
         0.05, "--render-voxel", help="Voxel size for rerun rendering (m)"
@@ -93,6 +98,9 @@ def main(
     ),
     normal_scale: float = typer.Option(
         0.1, "--normal-scale", help="Length of the normal arrows (m)"
+    ),
+    raw: bool = typer.Option(
+        True, "--raw/--no-raw", help="Log the raw unvoxelized sensor point cloud"
     ),
 ) -> None:
     db_path = resolve_named_path(dataset, ".db")
@@ -130,8 +138,10 @@ def main(
                 grace_depth=grace_depth,
                 min_health=min_health,
                 max_health=max_health,
+                graze_cos=graze_cos,
                 emit_every=emit_every,
                 emit_normals=normals,
+                emit_raw=raw,
             )
         )
 
@@ -139,6 +149,13 @@ def main(
         for obs in pipeline:
             rr.set_time(TIMELINE, timestamp=obs.ts)
             rr.log("world/raytrace_map", obs.data.to_rerun(voxel_size=render_voxel))
+
+            raw_points = obs.tags.get("raw_points")
+            if raw_points is not None:
+                rr.log(
+                    "world/raw_points",
+                    rr.Points3D(raw_points, colors=[[150, 150, 150]], radii=0.01),
+                )
 
             voxel_normals = obs.tags.get("voxel_normals")
             if voxel_normals is not None:

--- a/dimos/mapping/ray_tracing/utils/raytrace_rrd.py
+++ b/dimos/mapping/ray_tracing/utils/raytrace_rrd.py
@@ -1,0 +1,98 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Render a ray-traced voxel map from a recorded lidar stream into rerun.
+
+Usage:
+    uv run python -m dimos.mapping.ray_tracing.utils.raytrace_rrd mid360_sample
+    uv run python -m dimos.mapping.ray_tracing.utils.raytrace_rrd mid360_sample --out map.rrd && rerun map.rrd
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import rerun as rr
+import typer
+
+from dimos.mapping.ray_tracing.transformer import RayTraceMap
+from dimos.memory2.store.sqlite import SqliteStore
+from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2, register_colormap_annotation
+from dimos.utils.data import resolve_named_path
+
+TIMELINE = "ts"
+
+
+def main(
+    dataset: str = typer.Argument(..., help="Dataset .db: bare name (cwd or data/) or path"),
+    out: Path | None = typer.Option(
+        None, "--out", help="Output .rrd path. If omitted, spawn rerun live."
+    ),
+    stream: str = typer.Option(
+        "fastlio_lidar", "--stream", help="Lidar stream name in the recording"
+    ),
+    voxel_size: float = typer.Option(0.1, "--voxel-size", help="Raycaster voxel edge length (m)"),
+    max_range: float = typer.Option(
+        30.0, "--max-range", help="Max ray cast distance (m); 0 = no limit"
+    ),
+    ray_subsample: int = typer.Option(1, "--ray-subsample", help="Keep every Nth ray for clearing"),
+    shadow_depth: float = typer.Option(
+        0.2, "--shadow-depth", help="Ray extension past endpoint (m)"
+    ),
+    grace_depth: float = typer.Option(
+        0.2, "--grace-depth", help="Spare voxels within this dist of endpoint (m)"
+    ),
+    min_health: int = typer.Option(-2, "--min-health", help="Voxel removal threshold"),
+    max_health: int = typer.Option(1, "--max-health", help="Voxel saturation cap"),
+    emit_every: int = typer.Option(1, "--emit-every", help="Yield the current map every N frames"),
+    render_voxel: float = typer.Option(
+        0.05, "--render-voxel", help="Voxel size for rerun rendering (m)"
+    ),
+) -> None:
+    db_path = resolve_named_path(dataset, ".db")
+
+    rr.init("raytrace_rrd", recording_id=db_path.stem)
+    if out is not None:
+        rr.save(str(out))
+    else:
+        rr.spawn()
+    register_colormap_annotation("turbo")
+
+    store = SqliteStore(path=str(db_path))
+    with store:
+        pipeline = store.stream(stream, PointCloud2).transform(
+            RayTraceMap(
+                voxel_size=voxel_size,
+                max_range=max_range,
+                ray_subsample=ray_subsample,
+                shadow_depth=shadow_depth,
+                grace_depth=grace_depth,
+                min_health=min_health,
+                max_health=max_health,
+                emit_every=emit_every,
+            )
+        )
+        for obs in pipeline:
+            rr.set_time(TIMELINE, timestamp=obs.ts)
+            rr.log("world/raytrace_map", obs.data.to_rerun(voxel_size=render_voxel))
+            print(f"frame_count={obs.tags['frame_count']}", end="\r", flush=True)
+        print()
+
+    if out is not None:
+        print(f"wrote {out}")
+        print(f"open with: rerun {out}")
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/dimos/mapping/ray_tracing/utils/raytrace_rrd.py
+++ b/dimos/mapping/ray_tracing/utils/raytrace_rrd.py
@@ -94,7 +94,9 @@ def main(
     emit_every: int = typer.Option(1, "--emit-every", help="Log the maps every N frames"),
     render_voxel: float = typer.Option(0.05, "--render-voxel", help="Voxel render size (m)"),
     normal_scale: float = typer.Option(0.08, "--normal-scale", help="Normal arrow length (m)"),
-    raw: bool = typer.Option(True, "--raw/--no-raw", help="Also log the raw sensor cloud"),
+    from_time: float | None = typer.Option(
+        None, "--from-time", help="Start replay at this stream timestamp (s)"
+    ),
 ) -> None:
     db_path = resolve_named_path(dataset, ".db")
 
@@ -113,39 +115,26 @@ def main(
         static=True,
     )
 
-    # naive accumulates every voxel and never clears. no_normal_gate turns the
-    # normal gate off. no_recency keeps the gate but never expires a spare.
-    # normal_gate is the full default behavior.
     mappers = {
-        # "naive": VoxelRayMapper(
-        #     voxel_size=voxel_size,
-        #     max_range=max_range,
-        #     shadow_depth=0.0,
-        #     grace_depth=max_range,
-        #     min_health=0,
-        # ),
-        # "no_normal_gate": VoxelRayMapper(voxel_size=voxel_size, max_range=max_range, graze_cos=0.0),
-        # "no_recency": VoxelRayMapper(
-        #     voxel_size=voxel_size, max_range=max_range, recency_window=RECENCY_OFF
-        # ),
+        "naive": VoxelRayMapper(
+            voxel_size=voxel_size,
+            max_range=max_range,
+            shadow_depth=0.0,
+            grace_depth=max_range,
+            min_health=0,
+        ),
+        "no_normal_gate": VoxelRayMapper(voxel_size=voxel_size, max_range=max_range, graze_cos=0.0),
         "defaults": VoxelRayMapper(voxel_size=voxel_size, max_range=max_range),
+        "no_recency": VoxelRayMapper(
+            voxel_size=voxel_size, max_range=max_range, recency_window=RECENCY_OFF
+        ),
     }
 
     store = SqliteStore(path=str(db_path))
     with store:
-        # giradelli stairs
-        # lidar = store.stream(lidar_stream, PointCloud2).order_by("ts").from_time(215)
-
-        # yerba buena people sidewalk
-        # lidar = store.stream(lidar_stream, PointCloud2).order_by("ts").from_time(359)
-
-        # yerba entering park
-        lidar = store.stream(lidar_stream, PointCloud2).order_by("ts").from_time(784)
-
-        # yerba buena down stairs
-        # fast lio is absolutely busted here
-        # lidar = store.stream(lidar_stream, PointCloud2).order_by("ts").from_time(1096)
-
+        lidar = store.stream(lidar_stream, PointCloud2).order_by("ts")
+        if from_time is not None:
+            lidar = lidar.from_time(from_time)
         odom = store.stream(odom_stream, Odometry).order_by("ts")
         pose_tagged = lidar.align(odom, tolerance=align_tol).transform(
             FnTransformer(_attach_pose_from_odom)
@@ -190,7 +179,6 @@ def main(
                 )
                 keep = np.any(normals != 0.0, axis=1)
                 origins, vectors = centers[keep], normals[keep]
-                # PCA normals are sign-ambiguous. Orient them toward the robot.
                 flip = np.sum(vectors * (robot - origins), axis=1) < 0
                 vectors = np.where(flip[:, None], -vectors, vectors)
                 rr.log(
@@ -202,8 +190,7 @@ def main(
                         radii=0.005,
                     ),
                 )
-            if raw:
-                rr.log("world/raw_points", rr.Points3D(pts, colors=[[90, 90, 90]], radii=0.01))
+            rr.log("world/raw_points", rr.Points3D(pts, colors=[[90, 90, 90]], radii=0.01))
             rr.log(
                 "world/robot",
                 rr.Transform3D(

--- a/dimos/mapping/ray_tracing/utils/raytrace_rrd.py
+++ b/dimos/mapping/ray_tracing/utils/raytrace_rrd.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import numpy as np
 import rerun as rr
 import typer
 
@@ -87,6 +88,12 @@ def main(
     render_voxel: float = typer.Option(
         0.05, "--render-voxel", help="Voxel size for rerun rendering (m)"
     ),
+    normals: bool = typer.Option(
+        True, "--normals/--no-normals", help="Draw a surface-normal arrow on each voxel"
+    ),
+    normal_scale: float = typer.Option(
+        0.1, "--normal-scale", help="Length of the normal arrows (m)"
+    ),
 ) -> None:
     db_path = resolve_named_path(dataset, ".db")
 
@@ -124,6 +131,7 @@ def main(
                 min_health=min_health,
                 max_health=max_health,
                 emit_every=emit_every,
+                emit_normals=normals,
             )
         )
 
@@ -131,6 +139,26 @@ def main(
         for obs in pipeline:
             rr.set_time(TIMELINE, timestamp=obs.ts)
             rr.log("world/raytrace_map", obs.data.to_rerun(voxel_size=render_voxel))
+
+            voxel_normals = obs.tags.get("voxel_normals")
+            if voxel_normals is not None:
+                centers = obs.data.points_f32()
+                keep = np.any(voxel_normals != 0.0, axis=1)
+                origins = centers[keep]
+                vectors = voxel_normals[keep]
+                # PCA normals are sign-ambiguous; orient them toward the robot.
+                if obs.pose_tuple is not None:
+                    to_robot = np.asarray(obs.pose_tuple[:3], np.float32) - origins
+                    flip = np.sum(vectors * to_robot, axis=1) < 0
+                    vectors = np.where(flip[:, None], -vectors, vectors)
+                rr.log(
+                    "world/raytrace_map/normals",
+                    rr.Arrows3D(
+                        origins=origins,
+                        vectors=vectors * normal_scale,
+                        colors=[[123, 44, 191]],
+                    ),
+                )
 
             if obs.pose_tuple is not None:
                 x, y, z, qx, qy, qz, qw = obs.pose_tuple

--- a/dimos/mapping/ray_tracing/utils/raytrace_rrd.py
+++ b/dimos/mapping/ray_tracing/utils/raytrace_rrd.py
@@ -43,7 +43,7 @@ PairObs = Observation[tuple[Observation[PointCloud2], Observation[Odometry]]]
 COLORS = {
     "naive": [90, 200, 90],
     "no_normal_gate": [235, 120, 60],
-    "normal_gate": [70, 170, 235],
+    "defaults": [70, 170, 235],
     "no_recency": [200, 80, 200],
 }
 
@@ -51,7 +51,7 @@ COLORS = {
 RECENCY_OFF = 1_000_000_000
 
 # Variants whose normal gate is active, so their normals are worth drawing.
-NORMAL_VARIANTS = {"normal_gate", "no_recency"}
+NORMAL_VARIANTS = {"defaults", "no_recency"}
 
 
 def _height_colors(centers: np.ndarray, base: list[int]) -> np.ndarray:
@@ -117,23 +117,35 @@ def main(
     # normal gate off. no_recency keeps the gate but never expires a spare.
     # normal_gate is the full default behavior.
     mappers = {
-        "naive": VoxelRayMapper(
-            voxel_size=voxel_size,
-            max_range=max_range,
-            shadow_depth=0.0,
-            grace_depth=max_range,
-            min_health=0,
-        ),
-        "no_normal_gate": VoxelRayMapper(voxel_size=voxel_size, max_range=max_range, graze_cos=0.0),
-        "no_recency": VoxelRayMapper(
-            voxel_size=voxel_size, max_range=max_range, recency_window=RECENCY_OFF
-        ),
-        "normal_gate": VoxelRayMapper(voxel_size=voxel_size, max_range=max_range),
+        # "naive": VoxelRayMapper(
+        #     voxel_size=voxel_size,
+        #     max_range=max_range,
+        #     shadow_depth=0.0,
+        #     grace_depth=max_range,
+        #     min_health=0,
+        # ),
+        # "no_normal_gate": VoxelRayMapper(voxel_size=voxel_size, max_range=max_range, graze_cos=0.0),
+        # "no_recency": VoxelRayMapper(
+        #     voxel_size=voxel_size, max_range=max_range, recency_window=RECENCY_OFF
+        # ),
+        "defaults": VoxelRayMapper(voxel_size=voxel_size, max_range=max_range),
     }
 
     store = SqliteStore(path=str(db_path))
     with store:
-        lidar = store.stream(lidar_stream, PointCloud2).order_by("ts")
+        # giradelli stairs
+        # lidar = store.stream(lidar_stream, PointCloud2).order_by("ts").from_time(215)
+
+        # yerba buena people sidewalk
+        # lidar = store.stream(lidar_stream, PointCloud2).order_by("ts").from_time(359)
+
+        # yerba entering park
+        lidar = store.stream(lidar_stream, PointCloud2).order_by("ts").from_time(784)
+
+        # yerba buena down stairs
+        # fast lio is absolutely busted here
+        # lidar = store.stream(lidar_stream, PointCloud2).order_by("ts").from_time(1096)
+
         odom = store.stream(odom_stream, Odometry).order_by("ts")
         pose_tagged = lidar.align(odom, tolerance=align_tol).transform(
             FnTransformer(_attach_pose_from_odom)
@@ -184,7 +196,10 @@ def main(
                 rr.log(
                     f"world/maps/{name}/normals",
                     rr.Arrows3D(
-                        origins=origins, vectors=vectors * normal_scale, colors=[COLORS[name]]
+                        origins=origins,
+                        vectors=vectors * normal_scale,
+                        colors=[COLORS[name]],
+                        radii=0.005,
                     ),
                 )
             if raw:

--- a/dimos/mapping/ray_tracing/utils/raytrace_rrd.py
+++ b/dimos/mapping/ray_tracing/utils/raytrace_rrd.py
@@ -14,9 +14,13 @@
 
 """Render a ray-traced voxel map from a recorded lidar stream into rerun.
 
+Lidar and odometry are aligned by timestamp so each frame carries the robot
+pose used as the ray-cast origin. The robot pose axis and trajectory are
+logged alongside the map.
+
 Usage:
-    uv run python -m dimos.mapping.ray_tracing.utils.raytrace_rrd mid360_sample
-    uv run python -m dimos.mapping.ray_tracing.utils.raytrace_rrd mid360_sample --out map.rrd && rerun map.rrd
+    uv run python -m dimos.mapping.ray_tracing.utils.raytrace_rrd go2_mid360_stairs
+    uv run python -m dimos.mapping.ray_tracing.utils.raytrace_rrd go2_mid360_stairs --out map.rrd && rerun map.rrd
 """
 
 from __future__ import annotations
@@ -28,10 +32,30 @@ import typer
 
 from dimos.mapping.ray_tracing.transformer import RayTraceMap
 from dimos.memory2.store.sqlite import SqliteStore
+from dimos.memory2.transform import FnTransformer
+from dimos.memory2.type.observation import Observation
+from dimos.msgs.nav_msgs.Odometry import Odometry
 from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2, register_colormap_annotation
 from dimos.utils.data import resolve_named_path
 
 TIMELINE = "ts"
+
+PairObs = Observation[tuple[Observation[PointCloud2], Observation[Odometry]]]
+
+
+def _attach_pose_from_odom(pair_obs: PairObs) -> Observation[PointCloud2]:
+    lidar_obs, odom_obs = pair_obs.data
+    odom = odom_obs.data
+    pose_tuple = (
+        float(odom.position.x),
+        float(odom.position.y),
+        float(odom.position.z),
+        float(odom.orientation.x),
+        float(odom.orientation.y),
+        float(odom.orientation.z),
+        float(odom.orientation.w),
+    )
+    return lidar_obs.with_pose(pose_tuple)
 
 
 def main(
@@ -39,9 +63,13 @@ def main(
     out: Path | None = typer.Option(
         None, "--out", help="Output .rrd path. If omitted, spawn rerun live."
     ),
-    stream: str = typer.Option(
-        "fastlio_lidar", "--stream", help="Lidar stream name in the recording"
+    lidar_stream: str = typer.Option(
+        "fastlio_lidar", "--lidar-stream", help="Lidar stream name in the recording"
     ),
+    odom_stream: str = typer.Option(
+        "fastlio_odometry", "--odom-stream", help="Odometry stream name in the recording"
+    ),
+    align_tol: float = typer.Option(0.05, "--align-tol", help="Lidar/odom alignment tolerance (s)"),
     voxel_size: float = typer.Option(0.1, "--voxel-size", help="Raycaster voxel edge length (m)"),
     max_range: float = typer.Option(
         30.0, "--max-range", help="Max ray cast distance (m); 0 = no limit"
@@ -69,9 +97,24 @@ def main(
         rr.spawn()
     register_colormap_annotation("turbo")
 
+    rr.log(
+        "world/robot/axes",
+        rr.Arrows3D(
+            vectors=[[0.3, 0, 0], [0, 0.3, 0], [0, 0, 0.3]],
+            colors=[[255, 0, 0], [0, 255, 0], [0, 0, 255]],
+        ),
+        static=True,
+    )
+
     store = SqliteStore(path=str(db_path))
     with store:
-        pipeline = store.stream(stream, PointCloud2).transform(
+        lidar = store.stream(lidar_stream, PointCloud2).order_by("ts")
+        odom = store.stream(odom_stream, Odometry).order_by("ts")
+
+        pose_tagged = lidar.align(odom, tolerance=align_tol).transform(
+            FnTransformer(_attach_pose_from_odom)
+        )
+        pipeline = pose_tagged.transform(
             RayTraceMap(
                 voxel_size=voxel_size,
                 max_range=max_range,
@@ -83,9 +126,27 @@ def main(
                 emit_every=emit_every,
             )
         )
+
+        trajectory: list[tuple[float, float, float]] = []
         for obs in pipeline:
             rr.set_time(TIMELINE, timestamp=obs.ts)
             rr.log("world/raytrace_map", obs.data.to_rerun(voxel_size=render_voxel))
+
+            if obs.pose_tuple is not None:
+                x, y, z, qx, qy, qz, qw = obs.pose_tuple
+                rr.log(
+                    "world/robot",
+                    rr.Transform3D(
+                        translation=[x, y, z], quaternion=rr.Quaternion(xyzw=[qx, qy, qz, qw])
+                    ),
+                )
+                trajectory.append((x, y, z))
+                if len(trajectory) >= 2:
+                    rr.log(
+                        "world/robot_path",
+                        rr.LineStrips3D([trajectory], colors=[[255, 165, 0]]),
+                    )
+
             print(f"frame_count={obs.tags['frame_count']}", end="\r", flush=True)
         print()
 

--- a/dimos/mapping/ray_tracing/utils/raytrace_rrd.py
+++ b/dimos/mapping/ray_tracing/utils/raytrace_rrd.py
@@ -12,12 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Replay a lidar+odometry .db through several voxel-mapper variants at once.
+"""Replay a lidar+odometry .db through several voxel-mapper variants into rerun.
 
-Each variant's global map is logged to its own rerun entity (world/maps/<name>),
-so they overlay in one view and can be toggled on and off independently. Lidar
-and odometry are aligned by timestamp so each frame carries the robot pose used
-as the ray-cast origin.
+Each variant's global map is a separate, toggleable entity under world/maps.
 
 Usage:
     uv run python -m dimos.mapping.ray_tracing.utils.raytrace_rrd go2_mid360_stairs
@@ -27,6 +24,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import numpy as np
 import rerun as rr
 import typer
 
@@ -51,6 +49,21 @@ COLORS = {
 
 # A window large enough to never expire, i.e. recency gating off.
 RECENCY_OFF = 1_000_000_000
+
+# Variants whose normal gate is active, so their normals are worth drawing.
+NORMAL_VARIANTS = {"normal_gate", "no_recency"}
+
+
+def _height_colors(centers: np.ndarray, base: list[int]) -> np.ndarray:
+    """Shade each voxel by height, keeping the method's base hue."""
+    if len(centers) == 0:
+        return np.empty((0, 3), np.uint8)
+    z = centers[:, 2]
+    span = float(z.max() - z.min())
+    # Only the top half of the brightness scale, so the low end stays visible.
+    t = (z - z.min()) / span if span > 1e-6 else np.zeros(len(z), np.float32)
+    brightness = 0.5 + 0.5 * t
+    return (np.asarray(base, np.float32) * brightness[:, None]).astype(np.uint8)
 
 
 def _attach_pose_from_odom(pair_obs: PairObs) -> Observation[PointCloud2]:
@@ -80,6 +93,7 @@ def main(
     max_range: float = typer.Option(30.0, "--max-range", help="Max ray cast distance (m)"),
     emit_every: int = typer.Option(1, "--emit-every", help="Log the maps every N frames"),
     render_voxel: float = typer.Option(0.05, "--render-voxel", help="Voxel render size (m)"),
+    normal_scale: float = typer.Option(0.08, "--normal-scale", help="Normal arrow length (m)"),
     raw: bool = typer.Option(True, "--raw/--no-raw", help="Also log the raw sensor cloud"),
 ) -> None:
     db_path = resolve_named_path(dataset, ".db")
@@ -99,9 +113,9 @@ def main(
         static=True,
     )
 
-    # naive accumulates every voxel and never clears. The rest are defaults except:
-    # no_normal_gate turns the normal gate off; no_recency keeps the gate but never
-    # lets a spare expire (recency off); normal_gate is the full default behavior.
+    # naive accumulates every voxel and never clears. no_normal_gate turns the
+    # normal gate off. no_recency keeps the gate but never expires a spare.
+    # normal_gate is the full default behavior.
     mappers = {
         "naive": VoxelRayMapper(
             voxel_size=voxel_size,
@@ -140,10 +154,38 @@ def main(
                 continue
 
             rr.set_time(TIMELINE, timestamp=obs.ts)
+            robot = np.asarray([x, y, z], np.float32)
             for name, mapper in mappers.items():
+                if name not in NORMAL_VARIANTS:
+                    centers = mapper.global_map()
+                    rr.log(
+                        f"world/maps/{name}",
+                        rr.Points3D(
+                            centers,
+                            colors=_height_colors(centers, COLORS[name]),
+                            radii=render_voxel / 2,
+                        ),
+                    )
+                    continue
+                centers, normals = mapper.global_map_normals()
                 rr.log(
                     f"world/maps/{name}",
-                    rr.Points3D(mapper.global_map(), colors=[COLORS[name]], radii=render_voxel / 2),
+                    rr.Points3D(
+                        centers,
+                        colors=_height_colors(centers, COLORS[name]),
+                        radii=render_voxel / 2,
+                    ),
+                )
+                keep = np.any(normals != 0.0, axis=1)
+                origins, vectors = centers[keep], normals[keep]
+                # PCA normals are sign-ambiguous. Orient them toward the robot.
+                flip = np.sum(vectors * (robot - origins), axis=1) < 0
+                vectors = np.where(flip[:, None], -vectors, vectors)
+                rr.log(
+                    f"world/maps/{name}/normals",
+                    rr.Arrows3D(
+                        origins=origins, vectors=vectors * normal_scale, colors=[COLORS[name]]
+                    ),
                 )
             if raw:
                 rr.log("world/raw_points", rr.Points3D(pts, colors=[[90, 90, 90]], radii=0.01))

--- a/dimos/mapping/ray_tracing/voxel_map.pyi
+++ b/dimos/mapping/ray_tracing/voxel_map.pyi
@@ -28,6 +28,7 @@ class VoxelRayMapper:
         grace_depth: float = 0.2,
         min_health: int = -2,
         max_health: int = 1,
+        graze_cos: float = 0.7,
     ) -> None: ...
     def add_frame(
         self,

--- a/dimos/mapping/ray_tracing/voxel_map.pyi
+++ b/dimos/mapping/ray_tracing/voxel_map.pyi
@@ -41,6 +41,14 @@ class VoxelRayMapper:
         """Return the centers of all healthy voxels as (M, 3) float32."""
         ...
 
+    def global_map_normals(self) -> tuple[NDArray[np.float32], NDArray[np.float32]]:
+        """Return healthy voxel centers and their surface normals, both (M, 3) float32.
+
+        The two arrays are in matching order. The normal is the zero vector where
+        the voxel has no confident planar normal.
+        """
+        ...
+
     def local_map(
         self,
         origin: tuple[float, float, float],

--- a/dimos/mapping/ray_tracing/voxel_map.pyi
+++ b/dimos/mapping/ray_tracing/voxel_map.pyi
@@ -29,6 +29,7 @@ class VoxelRayMapper:
         min_health: int = -2,
         max_health: int = 1,
         graze_cos: float = 0.7,
+        recency_window: int = 15,
     ) -> None: ...
     def add_frame(
         self,

--- a/dimos/mapping/ray_tracing/voxel_map.pyi
+++ b/dimos/mapping/ray_tracing/voxel_map.pyi
@@ -46,8 +46,7 @@ class VoxelRayMapper:
     def global_map_normals(self) -> tuple[NDArray[np.float32], NDArray[np.float32]]:
         """Return healthy voxel centers and their surface normals, both (M, 3) float32.
 
-        The two arrays are in matching order. The normal is the zero vector where
-        the voxel has no confident planar normal.
+        Matching order. The normal is the zero vector where the voxel has no plane.
         """
         ...
 


### PR DESCRIPTION
## Problem

Voxel ray tracing can clip through other voxels even if the lidar point doesn't intersect the surface of the voxel. Especially common on planes, stairs, etc (you know, just the things we walk on).

Closes DIM-XXX

## Solution

Now we only clear voxels if the ray hits the voxel directly (with some threshold)

got rid of xy plane protection hack and replaced with:
- calculate normal vector for eligible voxels
- prevent clearing of grazing rays by gating on direct hits
- add recency field, so points hit a long time ago are not saved by normals

side note: now that we have normals, we can use them for path planning as well!

## How to Test

`uv run python -m dimos.mapping.ray_tracing.utils.raytrace_rrd <db path>`

Lands many more points on stairs
<img width="1153" height="847" alt="stairs_normal" src="https://github.com/user-attachments/assets/6b0d62ec-53a8-4fcc-b9ba-e8e6b1a28080" />

<img width="1153" height="847" alt="stairs_no_normal" src="https://github.com/user-attachments/assets/ea715661-a854-4149-8a11-49d67ee6f891" />

Planes and slopes much more dense
<img width="1148" height="847" alt="slope_normal" src="https://github.com/user-attachments/assets/d4edc693-2790-4946-9045-99b3dc72334d" />

<img width="1148" height="847" alt="slope_no_normal" src="https://github.com/user-attachments/assets/f7433ceb-6591-415e-b4e4-6364af0b7e02" />

## Contributor License Agreement

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).

