### PR TITLE
feat(config): add robot_id to GlobalConfig

### DIFF
--- a/dimos/core/global_config.py
+++ b/dimos/core/global_config.py
@@ -56,6 +56,7 @@ class GlobalConfig(BaseSettings):
     mujoco_start_pos: str = "-1.0, 1.0"
     mujoco_steps_per_frame: int = 7
     robot_model: str | None = None
+    robot_id: str | None = None
     robot_width: float = 0.3
     robot_rotation_diameter: float = 0.6
     nerf_speed: float = 1.0


### PR DESCRIPTION
Adds a `robot_id` field to `GlobalConfig` — a per-machine robot *instance* id, distinct from `robot_model` (the model *type*, e.g. `unitree_go2`).

- Auto-exposes a `--robot-id` CLI flag (same mechanism as `--robot-ip`/`--robot-model`); also settable via the `ROBOT_ID` env var or `.global_config(robot_id=…)`.
- **Field only** — lands on main independently. The hosted-teleop **WebRTC transport** (`BrokerProvider`, on the transport branch) consumes it so multiple robots sharing one API key register as distinct robots. (Not wiring `HostedTeleopModule`, which is deprecated.)

## Why
One API key across N robots currently collapses them into one entry.

need a per robot ID for teleop. can replace this with namespaces later