### PR TITLE
data: add china_office.db.zip (LFS)

### DIFF
--- a/data/.lfs/china_office.db.tar.gz
+++ b/data/.lfs/china_office.db.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c7d9b8d83b7eccff302d3881068f2064657b5903340ae54995e9cce80e41ffe
+size 4058639695


### PR DESCRIPTION
Adds the china_office recording (`fastlio2_pcap/china_office.db.zip`, ~4GB) tracked via git LFS. Data-only branch — no code changes.