### PR TITLE
chore: gate backport check on a release-in-flight label

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -6,9 +6,11 @@ name: pr-labels
 # synchronize` clears the stale label on a new push before CI finishes on
 # the new commit.
 #
-# `backport-check`: when a `backport release/X.Y.Z` label exists (release in
-# flight), every PR to main must declare backport intent via that label or
-# `backport:skip`.
+# `backport-check`: while the `release-in-flight` label exists on the repo,
+# every PR to main must declare backport intent via a `backport release/X.Y.Z`
+# label or `backport:skip`. Toggling that one label turns enforcement on and
+# off; the per-version `backport release/X.Y.Z` labels are left in place as a
+# record of what was backported into each release.
 #
 # Runs on the default branch via these events, so the GITHUB_TOKEN is
 # write-scoped even for PRs from forks — and the workflow file itself can't
@@ -133,11 +135,11 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
-          # Skip when no release is in flight (`backport:skip` is excluded by the prefix filter).
-          release_labels=$(gh api "repos/$REPO/labels" --paginate \
-            --jq '.[].name | select(startswith("backport release/"))')
-          if [[ -z "$release_labels" ]]; then
-            echo "::notice::No active 'backport release/*' labels; nothing to enforce."
+          # A release is in flight while the `release-in-flight` label exists.
+          # Skip the check when it's absent.
+          if [[ -z "$(gh api "repos/$REPO/labels" --paginate \
+              --jq '.[].name | select(. == "release-in-flight")')" ]]; then
+            echo "::notice::No 'release-in-flight' label; nothing to enforce."
             exit 0
           fi
           pr_labels=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
@@ -145,6 +147,8 @@ jobs:
           if echo "$pr_labels" | grep -qE '^(backport release/|backport:skip$)'; then
             exit 0
           fi
-          echo "::error::PR needs a 'backport release/X.Y.Z' label, or 'backport:skip' to opt out. Active release labels:"
+          release_labels=$(gh api "repos/$REPO/labels" --paginate \
+            --jq '.[].name | select(startswith("backport release/"))')
+          echo "::error::A release is in flight. This PR needs a 'backport release/X.Y.Z' label, or 'backport:skip' to opt out. Available release labels:"
           echo "$release_labels" | sed 's/^/  - /'
           exit 1

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -17,7 +17,8 @@ Throughout this document, replace `X.Y.Z` with the version you are releasing (e.
    ```
 
 4. Create a backport label for this release. Repo → Issues → Labels (in left sidebar) → New label, named `backport release/X.Y.Z`. (Or `gh label create "backport release/X.Y.Z" --repo dimensionalOS/dimos`.) The backport bot only runs when this label exists.
-5. To backport a fix from `main`: add the `backport release/X.Y.Z` label to a PR targeting `main` (before or after merging). The backport bot will open a cherry-pick PR onto the release branch; review it and squash-merge.
+5. Turn on the backport gate by creating the `release-in-flight` label, if it isn't already present from another release still in progress (`gh label create "release-in-flight" --repo dimensionalOS/dimos`). While it exists, every PR to `main` must carry a `backport release/X.Y.Z` label or `backport:skip` before it can merge.
+6. To backport a fix from `main`: add the `backport release/X.Y.Z` label to a PR targeting `main` (before or after merging). The backport bot will open a cherry-pick PR onto the release branch; review it and squash-merge.
 
 ## 2. Creating the release
 
@@ -48,13 +49,13 @@ When ready to cleanup the branch, follow these steps:
    git push origin --delete archived/X.Y.Z
    ```
 
-2. Delete the `backport release/X.Y.Z` label from the Labels page (or `gh label delete "backport release/X.Y.Z"`).
+2. If no other release is still in flight, delete the `release-in-flight` label to turn the backport gate back off (`gh label delete "release-in-flight" --repo dimensionalOS/dimos`). Leave the `backport release/X.Y.Z` label in place — it stays on the PRs it tagged as a record of what shipped in this release.
 
 ## Patch fix on a released version
 
 When you need to ship a patch fix:
 
-1. If the release branch has already been deleted, re-cut from the tag and recreate the label (step 1.4):
+1. If the release branch has already been deleted, re-cut from the tag and recreate the labels (steps 1.4 and 1.5):
 
    ```bash
    git fetch origin --tags


### PR DESCRIPTION
## Problem

The "release in flight" state that drives the backport-intent gate is inferred from the existence of any `backport release/X.Y.Z` label. That overloads those labels: they're the backport-bot trigger *and* the record of which PRs shipped into a release *and* the on/off switch for the gate.

The practical downside is cleanup. To stop the gate blocking every PR after a release wraps, you have to delete the `backport release/X.Y.Z` labels — which also strips them off the merged PRs they tagged, so we lose the record of what was backported. Just hit this cleaning up after 0.0.13 / 0.0.13.post1.

## Solution

Split the switch from the record. A single `release-in-flight` label now toggles enforcement:

- present → PRs to `main` must carry a `backport release/X.Y.Z` label or `backport:skip`
- absent → gate is a no-op

The `backport release/X.Y.Z` labels keep their existing jobs (backport-bot trigger + author intent) and are never deleted, so they persist on merged PRs as the shipped-in-X.Y.Z record. Ending a release is now deleting one throwaway control label instead of the version labels.

Considered two alternatives and went with the label:
- **repo variable** (`RELEASE_IN_FLIGHT`) — cleanest decoupling, but invisible in the PR/labels UI; you can't tell a release is active without opening repo settings.
- **open milestone** — more moving parts and a naming convention to maintain.

The label wins on being one visible, greppable toggle that anyone with triage rights can flip, and it needs no new plumbing since the gate already reads labels.

Runbook updated: create `release-in-flight` when cutting (§1.5), delete it at cleanup only if no other release is still active (§3.2).

## How to Test

n/a — CI/labels workflow change. The gate re-runs on the next `pull_request_target` event; with no `release-in-flight` label present it logs `No 'release-in-flight' label; nothing to enforce` and passes.