### PR TITLE
Fix cache key for native modules build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,6 +325,7 @@ jobs:
       contents: read  # For checkout
     outputs:
       cache-hit: ${{ steps.marker.outputs.cache-hit }}
+      key: ${{ steps.cache-key.outputs.key }}
     steps:
       - name: Checkout files used for cache key
         uses: actions/checkout@v6
@@ -333,12 +334,17 @@ jobs:
             bin/build-cmu-nav-natives
             dimos/navigation/cmu_nav/modules
           sparse-checkout-cone-mode: false
+      - name: Compute cache key
+        # Recomputing the key in cmu-nav-natives after build breaks the key.
+        # Save here so it can be reused verbatim.
+        id: cache-key
+        run: echo "key=cmu-nav-natives-${{ hashFiles('bin/build-cmu-nav-natives', 'dimos/navigation/cmu_nav/modules/**') }}" >> "$GITHUB_OUTPUT"
       - name: Look up marker cache
         id: marker
         uses: actions/cache/restore@v4
         with:
           path: /tmp/cmu-nav-natives-marker
-          key: cmu-nav-natives-${{ hashFiles('bin/build-cmu-nav-natives', 'dimos/navigation/cmu_nav/modules/**') }}
+          key: ${{ steps.cache-key.outputs.key }}
           lookup-only: true
 
   cmu-nav-natives:
@@ -409,7 +415,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: /tmp/cmu-nav-natives-marker
-          key: cmu-nav-natives-${{ hashFiles('bin/build-cmu-nav-natives', 'dimos/navigation/cmu_nav/modules/**') }}
+          key: ${{ needs.cmu-nav-natives-marker.outputs.key }}
 
   self-hosted-tests:
     # Skip on PRs from forks which would expose the self-hosted runner to untrusted code from external contributors.


### PR DESCRIPTION
Made a mistake here, so the key that was being saved in the cache was being computed on the built files and not matching the original key we are checking against.

This should ensure that cmu-nav-natives is correctly built in future and unrelated PRs stop deploying to Cachix.