### PR TITLE
feat(config): redact secret-looking fields in GlobalConfig dumps

### DIFF
--- a/dimos/core/global_config.py
+++ b/dimos/core/global_config.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import Iterable
 import re
+from typing import Any
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -28,6 +30,16 @@ from dimos.visualization.rerun.constants import (
 
 def _get_all_numbers(s: str) -> list[float]:
     return [float(x) for x in re.findall(r"-?\d+\.?\d*", s)]
+
+
+# Field names whose values must never be printed/serialized in the clear:
+# anything containing "_secret" or "token", or ending in "_key".
+_SECRET_KEY_RE = re.compile(r"_secret|token|_key$", re.IGNORECASE)
+_REDACTED = "***"
+
+
+def _is_secret_key(name: str) -> bool:
+    return _SECRET_KEY_RE.search(name) is not None
 
 
 class GlobalConfig(BaseSettings):
@@ -81,6 +93,19 @@ class GlobalConfig(BaseSettings):
             if not hasattr(self, key):
                 raise AttributeError(f"GlobalConfig has no field '{key}'")
             setattr(self, key, value)
+
+    def model_dump(self, **kwargs: Any) -> dict[str, Any]:
+        """Dump fields with secret-looking values redacted."""
+        return {
+            k: (_REDACTED if v is not None and _is_secret_key(k) else v)
+            for k, v in super().model_dump(**kwargs).items()
+        }
+
+    def __repr_args__(self) -> Iterable[tuple[str | None, Any]]:
+        return [
+            (k, _REDACTED if v is not None and k and _is_secret_key(k) else v)
+            for k, v in super().__repr_args__()
+        ]
 
     @property
     def unitree_connection_type(self) -> str:


### PR DESCRIPTION
## What

`GlobalConfig.model_dump()` and `repr()` now redact values of fields whose name looks secret — contains `_secret` or `token`, or ends in `_key` — replacing non-`None` values with `***`.

This keeps secrets out of `dimos show-config` output and any place a config is logged/repr'd. Matching is by field-name pattern, so future secret fields (or env-injected extras) are masked automatically. False positives (e.g. `tokenizer`) are acceptable — over-censoring is the safe direction.

## How to test

```bash
python - <<'PY'
from dimos.core.global_config import GlobalConfig

class C(GlobalConfig):
    api_key: str = "AKIA-secret"
    access_token: str = "tok_abc"
    client_secret: str = "shh"

c = C()
d = c.model_dump()
assert d["api_key"] == d["access_token"] == d["client_secret"] == "***"
assert "AKIA" not in repr(c) and "tok_abc" not in repr(c)
print("ok")
PY
```

Also: `dimos show-config` shows `***` for any secret-named field; `None` and non-secret fields are unchanged.

Existing `dimos/core/test_global_config.py` passes; `mypy dimos/core/global_config.py` clean.