### PR TITLE
fix(realsense): identity color TF fallback when depth disabled

### DIFF
--- a/dimos/hardware/sensors/camera/realsense/camera.py
+++ b/dimos/hardware/sensors/camera/realsense/camera.py
@@ -358,17 +358,29 @@ class RealSenseCamera(DepthCameraHardware, Module, perception.DepthCamera):
         )
         transforms.append(depth_to_depth_optical)
 
-        color_tf = self._extrinsics_to_transform(
-            self._color_to_depth_extrinsics,
-            self._camera_link,
-            self._color_frame,
-            ts,
-        )
-        # Invert the transform since extrinsics are color->depth
-        color_tf = color_tf.inverse()
-        color_tf.frame_id = self._camera_link
-        color_tf.child_frame_id = self._color_frame
-        color_tf.ts = ts
+        # camera_link -> camera_color_frame. With depth disabled there are no
+        # color->depth extrinsics, so fall back to identity (color at the
+        # camera_link origin) instead of dereferencing None.
+        if self._color_to_depth_extrinsics is not None:
+            color_tf = self._extrinsics_to_transform(
+                self._color_to_depth_extrinsics,
+                self._camera_link,
+                self._color_frame,
+                ts,
+            )
+            # Invert the transform since extrinsics are color->depth
+            color_tf = color_tf.inverse()
+            color_tf.frame_id = self._camera_link
+            color_tf.child_frame_id = self._color_frame
+            color_tf.ts = ts
+        else:
+            color_tf = Transform(
+                translation=Vector3(0.0, 0.0, 0.0),
+                rotation=Quaternion(0.0, 0.0, 0.0, 1.0),
+                frame_id=self._camera_link,
+                child_frame_id=self._color_frame,
+                ts=ts,
+            )
         transforms.append(color_tf)
 
         # camera_color_frame -> camera_color_optical_frame


### PR DESCRIPTION
## Problem

`RealSenseCamera` crashes its capture thread when started with `enable_depth=False`. `_publish_tf` unconditionally builds the `camera_link → camera_color_frame` transform from `_color_to_depth_extrinsics`, which is only populated from the depth stream. With depth off it stays `None`, so `_extrinsics_to_transform` dereferences `None.rotation`:

Closes DIM-XXX

The capture loop dies → no color frames. Surfaced by the color-only hosted-teleop multicam config (`RealSenseCamera.blueprint(enable_depth=False, enable_pointcloud=False)`).

## Solution

Guard the color extrinsics transform in `_publish_tf`: when `_color_to_depth_extrinsics is None`, fall back to an identity transform (color at the `camera_link` origin) - matching the identity pattern used by the sibling depth transforms. With depth enabled, behavior is unchanged.

## How to Test
```
dimos run real-sense-camera -o real_sense_camera.config.enable_depth=false
```

## Contributor License Agreement

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
