### PR TITLE
Add Transport.spec

### DIFF
--- a/dimos/control/blueprints/basic.py
+++ b/dimos/control/blueprints/basic.py
@@ -58,7 +58,7 @@ coordinator_basic = ControlCoordinator.blueprint(
     joint_state_frame_id="coordinator",
 ).transports(
     {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
+        ("joint_state", JointState): LCMTransport.spec("/coordinator/joint_state", JointState),
     }
 )
 
@@ -70,7 +70,7 @@ coordinator_mock = ControlCoordinator.blueprint(
     tasks=[_mock_cfg.to_task_config()],
 ).transports(
     {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
+        ("joint_state", JointState): LCMTransport.spec("/coordinator/joint_state", JointState),
     }
 )
 
@@ -89,7 +89,7 @@ coordinator_xarm7 = autoconnect(
     *_mujoco_if_sim(str(XARM7_SIM_PATH), _xarm7_cfg.dof),
 ).transports(
     {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
+        ("joint_state", JointState): LCMTransport.spec("/coordinator/joint_state", JointState),
     }
 )
 
@@ -108,7 +108,7 @@ coordinator_xarm6 = autoconnect(
     *_mujoco_if_sim(str(XARM6_SIM_PATH), _xarm6_cfg.dof),
 ).transports(
     {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
+        ("joint_state", JointState): LCMTransport.spec("/coordinator/joint_state", JointState),
     }
 )
 
@@ -127,7 +127,7 @@ coordinator_piper = autoconnect(
     *_mujoco_if_sim(str(PIPER_SIM_PATH), _piper_cfg.dof),
 ).transports(
     {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
+        ("joint_state", JointState): LCMTransport.spec("/coordinator/joint_state", JointState),
     }
 )
 

--- a/dimos/control/blueprints/dual.py
+++ b/dimos/control/blueprints/dual.py
@@ -41,7 +41,7 @@ coordinator_dual_mock = ControlCoordinator.blueprint(
     ],
 ).transports(
     {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
+        ("joint_state", JointState): LCMTransport.spec("/coordinator/joint_state", JointState),
     }
 )
 
@@ -59,7 +59,7 @@ coordinator_dual_xarm = ControlCoordinator.blueprint(
     ],
 ).transports(
     {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
+        ("joint_state", JointState): LCMTransport.spec("/coordinator/joint_state", JointState),
     }
 )
 
@@ -79,7 +79,7 @@ coordinator_piper_xarm = ControlCoordinator.blueprint(
     ],
 ).transports(
     {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
+        ("joint_state", JointState): LCMTransport.spec("/coordinator/joint_state", JointState),
     }
 )
 

--- a/dimos/control/blueprints/mobile.py
+++ b/dimos/control/blueprints/mobile.py
@@ -91,8 +91,8 @@ coordinator_mock_twist_base = ControlCoordinator.blueprint(
     ],
 ).transports(
     {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-        ("twist_command", Twist): LCMTransport("/cmd_vel", Twist),
+        ("joint_state", JointState): LCMTransport.spec("/coordinator/joint_state", JointState),
+        ("twist_command", Twist): LCMTransport.spec("/cmd_vel", Twist),
     }
 )
 
@@ -109,8 +109,8 @@ coordinator_flowbase = ControlCoordinator.blueprint(
     ],
 ).transports(
     {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-        ("twist_command", Twist): LCMTransport("/cmd_vel", Twist),
+        ("joint_state", JointState): LCMTransport.spec("/coordinator/joint_state", JointState),
+        ("twist_command", Twist): LCMTransport.spec("/cmd_vel", Twist),
     }
 )
 
@@ -130,8 +130,8 @@ coordinator_flowbase_keyboard_teleop = autoconnect(
     KeyboardTeleop.blueprint(),
 ).transports(
     {
-        ("twist_command", Twist): LCMTransport("/cmd_vel", Twist),
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
+        ("twist_command", Twist): LCMTransport.spec("/cmd_vel", Twist),
+        ("joint_state", JointState): LCMTransport.spec("/coordinator/joint_state", JointState),
     }
 )
 
@@ -209,8 +209,8 @@ coordinator_flowbase_nav = (
         {
             # MovementManager.cmd_vel publishes to LCM /cmd_vel by default; the
             # coordinator's twist_command listens on the same topic.
-            ("twist_command", Twist): LCMTransport("/cmd_vel", Twist),
-            ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
+            ("twist_command", Twist): LCMTransport.spec("/cmd_vel", Twist),
+            ("joint_state", JointState): LCMTransport.spec("/coordinator/joint_state", JointState),
         }
     )
     .global_config(n_workers=8)
@@ -233,8 +233,8 @@ coordinator_mobile_manip_mock = ControlCoordinator.blueprint(
     ],
 ).transports(
     {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-        ("twist_command", Twist): LCMTransport("/cmd_vel", Twist),
+        ("joint_state", JointState): LCMTransport.spec("/coordinator/joint_state", JointState),
+        ("twist_command", Twist): LCMTransport.spec("/cmd_vel", Twist),
     }
 )
 

--- a/dimos/control/blueprints/teleop.py
+++ b/dimos/control/blueprints/teleop.py
@@ -91,8 +91,8 @@ coordinator_servo_xarm6 = ControlCoordinator.blueprint(
     ],
 ).transports(
     {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-        ("joint_command", JointState): LCMTransport("/teleop/joint_command", JointState),
+        ("joint_state", JointState): LCMTransport.spec("/coordinator/joint_state", JointState),
+        ("joint_command", JointState): LCMTransport.spec("/teleop/joint_command", JointState),
     }
 )
 
@@ -104,8 +104,8 @@ coordinator_velocity_xarm6 = ControlCoordinator.blueprint(
     ],
 ).transports(
     {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-        ("joint_command", JointState): LCMTransport("/joystick/joint_command", JointState),
+        ("joint_state", JointState): LCMTransport.spec("/coordinator/joint_state", JointState),
+        ("joint_command", JointState): LCMTransport.spec("/joystick/joint_command", JointState),
     }
 )
 
@@ -118,8 +118,8 @@ coordinator_combined_xarm6 = ControlCoordinator.blueprint(
     ],
 ).transports(
     {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-        ("joint_command", JointState): LCMTransport("/control/joint_command", JointState),
+        ("joint_state", JointState): LCMTransport.spec("/coordinator/joint_state", JointState),
+        ("joint_command", JointState): LCMTransport.spec("/control/joint_command", JointState),
     }
 )
 
@@ -138,8 +138,8 @@ coordinator_cartesian_ik_mock = ControlCoordinator.blueprint(
     ],
 ).transports(
     {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-        ("cartesian_command", PoseStamped): LCMTransport(
+        ("joint_state", JointState): LCMTransport.spec("/coordinator/joint_state", JointState),
+        ("cartesian_command", PoseStamped): LCMTransport.spec(
             "/coordinator/cartesian_command", PoseStamped
         ),
     }
@@ -158,8 +158,8 @@ coordinator_cartesian_ik_piper = ControlCoordinator.blueprint(
     ],
 ).transports(
     {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-        ("cartesian_command", PoseStamped): LCMTransport(
+        ("joint_state", JointState): LCMTransport.spec("/coordinator/joint_state", JointState),
+        ("cartesian_command", PoseStamped): LCMTransport.spec(
             "/coordinator/cartesian_command", PoseStamped
         ),
     }
@@ -185,11 +185,11 @@ coordinator_teleop_xarm7 = autoconnect(
     *_mujoco_if_sim(str(XARM7_SIM_PATH), _xarm7_teleop_cfg.dof),
 ).transports(
     {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-        ("cartesian_command", PoseStamped): LCMTransport(
+        ("joint_state", JointState): LCMTransport.spec("/coordinator/joint_state", JointState),
+        ("cartesian_command", PoseStamped): LCMTransport.spec(
             "/coordinator/cartesian_command", PoseStamped
         ),
-        ("buttons", Buttons): LCMTransport("/teleop/buttons", Buttons),
+        ("buttons", Buttons): LCMTransport.spec("/teleop/buttons", Buttons),
     }
 )
 
@@ -213,11 +213,11 @@ coordinator_teleop_xarm6 = autoconnect(
     *_mujoco_if_sim(str(XARM6_SIM_PATH), _xarm6_teleop_cfg.dof),
 ).transports(
     {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-        ("cartesian_command", PoseStamped): LCMTransport(
+        ("joint_state", JointState): LCMTransport.spec("/coordinator/joint_state", JointState),
+        ("cartesian_command", PoseStamped): LCMTransport.spec(
             "/coordinator/cartesian_command", PoseStamped
         ),
-        ("buttons", Buttons): LCMTransport("/teleop/buttons", Buttons),
+        ("buttons", Buttons): LCMTransport.spec("/teleop/buttons", Buttons),
     }
 )
 
@@ -241,11 +241,11 @@ coordinator_teleop_piper = autoconnect(
     *_mujoco_if_sim(str(PIPER_SIM_PATH), _piper_teleop_cfg.dof),
 ).transports(
     {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-        ("cartesian_command", PoseStamped): LCMTransport(
+        ("joint_state", JointState): LCMTransport.spec("/coordinator/joint_state", JointState),
+        ("cartesian_command", PoseStamped): LCMTransport.spec(
             "/coordinator/cartesian_command", PoseStamped
         ),
-        ("buttons", Buttons): LCMTransport("/teleop/buttons", Buttons),
+        ("buttons", Buttons): LCMTransport.spec("/teleop/buttons", Buttons),
     }
 )
 
@@ -277,11 +277,11 @@ coordinator_teleop_dual = ControlCoordinator.blueprint(
     ],
 ).transports(
     {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-        ("cartesian_command", PoseStamped): LCMTransport(
+        ("joint_state", JointState): LCMTransport.spec("/coordinator/joint_state", JointState),
+        ("cartesian_command", PoseStamped): LCMTransport.spec(
             "/coordinator/cartesian_command", PoseStamped
         ),
-        ("buttons", Buttons): LCMTransport("/teleop/buttons", Buttons),
+        ("buttons", Buttons): LCMTransport.spec("/teleop/buttons", Buttons),
     }
 )
 

--- a/dimos/core/coordination/blueprints.py
+++ b/dimos/core/coordination/blueprints.py
@@ -21,15 +21,14 @@ import types as types_mod
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Literal, Union, get_args, get_origin, get_type_hints
 
-from pydantic import create_model
+from pydantic import BaseModel, create_model
 
 if TYPE_CHECKING:
     from dimos.protocol.service.system_configurator.base import SystemConfigurator
 
 from dimos.core.global_config import GlobalConfig
 from dimos.core.module import ModuleBase, is_module_type
-from dimos.core.stream import In, Out
-from dimos.core.transport import PubSubTransport
+from dimos.core.stream import In, Out, Transport
 from dimos.spec.utils import Spec, is_spec
 from dimos.utils.logging_config import setup_logger
 
@@ -141,6 +140,29 @@ class BlueprintAtom:
         )
 
 
+@dataclass(frozen=True)
+class TransportSpec:
+    """Deferred transport construction: a transport class plus its ctor args.
+
+    Blueprint authors declare transports via ``Cls.spec(...)`` so nothing is
+    constructed at blueprint-definition time. The coordinator materializes
+    specs at build time, once CLI/env/config overrides have resolved.
+    """
+
+    cls: type[Transport[Any]]
+    args: tuple[Any, ...] = ()
+    kwargs: Mapping[str, Any] = field(default_factory=dict)
+
+    @property
+    def config_cls(self) -> type[BaseModel] | None:
+        # Set by transports that expose a pydantic config override surface
+        return self.cls._config_cls
+
+    def build(self, config: BaseModel | None = None) -> Transport[Any]:
+        extra = {"config": config} if config is not None else {}
+        return self.cls(*self.args, **self.kwargs, **extra)
+
+
 # These fields cannot be pickled.
 _PROXY_FIELDS = ("transport_map", "global_config_overrides", "remapping_map")
 
@@ -149,7 +171,7 @@ _PROXY_FIELDS = ("transport_map", "global_config_overrides", "remapping_map")
 class Blueprint:
     blueprints: tuple[BlueprintAtom, ...]
     disabled_modules_tuple: tuple[type[ModuleBase], ...] = field(default_factory=tuple)
-    transport_map: Mapping[tuple[str, type], PubSubTransport[Any]] = field(
+    transport_map: Mapping[tuple[str, type], TransportSpec] = field(
         default_factory=lambda: MappingProxyType({})
     )
     global_config_overrides: Mapping[str, Any] = field(default_factory=lambda: MappingProxyType({}))
@@ -187,8 +209,8 @@ class Blueprint:
         configs["g"] = (GlobalConfig | None, None)
         transport_fields: dict[str, Any] = {}
         seen: set[type] = set()
-        for transport in self.transport_map.values():
-            cls = transport._config_cls
+        for spec in self.transport_map.values():
+            cls = spec.config_cls
             if cls is None or cls in seen:
                 continue
             seen.add(cls)
@@ -200,7 +222,7 @@ class Blueprint:
             configs["transports"] = (transports_model | None, None)
         return create_model("BlueprintConfig", __config__={"extra": "forbid"}, **configs)  # type: ignore[call-overload,no-any-return]
 
-    def transports(self, transports: dict[tuple[str, type], Any]) -> "Blueprint":
+    def transports(self, transports: dict[tuple[str, type], TransportSpec]) -> "Blueprint":
         return replace(self, transport_map=MappingProxyType({**self.transport_map, **transports}))
 
     def global_config(self, **kwargs: Any) -> "Blueprint":

--- a/dimos/core/coordination/module_coordinator.py
+++ b/dimos/core/coordination/module_coordinator.py
@@ -16,13 +16,11 @@ from __future__ import annotations
 
 from collections import defaultdict
 from collections.abc import Callable, Mapping, MutableMapping
-from dataclasses import replace
 import importlib
 import inspect
 import shutil
 import sys
 import threading
-from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, NamedTuple, cast
 
 from dimos.core.coordination.blueprints import transport_config_name
@@ -32,11 +30,8 @@ from dimos.core.coordination.worker_manager_python import WorkerManagerPython
 from dimos.core.global_config import GlobalConfig, global_config
 from dimos.core.module import ModuleBase, ModuleSpec
 from dimos.core.resource import Resource
-from dimos.core.transport import (
-    LCMTransport,
-    PubSubTransport,
-    pLCMTransport,
-)
+from dimos.core.stream import Transport
+from dimos.core.transport import LCMTransport, PubSubTransport, pLCMTransport
 from dimos.spec.utils import is_spec, spec_annotation_compliance, spec_structural_compliance
 from dimos.utils.generic import short_id
 from dimos.utils.logging_config import setup_logger
@@ -72,9 +67,9 @@ class ModuleCoordinator(Resource):
         self._deployed_modules = {}
         self._deployed_atoms: dict[type[ModuleBase], BlueprintAtom] = {}
         self._resolved_module_refs: dict[tuple[type[ModuleBase], str], type[ModuleBase]] = {}
-        self._transport_registry: dict[tuple[str, type], PubSubTransport[Any]] = {}
+        self._transport_registry: dict[tuple[str, type], Transport[Any]] = {}
         self._class_aliases: dict[type[ModuleBase], type[ModuleBase]] = {}
-        self._module_transports: dict[type[ModuleBase], dict[str, PubSubTransport[Any]]] = {}
+        self._module_transports: dict[type[ModuleBase], dict[str, Transport[Any]]] = {}
         self._started = False
         self._modules_lock = threading.RLock()
         self._coordinator_rpc: CoordinatorRPC | None = None
@@ -256,7 +251,9 @@ class ModuleCoordinator(Resource):
             if hasattr(module, "on_system_modules"):
                 module.on_system_modules(modules)
 
-    def _connect_streams(self, blueprint: Blueprint) -> None:
+    def _connect_streams(
+        self, blueprint: Blueprint, transports: Mapping[tuple[str, type], Transport[Any]]
+    ) -> None:
         streams: dict[tuple[str, type], list[tuple[type, str]]] = defaultdict(list)
 
         for bp in blueprint.active_blueprints:
@@ -270,7 +267,9 @@ class ModuleCoordinator(Resource):
             if key in self._transport_registry:
                 transport = self._transport_registry[key]
             else:
-                transport = _get_transport_for(blueprint, remapped_name, stream_type)
+                transport = transports.get(key) or _get_transport_for(
+                    blueprint, remapped_name, stream_type
+                )
             self._transport_registry[key] = transport
             for module, original_name in streams[key]:
                 instance = self.get_instance(module)  # type: ignore[assignment]
@@ -298,7 +297,7 @@ class ModuleCoordinator(Resource):
         if "g" in blueprint_args:
             global_config.update(**blueprint_args.pop("g"))
         transport_overrides = blueprint_args.pop("transports", None) or {}
-        blueprint = _apply_transport_overrides(blueprint, transport_overrides)
+        transports = _materialize_transports(blueprint, transport_overrides)
 
         _run_configurators(blueprint)
         _check_requirements(blueprint)
@@ -309,7 +308,7 @@ class ModuleCoordinator(Resource):
         coordinator.start()
 
         _deploy_all_modules(blueprint, coordinator, global_config, blueprint_args)
-        coordinator._connect_streams(blueprint)
+        coordinator._connect_streams(blueprint, transports)
         _connect_module_refs(blueprint, coordinator)
 
         coordinator.build_all_modules()
@@ -347,7 +346,7 @@ class ModuleCoordinator(Resource):
         if "g" in blueprint_args:
             self._global_config.update(**blueprint_args.pop("g"))
         transport_overrides = blueprint_args.pop("transports", None) or {}
-        blueprint = _apply_transport_overrides(blueprint, transport_overrides)
+        transports = _materialize_transports(blueprint, transport_overrides)
 
         # Scale worker pool.
         n_extra = int(blueprint.global_config_overrides.get("n_workers", 0))
@@ -372,7 +371,7 @@ class ModuleCoordinator(Resource):
         before = set(self._deployed_modules)
 
         _deploy_all_modules(blueprint, self, self._global_config, blueprint_args)
-        self._connect_streams(blueprint)
+        self._connect_streams(blueprint, transports)
         _connect_module_refs(blueprint, self, existing_modules=before)
 
         new_modules = [proxy for cls, proxy in self._deployed_modules.items() if cls not in before]
@@ -583,32 +582,29 @@ def _is_name_unique(blueprint: Blueprint, name: str) -> bool:
 
 
 def _get_transport_for(blueprint: Blueprint, name: str, stream_type: type) -> PubSubTransport[Any]:
-    transport = blueprint.transport_map.get((name, stream_type), None)
-    if transport:
-        return transport
-
     use_pickled = getattr(stream_type, "lcm_encode", None) is None
     topic = f"/{name}" if _is_name_unique(blueprint, name) else f"/{short_id()}"
-    transport = pLCMTransport(topic) if use_pickled else LCMTransport(topic, stream_type)
-
-    return transport
+    return pLCMTransport(topic) if use_pickled else LCMTransport(topic, stream_type)
 
 
-def _apply_transport_overrides(
+def _materialize_transports(
     blueprint: Blueprint, overrides: Mapping[str, Mapping[str, Any]]
-) -> Blueprint:
-    """Return a blueprint whose WebRTC transports carry CLI/env-merged configs."""
-    if not overrides:
-        return blueprint
-    new_map = dict(blueprint.transport_map)
-    for key, transport in new_map.items():
-        if transport._config_cls is None:
-            continue
-        sub = overrides.get(transport_config_name(transport._config_cls))
-        if not sub:
-            continue
-        new_map[key] = transport.with_config_overrides(sub)
-    return replace(blueprint, transport_map=MappingProxyType(new_map))
+) -> dict[tuple[str, type], Transport[Any]]:
+    """Build the blueprint's declared transports, merging CLI/env config overrides.
+
+    WebRTC transports get a freshly constructed provider config from the
+    resolved ``transports.<name>.*`` overrides; everything else builds from the
+    spec as-is. Returns ready-to-use instances pickled into module workers.
+    """
+    materialized: dict[tuple[str, type], Transport[Any]] = {}
+    for key, spec in blueprint.transport_map.items():
+        config = None
+        config_cls = spec.config_cls
+        if config_cls is not None:
+            sub = overrides.get(transport_config_name(config_cls), {})
+            config = config_cls(**sub)
+        materialized[key] = spec.build(config=config)
+    return materialized
 
 
 def _verify_no_name_conflicts(blueprint: Blueprint) -> None:
@@ -649,7 +645,7 @@ def _verify_no_name_conflicts(blueprint: Blueprint) -> None:
 
 def _verify_no_conflicts_with_existing(
     blueprint: Blueprint,
-    existing_registry: dict[tuple[str, type], PubSubTransport[Any]],
+    existing_registry: dict[tuple[str, type], Transport[Any]],
 ) -> None:
     """Check that a new blueprint's streams don't conflict with already-registered transports."""
     if not existing_registry:

--- a/dimos/core/coordination/module_coordinator.py
+++ b/dimos/core/coordination/module_coordinator.py
@@ -267,9 +267,9 @@ class ModuleCoordinator(Resource):
             if key in self._transport_registry:
                 transport = self._transport_registry[key]
             else:
-                transport = transports.get(key) or _get_transport_for(
-                    blueprint, remapped_name, stream_type
-                )
+                transport = transports.get(key)
+                if transport is None:
+                    transport = _get_transport_for(blueprint, remapped_name, stream_type)
             self._transport_registry[key] = transport
             for module, original_name in streams[key]:
                 instance = self.get_instance(module)  # type: ignore[assignment]

--- a/dimos/core/coordination/test_blueprints.py
+++ b/dimos/core/coordination/test_blueprints.py
@@ -138,13 +138,15 @@ def test_config() -> None:
 
 
 def test_transports() -> None:
-    custom_transport = LCMTransport("/custom_topic", Data1)
     blueprint_set = autoconnect(ModuleA.blueprint(), ModuleB.blueprint()).transports(
-        {("data1", Data1): custom_transport}
+        {("data1", Data1): LCMTransport.spec("/custom_topic", Data1)}
     )
 
     assert ("data1", Data1) in blueprint_set.transport_map
-    assert blueprint_set.transport_map[("data1", Data1)] == custom_transport
+    # TransportSpec compares by value (class + args + kwargs), not identity.
+    assert blueprint_set.transport_map[("data1", Data1)] == LCMTransport.spec(
+        "/custom_topic", Data1
+    )
 
 
 def test_global_config() -> None:

--- a/dimos/core/stream.py
+++ b/dimos/core/stream.py
@@ -19,7 +19,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Generic,
-    Self,
     TypeVar,
 )
 
@@ -35,7 +34,7 @@ import dimos.utils.reactive as reactive
 from dimos.utils.reactive import backpressure
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Mapping
+    from collections.abc import Callable
 
     from reactivex.observable import Observable
 
@@ -99,13 +98,6 @@ class Transport(Resource, ObservableMixin[T]):
 
     def publish(self, msg: T) -> None:
         self.broadcast(None, msg)  # type: ignore[arg-type]
-
-    def with_config_overrides(self, overrides: Mapping[str, Any]) -> Self:
-        """Return a new instance with `overrides` merged into the current config.
-
-        Default: NotImplementedError. Override when `_config_cls` is set.
-        """
-        raise NotImplementedError
 
 
 class Stream(Generic[T]):

--- a/dimos/core/test_native_module.py
+++ b/dimos/core/test_native_module.py
@@ -160,7 +160,7 @@ def test_autoconnect(args_file: str) -> None:
         StubProducer.blueprint(),
     ).transports(
         {
-            ("pointcloud", PointCloud2): LCMTransport("/my/custom/lidar", PointCloud2),
+            ("pointcloud", PointCloud2): LCMTransport.spec("/my/custom/lidar", PointCloud2),
         },
     )
 

--- a/dimos/core/transport.py
+++ b/dimos/core/transport.py
@@ -18,7 +18,6 @@ import threading
 from typing import (
     TYPE_CHECKING,
     Any,
-    Self,
     TypeVar,
 )
 
@@ -44,7 +43,9 @@ from dimos.utils.logging_config import setup_logger
 logger = setup_logger()
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Mapping
+    from collections.abc import Callable
+
+    from dimos.core.coordination.blueprints import TransportSpec
 
 T = TypeVar("T")
 
@@ -74,6 +75,13 @@ class PubSubTransport(Transport[T]):
 
     def __init__(self, topic: Any) -> None:
         self.topic = topic
+
+    @classmethod
+    def spec(cls, *args: Any, **kwargs: Any) -> TransportSpec:
+        """Defer construction: capture ctor args for the coordinator to build later."""
+        from dimos.core.coordination.blueprints import TransportSpec
+
+        return TransportSpec(cls, args, kwargs)
 
     def __str__(self) -> str:
         return (
@@ -389,10 +397,6 @@ class WebRTCTransport(PubSubTransport[M]):
     def __reduce__(self):  # type: ignore[no-untyped-def]
         return (_rebuild_webrtc_transport, (type(self), self.topic, self._msg_type, self._config))
 
-    def with_config_overrides(self, overrides: Mapping[str, Any]) -> Self:
-        new_config = self._config.model_copy(update=dict(overrides))
-        return type(self)(self.topic, self._msg_type, config=new_config)
-
     def broadcast(self, _: Out[M] | None, msg: M) -> None:
         if not self._started:
             self.start()
@@ -444,8 +448,8 @@ class CloudflareTransport(WebRTCTransport[M]):
     Blueprint usage::
 
         unitree_go2_hosted = unitree_go2_basic.transports({
-            ("cmd_vel", Twist): CloudflareTransport("cmd_unreliable", TwistStamped),
-            ("color_image", Image): CloudflareVideoTransport(),
+            ("cmd_vel", Twist): CloudflareTransport.spec("cmd_unreliable", TwistStamped),
+            ("color_image", Image): CloudflareVideoTransport.spec(),
         })
     """
 
@@ -473,6 +477,13 @@ class WebRTCVideoTransport(Transport[Any]):
     def __init__(self, *, config: ProviderConfig | None = None, **config_kwargs: Any) -> None:
         self._config = config or self._config_cls(**config_kwargs)
 
+    @classmethod
+    def spec(cls, *args: Any, **kwargs: Any) -> TransportSpec:
+        """Defer construction: capture ctor args for the coordinator to build later."""
+        from dimos.core.coordination.blueprints import TransportSpec
+
+        return TransportSpec(cls, args, kwargs)
+
     def start(self) -> None:
         pass  # provider starts lazily on first broadcast
 
@@ -496,9 +507,6 @@ class WebRTCVideoTransport(Transport[Any]):
             type(self).__name__,
         )
         return lambda: None
-
-    def with_config_overrides(self, overrides: Mapping[str, Any]) -> Self:
-        return type(self)(config=self._config.model_copy(update=dict(overrides)))
 
 
 class CloudflareVideoTransport(WebRTCVideoTransport):

--- a/dimos/manipulation/blueprints.py
+++ b/dimos/manipulation/blueprints.py
@@ -58,7 +58,7 @@ xarm6_planner_only = ManipulationModule.blueprint(
     enable_viz=True,
 ).transports(
     {
-        ("joint_state", JointState): LCMTransport("/xarm/joint_states", JointState),
+        ("joint_state", JointState): LCMTransport.spec("/xarm/joint_states", JointState),
     }
 )
 
@@ -87,7 +87,7 @@ dual_xarm6_planner = ManipulationModule.blueprint(
     enable_viz=True,
 ).transports(
     {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
+        ("joint_state", JointState): LCMTransport.spec("/coordinator/joint_state", JointState),
     }
 )
 
@@ -116,7 +116,7 @@ xarm7_planner_coordinator = autoconnect(
     ),
 ).transports(
     {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
+        ("joint_state", JointState): LCMTransport.spec("/coordinator/joint_state", JointState),
     }
 )
 
@@ -199,7 +199,7 @@ xarm_perception = (
     )
     .transports(
         {
-            ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
+            ("joint_state", JointState): LCMTransport.spec("/coordinator/joint_state", JointState),
         }
     )
     .global_config(n_workers=4)
@@ -325,7 +325,7 @@ xarm_perception_sim = autoconnect(
     RerunBridgeModule.blueprint(),
 ).transports(
     {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
+        ("joint_state", JointState): LCMTransport.spec("/coordinator/joint_state", JointState),
     }
 )
 

--- a/dimos/perception/fiducial/blueprints/desk_marker_tf.py
+++ b/dimos/perception/fiducial/blueprints/desk_marker_tf.py
@@ -159,7 +159,7 @@ desk_marker_tf = autoconnect(
     ),
 ).transports(
     {
-        ("detections", MarkerDetectionStreamModule): LCMTransport(
+        ("detections", MarkerDetectionStreamModule): LCMTransport.spec(
             "/marker_detection/detections",
             Detection3DArray,
         ),

--- a/dimos/perception/fiducial/blueprints/test_desk_marker_tf.py
+++ b/dimos/perception/fiducial/blueprints/test_desk_marker_tf.py
@@ -47,7 +47,7 @@ def test_desk_marker_tf_blueprint_declares_static_tf_module() -> None:
         == DESK_MARKER_NAMESPACE_PREFIX
     )
     assert (
-        desk_marker_tf.transport_map[("detections", MarkerDetectionStreamModule)].topic.topic
+        desk_marker_tf.transport_map[("detections", MarkerDetectionStreamModule)].args[0]
         == "/marker_detection/detections"
     )
 

--- a/dimos/protocol/pubsub/impl/webrtc/test_blueprint_e2e.py
+++ b/dimos/protocol/pubsub/impl/webrtc/test_blueprint_e2e.py
@@ -82,7 +82,7 @@ def test_blueprint_stream_over_cloudflare() -> None:
     # is the broker's job.
     blueprint = autoconnect(TwistSource.blueprint(), TwistSink.blueprint()).transports(
         {
-            ("cmd_webrtc", TwistStamped): WebRTCTransport(
+            ("cmd_webrtc", TwistStamped): WebRTCTransport.spec(
                 "cmd_webrtc", TwistStamped, config=CloudflareConfig()
             )
         }

--- a/dimos/protocol/pubsub/impl/webrtc/test_transport.py
+++ b/dimos/protocol/pubsub/impl/webrtc/test_transport.py
@@ -25,7 +25,7 @@ from pydantic import ValidationError
 import pytest
 
 from dimos.core.coordination.blueprints import Blueprint
-from dimos.core.coordination.module_coordinator import _apply_transport_overrides
+from dimos.core.coordination.module_coordinator import _materialize_transports
 from dimos.core.transport import WebRTCTransport
 from dimos.msgs.geometry_msgs.TwistStamped import TwistStamped
 from dimos.protocol.pubsub.impl.webrtc.providers.broker import BrokerConfig
@@ -225,7 +225,7 @@ def test_provider_config_is_frozen_and_hashable() -> None:
 
 def test_blueprint_config_exposes_transport_fields() -> None:
     """Each unique `_config_cls` becomes a `transports.<name>` sub-model on the schema."""
-    bp = Blueprint(blueprints=()).transports({("topic", FakeLCMMsg): MockTransport("topic")})
+    bp = Blueprint(blueprints=()).transports({("topic", FakeLCMMsg): MockTransport.spec("topic")})
     cfg = bp.config()
     parsed = cfg(transports={"mock": {"name": "override"}})
     assert parsed.transports.mock.name == "override"
@@ -237,8 +237,8 @@ def test_blueprint_config_exposes_transport_fields() -> None:
     # Multiple transports sharing one `_config_cls` collapse to one slot.
     bp_shared = Blueprint(blueprints=()).transports(
         {
-            ("a", FakeLCMMsg): MockTransport("a"),
-            ("b", FakeLCMMsg): MockTransport("b"),
+            ("a", FakeLCMMsg): MockTransport.spec("a"),
+            ("b", FakeLCMMsg): MockTransport.spec("b"),
         }
     )
     inner = next(
@@ -249,22 +249,28 @@ def test_blueprint_config_exposes_transport_fields() -> None:
     assert set(inner.model_fields.keys()) == {"mock"}
 
 
-def test_transport_overrides_rebuild_blueprint() -> None:
-    """Overrides return a new blueprint with rebuilt transports — originals untouched, pickle-safe."""
-    original = MockTransport("topic")
-    bp = Blueprint(blueprints=()).transports({("topic", FakeLCMMsg): original})
+def test_transport_overrides_apply_and_survive_pickle() -> None:
+    """Materialization builds each transport with its resolved config; pickle-safe."""
+    bp = Blueprint(blueprints=()).transports({("topic", FakeLCMMsg): MockTransport.spec("topic")})
 
-    new_bp = _apply_transport_overrides(bp, {"mock": {"name": "overridden"}})
-    new_transport = new_bp.transport_map[("topic", FakeLCMMsg)]
+    transport = _materialize_transports(bp, {"mock": {"name": "overridden"}})[("topic", FakeLCMMsg)]
 
-    # Fresh instance with the override; the original is untouched.
-    assert new_transport is not original
-    assert new_transport._config.name == "overridden"
-    assert original._config.name == "default"
-    assert pickle.loads(pickle.dumps(new_transport))._config.name == "overridden"
+    assert transport._config.name == "overridden"
+    assert pickle.loads(pickle.dumps(transport))._config.name == "overridden"
 
-    # No override → blueprint passes through unchanged (same identity).
-    assert _apply_transport_overrides(bp, {}) is bp
+    # No override → config built from the spec's defaults.
+    default = _materialize_transports(bp, {})[("topic", FakeLCMMsg)]
+    assert default._config.name == "default"
+
+
+def test_materialize_uses_resolved_config() -> None:
+    """The config reaching the transport is built straight from the overrides,
+    not a default instance that is later mutated."""
+    bp = Blueprint(blueprints=()).transports({("topic", FakeLCMMsg): MockTransport.spec("topic")})
+
+    transport = _materialize_transports(bp, {"mock": {"name": "resolved"}})[("topic", FakeLCMMsg)]
+
+    assert transport._config == MockConfig(name="resolved")
 
 
 # ─── Broker credential validation ────────────────────────────────────

--- a/dimos/robot/manipulators/a750/blueprints.py
+++ b/dimos/robot/manipulators/a750/blueprints.py
@@ -65,10 +65,10 @@ keyboard_teleop_a750 = autoconnect(
     ),
 ).transports(
     {
-        ("cartesian_command", PoseStamped): LCMTransport(
+        ("cartesian_command", PoseStamped): LCMTransport.spec(
             "/coordinator/cartesian_command", PoseStamped
         ),
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
+        ("joint_state", JointState): LCMTransport.spec("/coordinator/joint_state", JointState),
     }
 )
 

--- a/dimos/robot/manipulators/openarm/blueprints.py
+++ b/dimos/robot/manipulators/openarm/blueprints.py
@@ -41,7 +41,7 @@ coordinator_openarm_mock = ControlCoordinator.blueprint(
     ],
 ).transports(
     {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
+        ("joint_state", JointState): LCMTransport.spec("/coordinator/joint_state", JointState),
     }
 )
 
@@ -77,7 +77,7 @@ coordinator_openarm_left = ControlCoordinator.blueprint(
     tasks=[_left_hw.to_task_config()],
 ).transports(
     {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
+        ("joint_state", JointState): LCMTransport.spec("/coordinator/joint_state", JointState),
     }
 )
 
@@ -86,7 +86,7 @@ coordinator_openarm_right = ControlCoordinator.blueprint(
     tasks=[_right_hw.to_task_config()],
 ).transports(
     {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
+        ("joint_state", JointState): LCMTransport.spec("/coordinator/joint_state", JointState),
     }
 )
 
@@ -99,7 +99,7 @@ coordinator_openarm_bimanual = ControlCoordinator.blueprint(
     ],
 ).transports(
     {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
+        ("joint_state", JointState): LCMTransport.spec("/coordinator/joint_state", JointState),
     }
 )
 
@@ -121,7 +121,7 @@ openarm_mock_planner_coordinator = autoconnect(
     ),
 ).transports(
     {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
+        ("joint_state", JointState): LCMTransport.spec("/coordinator/joint_state", JointState),
     }
 )
 
@@ -141,7 +141,7 @@ openarm_planner_coordinator = autoconnect(
     ),
 ).transports(
     {
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
+        ("joint_state", JointState): LCMTransport.spec("/coordinator/joint_state", JointState),
     }
 )
 
@@ -171,10 +171,10 @@ keyboard_teleop_openarm_mock = autoconnect(
     ),
 ).transports(
     {
-        ("cartesian_command", PoseStamped): LCMTransport(
+        ("cartesian_command", PoseStamped): LCMTransport.spec(
             "/coordinator/cartesian_command", PoseStamped
         ),
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
+        ("joint_state", JointState): LCMTransport.spec("/coordinator/joint_state", JointState),
     }
 )
 
@@ -200,10 +200,10 @@ keyboard_teleop_openarm = autoconnect(
     ),
 ).transports(
     {
-        ("cartesian_command", PoseStamped): LCMTransport(
+        ("cartesian_command", PoseStamped): LCMTransport.spec(
             "/coordinator/cartesian_command", PoseStamped
         ),
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
+        ("joint_state", JointState): LCMTransport.spec("/coordinator/joint_state", JointState),
     }
 )
 

--- a/dimos/robot/manipulators/piper/blueprints.py
+++ b/dimos/robot/manipulators/piper/blueprints.py
@@ -61,10 +61,10 @@ keyboard_teleop_piper = autoconnect(
     ),
 ).transports(
     {
-        ("cartesian_command", PoseStamped): LCMTransport(
+        ("cartesian_command", PoseStamped): LCMTransport.spec(
             "/coordinator/cartesian_command", PoseStamped
         ),
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
+        ("joint_state", JointState): LCMTransport.spec("/coordinator/joint_state", JointState),
     }
 )
 

--- a/dimos/robot/manipulators/xarm/blueprints.py
+++ b/dimos/robot/manipulators/xarm/blueprints.py
@@ -74,10 +74,10 @@ keyboard_teleop_xarm6 = autoconnect(
     ),
 ).transports(
     {
-        ("cartesian_command", PoseStamped): LCMTransport(
+        ("cartesian_command", PoseStamped): LCMTransport.spec(
             "/coordinator/cartesian_command", PoseStamped
         ),
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
+        ("joint_state", JointState): LCMTransport.spec("/coordinator/joint_state", JointState),
     }
 )
 
@@ -104,10 +104,10 @@ keyboard_teleop_xarm7 = autoconnect(
     ),
 ).transports(
     {
-        ("cartesian_command", PoseStamped): LCMTransport(
+        ("cartesian_command", PoseStamped): LCMTransport.spec(
             "/coordinator/cartesian_command", PoseStamped
         ),
-        ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
+        ("joint_state", JointState): LCMTransport.spec("/coordinator/joint_state", JointState),
     }
 )
 

--- a/dimos/robot/unitree/g1/blueprints/basic/unitree_g1_coordinator.py
+++ b/dimos/robot/unitree/g1/blueprints/basic/unitree_g1_coordinator.py
@@ -64,13 +64,13 @@ unitree_g1_coordinator = (
     # collide with ControlCoordinator's (joint_state/joint_command/...).
     .transports(
         {
-            ("motor_states", JointState): LCMTransport("/g1/motor_states", JointState),
-            ("imu", Imu): LCMTransport("/g1/imu", Imu),
-            ("motor_command", MotorCommandArray): LCMTransport(
+            ("motor_states", JointState): LCMTransport.spec("/g1/motor_states", JointState),
+            ("imu", Imu): LCMTransport.spec("/g1/imu", Imu),
+            ("motor_command", MotorCommandArray): LCMTransport.spec(
                 "/g1/motor_command", MotorCommandArray
             ),
-            ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-            ("joint_command", JointState): LCMTransport("/g1/joint_command", JointState),
+            ("joint_state", JointState): LCMTransport.spec("/coordinator/joint_state", JointState),
+            ("joint_command", JointState): LCMTransport.spec("/g1/joint_command", JointState),
         }
     )
 )

--- a/dimos/robot/unitree/g1/blueprints/perceptive/unitree_g1_detection.py
+++ b/dimos/robot/unitree/g1/blueprints/perceptive/unitree_g1_detection.py
@@ -66,39 +66,45 @@ unitree_g1_detection = (
     .transports(
         {
             # Detection 3D module outputs
-            ("detections", Detection3DModule): LCMTransport(
+            ("detections", Detection3DModule): LCMTransport.spec(
                 "/detector3d/detections", Detection2DArray
             ),
-            ("detected_pointcloud_0", Detection3DModule): LCMTransport(
+            ("detected_pointcloud_0", Detection3DModule): LCMTransport.spec(
                 "/detector3d/pointcloud/0", PointCloud2
             ),
-            ("detected_pointcloud_1", Detection3DModule): LCMTransport(
+            ("detected_pointcloud_1", Detection3DModule): LCMTransport.spec(
                 "/detector3d/pointcloud/1", PointCloud2
             ),
-            ("detected_pointcloud_2", Detection3DModule): LCMTransport(
+            ("detected_pointcloud_2", Detection3DModule): LCMTransport.spec(
                 "/detector3d/pointcloud/2", PointCloud2
             ),
-            ("detected_image_0", Detection3DModule): LCMTransport("/detector3d/image/0", Image),
-            ("detected_image_1", Detection3DModule): LCMTransport("/detector3d/image/1", Image),
-            ("detected_image_2", Detection3DModule): LCMTransport("/detector3d/image/2", Image),
+            ("detected_image_0", Detection3DModule): LCMTransport.spec(
+                "/detector3d/image/0", Image
+            ),
+            ("detected_image_1", Detection3DModule): LCMTransport.spec(
+                "/detector3d/image/1", Image
+            ),
+            ("detected_image_2", Detection3DModule): LCMTransport.spec(
+                "/detector3d/image/2", Image
+            ),
             # Detection DB module outputs
-            ("detections", ObjectDBModule): LCMTransport(
+            ("detections", ObjectDBModule): LCMTransport.spec(
                 "/detectorDB/detections", Detection2DArray
             ),
-            ("detected_pointcloud_0", ObjectDBModule): LCMTransport(
+            ("detected_pointcloud_0", ObjectDBModule): LCMTransport.spec(
                 "/detectorDB/pointcloud/0", PointCloud2
             ),
-            ("detected_pointcloud_1", ObjectDBModule): LCMTransport(
+            ("detected_pointcloud_1", ObjectDBModule): LCMTransport.spec(
                 "/detectorDB/pointcloud/1", PointCloud2
             ),
-            ("detected_pointcloud_2", ObjectDBModule): LCMTransport(
+            ("detected_pointcloud_2", ObjectDBModule): LCMTransport.spec(
                 "/detectorDB/pointcloud/2", PointCloud2
             ),
-            ("detected_image_0", ObjectDBModule): LCMTransport("/detectorDB/image/0", Image),
-            ("detected_image_1", ObjectDBModule): LCMTransport("/detectorDB/image/1", Image),
-            ("detected_image_2", ObjectDBModule): LCMTransport("/detectorDB/image/2", Image),
+            ("detected_image_0", ObjectDBModule): LCMTransport.spec("/detectorDB/image/0", Image),
+            ("detected_image_1", ObjectDBModule): LCMTransport.spec("/detectorDB/image/1", Image),
+            ("detected_image_2", ObjectDBModule): LCMTransport.spec("/detectorDB/image/2", Image),
             # Person tracker outputs
-            ("target", PersonTracker): LCMTransport("/person_tracker/target", PoseStamped),
+            ("target", PersonTracker): LCMTransport.spec("/person_tracker/target", PoseStamped),
         }
     )
 )

--- a/dimos/robot/unitree/g1/blueprints/perceptive/unitree_g1_shm.py
+++ b/dimos/robot/unitree/g1/blueprints/perceptive/unitree_g1_shm.py
@@ -26,7 +26,7 @@ from dimos.visualization.vis_module import vis_module
 unitree_g1_shm = autoconnect(
     unitree_g1.transports(
         {
-            ("color_image", Image): pSHMTransport(
+            ("color_image", Image): pSHMTransport.spec(
                 "/color_image", default_capacity=DEFAULT_CAPACITY_COLOR_IMAGE
             ),
         }

--- a/dimos/robot/unitree/g1/blueprints/primitive/unitree_g1_primitive_no_nav.py
+++ b/dimos/robot/unitree/g1/blueprints/primitive/unitree_g1_primitive_no_nav.py
@@ -133,23 +133,23 @@ unitree_g1_primitive_no_nav = (
     .transports(
         {
             # G1 uses Twist for movement commands
-            ("cmd_vel", Twist): LCMTransport("/cmd_vel", Twist),
+            ("cmd_vel", Twist): LCMTransport.spec("/cmd_vel", Twist),
             # State estimation from ROS
-            ("state_estimation", Odometry): LCMTransport("/state_estimation", Odometry),
-            ("odom", PoseStamped): LCMTransport("/odom", PoseStamped),
+            ("state_estimation", Odometry): LCMTransport.spec("/state_estimation", Odometry),
+            ("odom", PoseStamped): LCMTransport.spec("/odom", PoseStamped),
             # Navigation module topics from nav_bot
-            ("goal_req", PoseStamped): LCMTransport("/goal_req", PoseStamped),
-            ("goal_active", PoseStamped): LCMTransport("/goal_active", PoseStamped),
-            ("path_active", Path): LCMTransport("/path_active", Path),
-            ("pointcloud", PointCloud2): LCMTransport("/lidar", PointCloud2),
-            ("global_pointcloud", PointCloud2): LCMTransport("/map", PointCloud2),
+            ("goal_req", PoseStamped): LCMTransport.spec("/goal_req", PoseStamped),
+            ("goal_active", PoseStamped): LCMTransport.spec("/goal_active", PoseStamped),
+            ("path_active", Path): LCMTransport.spec("/path_active", Path),
+            ("pointcloud", PointCloud2): LCMTransport.spec("/lidar", PointCloud2),
+            ("global_pointcloud", PointCloud2): LCMTransport.spec("/map", PointCloud2),
             # Original navigation topics for backwards compatibility
-            ("goal_pose", PoseStamped): LCMTransport("/goal_pose", PoseStamped),
-            ("goal_reached", Bool): LCMTransport("/goal_reached", Bool),
-            ("cancel_goal", Bool): LCMTransport("/cancel_goal", Bool),
+            ("goal_pose", PoseStamped): LCMTransport.spec("/goal_pose", PoseStamped),
+            ("goal_reached", Bool): LCMTransport.spec("/goal_reached", Bool),
+            ("cancel_goal", Bool): LCMTransport.spec("/cancel_goal", Bool),
             # Camera topics
-            ("color_image", Image): LCMTransport("/color_image", Image),
-            ("camera_info", CameraInfo): LCMTransport("/camera_info", CameraInfo),
+            ("color_image", Image): LCMTransport.spec("/color_image", Image),
+            ("camera_info", CameraInfo): LCMTransport.spec("/camera_info", CameraInfo),
         }
     )
 )

--- a/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_basic.py
+++ b/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_basic.py
@@ -18,7 +18,7 @@ import platform
 from typing import Any
 
 from dimos.constants import DEFAULT_CAPACITY_COLOR_IMAGE
-from dimos.core.coordination.blueprints import autoconnect
+from dimos.core.coordination.blueprints import TransportSpec, autoconnect
 from dimos.core.global_config import global_config
 from dimos.core.transport import pSHMTransport
 from dimos.mapping.costmapper import costmap_to_rerun
@@ -29,8 +29,8 @@ from dimos.visualization.vis_module import vis_module
 # Mac has some issue with high bandwidth UDP, so we use pSHMTransport for color_image
 # actually we can use pSHMTransport for all platforms, and for all streams
 # TODO need a global transport toggle on blueprints/global config
-_mac_transports: dict[tuple[str, type], pSHMTransport[Image]] = {
-    ("color_image", Image): pSHMTransport(
+_mac_transports: dict[tuple[str, type], TransportSpec] = {
+    ("color_image", Image): pSHMTransport.spec(
         "color_image", default_capacity=DEFAULT_CAPACITY_COLOR_IMAGE
     ),
 }

--- a/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_coordinator.py
+++ b/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_coordinator.py
@@ -63,11 +63,11 @@ unitree_go2_coordinator = (
     )
     .transports(
         {
-            ("cmd_vel", Twist): LCMTransport("/cmd_vel", Twist),
-            ("twist_command", Twist): LCMTransport("/cmd_vel", Twist),
-            ("go2_cmd_vel", Twist): LCMTransport("/go2/cmd_vel", Twist),
-            ("go2_odom", PoseStamped): LCMTransport("/go2/odom", PoseStamped),
-            ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
+            ("cmd_vel", Twist): LCMTransport.spec("/cmd_vel", Twist),
+            ("twist_command", Twist): LCMTransport.spec("/cmd_vel", Twist),
+            ("go2_cmd_vel", Twist): LCMTransport.spec("/go2/cmd_vel", Twist),
+            ("go2_odom", PoseStamped): LCMTransport.spec("/go2/odom", PoseStamped),
+            ("joint_state", JointState): LCMTransport.spec("/coordinator/joint_state", JointState),
         }
     )
     .global_config(obstacle_avoidance=False)

--- a/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_keyboard_teleop.py
+++ b/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_keyboard_teleop.py
@@ -58,8 +58,8 @@ unitree_go2_keyboard_teleop = (
     )
     .transports(
         {
-            ("twist_command", Twist): LCMTransport("/cmd_vel", Twist),
-            ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
+            ("twist_command", Twist): LCMTransport.spec("/cmd_vel", Twist),
+            ("joint_state", JointState): LCMTransport.spec("/coordinator/joint_state", JointState),
         }
     )
     .global_config(obstacle_avoidance=True)

--- a/dimos/robot/unitree/go2/blueprints/smart/test_unitree_go2_markers.py
+++ b/dimos/robot/unitree/go2/blueprints/smart/test_unitree_go2_markers.py
@@ -31,6 +31,6 @@ def test_unitree_go2_markers_uses_detector_backed_tf_stack() -> None:
     assert detector.kwargs["marker_length_m"] == 0.1
     assert detector.kwargs["camera_info"].frame_id == "camera_optical"
     assert (
-        unitree_go2_markers.transport_map[("detections", MarkerDetectionStreamModule)].topic.topic
+        unitree_go2_markers.transport_map[("detections", MarkerDetectionStreamModule)].args[0]
         == "/marker_detection/detections"
     )

--- a/dimos/robot/unitree/go2/blueprints/smart/unitree_go2.py
+++ b/dimos/robot/unitree/go2/blueprints/smart/unitree_go2.py
@@ -70,7 +70,7 @@ unitree_go2_markers = (
     )
     .transports(
         {
-            ("detections", MarkerDetectionStreamModule): LCMTransport(
+            ("detections", MarkerDetectionStreamModule): LCMTransport.spec(
                 "/marker_detection/detections",
                 Detection3DArray,
             ),

--- a/dimos/robot/unitree/go2/blueprints/smart/unitree_go2_detection.py
+++ b/dimos/robot/unitree/go2/blueprints/smart/unitree_go2_detection.py
@@ -37,21 +37,27 @@ unitree_go2_detection = (
     .transports(
         {
             # Detection 3D module outputs
-            ("detections", Detection3DModule): LCMTransport(
+            ("detections", Detection3DModule): LCMTransport.spec(
                 "/detector3d/detections", Detection2DArray
             ),
-            ("detected_pointcloud_0", Detection3DModule): LCMTransport(
+            ("detected_pointcloud_0", Detection3DModule): LCMTransport.spec(
                 "/detector3d/pointcloud/0", PointCloud2
             ),
-            ("detected_pointcloud_1", Detection3DModule): LCMTransport(
+            ("detected_pointcloud_1", Detection3DModule): LCMTransport.spec(
                 "/detector3d/pointcloud/1", PointCloud2
             ),
-            ("detected_pointcloud_2", Detection3DModule): LCMTransport(
+            ("detected_pointcloud_2", Detection3DModule): LCMTransport.spec(
                 "/detector3d/pointcloud/2", PointCloud2
             ),
-            ("detected_image_0", Detection3DModule): LCMTransport("/detector3d/image/0", Image),
-            ("detected_image_1", Detection3DModule): LCMTransport("/detector3d/image/1", Image),
-            ("detected_image_2", Detection3DModule): LCMTransport("/detector3d/image/2", Image),
+            ("detected_image_0", Detection3DModule): LCMTransport.spec(
+                "/detector3d/image/0", Image
+            ),
+            ("detected_image_1", Detection3DModule): LCMTransport.spec(
+                "/detector3d/image/1", Image
+            ),
+            ("detected_image_2", Detection3DModule): LCMTransport.spec(
+                "/detector3d/image/2", Image
+            ),
         }
     )
 )

--- a/dimos/robot/unitree/go2/blueprints/smart/unitree_go2_ros.py
+++ b/dimos/robot/unitree/go2/blueprints/smart/unitree_go2_ros.py
@@ -21,10 +21,10 @@ from dimos.robot.unitree.go2.blueprints.smart.unitree_go2 import unitree_go2
 
 unitree_go2_ros = unitree_go2.transports(
     {
-        ("lidar", PointCloud2): ROSTransport("lidar", PointCloud2),
-        ("global_map", PointCloud2): ROSTransport("global_map", PointCloud2),
-        ("odom", PoseStamped): ROSTransport("odom", PoseStamped),
-        ("color_image", Image): ROSTransport("color_image", Image),
+        ("lidar", PointCloud2): ROSTransport.spec("lidar", PointCloud2),
+        ("global_map", PointCloud2): ROSTransport.spec("global_map", PointCloud2),
+        ("odom", PoseStamped): ROSTransport.spec("odom", PoseStamped),
+        ("color_image", Image): ROSTransport.spec("color_image", Image),
     }
 )
 

--- a/dimos/teleop/quest/blueprints.py
+++ b/dimos/teleop/quest/blueprints.py
@@ -46,9 +46,13 @@ teleop_quest_rerun = autoconnect(
     vis_module("rerun"),
 ).transports(
     {
-        ("left_controller_output", PoseStamped): LCMTransport("/teleop/left_delta", PoseStamped),
-        ("right_controller_output", PoseStamped): LCMTransport("/teleop/right_delta", PoseStamped),
-        ("buttons", Buttons): LCMTransport("/teleop/buttons", Buttons),
+        ("left_controller_output", PoseStamped): LCMTransport.spec(
+            "/teleop/left_delta", PoseStamped
+        ),
+        ("right_controller_output", PoseStamped): LCMTransport.spec(
+            "/teleop/right_delta", PoseStamped
+        ),
+        ("buttons", Buttons): LCMTransport.spec("/teleop/buttons", Buttons),
     }
 )
 
@@ -59,10 +63,10 @@ teleop_quest_xarm7 = autoconnect(
     coordinator_teleop_xarm7,
 ).transports(
     {
-        ("right_controller_output", PoseStamped): LCMTransport(
+        ("right_controller_output", PoseStamped): LCMTransport.spec(
             "/coordinator/cartesian_command", PoseStamped
         ),
-        ("buttons", Buttons): LCMTransport("/teleop/buttons", Buttons),
+        ("buttons", Buttons): LCMTransport.spec("/teleop/buttons", Buttons),
     }
 )
 
@@ -73,11 +77,11 @@ teleop_quest_xarm7_video = autoconnect(
     coordinator_teleop_xarm7,
 ).transports(
     {
-        ("right_controller_output", PoseStamped): LCMTransport(
+        ("right_controller_output", PoseStamped): LCMTransport.spec(
             "/coordinator/cartesian_command", PoseStamped
         ),
-        ("buttons", Buttons): LCMTransport("/teleop/buttons", Buttons),
-        ("color_image", Image): LCMTransport("/teleop/color_image", Image),
+        ("buttons", Buttons): LCMTransport.spec("/teleop/buttons", Buttons),
+        ("color_image", Image): LCMTransport.spec("/teleop/color_image", Image),
     }
 )
 
@@ -88,10 +92,10 @@ teleop_quest_piper = autoconnect(
     coordinator_teleop_piper,
 ).transports(
     {
-        ("left_controller_output", PoseStamped): LCMTransport(
+        ("left_controller_output", PoseStamped): LCMTransport.spec(
             "/coordinator/cartesian_command", PoseStamped
         ),
-        ("buttons", Buttons): LCMTransport("/teleop/buttons", Buttons),
+        ("buttons", Buttons): LCMTransport.spec("/teleop/buttons", Buttons),
     }
 )
 
@@ -102,10 +106,10 @@ teleop_quest_xarm6 = autoconnect(
     coordinator_teleop_xarm6,
 ).transports(
     {
-        ("right_controller_output", PoseStamped): LCMTransport(
+        ("right_controller_output", PoseStamped): LCMTransport.spec(
             "/coordinator/cartesian_command", PoseStamped
         ),
-        ("buttons", Buttons): LCMTransport("/teleop/buttons", Buttons),
+        ("buttons", Buttons): LCMTransport.spec("/teleop/buttons", Buttons),
     }
 )
 
@@ -116,13 +120,13 @@ teleop_quest_dual = autoconnect(
     coordinator_teleop_dual,
 ).transports(
     {
-        ("right_controller_output", PoseStamped): LCMTransport(
+        ("right_controller_output", PoseStamped): LCMTransport.spec(
             "/coordinator/cartesian_command", PoseStamped
         ),
-        ("left_controller_output", PoseStamped): LCMTransport(
+        ("left_controller_output", PoseStamped): LCMTransport.spec(
             "/coordinator/cartesian_command", PoseStamped
         ),
-        ("buttons", Buttons): LCMTransport("/teleop/buttons", Buttons),
+        ("buttons", Buttons): LCMTransport.spec("/teleop/buttons", Buttons),
     }
 )
 
@@ -135,8 +139,8 @@ teleop_quest_go2 = (
     )
     .transports(
         {
-            ("cmd_vel", Twist): LCMTransport("/cmd_vel", Twist),
-            ("color_image", Image): pSHMTransport(
+            ("cmd_vel", Twist): LCMTransport.spec("/cmd_vel", Twist),
+            ("color_image", Image): pSHMTransport.spec(
                 "color_image", default_capacity=DEFAULT_CAPACITY_COLOR_IMAGE
             ),
         }

--- a/dimos/teleop/quest_hosted/blueprints.py
+++ b/dimos/teleop/quest_hosted/blueprints.py
@@ -41,10 +41,10 @@ teleop_hosted_xarm7 = (
     )
     .transports(
         {
-            ("right_controller_output", PoseStamped): LCMTransport(
+            ("right_controller_output", PoseStamped): LCMTransport.spec(
                 "/coordinator/cartesian_command", PoseStamped
             ),
-            ("buttons", Buttons): LCMTransport("/teleop/buttons", Buttons),
+            ("buttons", Buttons): LCMTransport.spec("/teleop/buttons", Buttons),
         }
     )
     .global_config(rerun_open="none")
@@ -65,7 +65,7 @@ teleop_hosted_go2 = autoconnect(
 # as sent: normalized [-1, 1], no speed rescaling). The camera stream feeds
 # the session's WebRTC video track via CloudflareVideoTransport (same
 # provider/PeerConnection), and robot → operator telemetry can ride
-# CloudflareTransport("state_reliable_back", ...) the same way.
+# CloudflareTransport.spec("state_reliable_back", ...) the same way.
 #
 # Run:  dimos run teleop-hosted-go2-transport -o transports.broker.api_key=dtk_live_...
 #       (or TRANSPORTS__BROKER__API_KEY=dtk_live_... in env; robot identity is
@@ -73,8 +73,8 @@ teleop_hosted_go2 = autoconnect(
 # then connect from https://teleop.dimensionalos.com (keyboard view).
 teleop_hosted_go2_transport = unitree_go2_basic.transports(
     {
-        ("cmd_vel", Twist): CloudflareTransport("cmd_unreliable", TwistStamped),
-        ("color_image", Image): CloudflareVideoTransport(),
+        ("cmd_vel", Twist): CloudflareTransport.spec("cmd_unreliable", TwistStamped),
+        ("color_image", Image): CloudflareVideoTransport.spec(),
     }
 ).global_config(viewer="none")
 


### PR DESCRIPTION
This avoids instantiating Transports in the Blueprint.transports() method. Instead we pass a .spec(), and instantiation happens later. This allows config etc. to be passed in at construction time cleanly.