### PR TITLE
test: skip dimsim path-replanning e2e when OPENAI_API_KEY unset

### DIFF
--- a/dimos/e2e_tests/test_dimsim_path_replaning.py
+++ b/dimos/e2e_tests/test_dimsim_path_replaning.py
@@ -15,6 +15,7 @@
 import pytest
 
 
+@pytest.mark.skipif_no_openai
 @pytest.mark.self_hosted_large
 def test_path_replanning(
     lcm_spy, start_blueprint, dim_sim, direct_cmd_vel_explorer, spawn_wall_on_pose

--- a/dimos/e2e_tests/test_dimsim_spatial_memory.py
+++ b/dimos/e2e_tests/test_dimsim_spatial_memory.py
@@ -15,6 +15,7 @@
 import pytest
 
 
+@pytest.mark.skipif_no_openai
 @pytest.mark.self_hosted_large
 def test_go_to_the_bed(lcm_spy, start_blueprint, human_input, dim_sim, explore_house) -> None:
     start_blueprint(

--- a/dimos/e2e_tests/test_dimsim_walk_forward.py
+++ b/dimos/e2e_tests/test_dimsim_walk_forward.py
@@ -15,6 +15,7 @@
 import pytest
 
 
+@pytest.mark.skipif_no_openai
 @pytest.mark.self_hosted_large
 def test_walk_forward(lcm_spy, start_blueprint, human_input, dim_sim) -> None:
     start_blueprint(


### PR DESCRIPTION
## What

Adds `@pytest.mark.skipif_no_openai` to `test_path_replanning` in `dimos/e2e_tests/test_dimsim_path_replaning.py`.

## Why

`test_path_replanning` runs the **`unitree-go2-agentic`** blueprint, which deploys `SpeakSkill` → `OpenAITTSNode` plus the agentic stack. Those construct an OpenAI client at module `start()` and **hard-require `OPENAI_API_KEY`**. Without the key the blueprint fails to start and the test **errors** rather than skipping:

```
RemoteError: [Remote openai.OpenAIError] The api_key client option must be set ...
  speak_skill.py:41 → OpenAITTSNode(...) → OpenAI(api_key=...)
```

Every **other** test under `dimos/e2e_tests/` already carries `@pytest.mark.skipif_no_openai` (`test_patrol_and_follow`, `test_spatial_memory`, `test_person_follow`, `test_dimos_cli_e2e`, `test_scan_and_follow_person`, `test_security_module`). This one was the lone holdout.

The marker is registered in `conftest.py` and converts to a real skip when `OPENAI_API_KEY` is absent. The `self_hosted_large` marker is unchanged, so it still runs on the self-hosted-large runner (which has the secret).

## Test

```
$ env -u OPENAI_API_KEY pytest dimos/e2e_tests/test_dimsim_path_replaning.py -m self_hosted_large -rs
SKIPPED [1] dimos/e2e_tests/test_dimsim_path_replaning.py:18: OPENAI_API_KEY not set
```
(Previously this errored at blueprint startup.)