### PR TITLE
test: remove flaky skipped test_basic_deployment

### DIFF
--- a/dimos/core/test_core.py
+++ b/dimos/core/test_core.py
@@ -14,14 +14,11 @@
 
 import time
 
-import pytest
 from reactivex.disposable import Disposable
 
 from dimos.core.core import rpc
 from dimos.core.module import Module
 from dimos.core.stream import In, Out
-from dimos.core.testing import MockRobotClient
-from dimos.core.transport import LCMTransport, pLCMTransport
 from dimos.msgs.geometry_msgs.Vector3 import Vector3
 from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
 from dimos.robot.unitree.type.odometry import Odometry
@@ -90,34 +87,3 @@ def test_classmethods() -> None:
     assert hasattr(class_rpcs["start"], "__rpc__"), "start should have __rpc__ attribute"
 
     nav._close_module()
-
-
-@pytest.mark.skipif_in_ci
-def test_basic_deployment(dimos) -> None:
-    robot = dimos.deploy(MockRobotClient)
-
-    print("\n")
-    print("lidar stream", robot.lidar)
-    print("odom stream", robot.odometry)
-
-    nav = dimos.deploy(Navigation)
-
-    # this one encodes proper LCM messages
-    robot.lidar.transport = LCMTransport("/lidar", PointCloud2)
-
-    # odometry & mov using just a pickle over LCM
-    robot.odometry.transport = pLCMTransport("/odom")
-    nav.mov.transport = pLCMTransport("/mov")
-
-    nav.lidar.connect(robot.lidar)
-    nav.odometry.connect(robot.odometry)
-    robot.mov.connect(nav.mov)
-
-    robot.start()
-    nav.start()
-
-    time.sleep(1)
-
-    assert robot.mov_msg_count >= 8
-    assert nav.odom_msg_count >= 8
-    assert nav.lidar_msg_count >= 8


### PR DESCRIPTION
## What

Deletes `test_basic_deployment` from `dimos/core/test_core.py` (and its now-unused `MockRobotClient` / `LCMTransport` / `pLCMTransport` / `pytest` imports).

## Why

- The test was marked `@pytest.mark.skipif_in_ci`, so **it never ran in CI** — it gated nothing.
- It deploys two modules in separate worker processes and streams over LCM, then asserts a **sustained ~10 Hz message rate** (`>= 8` messages in a fixed sleep window). That wall-clock throughput assertion races worker-process startup and is **inherently flaky** — locally it returns anywhere from 1 to passing across consecutive runs.
- The behavior it exercised (cross-process `deploy()` + `LCMTransport`/`pLCMTransport` publish/subscribe + RPC counters) is **already covered by CI-active tests**: `test_stream.py` reuses the same `MockRobotClient`; `test_rpcstress.py`, `test_module_coordinator.py`, and `test_async_module_dispatch_serialization.py` cover the cross-process LCM + RPC paths.

The only unique thing it added was the throughput/rate guarantee, which CI never enforced anyway.

## Test

`dimos/core/test_core.py::test_classmethods` still passes; `ruff check` clean (no unused imports left).