### PR TITLE
china_office.db: pointlio-only (mid360_link), fastlio removed, ts aligned

### DIFF
--- a/data/.lfs/china_office.db.tar.gz
+++ b/data/.lfs/china_office.db.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5c7d9b8d83b7eccff302d3881068f2064657b5903340ae54995e9cce80e41ffe
-size 4058639695
+oid sha256:243a19ac6aef7f7feb9841e131be7d657781f3a1f5ed8a3be25b80e9d453aa4b
+size 4507943536


### PR DESCRIPTION
Replaces the `china_office.db` LFS dataset with a regenerated pointlio-only version anchored to `mid360_link` — fastlio, `tf_graph`, and empty stub streams removed (go2, gt_pointlio, tf, color_image retained). Pointlio was rebuilt from the raw Mid-360 pcap and its in-cloud timestamps aligned to the recording timeline.
