### PR TITLE
test: skip test_security_module when ALIBABA_API_KEY is unset

### DIFF
--- a/dimos/e2e_tests/test_security_module.py
+++ b/dimos/e2e_tests/test_security_module.py
@@ -25,6 +25,7 @@ from dimos.e2e_tests.lcm_spy import LcmSpy
 
 @pytest.mark.skipif_in_ci
 @pytest.mark.skipif_no_openai
+@pytest.mark.skipif_no_alibaba
 @pytest.mark.mujoco
 def test_security_module(
     lcm_spy: LcmSpy,


### PR DESCRIPTION
## What

Adds `@pytest.mark.skipif_no_alibaba` to `test_security_module`.

## Why

The test reaches a person-follow path that calls Qwen VL (`ALIBABA_API_KEY`),
but it was only gated by `skipif_no_openai`. On a machine with `OPENAI_API_KEY`
but no `ALIBABA_API_KEY`, it ran and hung until the 360s timeout instead of
skipping. The `skipif_no_alibaba` marker already exists in conftest; this just
applies it, mirroring the existing `skipif_no_openai` gate.

## Test

`ruff check` clean. With `ALIBABA_API_KEY` unset the test is skipped at
collection (`pytest_collection_modifyitems`) instead of running; with the key
set it still runs.

## Contributor License Agreement

- [ ] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
