### PR TITLE
refactor(viz): drop shared costmap_to_rerun, inline per-robot costmap converters

### DIFF
--- a/dimos/mapping/costmapper.py
+++ b/dimos/mapping/costmapper.py
@@ -14,7 +14,6 @@
 
 from dataclasses import asdict
 import time
-from typing import Any
 
 import numpy as np
 from pydantic import Field
@@ -33,27 +32,6 @@ from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
 from dimos.utils.logging_config import setup_logger
 
 logger = setup_logger()
-
-_COLOR_UNKNOWN = (0, 0, 0, 0)
-_COLOR_FREE = (72, 73, 129, 255)
-_COLOR_OCCUPIED = (255, 140, 0, 255)
-_COLOR_LETHAL = (220, 30, 30, 255)
-
-# Indexed by grid value + 1: 0 = unknown, 1 = free, 2..101 = cost 1..100.
-_COSTMAP_COLOR_LOOKUP_TABLE = np.empty((102, 4), dtype=np.uint8)
-_COSTMAP_COLOR_LOOKUP_TABLE[0] = _COLOR_UNKNOWN
-_COSTMAP_COLOR_LOOKUP_TABLE[1] = _COLOR_FREE
-_COSTMAP_COLOR_LOOKUP_TABLE[2:101] = _COLOR_OCCUPIED
-_COSTMAP_COLOR_LOOKUP_TABLE[101] = _COLOR_LETHAL
-
-_COSTMAP_Z_OFFSET = 0.02
-
-
-def costmap_to_rerun(grid: OccupancyGrid) -> Any:
-    return grid.to_rerun(
-        color_lookup_table=_COSTMAP_COLOR_LOOKUP_TABLE,
-        z_offset=_COSTMAP_Z_OFFSET,
-    )
 
 
 class Config(ModuleConfig):

--- a/dimos/robot/unitree/g1/blueprints/primitive/unitree_g1_primitive_no_nav.py
+++ b/dimos/robot/unitree/g1/blueprints/primitive/unitree_g1_primitive_no_nav.py
@@ -25,7 +25,7 @@ from dimos.core.transport import LCMTransport
 from dimos.hardware.sensors.camera.module import CameraModule
 from dimos.hardware.sensors.camera.webcam import Webcam
 from dimos.hardware.sensors.camera.zed import compat as zed
-from dimos.mapping.costmapper import CostMapper, costmap_to_rerun
+from dimos.mapping.costmapper import CostMapper
 from dimos.mapping.voxels import VoxelGridMapper
 from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
 from dimos.msgs.geometry_msgs.Quaternion import Quaternion
@@ -40,6 +40,7 @@ from dimos.msgs.std_msgs.Bool import Bool
 from dimos.navigation.frontier_exploration.wavefront_frontier_goal_selector import (
     WavefrontFrontierExplorer,
 )
+from dimos.robot.unitree.g1.g1_rerun import g1_costmap
 from dimos.visualization.vis_module import vis_module
 
 
@@ -86,7 +87,7 @@ rerun_config = {
     "blueprint": _g1_rerun_blueprint,
     "visual_override": {
         "world/camera_info": _convert_camera_info,
-        "world/navigation_costmap": costmap_to_rerun,
+        "world/navigation_costmap": g1_costmap,
     },
     "static": {
         "world/tf/base_link": _static_base_link,

--- a/dimos/robot/unitree/g1/blueprints/primitive/unitree_g1_vis.py
+++ b/dimos/robot/unitree/g1/blueprints/primitive/unitree_g1_vis.py
@@ -20,10 +20,9 @@ from typing import Any
 import rerun as rr
 
 from dimos.core.global_config import global_config
-from dimos.mapping.costmapper import costmap_to_rerun
 from dimos.msgs.nav_msgs.Path import Path
 from dimos.navigation.nav_stack.main import nav_stack_rerun_config
-from dimos.robot.unitree.g1.g1_rerun import g1_odometry_tf_override, g1_static_robot
+from dimos.robot.unitree.g1.g1_rerun import g1_costmap, g1_odometry_tf_override, g1_static_robot
 from dimos.visualization.vis_module import vis_module
 
 _PATH_Z_LIFT = 0.3
@@ -49,7 +48,7 @@ unitree_g1_vis = vis_module(
                 "world/lidar": None,
                 "world/local_map": None,
                 "world/global_map_fastlio": None,
-                "world/global_costmap": costmap_to_rerun,
+                "world/global_costmap": g1_costmap,
                 "world/path": _g1_path_colors,
             },
             "static": {"world/tf/robot": g1_static_robot},

--- a/dimos/robot/unitree/g1/g1_rerun.py
+++ b/dimos/robot/unitree/g1/g1_rerun.py
@@ -18,6 +18,24 @@ from __future__ import annotations
 
 from typing import Any
 
+import numpy as np
+
+# Classic costmap palette, indexed by grid value + 1:
+# transparent unknown, blue free, orange occupied, red lethal.
+_COSTMAP_LOOKUP_TABLE = np.zeros((102, 4), dtype=np.uint8)
+_COSTMAP_LOOKUP_TABLE[0] = (0, 0, 0, 0)
+_COSTMAP_LOOKUP_TABLE[1] = (72, 73, 129, 255)
+_COSTMAP_LOOKUP_TABLE[2:101] = (255, 140, 0, 255)
+_COSTMAP_LOOKUP_TABLE[101] = (220, 30, 30, 255)
+
+
+def g1_costmap(grid: Any) -> Any:
+    """Render an OccupancyGrid with the classic costmap palette.
+
+    Lifts the mesh 2cm off the floor plane to avoid z-fighting with the ground.
+    """
+    return grid.to_rerun(color_lookup_table=_COSTMAP_LOOKUP_TABLE, z_offset=0.02)
+
 
 def g1_static_robot(rr: Any) -> list[Any]:
     """Static G1 humanoid wireframe box attached to the sensor TF frame.

--- a/dimos/robot/unitree/go2/blueprints/agentic/unitree_go2_security.py
+++ b/dimos/robot/unitree/go2/blueprints/agentic/unitree_go2_security.py
@@ -17,7 +17,6 @@ from typing import Any
 
 from dimos.core.coordination.blueprints import autoconnect
 from dimos.core.global_config import global_config
-from dimos.mapping.costmapper import costmap_to_rerun
 from dimos.robot.unitree.go2.blueprints.agentic.unitree_go2_agentic import unitree_go2_agentic
 from dimos.visualization.vis_module import vis_module
 
@@ -26,6 +25,15 @@ def _convert_camera_info(camera_info: Any) -> Any:
     return camera_info.to_rerun(
         image_topic="/world/color_image",
         optical_frame="camera_optical",
+    )
+
+
+def _convert_navigation_costmap(grid: Any) -> Any:
+    return grid.to_rerun(
+        colormap="Accent",
+        z_offset=0.015,
+        opacity=0.2,
+        background="#484981",
     )
 
 
@@ -67,7 +75,7 @@ _rerun_config = {
     "blueprint": _go2_rerun_blueprint,
     "visual_override": {
         "world/camera_info": _convert_camera_info,
-        "world/navigation_costmap": costmap_to_rerun,
+        "world/navigation_costmap": _convert_navigation_costmap,
     },
     "static": {
         "world/tf/base_link": _static_base_link,

--- a/dimos/robot/unitree/go2/blueprints/agentic/unitree_go2_security.py
+++ b/dimos/robot/unitree/go2/blueprints/agentic/unitree_go2_security.py
@@ -18,34 +18,8 @@ from typing import Any
 from dimos.core.coordination.blueprints import autoconnect
 from dimos.core.global_config import global_config
 from dimos.robot.unitree.go2.blueprints.agentic.unitree_go2_agentic import unitree_go2_agentic
+from dimos.robot.unitree.go2.blueprints.basic.unitree_go2_basic import rerun_config
 from dimos.visualization.vis_module import vis_module
-
-
-def _convert_camera_info(camera_info: Any) -> Any:
-    return camera_info.to_rerun(
-        image_topic="/world/color_image",
-        optical_frame="camera_optical",
-    )
-
-
-def _convert_navigation_costmap(grid: Any) -> Any:
-    return grid.to_rerun(
-        colormap="Accent",
-        z_offset=0.015,
-        opacity=0.2,
-        background="#484981",
-    )
-
-
-def _static_base_link(rr: Any) -> list[Any]:
-    return [
-        rr.Boxes3D(
-            half_sizes=[0.35, 0.155, 0.2],
-            colors=[(0, 255, 127)],
-            fill_mode="wireframe",
-        ),
-        rr.Transform3D(parent_frame="tf#/base_link"),
-    ]
 
 
 def _go2_rerun_blueprint() -> Any:
@@ -71,20 +45,12 @@ def _go2_rerun_blueprint() -> Any:
     )
 
 
-_rerun_config = {
-    "blueprint": _go2_rerun_blueprint,
-    "visual_override": {
-        "world/camera_info": _convert_camera_info,
-        "world/navigation_costmap": _convert_navigation_costmap,
-    },
-    "static": {
-        "world/tf/base_link": _static_base_link,
-    },
-}
-
 unitree_go2_security = autoconnect(
     unitree_go2_agentic,
-    vis_module(viewer_backend=global_config.viewer, rerun_config=_rerun_config),
+    vis_module(
+        viewer_backend=global_config.viewer,
+        rerun_config={**rerun_config, "blueprint": _go2_rerun_blueprint},
+    ),
 )
 
 __all__ = ["unitree_go2_security"]

--- a/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_basic.py
+++ b/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_basic.py
@@ -142,5 +142,6 @@ unitree_go2_basic = (
 )
 
 __all__ = [
+    "rerun_config",
     "unitree_go2_basic",
 ]

--- a/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_basic.py
+++ b/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_basic.py
@@ -21,7 +21,6 @@ from dimos.constants import DEFAULT_CAPACITY_COLOR_IMAGE
 from dimos.core.coordination.blueprints import autoconnect
 from dimos.core.global_config import global_config
 from dimos.core.transport import pSHMTransport
-from dimos.mapping.costmapper import costmap_to_rerun
 from dimos.msgs.sensor_msgs.Image import Image
 from dimos.robot.unitree.go2.connection import GO2Connection
 from dimos.visualization.vis_module import vis_module
@@ -49,6 +48,15 @@ def _convert_camera_info(camera_info: Any) -> Any:
 
 def _convert_global_map(grid: Any) -> Any:
     return grid.to_rerun(bottom_cutoff=0)
+
+
+def _convert_navigation_costmap(grid: Any) -> Any:
+    return grid.to_rerun(
+        colormap="Accent",
+        z_offset=0.015,
+        opacity=0.2,
+        background="#484981",
+    )
 
 
 def _static_base_link(rr: Any) -> list[Any]:
@@ -98,7 +106,7 @@ rerun_config = {
         "world/camera_info": _convert_camera_info,
         "world/global_map": _convert_global_map,
         "world/merged_map": _convert_global_map,
-        "world/navigation_costmap": costmap_to_rerun,
+        "world/navigation_costmap": _convert_navigation_costmap,
     },
     "max_hz": {
         "world/global_map": 0,  # publishes at ~7.8 Hz


### PR DESCRIPTION
## What

Removes the shared `costmap_to_rerun` helper (and its color-table/z-offset constants) from `dimos/mapping/costmapper.py` and moves costmap rendering into per-robot converters.