### PR TITLE
fix(config): increase largefiles threshold to 75KB

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -618,14 +618,9 @@ exclude_also = [
 ]
 
 [tool.largefiles]
-max_size_kb = 50
+max_size_kb = 75
 ignore = [
     "uv.lock",
     "*/package-lock.json",
-    "dimos/dashboard/dimos.rbl",
     "dimos/web/dimos_interface/themes.json",
-    "dimos/manipulation/manipulation_module.py",
-    "dimos/manipulation/visualization/viser/test_viser_visualization.py",
-    "dimos/navigation/cmu_nav/modules/*/main.cpp",
-    "dimos/navigation/cmu_nav/common/*.hpp",
 ]


### PR DESCRIPTION
Bump `max_size_kb` from 50 → 75 in `[tool.largefiles]` to allow source files up to ~2000 lines before requiring LFS.

## Changes
- Increase threshold from 50KB to 75KB
- Remove stale ignore entries for deleted files (`dimos.rbl`, nav_stack cpp/hpp)
- Remove source code files from ignore (`manipulation_module.py`, `test_viser_visualization.py`) to enforce 75KB as a hard limit
- Only non-source generated files (`uv.lock`, `package-lock.json`, `themes.json`) remain exempt

## Risk
Minimal — config-only change. No existing source files exceed 75KB, so nothing breaks.

Closes #2740