### PR TITLE
feat: native module config macro

### DIFF
--- a/dimos/mapping/ray_tracing/rust/src/voxel_ray_tracer.rs
+++ b/dimos/mapping/ray_tracing/rust/src/voxel_ray_tracer.rs
@@ -2,15 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use ahash::{AHashMap, AHashSet};
+use dimos_module::native_config;
 use nalgebra::{Matrix3, Vector3};
-use serde::Deserialize;
-use validator::{Validate, ValidationError};
+use validator::ValidationError;
 
 pub type VoxelKey = (i32, i32, i32);
 pub type VoxelHealth = i32;
 
-#[derive(Debug, Deserialize, Validate)]
-#[serde(deny_unknown_fields)]
+#[native_config]
 #[validate(schema(function = "validate_health_range"))]
 pub struct Config {
     #[validate(range(exclusive_min = 0.0))]

--- a/dimos/navigation/nav_3d/mls_planner/rust/src/mls_planner.rs
+++ b/dimos/navigation/nav_3d/mls_planner/rust/src/mls_planner.rs
@@ -4,8 +4,7 @@
 //! Config and the owned-state Planner that builds and queries the MLS graph.
 
 use ahash::AHashSet;
-use serde::Deserialize;
-use validator::Validate;
+use dimos_module::native_config;
 
 use crate::adjacency::{build_surface_cells, build_surface_lookup};
 use crate::edges::{build_node_edges, PlannerGraph};
@@ -14,8 +13,7 @@ use crate::planner;
 use crate::surfaces::{extract_surfaces, ColumnIz};
 use crate::voxel::{voxelize, VoxelKey};
 
-#[derive(Debug, Deserialize, Validate)]
-#[serde(deny_unknown_fields)]
+#[native_config]
 pub struct Config {
     pub world_frame: String,
     #[validate(range(exclusive_min = 0.0))]

--- a/examples/native-modules/rust/src/native_pong.rs
+++ b/examples/native-modules/rust/src/native_pong.rs
@@ -1,10 +1,7 @@
-use dimos_module::{run, Input, LcmTransport, Module, Output};
+use dimos_module::{native_config, run, Input, LcmTransport, Module, Output};
 use lcm_msgs::geometry_msgs::{Twist, Vector3};
-use serde::Deserialize;
-use validator::Validate;
 
-#[derive(Debug, Deserialize, Default, Validate)]
-#[serde(deny_unknown_fields)]
+#[native_config]
 struct PongConfig {
     #[validate(range(min = 0, max = 1000))]
     sample_config: i64,

--- a/native/rust/README.md
+++ b/native/rust/README.md
@@ -61,13 +61,13 @@ async fn main() {
 
 A config struct is defined with `#[native_config]`. The attribute enforces a one-to-one mapping with the Python wrapper: every field is required and supplied by Python over stdin, with no Rust-side defaults.
 
-It injects `#[derive(Debug, Deserialize, Validate)]` and `#[serde(deny_unknown_fields)]`, emits the `NativeConfig` marker impl that `#[config]` requires, and rejects at compile time anything that would let a field be filled in by Rust:
+It injects `#[derive(Debug, Deserialize, Serialize, Validate)]` and `#[serde(deny_unknown_fields)]`, emits the `NativeConfig` marker impl that `#[config]` requires, and rejects at compile time anything that would let a field be filled in by Rust:
 
 - `Option<T>` fields
 - `#[serde(default)]`, field or container
 - `#[serde(skip)]`, `#[serde(skip_deserializing)]`, `#[serde(flatten)]`
 
-A type alias that resolves to `Option` is not detected.
+A type alias to `Option` slips past the compile-time check, but the runtime check below still rejects it.
 
 Field-level `#[validate(...)]` and a container `#[validate(schema(function = "..."))]` (from the [`validator`](https://docs.rs/validator) crate) pass through for value and cross-field validation. `run()` calls `config.validate()` after deserializing and bails with an `io::Error` on failure.
 
@@ -93,7 +93,7 @@ fn validate_health_range(cfg: &Config) -> Result<(), ValidationError> {
 }
 ```
 
-At runtime serde enforces the mapping on the Python payload: a missing or unknown field is a hard error.
+At runtime `run()` enforces the mapping on the Python payload: deserialization rejects an unknown field, and a key-set check rejects any field whose JSON key is absent, even an `Option` or a type alias to `Option` that serde would otherwise accept as `None`.
 
 Field name = port name. Ports map to topics via the stdin JSON; unmapped ports fall back to `/{port}`.
 

--- a/native/rust/README.md
+++ b/native/rust/README.md
@@ -3,17 +3,15 @@
 Two crates:
 
 - **`dimos-module`**: runtime. `Module` trait, `Builder`, `Input`/`Output`, `Transport`/`LcmTransport`, `run()`.
-- **`dimos-module-macros`**: `#[derive(Module)]` proc-macro.
+- **`dimos-module-macros`**: `#[derive(Module)]` and `#[native_config]` proc-macros.
 
 ## Writing a module
 
 ```rust
-use dimos_module::{run, Input, LcmTransport, Module, Output};
+use dimos_module::{native_config, run, Input, LcmTransport, Module, Output};
 use lcm_msgs::geometry_msgs::Twist;
-use serde::Deserialize;
-use validator::Validate;
 
-#[derive(Debug, Deserialize, Default, Validate)]
+#[native_config]
 struct MyConfig {
     #[validate(range(min = 0.0))]
     threshold: f64,
@@ -56,17 +54,28 @@ async fn main() {
 - `#[module(setup = fn, teardown = fn)]`: on the struct. Both optional. Names methods on `Self`. `setup` runs once before the input dispatch loop starts (use it to spawn background tasks or initialize resources); `teardown` runs once after the loop exits (use it for cleanup).
 - `#[input(decode = fn, handler = fn)]`: on a field of type `Input<T>`. `decode` is required; `handler` defaults to `handle_<field_name>`.
 - `#[output(encode = fn)]`: on a field of type `Output<T>`. `encode` is required.
-- `#[config]`: on one field. The type must derive `Deserialize + Debug + Validate` (from the [`validator`](https://docs.rs/validator) crate). At most one per struct. If absent, `Config` defaults to `dimos_module::NoConfig`.
+- `#[config]`: on one field. The type must be defined with `#[native_config]` (see [Config](#config)). At most one per struct. If absent, `Config` defaults to `dimos_module::NoConfig`.
 - Unattributed fields are initialized via `Default::default()` and treated as module state.
 
-## Config validation
+## Config
 
-`run()` calls `config.validate()` after deserializing and bails with an `io::Error` on failure. Use `#[validate(schema(function = "..."))]` on the struct for cross-field invariants.
+A config struct is defined with `#[native_config]`. The attribute enforces a one-to-one mapping with the Python wrapper: every field is required and supplied by Python over stdin, with no Rust-side defaults.
+
+It injects `#[derive(Debug, Deserialize, Validate)]` and `#[serde(deny_unknown_fields)]`, emits the `NativeConfig` marker impl that `#[config]` requires, and rejects at compile time anything that would let a field be filled in by Rust:
+
+- `Option<T>` fields
+- `#[serde(default)]`, field or container
+- `#[serde(skip)]`, `#[serde(skip_deserializing)]`, `#[serde(flatten)]`
+
+A type alias that resolves to `Option` is not detected.
+
+Field-level `#[validate(...)]` and a container `#[validate(schema(function = "..."))]` (from the [`validator`](https://docs.rs/validator) crate) pass through for value and cross-field validation. `run()` calls `config.validate()` after deserializing and bails with an `io::Error` on failure.
 
 ```rust
-use validator::{Validate, ValidationError};
+use dimos_module::native_config;
+use validator::ValidationError;
 
-#[derive(Debug, Deserialize, Validate)]
+#[native_config]
 #[validate(schema(function = "validate_health_range"))]
 struct Config {
     #[validate(range(exclusive_min = 0.0))]
@@ -83,6 +92,8 @@ fn validate_health_range(cfg: &Config) -> Result<(), ValidationError> {
     Ok(())
 }
 ```
+
+At runtime serde enforces the mapping on the Python payload: a missing or unknown field is a hard error.
 
 Field name = port name. Ports map to topics via the stdin JSON; unmapped ports fall back to `/{port}`.
 

--- a/native/rust/dimos-module-macros/src/lib.rs
+++ b/native/rust/dimos-module-macros/src/lib.rs
@@ -23,7 +23,7 @@ pub fn derive_module(input: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// Injects `#[derive(Debug, Deserialize, Validate)]` and
+/// Injects `#[derive(Debug, Deserialize, Serialize, Validate)]` and
 /// `#[serde(deny_unknown_fields)]`, and emits `impl NativeConfig`.
 ///
 /// Rejected at compile time:
@@ -31,7 +31,8 @@ pub fn derive_module(input: TokenStream) -> TokenStream {
 /// - `#[serde(default)]`, field or container
 /// - `#[serde(skip)]`, `#[serde(skip_deserializing)]`, `#[serde(flatten)]`
 ///
-/// A type alias that resolves to `Option` is not detected.
+/// A type alias to `Option` is not caught here, but `run()` rejects a missing
+/// field at startup regardless of how the field is spelled.
 #[proc_macro_attribute]
 pub fn native_config(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item as DeriveInput);
@@ -51,7 +52,7 @@ pub fn native_config(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let name = &input.ident;
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
     quote! {
-        #[derive(Debug, ::serde::Deserialize, ::validator::Validate)]
+        #[derive(Debug, ::serde::Deserialize, ::serde::Serialize, ::validator::Validate)]
         #[serde(deny_unknown_fields)]
         #input
         impl #impl_generics ::dimos_module::NativeConfig for #name #ty_generics #where_clause {}

--- a/native/rust/dimos-module-macros/src/lib.rs
+++ b/native/rust/dimos-module-macros/src/lib.rs
@@ -12,6 +12,155 @@ pub fn derive_module(input: TokenStream) -> TokenStream {
     }
 }
 
+/// Defines a native-module config with a strict one-to-one mapping to the Python
+/// wrapper. The Python side owns every default and sends every field over stdin,
+/// so a config declares all fields as required, with no Rust-side defaults.
+///
+/// The attribute supplies all the boilerplate: it injects
+/// `#[derive(Debug, Deserialize, Validate)]` and `#[serde(deny_unknown_fields)]`,
+/// emits the `NativeConfig` marker impl, and rejects, at compile time, anything
+/// that would let a field be filled in by Rust:
+///
+/// - `Option<T>` fields (an absent field becomes `None`).
+/// - `#[serde(default)]` at the field or container level.
+/// - `#[serde(skip)]` / `skip_deserializing` / `flatten`.
+///
+/// ```ignore
+/// #[native_config]
+/// pub struct Config {
+///     #[validate(range(min = 0.0))]
+///     pub voxel_size: f32,
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn native_config(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(item as DeriveInput);
+    let maybe_err = check_native_config(&input)
+        .err()
+        .map(|e| e.to_compile_error());
+
+    // For a named/unit struct still emit the full expansion alongside any error, so
+    // a single check failure surfaces our message instead of a cascade of missing
+    // derive/impl errors. Other inputs (tuple structs, enums) stand with the error.
+    let injectable = matches!(
+        &input.data,
+        Data::Struct(s) if matches!(s.fields, Fields::Named(_) | Fields::Unit)
+    );
+    if !injectable {
+        return quote!(#input #maybe_err).into();
+    }
+
+    let name = &input.ident;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+    quote! {
+        #[derive(Debug, ::serde::Deserialize, ::validator::Validate)]
+        #[serde(deny_unknown_fields)]
+        #input
+        impl #impl_generics ::dimos_module::NativeConfig for #name #ty_generics #where_clause {}
+        #maybe_err
+    }
+    .into()
+}
+
+fn check_native_config(input: &DeriveInput) -> syn::Result<()> {
+    let fields = match &input.data {
+        Data::Struct(s) => match &s.fields {
+            Fields::Named(named) => &named.named,
+            Fields::Unit => return check_container_serde(input),
+            Fields::Unnamed(_) => {
+                return Err(syn::Error::new_spanned(
+                    input,
+                    "native_config requires a struct with named fields or a unit struct",
+                ))
+            }
+        },
+        _ => {
+            return Err(syn::Error::new_spanned(
+                input,
+                "native_config can only be applied to structs",
+            ))
+        }
+    };
+
+    check_container_serde(input)?;
+
+    for field in fields {
+        if is_option(&field.ty) {
+            return Err(syn::Error::new_spanned(
+                &field.ty,
+                "native_config forbids Option fields: an absent field would silently become None. \
+                 Make it required and let Python always send it.",
+            ));
+        }
+        check_field_serde(field)?;
+    }
+
+    Ok(())
+}
+
+/// Reject a container-level `#[serde(default)]` (the attribute injects
+/// `deny_unknown_fields` itself, so it is not required here).
+fn check_container_serde(input: &DeriveInput) -> syn::Result<()> {
+    for attr in &input.attrs {
+        if !attr.path().is_ident("serde") {
+            continue;
+        }
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("default") {
+                return Err(meta.error(
+                    "native_config forbids #[serde(default)]: Python owns defaults and sends \
+                     every field. Remove the default and make every field required.",
+                ));
+            }
+            // consume an optional `= value` so unrelated serde args don't error
+            consume_optional_value(&meta);
+            Ok(())
+        })?;
+    }
+    Ok(())
+}
+
+/// Reject field-level `#[serde(default | skip | skip_deserializing | flatten)]`.
+fn check_field_serde(field: &Field) -> syn::Result<()> {
+    for attr in &field.attrs {
+        if !attr.path().is_ident("serde") {
+            continue;
+        }
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("default") {
+                return Err(meta.error(
+                    "native_config forbids #[serde(default)]: Python owns defaults and sends \
+                     every field. Make it required.",
+                ));
+            }
+            if meta.path.is_ident("skip") || meta.path.is_ident("skip_deserializing") {
+                return Err(meta.error(
+                    "native_config forbids #[serde(skip)]: a skipped field is filled by Rust \
+                     instead of Python.",
+                ));
+            }
+            if meta.path.is_ident("flatten") {
+                return Err(meta.error(
+                    "native_config forbids #[serde(flatten)]: it bypasses deny_unknown_fields.",
+                ));
+            }
+            consume_optional_value(&meta);
+            Ok(())
+        })?;
+    }
+    Ok(())
+}
+
+fn consume_optional_value(meta: &syn::meta::ParseNestedMeta) {
+    if meta.input.peek(syn::Token![=]) {
+        let _ = meta.value().and_then(|v| v.parse::<syn::Expr>());
+    }
+}
+
+fn is_option(ty: &Type) -> bool {
+    matches!(ty, Type::Path(p) if p.path.segments.last().is_some_and(|s| s.ident == "Option"))
+}
+
 enum FieldKind {
     Input { decode: Path, handler: Ident },
     Output { encode: Path },
@@ -248,4 +397,67 @@ fn classify_field(field: &Field, name: &Ident) -> syn::Result<FieldKind> {
     }
 
     Ok(found.unwrap_or(FieldKind::State))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::check_native_config;
+    use syn::parse_str;
+
+    fn check(src: &str) -> syn::Result<()> {
+        check_native_config(&parse_str(src).expect("test input should parse"))
+    }
+
+    #[test]
+    fn accepts_plain_required_fields() {
+        check(r#"struct Config { a: f32, b: String, c: u32 }"#)
+            .expect("a plain required-field struct should pass");
+    }
+
+    #[test]
+    fn accepts_unit_struct() {
+        check(r#"struct NoConfig;"#).expect("a field-less struct should pass");
+    }
+
+    #[test]
+    fn accepts_validate_attrs() {
+        check(r#"struct Config { #[validate(range(min = 0))] a: i64 }"#)
+            .expect("validate attrs should pass through");
+    }
+
+    #[test]
+    fn rejects_option_field() {
+        let err =
+            check(r#"struct Config { a: Option<f32> }"#).expect_err("Option fields are forbidden");
+        assert!(err.to_string().contains("Option"), "{err}");
+    }
+
+    #[test]
+    fn rejects_field_default() {
+        check(r#"struct Config { #[serde(default)] a: f32 }"#)
+            .expect_err("field #[serde(default)] is forbidden");
+    }
+
+    #[test]
+    fn rejects_field_default_with_path() {
+        check(r#"struct Config { #[serde(default = "mk")] a: f32 }"#)
+            .expect_err("#[serde(default = ...)] is forbidden");
+    }
+
+    #[test]
+    fn rejects_container_default() {
+        check(r#"#[serde(default)] struct Config { a: f32 }"#)
+            .expect_err("container #[serde(default)] is forbidden");
+    }
+
+    #[test]
+    fn rejects_flatten_and_skip() {
+        check(r#"struct Config { #[serde(flatten)] a: Inner }"#).expect_err("flatten is forbidden");
+        check(r#"struct Config { #[serde(skip)] a: f32 }"#).expect_err("skip is forbidden");
+    }
+
+    #[test]
+    fn rejects_enum() {
+        check(r#"enum Config { A, B }"#).expect_err("enums are not valid configs");
+    }
 }

--- a/native/rust/dimos-module-macros/src/lib.rs
+++ b/native/rust/dimos-module-macros/src/lib.rs
@@ -453,6 +453,8 @@ mod tests {
     fn rejects_flatten_and_skip() {
         check(r#"struct Config { #[serde(flatten)] a: Inner }"#).expect_err("flatten is forbidden");
         check(r#"struct Config { #[serde(skip)] a: f32 }"#).expect_err("skip is forbidden");
+        check(r#"struct Config { #[serde(skip_deserializing)] a: f32 }"#)
+            .expect_err("skip_deserializing is forbidden");
     }
 
     #[test]

--- a/native/rust/dimos-module-macros/src/lib.rs
+++ b/native/rust/dimos-module-macros/src/lib.rs
@@ -12,18 +12,8 @@ pub fn derive_module(input: TokenStream) -> TokenStream {
     }
 }
 
-/// Defines a native-module config with a strict one-to-one mapping to the Python
-/// wrapper. The Python side owns every default and sends every field over stdin,
-/// so a config declares all fields as required, with no Rust-side defaults.
-///
-/// The attribute supplies all the boilerplate: it injects
-/// `#[derive(Debug, Deserialize, Validate)]` and `#[serde(deny_unknown_fields)]`,
-/// emits the `NativeConfig` marker impl, and rejects, at compile time, anything
-/// that would let a field be filled in by Rust:
-///
-/// - `Option<T>` fields (an absent field becomes `None`).
-/// - `#[serde(default)]` at the field or container level.
-/// - `#[serde(skip)]` / `skip_deserializing` / `flatten`.
+/// Defines a native-module config: every field is required and supplied by the Python wrapper
+/// over stdin, with no Rust-side defaults.
 ///
 /// ```ignore
 /// #[native_config]
@@ -32,6 +22,16 @@ pub fn derive_module(input: TokenStream) -> TokenStream {
 ///     pub voxel_size: f32,
 /// }
 /// ```
+///
+/// Injects `#[derive(Debug, Deserialize, Validate)]` and
+/// `#[serde(deny_unknown_fields)]`, and emits `impl NativeConfig`.
+///
+/// Rejected at compile time:
+/// - `Option<T>` fields
+/// - `#[serde(default)]`, field or container
+/// - `#[serde(skip)]`, `#[serde(skip_deserializing)]`, `#[serde(flatten)]`
+///
+/// A type alias that resolves to `Option` is not detected.
 #[proc_macro_attribute]
 pub fn native_config(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item as DeriveInput);
@@ -39,9 +39,7 @@ pub fn native_config(_attr: TokenStream, item: TokenStream) -> TokenStream {
         .err()
         .map(|e| e.to_compile_error());
 
-    // For a named/unit struct still emit the full expansion alongside any error, so
-    // a single check failure surfaces our message instead of a cascade of missing
-    // derive/impl errors. Other inputs (tuple structs, enums) stand with the error.
+    // Emit the expansion with any error so a failed check shows our useful message.
     let injectable = matches!(
         &input.data,
         Data::Struct(s) if matches!(s.fields, Fields::Named(_) | Fields::Unit)
@@ -98,8 +96,8 @@ fn check_native_config(input: &DeriveInput) -> syn::Result<()> {
     Ok(())
 }
 
-/// Reject a container-level `#[serde(default)]` (the attribute injects
-/// `deny_unknown_fields` itself, so it is not required here).
+/// Reject a container-level `#[serde(default)]`. The macro injects
+/// `deny_unknown_fields` itself.
 fn check_container_serde(input: &DeriveInput) -> syn::Result<()> {
     for attr in &input.attrs {
         if !attr.path().is_ident("serde") {
@@ -112,7 +110,7 @@ fn check_container_serde(input: &DeriveInput) -> syn::Result<()> {
                      every field. Remove the default and make every field required.",
                 ));
             }
-            // consume an optional `= value` so unrelated serde args don't error
+            // allow other serde args that take a `= value`
             consume_optional_value(&meta);
             Ok(())
         })?;
@@ -454,6 +452,11 @@ mod tests {
     fn rejects_flatten_and_skip() {
         check(r#"struct Config { #[serde(flatten)] a: Inner }"#).expect_err("flatten is forbidden");
         check(r#"struct Config { #[serde(skip)] a: f32 }"#).expect_err("skip is forbidden");
+    }
+
+    #[test]
+    fn rejects_tuple_struct() {
+        check(r#"struct Config(f32);"#).expect_err("tuple structs are not valid configs");
     }
 
     #[test]

--- a/native/rust/dimos-module/src/lib.rs
+++ b/native/rust/dimos-module/src/lib.rs
@@ -3,9 +3,9 @@ pub mod log;
 pub mod module;
 pub mod transport;
 
-pub use dimos_module_macros::Module;
+pub use dimos_module_macros::{native_config, Module};
 pub use lcm::LcmTransport;
-pub use module::{run, Builder, Input, Module, ModuleConfig, NoConfig, Output};
+pub use module::{run, Builder, Input, Module, ModuleConfig, NativeConfig, NoConfig, Output};
 pub use transport::Transport;
 
 // Re-export LcmOptions so callers don't need to depend on dimos-lcm directly.

--- a/native/rust/dimos-module/src/module.rs
+++ b/native/rust/dimos-module/src/module.rs
@@ -15,10 +15,8 @@ use validator::Validate;
 
 use crate::transport::Transport;
 
-/// Marker trait proving a config was checked by `#[native_config]` for a strict
-/// one-to-one mapping with the Python wrapper: every field required, no Rust-side
-/// defaults, no unknown fields. The attribute is the only blessed way to
-/// implement it.
+/// Marker trait for a config checked by `#[native_config]`: every field required,
+/// no Rust-side defaults, no unknown fields. Implemented only by the macro.
 pub trait NativeConfig {}
 
 /// Trait required by `Module::Config`s to ensure that configurations are

--- a/native/rust/dimos-module/src/module.rs
+++ b/native/rust/dimos-module/src/module.rs
@@ -15,16 +15,24 @@ use validator::Validate;
 
 use crate::transport::Transport;
 
+/// Marker trait proving a config was checked by `#[native_config]` for a strict
+/// one-to-one mapping with the Python wrapper: every field required, no Rust-side
+/// defaults, no unknown fields. The attribute is the only blessed way to
+/// implement it.
+pub trait NativeConfig {}
+
 /// Trait required by `Module::Config`s to ensure that configurations are
 /// validated correctly.
-pub trait ModuleConfig: DeserializeOwned + Debug + Validate {}
-impl<T: DeserializeOwned + Debug + Validate> ModuleConfig for T {}
+pub trait ModuleConfig: DeserializeOwned + Debug + Validate + NativeConfig {}
+impl<T: DeserializeOwned + Debug + Validate + NativeConfig> ModuleConfig for T {}
 
 /// Default config type used by `#[derive(Module)]` when no `#[config]` field
 /// is used. Just a stand in for modules that don't use configurations.
 #[derive(Debug, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct NoConfig;
+
+impl NativeConfig for NoConfig {}
 
 impl Validate for NoConfig {
     fn validate(&self) -> Result<(), validator::ValidationErrors> {

--- a/native/rust/dimos-module/src/module.rs
+++ b/native/rust/dimos-module/src/module.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::fmt::Debug;
 use std::io;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -10,7 +10,7 @@ use tracing::{error, info, warn};
 use tracing_subscriber::EnvFilter;
 
 use serde::de::DeserializeOwned;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use validator::Validate;
 
 use crate::transport::Transport;
@@ -21,12 +21,12 @@ pub trait NativeConfig {}
 
 /// Trait required by `Module::Config`s to ensure that configurations are
 /// validated correctly.
-pub trait ModuleConfig: DeserializeOwned + Debug + Validate + NativeConfig {}
-impl<T: DeserializeOwned + Debug + Validate + NativeConfig> ModuleConfig for T {}
+pub trait ModuleConfig: DeserializeOwned + Serialize + Debug + Validate + NativeConfig {}
+impl<T: DeserializeOwned + Serialize + Debug + Validate + NativeConfig> ModuleConfig for T {}
 
 /// Default config type used by `#[derive(Module)]` when no `#[config]` field
 /// is used. Just a stand in for modules that don't use configurations.
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct NoConfig;
 
@@ -121,7 +121,9 @@ impl<T> Output<T> {
 
 /// Parse a JSON config line as written by the Python NativeModule coordinator.
 /// Returns `(topics, config)`. Extracted so it can be unit-tested without stdin.
-fn parse_config_json<C: DeserializeOwned>(line: &str) -> io::Result<(HashMap<String, String>, C)> {
+fn parse_config_json<C: DeserializeOwned + Serialize>(
+    line: &str,
+) -> io::Result<(HashMap<String, String>, C)> {
     let json: serde_json::Value = serde_json::from_str(line.trim())
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
 
@@ -134,20 +136,50 @@ fn parse_config_json<C: DeserializeOwned>(line: &str) -> io::Result<(HashMap<Str
         }
     }
 
-    let config: C = match json.get("config") {
-        None => return Err(io::Error::new(
+    let config_value = json.get("config").ok_or_else(|| {
+        io::Error::new(
             io::ErrorKind::InvalidData,
             "missing 'config' field in stdin JSON — coordinator must always send a config object",
-        )),
-        Some(v) => serde_json::from_value(v.clone()).map_err(|e| {
-            io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("failed to deserialize config: {e}"),
-            )
-        })?,
-    };
+        )
+    })?;
+
+    let config: C = serde_json::from_value(config_value.clone()).map_err(|e| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("failed to deserialize config: {e}"),
+        )
+    })?;
+
+    enforce_one_to_one(config_value, &config)?;
 
     Ok((topics, config))
+}
+
+fn object_keys(value: &serde_json::Value) -> BTreeSet<String> {
+    value
+        .as_object()
+        .map(|m| m.keys().cloned().collect())
+        .unwrap_or_default()
+}
+
+fn enforce_one_to_one<C: Serialize>(provided: &serde_json::Value, config: &C) -> io::Result<()> {
+    let expected_value = serde_json::to_value(config).map_err(|e| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("failed to re-serialize config: {e}"),
+        )
+    })?;
+    let provided_keys = object_keys(provided);
+    let expected_keys = object_keys(&expected_value);
+    if provided_keys == expected_keys {
+        return Ok(());
+    }
+    let missing: Vec<&String> = expected_keys.difference(&provided_keys).collect();
+    let unexpected: Vec<&String> = provided_keys.difference(&expected_keys).collect();
+    Err(io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!("config keys do not match struct fields: missing {missing:?}, unexpected {unexpected:?}"),
+    ))
 }
 
 fn with_field(field: &str, message: String) -> String {
@@ -471,7 +503,7 @@ mod tests {
         }
     }
 
-    #[derive(Debug, Deserialize, Default, PartialEq)]
+    #[derive(Debug, Deserialize, Serialize, Default, PartialEq)]
     #[serde(deny_unknown_fields)]
     struct TestConfig {
         value: i64,
@@ -554,6 +586,45 @@ mod tests {
         let json = r#"{"topics": {}, "config": {"value": 1, "name": "x", "unexpected": true}}"#;
         let result = parse_config_json::<TestConfig>(json);
         assert!(result.is_err());
+    }
+
+    // one-to-one key check: serde alone would accept a missing Option field as None.
+
+    #[derive(Debug, Deserialize, Serialize)]
+    #[serde(deny_unknown_fields)]
+    struct OptionalConfig {
+        required: i64,
+        maybe: Option<i64>,
+    }
+
+    type MaybeI = Option<i64>;
+
+    #[derive(Debug, Deserialize, Serialize)]
+    #[serde(deny_unknown_fields)]
+    struct AliasedConfig {
+        required: i64,
+        maybe: MaybeI,
+    }
+
+    #[test]
+    fn missing_optional_field_is_rejected() {
+        let json = r#"{"config": {"required": 1}}"#;
+        let err = parse_config_json::<OptionalConfig>(json)
+            .expect_err("a missing Option field must be rejected, not defaulted to None");
+        assert!(err.to_string().contains("maybe"), "{err}");
+    }
+
+    #[test]
+    fn missing_aliased_option_field_is_rejected() {
+        let json = r#"{"config": {"required": 1}}"#;
+        assert!(parse_config_json::<AliasedConfig>(json).is_err());
+    }
+
+    #[test]
+    fn optional_field_sent_explicitly_succeeds() {
+        let json = r#"{"config": {"required": 1, "maybe": null}}"#;
+        let (_topics, config) = parse_config_json::<OptionalConfig>(json).unwrap();
+        assert_eq!(config.maybe, None);
     }
 
     // validate_config


### PR DESCRIPTION
## Problem

Config defaults for native modules should only be declared in one place (the Python wrapper) and the native module config should have fields iff they are supplied by Python.

Closes DIM-XXX

## Solution

Introduce a native_config proc macro for Rust native module config structs. It reduces the boiler plate and ensure that there are no optional configs or default values.

## How to Test

<!-- oneliner required to run the actual feature -->
<!-- blueprint for robot changes, benchmarks for transport changes etc -->

## Contributor License Agreement

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
