### PR TITLE
chore: reduce transport duplication

### DIFF
--- a/dimos/control/README.md
+++ b/dimos/control/README.md
@@ -205,4 +205,4 @@ JointState(
 )
 ```
 
-Subscribe via: `/coordinator/joint_state`
+Subscribe via: `/coordinator_joint_state`

--- a/dimos/control/blueprints/basic.py
+++ b/dimos/control/blueprints/basic.py
@@ -31,8 +31,6 @@ from __future__ import annotations
 from dimos.control.coordinator import ControlCoordinator
 from dimos.core.coordination.blueprints import Blueprint, autoconnect
 from dimos.core.global_config import global_config
-from dimos.core.transport import LCMTransport
-from dimos.msgs.sensor_msgs.JointState import JointState
 from dimos.robot.catalog.piper import PIPER_SIM_PATH, piper as _catalog_piper
 from dimos.robot.catalog.ufactory import (
     XARM6_SIM_PATH,
@@ -56,10 +54,6 @@ coordinator_basic = ControlCoordinator.blueprint(
     tick_rate=100.0,
     publish_joint_state=True,
     joint_state_frame_id="coordinator",
-).transports(
-    {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-    }
 )
 
 # Mock 7-DOF arm (for testing)
@@ -68,10 +62,6 @@ _mock_cfg = _catalog_xarm7(name="arm")
 coordinator_mock = ControlCoordinator.blueprint(
     hardware=[_mock_cfg.to_hardware_component()],
     tasks=[_mock_cfg.to_task_config()],
-).transports(
-    {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-    }
 )
 
 # XArm7 (real, or MuJoCo with --simulation)
@@ -87,10 +77,6 @@ coordinator_xarm7 = autoconnect(
         tasks=[_xarm7_cfg.to_task_config()],
     ),
     *_mujoco_if_sim(str(XARM7_SIM_PATH), _xarm7_cfg.dof),
-).transports(
-    {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-    }
 )
 
 # XArm6 (real, or MuJoCo with --simulation)
@@ -106,10 +92,6 @@ coordinator_xarm6 = autoconnect(
         tasks=[_xarm6_cfg.to_task_config(task_name="traj_xarm")],
     ),
     *_mujoco_if_sim(str(XARM6_SIM_PATH), _xarm6_cfg.dof),
-).transports(
-    {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-    }
 )
 
 # Piper 6-DOF (CAN bus, or MuJoCo with --simulation)
@@ -125,10 +107,6 @@ coordinator_piper = autoconnect(
         tasks=[_piper_cfg.to_task_config(task_name="traj_piper")],
     ),
     *_mujoco_if_sim(str(PIPER_SIM_PATH), _piper_cfg.dof),
-).transports(
-    {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-    }
 )
 
 

--- a/dimos/control/blueprints/dual.py
+++ b/dimos/control/blueprints/dual.py
@@ -24,8 +24,6 @@ from __future__ import annotations
 
 from dimos.control.coordinator import ControlCoordinator
 from dimos.core.global_config import global_config
-from dimos.core.transport import LCMTransport
-from dimos.msgs.sensor_msgs.JointState import JointState
 from dimos.robot.catalog.piper import piper as _catalog_piper
 from dimos.robot.catalog.ufactory import xarm6 as _catalog_xarm6, xarm7 as _catalog_xarm7
 
@@ -39,10 +37,6 @@ coordinator_dual_mock = ControlCoordinator.blueprint(
         _mock_left.to_task_config(task_name="traj_left"),
         _mock_right.to_task_config(task_name="traj_right"),
     ],
-).transports(
-    {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-    }
 )
 
 # Dual XArm (XArm7 left, XArm6 right)
@@ -57,10 +51,6 @@ coordinator_dual_xarm = ControlCoordinator.blueprint(
         _xarm7_left.to_task_config(task_name="traj_left"),
         _xarm6_right.to_task_config(task_name="traj_right"),
     ],
-).transports(
-    {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-    }
 )
 
 # Dual arm (XArm6 + Piper)
@@ -77,10 +67,6 @@ coordinator_piper_xarm = ControlCoordinator.blueprint(
         _xarm6_dual.to_task_config(task_name="traj_xarm"),
         _piper_dual.to_task_config(task_name="traj_piper"),
     ],
-).transports(
-    {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-    }
 )
 
 

--- a/dimos/control/blueprints/mobile.py
+++ b/dimos/control/blueprints/mobile.py
@@ -33,13 +33,10 @@ from dimos.control.components import (
 )
 from dimos.control.coordinator import ControlCoordinator, TaskConfig
 from dimos.core.coordination.blueprints import autoconnect
-from dimos.core.transport import LCMTransport
 from dimos.hardware.sensors.lidar.fastlio2.module import FastLio2
 from dimos.msgs.geometry_msgs.Pose import Pose
 from dimos.msgs.geometry_msgs.Quaternion import Quaternion
-from dimos.msgs.geometry_msgs.Twist import Twist
 from dimos.msgs.geometry_msgs.Vector3 import Vector3
-from dimos.msgs.sensor_msgs.JointState import JointState
 from dimos.navigation.movement_manager.movement_manager import MovementManager
 from dimos.navigation.nav_stack.main import create_nav_stack, nav_stack_rerun_config
 from dimos.robot.catalog.ufactory import xarm7 as _catalog_xarm7
@@ -89,12 +86,7 @@ coordinator_mock_twist_base = ControlCoordinator.blueprint(
             priority=10,
         ),
     ],
-).transports(
-    {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-        ("twist_command", Twist): LCMTransport("/cmd_vel", Twist),
-    }
-)
+).remappings([(ControlCoordinator, "twist_command", "cmd_vel")])
 
 # FlowBase holonomic twist base (3-DOF: vx, vy, wz) over Portal RPC
 coordinator_flowbase = ControlCoordinator.blueprint(
@@ -107,12 +99,7 @@ coordinator_flowbase = ControlCoordinator.blueprint(
             priority=10,
         ),
     ],
-).transports(
-    {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-        ("twist_command", Twist): LCMTransport("/cmd_vel", Twist),
-    }
-)
+).remappings([(ControlCoordinator, "twist_command", "cmd_vel")])
 
 # FlowBase + WASD pygame keyboard teleop in a single blueprint
 coordinator_flowbase_keyboard_teleop = autoconnect(
@@ -128,12 +115,7 @@ coordinator_flowbase_keyboard_teleop = autoconnect(
         ],
     ),
     KeyboardTeleop.blueprint(),
-).transports(
-    {
-        ("twist_command", Twist): LCMTransport("/cmd_vel", Twist),
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-    }
-)
+).remappings([(ControlCoordinator, "twist_command", "cmd_vel")])
 
 # FlowBase + Livox MID-360 + FastLio2 SLAM + nav stack with click-to-drive in Rerun. The velocity
 # sink is ControlCoordinator + FlowBaseAdapter
@@ -203,15 +185,10 @@ coordinator_flowbase_nav = (
             # SimplePlanner / FarPlanner owns way_point — disconnect MovementManager's
             # redundant pass-through copy (matches unitree-g1-nav-onboard).
             (MovementManager, "way_point", "_mgr_way_point_unused"),
-        ]
-    )
-    .transports(
-        {
             # MovementManager.cmd_vel publishes to LCM /cmd_vel by default; the
-            # coordinator's twist_command listens on the same topic.
-            ("twist_command", Twist): LCMTransport("/cmd_vel", Twist),
-            ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-        }
+            # coordinator's twist_command listens on the same name.
+            (ControlCoordinator, "twist_command", "cmd_vel"),
+        ]
     )
     .global_config(n_workers=8)
 )
@@ -231,12 +208,7 @@ coordinator_mobile_manip_mock = ControlCoordinator.blueprint(
             priority=10,
         ),
     ],
-).transports(
-    {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-        ("twist_command", Twist): LCMTransport("/cmd_vel", Twist),
-    }
-)
+).remappings([(ControlCoordinator, "twist_command", "cmd_vel")])
 
 
 __all__ = [

--- a/dimos/control/blueprints/teleop.py
+++ b/dimos/control/blueprints/teleop.py
@@ -37,9 +37,6 @@ from dimos.control.components import make_gripper_joints
 from dimos.control.coordinator import ControlCoordinator
 from dimos.core.coordination.blueprints import Blueprint, autoconnect
 from dimos.core.global_config import global_config
-from dimos.core.transport import LCMTransport
-from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
-from dimos.msgs.sensor_msgs.JointState import JointState
 from dimos.robot.catalog.piper import PIPER_FK_MODEL, PIPER_SIM_PATH, piper as _catalog_piper
 from dimos.robot.catalog.ufactory import (
     XARM6_FK_MODEL,
@@ -50,7 +47,6 @@ from dimos.robot.catalog.ufactory import (
     xarm7 as _catalog_xarm7,
 )
 from dimos.simulation.engines.mujoco_sim_module import MujocoSimModule
-from dimos.teleop.quest.quest_types import Buttons
 
 _is_sim = global_config.simulation
 
@@ -89,11 +85,6 @@ coordinator_servo_xarm6 = ControlCoordinator.blueprint(
     tasks=[
         _xarm6_cfg.to_task_config(task_type="servo", task_name="servo_arm"),
     ],
-).transports(
-    {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-        ("joint_command", JointState): LCMTransport("/teleop/joint_command", JointState),
-    }
 )
 
 # XArm6 velocity control - streaming velocity for joystick
@@ -102,11 +93,6 @@ coordinator_velocity_xarm6 = ControlCoordinator.blueprint(
     tasks=[
         _xarm6_cfg.to_task_config(task_type="velocity", task_name="velocity_arm"),
     ],
-).transports(
-    {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-        ("joint_command", JointState): LCMTransport("/joystick/joint_command", JointState),
-    }
 )
 
 # XArm6 combined (servo + velocity tasks)
@@ -116,11 +102,6 @@ coordinator_combined_xarm6 = ControlCoordinator.blueprint(
         _xarm6_cfg.to_task_config(task_type="servo", task_name="servo_arm"),
         _xarm6_cfg.to_task_config(task_type="velocity", task_name="velocity_arm"),
     ],
-).transports(
-    {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-        ("joint_command", JointState): LCMTransport("/control/joint_command", JointState),
-    }
 )
 
 # Mock 6-DOF arm with CartesianIK
@@ -136,13 +117,6 @@ coordinator_cartesian_ik_mock = ControlCoordinator.blueprint(
             ee_joint_id=_mock_6dof_cfg.dof,
         ),
     ],
-).transports(
-    {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-        ("cartesian_command", PoseStamped): LCMTransport(
-            "/coordinator/cartesian_command", PoseStamped
-        ),
-    }
 )
 
 # Piper arm with CartesianIK
@@ -156,13 +130,6 @@ coordinator_cartesian_ik_piper = ControlCoordinator.blueprint(
             ee_joint_id=_piper_cfg.dof,
         ),
     ],
-).transports(
-    {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-        ("cartesian_command", PoseStamped): LCMTransport(
-            "/coordinator/cartesian_command", PoseStamped
-        ),
-    }
 )
 
 # XArm7 with TeleopIK (real, or MuJoCo with --simulation)
@@ -183,14 +150,6 @@ coordinator_teleop_xarm7 = autoconnect(
         ],
     ),
     *_mujoco_if_sim(str(XARM7_SIM_PATH), _xarm7_teleop_cfg.dof),
-).transports(
-    {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-        ("cartesian_command", PoseStamped): LCMTransport(
-            "/coordinator/cartesian_command", PoseStamped
-        ),
-        ("buttons", Buttons): LCMTransport("/teleop/buttons", Buttons),
-    }
 )
 
 # XArm6 with TeleopIK (real, or MuJoCo with --simulation)
@@ -211,14 +170,6 @@ coordinator_teleop_xarm6 = autoconnect(
         ],
     ),
     *_mujoco_if_sim(str(XARM6_SIM_PATH), _xarm6_teleop_cfg.dof),
-).transports(
-    {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-        ("cartesian_command", PoseStamped): LCMTransport(
-            "/coordinator/cartesian_command", PoseStamped
-        ),
-        ("buttons", Buttons): LCMTransport("/teleop/buttons", Buttons),
-    }
 )
 
 # Piper with TeleopIK (real, or MuJoCo with --simulation)
@@ -239,14 +190,6 @@ coordinator_teleop_piper = autoconnect(
         ],
     ),
     *_mujoco_if_sim(str(PIPER_SIM_PATH), _piper_teleop_cfg.dof),
-).transports(
-    {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-        ("cartesian_command", PoseStamped): LCMTransport(
-            "/coordinator/cartesian_command", PoseStamped
-        ),
-        ("buttons", Buttons): LCMTransport("/teleop/buttons", Buttons),
-    }
 )
 
 # Dual arm teleop: XArm6 + Piper with TeleopIK (real-only)
@@ -275,14 +218,6 @@ coordinator_teleop_dual = ControlCoordinator.blueprint(
             hand="right",
         ),
     ],
-).transports(
-    {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-        ("cartesian_command", PoseStamped): LCMTransport(
-            "/coordinator/cartesian_command", PoseStamped
-        ),
-        ("buttons", Buttons): LCMTransport("/teleop/buttons", Buttons),
-    }
 )
 
 

--- a/dimos/control/coordinator.py
+++ b/dimos/control/coordinator.py
@@ -142,20 +142,20 @@ class ControlCoordinator(Module):
     config: ControlCoordinatorConfig
 
     # Output: Aggregated joint state for external consumers
-    joint_state: Out[JointState]
+    coordinator_joint_state: Out[JointState]
 
     # Input: Streaming joint commands for real-time control
     joint_command: In[JointState]
 
     # Input: Streaming cartesian commands for CartesianIKTask
     # Uses frame_id as task name for routing
-    cartesian_command: In[PoseStamped]
+    coordinator_cartesian_command: In[PoseStamped]
 
     # Input: Streaming twist commands for velocity-commanded platforms
     twist_command: In[Twist]
 
     # Input: Teleop buttons for engage/disengage signaling
-    buttons: In[Buttons]
+    teleop_buttons: In[Buttons]
 
     # Arming and dry-run are one-shot RPCs, not streams.
 
@@ -621,7 +621,9 @@ class ControlCoordinator(Module):
             self._setup_from_config()
 
         # Create and start tick loop
-        publish_cb = self.joint_state.publish if self.config.publish_joint_state else None
+        publish_cb = (
+            self.coordinator_joint_state.publish if self.config.publish_joint_state else None
+        )
         self._tick_loop = TickLoop(
             tick_rate=self.config.tick_rate,
             hardware=self._hardware,
@@ -652,7 +654,7 @@ class ControlCoordinator(Module):
         has_cartesian_ik = any(t.type in ("cartesian_ik", "teleop_ik") for t in self.config.tasks)
         if has_cartesian_ik:
             try:
-                self._cartesian_command_unsub = self.cartesian_command.subscribe(
+                self._cartesian_command_unsub = self.coordinator_cartesian_command.subscribe(
                     self._on_cartesian_command
                 )
                 logger.info("Subscribed to cartesian_command for CartesianIK/TeleopIK tasks")
@@ -682,7 +684,7 @@ class ControlCoordinator(Module):
         # Subscribe to buttons if any teleop_ik tasks configured (engage/disengage)
         has_teleop_ik = any(t.type == "teleop_ik" for t in self.config.tasks)
         if has_teleop_ik:
-            self._buttons_unsub = self.buttons.subscribe(self._on_buttons)
+            self._buttons_unsub = self.teleop_buttons.subscribe(self._on_buttons)
             logger.info("Subscribed to buttons for engage/disengage")
 
         # Arming + dry-run are RPC-only; no stream subscription here.

--- a/dimos/control/examples/cartesian_ik_jogger.py
+++ b/dimos/control/examples/cartesian_ik_jogger.py
@@ -188,12 +188,12 @@ def run_jogger_ui(model_path: str | None = None, ee_joint_id: int = 6) -> None:
         model_path = _get_piper_model_path()
 
     print("Starting Cartesian IK Jogger UI...")
-    print("Publishing to /coordinator/cartesian_command")
+    print("Publishing to /coordinator_cartesian_command")
     print("(Coordinator must be running separately to receive commands)")
 
     # Create LCM publisher for sending cartesian commands
     transport: LCMTransport[PoseStamped] = LCMTransport(
-        "/coordinator/cartesian_command", PoseStamped
+        "/coordinator_cartesian_command", PoseStamped
     )
 
     # Initialize pygame

--- a/dimos/e2e_tests/test_control_coordinator.py
+++ b/dimos/e2e_tests/test_control_coordinator.py
@@ -37,7 +37,7 @@ class TestControlCoordinatorE2E:
     def test_coordinator_starts_and_responds_to_rpc(self, lcm_spy, start_blueprint) -> None:
         """Test that coordinator starts and responds to RPC queries."""
         # Save topics we care about (LCM topics include type suffix)
-        joint_state_topic = "/coordinator/joint_state#sensor_msgs.JointState"
+        joint_state_topic = "/coordinator_joint_state#sensor_msgs.JointState"
         lcm_spy.save_topic(joint_state_topic)
         lcm_spy.save_topic("/rpc/ControlCoordinator/list_joints/res")
         lcm_spy.save_topic("/rpc/ControlCoordinator/list_tasks/res")
@@ -72,13 +72,13 @@ class TestControlCoordinatorE2E:
     def test_coordinator_executes_trajectory(self, lcm_spy, start_blueprint) -> None:
         """Test that coordinator executes a trajectory via RPC."""
         # Save topics
-        lcm_spy.save_topic("/coordinator/joint_state#sensor_msgs.JointState")
+        lcm_spy.save_topic("/coordinator_joint_state#sensor_msgs.JointState")
 
         # Start coordinator
         start_blueprint("coordinator-mock")
 
         # Wait for it to be ready
-        lcm_spy.wait_for_saved_topic("/coordinator/joint_state#sensor_msgs.JointState")
+        lcm_spy.wait_for_saved_topic("/coordinator_joint_state#sensor_msgs.JointState")
 
         # Create RPC client
         client = RPCClient(None, ControlCoordinator)
@@ -126,7 +126,7 @@ class TestControlCoordinatorE2E:
 
     def test_coordinator_joint_state_published(self, lcm_spy, start_blueprint) -> None:
         """Test that joint state messages are published at expected rate."""
-        joint_state_topic = "/coordinator/joint_state#sensor_msgs.JointState"
+        joint_state_topic = "/coordinator_joint_state#sensor_msgs.JointState"
         lcm_spy.save_topic(joint_state_topic)
 
         # Start coordinator
@@ -156,11 +156,11 @@ class TestControlCoordinatorE2E:
 
     def test_coordinator_cancel_trajectory(self, lcm_spy, start_blueprint) -> None:
         """Test that a running trajectory can be cancelled."""
-        lcm_spy.save_topic("/coordinator/joint_state#sensor_msgs.JointState")
+        lcm_spy.save_topic("/coordinator_joint_state#sensor_msgs.JointState")
 
         # Start coordinator
         start_blueprint("coordinator-mock")
-        lcm_spy.wait_for_saved_topic("/coordinator/joint_state#sensor_msgs.JointState")
+        lcm_spy.wait_for_saved_topic("/coordinator_joint_state#sensor_msgs.JointState")
 
         client = RPCClient(None, ControlCoordinator)
         try:
@@ -199,11 +199,11 @@ class TestControlCoordinatorE2E:
 
     def test_dual_arm_coordinator(self, lcm_spy, start_blueprint) -> None:
         """Test dual-arm coordinator with independent trajectories."""
-        lcm_spy.save_topic("/coordinator/joint_state#sensor_msgs.JointState")
+        lcm_spy.save_topic("/coordinator_joint_state#sensor_msgs.JointState")
 
         # Start dual-arm mock coordinator
         start_blueprint("coordinator-dual-mock")
-        lcm_spy.wait_for_saved_topic("/coordinator/joint_state#sensor_msgs.JointState")
+        lcm_spy.wait_for_saved_topic("/coordinator_joint_state#sensor_msgs.JointState")
 
         client = RPCClient(None, ControlCoordinator)
         try:

--- a/dimos/hardware/drive_trains/flowbase/README.md
+++ b/dimos/hardware/drive_trains/flowbase/README.md
@@ -64,7 +64,7 @@ WAYLAND_DISPLAY=wayland-0 XDG_SESSION_TYPE=wayland \
 ```
 
 All three use the `flowbase` adapter against `172.6.2.20:11323` and
-publish/subscribe on LCM `/cmd_vel` + `/coordinator/joint_state`.
+publish/subscribe on LCM `/cmd_vel` + `/coordinator_joint_state`.
 
 ### Blueprint notes
 

--- a/dimos/manipulation/blueprints.py
+++ b/dimos/manipulation/blueprints.py
@@ -58,7 +58,7 @@ xarm6_planner_only = ManipulationModule.blueprint(
     enable_viz=True,
 ).transports(
     {
-        ("joint_state", JointState): LCMTransport("/xarm/joint_states", JointState),
+        ("coordinator_joint_state", JointState): LCMTransport("/xarm/joint_states", JointState),
     }
 )
 
@@ -85,10 +85,6 @@ dual_xarm6_planner = ManipulationModule.blueprint(
     ],
     planning_timeout=10.0,
     enable_viz=True,
-).transports(
-    {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-    }
 )
 
 
@@ -114,10 +110,6 @@ xarm7_planner_coordinator = autoconnect(
         hardware=[_xarm7_cfg.to_hardware_component()],
         tasks=[_xarm7_cfg.to_task_config()],
     ),
-).transports(
-    {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-    }
 )
 
 
@@ -176,34 +168,26 @@ _xarm7_perception_cfg = _catalog_xarm7(
     tf_extra_links=["link7"],
 )
 
-xarm_perception = (
-    autoconnect(
-        PickAndPlaceModule.blueprint(
-            robots=[_xarm7_perception_cfg.to_robot_model_config()],
-            planning_timeout=10.0,
-            enable_viz=True,
-            floor_z=-0.02,
-        ),
-        RealSenseCamera.blueprint(
-            base_frame_id="link7",
-            base_transform=_XARM_PERCEPTION_CAMERA_TRANSFORM,
-        ),
-        ObjectSceneRegistrationModule.blueprint(
-            target_frame="world",
-            distance_threshold=0.08,
-            min_detections_for_permanent=3,
-            max_distance=1.0,
-            use_aabb=True,
-            max_obstacle_width=0.06,
-        ),
-    )
-    .transports(
-        {
-            ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-        }
-    )
-    .global_config(n_workers=4)
-)
+xarm_perception = autoconnect(
+    PickAndPlaceModule.blueprint(
+        robots=[_xarm7_perception_cfg.to_robot_model_config()],
+        planning_timeout=10.0,
+        enable_viz=True,
+        floor_z=-0.02,
+    ),
+    RealSenseCamera.blueprint(
+        base_frame_id="link7",
+        base_transform=_XARM_PERCEPTION_CAMERA_TRANSFORM,
+    ),
+    ObjectSceneRegistrationModule.blueprint(
+        target_frame="world",
+        distance_threshold=0.08,
+        min_detections_for_permanent=3,
+        max_distance=1.0,
+        use_aabb=True,
+        max_obstacle_width=0.06,
+    ),
+).global_config(n_workers=4)
 
 
 # XArm7 perception + LLM agent for agentic manipulation.
@@ -323,10 +307,6 @@ xarm_perception_sim = autoconnect(
         tasks=[_xarm7_sim_cfg.to_task_config()],
     ),
     RerunBridgeModule.blueprint(),
-).transports(
-    {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-    }
 )
 
 

--- a/dimos/manipulation/manipulation_module.py
+++ b/dimos/manipulation/manipulation_module.py
@@ -123,7 +123,7 @@ class ManipulationModule(Module):
     config: ManipulationModuleConfig
 
     # Input: Joint state from coordinator (for world sync)
-    joint_state: In[JointState]
+    coordinator_joint_state: In[JointState]
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
@@ -166,9 +166,9 @@ class ManipulationModule(Module):
         self._initialize_planning()
 
         # Subscribe to joint state via port
-        if self.joint_state is not None:
-            self.joint_state.subscribe(self._on_joint_state)
-            logger.info("Subscribed to joint_state port")
+        if self.coordinator_joint_state is not None:
+            self.coordinator_joint_state.subscribe(self._on_joint_state)
+            logger.info("Subscribed to coordinator_joint_state port")
 
         logger.info("ManipulationModule started")
 

--- a/dimos/manipulation/test_manipulation_module.py
+++ b/dimos/manipulation/test_manipulation_module.py
@@ -114,7 +114,7 @@ def module(xarm7_config):
         planning_timeout=10.0,
         enable_viz=False,
     )
-    mod.joint_state = None
+    mod.coordinator_joint_state = None
     mod.objects = None
     mod.start()
     yield mod

--- a/dimos/robot/manipulators/a750/blueprints.py
+++ b/dimos/robot/manipulators/a750/blueprints.py
@@ -25,10 +25,7 @@ Usage:
 from dimos.control.coordinator import ControlCoordinator
 from dimos.core.coordination.blueprints import autoconnect
 from dimos.core.global_config import global_config
-from dimos.core.transport import LCMTransport
 from dimos.manipulation.manipulation_module import ManipulationModule
-from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
-from dimos.msgs.sensor_msgs.JointState import JointState
 from dimos.robot.catalog.a750 import A750_FK_MODEL, a750 as _catalog_a750
 from dimos.teleop.keyboard.keyboard_teleop_module import KeyboardTeleopModule
 
@@ -63,13 +60,6 @@ keyboard_teleop_a750 = autoconnect(
         robots=[_a750_cfg.to_robot_model_config()],
         enable_viz=True,
     ),
-).transports(
-    {
-        ("cartesian_command", PoseStamped): LCMTransport(
-            "/coordinator/cartesian_command", PoseStamped
-        ),
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-    }
 )
 
 __all__ = ["keyboard_teleop_a750"]

--- a/dimos/robot/manipulators/openarm/blueprints.py
+++ b/dimos/robot/manipulators/openarm/blueprints.py
@@ -18,10 +18,7 @@ from __future__ import annotations
 
 from dimos.control.coordinator import ControlCoordinator
 from dimos.core.coordination.blueprints import autoconnect
-from dimos.core.transport import LCMTransport
 from dimos.manipulation.manipulation_module import ManipulationModule
-from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
-from dimos.msgs.sensor_msgs.JointState import JointState
 from dimos.robot.catalog.openarm import (
     OPENARM_V10_FK_MODEL,
     openarm_arm as _openarm,
@@ -39,10 +36,6 @@ coordinator_openarm_mock = ControlCoordinator.blueprint(
         _mock_left.to_task_config(),
         _mock_right.to_task_config(),
     ],
-).transports(
-    {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-    }
 )
 
 # ── Single-arm hardware blueprints (first real bring-up targets) ───────
@@ -75,19 +68,11 @@ _right_hw = _openarm(
 coordinator_openarm_left = ControlCoordinator.blueprint(
     hardware=[_left_hw.to_hardware_component()],
     tasks=[_left_hw.to_task_config()],
-).transports(
-    {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-    }
 )
 
 coordinator_openarm_right = ControlCoordinator.blueprint(
     hardware=[_right_hw.to_hardware_component()],
     tasks=[_right_hw.to_task_config()],
-).transports(
-    {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-    }
 )
 
 # ── Bimanual hardware blueprint ────────────────────────────────────────
@@ -97,10 +82,6 @@ coordinator_openarm_bimanual = ControlCoordinator.blueprint(
         _left_hw.to_task_config(),
         _right_hw.to_task_config(),
     ],
-).transports(
-    {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-    }
 )
 
 
@@ -119,10 +100,6 @@ openarm_mock_planner_coordinator = autoconnect(
             _mock_right.to_task_config(),
         ],
     ),
-).transports(
-    {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-    }
 )
 
 # ── Planner + coordinator (real hw): plan & execute on both arms ────────
@@ -139,10 +116,6 @@ openarm_planner_coordinator = autoconnect(
             _right_hw.to_task_config(),
         ],
     ),
-).transports(
-    {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-    }
 )
 
 
@@ -169,13 +142,6 @@ keyboard_teleop_openarm_mock = autoconnect(
         robots=[_teleop_cfg.to_robot_model_config()],
         enable_viz=True,
     ),
-).transports(
-    {
-        ("cartesian_command", PoseStamped): LCMTransport(
-            "/coordinator/cartesian_command", PoseStamped
-        ),
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-    }
 )
 
 # ── Keyboard teleop (single arm, real hw on can0) ───────────────────────
@@ -198,13 +164,6 @@ keyboard_teleop_openarm = autoconnect(
         robots=[_teleop_hw_cfg.to_robot_model_config()],
         enable_viz=True,
     ),
-).transports(
-    {
-        ("cartesian_command", PoseStamped): LCMTransport(
-            "/coordinator/cartesian_command", PoseStamped
-        ),
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-    }
 )
 
 

--- a/dimos/robot/manipulators/piper/blueprints.py
+++ b/dimos/robot/manipulators/piper/blueprints.py
@@ -25,10 +25,7 @@ Usage:
 from dimos.control.coordinator import ControlCoordinator
 from dimos.core.coordination.blueprints import autoconnect
 from dimos.core.global_config import global_config
-from dimos.core.transport import LCMTransport
 from dimos.manipulation.manipulation_module import ManipulationModule
-from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
-from dimos.msgs.sensor_msgs.JointState import JointState
 from dimos.robot.catalog.piper import PIPER_FK_MODEL, piper as _catalog_piper
 from dimos.teleop.keyboard.keyboard_teleop_module import KeyboardTeleopModule
 
@@ -59,13 +56,6 @@ keyboard_teleop_piper = autoconnect(
         robots=[_piper_cfg.to_robot_model_config()],
         enable_viz=True,
     ),
-).transports(
-    {
-        ("cartesian_command", PoseStamped): LCMTransport(
-            "/coordinator/cartesian_command", PoseStamped
-        ),
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-    }
 )
 
 __all__ = ["keyboard_teleop_piper"]

--- a/dimos/robot/manipulators/xarm/blueprints.py
+++ b/dimos/robot/manipulators/xarm/blueprints.py
@@ -26,10 +26,7 @@ Usage:
 from dimos.control.coordinator import ControlCoordinator
 from dimos.core.coordination.blueprints import autoconnect
 from dimos.core.global_config import global_config
-from dimos.core.transport import LCMTransport
 from dimos.manipulation.manipulation_module import ManipulationModule
-from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
-from dimos.msgs.sensor_msgs.JointState import JointState
 from dimos.robot.catalog.ufactory import (
     XARM6_FK_MODEL,
     XARM7_FK_MODEL,
@@ -76,13 +73,6 @@ keyboard_teleop_xarm6 = autoconnect(
         robots=[_xarm6_cfg.to_robot_model_config()],
         enable_viz=True,
     ),
-).transports(
-    {
-        ("cartesian_command", PoseStamped): LCMTransport(
-            "/coordinator/cartesian_command", PoseStamped
-        ),
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-    }
 )
 
 # XArm7 mock sim + keyboard teleop + Drake visualization
@@ -110,13 +100,6 @@ keyboard_teleop_xarm7 = autoconnect(
         robots=[_xarm7_cfg.to_robot_model_config()],
         enable_viz=True,
     ),
-).transports(
-    {
-        ("cartesian_command", PoseStamped): LCMTransport(
-            "/coordinator/cartesian_command", PoseStamped
-        ),
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-    }
 )
 
 __all__ = ["keyboard_teleop_xarm6", "keyboard_teleop_xarm7"]

--- a/dimos/robot/test_all_blueprints_generation.py
+++ b/dimos/robot/test_all_blueprints_generation.py
@@ -32,7 +32,17 @@ IGNORED_FILES: set[str] = {
     "dimos/core/blueprints.py",
     "dimos/core/test_blueprints.py",
 }
-BLUEPRINT_METHODS = {"transports", "global_config", "remappings", "requirements", "configurators"}
+# Terminal builder methods that mark a top-level blueprint expression. "blueprint"
+# is included so a bare single-module `X.blueprint(...)` (no transports/remappings
+# override needed) is still discovered as a runnable blueprint.
+BLUEPRINT_METHODS = {
+    "blueprint",
+    "transports",
+    "global_config",
+    "remappings",
+    "requirements",
+    "configurators",
+}
 _EXCLUDED_MODULE_NAMES = {"Module", "ModuleBase", "StreamModule"}
 
 

--- a/dimos/robot/unitree/g1/blueprints/basic/unitree_g1_coordinator.py
+++ b/dimos/robot/unitree/g1/blueprints/basic/unitree_g1_coordinator.py
@@ -69,7 +69,6 @@ unitree_g1_coordinator = (
             ("motor_command", MotorCommandArray): LCMTransport(
                 "/g1/motor_command", MotorCommandArray
             ),
-            ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
             ("joint_command", JointState): LCMTransport("/g1/joint_command", JointState),
         }
     )

--- a/dimos/robot/unitree/g1/blueprints/basic/unitree_g1_groot_wbc.py
+++ b/dimos/robot/unitree/g1/blueprints/basic/unitree_g1_groot_wbc.py
@@ -245,7 +245,6 @@ _coordinator = ControlCoordinator.blueprint(
     ],
 ).transports(
     {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
         ("joint_command", JointState): LCMTransport("/g1/joint_command", JointState),
         ("twist_command", Twist): LCMTransport("/g1/cmd_vel", Twist),
         ("tele_cmd_vel", Twist): LCMTransport("/g1/cmd_vel", Twist),

--- a/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_coordinator.py
+++ b/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_coordinator.py
@@ -28,7 +28,6 @@ from dimos.core.coordination.blueprints import autoconnect
 from dimos.core.transport import LCMTransport
 from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
 from dimos.msgs.geometry_msgs.Twist import Twist
-from dimos.msgs.sensor_msgs.JointState import JointState
 from dimos.robot.unitree.go2.connection import GO2Connection
 
 _go2_joints = make_twist_base_joints("go2")
@@ -67,7 +66,6 @@ unitree_go2_coordinator = (
             ("twist_command", Twist): LCMTransport("/cmd_vel", Twist),
             ("go2_cmd_vel", Twist): LCMTransport("/go2/cmd_vel", Twist),
             ("go2_odom", PoseStamped): LCMTransport("/go2/odom", PoseStamped),
-            ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
         }
     )
     .global_config(obstacle_avoidance=False)

--- a/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_keyboard_teleop.py
+++ b/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_keyboard_teleop.py
@@ -26,9 +26,6 @@ from __future__ import annotations
 from dimos.control.components import HardwareComponent, HardwareType, make_twist_base_joints
 from dimos.control.coordinator import ControlCoordinator, TaskConfig
 from dimos.core.coordination.blueprints import autoconnect
-from dimos.core.transport import LCMTransport
-from dimos.msgs.geometry_msgs.Twist import Twist
-from dimos.msgs.sensor_msgs.JointState import JointState
 from dimos.robot.unitree.keyboard_teleop import KeyboardTeleop
 
 _go2_joints = make_twist_base_joints("go2")
@@ -56,12 +53,7 @@ unitree_go2_keyboard_teleop = (
         ),
         KeyboardTeleop.blueprint(),
     )
-    .transports(
-        {
-            ("twist_command", Twist): LCMTransport("/cmd_vel", Twist),
-            ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-        }
-    )
+    .remappings([(ControlCoordinator, "twist_command", "cmd_vel")])
     .global_config(obstacle_avoidance=True)
 )
 

--- a/dimos/teleop/keyboard/keyboard_teleop_module.py
+++ b/dimos/teleop/keyboard/keyboard_teleop_module.py
@@ -87,8 +87,8 @@ class KeyboardTeleopModule(Module):
 
     config: KeyboardTeleopConfig
 
-    joint_state: In[JointState]
-    cartesian_command: Out[PoseStamped]
+    coordinator_joint_state: In[JointState]
+    coordinator_cartesian_command: Out[PoseStamped]
 
     _stop_event: threading.Event
     _thread: threading.Thread | None = None
@@ -116,7 +116,7 @@ class KeyboardTeleopModule(Module):
 
     def _read_joint_positions(self, timeout: float) -> list[float] | None:
         try:
-            msg = self.joint_state.get_next(timeout)
+            msg = self.coordinator_joint_state.get_next(timeout)
         except Exception:
             return None
         if not msg.position:
@@ -148,7 +148,7 @@ class KeyboardTeleopModule(Module):
         current_pose = JogState.from_fk(model_path, ee_joint_id, initial_joints).copy()
 
         # Publish initial pose
-        self.cartesian_command.publish(current_pose.to_pose_stamped(task_name))
+        self.coordinator_cartesian_command.publish(current_pose.to_pose_stamped(task_name))
 
         pygame.init()
         screen = pygame.display.set_mode((600, 400), pygame.SWSURFACE)
@@ -207,7 +207,7 @@ class KeyboardTeleopModule(Module):
             current_pose.z = _clamp(current_pose.z, *Z_LIMITS)
 
             # Publish
-            self.cartesian_command.publish(current_pose.to_pose_stamped(task_name))
+            self.coordinator_cartesian_command.publish(current_pose.to_pose_stamped(task_name))
 
             # Draw UI
             screen.fill((30, 30, 30))

--- a/dimos/teleop/keyboard/test_keyboard_teleop_module.py
+++ b/dimos/teleop/keyboard/test_keyboard_teleop_module.py
@@ -41,8 +41,8 @@ def test_keyboard_teleop_exits_without_publishing_when_initial_state_is_missing(
     monkeypatch.setattr(keyboard_mod, "pygame", object())
     module = KeyboardTeleopModule(initial_state_timeout=0.01)
     published = _PublishedCommands()
-    module.joint_state = _NoInitialJointState()  # type: ignore[assignment]
-    module.cartesian_command = published  # type: ignore[assignment]
+    module.coordinator_joint_state = _NoInitialJointState()  # type: ignore[assignment]
+    module.coordinator_cartesian_command = published  # type: ignore[assignment]
 
     try:
         module.start()

--- a/dimos/teleop/quest/blueprints.py
+++ b/dimos/teleop/quest/blueprints.py
@@ -37,7 +37,6 @@ from dimos.teleop.quest.quest_extensions import (
     Go2TeleopModule,
     VideoArmTeleopModule,
 )
-from dimos.teleop.quest.quest_types import Buttons
 from dimos.visualization.vis_module import vis_module
 
 # Arm teleop with press-and-hold engage (has rerun viz)
@@ -48,7 +47,6 @@ teleop_quest_rerun = autoconnect(
     {
         ("left_controller_output", PoseStamped): LCMTransport("/teleop/left_delta", PoseStamped),
         ("right_controller_output", PoseStamped): LCMTransport("/teleop/right_delta", PoseStamped),
-        ("buttons", Buttons): LCMTransport("/teleop/buttons", Buttons),
     }
 )
 
@@ -57,28 +55,23 @@ teleop_quest_rerun = autoconnect(
 teleop_quest_xarm7 = autoconnect(
     ArmTeleopModule.blueprint(task_names={"right": "teleop_xarm"}),
     coordinator_teleop_xarm7,
-).transports(
-    {
-        ("right_controller_output", PoseStamped): LCMTransport(
-            "/coordinator/cartesian_command", PoseStamped
-        ),
-        ("buttons", Buttons): LCMTransport("/teleop/buttons", Buttons),
-    }
-)
+).remappings([(ArmTeleopModule, "right_controller_output", "coordinator_cartesian_command")])
 
 
 # XArm7 teleop + camera streaming into the Quest scene as a panel.
-teleop_quest_xarm7_video = autoconnect(
-    VideoArmTeleopModule.blueprint(task_names={"right": "teleop_xarm"}),
-    coordinator_teleop_xarm7,
-).transports(
-    {
-        ("right_controller_output", PoseStamped): LCMTransport(
-            "/coordinator/cartesian_command", PoseStamped
-        ),
-        ("buttons", Buttons): LCMTransport("/teleop/buttons", Buttons),
-        ("color_image", Image): LCMTransport("/teleop/color_image", Image),
-    }
+teleop_quest_xarm7_video = (
+    autoconnect(
+        VideoArmTeleopModule.blueprint(task_names={"right": "teleop_xarm"}),
+        coordinator_teleop_xarm7,
+    )
+    .remappings(
+        [(VideoArmTeleopModule, "right_controller_output", "coordinator_cartesian_command")]
+    )
+    .transports(
+        {
+            ("color_image", Image): LCMTransport("/teleop/color_image", Image),
+        }
+    )
 )
 
 
@@ -86,44 +79,25 @@ teleop_quest_xarm7_video = autoconnect(
 teleop_quest_piper = autoconnect(
     ArmTeleopModule.blueprint(task_names={"left": "teleop_piper"}),
     coordinator_teleop_piper,
-).transports(
-    {
-        ("left_controller_output", PoseStamped): LCMTransport(
-            "/coordinator/cartesian_command", PoseStamped
-        ),
-        ("buttons", Buttons): LCMTransport("/teleop/buttons", Buttons),
-    }
-)
+).remappings([(ArmTeleopModule, "left_controller_output", "coordinator_cartesian_command")])
 
 
 # XArm6 teleop (sim with --simulation, real otherwise): right controller -> xarm6
 teleop_quest_xarm6 = autoconnect(
     ArmTeleopModule.blueprint(task_names={"right": "teleop_xarm"}),
     coordinator_teleop_xarm6,
-).transports(
-    {
-        ("right_controller_output", PoseStamped): LCMTransport(
-            "/coordinator/cartesian_command", PoseStamped
-        ),
-        ("buttons", Buttons): LCMTransport("/teleop/buttons", Buttons),
-    }
-)
+).remappings([(ArmTeleopModule, "right_controller_output", "coordinator_cartesian_command")])
 
 
 # Dual arm teleop: right -> piper, left -> xarm6 (TeleopIK, real-only)
 teleop_quest_dual = autoconnect(
     ArmTeleopModule.blueprint(task_names={"right": "teleop_piper", "left": "teleop_xarm"}),
     coordinator_teleop_dual,
-).transports(
-    {
-        ("right_controller_output", PoseStamped): LCMTransport(
-            "/coordinator/cartesian_command", PoseStamped
-        ),
-        ("left_controller_output", PoseStamped): LCMTransport(
-            "/coordinator/cartesian_command", PoseStamped
-        ),
-        ("buttons", Buttons): LCMTransport("/teleop/buttons", Buttons),
-    }
+).remappings(
+    [
+        (ArmTeleopModule, "right_controller_output", "coordinator_cartesian_command"),
+        (ArmTeleopModule, "left_controller_output", "coordinator_cartesian_command"),
+    ]
 )
 
 

--- a/dimos/teleop/quest/quest_extensions.py
+++ b/dimos/teleop/quest/quest_extensions.py
@@ -192,7 +192,7 @@ class ArmTeleopModule(QuestTeleopModule):
             left=left.trigger if left is not None else 0.0,
             right=right.trigger if right is not None else 0.0,
         )
-        self.buttons.publish(buttons)
+        self.teleop_buttons.publish(buttons)
 
 
 class VideoArmTeleopConfig(ArmTeleopConfig):

--- a/dimos/teleop/quest/quest_teleop_module.py
+++ b/dimos/teleop/quest/quest_teleop_module.py
@@ -89,7 +89,7 @@ class QuestTeleopModule(Module):
     Outputs:
         - left_controller_output: PoseStamped (output pose for left hand)
         - right_controller_output: PoseStamped (output pose for right hand)
-        - buttons: Buttons (button states for both controllers)
+        - teleop_buttons: Buttons (button states for both controllers)
     """
 
     config: QuestTeleopConfig
@@ -97,7 +97,7 @@ class QuestTeleopModule(Module):
     # Outputs: delta poses for each controller
     left_controller_output: Out[PoseStamped]
     right_controller_output: Out[PoseStamped]
-    buttons: Out[Buttons]
+    teleop_buttons: Out[Buttons]
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
@@ -392,4 +392,4 @@ class QuestTeleopModule(Module):
         keep analog values, add extra streams).
         """
         buttons = Buttons.from_controllers(left, right)
-        self.buttons.publish(buttons)
+        self.teleop_buttons.publish(buttons)

--- a/dimos/teleop/quest_hosted/blueprints.py
+++ b/dimos/teleop/quest_hosted/blueprints.py
@@ -19,10 +19,7 @@ from pathlib import Path
 from dimos.constants import STATE_DIR
 from dimos.control.blueprints.teleop import coordinator_teleop_xarm7
 from dimos.core.coordination.blueprints import autoconnect
-from dimos.core.transport import LCMTransport
-from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
 from dimos.robot.unitree.go2.blueprints.basic.unitree_go2_basic import unitree_go2_basic
-from dimos.teleop.quest.quest_types import Buttons
 from dimos.teleop.quest_hosted.hosted_extensions import (
     HostedArmTeleopModule,
     HostedTwistTeleopModule,
@@ -36,13 +33,8 @@ teleop_hosted_xarm7 = (
         HostedArmTeleopModule.blueprint(task_names={"right": "teleop_xarm"}),
         coordinator_teleop_xarm7,
     )
-    .transports(
-        {
-            ("right_controller_output", PoseStamped): LCMTransport(
-                "/coordinator/cartesian_command", PoseStamped
-            ),
-            ("buttons", Buttons): LCMTransport("/teleop/buttons", Buttons),
-        }
+    .remappings(
+        [(HostedArmTeleopModule, "right_controller_output", "coordinator_cartesian_command")]
     )
     .global_config(rerun_open="none")
 )

--- a/dimos/teleop/quest_hosted/hosted_extensions.py
+++ b/dimos/teleop/quest_hosted/hosted_extensions.py
@@ -72,7 +72,7 @@ class HostedArmTeleopModule(HostedTeleopModule):
             left=left.trigger if left is not None else 0.0,
             right=right.trigger if right is not None else 0.0,
         )
-        self.buttons.publish(buttons)
+        self.teleop_buttons.publish(buttons)
 
 
 class HostedTwistTeleopConfig(HostedTeleopConfig):

--- a/dimos/teleop/quest_hosted/hosted_teleop_module.py
+++ b/dimos/teleop/quest_hosted/hosted_teleop_module.py
@@ -90,7 +90,7 @@ class HostedTeleopModule(Module):
 
     left_controller_output: Out[PoseStamped]
     right_controller_output: Out[PoseStamped]
-    buttons: Out[Buttons]
+    teleop_buttons: Out[Buttons]
     # cmd_vel actuation port is on the mobile-base subclass; this stays generic.
     cmd_vel_stamped: Out[TwistStamped]
     # Operator-side video health, sampled in the browser via getStats() and
@@ -632,4 +632,4 @@ class HostedTeleopModule(Module):
         right: QuestControllerState | None,
     ) -> None:
         buttons = Buttons.from_controllers(left, right)
-        self.buttons.publish(buttons)
+        self.teleop_buttons.publish(buttons)

--- a/dimos/teleop/utils/recorder.py
+++ b/dimos/teleop/utils/recorder.py
@@ -61,7 +61,7 @@ class TeleopRecorder(Recorder):
 
     left_controller_output: In[PoseStamped]
     right_controller_output: In[PoseStamped]
-    buttons: In[Buttons]
+    teleop_buttons: In[Buttons]
     cmd_vel_stamped: In[TwistStamped]
     video_stats: In[VideoStats]
     config: TeleopRecorderConfig

--- a/dimos/teleop/utils/report.py
+++ b/dimos/teleop/utils/report.py
@@ -52,7 +52,7 @@ _STREAM_TYPES = {
     "cmd_vel_stamped": TwistStamped,
     "left_controller_output": PoseStamped,
     "right_controller_output": PoseStamped,
-    "buttons": Buttons,
+    "teleop_buttons": Buttons,
     "video_stats": VideoStats,
 }
 

--- a/docs/capabilities/manipulation/a750.md
+++ b/docs/capabilities/manipulation/a750.md
@@ -111,10 +111,10 @@ The `keyboard-teleop-a750` blueprint is defined in [`dimos/robot/manipulators/a7
 
 ```text
 KeyboardTeleopModule
-  -> /coordinator/cartesian_command PoseStamped
+  -> /coordinator_cartesian_command PoseStamped
   -> ControlCoordinator CartesianIK task
   -> A750Adapter or mock adapter
-  -> /coordinator/joint_state JointState
+  -> /coordinator_joint_state JointState
   -> ManipulationModule Drake/Meshcat visualization
 ```
 

--- a/docs/capabilities/manipulation/adding_a_custom_arm.md
+++ b/docs/capabilities/manipulation/adding_a_custom_arm.md
@@ -448,8 +448,6 @@ from pathlib import Path
 
 from dimos.control.components import HardwareComponent, HardwareType, make_joints
 from dimos.control.coordinator import ControlCoordinator, TaskConfig
-from dimos.core.transport import LCMTransport
-from dimos.msgs.sensor_msgs import JointState
 
 
 # YourArm (6-DOF) — real hardware
@@ -475,10 +473,6 @@ coordinator_yourarm = ControlCoordinator.blueprint(
             priority=10,                              # Higher priority wins arbitration
         ),
     ],
-).transports(
-    {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-    }
 )
 
 
@@ -575,11 +569,10 @@ yourarm_planner = manipulation_module(
     robots=[_make_yourarm_config("arm", joint_prefix="arm_", coordinator_task="traj_arm")],
     planning_timeout=10.0,
     enable_viz=True,
-).transports(
-    {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-    }
 )
+# The planner's `coordinator_joint_state` input auto-connects to the
+# ControlCoordinator's output on the default `/coordinator_joint_state`
+# topic, so no `.transports(...)` override is needed.
 ```
 
 ### Key config fields

--- a/scripts/g1_replay.py
+++ b/scripts/g1_replay.py
@@ -113,13 +113,13 @@ def main() -> None:
                 current_q[n] = q
         state_event.set()
 
-    state_sub: LCMTransport[JointState] = LCMTransport("/coordinator/joint_state", JointState)
+    state_sub: LCMTransport[JointState] = LCMTransport("/coordinator_joint_state", JointState)
     # subscribe() returns an unsub callable; signature claims None (see transport.py).
     state_unsub = state_sub.subscribe(on_state)  # type: ignore[func-returns-value]
     cmd_pub: LCMTransport[JointState] = LCMTransport("/g1/joint_command", JointState)
 
     try:
-        logger.info("waiting up to 10s for /coordinator/joint_state ...")
+        logger.info("waiting up to 10s for /coordinator_joint_state ...")
         if not state_event.wait(timeout=10.0):
             logger.error("no joint_state received — is `dimos run unitree-g1-coordinator` running?")
             return


### PR DESCRIPTION
## Problem

* We have a lot of duplication in transport definitions.
* We almost always define LCM transports, which makes it difficult to switch to Zenoh

Closes DIM-1020

## Solution

* Reduce duplication

## How to Test

## Contributor License Agreement

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
