### PR TITLE
chore: exclude test_ files from published package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -34,3 +34,6 @@ prune .pytest_cache
 prune .ruff_cache
 prune .vscode
 prune dimos/web/command-center-extension
+
+global-exclude test_*.py
+global-exclude conftest.py

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import fnmatch
 import os
 from pathlib import Path
 import struct
@@ -19,6 +20,7 @@ import sys
 
 from pybind11.setup_helpers import Pybind11Extension, build_ext
 from setuptools import find_packages, setup
+from setuptools.command.build_py import build_py as _build_py
 
 
 def python_is_macos_universal_binary(executable: str | None = None) -> bool:
@@ -54,6 +56,20 @@ def python_is_macos_universal_binary(executable: str | None = None) -> bool:
         return False
 
 
+TEST_MODULE_PATTERNS = ("test_*.py", "conftest.py")
+
+
+class build_py(_build_py):
+    def find_package_modules(self, package, package_dir):
+        return [
+            (pkg, mod, filepath)
+            for pkg, mod, filepath in super().find_package_modules(package, package_dir)
+            if not any(
+                fnmatch.fnmatch(os.path.basename(filepath), pat) for pat in TEST_MODULE_PATTERNS
+            )
+        ]
+
+
 extra_compile_args = [
     "-O3",  # Maximum optimization
     "-ffast-math",  # Fast floating point
@@ -81,5 +97,5 @@ setup(
     packages=find_packages(),
     package_dir={"": "."},
     ext_modules=ext_modules,
-    cmdclass={"build_ext": build_ext},
+    cmdclass={"build_ext": build_ext, "build_py": build_py},
 )


### PR DESCRIPTION
## Problem

We ship a lot of `test_*.py` files. They are useless for the users.

Closes DIM-539

## Solution

Don't include them.