### PR TITLE
fix: test-suite stability and drone camera pinhole

### DIFF
--- a/dimos/agents/conftest.py
+++ b/dimos/agents/conftest.py
@@ -27,6 +27,7 @@ from dimos.core.coordination.blueprints import autoconnect
 from dimos.core.coordination.module_coordinator import ModuleCoordinator
 from dimos.core.global_config import global_config
 from dimos.core.transport import pLCMTransport
+from dimos.utils.testing.agent_teardown import teardown_agent_setup
 
 load_dotenv()
 
@@ -96,11 +97,4 @@ def agent_setup(request, mcp_url: str, lcm_url: str):
 
     yield fn
 
-    if coordinator is not None:
-        coordinator.stop()
-
-    for transport in transports:
-        transport.stop()
-
-    for unsub in unsubs:
-        unsub()
+    teardown_agent_setup(coordinator, transports, unsubs)

--- a/dimos/agents/mcp/conftest.py
+++ b/dimos/agents/mcp/conftest.py
@@ -27,6 +27,7 @@ from dimos.core.coordination.blueprints import autoconnect
 from dimos.core.coordination.module_coordinator import ModuleCoordinator
 from dimos.core.global_config import global_config
 from dimos.core.transport import pLCMTransport
+from dimos.utils.testing.agent_teardown import teardown_agent_setup
 
 load_dotenv()
 
@@ -93,11 +94,4 @@ def agent_setup(request, mcp_url: str, lcm_url: str):
 
     yield fn
 
-    if coordinator is not None:
-        coordinator.stop()
-
-    for transport in transports:
-        transport.stop()
-
-    for unsub in unsubs:
-        unsub()
+    teardown_agent_setup(coordinator, transports, unsubs)

--- a/dimos/core/test_core.py
+++ b/dimos/core/test_core.py
@@ -116,7 +116,16 @@ def test_basic_deployment(dimos) -> None:
     robot.start()
     nav.start()
 
-    time.sleep(1)
+    # Messages flow end-to-end at ~10 Hz, but under heavy parallel load
+    # (e.g. `pytest -n auto`) the publisher and LCM transport threads get
+    # starved, so the count after a fixed 1s window is unreliable. Poll up to a
+    # generous deadline instead — this still verifies the pipeline delivers, it
+    # just doesn't assume a wall-clock throughput.
+    deadline = time.perf_counter() + 15
+    while time.perf_counter() < deadline:
+        if robot.mov_msg_count >= 8 and nav.odom_msg_count >= 8 and nav.lidar_msg_count >= 8:
+            break
+        time.sleep(0.1)
 
     assert robot.mov_msg_count >= 8
     assert nav.odom_msg_count >= 8

--- a/dimos/robot/drone/blueprints/basic/drone_basic.py
+++ b/dimos/robot/drone/blueprints/basic/drone_basic.py
@@ -24,6 +24,10 @@ from dimos.robot.drone.camera_module import DroneCameraModule
 from dimos.robot.drone.connection_module import DroneConnectionModule
 from dimos.visualization.vis_module import vis_module
 
+# Camera intrinsics [fx, fy, cx, cy], shared by the camera module and the
+# static Rerun pinhole below so the two can't drift.
+_CAMERA_INTRINSICS = [1000.0, 1000.0, 960.0, 540.0]
+
 
 def _static_drone_body(rr: Any) -> list[Any]:
     """Static visualization of drone body."""
@@ -33,6 +37,25 @@ def _static_drone_body(rr: Any) -> list[Any]:
             colors=[(255, 100, 0)],
         ),
         rr.Transform3D(parent_frame="tf#/base_link"),
+    ]
+
+
+def _static_camera_pinhole(rr: Any) -> list[Any]:
+    """Pinhole at the camera-image entity.
+
+    The camera feed is logged at ``world/video``, which falls under the 3D
+    view's ``world`` origin. A 2D image needs a pinhole ancestor to be placed
+    in a 3D view, so without this Rerun warns ("2D visualizers require a
+    pinhole ancestor to be shown in a 3D view") and the feed only renders in
+    the dedicated 2D pane. Logging the pinhole here lets it also show as a
+    camera frustum in 3D.
+    """
+    fx, fy, cx, cy = _CAMERA_INTRINSICS
+    return [
+        rr.Pinhole(
+            image_from_camera=[[fx, 0.0, cx], [0.0, fy, cy], [0.0, 0.0, 1.0]],
+            resolution=[2.0 * cx, 2.0 * cy],
+        ),
     ]
 
 
@@ -61,6 +84,7 @@ _rerun_config = {
     "blueprint": _drone_rerun_blueprint,
     "static": {
         "world/tf/base_link": _static_drone_body,
+        "world/video": _static_camera_pinhole,
     },
 }
 
@@ -79,7 +103,7 @@ drone_basic = autoconnect(
         video_port=video_port,
         outdoor=False,
     ),
-    DroneCameraModule.blueprint(camera_intrinsics=[1000.0, 1000.0, 960.0, 540.0]),
+    DroneCameraModule.blueprint(camera_intrinsics=_CAMERA_INTRINSICS),
 )
 
 __all__ = [

--- a/dimos/utils/testing/agent_teardown.py
+++ b/dimos/utils/testing/agent_teardown.py
@@ -1,0 +1,56 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Best-effort teardown for the ``agent_setup`` test fixtures.
+
+When an agent test fails mid-run — e.g. the LLM is slow under heavy parallel
+load and ``finished_event.wait`` times out — the fixture still has to release
+everything it created: the coordinator's worker processes, the LCM transports,
+and their subscriptions. If one cleanup step raises, the remaining steps must
+still run; otherwise threads leak and the autouse ``monitor_threads`` fixture
+turns a plain test failure into a failure *and* a teardown error. So each step
+is isolated and its failure logged rather than propagated.
+"""
+
+from collections.abc import Callable, Iterable
+from typing import Any
+
+from dimos.utils.logging_config import setup_logger
+
+logger = setup_logger()
+
+
+def teardown_agent_setup(
+    coordinator: Any | None,
+    transports: Iterable[Any],
+    unsubs: Iterable[Callable[[], Any]],
+) -> None:
+    """Tear down an ``agent_setup`` run, attempting every step regardless of failures."""
+
+    def _safe(action: Callable[[], Any], step: str) -> None:
+        try:
+            action()
+        except Exception:
+            # Cleanup is best-effort: log and keep going so a single failing
+            # step never leaks the rest or masks the test's own result.
+            logger.error("agent_setup teardown step failed", step=step, exc_info=True)
+
+    if coordinator is not None:
+        _safe(coordinator.stop, "coordinator.stop")
+
+    for transport in transports:
+        _safe(transport.stop, f"{type(transport).__name__}.stop")
+
+    for i, unsub in enumerate(unsubs):
+        _safe(unsub, f"unsubscribe[{i}]")

--- a/dimos/utils/testing/test_agent_teardown.py
+++ b/dimos/utils/testing/test_agent_teardown.py
@@ -1,0 +1,77 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dimos.utils.testing.agent_teardown import teardown_agent_setup
+
+
+class _Stopper:
+    """Stand-in for the coordinator / a transport: records its stop() call."""
+
+    def __init__(self, calls: list[str], name: str, *, raises: bool = False) -> None:
+        self._calls = calls
+        self._name = name
+        self._raises = raises
+
+    def stop(self) -> None:
+        self._calls.append(self._name)
+        if self._raises:
+            raise RuntimeError(f"{self._name} boom")
+
+
+def _unsub(calls: list[str], name: str, *, raises: bool = False):
+    def _call() -> None:
+        calls.append(name)
+        if raises:
+            raise RuntimeError(f"{name} boom")
+
+    return _call
+
+
+def test_runs_every_step_in_order() -> None:
+    calls: list[str] = []
+    coordinator = _Stopper(calls, "coordinator")
+    transports = [_Stopper(calls, "t0"), _Stopper(calls, "t1")]
+    unsubs = [_unsub(calls, "u0"), _unsub(calls, "u1")]
+
+    teardown_agent_setup(coordinator, transports, unsubs)
+
+    assert calls == ["coordinator", "t0", "t1", "u0", "u1"]
+
+
+def test_continues_when_coordinator_stop_raises() -> None:
+    # The whole point of the helper: a failing step must not skip the rest,
+    # so transports/unsubs still get cleaned up and no exception propagates.
+    calls: list[str] = []
+    coordinator = _Stopper(calls, "coordinator", raises=True)
+    transports = [_Stopper(calls, "t0")]
+    unsubs = [_unsub(calls, "u0")]
+
+    teardown_agent_setup(coordinator, transports, unsubs)
+
+    assert calls == ["coordinator", "t0", "u0"]
+
+
+def test_continues_when_a_transport_raises() -> None:
+    calls: list[str] = []
+    transports = [_Stopper(calls, "t0", raises=True), _Stopper(calls, "t1")]
+    unsubs = [_unsub(calls, "u0", raises=True), _unsub(calls, "u1")]
+
+    # coordinator=None must be skipped without error; later steps still run.
+    teardown_agent_setup(None, transports, unsubs)
+
+    assert calls == ["t0", "t1", "u0", "u1"]
+
+
+def test_none_coordinator_and_empty_collections() -> None:
+    teardown_agent_setup(None, [], [])  # must be a no-op, not raise


### PR DESCRIPTION
Three independent fixes surfaced while running the test suite and the demo simulation. Each is its own commit.

### 1. `fix(core)` — flaky `test_basic_deployment`
The test asserted `>= 8` messages after a fixed `time.sleep(1)`. Under heavy parallel load (`pytest -n auto`) the publisher and LCM transport threads get starved and deliver fewer within that window, failing with `assert 5 >= 8`. It now polls up to a 15s deadline — still verifying end-to-end delivery through the deployment, without assuming a wall-clock throughput.

### 2. `fix(tests)` — resilient `agent_setup` teardown
When an agent test fails mid-run (e.g. the LLM is slow under load and `finished_event.wait(60)` times out), a single raising cleanup step skipped the remaining ones, leaking LCM transport threads. The autouse `monitor_threads` fixture then flagged the leak, turning one failure into a failure **and** a teardown error. A shared `teardown_agent_setup()` helper now runs every cleanup step (coordinator, transports, unsubs) best-effort and logs failures instead of propagating. Wired into both `agent_setup` fixtures.

### 3. `fix(drone)` — camera pinhole for the 3D view
The drone camera feed is logged at `world/video`, inside the 3D view's `world` origin, but no `Pinhole` was ever logged — so Rerun warned *"2D visualizers require a pinhole ancestor to be shown in a 3D view"* and the feed only rendered in the dedicated 2D pane. A static `Pinhole` is now logged at `world/video`, built from the camera intrinsics (pulled into a shared `_CAMERA_INTRINSICS` constant so they can't drift from the camera module).
...
## Testing
- `test_basic_deployment` passes under deliberate full-CPU starvation (previously failed `assert 5 >= 8`).
- 3 navigation + 28 mcp tool-stream tests pass with clean teardown via the new helper.
- `drone-basic` replay boots cleanly; the static pinhole logs at bridge start without error.
- `ruff check` and `ruff format --check` clean on all changed files.
