### PR TITLE
feat(robot): add XLeRobot support — omni base, dual arms, head

### DIFF
--- a/dimos/robot/all_blueprints.py
+++ b/dimos/robot/all_blueprints.py
@@ -127,6 +127,8 @@ all_blueprints = {
     "xarm6-planner-only": "dimos.manipulation.blueprints:xarm6_planner_only",
     "xarm7-planner-coordinator": "dimos.manipulation.blueprints:xarm7_planner_coordinator",
     "xarm7-planner-coordinator-agent": "dimos.manipulation.blueprints:xarm7_planner_coordinator_agent",
+    "xlerobot-agentic": "dimos.robot.xlerobot.blueprints.agentic.xlerobot_agentic:xlerobot_agentic",
+    "xlerobot-basic": "dimos.robot.xlerobot.blueprints.basic.xlerobot_basic:xlerobot_basic",
 }
 
 
@@ -239,5 +241,6 @@ all_modules = {
     "wavefront-frontier-explorer": "dimos.navigation.frontier_exploration.wavefront_frontier_goal_selector.WavefrontFrontierExplorer",
     "web-input": "dimos.agents.web_human_input.WebInput",
     "websocket-vis-module": "dimos.web.websocket_vis.websocket_vis_module.WebsocketVisModule",
+    "x-le-robot-connection": "dimos.robot.xlerobot.xlerobot_module.XLeRobotConnection",
     "zed-camera": "dimos.hardware.sensors.camera.zed.camera.ZEDCamera",
 }

--- a/dimos/robot/xlerobot/__init__.py
+++ b/dimos/robot/xlerobot/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2026 Dimensional Inc.
+# XLeRobot integration for DimOS

--- a/dimos/robot/xlerobot/__init__.py
+++ b/dimos/robot/xlerobot/__init__.py
@@ -1,2 +1,0 @@
-# Copyright 2026 Dimensional Inc.
-# XLeRobot integration for DimOS

--- a/dimos/robot/xlerobot/blueprints/agentic/xlerobot_agentic.py
+++ b/dimos/robot/xlerobot/blueprints/agentic/xlerobot_agentic.py
@@ -1,0 +1,47 @@
+"""Agentic XLeRobot blueprint — LLM agent control via MCP.
+
+Composes on top of xlerobot_basic and adds MCP server/client
+for agent-driven control of the XLeRobot. Includes all skills:
+base movement, dual-arm manipulation, head, grippers, and vision.
+"""
+
+from dimos.agents.mcp.mcp_client import McpClient
+from dimos.agents.mcp.mcp_server import McpServer
+from dimos.agents.web_human_input import WebInput
+from dimos.core.coordination.blueprints import autoconnect
+from dimos.robot.xlerobot.blueprints.basic.xlerobot_basic import xlerobot_basic
+
+XLEROBOT_SYSTEM_PROMPT = """\
+You are controlling an XLeRobot — a 3-wheel omni-directional mobile robot with dual 6-DOF arms and a 2-DOF head.
+
+# AVAILABLE SKILLS
+
+## Base Movement
+- move_base(x, y, theta, duration): Drive the base. x=forward m/s, y=left m/s, theta=rotation deg/s.
+- stop_base(): Emergency stop all wheel motors.
+
+## Arms & Manipulation
+- move_arm(arm, joint_positions, duration): Move "left" or "right" arm. joint_positions is a JSON string mapping joint names to target values.
+  Left arm joints: left_arm_shoulder_pan, left_arm_shoulder_lift, left_arm_elbow_flex, left_arm_wrist_flex, left_arm_wrist_roll, left_arm_gripper
+  Right arm joints: right_arm_shoulder_pan, right_arm_shoulder_lift, right_arm_elbow_flex, right_arm_wrist_flex, right_arm_wrist_roll, right_arm_gripper
+- open_gripper(arm): Open gripper on "left" or "right" arm.
+- close_gripper(arm): Close gripper on "left" or "right" arm.
+- home_arms(): Move both arms and head to zero position.
+- get_joint_positions(): Get all current joint angles as JSON.
+
+## Head
+- move_head(pan, tilt): Point the head camera.
+
+## Vision
+- observe(): Get the latest camera frame.
+
+When given a task, plan movements and confirm results with observe()."""
+
+xlerobot_agentic = autoconnect(
+    xlerobot_basic,
+    McpServer.blueprint(),
+    McpClient.blueprint(system_prompt=XLEROBOT_SYSTEM_PROMPT),
+    WebInput.blueprint(),
+)
+
+__all__ = ["XLEROBOT_SYSTEM_PROMPT", "xlerobot_agentic"]

--- a/dimos/robot/xlerobot/blueprints/basic/xlerobot_basic.py
+++ b/dimos/robot/xlerobot/blueprints/basic/xlerobot_basic.py
@@ -1,0 +1,89 @@
+"""Basic XLeRobot blueprint — connection + camera + visualization.
+
+Supports full robot (arms + head + base) or base-only mode via config.
+"""
+
+import platform
+from typing import Any
+
+from dimos.constants import DEFAULT_CAPACITY_COLOR_IMAGE
+from dimos.core.coordination.blueprints import autoconnect
+from dimos.core.global_config import global_config
+from dimos.core.transport import pSHMTransport
+from dimos.msgs.sensor_msgs.Image import Image
+from dimos.robot.xlerobot.xlerobot_module import XLeRobotConnection
+from dimos.web.websocket_vis.websocket_vis_module import WebsocketVisModule
+
+_mac_transports: dict[tuple[str, type], pSHMTransport[Image]] = {
+    ("color_image", Image): pSHMTransport(
+        "color_image", default_capacity=DEFAULT_CAPACITY_COLOR_IMAGE
+    ),
+}
+
+_transports_base = (
+    autoconnect() if platform.system() == "Linux" else autoconnect().transports(_mac_transports)
+)
+
+
+def _xlerobot_rerun_blueprint() -> Any:
+    """Split layout: camera + 3D view side by side."""
+    import rerun as rr
+    import rerun.blueprint as rrb
+
+    return rrb.Blueprint(
+        rrb.Horizontal(
+            rrb.Spatial2DView(origin="world/color_image", name="Camera"),
+            rrb.Spatial3DView(
+                origin="world",
+                name="3D",
+                background=rrb.Background(kind="SolidColor", color=[0, 0, 0]),
+                line_grid=rrb.LineGrid3D(
+                    plane=rr.components.Plane3D.XY.with_distance(0.5),
+                ),
+            ),
+            column_shares=[1, 2],
+        ),
+        rrb.TimePanel(state="hidden"),
+        rrb.SelectionPanel(state="hidden"),
+    )
+
+
+def _static_base_link(rr: Any) -> list[Any]:
+    """XLeRobot body wireframe — roughly a cylinder shape."""
+    return [
+        rr.Boxes3D(
+            half_sizes=[0.15, 0.15, 0.12],
+            colors=[(0, 200, 255)],
+        ),
+        rr.Transform3D(),
+    ]
+
+
+rerun_config = {
+    "blueprint": _xlerobot_rerun_blueprint,
+    "max_hz": {
+        "world/color_image": 10,
+    },
+    "static": {
+        "world/tf/base_link": _static_base_link,
+    },
+}
+
+
+if global_config.viewer.startswith("rerun"):
+    from dimos.visualization.rerun.bridge import RerunBridgeModule, _resolve_viewer_mode
+
+    _vis = autoconnect(
+        _transports_base,
+        RerunBridgeModule.blueprint(viewer_mode=_resolve_viewer_mode(), **rerun_config),
+    )
+else:
+    _vis = _transports_base
+
+xlerobot_basic = autoconnect(
+    _vis,
+    XLeRobotConnection.blueprint(),
+    WebsocketVisModule.blueprint(),
+)
+
+__all__ = ["xlerobot_basic"]

--- a/dimos/robot/xlerobot/calibrate.py
+++ b/dimos/robot/xlerobot/calibrate.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Interactive calibration script for XLeRobot.
+
+Run this BEFORE starting DimOS to create a calibration file that the
+XLeRobotDriver can load headlessly.
+
+Usage:
+    python -m dimos.robot.xlerobot.calibrate
+    python -m dimos.robot.xlerobot.calibrate --port1 /dev/ttyACM0 --port2 /dev/ttyACM1
+    python -m dimos.robot.xlerobot.calibrate --output /path/to/calibration.json
+
+The calibration procedure:
+  1. Connects to both servo buses
+  2. Disables torque on arm + head motors
+  3. Prompts you to move joints to center, then through full range
+  4. Records homing offsets and range of motion
+  5. Saves calibration JSON to ~/.cache/xlerobot/calibration.json (or --output)
+"""
+
+import argparse
+import json
+import logging
+import platform
+import sys
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+try:
+    from lerobot.motors import Motor, MotorCalibration, MotorNormMode
+    from lerobot.motors.feetech import FeetechMotorsBus, OperatingMode
+except ImportError:
+    logger.error("lerobot[feetech] is required. Install with: pip install lerobot[feetech]")
+    sys.exit(1)
+
+
+def _default_port1() -> str:
+    return "/dev/cu.usbmodem1101" if platform.system() == "Darwin" else "/dev/ttyACM0"
+
+
+def _default_port2() -> str:
+    return "/dev/cu.usbmodem1201" if platform.system() == "Darwin" else "/dev/ttyACM1"
+
+
+def _default_output() -> Path:
+    return Path.home() / ".cache" / "xlerobot" / "calibration.json"
+
+
+def build_bus1(port: str) -> tuple[FeetechMotorsBus, list[str], list[str]]:
+    norm = MotorNormMode.RANGE_M100_100
+    bus = FeetechMotorsBus(
+        port=port,
+        motors={
+            "left_arm_shoulder_pan": Motor(1, "sts3215", norm),
+            "left_arm_shoulder_lift": Motor(2, "sts3215", norm),
+            "left_arm_elbow_flex": Motor(3, "sts3215", norm),
+            "left_arm_wrist_flex": Motor(4, "sts3215", norm),
+            "left_arm_wrist_roll": Motor(5, "sts3215", norm),
+            "left_arm_gripper": Motor(6, "sts3215", MotorNormMode.RANGE_0_100),
+            "head_motor_1": Motor(7, "sts3215", norm),
+            "head_motor_2": Motor(8, "sts3215", norm),
+        },
+    )
+    left_arm = [m for m in bus.motors if m.startswith("left_arm")]
+    head = [m for m in bus.motors if m.startswith("head")]
+    return bus, left_arm, head
+
+
+def build_bus2(port: str) -> tuple[FeetechMotorsBus, list[str], list[str]]:
+    norm = MotorNormMode.RANGE_M100_100
+    bus = FeetechMotorsBus(
+        port=port,
+        motors={
+            "right_arm_shoulder_pan": Motor(1, "sts3215", norm),
+            "right_arm_shoulder_lift": Motor(2, "sts3215", norm),
+            "right_arm_elbow_flex": Motor(3, "sts3215", norm),
+            "right_arm_wrist_flex": Motor(4, "sts3215", norm),
+            "right_arm_wrist_roll": Motor(5, "sts3215", norm),
+            "right_arm_gripper": Motor(6, "sts3215", MotorNormMode.RANGE_0_100),
+            "base_left_wheel": Motor(7, "sts3215", MotorNormMode.RANGE_M100_100),
+            "base_back_wheel": Motor(8, "sts3215", MotorNormMode.RANGE_M100_100),
+            "base_right_wheel": Motor(9, "sts3215", MotorNormMode.RANGE_M100_100),
+        },
+    )
+    right_arm = [m for m in bus.motors if m.startswith("right_arm")]
+    base = [m for m in bus.motors if m.startswith("base")]
+    return bus, right_arm, base
+
+
+def calibrate_bus1(bus: FeetechMotorsBus, left_arm: list[str], head: list[str]) -> dict[str, MotorCalibration]:
+    motors_to_calibrate = left_arm + head
+    bus.disable_torque()
+
+    for name in motors_to_calibrate:
+        bus.write("Operating_Mode", name, OperatingMode.POSITION.value)
+
+    input(
+        "\n>>> Move LEFT ARM and HEAD motors to the MIDDLE of their range of motion.\n"
+        "    Press ENTER when ready..."
+    )
+
+    homing_offsets = bus.set_half_turn_homings(motors_to_calibrate)
+
+    print(
+        "\n>>> Now move all LEFT ARM and HEAD joints sequentially through their\n"
+        "    ENTIRE range of motion. Recording positions...\n"
+        "    Press ENTER to stop recording."
+    )
+    range_mins, range_maxes = bus.record_ranges_of_motion(motors_to_calibrate)
+
+    calibration = {}
+    for name, motor in bus.motors.items():
+        calibration[name] = MotorCalibration(
+            id=motor.id,
+            drive_mode=0,
+            homing_offset=homing_offsets.get(name, 0),
+            range_min=range_mins.get(name, 0),
+            range_max=range_maxes.get(name, 4095),
+        )
+
+    bus.write_calibration(calibration)
+    return calibration
+
+
+def calibrate_bus2(bus: FeetechMotorsBus, right_arm: list[str], base: list[str]) -> dict[str, MotorCalibration]:
+    bus.disable_torque(right_arm)
+
+    for name in right_arm:
+        bus.write("Operating_Mode", name, OperatingMode.POSITION.value)
+
+    input(
+        "\n>>> Move RIGHT ARM motors to the MIDDLE of their range of motion.\n"
+        "    Press ENTER when ready..."
+    )
+
+    homing_offsets = bus.set_half_turn_homings(right_arm)
+    homing_offsets.update(dict.fromkeys(base, 0))
+
+    print(
+        "\n>>> Now move all RIGHT ARM joints sequentially through their\n"
+        "    ENTIRE range of motion (wheels are skipped).\n"
+        "    Press ENTER to stop recording."
+    )
+    range_mins, range_maxes = bus.record_ranges_of_motion(right_arm)
+
+    for name in base:
+        range_mins[name] = 0
+        range_maxes[name] = 4095
+
+    calibration = {}
+    for name, motor in bus.motors.items():
+        calibration[name] = MotorCalibration(
+            id=motor.id,
+            drive_mode=0,
+            homing_offset=homing_offsets.get(name, 0),
+            range_min=range_mins.get(name, 0),
+            range_max=range_maxes.get(name, 4095),
+        )
+
+    bus.write_calibration(calibration)
+    return calibration
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Interactive XLeRobot calibration")
+    parser.add_argument("--port1", default=_default_port1(), help="Bus 1 serial port (left arm + head)")
+    parser.add_argument("--port2", default=_default_port2(), help="Bus 2 serial port (right arm + wheels)")
+    parser.add_argument("--output", default=str(_default_output()), help="Output calibration JSON path")
+    args = parser.parse_args()
+
+    output_path = Path(args.output)
+
+    print("=" * 60)
+    print("  XLeRobot Calibration")
+    print("=" * 60)
+    print(f"  Bus 1: {args.port1}")
+    print(f"  Bus 2: {args.port2}")
+    print(f"  Output: {output_path}")
+    print("=" * 60)
+
+    bus1, left_arm, head = build_bus1(args.port1)
+    bus2, right_arm, base = build_bus2(args.port2)
+
+    print("\nConnecting bus 1...")
+    bus1.connect()
+    print("Connecting bus 2...")
+    bus2.connect()
+
+    print("\n--- Calibrating Bus 1 (left arm + head) ---")
+    cal1 = calibrate_bus1(bus1, left_arm, head)
+
+    print("\n--- Calibrating Bus 2 (right arm + wheels) ---")
+    cal2 = calibrate_bus2(bus2, right_arm, base)
+
+    combined = {**cal1, **cal2}
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    serializable = {}
+    for name, mc in combined.items():
+        serializable[name] = {
+            "id": mc.id,
+            "drive_mode": mc.drive_mode,
+            "homing_offset": mc.homing_offset,
+            "range_min": mc.range_min,
+            "range_max": mc.range_max,
+        }
+
+    with open(output_path, "w") as f:
+        json.dump(serializable, f, indent=2)
+
+    print(f"\nCalibration saved to {output_path}")
+    print("You can now start DimOS with: dimos run xlerobot-basic")
+
+    bus1.disconnect(True)
+    bus2.disconnect(True)
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/dimos/robot/xlerobot/calibrate.py
+++ b/dimos/robot/xlerobot/calibrate.py
@@ -33,13 +33,13 @@ The calibration procedure:
 
 import argparse
 import json
-import logging
+from pathlib import Path
 import platform
 import sys
-from pathlib import Path
 
-logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
-logger = logging.getLogger(__name__)
+from dimos.utils.logging_config import setup_logger
+
+logger = setup_logger()
 
 try:
     from lerobot.motors import Motor, MotorCalibration, MotorNormMode
@@ -201,33 +201,34 @@ def main() -> None:
     print("Connecting bus 2...")
     bus2.connect()
 
-    print("\n--- Calibrating Bus 1 (left arm + head) ---")
-    cal1 = calibrate_bus1(bus1, left_arm, head)
+    try:
+        print("\n--- Calibrating Bus 1 (left arm + head) ---")
+        cal1 = calibrate_bus1(bus1, left_arm, head)
 
-    print("\n--- Calibrating Bus 2 (right arm + wheels) ---")
-    cal2 = calibrate_bus2(bus2, right_arm, base)
+        print("\n--- Calibrating Bus 2 (right arm + wheels) ---")
+        cal2 = calibrate_bus2(bus2, right_arm, base)
 
-    combined = {**cal1, **cal2}
+        combined = {**cal1, **cal2}
 
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    serializable = {}
-    for name, mc in combined.items():
-        serializable[name] = {
-            "id": mc.id,
-            "drive_mode": mc.drive_mode,
-            "homing_offset": mc.homing_offset,
-            "range_min": mc.range_min,
-            "range_max": mc.range_max,
-        }
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        serializable = {}
+        for name, mc in combined.items():
+            serializable[name] = {
+                "id": mc.id,
+                "drive_mode": mc.drive_mode,
+                "homing_offset": mc.homing_offset,
+                "range_min": mc.range_min,
+                "range_max": mc.range_max,
+            }
 
-    with open(output_path, "w") as f:
-        json.dump(serializable, f, indent=2)
+        with open(output_path, "w") as f:
+            json.dump(serializable, f, indent=2)
 
-    print(f"\nCalibration saved to {output_path}")
-    print("You can now start DimOS with: dimos run xlerobot-basic")
-
-    bus1.disconnect(True)
-    bus2.disconnect(True)
+        print(f"\nCalibration saved to {output_path}")
+        print("You can now start DimOS with: dimos run xlerobot-basic")
+    finally:
+        bus1.disconnect(True)
+        bus2.disconnect(True)
     print("Done.")
 
 

--- a/dimos/robot/xlerobot/config.py
+++ b/dimos/robot/xlerobot/config.py
@@ -1,0 +1,112 @@
+"""XLeRobot configuration for DimOS."""
+
+import platform
+
+from pydantic import Field
+
+from dimos.core.module import ModuleConfig
+
+
+def _default_bus1_port() -> str:
+    if platform.system() == "Darwin":
+        return "/dev/cu.usbmodem1101"
+    return "/dev/ttyACM0"
+
+
+def _default_bus2_port() -> str:
+    if platform.system() == "Darwin":
+        return "/dev/cu.usbmodem1201"
+    return "/dev/ttyACM1"
+
+
+class XLeRobotConfig(ModuleConfig):
+    """Configuration for XLeRobot connection module.
+
+    The XLeRobot has two serial buses:
+      - Bus 1: left arm (6 DOF) + head (2 DOF)
+      - Bus 2: right arm (6 DOF) + base wheels (3)
+
+    On macOS, serial ports appear as /dev/cu.usbmodem* instead of /dev/ttyACM*.
+    The defaults auto-detect the platform.
+    """
+
+    # Serial ports
+    port_bus1: str = Field(
+        default_factory=_default_bus1_port,
+        description="Serial port for bus 1 (left arm + head)",
+    )
+    port_bus2: str = Field(
+        default_factory=_default_bus2_port,
+        description="Serial port for bus 2 (right arm + omni base wheels)",
+    )
+
+    # Feature flags
+    enable_arms: bool = Field(default=True, description="Enable arm motor control")
+    enable_head: bool = Field(default=True, description="Enable head motor control")
+
+    # Camera
+    camera_index: int = Field(
+        default=0,
+        description="OpenCV camera device index or /dev/videoN",
+    )
+    camera_width: int = 640
+    camera_height: int = 480
+    camera_fps: int = 30
+
+    # Omni base kinematics
+    wheel_radius: float = Field(default=0.05, description="Omni wheel radius in meters")
+    base_radius: float = Field(default=0.125, description="Distance from center to wheel in meters")
+    max_wheel_raw: int = Field(default=3000, description="Max raw velocity ticks per wheel")
+
+    # Bus 1 servo IDs (left arm + head)
+    left_arm_shoulder_pan_id: int = 1
+    left_arm_shoulder_lift_id: int = 2
+    left_arm_elbow_flex_id: int = 3
+    left_arm_wrist_flex_id: int = 4
+    left_arm_wrist_roll_id: int = 5
+    left_arm_gripper_id: int = 6
+    head_motor_1_id: int = 7
+    head_motor_2_id: int = 8
+
+    # Bus 2 servo IDs (right arm + wheels)
+    right_arm_shoulder_pan_id: int = 1
+    right_arm_shoulder_lift_id: int = 2
+    right_arm_elbow_flex_id: int = 3
+    right_arm_wrist_flex_id: int = 4
+    right_arm_wrist_roll_id: int = 5
+    right_arm_gripper_id: int = 6
+    wheel_left_id: int = 7
+    wheel_back_id: int = 8
+    wheel_right_id: int = 9
+
+    # Motor tuning
+    disable_torque_on_disconnect: bool = Field(
+        default=True,
+        description="Disable torque on all motors when disconnecting",
+    )
+    max_relative_target: int | None = Field(
+        default=None,
+        description="Max position delta per step for arm safety clamping (None = no limit)",
+    )
+    use_degrees: bool = Field(
+        default=False,
+        description="Use degree-based motor normalization instead of range [-100, 100]",
+    )
+
+    # PID tuning (applied to arm + head position-mode motors)
+    arm_p_coefficient: int = 16
+    arm_i_coefficient: int = 0
+    arm_d_coefficient: int = 43
+
+    # Calibration
+    calibration_file: str | None = Field(
+        default=None,
+        description="Path to saved calibration JSON. If None, looks for default location.",
+    )
+
+    # Connection
+    strict_handshake: bool = Field(
+        default=False,
+        description="If True, fail on connect when any expected motor is missing. "
+        "If False, log a warning and continue with the motors that are found.",
+    )

--- a/dimos/robot/xlerobot/connection.py
+++ b/dimos/robot/xlerobot/connection.py
@@ -1,0 +1,555 @@
+"""Low-level XLeRobot hardware driver.
+
+Wraps the Feetech servo buses for full robot control:
+  - Bus 1: left arm (6 DOF) + head (2 DOF) — position mode
+  - Bus 2: right arm (6 DOF) + base wheels (3) — position + velocity mode
+  - USB camera via OpenCV
+
+Mirrors the hardware API from XLeRobot/software/src/robots/xlerobot/xlerobot.py
+but adapted for headless DimOS operation (no interactive calibration).
+
+Requires: pip install lerobot[feetech]
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+import cv2
+import numpy as np
+
+from dimos.robot.xlerobot.config import XLeRobotConfig
+
+logger = logging.getLogger(__name__)
+
+try:
+    from lerobot.motors import Motor, MotorCalibration, MotorNormMode
+    from lerobot.motors.feetech import FeetechMotorsBus, OperatingMode
+
+    _HAS_LEROBOT = True
+except ImportError:
+    _HAS_LEROBOT = False
+
+
+def _degps_to_raw(degps: float) -> int:
+    """Convert degrees/sec to Feetech raw velocity ticks."""
+    steps_per_deg = 4096.0 / 360.0
+    raw = int(round(degps * steps_per_deg))
+    return max(-0x8000, min(0x7FFF, raw))
+
+
+def _raw_to_degps(raw: int) -> float:
+    return raw / (4096.0 / 360.0)
+
+
+LEFT_ARM_MOTOR_NAMES = [
+    "left_arm_shoulder_pan",
+    "left_arm_shoulder_lift",
+    "left_arm_elbow_flex",
+    "left_arm_wrist_flex",
+    "left_arm_wrist_roll",
+    "left_arm_gripper",
+]
+
+HEAD_MOTOR_NAMES = ["head_motor_1", "head_motor_2"]
+
+RIGHT_ARM_MOTOR_NAMES = [
+    "right_arm_shoulder_pan",
+    "right_arm_shoulder_lift",
+    "right_arm_elbow_flex",
+    "right_arm_wrist_flex",
+    "right_arm_wrist_roll",
+    "right_arm_gripper",
+]
+
+BASE_MOTOR_NAMES = ["base_left_wheel", "base_back_wheel", "base_right_wheel"]
+
+ALL_ARM_JOINT_NAMES = LEFT_ARM_MOTOR_NAMES + RIGHT_ARM_MOTOR_NAMES + HEAD_MOTOR_NAMES
+
+
+class XLeRobotDriver:
+    """Full driver for XLeRobot: dual arms, head, omni base, and camera.
+
+    Handles:
+      - Bus 1: left arm (6 position-mode servos) + head (2 position-mode servos)
+      - Bus 2: right arm (6 position-mode servos) + wheels (3 velocity-mode servos)
+      - USB camera via OpenCV
+      - Omni-wheel inverse/forward kinematics
+      - Calibration loading from file
+      - Safety clamping on arm position targets
+    """
+
+    def __init__(self, config: XLeRobotConfig) -> None:
+        if not _HAS_LEROBOT:
+            raise ImportError(
+                "lerobot[feetech] is required for XLeRobot hardware control. "
+                "Install with: pip install lerobot[feetech]"
+            )
+
+        self._config = config
+        self._connected = False
+        self._camera: cv2.VideoCapture | None = None
+        self._latest_frame: np.ndarray | None = None
+        self._frame_lock = threading.Lock()
+
+        # Kinematics matrices (omni base)
+        angles = np.radians(np.array([240, 0, 120]) - 90)
+        self._kin_matrix = np.array(
+            [[np.cos(a), np.sin(a), config.base_radius] for a in angles]
+        )
+        self._kin_matrix_inv = np.linalg.inv(self._kin_matrix)
+
+        # Motor norm mode
+        norm_mode_body = MotorNormMode.DEGREES if config.use_degrees else MotorNormMode.RANGE_M100_100
+
+        # Bus 1: left arm + head
+        self._bus1: FeetechMotorsBus | None = None
+        if config.enable_arms or config.enable_head:
+            bus1_motors: dict[str, Motor] = {}
+            if config.enable_arms:
+                bus1_motors.update(
+                    {
+                        "left_arm_shoulder_pan": Motor(config.left_arm_shoulder_pan_id, "sts3215", norm_mode_body),
+                        "left_arm_shoulder_lift": Motor(config.left_arm_shoulder_lift_id, "sts3215", norm_mode_body),
+                        "left_arm_elbow_flex": Motor(config.left_arm_elbow_flex_id, "sts3215", norm_mode_body),
+                        "left_arm_wrist_flex": Motor(config.left_arm_wrist_flex_id, "sts3215", norm_mode_body),
+                        "left_arm_wrist_roll": Motor(config.left_arm_wrist_roll_id, "sts3215", norm_mode_body),
+                        "left_arm_gripper": Motor(config.left_arm_gripper_id, "sts3215", MotorNormMode.RANGE_0_100),
+                    }
+                )
+            if config.enable_head:
+                bus1_motors.update(
+                    {
+                        "head_motor_1": Motor(config.head_motor_1_id, "sts3215", norm_mode_body),
+                        "head_motor_2": Motor(config.head_motor_2_id, "sts3215", norm_mode_body),
+                    }
+                )
+            self._bus1 = FeetechMotorsBus(port=config.port_bus1, motors=bus1_motors)
+
+        # Bus 2: right arm + wheels (always created — wheels are required)
+        bus2_motors: dict[str, Motor] = {
+            "base_left_wheel": Motor(config.wheel_left_id, "sts3215", MotorNormMode.RANGE_M100_100),
+            "base_back_wheel": Motor(config.wheel_back_id, "sts3215", MotorNormMode.RANGE_M100_100),
+            "base_right_wheel": Motor(config.wheel_right_id, "sts3215", MotorNormMode.RANGE_M100_100),
+        }
+        if config.enable_arms:
+            bus2_motors.update(
+                {
+                    "right_arm_shoulder_pan": Motor(config.right_arm_shoulder_pan_id, "sts3215", norm_mode_body),
+                    "right_arm_shoulder_lift": Motor(config.right_arm_shoulder_lift_id, "sts3215", norm_mode_body),
+                    "right_arm_elbow_flex": Motor(config.right_arm_elbow_flex_id, "sts3215", norm_mode_body),
+                    "right_arm_wrist_flex": Motor(config.right_arm_wrist_flex_id, "sts3215", norm_mode_body),
+                    "right_arm_wrist_roll": Motor(config.right_arm_wrist_roll_id, "sts3215", norm_mode_body),
+                    "right_arm_gripper": Motor(config.right_arm_gripper_id, "sts3215", MotorNormMode.RANGE_0_100),
+                }
+            )
+        self._bus2 = FeetechMotorsBus(port=config.port_bus2, motors=bus2_motors)
+
+        # Classify motor names for this instance
+        self._left_arm_motors = [m for m in (self._bus1.motors if self._bus1 else {}) if m.startswith("left_arm")]
+        self._head_motors = [m for m in (self._bus1.motors if self._bus1 else {}) if m.startswith("head")]
+        self._right_arm_motors = [m for m in self._bus2.motors if m.startswith("right_arm")]
+        self._base_motors = [m for m in self._bus2.motors if m.startswith("base")]
+        self._wheel_names = ["base_left_wheel", "base_back_wheel", "base_right_wheel"]
+
+    @property
+    def connected(self) -> bool:
+        return self._connected
+
+    @property
+    def arms_enabled(self) -> bool:
+        return self._config.enable_arms
+
+    @property
+    def head_enabled(self) -> bool:
+        return self._config.enable_head
+
+    def connect(self) -> None:
+        """Connect to servo buses, load calibration, configure motors, and open camera."""
+        logger.info("Connecting XLeRobot...")
+        handshake = self._config.strict_handshake
+
+        if self._bus1 is not None:
+            logger.info(f"Connecting bus 1 on {self._config.port_bus1}")
+            self._bus1.connect(handshake=handshake)
+
+        logger.info(f"Connecting bus 2 on {self._config.port_bus2}")
+        self._bus2.connect(handshake=handshake)
+
+        if not handshake:
+            self._prune_missing_motors()
+
+        self._load_calibration()
+        self._configure_motors()
+        self._open_camera()
+
+        self._connected = True
+        logger.info("XLeRobot fully connected")
+
+    def _prune_missing_motors(self) -> None:
+        """Ping each motor; remove any that don't respond and update name lists."""
+        for label, bus in [("bus1", self._bus1), ("bus2", self._bus2)]:
+            if bus is None:
+                continue
+            missing = []
+            for name in list(bus.motors):
+                if bus.ping(name, num_retry=2) is None:
+                    missing.append(name)
+            if missing:
+                logger.warning(f"{label}: motors not found, disabling: {missing}")
+                for name in missing:
+                    del bus.motors[name]
+
+        self._left_arm_motors = [m for m in (self._bus1.motors if self._bus1 else {}) if m.startswith("left_arm")]
+        self._head_motors = [m for m in (self._bus1.motors if self._bus1 else {}) if m.startswith("head")]
+        self._right_arm_motors = [m for m in self._bus2.motors if m.startswith("right_arm")]
+        self._base_motors = [m for m in self._bus2.motors if m.startswith("base")]
+        self._wheel_names = [n for n in ["base_left_wheel", "base_back_wheel", "base_right_wheel"] if n in self._bus2.motors]
+
+    def _load_calibration(self) -> None:
+        """Load calibration from file if available."""
+        cal_path = self._resolve_calibration_path()
+        if cal_path is None or not cal_path.is_file():
+            if self._config.enable_arms or self._config.enable_head:
+                logger.warning(
+                    "No calibration file found. Arm/head positions may be inaccurate. "
+                    "Run `python -m dimos.robot.xlerobot.calibrate` to create one."
+                )
+            return
+
+        logger.info(f"Loading calibration from {cal_path}")
+        try:
+            with open(cal_path) as f:
+                cal_data = json.load(f)
+
+            if self._bus1 is not None:
+                bus1_cal = {
+                    k: MotorCalibration(**v) for k, v in cal_data.items() if k in self._bus1.motors
+                }
+                if bus1_cal:
+                    self._bus1.calibration = bus1_cal
+                    self._bus1.write_calibration(bus1_cal)
+
+            bus2_cal = {
+                k: MotorCalibration(**v) for k, v in cal_data.items() if k in self._bus2.motors
+            }
+            if bus2_cal:
+                self._bus2.calibration = bus2_cal
+                self._bus2.write_calibration(bus2_cal)
+
+            logger.info("Calibration loaded successfully")
+        except Exception as e:
+            logger.warning(f"Failed to load calibration: {e}")
+
+    def _resolve_calibration_path(self) -> Path | None:
+        if self._config.calibration_file:
+            return Path(self._config.calibration_file)
+        default = Path.home() / ".cache" / "xlerobot" / "calibration.json"
+        if default.is_file():
+            return default
+        return None
+
+    def _configure_motors(self) -> None:
+        """Set operating modes and PID for all motors."""
+        cfg = self._config
+
+        if self._bus1 is not None:
+            self._bus1.disable_torque()
+            self._bus1.configure_motors()
+            for name in self._left_arm_motors + self._head_motors:
+                self._bus1.write("Operating_Mode", name, OperatingMode.POSITION.value)
+                self._bus1.write("P_Coefficient", name, cfg.arm_p_coefficient)
+                self._bus1.write("I_Coefficient", name, cfg.arm_i_coefficient)
+                self._bus1.write("D_Coefficient", name, cfg.arm_d_coefficient)
+            self._bus1.enable_torque()
+
+        self._bus2.disable_torque()
+        self._bus2.configure_motors()
+        for name in self._right_arm_motors:
+            self._bus2.write("Operating_Mode", name, OperatingMode.POSITION.value)
+            self._bus2.write("P_Coefficient", name, cfg.arm_p_coefficient)
+            self._bus2.write("I_Coefficient", name, cfg.arm_i_coefficient)
+            self._bus2.write("D_Coefficient", name, cfg.arm_d_coefficient)
+        for name in self._base_motors:
+            self._bus2.write("Operating_Mode", name, OperatingMode.VELOCITY.value)
+        self._bus2.enable_torque()
+
+    def _open_camera(self) -> None:
+        self._camera = cv2.VideoCapture(self._config.camera_index)
+        if self._camera.isOpened():
+            self._camera.set(cv2.CAP_PROP_FRAME_WIDTH, self._config.camera_width)
+            self._camera.set(cv2.CAP_PROP_FRAME_HEIGHT, self._config.camera_height)
+            self._camera.set(cv2.CAP_PROP_FPS, self._config.camera_fps)
+            logger.info(f"Camera {self._config.camera_index} opened")
+        else:
+            logger.warning(f"Camera {self._config.camera_index} failed to open — vision disabled")
+            self._camera = None
+
+    # ---- Base movement ----
+
+    def _body_to_wheel_raw(self, x: float, y: float, theta_deg: float) -> dict[str, int]:
+        """Convert body-frame velocity to per-wheel raw commands."""
+        theta_rad = np.radians(theta_deg)
+        wheel_linear = self._kin_matrix.dot([x, y, theta_rad])
+        wheel_degps = np.degrees(wheel_linear / self._config.wheel_radius)
+
+        raw_abs = np.abs(wheel_degps) * (4096.0 / 360.0)
+        peak = raw_abs.max()
+        if peak > self._config.max_wheel_raw:
+            wheel_degps *= self._config.max_wheel_raw / peak
+
+        return {
+            name: _degps_to_raw(deg)
+            for name, deg in zip(self._wheel_names, wheel_degps)
+        }
+
+    def _wheel_raw_to_body(self, raw: dict[str, int]) -> dict[str, float]:
+        """Convert wheel feedback back to body-frame velocities."""
+        wheel_degps = np.array([_raw_to_degps(raw[n]) for n in self._wheel_names])
+        wheel_linear = np.radians(wheel_degps) * self._config.wheel_radius
+        body = self._kin_matrix_inv.dot(wheel_linear)
+        return {"x_vel": body[0], "y_vel": body[1], "theta_vel": np.degrees(body[2])}
+
+    def move(self, x: float = 0.0, y: float = 0.0, theta: float = 0.0) -> None:
+        """Send base velocity command.
+
+        Args:
+            x: forward m/s
+            y: lateral m/s (positive = left)
+            theta: rotation deg/s (positive = ccw)
+        """
+        if not self._wheel_names:
+            logger.warning("No wheel motors available — ignoring move command")
+            return
+        cmds = self._body_to_wheel_raw(x, y, theta)
+        cmds = {k: v for k, v in cmds.items() if k in self._wheel_names}
+        if cmds:
+            self._bus2.sync_write("Goal_Velocity", cmds)
+
+    def stop_base(self) -> None:
+        if not self._wheel_names:
+            return
+        self._bus2.sync_write(
+            "Goal_Velocity", dict.fromkeys(self._wheel_names, 0), num_retry=5
+        )
+
+    def read_wheel_velocities(self) -> dict[str, float]:
+        """Read current body-frame velocities from wheel encoders."""
+        if not self._base_motors:
+            return {"x_vel": 0.0, "y_vel": 0.0, "theta_vel": 0.0}
+        raw = self._bus2.sync_read("Present_Velocity", self._base_motors)
+        return self._wheel_raw_to_body(raw)
+
+    # ---- Arm control ----
+
+    def move_arm(self, arm: str, positions: dict[str, float]) -> None:
+        """Set arm joint position targets.
+
+        Args:
+            arm: "left" or "right"
+            positions: dict of joint_name -> target position value
+        """
+        if arm == "left":
+            if self._bus1 is None:
+                raise RuntimeError("Bus 1 not initialized — arms disabled")
+            goal = {k: v for k, v in positions.items() if k in self._left_arm_motors}
+            if self._config.max_relative_target is not None:
+                goal = self._clamp_arm_positions(self._bus1, goal, self._left_arm_motors)
+            if goal:
+                self._bus1.sync_write("Goal_Position", goal)
+        elif arm == "right":
+            goal = {k: v for k, v in positions.items() if k in self._right_arm_motors}
+            if self._config.max_relative_target is not None:
+                goal = self._clamp_arm_positions(self._bus2, goal, self._right_arm_motors)
+            if goal:
+                self._bus2.sync_write("Goal_Position", goal)
+        else:
+            raise ValueError(f"Unknown arm '{arm}', expected 'left' or 'right'")
+
+    def _clamp_arm_positions(
+        self, bus: FeetechMotorsBus, goal: dict[str, float], motor_names: list[str]
+    ) -> dict[str, float]:
+        """Clamp goal positions to be within max_relative_target of current."""
+        present = bus.sync_read("Present_Position", [m for m in motor_names if m in goal])
+        max_delta = self._config.max_relative_target
+        assert max_delta is not None
+        clamped = {}
+        for name, target in goal.items():
+            if name in present:
+                current = present[name]
+                delta = target - current
+                if abs(delta) > max_delta:
+                    delta = max_delta if delta > 0 else -max_delta
+                clamped[name] = current + delta
+            else:
+                clamped[name] = target
+        return clamped
+
+    def move_head(self, pan: float, tilt: float) -> None:
+        """Set head joint position targets.
+
+        Args:
+            pan: head_motor_1 target position
+            tilt: head_motor_2 target position
+        """
+        if self._bus1 is None:
+            raise RuntimeError("Bus 1 not initialized — head disabled")
+        goal = {"head_motor_1": pan, "head_motor_2": tilt}
+        if self._config.max_relative_target is not None:
+            goal = self._clamp_arm_positions(self._bus1, goal, self._head_motors)
+        self._bus1.sync_write("Goal_Position", goal)
+
+    def open_gripper(self, arm: str) -> None:
+        """Open the gripper on the specified arm (100 = fully open)."""
+        self._set_gripper(arm, 100.0)
+
+    def close_gripper(self, arm: str) -> None:
+        """Close the gripper on the specified arm (0 = fully closed)."""
+        self._set_gripper(arm, 0.0)
+
+    def _set_gripper(self, arm: str, value: float) -> None:
+        if arm == "left":
+            if self._bus1 is None:
+                raise RuntimeError("Bus 1 not initialized — arms disabled")
+            self._bus1.sync_write("Goal_Position", {"left_arm_gripper": value})
+        elif arm == "right":
+            self._bus2.sync_write("Goal_Position", {"right_arm_gripper": value})
+        else:
+            raise ValueError(f"Unknown arm '{arm}', expected 'left' or 'right'")
+
+    def read_joint_positions(self) -> dict[str, float]:
+        """Read current positions of all arm and head joints.
+
+        Returns:
+            Dict mapping joint name -> position value (14 entries max).
+        """
+        positions: dict[str, float] = {}
+        if self._bus1 is not None and self._left_arm_motors:
+            positions.update(self._bus1.sync_read("Present_Position", self._left_arm_motors))
+        if self._bus1 is not None and self._head_motors:
+            positions.update(self._bus1.sync_read("Present_Position", self._head_motors))
+        if self._right_arm_motors:
+            positions.update(self._bus2.sync_read("Present_Position", self._right_arm_motors))
+        return positions
+
+    def home_arms(self) -> None:
+        """Move all arm and head joints to zero position."""
+        if self._bus1 is not None:
+            zeros_bus1 = dict.fromkeys(self._left_arm_motors + self._head_motors, 0.0)
+            self._bus1.sync_write("Goal_Position", zeros_bus1)
+        if self._right_arm_motors:
+            zeros_bus2 = dict.fromkeys(self._right_arm_motors, 0.0)
+            self._bus2.sync_write("Goal_Position", zeros_bus2)
+
+    # ---- Full observation (mirrors XLerobot.get_observation) ----
+
+    def get_observation(self) -> dict[str, Any]:
+        """Read all 17 state features + camera frame.
+
+        Returns dict with keys like 'left_arm_shoulder_pan.pos', 'x.vel', etc.
+        """
+        obs: dict[str, Any] = {}
+
+        if self._bus1 is not None and self._left_arm_motors:
+            left_pos = self._bus1.sync_read("Present_Position", self._left_arm_motors)
+            obs.update({f"{k}.pos": v for k, v in left_pos.items()})
+
+        if self._bus1 is not None and self._head_motors:
+            head_pos = self._bus1.sync_read("Present_Position", self._head_motors)
+            obs.update({f"{k}.pos": v for k, v in head_pos.items()})
+
+        if self._right_arm_motors:
+            right_pos = self._bus2.sync_read("Present_Position", self._right_arm_motors)
+            obs.update({f"{k}.pos": v for k, v in right_pos.items()})
+
+        wheel_vel = self._bus2.sync_read("Present_Velocity", self._base_motors)
+        body_vel = self._wheel_raw_to_body(wheel_vel)
+        obs["x.vel"] = body_vel["x_vel"]
+        obs["y.vel"] = body_vel["y_vel"]
+        obs["theta.vel"] = body_vel["theta_vel"]
+
+        return obs
+
+    def send_action(self, action: dict[str, Any]) -> dict[str, Any]:
+        """Send a full action dict (mirrors XLerobot.send_action).
+
+        Arm/head keys ending in '.pos' set Goal_Position.
+        Velocity keys ('x.vel', 'y.vel', 'theta.vel') set wheel Goal_Velocity.
+        """
+        left_arm = {k.replace(".pos", ""): v for k, v in action.items()
+                     if k.startswith("left_arm_") and k.endswith(".pos")}
+        right_arm = {k.replace(".pos", ""): v for k, v in action.items()
+                      if k.startswith("right_arm_") and k.endswith(".pos")}
+        head = {k.replace(".pos", ""): v for k, v in action.items()
+                 if k.startswith("head_") and k.endswith(".pos")}
+        base_vel = {k: v for k, v in action.items() if k.endswith(".vel")}
+
+        if self._config.max_relative_target is not None:
+            if left_arm and self._bus1 is not None:
+                left_arm = self._clamp_arm_positions(self._bus1, left_arm, self._left_arm_motors)
+            if right_arm:
+                right_arm = self._clamp_arm_positions(self._bus2, right_arm, self._right_arm_motors)
+            if head and self._bus1 is not None:
+                head = self._clamp_arm_positions(self._bus1, head, self._head_motors)
+
+        if left_arm and self._bus1 is not None:
+            self._bus1.sync_write("Goal_Position", left_arm)
+        if head and self._bus1 is not None:
+            self._bus1.sync_write("Goal_Position", head)
+        if right_arm:
+            self._bus2.sync_write("Goal_Position", right_arm)
+
+        if base_vel:
+            wheel_cmds = self._body_to_wheel_raw(
+                base_vel.get("x.vel", 0.0),
+                base_vel.get("y.vel", 0.0),
+                base_vel.get("theta.vel", 0.0),
+            )
+            self._bus2.sync_write("Goal_Velocity", wheel_cmds)
+
+        return action
+
+    # ---- Camera ----
+
+    def read_camera(self) -> np.ndarray | None:
+        """Capture a single camera frame (BGR numpy array)."""
+        if self._camera is None:
+            return None
+        ret, frame = self._camera.read()
+        if ret:
+            with self._frame_lock:
+                self._latest_frame = frame
+            return frame
+        return None
+
+    @property
+    def latest_frame(self) -> np.ndarray | None:
+        with self._frame_lock:
+            return self._latest_frame
+
+    # ---- Lifecycle ----
+
+    def disconnect(self) -> None:
+        if not self._connected:
+            return
+
+        self.stop_base()
+
+        if self._config.enable_arms or self._config.enable_head:
+            if self._bus1 is not None:
+                self.home_arms()
+                time.sleep(0.5)
+                self._bus1.disconnect(self._config.disable_torque_on_disconnect)
+
+        self._bus2.disconnect(self._config.disable_torque_on_disconnect)
+
+        if self._camera is not None:
+            self._camera.release()
+
+        self._connected = False
+        logger.info("XLeRobot disconnected")

--- a/dimos/robot/xlerobot/connection.py
+++ b/dimos/robot/xlerobot/connection.py
@@ -14,18 +14,18 @@ Requires: pip install lerobot[feetech]
 from __future__ import annotations
 
 import json
-import logging
+from pathlib import Path
 import threading
 import time
-from pathlib import Path
 from typing import Any
 
 import cv2
 import numpy as np
 
 from dimos.robot.xlerobot.config import XLeRobotConfig
+from dimos.utils.logging_config import setup_logger
 
-logger = logging.getLogger(__name__)
+logger = setup_logger()
 
 try:
     from lerobot.motors import Motor, MotorCalibration, MotorNormMode
@@ -39,7 +39,7 @@ except ImportError:
 def _degps_to_raw(degps: float) -> int:
     """Convert degrees/sec to Feetech raw velocity ticks."""
     steps_per_deg = 4096.0 / 360.0
-    raw = int(round(degps * steps_per_deg))
+    raw = round(degps * steps_per_deg)
     return max(-0x8000, min(0x7FFF, raw))
 
 
@@ -96,6 +96,12 @@ class XLeRobotDriver:
         self._camera: cv2.VideoCapture | None = None
         self._latest_frame: np.ndarray | None = None
         self._frame_lock = threading.Lock()
+
+        # Serial buses are not re-entrant: the sensor thread, cmd_vel callback,
+        # and skill/RPC calls all share them, so every bus read/write is
+        # serialized through this lock. Reentrant so high-level ops (e.g.
+        # disconnect -> stop_base) can nest without deadlocking.
+        self._io_lock = threading.RLock()
 
         # Kinematics matrices (omni base)
         angles = np.radians(np.array([240, 0, 120]) - 90)
@@ -174,18 +180,20 @@ class XLeRobotDriver:
         logger.info("Connecting XLeRobot...")
         handshake = self._config.strict_handshake
 
-        if self._bus1 is not None:
-            logger.info(f"Connecting bus 1 on {self._config.port_bus1}")
-            self._bus1.connect(handshake=handshake)
+        with self._io_lock:
+            if self._bus1 is not None:
+                logger.info(f"Connecting bus 1 on {self._config.port_bus1}")
+                self._bus1.connect(handshake=handshake)
 
-        logger.info(f"Connecting bus 2 on {self._config.port_bus2}")
-        self._bus2.connect(handshake=handshake)
+            logger.info(f"Connecting bus 2 on {self._config.port_bus2}")
+            self._bus2.connect(handshake=handshake)
 
-        if not handshake:
-            self._prune_missing_motors()
+            if not handshake:
+                self._prune_missing_motors()
 
-        self._load_calibration()
-        self._configure_motors()
+            self._load_calibration()
+            self._configure_motors()
+
         self._open_camera()
 
         self._connected = True
@@ -290,8 +298,6 @@ class XLeRobotDriver:
             logger.warning(f"Camera {self._config.camera_index} failed to open — vision disabled")
             self._camera = None
 
-    # ---- Base movement ----
-
     def _body_to_wheel_raw(self, x: float, y: float, theta_deg: float) -> dict[str, int]:
         """Convert body-frame velocity to per-wheel raw commands."""
         theta_rad = np.radians(theta_deg)
@@ -305,11 +311,18 @@ class XLeRobotDriver:
 
         return {
             name: _degps_to_raw(deg)
-            for name, deg in zip(self._wheel_names, wheel_degps)
+            for name, deg in zip(self._wheel_names, wheel_degps, strict=True)
         }
 
     def _wheel_raw_to_body(self, raw: dict[str, int]) -> dict[str, float]:
-        """Convert wheel feedback back to body-frame velocities."""
+        """Convert wheel feedback back to body-frame velocities.
+
+        The omni-base forward kinematics require all three wheels; if any were
+        pruned (missing motor with strict_handshake=False) the 3x3 inverse can't
+        be applied, so report zero velocity rather than crashing the caller.
+        """
+        if len(self._wheel_names) != 3:
+            return {"x_vel": 0.0, "y_vel": 0.0, "theta_vel": 0.0}
         wheel_degps = np.array([_raw_to_degps(raw[n]) for n in self._wheel_names])
         wheel_linear = np.radians(wheel_degps) * self._config.wheel_radius
         body = self._kin_matrix_inv.dot(wheel_linear)
@@ -323,29 +336,30 @@ class XLeRobotDriver:
             y: lateral m/s (positive = left)
             theta: rotation deg/s (positive = ccw)
         """
-        if not self._wheel_names:
-            logger.warning("No wheel motors available — ignoring move command")
+        # Omni IK maps a body twist onto all three wheels; with any wheel
+        # pruned the mapping is ambiguous, so skip rather than drive blindly.
+        if len(self._wheel_names) != 3:
+            logger.warning("Need all 3 wheel motors to drive base — ignoring move command")
             return
         cmds = self._body_to_wheel_raw(x, y, theta)
-        cmds = {k: v for k, v in cmds.items() if k in self._wheel_names}
-        if cmds:
+        with self._io_lock:
             self._bus2.sync_write("Goal_Velocity", cmds)
 
     def stop_base(self) -> None:
         if not self._wheel_names:
             return
-        self._bus2.sync_write(
-            "Goal_Velocity", dict.fromkeys(self._wheel_names, 0), num_retry=5
-        )
+        with self._io_lock:
+            self._bus2.sync_write(
+                "Goal_Velocity", dict.fromkeys(self._wheel_names, 0), num_retry=5
+            )
 
     def read_wheel_velocities(self) -> dict[str, float]:
         """Read current body-frame velocities from wheel encoders."""
-        if not self._base_motors:
+        if len(self._wheel_names) != 3:
             return {"x_vel": 0.0, "y_vel": 0.0, "theta_vel": 0.0}
-        raw = self._bus2.sync_read("Present_Velocity", self._base_motors)
+        with self._io_lock:
+            raw = self._bus2.sync_read("Present_Velocity", self._base_motors)
         return self._wheel_raw_to_body(raw)
-
-    # ---- Arm control ----
 
     def move_arm(self, arm: str, positions: dict[str, float]) -> None:
         """Set arm joint position targets.
@@ -361,13 +375,15 @@ class XLeRobotDriver:
             if self._config.max_relative_target is not None:
                 goal = self._clamp_arm_positions(self._bus1, goal, self._left_arm_motors)
             if goal:
-                self._bus1.sync_write("Goal_Position", goal)
+                with self._io_lock:
+                    self._bus1.sync_write("Goal_Position", goal)
         elif arm == "right":
             goal = {k: v for k, v in positions.items() if k in self._right_arm_motors}
             if self._config.max_relative_target is not None:
                 goal = self._clamp_arm_positions(self._bus2, goal, self._right_arm_motors)
             if goal:
-                self._bus2.sync_write("Goal_Position", goal)
+                with self._io_lock:
+                    self._bus2.sync_write("Goal_Position", goal)
         else:
             raise ValueError(f"Unknown arm '{arm}', expected 'left' or 'right'")
 
@@ -375,7 +391,8 @@ class XLeRobotDriver:
         self, bus: FeetechMotorsBus, goal: dict[str, float], motor_names: list[str]
     ) -> dict[str, float]:
         """Clamp goal positions to be within max_relative_target of current."""
-        present = bus.sync_read("Present_Position", [m for m in motor_names if m in goal])
+        with self._io_lock:
+            present = bus.sync_read("Present_Position", [m for m in motor_names if m in goal])
         max_delta = self._config.max_relative_target
         assert max_delta is not None
         clamped = {}
@@ -402,7 +419,8 @@ class XLeRobotDriver:
         goal = {"head_motor_1": pan, "head_motor_2": tilt}
         if self._config.max_relative_target is not None:
             goal = self._clamp_arm_positions(self._bus1, goal, self._head_motors)
-        self._bus1.sync_write("Goal_Position", goal)
+        with self._io_lock:
+            self._bus1.sync_write("Goal_Position", goal)
 
     def open_gripper(self, arm: str) -> None:
         """Open the gripper on the specified arm (100 = fully open)."""
@@ -416,9 +434,11 @@ class XLeRobotDriver:
         if arm == "left":
             if self._bus1 is None:
                 raise RuntimeError("Bus 1 not initialized — arms disabled")
-            self._bus1.sync_write("Goal_Position", {"left_arm_gripper": value})
+            with self._io_lock:
+                self._bus1.sync_write("Goal_Position", {"left_arm_gripper": value})
         elif arm == "right":
-            self._bus2.sync_write("Goal_Position", {"right_arm_gripper": value})
+            with self._io_lock:
+                self._bus2.sync_write("Goal_Position", {"right_arm_gripper": value})
         else:
             raise ValueError(f"Unknown arm '{arm}', expected 'left' or 'right'")
 
@@ -429,24 +449,24 @@ class XLeRobotDriver:
             Dict mapping joint name -> position value (14 entries max).
         """
         positions: dict[str, float] = {}
-        if self._bus1 is not None and self._left_arm_motors:
-            positions.update(self._bus1.sync_read("Present_Position", self._left_arm_motors))
-        if self._bus1 is not None and self._head_motors:
-            positions.update(self._bus1.sync_read("Present_Position", self._head_motors))
-        if self._right_arm_motors:
-            positions.update(self._bus2.sync_read("Present_Position", self._right_arm_motors))
+        with self._io_lock:
+            if self._bus1 is not None and self._left_arm_motors:
+                positions.update(self._bus1.sync_read("Present_Position", self._left_arm_motors))
+            if self._bus1 is not None and self._head_motors:
+                positions.update(self._bus1.sync_read("Present_Position", self._head_motors))
+            if self._right_arm_motors:
+                positions.update(self._bus2.sync_read("Present_Position", self._right_arm_motors))
         return positions
 
     def home_arms(self) -> None:
         """Move all arm and head joints to zero position."""
-        if self._bus1 is not None:
-            zeros_bus1 = dict.fromkeys(self._left_arm_motors + self._head_motors, 0.0)
-            self._bus1.sync_write("Goal_Position", zeros_bus1)
-        if self._right_arm_motors:
-            zeros_bus2 = dict.fromkeys(self._right_arm_motors, 0.0)
-            self._bus2.sync_write("Goal_Position", zeros_bus2)
-
-    # ---- Full observation (mirrors XLerobot.get_observation) ----
+        with self._io_lock:
+            if self._bus1 is not None:
+                zeros_bus1 = dict.fromkeys(self._left_arm_motors + self._head_motors, 0.0)
+                self._bus1.sync_write("Goal_Position", zeros_bus1)
+            if self._right_arm_motors:
+                zeros_bus2 = dict.fromkeys(self._right_arm_motors, 0.0)
+                self._bus2.sync_write("Goal_Position", zeros_bus2)
 
     def get_observation(self) -> dict[str, Any]:
         """Read all 17 state features + camera frame.
@@ -455,20 +475,20 @@ class XLeRobotDriver:
         """
         obs: dict[str, Any] = {}
 
-        if self._bus1 is not None and self._left_arm_motors:
-            left_pos = self._bus1.sync_read("Present_Position", self._left_arm_motors)
-            obs.update({f"{k}.pos": v for k, v in left_pos.items()})
+        with self._io_lock:
+            if self._bus1 is not None and self._left_arm_motors:
+                left_pos = self._bus1.sync_read("Present_Position", self._left_arm_motors)
+                obs.update({f"{k}.pos": v for k, v in left_pos.items()})
 
-        if self._bus1 is not None and self._head_motors:
-            head_pos = self._bus1.sync_read("Present_Position", self._head_motors)
-            obs.update({f"{k}.pos": v for k, v in head_pos.items()})
+            if self._bus1 is not None and self._head_motors:
+                head_pos = self._bus1.sync_read("Present_Position", self._head_motors)
+                obs.update({f"{k}.pos": v for k, v in head_pos.items()})
 
-        if self._right_arm_motors:
-            right_pos = self._bus2.sync_read("Present_Position", self._right_arm_motors)
-            obs.update({f"{k}.pos": v for k, v in right_pos.items()})
+            if self._right_arm_motors:
+                right_pos = self._bus2.sync_read("Present_Position", self._right_arm_motors)
+                obs.update({f"{k}.pos": v for k, v in right_pos.items()})
 
-        wheel_vel = self._bus2.sync_read("Present_Velocity", self._base_motors)
-        body_vel = self._wheel_raw_to_body(wheel_vel)
+        body_vel = self.read_wheel_velocities()
         obs["x.vel"] = body_vel["x_vel"]
         obs["y.vel"] = body_vel["y_vel"]
         obs["theta.vel"] = body_vel["theta_vel"]
@@ -497,24 +517,23 @@ class XLeRobotDriver:
             if head and self._bus1 is not None:
                 head = self._clamp_arm_positions(self._bus1, head, self._head_motors)
 
-        if left_arm and self._bus1 is not None:
-            self._bus1.sync_write("Goal_Position", left_arm)
-        if head and self._bus1 is not None:
-            self._bus1.sync_write("Goal_Position", head)
-        if right_arm:
-            self._bus2.sync_write("Goal_Position", right_arm)
+        with self._io_lock:
+            if left_arm and self._bus1 is not None:
+                self._bus1.sync_write("Goal_Position", left_arm)
+            if head and self._bus1 is not None:
+                self._bus1.sync_write("Goal_Position", head)
+            if right_arm:
+                self._bus2.sync_write("Goal_Position", right_arm)
 
-        if base_vel:
-            wheel_cmds = self._body_to_wheel_raw(
-                base_vel.get("x.vel", 0.0),
-                base_vel.get("y.vel", 0.0),
-                base_vel.get("theta.vel", 0.0),
-            )
-            self._bus2.sync_write("Goal_Velocity", wheel_cmds)
+            if base_vel and len(self._wheel_names) == 3:
+                wheel_cmds = self._body_to_wheel_raw(
+                    base_vel.get("x.vel", 0.0),
+                    base_vel.get("y.vel", 0.0),
+                    base_vel.get("theta.vel", 0.0),
+                )
+                self._bus2.sync_write("Goal_Velocity", wheel_cmds)
 
         return action
-
-    # ---- Camera ----
 
     def read_camera(self) -> np.ndarray | None:
         """Capture a single camera frame (BGR numpy array)."""
@@ -532,21 +551,20 @@ class XLeRobotDriver:
         with self._frame_lock:
             return self._latest_frame
 
-    # ---- Lifecycle ----
-
     def disconnect(self) -> None:
         if not self._connected:
             return
 
         self.stop_base()
 
-        if self._config.enable_arms or self._config.enable_head:
-            if self._bus1 is not None:
-                self.home_arms()
-                time.sleep(0.5)
-                self._bus1.disconnect(self._config.disable_torque_on_disconnect)
+        with self._io_lock:
+            if self._config.enable_arms or self._config.enable_head:
+                if self._bus1 is not None:
+                    self.home_arms()
+                    time.sleep(0.5)
+                    self._bus1.disconnect(self._config.disable_torque_on_disconnect)
 
-        self._bus2.disconnect(self._config.disable_torque_on_disconnect)
+            self._bus2.disconnect(self._config.disable_torque_on_disconnect)
 
         if self._camera is not None:
             self._camera.release()

--- a/dimos/robot/xlerobot/connection_spec.py
+++ b/dimos/robot/xlerobot/connection_spec.py
@@ -1,0 +1,33 @@
+"""XLeRobot connection spec for dependency injection."""
+
+from typing import Protocol
+
+from dimos.spec.utils import Spec
+
+
+class XLeRobotSpec(Spec, Protocol):
+    """Protocol defining the full XLeRobot connection interface."""
+
+    def move_base(
+        self,
+        x: float = 0.0,
+        y: float = 0.0,
+        theta: float = 0.0,
+        duration: float = 0.0,
+    ) -> str: ...
+
+    def stop_base(self) -> str: ...
+
+    def move_arm(self, arm: str, joint_positions: str, duration: float = 1.0) -> str: ...
+
+    def move_head(self, pan: float, tilt: float) -> str: ...
+
+    def open_gripper(self, arm: str) -> str: ...
+
+    def close_gripper(self, arm: str) -> str: ...
+
+    def get_joint_positions(self) -> str: ...
+
+    def home_arms(self) -> str: ...
+
+    def observe(self) -> object: ...

--- a/dimos/robot/xlerobot/xlerobot_module.py
+++ b/dimos/robot/xlerobot/xlerobot_module.py
@@ -1,0 +1,411 @@
+"""DimOS module for XLeRobot — full mobile manipulator.
+
+Exposes the XLeRobot as a DimOS Module with:
+  - cmd_vel input for velocity commands (Twist)
+  - color_image output for camera frames
+  - odom output for dead-reckoning odometry
+  - joint_states output for arm/head joint positions
+  - Skills: move_base, stop_base, observe, move_arm, move_head,
+            open_gripper, close_gripper, get_joint_positions, home_arms
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import threading
+import time
+from typing import Any
+
+import numpy as np
+from reactivex.disposable import Disposable
+
+from dimos.agents.annotation import skill
+from dimos.constants import DEFAULT_THREAD_JOIN_TIMEOUT
+from dimos.core.core import rpc
+from dimos.core.module import Module
+from dimos.core.stream import In, Out
+from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
+from dimos.msgs.geometry_msgs.Quaternion import Quaternion
+from dimos.msgs.geometry_msgs.Transform import Transform
+from dimos.msgs.geometry_msgs.Twist import Twist
+from dimos.msgs.geometry_msgs.Vector3 import Vector3
+from dimos.msgs.sensor_msgs.Image import Image
+from dimos.msgs.sensor_msgs.JointState import JointState
+from dimos.robot.xlerobot.config import XLeRobotConfig
+from dimos.robot.xlerobot.connection import XLeRobotDriver
+from dimos.spec.perception import Camera
+
+logger = logging.getLogger(__name__)
+
+
+class XLeRobotConnection(Module):
+    """DimOS module wrapping the full XLeRobot: omni base, dual arms, head, camera."""
+
+    config: XLeRobotConfig
+
+    # Inputs
+    cmd_vel: In[Twist]
+
+    # Outputs
+    color_image: Out[Image]
+    odom: Out[PoseStamped]
+    joint_states: Out[JointState]
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._driver: XLeRobotDriver | None = None
+        self._latest_image: Image | None = None
+        self._running = False
+        self._sensor_thread: threading.Thread | None = None
+        self._recording: bool = False
+        self._record_path: str | None = None
+        self._record_data: list[dict[str, Any]] = []
+
+        # Dead-reckoning state
+        self._pose_x = 0.0
+        self._pose_y = 0.0
+        self._pose_theta = 0.0
+        self._last_odom_time: float | None = None
+
+    @rpc
+    def start(self) -> None:
+        """Connect to XLeRobot hardware and start sensor streaming."""
+        super().start()
+        self._driver = XLeRobotDriver(self.config)
+
+        try:
+            self._driver.connect()
+        except Exception as e:
+            logger.error(f"Failed to connect to XLeRobot hardware: {e}")
+            logger.error(
+                "Check that serial ports are correct and the robot is powered on. "
+                f"Bus 1: {self.config.port_bus1}, Bus 2: {self.config.port_bus2}"
+            )
+            self._driver = None
+            return
+
+        # Subscribe cmd_vel → move
+        if self.cmd_vel.transport:
+            self.register_disposable(Disposable(self.cmd_vel.subscribe(self._on_cmd_vel)))
+
+        # Start sensor polling thread
+        self._running = True
+        self._sensor_thread = threading.Thread(target=self._sensor_loop, daemon=True)
+        self._sensor_thread.start()
+
+        logger.info("XLeRobotConnection started")
+
+    def _on_cmd_vel(self, twist: Twist) -> None:
+        if self._driver and self._driver.connected:
+            self._driver.move(
+                x=twist.linear.x,
+                y=twist.linear.y,
+                theta=math.degrees(twist.angular.z),
+            )
+
+    def _sensor_loop(self) -> None:
+        """Poll camera, wheel encoders, and joint states at ~20 Hz."""
+        while self._running:
+            try:
+                if self._driver and self._driver.connected:
+                    self._update_camera()
+                    self._update_odom()
+                    self._update_joint_states()
+                time.sleep(0.05)
+            except Exception as e:
+                logger.debug(f"Sensor loop error: {e}")
+                time.sleep(0.1)
+
+    def _update_camera(self) -> None:
+        assert self._driver is not None
+        frame = self._driver.read_camera()
+        if frame is not None:
+            img = Image(
+                data=frame,
+                height=frame.shape[0],
+                width=frame.shape[1],
+                encoding="bgr8",
+            )
+            self._latest_image = img
+            self.color_image.publish(img)
+
+    def _update_odom(self) -> None:
+        assert self._driver is not None
+        now = time.time()
+        if self._last_odom_time is None:
+            self._last_odom_time = now
+            return
+
+        dt = now - self._last_odom_time
+        self._last_odom_time = now
+
+        vels = self._driver.read_wheel_velocities()
+        vx = vels["x_vel"]
+        vy = vels["y_vel"]
+        vtheta = math.radians(vels["theta_vel"])
+
+        cos_t = math.cos(self._pose_theta)
+        sin_t = math.sin(self._pose_theta)
+        self._pose_x += (vx * cos_t - vy * sin_t) * dt
+        self._pose_y += (vx * sin_t + vy * cos_t) * dt
+        self._pose_theta += vtheta * dt
+
+        half = self._pose_theta / 2.0
+        qz = math.sin(half)
+        qw = math.cos(half)
+
+        pose = PoseStamped(
+            position=Vector3(self._pose_x, self._pose_y, 0.0),
+            orientation=Quaternion(0.0, 0.0, qz, qw),
+            frame_id="odom",
+            ts=now,
+        )
+        self.odom.publish(pose)
+
+        self.tf.publish(
+            Transform(
+                translation=Vector3(self._pose_x, self._pose_y, 0.0),
+                rotation=Quaternion(0.0, 0.0, qz, qw),
+                frame_id="odom",
+                child_frame_id="base_link",
+                ts=now,
+            )
+        )
+
+    def _update_joint_states(self) -> None:
+        """Publish arm + head joint positions as a JointState message."""
+        assert self._driver is not None
+        if not self._driver.arms_enabled and not self._driver.head_enabled:
+            return
+
+        try:
+            positions = self._driver.read_joint_positions()
+        except Exception:
+            return
+
+        if not positions:
+            return
+
+        names = list(positions.keys())
+        pos_values = [float(positions[n]) for n in names]
+
+        js = JointState(
+            ts=time.time(),
+            frame_id="base_link",
+            name=names,
+            position=pos_values,
+            velocity=[0.0] * len(names),
+            effort=[0.0] * len(names),
+        )
+        self.joint_states.publish(js)
+
+        if self._recording:
+            self._record_data.append({
+                "ts": js.ts,
+                "joint_positions": dict(zip(names, pos_values)),
+            })
+
+    # ---- Skills (exposed to MCP / agent) ----
+
+    @skill
+    def observe(self) -> Image | None:
+        """Return the latest camera frame from the XLeRobot's head camera."""
+        return self._latest_image
+
+    @skill
+    def move_base(
+        self,
+        x: float = 0.0,
+        y: float = 0.0,
+        theta: float = 0.0,
+        duration: float = 0.0,
+    ) -> str:
+        """Drive the XLeRobot base.
+
+        Args:
+            x: forward speed in m/s (positive = forward)
+            y: lateral speed in m/s (positive = left)
+            theta: rotation speed in deg/s (positive = counter-clockwise)
+            duration: seconds to move (0 = send single command)
+        """
+        if not self._driver or not self._driver.connected:
+            return "Not connected"
+
+        self._driver.move(x, y, theta)
+        if duration > 0:
+            time.sleep(duration)
+            self._driver.stop_base()
+            return f"Moved for {duration:.1f}s then stopped"
+        return "Velocity command sent"
+
+    @skill
+    def stop_base(self) -> str:
+        """Emergency stop — zero all wheel velocities."""
+        if self._driver and self._driver.connected:
+            self._driver.stop_base()
+            return "Base stopped"
+        return "Not connected"
+
+    @skill
+    def move_arm(self, arm: str, joint_positions: str, duration: float = 1.0) -> str:
+        """Move an arm to target joint positions.
+
+        Args:
+            arm: which arm to move, either "left" or "right"
+            joint_positions: JSON string mapping joint names to target values, e.g. '{"left_arm_shoulder_pan": 45.0}'
+            duration: time to wait for motion to complete in seconds
+        """
+        if not self._driver or not self._driver.connected:
+            return "Not connected"
+        if not self._driver.arms_enabled:
+            return "Arms are disabled in config"
+
+        try:
+            positions = json.loads(joint_positions) if isinstance(joint_positions, str) else joint_positions
+        except json.JSONDecodeError as e:
+            return f"Invalid joint_positions JSON: {e}"
+
+        try:
+            self._driver.move_arm(arm, positions)
+            if duration > 0:
+                time.sleep(duration)
+            return f"Moved {arm} arm to target positions"
+        except Exception as e:
+            return f"Failed to move {arm} arm: {e}"
+
+    @skill
+    def move_head(self, pan: float, tilt: float) -> str:
+        """Move the head to look in a direction.
+
+        Args:
+            pan: head_motor_1 target position (horizontal rotation)
+            tilt: head_motor_2 target position (vertical rotation)
+        """
+        if not self._driver or not self._driver.connected:
+            return "Not connected"
+        if not self._driver.head_enabled:
+            return "Head is disabled in config"
+
+        try:
+            self._driver.move_head(pan, tilt)
+            return f"Head moved to pan={pan:.1f}, tilt={tilt:.1f}"
+        except Exception as e:
+            return f"Failed to move head: {e}"
+
+    @skill
+    def open_gripper(self, arm: str) -> str:
+        """Open the gripper on the specified arm.
+
+        Args:
+            arm: which gripper to open, either "left" or "right"
+        """
+        if not self._driver or not self._driver.connected:
+            return "Not connected"
+        if not self._driver.arms_enabled:
+            return "Arms are disabled in config"
+
+        try:
+            self._driver.open_gripper(arm)
+            return f"{arm.capitalize()} gripper opened"
+        except Exception as e:
+            return f"Failed to open {arm} gripper: {e}"
+
+    @skill
+    def close_gripper(self, arm: str) -> str:
+        """Close the gripper on the specified arm.
+
+        Args:
+            arm: which gripper to close, either "left" or "right"
+        """
+        if not self._driver or not self._driver.connected:
+            return "Not connected"
+        if not self._driver.arms_enabled:
+            return "Arms are disabled in config"
+
+        try:
+            self._driver.close_gripper(arm)
+            return f"{arm.capitalize()} gripper closed"
+        except Exception as e:
+            return f"Failed to close {arm} gripper: {e}"
+
+    @skill
+    def get_joint_positions(self) -> str:
+        """Return all arm and head joint positions as a JSON string."""
+        if not self._driver or not self._driver.connected:
+            return "Not connected"
+
+        try:
+            positions = self._driver.read_joint_positions()
+            return json.dumps(positions, indent=2)
+        except Exception as e:
+            return f"Failed to read joints: {e}"
+
+    @skill
+    def home_arms(self) -> str:
+        """Move both arms and head to their zero (home) position."""
+        if not self._driver or not self._driver.connected:
+            return "Not connected"
+        if not self._driver.arms_enabled:
+            return "Arms are disabled in config"
+
+        try:
+            self._driver.home_arms()
+            time.sleep(2.0)
+            return "Arms and head moved to home position"
+        except Exception as e:
+            return f"Failed to home arms: {e}"
+
+    # ---- @rpc methods ----
+
+    @rpc
+    def record(self, name: str) -> str:
+        """Start recording camera + joint states to disk.
+
+        Args:
+            name: recording session name (used as subdirectory)
+        """
+        from pathlib import Path
+
+        record_dir = Path.home() / ".cache" / "xlerobot" / "recordings" / name
+        record_dir.mkdir(parents=True, exist_ok=True)
+        self._record_path = str(record_dir)
+        self._record_data = []
+        self._recording = True
+        logger.info(f"Recording started: {self._record_path}")
+        return f"Recording to {self._record_path}"
+
+    @rpc
+    def stop_recording(self) -> str:
+        """Stop recording and save data to disk."""
+        if not self._recording:
+            return "Not recording"
+
+        self._recording = False
+        if self._record_path and self._record_data:
+            from pathlib import Path
+
+            out = Path(self._record_path) / "joint_states.json"
+            with open(out, "w") as f:
+                json.dump(self._record_data, f, indent=2)
+            count = len(self._record_data)
+            self._record_data = []
+            return f"Saved {count} frames to {out}"
+        return "No data recorded"
+
+    @rpc
+    def stop(self) -> None:
+        """Stop the module and disconnect hardware."""
+        self._running = False
+        if self._sensor_thread and self._sensor_thread.is_alive():
+            self._sensor_thread.join(timeout=DEFAULT_THREAD_JOIN_TIMEOUT)
+
+        if self._recording:
+            self.stop_recording()
+
+        if self._driver and self._driver.connected:
+            self._driver.disconnect()
+
+        logger.info("XLeRobotConnection stopped")
+        super().stop()

--- a/dimos/robot/xlerobot/xlerobot_module.py
+++ b/dimos/robot/xlerobot/xlerobot_module.py
@@ -12,13 +12,11 @@ Exposes the XLeRobot as a DimOS Module with:
 from __future__ import annotations
 
 import json
-import logging
 import math
 import threading
 import time
 from typing import Any
 
-import numpy as np
 from reactivex.disposable import Disposable
 
 from dimos.agents.annotation import skill
@@ -31,13 +29,13 @@ from dimos.msgs.geometry_msgs.Quaternion import Quaternion
 from dimos.msgs.geometry_msgs.Transform import Transform
 from dimos.msgs.geometry_msgs.Twist import Twist
 from dimos.msgs.geometry_msgs.Vector3 import Vector3
-from dimos.msgs.sensor_msgs.Image import Image
+from dimos.msgs.sensor_msgs.Image import Image, ImageFormat
 from dimos.msgs.sensor_msgs.JointState import JointState
 from dimos.robot.xlerobot.config import XLeRobotConfig
 from dimos.robot.xlerobot.connection import XLeRobotDriver
-from dimos.spec.perception import Camera
+from dimos.utils.logging_config import setup_logger
 
-logger = logging.getLogger(__name__)
+logger = setup_logger()
 
 
 class XLeRobotConnection(Module):
@@ -122,12 +120,7 @@ class XLeRobotConnection(Module):
         assert self._driver is not None
         frame = self._driver.read_camera()
         if frame is not None:
-            img = Image(
-                data=frame,
-                height=frame.shape[0],
-                width=frame.shape[1],
-                encoding="bgr8",
-            )
+            img = Image.from_numpy(frame, format=ImageFormat.BGR, frame_id="head_camera")
             self._latest_image = img
             self.color_image.publish(img)
 
@@ -204,10 +197,8 @@ class XLeRobotConnection(Module):
         if self._recording:
             self._record_data.append({
                 "ts": js.ts,
-                "joint_positions": dict(zip(names, pos_values)),
+                "joint_positions": dict(zip(names, pos_values, strict=True)),
             })
-
-    # ---- Skills (exposed to MCP / agent) ----
 
     @skill
     def observe(self) -> Image | None:
@@ -356,8 +347,6 @@ class XLeRobotConnection(Module):
             return "Arms and head moved to home position"
         except Exception as e:
             return f"Failed to home arms: {e}"
-
-    # ---- @rpc methods ----
 
     @rpc
     def record(self, name: str) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -338,7 +338,7 @@ apriltag = [
 ]
 
 all = [
-    "dimos[agents,apriltag,base,cpu,cuda,drone,manipulation,misc,perception,psql,sim,unitree,visualization,web]",
+    "dimos[agents,apriltag,base,cpu,cuda,drone,manipulation,misc,perception,psql,sim,unitree,visualization,web,xlerobot]",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -319,6 +319,10 @@ drone = [
     "pymavlink"
 ]
 
+xlerobot = [
+    "lerobot[feetech]",
+]
+
 dds = [
     "cyclonedds>=0.10.5",
 ]


### PR DESCRIPTION
## Summary

Adds full DimOS integration for the [XLeRobot](https://github.com/XUANMO-REN/XLeRobot) mobile manipulator — a 3-wheel omni-directional base with dual 6-DOF Feetech STS3215 arms and a 2-DOF head (17 DOF total).

- **Hardware driver** (`connection.py`): dual serial bus control, omni-wheel IK/FK, position-mode arms with safety clamping, velocity-mode wheels, USB camera, calibration loading, macOS + Linux serial port auto-detection
- **DimOS module** (`xlerobot_module.py`): cmd_vel input, color_image/odom/joint_states outputs, 20 Hz sensor loop, dead-reckoning odometry, 9 skills (move_base, stop_base, move_arm, move_head, open/close_gripper, get_joint_positions, home_arms, observe)
- **Blueprints**: `xlerobot-basic` (connection + camera + Rerun viz) and `xlerobot-agentic` (+ MCP server/client for LLM agent control)
- **Calibration script**: `python -m dimos.robot.xlerobot.calibrate` — interactive calibration for arm/head servos
- **Optional dep**: `dimos[xlerobot]` installs `lerobot[feetech]`

### Hardware specs
| Component | Details |
|---|---|
| Base | 3× omni wheels (velocity mode) |
| Left arm | 6 DOF + gripper (bus 1, position mode) |
| Right arm | 6 DOF + gripper (bus 2, position mode) |
| Head | 2 DOF pan/tilt (bus 1, position mode) |
| Camera | USB webcam (640×480 @ 30fps default) |
| Servos | Feetech STS3215 on both buses |

### macOS support
Serial ports auto-detect platform: `/dev/cu.usbmodem*` on macOS vs `/dev/ttyACM*` on Linux. The `pSHMTransport` workaround is applied on Darwin (same pattern as existing Go2 blueprints).

## Test plan
- [ ] `xlerobot-basic` and `xlerobot-agentic` appear in `all_blueprints` after running the generation test
- [ ] `dimos[xlerobot]` resolves `lerobot[feetech]` correctly
- [ ] Module starts without hardware (graceful error logging)
- [ ] With hardware: base movement, arm control, camera feed, and calibration script work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)