### PR TITLE
Remove arkluc from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 * @leshy @paul-nechifor @spomichter @mustafab0
 /.github/ @Dreamsorcerer @leshy @paul-nechifor @spomichter
-/dimos/mapping/ @leshy @arkluc @paul-nechifor @spomichter
+/dimos/mapping/ @leshy @paul-nechifor @spomichter


### PR DESCRIPTION
Removes @arkluc from the `/dimos/mapping/` owners line in CODEOWNERS.