### PR TITLE
feat(perception): StereoPointCloud module + FlowBase stereo-nav blueprint

### DIFF
--- a/dimos/control/blueprints/mobile.py
+++ b/dimos/control/blueprints/mobile.py
@@ -35,8 +35,8 @@ from dimos.control.components import (
 )
 from dimos.control.coordinator import ControlCoordinator, TaskConfig
 from dimos.core.coordination.blueprints import autoconnect
-from dimos.hardware.sensors.camera.realsense.camera import RealSenseCamera
 from dimos.hardware.sensors.lidar.fastlio2.module import FastLio2
+from dimos.perception.stereo_point_cloud.filtered_realsense import FilteredRealSenseCamera
 from dimos.mapping.costmapper import CostMapper
 from dimos.navigation.cmu_nav.main import cmu_nav_rerun_config, create_cmu_nav
 from dimos.navigation.movement_manager.movement_manager import MovementManager
@@ -221,7 +221,7 @@ coordinator_mobile_manip_mock = ControlCoordinator.blueprint(
 # FlowBase + RealSense D435i stereo depth + CostMapper + nav stack
 coordinator_flowbase_stereo_nav = (
     autoconnect(
-        RealSenseCamera.blueprint(enable_depth=True, enable_pointcloud=False),
+        FilteredRealSenseCamera.blueprint(enable_depth=True, enable_pointcloud=False),
         StereoPointCloud.blueprint(),
         CostMapper.blueprint(),
         MovementManager.blueprint(),

--- a/dimos/control/blueprints/mobile.py
+++ b/dimos/control/blueprints/mobile.py
@@ -40,7 +40,7 @@ from dimos.hardware.sensors.lidar.fastlio2.module import FastLio2
 from dimos.mapping.costmapper import CostMapper
 from dimos.navigation.cmu_nav.main import cmu_nav_rerun_config, create_cmu_nav
 from dimos.navigation.movement_manager.movement_manager import MovementManager
-from dimos.perception.stereo_point_cloud import StereoPointCloud
+from dimos.perception.stereo_point_cloud.module import StereoPointCloud
 from dimos.robot.unitree.g1.config import G1_LOCAL_PLANNER_PRECOMPUTED_PATHS
 from dimos.robot.unitree.keyboard_teleop import KeyboardTeleop
 from dimos.visualization.rerun.bridge import RerunBridgeModule

--- a/dimos/control/blueprints/mobile.py
+++ b/dimos/control/blueprints/mobile.py
@@ -20,6 +20,7 @@ Usage:
     dimos run coordinator-flowbase                       # FlowBase holonomic base (Portal RPC)
     dimos run coordinator-flowbase-keyboard-teleop       # FlowBase + WASD pygame teleop
     dimos run coordinator-flowbase-nav                   # FlowBase + FastLio2 + nav stack (click-to-drive)
+    dimos run coordinator-flowbase-stereo-nav            # FlowBase + RealSense D435i stereo depth + nav stack
 """
 
 from __future__ import annotations
@@ -34,9 +35,12 @@ from dimos.control.components import (
 )
 from dimos.control.coordinator import ControlCoordinator, TaskConfig
 from dimos.core.coordination.blueprints import autoconnect
+from dimos.hardware.sensors.camera.realsense.camera import RealSenseCamera
 from dimos.hardware.sensors.lidar.fastlio2.module import FastLio2
+from dimos.mapping.costmapper import CostMapper
 from dimos.navigation.cmu_nav.main import cmu_nav_rerun_config, create_cmu_nav
 from dimos.navigation.movement_manager.movement_manager import MovementManager
+from dimos.perception.stereo_point_cloud import StereoPointCloud
 from dimos.robot.unitree.g1.config import G1_LOCAL_PLANNER_PRECOMPUTED_PATHS
 from dimos.robot.unitree.keyboard_teleop import KeyboardTeleop
 from dimos.visualization.rerun.bridge import RerunBridgeModule
@@ -212,3 +216,34 @@ coordinator_mobile_manip_mock = ControlCoordinator.blueprint(
         ),
     ],
 ).remappings([(ControlCoordinator, "twist_command", "cmd_vel")])
+
+
+# FlowBase + RealSense D435i stereo depth + CostMapper + nav stack
+coordinator_flowbase_stereo_nav = (
+    autoconnect(
+        RealSenseCamera.blueprint(enable_depth=True, enable_pointcloud=False),
+        StereoPointCloud.blueprint(),
+        CostMapper.blueprint(),
+        MovementManager.blueprint(),
+        ControlCoordinator.blueprint(
+            hardware=[_flowbase_twist_base()],
+            tasks=[
+                TaskConfig(
+                    name="vel_base",
+                    type="velocity",
+                    joint_names=_base_joints,
+                    priority=10,
+                ),
+            ],
+        ),
+        RerunBridgeModule.blueprint(rerun_open="web"),
+        RerunWebSocketServer.blueprint(),
+    )
+    .remappings(
+        [
+            (MovementManager, "way_point", "_mgr_way_point_unused"),
+            (ControlCoordinator, "twist_command", "cmd_vel"),
+        ]
+    )
+    .global_config(n_workers=8)
+)

--- a/dimos/control/blueprints/mobile.py
+++ b/dimos/control/blueprints/mobile.py
@@ -36,10 +36,10 @@ from dimos.control.components import (
 from dimos.control.coordinator import ControlCoordinator, TaskConfig
 from dimos.core.coordination.blueprints import autoconnect
 from dimos.hardware.sensors.lidar.fastlio2.module import FastLio2
-from dimos.perception.stereo_point_cloud.filtered_realsense import FilteredRealSenseCamera
 from dimos.mapping.costmapper import CostMapper
 from dimos.navigation.cmu_nav.main import cmu_nav_rerun_config, create_cmu_nav
 from dimos.navigation.movement_manager.movement_manager import MovementManager
+from dimos.perception.stereo_point_cloud.filtered_realsense import FilteredRealSenseCamera
 from dimos.perception.stereo_point_cloud.module import StereoPointCloud
 from dimos.robot.unitree.g1.config import G1_LOCAL_PLANNER_PRECOMPUTED_PATHS
 from dimos.robot.unitree.keyboard_teleop import KeyboardTeleop

--- a/dimos/perception/stereo_point_cloud.py
+++ b/dimos/perception/stereo_point_cloud.py
@@ -38,9 +38,6 @@ logger = setup_logger()
 _VOFF  = np.int64(100_000)
 _VMASK = np.int64(0x3FFFF)
 
-# Optical frame (X=right, Y=down, Z=depth) → camera_link (X=fwd, Y=left, Z=up)
-_R_OPT_TO_LINK = np.array([[0, 0, 1], [-1, 0, 0], [0, -1, 0]], dtype=np.float32)
-
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -58,23 +55,24 @@ def _gradient_mask(depth: np.ndarray, threshold: float) -> np.ndarray:
 
 
 def _raycast_free_keys(
-    xyz_rel: np.ndarray,
+    origin: np.ndarray,
+    surface_pts: np.ndarray,
     vox: float,
     n_rays: int = 200,
     max_steps: int = 40,
 ) -> np.ndarray:
-    """Keys of free-space voxels on rays from camera origin to observed surfaces (xyz_rel is camera-relative)."""
-    if len(xyz_rel) == 0:
+    """World-frame voxel keys on rays from origin to surface_pts. Keys match floor(pts/vox) world voxelisation."""
+    if len(surface_pts) == 0:
         return np.array([], dtype=np.int64)
 
-    idx  = np.random.choice(len(xyz_rel), min(n_rays, len(xyz_rel)), replace=False)
-    dirs = xyz_rel[idx].astype(np.float32)
-    dist = np.linalg.norm(dirs, axis=1, keepdims=True)
+    idx  = np.random.choice(len(surface_pts), min(n_rays, len(surface_pts)), replace=False)
+    vecs = (surface_pts[idx] - origin).astype(np.float32)
+    dist = np.linalg.norm(vecs, axis=1, keepdims=True)
     dist = np.where(dist < 1e-6, 1e-6, dist)
-    dirs /= dist
+    dirs = vecs / dist
 
     steps = np.linspace(0.1, 0.9, max_steps, dtype=np.float32)
-    pts   = dirs[:, None, :] * (dist[:, None, :] * steps[None, :, None])
+    pts   = origin + dirs[:, None, :] * (dist[:, None, :] * steps[None, :, None])
     pts   = pts.reshape(-1, 3)
     return np.unique(_pack(np.floor(pts / vox).astype(np.int32)))
 
@@ -91,7 +89,7 @@ class Config(ModuleConfig):
     max_global_pts: int       = 200_000
     publish_every: int        = 3       # emit global_map every N frames
     world_frame: str          = "world"
-    camera_frame: str         = "camera_depth_optical_frame"
+    camera_frame: str         = "camera_color_optical_frame"
     base_frame: str           = "base_link"
     tf_timeout: float         = 0.2
 
@@ -167,7 +165,6 @@ class StereoPointCloud(Module):
             (vv[mask] - cy) * dd / fy,
             dd,
         ]).astype(np.float32)
-        xyz_cam = xyz_opt @ _R_OPT_TO_LINK.T
 
         tf = self.tf.get(
             self.config.world_frame, self.config.camera_frame, img.ts, self.config.tf_timeout
@@ -185,7 +182,7 @@ class StereoPointCloud(Module):
         else:
             R, t = np.eye(3, dtype=np.float32), np.zeros(3, dtype=np.float32)
 
-        xyz_world = (xyz_cam @ R.T + t).astype(np.float32)
+        xyz_world = (xyz_opt @ R.T + t).astype(np.float32)
 
         # TF-primary floor detection; falls back to rolling low-Z percentile
         base_tf = self.tf.get(
@@ -213,15 +210,13 @@ class StereoPointCloud(Module):
             PointCloud2.from_numpy(xyz_vox, frame_id=self.config.world_frame, timestamp=img.ts)
         )
 
-        xyz_rel  = xyz_vox - t
         pts_snap = None
 
         with self._lock:
             if len(self._acc_pts) > 0:
-                free = _raycast_free_keys(xyz_rel, self.config.global_vox_size)
+                free = _raycast_free_keys(t, xyz_vox, self.config.global_vox_size)
                 if len(free):
-                    acc_rel  = self._acc_pts - t
-                    keys_acc = _pack(np.floor(acc_rel / self.config.global_vox_size).astype(np.int32))
+                    keys_acc = _pack(np.floor(self._acc_pts / self.config.global_vox_size).astype(np.int32))
                     self._acc_pts = self._acc_pts[~np.isin(keys_acc, free)]
 
             self._acc_pts = (

--- a/dimos/perception/stereo_point_cloud.py
+++ b/dimos/perception/stereo_point_cloud.py
@@ -1,0 +1,246 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Stereo depth → per-frame cloud + persistent global map for CostMapper."""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+import numpy as np
+from reactivex.disposable import Disposable
+from scipy.ndimage import sobel
+
+from dimos.core.core import rpc
+from dimos.core.module import Module, ModuleConfig
+from dimos.core.stream import In, Out
+from dimos.msgs.sensor_msgs.CameraInfo import CameraInfo
+from dimos.msgs.sensor_msgs.Image import Image
+from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
+from dimos.utils.logging_config import setup_logger
+
+logger = setup_logger()
+
+# ── Constants ─────────────────────────────────────────────────────────────────
+
+_VOFF  = np.int64(100_000)
+_VMASK = np.int64(0x3FFFF)
+
+# Optical frame (X=right, Y=down, Z=depth) → camera_link (X=fwd, Y=left, Z=up)
+_R_OPT_TO_LINK = np.array([[0, 0, 1], [-1, 0, 0], [0, -1, 0]], dtype=np.float32)
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _pack(vkeys: np.ndarray) -> np.ndarray:
+    v = (vkeys.astype(np.int64) + _VOFF) & _VMASK
+    return (v[:, 0] << 36) | (v[:, 1] << 18) | v[:, 2]
+
+
+def _gradient_mask(depth: np.ndarray, threshold: float) -> np.ndarray:
+    """True where depth is valid and Sobel gradient magnitude is below threshold (m/px)."""
+    valid   = np.isfinite(depth)
+    depth_f = np.where(valid, depth, 0.0).astype(np.float64)
+    grad    = np.hypot(sobel(depth_f, axis=1), sobel(depth_f, axis=0))
+    return valid & (grad < threshold)
+
+
+def _raycast_free_keys(
+    xyz_rel: np.ndarray,
+    vox: float,
+    n_rays: int = 200,
+    max_steps: int = 40,
+) -> np.ndarray:
+    """Keys of free-space voxels on rays from camera origin to observed surfaces (xyz_rel is camera-relative)."""
+    if len(xyz_rel) == 0:
+        return np.array([], dtype=np.int64)
+
+    idx  = np.random.choice(len(xyz_rel), min(n_rays, len(xyz_rel)), replace=False)
+    dirs = xyz_rel[idx].astype(np.float32)
+    dist = np.linalg.norm(dirs, axis=1, keepdims=True)
+    dist = np.where(dist < 1e-6, 1e-6, dist)
+    dirs /= dist
+
+    steps = np.linspace(0.1, 0.9, max_steps, dtype=np.float32)
+    pts   = dirs[:, None, :] * (dist[:, None, :] * steps[None, :, None])
+    pts   = pts.reshape(-1, 3)
+    return np.unique(_pack(np.floor(pts / vox).astype(np.int32)))
+
+
+# ── Module ────────────────────────────────────────────────────────────────────
+
+class Config(ModuleConfig):
+    min_depth: float          = 0.3
+    max_depth: float          = 8.0
+    gradient_threshold: float = 0.30    # m/px; above → depth edge artifact → reject
+    vox_size: float           = 0.020   # per-frame dedup voxel (2 cm)
+    global_vox_size: float    = 0.040   # accumulation voxel (4 cm, absorbs pose jitter)
+    floor_margin: float       = 0.04    # metres above detected floor to keep points
+    max_global_pts: int       = 200_000
+    publish_every: int        = 3       # emit global_map every N frames
+    world_frame: str          = "world"
+    camera_frame: str         = "camera_depth_optical_frame"
+    base_frame: str           = "base_link"
+    tf_timeout: float         = 0.2
+
+
+class StereoPointCloud(Module):
+    """Gradient filter → backproject → floor removal → voxel dedup → ray-cast ghost clearing → global_map."""
+
+    config: Config
+
+    depth_image:       In[Image]
+    depth_camera_info: In[CameraInfo]
+
+    frame_cloud: Out[PointCloud2]
+    global_map:  Out[PointCloud2]
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._lock                          = threading.Lock()
+        self._latest_info: CameraInfo | None = None
+        self._last_tf                       = None
+        self._floor_buf: list[float]        = []
+        self._acc_pts: np.ndarray           = np.empty((0, 3), dtype=np.float32)
+        self._frame                         = 0
+
+    @rpc
+    def start(self) -> None:
+        super().start()
+        self.register_disposable(Disposable(self.depth_camera_info.subscribe(self._on_info)))
+        self.register_disposable(Disposable(self.depth_image.subscribe(self._on_depth)))
+
+    @rpc
+    def stop(self) -> None:
+        super().stop()
+
+    def _on_info(self, info: CameraInfo) -> None:
+        with self._lock:
+            self._latest_info = info
+
+    def _on_depth(self, img: Image) -> None:
+        with self._lock:
+            info = self._latest_info
+
+        depth = img.data
+        if hasattr(depth, "get"):
+            depth = depth.get()
+        if depth.ndim == 3:
+            depth = depth[:, :, 0]
+        depth = depth.astype(np.float32)
+        if np.nanmedian(depth[depth > 0]) > 100:
+            depth /= 1000.0
+
+        H, W = depth.shape
+
+        if info is not None:
+            K = info.get_K_matrix()
+            fx, fy, cx, cy = float(K[0, 0]), float(K[1, 1]), float(K[0, 2]), float(K[1, 2])
+        else:
+            fx = fy = float(max(H, W)) / 2.0
+            cx, cy  = W / 2.0, H / 2.0
+
+        mask = (
+            _gradient_mask(depth, self.config.gradient_threshold)
+            & (depth > self.config.min_depth)
+            & (depth < self.config.max_depth)
+        )
+        if not mask.any():
+            return
+
+        uu, vv  = np.meshgrid(np.arange(W, dtype=np.float32), np.arange(H, dtype=np.float32))
+        dd      = depth[mask]
+        xyz_opt = np.column_stack([
+            (uu[mask] - cx) * dd / fx,
+            (vv[mask] - cy) * dd / fy,
+            dd,
+        ]).astype(np.float32)
+        xyz_cam = xyz_opt @ _R_OPT_TO_LINK.T
+
+        tf = self.tf.get(
+            self.config.world_frame, self.config.camera_frame, img.ts, self.config.tf_timeout
+        )
+        if tf is not None:
+            self._last_tf = tf
+        if self._last_tf is not None:
+            R = self._last_tf.rotation.to_rotation_matrix().astype(np.float32)
+            t = np.array(
+                [self._last_tf.translation.x,
+                 self._last_tf.translation.y,
+                 self._last_tf.translation.z],
+                dtype=np.float32,
+            )
+        else:
+            R, t = np.eye(3, dtype=np.float32), np.zeros(3, dtype=np.float32)
+
+        xyz_world = (xyz_cam @ R.T + t).astype(np.float32)
+
+        # TF-primary floor detection; falls back to rolling low-Z percentile
+        base_tf = self.tf.get(
+            self.config.world_frame, self.config.base_frame, img.ts, self.config.tf_timeout
+        )
+        if base_tf is not None:
+            floor_z = float(base_tf.translation.z)
+        else:
+            bot = xyz_world[xyz_world[:, 2] < np.percentile(xyz_world[:, 2], 10)]
+            if len(bot):
+                self._floor_buf.append(float(np.median(bot[:, 2])))
+                if len(self._floor_buf) > 30:
+                    self._floor_buf.pop(0)
+            floor_z = float(np.percentile(self._floor_buf, 20)) if len(self._floor_buf) >= 5 else None
+
+        vk      = np.floor(xyz_world / self.config.vox_size).astype(np.int32)
+        _, ui   = np.unique(_pack(vk), return_index=True)
+        xyz_vox = xyz_world[ui]
+        if floor_z is not None:
+            xyz_vox = xyz_vox[xyz_vox[:, 2] > floor_z + self.config.floor_margin]
+        if len(xyz_vox) == 0:
+            return
+
+        self.frame_cloud.publish(
+            PointCloud2.from_numpy(xyz_vox, frame_id=self.config.world_frame, timestamp=img.ts)
+        )
+
+        xyz_rel  = xyz_vox - t
+        pts_snap = None
+
+        with self._lock:
+            if len(self._acc_pts) > 0:
+                free = _raycast_free_keys(xyz_rel, self.config.global_vox_size)
+                if len(free):
+                    acc_rel  = self._acc_pts - t
+                    keys_acc = _pack(np.floor(acc_rel / self.config.global_vox_size).astype(np.int32))
+                    self._acc_pts = self._acc_pts[~np.isin(keys_acc, free)]
+
+            self._acc_pts = (
+                np.vstack([self._acc_pts, xyz_vox])
+                if len(self._acc_pts) else xyz_vox.copy()
+            )
+            vk_g    = np.floor(self._acc_pts / self.config.global_vox_size).astype(np.int32)
+            _, ui_g = np.unique(_pack(vk_g), return_index=True)
+            self._acc_pts = self._acc_pts[ui_g]
+
+            if len(self._acc_pts) > self.config.max_global_pts:
+                keep = np.random.choice(len(self._acc_pts), self.config.max_global_pts, replace=False)
+                self._acc_pts = self._acc_pts[keep]
+
+            self._frame += 1
+            if self._frame % self.config.publish_every == 0 and len(self._acc_pts):
+                pts_snap = self._acc_pts.copy()
+
+        if pts_snap is not None:
+            self.global_map.publish(
+                PointCloud2.from_numpy(pts_snap, frame_id=self.config.world_frame, timestamp=img.ts)
+            )

--- a/dimos/perception/stereo_point_cloud.py
+++ b/dimos/perception/stereo_point_cloud.py
@@ -12,25 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Stereo depth → per-frame cloud + persistent global map for CostMapper.
-
-Pose source (in priority order):
-  1. TF lookup (world → camera_color_optical_frame) — used when a robot TF stack is running.
-  2. ICP fallback — rotation-decoupled point-cloud odometry for translation when TF is
-     unavailable. Rotation is assumed near-identity (no IMU in Module context).
-
-Global map frame:
-  - TF mode:  full world frame — TF translation is reliable so no rotation-only trick needed.
-  - ICP mode: rotation-only frame (xyz_world - t) — strips ICP translation to prevent
-    ±2 cm ICP centroid noise from accumulating duplicate voxels, matching the behaviour
-    of the standalone realsense_stereo_nav.py script.
-
-Floor calibration:
-  Histogram-based one-shot estimator (ported from realsense_stereo_nav.py): skips the
-  first SKIP_FRAMES, then histograms candidate floor-point Z values over CALIB_FRAMES
-  and takes the mode.  More robust than a rolling percentile when the floor is partially
-  occluded or when the camera tilts slightly at startup.
-"""
+"""D435i depth → per-frame voxel cloud + persistent global map (Madgwick + ICP VIO)."""
 
 from __future__ import annotations
 
@@ -58,12 +40,15 @@ logger = setup_logger()
 _VOFF  = np.int64(100_000)
 _VMASK = np.int64(0x3FFFF)
 
+# Optical frame (X=right, Y=down, Z=depth) → camera_link (X=fwd, Y=left, Z=up)
+_R_OPT_TO_LINK = np.array([[0, 0, 1], [-1, 0, 0], [0, -1, 0]], dtype=np.float32)
+
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
 def _pack(vkeys: np.ndarray) -> np.ndarray:
     v = (vkeys.astype(np.int64) + _VOFF) & _VMASK
-    return (v[:, 0] << 36) | (v[:, 1] << 18) | v[:, 2]
+    return (v[:, 0] << np.int64(36)) | (v[:, 1] << np.int64(18)) | v[:, 2]
 
 
 def _gradient_mask(depth: np.ndarray, threshold: float) -> np.ndarray:
@@ -73,51 +58,34 @@ def _gradient_mask(depth: np.ndarray, threshold: float) -> np.ndarray:
     return valid & (grad < threshold)
 
 
-def _raycast_free_keys(
-    origin: np.ndarray,
-    surface_pts: np.ndarray,
-    vox: float,
-    n_rays: int = 400,
-) -> np.ndarray:
-    """World-frame voxel keys on rays from origin to surface_pts.
-
-    Fully vectorised. Stops 1.5 voxels short of each surface so the surface
-    voxel itself is never cleared. Keys use floor(pts/vox) world voxelisation —
-    directly comparable with accumulated-point world-frame keys.
-    """
-    if len(surface_pts) == 0:
-        return np.array([], dtype=np.int64)
-
-    n    = min(len(surface_pts), n_rays)
-    idx  = (np.random.choice(len(surface_pts), n, replace=False)
-            if len(surface_pts) > n else np.arange(n))
-    vecs = (surface_pts[idx] - origin).astype(np.float32)
-    dist = np.linalg.norm(vecs, axis=1)
-    ok   = dist > vox * 2
-    vecs, dist = vecs[ok], dist[ok]
+def _raycast_free_keys(surface_pts: np.ndarray, vox_size: float, n_rays: int = 400) -> np.ndarray:
+    """Free-space voxel keys on rays from camera origin (rotation-only frame) to surface_pts."""
+    origin = np.zeros(3, dtype=np.float32)
+    n = min(len(surface_pts), n_rays)
+    if n == 0:
+        return np.empty(0, dtype=np.int64)
+    idx   = np.random.choice(len(surface_pts), n, replace=False) if len(surface_pts) > n else np.arange(n)
+    pts   = surface_pts[idx]
+    vecs  = pts - origin
+    dists = np.linalg.norm(vecs, axis=1)
+    ok    = dists > vox_size * 2
+    vecs, dists = vecs[ok], dists[ok]
     if not len(vecs):
-        return np.array([], dtype=np.int64)
-
-    dirs      = vecs / dist[:, None]
-    max_steps = int(np.ceil(dist.max() / vox))
-    t_vals    = np.arange(max_steps, dtype=np.float32) * vox
-    t_end     = (dist - vox * 1.5)[:, None]
+        return np.empty(0, dtype=np.int64)
+    dirs      = vecs / dists[:, None]
+    max_steps = int(np.ceil(dists.max() / vox_size))
+    t_vals    = np.arange(max_steps, dtype=np.float32) * vox_size
+    t_end     = (dists - vox_size * 1.5)[:, None]
     valid_m   = (t_vals[None, :] >= 0) & (t_vals[None, :] < t_end)
-
-    pts = origin + dirs[:, None, :] * t_vals[None, :, None]
-    vk  = np.floor(pts.reshape(-1, 3) / vox).astype(np.int32)
-    return np.unique(_pack(vk)[valid_m.ravel()])
+    ray_pts   = origin + dirs[:, None, :] * t_vals[None, :, None]
+    vk_flat   = np.floor(ray_pts.reshape(-1, 3) / vox_size).astype(np.int32)
+    return np.unique(_pack(vk_flat)[valid_m.ravel()])
 
 
 # ── Floor calibration ─────────────────────────────────────────────────────────
 
 class _FloorCalibrator:
-    """One-shot floor height estimator.
-
-    Skips SKIP_FRAMES for sensor settle, then histograms candidate floor-point
-    depths over CALIB_FRAMES and takes the mode bin centre. More robust than a
-    rolling percentile when the floor is partially visible or the camera tilts.
-    """
+    """Histogram-based one-shot floor height estimator in camera_link frame (Z=up)."""
 
     SKIP_FRAMES  = 30
     CALIB_FRAMES = 30
@@ -126,7 +94,7 @@ class _FloorCalibrator:
     def __init__(self) -> None:
         self._frame   = 0
         self._samples: list[float] = []
-        self.floor_z:   float | None = None
+        self.floor_z:    float | None = None
         self.cam_height: float | None = None
 
     @property
@@ -134,40 +102,87 @@ class _FloorCalibrator:
         return self.floor_z is not None
 
     def update(self, xyz_cam: np.ndarray) -> None:
-        """xyz_cam: (N,3) points in camera_link frame (Z = up)."""
         self._frame += 1
         if self.ready or self._frame <= self.SKIP_FRAMES:
             return
-
         z    = xyz_cam[:, 2]
         dist = np.linalg.norm(xyz_cam[:, :2], axis=1)
         mask = (z < -0.30) & (dist < 4.0)
         if mask.sum() < 200:
             return
-
         z_floor = z[mask]
         lo, hi  = z_floor.min(), z_floor.max()
         if hi - lo < self.BIN_M:
             return
         bins          = np.arange(lo, hi + self.BIN_M, self.BIN_M)
         counts, edges = np.histogram(z_floor, bins=bins)
-        mode_z        = float(edges[int(np.argmax(counts))] + self.BIN_M / 2)
-        self._samples.append(mode_z)
-
+        self._samples.append(float(edges[int(np.argmax(counts))] + self.BIN_M / 2))
         if len(self._samples) >= self.CALIB_FRAMES:
             self.floor_z    = float(np.median(self._samples))
             self.cam_height = -self.floor_z
             logger.info(f"StereoPointCloud: floor calibrated — camera {self.cam_height:.3f} m above floor")
 
 
-# ── ICP translation odometry (fallback when TF unavailable) ──────────────────
+# ── Madgwick AHRS ─────────────────────────────────────────────────────────────
 
-class _PointCloudOdometry:
-    """Frame-to-frame translation via rotation-decoupled ICP.
+class MadgwickFilter:
+    """Gyro + accel → orientation R (camera_link → world, Z-up). beta=0.033."""
 
-    Rotation is assumed near-identity (no IMU available in Module context).
-    Used only when TF lookup fails — on a robot TF is always preferred.
-    """
+    def __init__(self, beta: float = 0.033) -> None:
+        self._q      = np.array([1., 0., 0., 0.], dtype=np.float64)
+        self._beta   = beta
+        self._t_prev: float | None = None
+
+    def update(self, gyro: np.ndarray, accel: np.ndarray, t: float) -> None:
+        if self._t_prev is None:
+            self._t_prev = t
+            return
+        dt = min(t - self._t_prev, 0.1)
+        self._t_prev = t
+        if dt <= 0:
+            return
+        q0, q1, q2, q3 = self._q
+        gx, gy, gz = gyro.astype(np.float64)
+        a_n = np.linalg.norm(accel)
+        if a_n > 0.5:
+            ax, ay, az = accel.astype(np.float64) / a_n
+            f1 = 2*(q1*q3 - q0*q2) - ax
+            f2 = 2*(q0*q1 + q2*q3) - ay
+            f3 = 2*(0.5 - q1**2 - q2**2) - az
+            J  = np.array([
+                [-2*q2,  2*q3, -2*q0, 2*q1],
+                [ 2*q1,  2*q0,  2*q3, 2*q2],
+                [    0, -4*q1, -4*q2,    0],
+            ])
+            grad = J.T @ np.array([f1, f2, f3])
+            gn   = np.linalg.norm(grad)
+            if gn > 1e-9:
+                grad /= gn
+        else:
+            grad = np.zeros(4)
+        q_dot = 0.5 * np.array([
+            -q1*gx - q2*gy - q3*gz,
+             q0*gx + q2*gz - q3*gy,
+             q0*gy - q1*gz + q3*gx,
+             q0*gz + q1*gy - q2*gx,
+        ]) - self._beta * grad
+        self._q = self._q + q_dot * dt
+        self._q /= np.linalg.norm(self._q) + 1e-12
+
+    @property
+    def R(self) -> np.ndarray:
+        q0, q1, q2, q3 = self._q
+        return np.array([
+            [1-2*(q2**2+q3**2), 2*(q1*q2-q0*q3),   2*(q1*q3+q0*q2)  ],
+            [2*(q1*q2+q0*q3),   1-2*(q1**2+q3**2), 2*(q2*q3-q0*q1)  ],
+            [2*(q1*q3-q0*q2),   2*(q2*q3+q0*q1),   1-2*(q1**2+q2**2)],
+        ], dtype=np.float32)
+
+
+# ── Point-cloud odometry ──────────────────────────────────────────────────────
+
+class PointCloudOdometry:
+    """Rotation-decoupled ICP for translation t. Takes R from Madgwick, converges in 3-4 iters."""
 
     ITERS    = 4
     MAX_DIST = 0.40
@@ -185,16 +200,16 @@ class _PointCloudOdometry:
         with self._lock:
             return self._t.copy()
 
-    def update(self, xyz_cam: np.ndarray) -> np.ndarray:
+    def update(self, xyz_cam: np.ndarray, R: np.ndarray) -> np.ndarray:
+        pts_ga = (xyz_cam @ R.T).astype(np.float32)
         with self._lock:
             t_est = self._t.copy()
-
-        if self._prev_world is None or len(xyz_cam) < 50:
+        if self._prev_world is None or len(pts_ga) < 50:
             t_new = t_est
         else:
-            n_src = min(self.N_SRC, len(xyz_cam))
+            n_src = min(self.N_SRC, len(pts_ga))
             n_dst = min(self.N_DST, len(self._prev_world))
-            src   = xyz_cam[np.random.choice(len(xyz_cam), n_src, replace=False)]
+            src   = pts_ga[np.random.choice(len(pts_ga), n_src, replace=False)]
             dst   = self._prev_world[np.random.choice(len(self._prev_world), n_dst, replace=False)]
             tree  = cKDTree(dst)
             for _ in range(self.ITERS):
@@ -205,10 +220,9 @@ class _PointCloudOdometry:
                 delta = dst[idx[mask]].mean(axis=0) - (src[mask] + t_est).mean(axis=0)
                 t_est = (t_est + 0.7 * delta).astype(np.float32)
             t_new = t_est
-
-        n_st = min(self.N_STORE, len(xyz_cam))
-        self._prev_world = (xyz_cam[np.random.choice(len(xyz_cam), n_st, replace=False)] + t_new).astype(np.float32)
-
+        n_st  = min(self.N_STORE, len(pts_ga))
+        idx_s = np.random.choice(len(pts_ga), n_st, replace=False)
+        self._prev_world = (pts_ga[idx_s] + t_new).astype(np.float32)
         with self._lock:
             self._t = t_new
         return t_new
@@ -217,27 +231,20 @@ class _PointCloudOdometry:
 # ── Module ────────────────────────────────────────────────────────────────────
 
 class Config(ModuleConfig):
-    min_depth: float          = 0.3
+    min_depth: float          = 0.1
     max_depth: float          = 8.0
     gradient_threshold: float = 0.30
     vox_size: float           = 0.020
     global_vox_size: float    = 0.020
-    floor_margin: float       = 0.03
-    max_global_pts: int       = 200_000
-    publish_every: int        = 3
+    floor_margin: float       = 0.04
+    max_global_pts: int       = 500_000
+    publish_every: int        = 1
     world_frame: str          = "world"
-    camera_frame: str         = "camera_color_optical_frame"
-    base_frame: str           = "base_link"
-    tf_timeout: float         = 0.2
+    madgwick_beta: float      = 0.033
 
 
 class StereoPointCloud(Module):
-    """Gradient filter → backproject → floor removal → voxel dedup → ray-cast ghost clearing → global_map.
-
-    Mirrors the realsense_stereo_nav.py standalone pipeline as a dimos Module.
-    Uses TF for pose when available; falls back to ICP odometry with rotation-only
-    global map frame to prevent translation-drift accumulation.
-    """
+    """D435i depth → frame_cloud + global_map. Pose from Madgwick IMU + ICP odometry."""
 
     config: Config
 
@@ -249,31 +256,104 @@ class StereoPointCloud(Module):
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
-        self._lock                           = threading.Lock()
+        self._lock                       = threading.Lock()
         self._latest_info: CameraInfo | None = None
-        self._last_tf                        = None
-        self._floor_calib                    = _FloorCalibrator()
-        self._odom                           = _PointCloudOdometry()
-        self._acc_pts: np.ndarray            = np.empty((0, 3), dtype=np.float32)
-        self._map_ready                      = False
-        self._world_floor_z: float           = 0.0
-        self._frame                          = 0
+        self._floor_calib                = _FloorCalibrator()
+        self._madgwick: MadgwickFilter | None = None
+        self._odom                       = PointCloudOdometry()
+        self._imu_lock                   = threading.Lock()
+        self._last_accel                 = np.array([0.0, 0.0, -9.81], dtype=np.float32)
+        self._R_imu_to_link: np.ndarray  = np.eye(3, dtype=np.float32)
+        self._motion_sensor              = None
+        self._acc_pts: np.ndarray        = np.empty((0, 3), dtype=np.float32)
+        self._map_ready                  = False
+        self._world_floor_z: float       = 0.0
+        self._frame                      = 0
 
     @rpc
     def start(self) -> None:
         super().start()
+        self._madgwick = MadgwickFilter(beta=self.config.madgwick_beta)
+        if not self._init_imu():
+            logger.warning("StereoPointCloud: no IMU — R=identity, translation from ICP only")
         self.register_disposable(Disposable(self.depth_camera_info.subscribe(self._on_info)))
         self.register_disposable(Disposable(self.depth_image.subscribe(self._on_depth)))
 
     @rpc
     def stop(self) -> None:
+        if self._motion_sensor is not None:
+            try:
+                self._motion_sensor.stop()
+                self._motion_sensor.close()
+            except Exception:
+                pass
+            self._motion_sensor = None
         super().stop()
+
+    def _init_imu(self) -> bool:
+        try:
+            import pyrealsense2 as rs
+        except ImportError:
+            return False
+        ctx     = rs.context()
+        devices = ctx.query_devices()
+        if not devices:
+            return False
+        device = devices[0]
+        depth_profile = None
+        for sensor in device.query_sensors():
+            if sensor.is_motion_sensor():
+                continue
+            for p in sensor.get_stream_profiles():
+                if p.stream_type() == rs.stream.depth:
+                    depth_profile = p
+                    break
+            if depth_profile is not None:
+                break
+        for sensor in device.query_sensors():
+            if not sensor.is_motion_sensor():
+                continue
+            all_profiles   = sensor.get_stream_profiles()
+            gyro_profiles  = [p for p in all_profiles if p.stream_type() == rs.stream.gyro]
+            accel_profiles = [p for p in all_profiles if p.stream_type() == rs.stream.accel]
+            if not gyro_profiles or not accel_profiles:
+                break
+            gyro_p  = max(gyro_profiles,  key=lambda p: p.fps())
+            accel_p = max(accel_profiles, key=lambda p: p.fps())
+            if depth_profile is not None:
+                ext                 = accel_p.get_extrinsics_to(depth_profile)
+                R_imu_to_depth      = np.array(ext.rotation, dtype=np.float32).reshape(3, 3)
+                self._R_imu_to_link = _R_OPT_TO_LINK @ R_imu_to_depth
+            sensor.open([gyro_p, accel_p])
+            sensor.start(self._on_motion)
+            self._motion_sensor = sensor
+            logger.info(f"StereoPointCloud: IMU — gyro@{gyro_p.fps()}Hz accel@{accel_p.fps()}Hz")
+            return True
+        return False
+
+    def _on_motion(self, frame: Any) -> None:
+        try:
+            import pyrealsense2 as rs
+            st = frame.get_profile().stream_type()
+            if st == rs.stream.gyro:
+                g        = frame.as_motion_frame().get_motion_data()
+                gyro_lnk = self._R_imu_to_link @ np.array([g.x, g.y, g.z], dtype=np.float32)
+                ts_s     = frame.get_timestamp() / 1000.0
+                with self._imu_lock:
+                    if self._madgwick is not None:
+                        self._madgwick.update(gyro_lnk, self._last_accel, ts_s)
+            elif st == rs.stream.accel:
+                a = frame.as_motion_frame().get_motion_data()
+                with self._imu_lock:
+                    self._last_accel = self._R_imu_to_link @ np.array([a.x, a.y, a.z], dtype=np.float32)
+        except Exception:
+            pass
 
     def _on_info(self, info: CameraInfo) -> None:
         with self._lock:
             self._latest_info = info
 
-    def _on_depth(self, img: Image) -> None:
+    def _on_depth(self, img: Image) -> None:  # noqa: C901
         with self._lock:
             info = self._latest_info
 
@@ -283,11 +363,13 @@ class StereoPointCloud(Module):
         if depth.ndim == 3:
             depth = depth[:, :, 0]
         depth = depth.astype(np.float32)
-        if np.nanmedian(depth[depth > 0]) > 100:
+        valid_d = depth[depth > 0]
+        if len(valid_d) and np.median(valid_d) > 100:
             depth /= 1000.0
+        invalid = (depth <= 0) | (depth < self.config.min_depth) | (depth > self.config.max_depth)
+        depth[invalid] = np.nan
 
         H, W = depth.shape
-
         if info is not None:
             K = info.get_K_matrix()
             fx, fy, cx, cy = float(K[0, 0]), float(K[1, 1]), float(K[0, 2]), float(K[1, 2])
@@ -295,116 +377,86 @@ class StereoPointCloud(Module):
             fx = fy = float(max(H, W)) / 2.0
             cx, cy  = W / 2.0, H / 2.0
 
-        mask = (
-            _gradient_mask(depth, self.config.gradient_threshold)
-            & (depth > self.config.min_depth)
-            & (depth < self.config.max_depth)
-        )
-        if not mask.any():
+        stable = _gradient_mask(depth, self.config.gradient_threshold)
+        valid  = np.isfinite(depth) & stable
+        if not valid.any():
             return
 
         uu, vv  = np.meshgrid(np.arange(W, dtype=np.float32), np.arange(H, dtype=np.float32))
-        dd      = depth[mask]
+        dd      = depth[valid]
         xyz_opt = np.column_stack([
-            (uu[mask] - cx) * dd / fx,
-            (vv[mask] - cy) * dd / fy,
+            (uu[valid] - cx) * dd / fx,
+            (vv[valid] - cy) * dd / fy,
             dd,
         ]).astype(np.float32)
 
-        # ── Pose: TF primary, ICP fallback ───────────────────────────────────
-        tf = self.tf.get(
-            self.config.world_frame, self.config.camera_frame, img.ts, self.config.tf_timeout
-        )
-        if tf is not None:
-            self._last_tf = tf
+        with self._imu_lock:
+            R = self._madgwick.R.copy() if self._madgwick is not None else np.eye(3, dtype=np.float32)
+        t = self._odom.t
 
-        use_tf = self._last_tf is not None
-        if use_tf:
-            R = self._last_tf.rotation.to_rotation_matrix().astype(np.float32)
-            t = np.array([
-                self._last_tf.translation.x,
-                self._last_tf.translation.y,
-                self._last_tf.translation.z,
-            ], dtype=np.float32)
-            xyz_world = (xyz_opt @ R.T + t).astype(np.float32)
-            # xyz_cam approximation for floor calibration (R ~ optical→link not critical here)
-            xyz_cam = xyz_opt
-        else:
-            # ICP fallback: no rotation (no IMU), translation from ICP
-            t         = self._odom.t
-            xyz_world = (xyz_opt + t).astype(np.float32)
-            xyz_cam   = xyz_opt
+        xyz_cam   = xyz_opt @ _R_OPT_TO_LINK.T
+        xyz_world = (xyz_cam @ R.T + t).astype(np.float32)
+        cam_z     = float(t[2])
 
-        # ── Floor calibration (histogram-based, camera-frame Z) ───────────────
         self._floor_calib.update(xyz_cam)
 
-        cam_z = float(t[2]) if use_tf else 0.0
-
-        # ── Per-frame voxel map with floor filter ─────────────────────────────
         if self._floor_calib.ready:
-            floor_z_world = cam_z + self._floor_calib.floor_z if use_tf else self._floor_calib.floor_z
-            keep = xyz_world[:, 2] > floor_z_world + self.config.floor_margin
+            keep = xyz_cam[:, 2] > (self._floor_calib.floor_z + self.config.floor_margin)
         else:
-            keep = (xyz_world[:, 2] - cam_z >= -1.4) & (xyz_world[:, 2] - cam_z <= 1.5)
+            keep = (xyz_cam[:, 2] >= -1.4) & (xyz_cam[:, 2] <= 1.5)
 
-        xyz_kept = xyz_world[keep]
-        if not len(xyz_kept):
+        xyz_world_kept = xyz_world[keep]
+        xyz_cam_kept   = xyz_cam[keep]
+        if not len(xyz_world_kept):
             self._frame += 1
             return
 
-        vk       = np.floor(xyz_kept / self.config.vox_size).astype(np.int32)
+        vk       = np.floor(xyz_world_kept / self.config.vox_size).astype(np.int32)
         _, first = np.unique(_pack(vk), return_index=True)
-        xyz_vox  = xyz_kept[first]
+        xyz_vox  = xyz_world_kept[first]
 
         self.frame_cloud.publish(
             PointCloud2.from_numpy(xyz_vox, frame_id=self.config.world_frame, timestamp=img.ts)
         )
 
-        # ── ICP update (runs even when TF available, for future fallback) ─────
-        if not use_tf and len(xyz_cam[keep]) >= 50:
-            self._odom.update(xyz_cam[keep])
+        if len(xyz_cam_kept) >= 50:
+            self._odom.update(xyz_cam_kept, R)
 
-        # ── Global map ────────────────────────────────────────────────────────
         if not self._floor_calib.ready:
             self._frame += 1
             return
 
         if not self._map_ready:
-            self._map_ready   = True
-            self._world_floor_z = floor_z_world if self._floor_calib.ready else 0.0
-            logger.info("StereoPointCloud: global map started")
+            self._map_ready     = True
+            self._world_floor_z = cam_z + self._floor_calib.floor_z
+            logger.info(f"StereoPointCloud: global map started — floor at Z ≈ {self._world_floor_z:.3f} m")
 
-        if use_tf:
-            # Full world frame — TF translation is reliable
-            xyz_for_map = xyz_vox[xyz_vox[:, 2] > self._world_floor_z + self.config.floor_margin]
-        else:
-            # Rotation-only frame — strips ICP translation drift
-            xyz_ronly = xyz_vox - t
-            vk_r      = np.floor(xyz_ronly / self.config.vox_size).astype(np.int32)
-            _, fr     = np.unique(_pack(vk_r), return_index=True)
-            xyz_ronly = xyz_ronly[fr]
-            xyz_for_map = xyz_ronly[xyz_ronly[:, 2] > self._world_floor_z + self.config.floor_margin]
+        # Rotation-only frame: strip ICP translation so ±2 cm t-noise doesn't shift voxel keys
+        xyz_ronly  = xyz_vox - t
+        vk_r       = np.floor(xyz_ronly / self.config.vox_size).astype(np.int32)
+        _, first_r = np.unique(_pack(vk_r), return_index=True)
+        xyz_vox_r  = xyz_ronly[first_r]
+        xyz_for_map = xyz_vox_r[xyz_vox_r[:, 2] > self._world_floor_z + self.config.floor_margin]
 
         pts_snap = None
         with self._lock:
             if len(self._acc_pts) > 0 and len(xyz_for_map) > 0:
-                origin_for_clear = t if use_tf else np.zeros(3, dtype=np.float32)
-                free = _raycast_free_keys(origin_for_clear, xyz_for_map, self.config.global_vox_size)
-                if len(free):
-                    keys_acc  = _pack(np.floor(self._acc_pts / self.config.global_vox_size).astype(np.int32))
-                    self._acc_pts = self._acc_pts[~np.isin(keys_acc, free)]
+                free_keys = _raycast_free_keys(xyz_for_map, self.config.global_vox_size)
+                if len(free_keys):
+                    keys_acc      = _pack(np.floor(self._acc_pts / self.config.global_vox_size).astype(np.int32))
+                    self._acc_pts = self._acc_pts[~np.isin(keys_acc, free_keys)]
 
             if len(xyz_for_map):
                 self._acc_pts = (
-                    np.vstack([self._acc_pts, xyz_for_map])
-                    if len(self._acc_pts) else xyz_for_map.copy()
+                    np.vstack([self._acc_pts, xyz_for_map]) if len(self._acc_pts) else xyz_for_map.copy()
                 )
-                vk_g    = np.floor(self._acc_pts / self.config.global_vox_size).astype(np.int32)
-                _, ui_g = np.unique(_pack(vk_g), return_index=True)
-                self._acc_pts = self._acc_pts[ui_g]
-
+                _, ui         = np.unique(
+                    _pack(np.floor(self._acc_pts / self.config.global_vox_size).astype(np.int32)),
+                    return_index=True,
+                )
+                self._acc_pts = self._acc_pts[ui]
                 if len(self._acc_pts) > self.config.max_global_pts:
-                    keep_idx = np.random.choice(len(self._acc_pts), self.config.max_global_pts, replace=False)
+                    keep_idx      = np.random.choice(len(self._acc_pts), self.config.max_global_pts, replace=False)
                     self._acc_pts = self._acc_pts[keep_idx]
 
             self._frame += 1

--- a/dimos/perception/stereo_point_cloud.py
+++ b/dimos/perception/stereo_point_cloud.py
@@ -12,7 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Stereo depth → per-frame cloud + persistent global map for CostMapper."""
+"""Stereo depth → per-frame cloud + persistent global map for CostMapper.
+
+Pose source (in priority order):
+  1. TF lookup (world → camera_color_optical_frame) — used when a robot TF stack is running.
+  2. ICP fallback — rotation-decoupled point-cloud odometry for translation when TF is
+     unavailable. Rotation is assumed near-identity (no IMU in Module context).
+
+Global map frame:
+  - TF mode:  full world frame — TF translation is reliable so no rotation-only trick needed.
+  - ICP mode: rotation-only frame (xyz_world - t) — strips ICP translation to prevent
+    ±2 cm ICP centroid noise from accumulating duplicate voxels, matching the behaviour
+    of the standalone realsense_stereo_nav.py script.
+
+Floor calibration:
+  Histogram-based one-shot estimator (ported from realsense_stereo_nav.py): skips the
+  first SKIP_FRAMES, then histograms candidate floor-point Z values over CALIB_FRAMES
+  and takes the mode.  More robust than a rolling percentile when the floor is partially
+  occluded or when the camera tilts slightly at startup.
+"""
 
 from __future__ import annotations
 
@@ -22,6 +40,7 @@ from typing import Any
 import numpy as np
 from reactivex.disposable import Disposable
 from scipy.ndimage import sobel
+from scipy.spatial import cKDTree
 
 from dimos.core.core import rpc
 from dimos.core.module import Module, ModuleConfig
@@ -32,6 +51,7 @@ from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
 from dimos.utils.logging_config import setup_logger
 
 logger = setup_logger()
+
 
 # ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -47,7 +67,6 @@ def _pack(vkeys: np.ndarray) -> np.ndarray:
 
 
 def _gradient_mask(depth: np.ndarray, threshold: float) -> np.ndarray:
-    """True where depth is valid and Sobel gradient magnitude is below threshold (m/px)."""
     valid   = np.isfinite(depth)
     depth_f = np.where(valid, depth, 0.0).astype(np.float64)
     grad    = np.hypot(sobel(depth_f, axis=1), sobel(depth_f, axis=0))
@@ -58,23 +77,141 @@ def _raycast_free_keys(
     origin: np.ndarray,
     surface_pts: np.ndarray,
     vox: float,
-    n_rays: int = 200,
-    max_steps: int = 40,
+    n_rays: int = 400,
 ) -> np.ndarray:
-    """World-frame voxel keys on rays from origin to surface_pts. Keys match floor(pts/vox) world voxelisation."""
+    """World-frame voxel keys on rays from origin to surface_pts.
+
+    Fully vectorised. Stops 1.5 voxels short of each surface so the surface
+    voxel itself is never cleared. Keys use floor(pts/vox) world voxelisation —
+    directly comparable with accumulated-point world-frame keys.
+    """
     if len(surface_pts) == 0:
         return np.array([], dtype=np.int64)
 
-    idx  = np.random.choice(len(surface_pts), min(n_rays, len(surface_pts)), replace=False)
+    n    = min(len(surface_pts), n_rays)
+    idx  = (np.random.choice(len(surface_pts), n, replace=False)
+            if len(surface_pts) > n else np.arange(n))
     vecs = (surface_pts[idx] - origin).astype(np.float32)
-    dist = np.linalg.norm(vecs, axis=1, keepdims=True)
-    dist = np.where(dist < 1e-6, 1e-6, dist)
-    dirs = vecs / dist
+    dist = np.linalg.norm(vecs, axis=1)
+    ok   = dist > vox * 2
+    vecs, dist = vecs[ok], dist[ok]
+    if not len(vecs):
+        return np.array([], dtype=np.int64)
 
-    steps = np.linspace(0.1, 0.9, max_steps, dtype=np.float32)
-    pts   = origin + dirs[:, None, :] * (dist[:, None, :] * steps[None, :, None])
-    pts   = pts.reshape(-1, 3)
-    return np.unique(_pack(np.floor(pts / vox).astype(np.int32)))
+    dirs      = vecs / dist[:, None]
+    max_steps = int(np.ceil(dist.max() / vox))
+    t_vals    = np.arange(max_steps, dtype=np.float32) * vox
+    t_end     = (dist - vox * 1.5)[:, None]
+    valid_m   = (t_vals[None, :] >= 0) & (t_vals[None, :] < t_end)
+
+    pts = origin + dirs[:, None, :] * t_vals[None, :, None]
+    vk  = np.floor(pts.reshape(-1, 3) / vox).astype(np.int32)
+    return np.unique(_pack(vk)[valid_m.ravel()])
+
+
+# ── Floor calibration ─────────────────────────────────────────────────────────
+
+class _FloorCalibrator:
+    """One-shot floor height estimator.
+
+    Skips SKIP_FRAMES for sensor settle, then histograms candidate floor-point
+    depths over CALIB_FRAMES and takes the mode bin centre. More robust than a
+    rolling percentile when the floor is partially visible or the camera tilts.
+    """
+
+    SKIP_FRAMES  = 30
+    CALIB_FRAMES = 30
+    BIN_M        = 0.02
+
+    def __init__(self) -> None:
+        self._frame   = 0
+        self._samples: list[float] = []
+        self.floor_z:   float | None = None
+        self.cam_height: float | None = None
+
+    @property
+    def ready(self) -> bool:
+        return self.floor_z is not None
+
+    def update(self, xyz_cam: np.ndarray) -> None:
+        """xyz_cam: (N,3) points in camera_link frame (Z = up)."""
+        self._frame += 1
+        if self.ready or self._frame <= self.SKIP_FRAMES:
+            return
+
+        z    = xyz_cam[:, 2]
+        dist = np.linalg.norm(xyz_cam[:, :2], axis=1)
+        mask = (z < -0.30) & (dist < 4.0)
+        if mask.sum() < 200:
+            return
+
+        z_floor = z[mask]
+        lo, hi  = z_floor.min(), z_floor.max()
+        if hi - lo < self.BIN_M:
+            return
+        bins          = np.arange(lo, hi + self.BIN_M, self.BIN_M)
+        counts, edges = np.histogram(z_floor, bins=bins)
+        mode_z        = float(edges[int(np.argmax(counts))] + self.BIN_M / 2)
+        self._samples.append(mode_z)
+
+        if len(self._samples) >= self.CALIB_FRAMES:
+            self.floor_z    = float(np.median(self._samples))
+            self.cam_height = -self.floor_z
+            logger.info(f"StereoPointCloud: floor calibrated — camera {self.cam_height:.3f} m above floor")
+
+
+# ── ICP translation odometry (fallback when TF unavailable) ──────────────────
+
+class _PointCloudOdometry:
+    """Frame-to-frame translation via rotation-decoupled ICP.
+
+    Rotation is assumed near-identity (no IMU available in Module context).
+    Used only when TF lookup fails — on a robot TF is always preferred.
+    """
+
+    ITERS    = 4
+    MAX_DIST = 0.40
+    N_SRC    = 1_500
+    N_DST    = 8_000
+    N_STORE  = 10_000
+
+    def __init__(self) -> None:
+        self._t          = np.zeros(3, dtype=np.float32)
+        self._lock       = threading.Lock()
+        self._prev_world: np.ndarray | None = None
+
+    @property
+    def t(self) -> np.ndarray:
+        with self._lock:
+            return self._t.copy()
+
+    def update(self, xyz_cam: np.ndarray) -> np.ndarray:
+        with self._lock:
+            t_est = self._t.copy()
+
+        if self._prev_world is None or len(xyz_cam) < 50:
+            t_new = t_est
+        else:
+            n_src = min(self.N_SRC, len(xyz_cam))
+            n_dst = min(self.N_DST, len(self._prev_world))
+            src   = xyz_cam[np.random.choice(len(xyz_cam), n_src, replace=False)]
+            dst   = self._prev_world[np.random.choice(len(self._prev_world), n_dst, replace=False)]
+            tree  = cKDTree(dst)
+            for _ in range(self.ITERS):
+                dists, idx = tree.query(src + t_est, k=1, workers=1)
+                mask = dists < self.MAX_DIST
+                if mask.sum() < 30:
+                    break
+                delta = dst[idx[mask]].mean(axis=0) - (src[mask] + t_est).mean(axis=0)
+                t_est = (t_est + 0.7 * delta).astype(np.float32)
+            t_new = t_est
+
+        n_st = min(self.N_STORE, len(xyz_cam))
+        self._prev_world = (xyz_cam[np.random.choice(len(xyz_cam), n_st, replace=False)] + t_new).astype(np.float32)
+
+        with self._lock:
+            self._t = t_new
+        return t_new
 
 
 # ── Module ────────────────────────────────────────────────────────────────────
@@ -82,12 +219,12 @@ def _raycast_free_keys(
 class Config(ModuleConfig):
     min_depth: float          = 0.3
     max_depth: float          = 8.0
-    gradient_threshold: float = 0.30    # m/px; above → depth edge artifact → reject
-    vox_size: float           = 0.020   # per-frame dedup voxel (2 cm)
-    global_vox_size: float    = 0.040   # accumulation voxel (4 cm, absorbs pose jitter)
-    floor_margin: float       = 0.04    # metres above detected floor to keep points
+    gradient_threshold: float = 0.30
+    vox_size: float           = 0.020
+    global_vox_size: float    = 0.020
+    floor_margin: float       = 0.03
     max_global_pts: int       = 200_000
-    publish_every: int        = 3       # emit global_map every N frames
+    publish_every: int        = 3
     world_frame: str          = "world"
     camera_frame: str         = "camera_color_optical_frame"
     base_frame: str           = "base_link"
@@ -95,7 +232,12 @@ class Config(ModuleConfig):
 
 
 class StereoPointCloud(Module):
-    """Gradient filter → backproject → floor removal → voxel dedup → ray-cast ghost clearing → global_map."""
+    """Gradient filter → backproject → floor removal → voxel dedup → ray-cast ghost clearing → global_map.
+
+    Mirrors the realsense_stereo_nav.py standalone pipeline as a dimos Module.
+    Uses TF for pose when available; falls back to ICP odometry with rotation-only
+    global map frame to prevent translation-drift accumulation.
+    """
 
     config: Config
 
@@ -107,12 +249,15 @@ class StereoPointCloud(Module):
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
-        self._lock                          = threading.Lock()
+        self._lock                           = threading.Lock()
         self._latest_info: CameraInfo | None = None
-        self._last_tf                       = None
-        self._floor_buf: list[float]        = []
-        self._acc_pts: np.ndarray           = np.empty((0, 3), dtype=np.float32)
-        self._frame                         = 0
+        self._last_tf                        = None
+        self._floor_calib                    = _FloorCalibrator()
+        self._odom                           = _PointCloudOdometry()
+        self._acc_pts: np.ndarray            = np.empty((0, 3), dtype=np.float32)
+        self._map_ready                      = False
+        self._world_floor_z: float           = 0.0
+        self._frame                          = 0
 
     @rpc
     def start(self) -> None:
@@ -166,70 +311,101 @@ class StereoPointCloud(Module):
             dd,
         ]).astype(np.float32)
 
+        # ── Pose: TF primary, ICP fallback ───────────────────────────────────
         tf = self.tf.get(
             self.config.world_frame, self.config.camera_frame, img.ts, self.config.tf_timeout
         )
         if tf is not None:
             self._last_tf = tf
-        if self._last_tf is not None:
+
+        use_tf = self._last_tf is not None
+        if use_tf:
             R = self._last_tf.rotation.to_rotation_matrix().astype(np.float32)
-            t = np.array(
-                [self._last_tf.translation.x,
-                 self._last_tf.translation.y,
-                 self._last_tf.translation.z],
-                dtype=np.float32,
-            )
+            t = np.array([
+                self._last_tf.translation.x,
+                self._last_tf.translation.y,
+                self._last_tf.translation.z,
+            ], dtype=np.float32)
+            xyz_world = (xyz_opt @ R.T + t).astype(np.float32)
+            # xyz_cam approximation for floor calibration (R ~ optical→link not critical here)
+            xyz_cam = xyz_opt
         else:
-            R, t = np.eye(3, dtype=np.float32), np.zeros(3, dtype=np.float32)
+            # ICP fallback: no rotation (no IMU), translation from ICP
+            t         = self._odom.t
+            xyz_world = (xyz_opt + t).astype(np.float32)
+            xyz_cam   = xyz_opt
 
-        xyz_world = (xyz_opt @ R.T + t).astype(np.float32)
+        # ── Floor calibration (histogram-based, camera-frame Z) ───────────────
+        self._floor_calib.update(xyz_cam)
 
-        # TF-primary floor detection; falls back to rolling low-Z percentile
-        base_tf = self.tf.get(
-            self.config.world_frame, self.config.base_frame, img.ts, self.config.tf_timeout
-        )
-        if base_tf is not None:
-            floor_z = float(base_tf.translation.z)
+        cam_z = float(t[2]) if use_tf else 0.0
+
+        # ── Per-frame voxel map with floor filter ─────────────────────────────
+        if self._floor_calib.ready:
+            floor_z_world = cam_z + self._floor_calib.floor_z if use_tf else self._floor_calib.floor_z
+            keep = xyz_world[:, 2] > floor_z_world + self.config.floor_margin
         else:
-            bot = xyz_world[xyz_world[:, 2] < np.percentile(xyz_world[:, 2], 10)]
-            if len(bot):
-                self._floor_buf.append(float(np.median(bot[:, 2])))
-                if len(self._floor_buf) > 30:
-                    self._floor_buf.pop(0)
-            floor_z = float(np.percentile(self._floor_buf, 20)) if len(self._floor_buf) >= 5 else None
+            keep = (xyz_world[:, 2] - cam_z >= -1.4) & (xyz_world[:, 2] - cam_z <= 1.5)
 
-        vk      = np.floor(xyz_world / self.config.vox_size).astype(np.int32)
-        _, ui   = np.unique(_pack(vk), return_index=True)
-        xyz_vox = xyz_world[ui]
-        if floor_z is not None:
-            xyz_vox = xyz_vox[xyz_vox[:, 2] > floor_z + self.config.floor_margin]
-        if len(xyz_vox) == 0:
+        xyz_kept = xyz_world[keep]
+        if not len(xyz_kept):
+            self._frame += 1
             return
+
+        vk       = np.floor(xyz_kept / self.config.vox_size).astype(np.int32)
+        _, first = np.unique(_pack(vk), return_index=True)
+        xyz_vox  = xyz_kept[first]
 
         self.frame_cloud.publish(
             PointCloud2.from_numpy(xyz_vox, frame_id=self.config.world_frame, timestamp=img.ts)
         )
 
-        pts_snap = None
+        # ── ICP update (runs even when TF available, for future fallback) ─────
+        if not use_tf and len(xyz_cam[keep]) >= 50:
+            self._odom.update(xyz_cam[keep])
 
+        # ── Global map ────────────────────────────────────────────────────────
+        if not self._floor_calib.ready:
+            self._frame += 1
+            return
+
+        if not self._map_ready:
+            self._map_ready   = True
+            self._world_floor_z = floor_z_world if self._floor_calib.ready else 0.0
+            logger.info("StereoPointCloud: global map started")
+
+        if use_tf:
+            # Full world frame — TF translation is reliable
+            xyz_for_map = xyz_vox[xyz_vox[:, 2] > self._world_floor_z + self.config.floor_margin]
+        else:
+            # Rotation-only frame — strips ICP translation drift
+            xyz_ronly = xyz_vox - t
+            vk_r      = np.floor(xyz_ronly / self.config.vox_size).astype(np.int32)
+            _, fr     = np.unique(_pack(vk_r), return_index=True)
+            xyz_ronly = xyz_ronly[fr]
+            xyz_for_map = xyz_ronly[xyz_ronly[:, 2] > self._world_floor_z + self.config.floor_margin]
+
+        pts_snap = None
         with self._lock:
-            if len(self._acc_pts) > 0:
-                free = _raycast_free_keys(t, xyz_vox, self.config.global_vox_size)
+            if len(self._acc_pts) > 0 and len(xyz_for_map) > 0:
+                origin_for_clear = t if use_tf else np.zeros(3, dtype=np.float32)
+                free = _raycast_free_keys(origin_for_clear, xyz_for_map, self.config.global_vox_size)
                 if len(free):
-                    keys_acc = _pack(np.floor(self._acc_pts / self.config.global_vox_size).astype(np.int32))
+                    keys_acc  = _pack(np.floor(self._acc_pts / self.config.global_vox_size).astype(np.int32))
                     self._acc_pts = self._acc_pts[~np.isin(keys_acc, free)]
 
-            self._acc_pts = (
-                np.vstack([self._acc_pts, xyz_vox])
-                if len(self._acc_pts) else xyz_vox.copy()
-            )
-            vk_g    = np.floor(self._acc_pts / self.config.global_vox_size).astype(np.int32)
-            _, ui_g = np.unique(_pack(vk_g), return_index=True)
-            self._acc_pts = self._acc_pts[ui_g]
+            if len(xyz_for_map):
+                self._acc_pts = (
+                    np.vstack([self._acc_pts, xyz_for_map])
+                    if len(self._acc_pts) else xyz_for_map.copy()
+                )
+                vk_g    = np.floor(self._acc_pts / self.config.global_vox_size).astype(np.int32)
+                _, ui_g = np.unique(_pack(vk_g), return_index=True)
+                self._acc_pts = self._acc_pts[ui_g]
 
-            if len(self._acc_pts) > self.config.max_global_pts:
-                keep = np.random.choice(len(self._acc_pts), self.config.max_global_pts, replace=False)
-                self._acc_pts = self._acc_pts[keep]
+                if len(self._acc_pts) > self.config.max_global_pts:
+                    keep_idx = np.random.choice(len(self._acc_pts), self.config.max_global_pts, replace=False)
+                    self._acc_pts = self._acc_pts[keep_idx]
 
             self._frame += 1
             if self._frame % self.config.publish_every == 0 and len(self._acc_pts):

--- a/dimos/perception/stereo_point_cloud/filtered_realsense.py
+++ b/dimos/perception/stereo_point_cloud/filtered_realsense.py
@@ -1,0 +1,89 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""RealSenseCamera subclass that applies rs.spatial_filter + rs.hole_filling_filter
+before converting depth frames to numpy — identical to the original realsense_stereo_nav.py."""
+
+from __future__ import annotations
+
+import time
+
+import cv2
+import numpy as np
+
+from dimos.hardware.sensors.camera.realsense.camera import RealSenseCamera
+from dimos.msgs.sensor_msgs.Image import Image, ImageFormat
+
+
+class FilteredRealSenseCamera(RealSenseCamera):
+    """Adds rs.spatial_filter + rs.hole_filling_filter to depth frames before publishing."""
+
+    def _capture_loop(self) -> None:
+        import pyrealsense2 as rs
+
+        spatial_filter   = rs.spatial_filter()
+        hole_fill_filter = rs.hole_filling_filter()
+
+        while self._running and self._pipeline is not None:
+            try:
+                frames = self._pipeline.wait_for_frames(timeout_ms=1000)
+            except (RuntimeError, AttributeError):
+                break
+
+            ts = time.time()
+
+            if self._align is not None:
+                frames = self._align.process(frames)
+
+            color_frame = frames.get_color_frame()
+            depth_frame = frames.get_depth_frame() if self.config.enable_depth else None
+
+            if depth_frame:
+                depth_frame = spatial_filter.process(depth_frame)
+                depth_frame = hole_fill_filter.process(depth_frame)
+
+            color_img = None
+            if color_frame:
+                color_data = np.asanyarray(color_frame.get_data())
+                color_data = cv2.cvtColor(color_data, cv2.COLOR_BGR2RGB)
+                color_img = Image(
+                    data=color_data,
+                    format=ImageFormat.RGB,
+                    frame_id=self._color_optical_frame,
+                    ts=ts,
+                )
+                self.color_image.publish(color_img)
+
+            depth_img = None
+            if depth_frame:
+                depth_data = np.asanyarray(depth_frame.get_data())
+                depth_frame_id = (
+                    self._color_optical_frame
+                    if self.config.align_depth_to_color
+                    else self._depth_optical_frame
+                )
+                depth_img = Image(
+                    data=depth_data,
+                    format=ImageFormat.DEPTH16,
+                    frame_id=depth_frame_id,
+                    ts=ts,
+                )
+                self.depth_image.publish(depth_img)
+
+            if self.config.enable_pointcloud and color_img is not None and depth_img is not None:
+                with self._pointcloud_lock:
+                    self._latest_color_img = color_img
+                    self._latest_depth_img = depth_img
+
+            self._publish_tf(ts)

--- a/dimos/perception/stereo_point_cloud/filtered_realsense.py
+++ b/dimos/perception/stereo_point_cloud/filtered_realsense.py
@@ -34,6 +34,7 @@ class FilteredRealSenseCamera(RealSenseCamera):
 
         spatial_filter   = rs.spatial_filter()
         hole_fill_filter = rs.hole_filling_filter()
+        hole_fill_filter.set_option(rs.option.holes_fill, 2)  # nearest-from-around: preserves thin features like chair legs
 
         while self._running and self._pipeline is not None:
             try:

--- a/dimos/perception/stereo_point_cloud/filtered_realsense.py
+++ b/dimos/perception/stereo_point_cloud/filtered_realsense.py
@@ -32,7 +32,7 @@ class FilteredRealSenseCamera(RealSenseCamera):
     def _capture_loop(self) -> None:
         import pyrealsense2 as rs
 
-        spatial_filter   = rs.spatial_filter()
+        spatial_filter = rs.spatial_filter()
         hole_fill_filter = rs.hole_filling_filter()
 
         while self._running and self._pipeline is not None:

--- a/dimos/perception/stereo_point_cloud/filtered_realsense.py
+++ b/dimos/perception/stereo_point_cloud/filtered_realsense.py
@@ -34,7 +34,6 @@ class FilteredRealSenseCamera(RealSenseCamera):
 
         spatial_filter   = rs.spatial_filter()
         hole_fill_filter = rs.hole_filling_filter()
-        hole_fill_filter.set_option(rs.option.holes_fill, 2)  # nearest-from-around: preserves thin features like chair legs
 
         while self._running and self._pipeline is not None:
             try:

--- a/dimos/perception/stereo_point_cloud/module.py
+++ b/dimos/perception/stereo_point_cloud/module.py
@@ -21,6 +21,7 @@ from typing import Any
 
 import numpy as np
 from reactivex.disposable import Disposable
+from scipy.ndimage import median_filter
 
 from dimos.core.core import rpc
 from dimos.core.module import Module, ModuleConfig
@@ -41,8 +42,6 @@ from dimos.utils.logging_config import setup_logger
 logger = setup_logger()
 
 _DEPTH_MM_THRESHOLD = 100
-_FALLBACK_FLOOR_Z   = -1.4
-_FALLBACK_CEILING_Z =  1.5
 
 
 class Config(ModuleConfig):
@@ -182,6 +181,10 @@ class StereoPointCloud(Module):
         valid_d = depth[depth > 0]
         if len(valid_d) and np.median(valid_d) > _DEPTH_MM_THRESHOLD:
             depth /= 1000.0
+        valid_mask = depth > 0
+        depth[valid_mask] = median_filter(depth, size=3)[valid_mask]
+        fill = median_filter(np.where(valid_mask, depth, 0.0), size=5)
+        depth[~valid_mask & (fill > 0)] = fill[~valid_mask & (fill > 0)]
         invalid = (depth <= 0) | (depth < self.config.min_depth) | (depth > self.config.max_depth)
         depth[invalid] = np.nan
 
@@ -222,7 +225,7 @@ class StereoPointCloud(Module):
         if self._floor_calib.ready:
             keep = xyz_cam[:, 2] > (self._floor_calib.floor_z + self.config.floor_margin)
         else:
-            keep = (xyz_cam[:, 2] >= _FALLBACK_FLOOR_Z) & (xyz_cam[:, 2] <= _FALLBACK_CEILING_Z)
+            keep = np.ones(len(xyz_cam), dtype=bool)
 
         xyz_world_kept = xyz_world[keep]
         xyz_cam_kept   = xyz_cam[keep]
@@ -255,7 +258,7 @@ class StereoPointCloud(Module):
         vk_r       = np.floor(xyz_ronly / self.config.vox_size).astype(np.int32)
         _, first_r = np.unique(_pack(vk_r), return_index=True)
         xyz_vox_r  = xyz_ronly[first_r]
-        xyz_for_map = xyz_vox_r[xyz_vox_r[:, 2] > self._world_floor_z + self.config.floor_margin]
+        xyz_for_map = xyz_vox_r
 
         pts_snap = None
         with self._lock:

--- a/dimos/perception/stereo_point_cloud/module.py
+++ b/dimos/perception/stereo_point_cloud/module.py
@@ -50,7 +50,8 @@ class Config(ModuleConfig):
     gradient_threshold: float = 0.30
     vox_size: float           = 0.020
     global_vox_size: float    = 0.020
-    floor_margin: float       = 0.04
+    floor_margin: float       = 0.03
+    global_floor_margin: float = 0.04
     max_global_pts: int       = 500_000
     publish_every: int        = 1
     world_frame: str          = "world"
@@ -181,13 +182,13 @@ class StereoPointCloud(Module):
         valid_d = depth[depth > 0]
         is_mm = len(valid_d) > 0 and np.median(valid_d) > _DEPTH_MM_THRESHOLD
         valid_mask = depth > 0
-        depth_u16 = depth.clip(0, 65535).astype(np.uint16)
-        depth_u16[~valid_mask] = 65535
-        depth_u16 = cv2.medianBlur(depth_u16, 3)
-        depth_u16[~valid_mask] = 0
-        hole_fill = cv2.medianBlur(depth_u16, 5)
-        depth_u16[(depth_u16 == 0) & (hole_fill > 0) & (hole_fill < 60000)] = hole_fill[(depth_u16 == 0) & (hole_fill > 0) & (hole_fill < 60000)]
-        depth = depth_u16.astype(np.float32)
+        kernel = np.ones((3, 3), np.uint8)
+        dilated = cv2.dilate(depth, kernel)
+        depth_tmp = np.where(valid_mask, depth, dilated).astype(np.float32)
+        smoothed = cv2.bilateralFilter(depth_tmp, d=5, sigmaColor=30.0, sigmaSpace=5.0)
+        depth[valid_mask] = smoothed[valid_mask]
+        depth_after = cv2.dilate(depth, kernel)
+        depth[~valid_mask & (depth_after > 0)] = depth_after[~valid_mask & (depth_after > 0)]
         if is_mm:
             depth /= 1000.0
         invalid = (depth <= 0) | (depth < self.config.min_depth) | (depth > self.config.max_depth)
@@ -263,7 +264,7 @@ class StereoPointCloud(Module):
         vk_r       = np.floor(xyz_ronly / self.config.vox_size).astype(np.int32)
         _, first_r = np.unique(_pack(vk_r), return_index=True)
         xyz_vox_r  = xyz_ronly[first_r]
-        xyz_for_map = xyz_vox_r[xyz_vox_r[:, 2] > self._world_floor_z + self.config.floor_margin]
+        xyz_for_map = xyz_vox_r[xyz_vox_r[:, 2] > self._world_floor_z + self.config.global_floor_margin]
 
         pts_snap = None
         with self._lock:

--- a/dimos/perception/stereo_point_cloud/module.py
+++ b/dimos/perception/stereo_point_cloud/module.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import threading
 from typing import Any
 
-import cv2
 import numpy as np
 from reactivex.disposable import Disposable
 
@@ -181,14 +180,6 @@ class StereoPointCloud(Module):
         depth = depth.astype(np.float32)
         valid_d = depth[depth > 0]
         is_mm = len(valid_d) > 0 and np.median(valid_d) > _DEPTH_MM_THRESHOLD
-        valid_mask = depth > 0
-        kernel = np.ones((3, 3), np.uint8)
-        dilated = cv2.dilate(depth, kernel)
-        depth_tmp = np.where(valid_mask, depth, dilated).astype(np.float32)
-        smoothed = cv2.bilateralFilter(depth_tmp, d=5, sigmaColor=30.0, sigmaSpace=5.0)
-        depth[valid_mask] = smoothed[valid_mask]
-        depth_after = cv2.dilate(depth, kernel)
-        depth[~valid_mask & (depth_after > 0)] = depth_after[~valid_mask & (depth_after > 0)]
         if is_mm:
             depth /= 1000.0
         invalid = (depth <= 0) | (depth < self.config.min_depth) | (depth > self.config.max_depth)

--- a/dimos/perception/stereo_point_cloud/module.py
+++ b/dimos/perception/stereo_point_cloud/module.py
@@ -29,8 +29,8 @@ from dimos.msgs.sensor_msgs.CameraInfo import CameraInfo
 from dimos.msgs.sensor_msgs.Image import Image
 from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
 from dimos.perception.stereo_point_cloud.utils import (
-    _FloorCalibrator,
     _R_OPT_TO_LINK,
+    _FloorCalibrator,
     _gradient_mask,
     _pack,
     _raycast_free_keys,
@@ -44,17 +44,17 @@ _DEPTH_MM_THRESHOLD = 100
 
 
 class Config(ModuleConfig):
-    min_depth: float          = 0.1
-    max_depth: float          = 8.0
+    min_depth: float = 0.1
+    max_depth: float = 8.0
     gradient_threshold: float = 0.30
-    vox_size: float           = 0.020
-    global_vox_size: float    = 0.020
-    floor_margin: float       = 0.03
+    vox_size: float = 0.020
+    global_vox_size: float = 0.020
+    floor_margin: float = 0.03
     global_floor_margin: float = 0.04
-    max_global_pts: int       = 500_000
-    publish_every: int        = 1
-    world_frame: str          = "world"
-    madgwick_beta: float      = 0.033
+    max_global_pts: int = 500_000
+    publish_every: int = 1
+    world_frame: str = "world"
+    madgwick_beta: float = 0.033
 
 
 class StereoPointCloud(Module):
@@ -62,28 +62,28 @@ class StereoPointCloud(Module):
 
     config: Config
 
-    depth_image:       In[Image]
+    depth_image: In[Image]
     depth_camera_info: In[CameraInfo]
 
     frame_cloud: Out[PointCloud2]
-    global_map:  Out[PointCloud2]
+    global_map: Out[PointCloud2]
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
-        self._lock                       = threading.Lock()
+        self._lock = threading.Lock()
         self._latest_info: CameraInfo | None = None
-        self._floor_calib                = _FloorCalibrator()
+        self._floor_calib = _FloorCalibrator()
         self._madgwick: MadgwickFilter | None = None
-        self._odom                       = PointCloudOdometry()
-        self._imu_lock                   = threading.Lock()
-        self._last_accel                 = np.array([0.0, 0.0, -9.81], dtype=np.float32)
-        self._R_imu_to_link: np.ndarray  = np.eye(3, dtype=np.float32)
-        self._motion_sensor              = None
-        self._acc_pts: np.ndarray        = np.empty((0, 3), dtype=np.float32)
-        self._map_ready                  = False
-        self._world_floor_z: float       = 0.0
-        self._frame                      = 0
-        self._warned_no_intrinsics       = False
+        self._odom = PointCloudOdometry()
+        self._imu_lock = threading.Lock()
+        self._last_accel = np.array([0.0, 0.0, -9.81], dtype=np.float32)
+        self._R_imu_to_link: np.ndarray = np.eye(3, dtype=np.float32)
+        self._motion_sensor = None
+        self._acc_pts: np.ndarray = np.empty((0, 3), dtype=np.float32)
+        self._map_ready = False
+        self._world_floor_z: float = 0.0
+        self._frame = 0
+        self._warned_no_intrinsics = False
 
     @rpc
     def start(self) -> None:
@@ -110,7 +110,7 @@ class StereoPointCloud(Module):
             import pyrealsense2 as rs
         except ImportError:
             return False
-        ctx     = rs.context()
+        ctx = rs.context()
         devices = ctx.query_devices()
         if not devices:
             return False
@@ -128,16 +128,16 @@ class StereoPointCloud(Module):
         for sensor in device.query_sensors():
             if not sensor.is_motion_sensor():
                 continue
-            all_profiles   = sensor.get_stream_profiles()
-            gyro_profiles  = [p for p in all_profiles if p.stream_type() == rs.stream.gyro]
+            all_profiles = sensor.get_stream_profiles()
+            gyro_profiles = [p for p in all_profiles if p.stream_type() == rs.stream.gyro]
             accel_profiles = [p for p in all_profiles if p.stream_type() == rs.stream.accel]
             if not gyro_profiles or not accel_profiles:
                 break
-            gyro_p  = max(gyro_profiles,  key=lambda p: p.fps())
+            gyro_p = max(gyro_profiles, key=lambda p: p.fps())
             accel_p = max(accel_profiles, key=lambda p: p.fps())
             if depth_profile is not None:
-                ext                 = accel_p.get_extrinsics_to(depth_profile)
-                R_imu_to_depth      = np.array(ext.rotation, dtype=np.float32).reshape(3, 3)
+                ext = accel_p.get_extrinsics_to(depth_profile)
+                R_imu_to_depth = np.array(ext.rotation, dtype=np.float32).reshape(3, 3)
                 self._R_imu_to_link = _R_OPT_TO_LINK @ R_imu_to_depth
             sensor.open([gyro_p, accel_p])
             sensor.start(self._on_motion)
@@ -149,18 +149,21 @@ class StereoPointCloud(Module):
     def _on_motion(self, frame: Any) -> None:
         try:
             import pyrealsense2 as rs
+
             st = frame.get_profile().stream_type()
             if st == rs.stream.gyro:
-                g        = frame.as_motion_frame().get_motion_data()
+                g = frame.as_motion_frame().get_motion_data()
                 gyro_lnk = self._R_imu_to_link @ np.array([g.x, g.y, g.z], dtype=np.float32)
-                ts_s     = frame.get_timestamp() / 1000.0
+                ts_s = frame.get_timestamp() / 1000.0
                 with self._imu_lock:
                     if self._madgwick is not None:
                         self._madgwick.update(gyro_lnk, self._last_accel, ts_s)
             elif st == rs.stream.accel:
                 a = frame.as_motion_frame().get_motion_data()
                 with self._imu_lock:
-                    self._last_accel = self._R_imu_to_link @ np.array([a.x, a.y, a.z], dtype=np.float32)
+                    self._last_accel = self._R_imu_to_link @ np.array(
+                        [a.x, a.y, a.z], dtype=np.float32
+                    )
         except Exception:
             pass
 
@@ -168,7 +171,7 @@ class StereoPointCloud(Module):
         with self._lock:
             self._latest_info = info
 
-    def _on_depth(self, img: Image) -> None:  # noqa: C901
+    def _on_depth(self, img: Image) -> None:
         with self._lock:
             info = self._latest_info
 
@@ -191,31 +194,39 @@ class StereoPointCloud(Module):
             fx, fy, cx, cy = float(K[0, 0]), float(K[1, 1]), float(K[0, 2]), float(K[1, 2])
         else:
             if not self._warned_no_intrinsics:
-                logger.warning("StereoPointCloud: no camera intrinsics — falling back to rough guess, check depth_camera_info is connected")
+                logger.warning(
+                    "StereoPointCloud: no camera intrinsics — falling back to rough guess, check depth_camera_info is connected"
+                )
                 self._warned_no_intrinsics = True
             fx = fy = float(max(H, W)) / 2.0
-            cx, cy  = W / 2.0, H / 2.0
+            cx, cy = W / 2.0, H / 2.0
 
         stable = _gradient_mask(depth, self.config.gradient_threshold)
-        valid  = np.isfinite(depth) & stable
+        valid = np.isfinite(depth) & stable
         if not valid.any():
             return
 
-        uu, vv  = np.meshgrid(np.arange(W, dtype=np.float32), np.arange(H, dtype=np.float32))
-        dd      = depth[valid]
-        xyz_opt = np.column_stack([
-            (uu[valid] - cx) * dd / fx,
-            (vv[valid] - cy) * dd / fy,
-            dd,
-        ]).astype(np.float32)
+        uu, vv = np.meshgrid(np.arange(W, dtype=np.float32), np.arange(H, dtype=np.float32))
+        dd = depth[valid]
+        xyz_opt = np.column_stack(
+            [
+                (uu[valid] - cx) * dd / fx,
+                (vv[valid] - cy) * dd / fy,
+                dd,
+            ]
+        ).astype(np.float32)
 
         with self._imu_lock:
-            R = self._madgwick.R.copy() if self._madgwick is not None else np.eye(3, dtype=np.float32)
+            R = (
+                self._madgwick.R.copy()
+                if self._madgwick is not None
+                else np.eye(3, dtype=np.float32)
+            )
         t = self._odom.t
 
-        xyz_cam   = xyz_opt @ _R_OPT_TO_LINK.T
+        xyz_cam = xyz_opt @ _R_OPT_TO_LINK.T
         xyz_world = (xyz_cam @ R.T + t).astype(np.float32)
-        cam_z     = float(t[2])
+        cam_z = float(t[2])
 
         self._floor_calib.update(xyz_cam)
 
@@ -227,14 +238,14 @@ class StereoPointCloud(Module):
         #     keep = np.ones(len(xyz_cam), dtype=bool)
 
         xyz_world_kept = xyz_world
-        xyz_cam_kept   = xyz_cam
+        xyz_cam_kept = xyz_cam
         if not len(xyz_world_kept):
             self._frame += 1
             return
 
-        vk       = np.floor(xyz_world_kept / self.config.vox_size).astype(np.int32)
+        vk = np.floor(xyz_world_kept / self.config.vox_size).astype(np.int32)
         _, first = np.unique(_pack(vk), return_index=True)
-        xyz_vox  = xyz_world_kept[first]
+        xyz_vox = xyz_world_kept[first]
 
         self.frame_cloud.publish(
             PointCloud2.from_numpy(xyz_vox, frame_id=self.config.world_frame, timestamp=img.ts)
@@ -248,36 +259,46 @@ class StereoPointCloud(Module):
             return
 
         if not self._map_ready:
-            self._map_ready     = True
+            self._map_ready = True
             self._world_floor_z = cam_z + self._floor_calib.floor_z
-            logger.info(f"StereoPointCloud: global map started — floor at Z ≈ {self._world_floor_z:.3f} m")
+            logger.info(
+                f"StereoPointCloud: global map started — floor at Z ≈ {self._world_floor_z:.3f} m"
+            )
 
         # Rotation-only frame: strip ICP translation so ±2 cm t-noise doesn't shift voxel keys
-        xyz_ronly  = xyz_vox - t
-        vk_r       = np.floor(xyz_ronly / self.config.vox_size).astype(np.int32)
+        xyz_ronly = xyz_vox - t
+        vk_r = np.floor(xyz_ronly / self.config.vox_size).astype(np.int32)
         _, first_r = np.unique(_pack(vk_r), return_index=True)
-        xyz_vox_r  = xyz_ronly[first_r]
-        xyz_for_map = xyz_vox_r[xyz_vox_r[:, 2] > self._world_floor_z + self.config.global_floor_margin]
+        xyz_vox_r = xyz_ronly[first_r]
+        xyz_for_map = xyz_vox_r[
+            xyz_vox_r[:, 2] > self._world_floor_z + self.config.global_floor_margin
+        ]
 
         pts_snap = None
         with self._lock:
             if len(self._acc_pts) > 0 and len(xyz_for_map) > 0:
                 free_keys = _raycast_free_keys(xyz_for_map, self.config.global_vox_size)
                 if len(free_keys):
-                    keys_acc      = _pack(np.floor(self._acc_pts / self.config.global_vox_size).astype(np.int32))
+                    keys_acc = _pack(
+                        np.floor(self._acc_pts / self.config.global_vox_size).astype(np.int32)
+                    )
                     self._acc_pts = self._acc_pts[~np.isin(keys_acc, free_keys)]
 
             if len(xyz_for_map):
                 self._acc_pts = (
-                    np.vstack([self._acc_pts, xyz_for_map]) if len(self._acc_pts) else xyz_for_map.copy()
+                    np.vstack([self._acc_pts, xyz_for_map])
+                    if len(self._acc_pts)
+                    else xyz_for_map.copy()
                 )
-                _, ui         = np.unique(
+                _, ui = np.unique(
                     _pack(np.floor(self._acc_pts / self.config.global_vox_size).astype(np.int32)),
                     return_index=True,
                 )
                 self._acc_pts = self._acc_pts[ui]
                 if len(self._acc_pts) > self.config.max_global_pts:
-                    keep_idx      = np.random.choice(len(self._acc_pts), self.config.max_global_pts, replace=False)
+                    keep_idx = np.random.choice(
+                        len(self._acc_pts), self.config.max_global_pts, replace=False
+                    )
                     self._acc_pts = self._acc_pts[keep_idx]
 
             self._frame += 1

--- a/dimos/perception/stereo_point_cloud/module.py
+++ b/dimos/perception/stereo_point_cloud/module.py
@@ -40,6 +40,10 @@ from dimos.utils.logging_config import setup_logger
 
 logger = setup_logger()
 
+_DEPTH_MM_THRESHOLD = 100
+_FALLBACK_FLOOR_Z   = -1.4
+_FALLBACK_CEILING_Z =  1.5
+
 
 class Config(ModuleConfig):
     min_depth: float          = 0.1
@@ -80,6 +84,7 @@ class StereoPointCloud(Module):
         self._map_ready                  = False
         self._world_floor_z: float       = 0.0
         self._frame                      = 0
+        self._warned_no_intrinsics       = False
 
     @rpc
     def start(self) -> None:
@@ -175,7 +180,7 @@ class StereoPointCloud(Module):
             depth = depth[:, :, 0]
         depth = depth.astype(np.float32)
         valid_d = depth[depth > 0]
-        if len(valid_d) and np.median(valid_d) > 100:
+        if len(valid_d) and np.median(valid_d) > _DEPTH_MM_THRESHOLD:
             depth /= 1000.0
         invalid = (depth <= 0) | (depth < self.config.min_depth) | (depth > self.config.max_depth)
         depth[invalid] = np.nan
@@ -185,6 +190,9 @@ class StereoPointCloud(Module):
             K = info.get_K_matrix()
             fx, fy, cx, cy = float(K[0, 0]), float(K[1, 1]), float(K[0, 2]), float(K[1, 2])
         else:
+            if not self._warned_no_intrinsics:
+                logger.warning("StereoPointCloud: no camera intrinsics — falling back to rough guess, check depth_camera_info is connected")
+                self._warned_no_intrinsics = True
             fx = fy = float(max(H, W)) / 2.0
             cx, cy  = W / 2.0, H / 2.0
 
@@ -214,7 +222,7 @@ class StereoPointCloud(Module):
         if self._floor_calib.ready:
             keep = xyz_cam[:, 2] > (self._floor_calib.floor_z + self.config.floor_margin)
         else:
-            keep = (xyz_cam[:, 2] >= -1.4) & (xyz_cam[:, 2] <= 1.5)
+            keep = (xyz_cam[:, 2] >= _FALLBACK_FLOOR_Z) & (xyz_cam[:, 2] <= _FALLBACK_CEILING_Z)
 
         xyz_world_kept = xyz_world[keep]
         xyz_cam_kept   = xyz_cam[keep]
@@ -230,7 +238,7 @@ class StereoPointCloud(Module):
             PointCloud2.from_numpy(xyz_vox, frame_id=self.config.world_frame, timestamp=img.ts)
         )
 
-        if len(xyz_cam_kept) >= 50:
+        if len(xyz_cam_kept) >= PointCloudOdometry.MIN_PTS:
             self._odom.update(xyz_cam_kept, R)
 
         if not self._floor_calib.ready:

--- a/dimos/perception/stereo_point_cloud/module.py
+++ b/dimos/perception/stereo_point_cloud/module.py
@@ -49,7 +49,6 @@ class Config(ModuleConfig):
     gradient_threshold: float = 0.30
     vox_size: float           = 0.020
     global_vox_size: float    = 0.020
-    floor_margin: float       = 0.03
     global_floor_margin: float = 0.04
     max_global_pts: int       = 500_000
     publish_every: int        = 1
@@ -219,13 +218,8 @@ class StereoPointCloud(Module):
 
         self._floor_calib.update(xyz_cam)
 
-        if self._floor_calib.ready:
-            keep = xyz_cam[:, 2] > (self._floor_calib.floor_z + self.config.floor_margin)
-        else:
-            keep = np.ones(len(xyz_cam), dtype=bool)
-
-        xyz_world_kept = xyz_world[keep]
-        xyz_cam_kept   = xyz_cam[keep]
+        xyz_world_kept = xyz_world
+        xyz_cam_kept   = xyz_cam
         if not len(xyz_world_kept):
             self._frame += 1
             return

--- a/dimos/perception/stereo_point_cloud/module.py
+++ b/dimos/perception/stereo_point_cloud/module.py
@@ -19,9 +19,9 @@ from __future__ import annotations
 import threading
 from typing import Any
 
+import cv2
 import numpy as np
 from reactivex.disposable import Disposable
-from scipy.ndimage import median_filter
 
 from dimos.core.core import rpc
 from dimos.core.module import Module, ModuleConfig
@@ -179,12 +179,17 @@ class StereoPointCloud(Module):
             depth = depth[:, :, 0]
         depth = depth.astype(np.float32)
         valid_d = depth[depth > 0]
-        if len(valid_d) and np.median(valid_d) > _DEPTH_MM_THRESHOLD:
-            depth /= 1000.0
+        is_mm = len(valid_d) > 0 and np.median(valid_d) > _DEPTH_MM_THRESHOLD
         valid_mask = depth > 0
-        depth[valid_mask] = median_filter(depth, size=3)[valid_mask]
-        fill = median_filter(np.where(valid_mask, depth, 0.0), size=5)
-        depth[~valid_mask & (fill > 0)] = fill[~valid_mask & (fill > 0)]
+        depth_u16 = depth.clip(0, 65535).astype(np.uint16)
+        depth_u16[~valid_mask] = 65535
+        depth_u16 = cv2.medianBlur(depth_u16, 3)
+        depth_u16[~valid_mask] = 0
+        hole_fill = cv2.medianBlur(depth_u16, 5)
+        depth_u16[(depth_u16 == 0) & (hole_fill > 0) & (hole_fill < 60000)] = hole_fill[(depth_u16 == 0) & (hole_fill > 0) & (hole_fill < 60000)]
+        depth = depth_u16.astype(np.float32)
+        if is_mm:
+            depth /= 1000.0
         invalid = (depth <= 0) | (depth < self.config.min_depth) | (depth > self.config.max_depth)
         depth[invalid] = np.nan
 
@@ -258,7 +263,7 @@ class StereoPointCloud(Module):
         vk_r       = np.floor(xyz_ronly / self.config.vox_size).astype(np.int32)
         _, first_r = np.unique(_pack(vk_r), return_index=True)
         xyz_vox_r  = xyz_ronly[first_r]
-        xyz_for_map = xyz_vox_r
+        xyz_for_map = xyz_vox_r[xyz_vox_r[:, 2] > self._world_floor_z + self.config.floor_margin]
 
         pts_snap = None
         with self._lock:

--- a/dimos/perception/stereo_point_cloud/module.py
+++ b/dimos/perception/stereo_point_cloud/module.py
@@ -21,8 +21,6 @@ from typing import Any
 
 import numpy as np
 from reactivex.disposable import Disposable
-from scipy.ndimage import sobel
-from scipy.spatial import cKDTree
 
 from dimos.core.core import rpc
 from dimos.core.module import Module, ModuleConfig
@@ -30,205 +28,18 @@ from dimos.core.stream import In, Out
 from dimos.msgs.sensor_msgs.CameraInfo import CameraInfo
 from dimos.msgs.sensor_msgs.Image import Image
 from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
+from dimos.perception.stereo_point_cloud.utils import (
+    _FloorCalibrator,
+    _R_OPT_TO_LINK,
+    _gradient_mask,
+    _pack,
+    _raycast_free_keys,
+)
+from dimos.perception.stereo_point_cloud.vio import MadgwickFilter, PointCloudOdometry
 from dimos.utils.logging_config import setup_logger
 
 logger = setup_logger()
 
-
-# ── Constants ─────────────────────────────────────────────────────────────────
-
-_VOFF  = np.int64(100_000)
-_VMASK = np.int64(0x3FFFF)
-
-# Optical frame (X=right, Y=down, Z=depth) → camera_link (X=fwd, Y=left, Z=up)
-_R_OPT_TO_LINK = np.array([[0, 0, 1], [-1, 0, 0], [0, -1, 0]], dtype=np.float32)
-
-
-# ── Helpers ───────────────────────────────────────────────────────────────────
-
-def _pack(vkeys: np.ndarray) -> np.ndarray:
-    v = (vkeys.astype(np.int64) + _VOFF) & _VMASK
-    return (v[:, 0] << np.int64(36)) | (v[:, 1] << np.int64(18)) | v[:, 2]
-
-
-def _gradient_mask(depth: np.ndarray, threshold: float) -> np.ndarray:
-    valid   = np.isfinite(depth)
-    depth_f = np.where(valid, depth, 0.0).astype(np.float64)
-    grad    = np.hypot(sobel(depth_f, axis=1), sobel(depth_f, axis=0))
-    return valid & (grad < threshold)
-
-
-def _raycast_free_keys(surface_pts: np.ndarray, vox_size: float, n_rays: int = 400) -> np.ndarray:
-    """Free-space voxel keys on rays from camera origin (rotation-only frame) to surface_pts."""
-    origin = np.zeros(3, dtype=np.float32)
-    n = min(len(surface_pts), n_rays)
-    if n == 0:
-        return np.empty(0, dtype=np.int64)
-    idx   = np.random.choice(len(surface_pts), n, replace=False) if len(surface_pts) > n else np.arange(n)
-    pts   = surface_pts[idx]
-    vecs  = pts - origin
-    dists = np.linalg.norm(vecs, axis=1)
-    ok    = dists > vox_size * 2
-    vecs, dists = vecs[ok], dists[ok]
-    if not len(vecs):
-        return np.empty(0, dtype=np.int64)
-    dirs      = vecs / dists[:, None]
-    max_steps = int(np.ceil(dists.max() / vox_size))
-    t_vals    = np.arange(max_steps, dtype=np.float32) * vox_size
-    t_end     = (dists - vox_size * 1.5)[:, None]
-    valid_m   = (t_vals[None, :] >= 0) & (t_vals[None, :] < t_end)
-    ray_pts   = origin + dirs[:, None, :] * t_vals[None, :, None]
-    vk_flat   = np.floor(ray_pts.reshape(-1, 3) / vox_size).astype(np.int32)
-    return np.unique(_pack(vk_flat)[valid_m.ravel()])
-
-
-# ── Floor calibration ─────────────────────────────────────────────────────────
-
-class _FloorCalibrator:
-    """Histogram-based one-shot floor height estimator in camera_link frame (Z=up)."""
-
-    SKIP_FRAMES  = 30
-    CALIB_FRAMES = 30
-    BIN_M        = 0.02
-
-    def __init__(self) -> None:
-        self._frame   = 0
-        self._samples: list[float] = []
-        self.floor_z:    float | None = None
-        self.cam_height: float | None = None
-
-    @property
-    def ready(self) -> bool:
-        return self.floor_z is not None
-
-    def update(self, xyz_cam: np.ndarray) -> None:
-        self._frame += 1
-        if self.ready or self._frame <= self.SKIP_FRAMES:
-            return
-        z    = xyz_cam[:, 2]
-        dist = np.linalg.norm(xyz_cam[:, :2], axis=1)
-        mask = (z < -0.30) & (dist < 4.0)
-        if mask.sum() < 200:
-            return
-        z_floor = z[mask]
-        lo, hi  = z_floor.min(), z_floor.max()
-        if hi - lo < self.BIN_M:
-            return
-        bins          = np.arange(lo, hi + self.BIN_M, self.BIN_M)
-        counts, edges = np.histogram(z_floor, bins=bins)
-        self._samples.append(float(edges[int(np.argmax(counts))] + self.BIN_M / 2))
-        if len(self._samples) >= self.CALIB_FRAMES:
-            self.floor_z    = float(np.median(self._samples))
-            self.cam_height = -self.floor_z
-            logger.info(f"StereoPointCloud: floor calibrated — camera {self.cam_height:.3f} m above floor")
-
-
-# ── Madgwick AHRS ─────────────────────────────────────────────────────────────
-
-class MadgwickFilter:
-    """Gyro + accel → orientation R (camera_link → world, Z-up). beta=0.033."""
-
-    def __init__(self, beta: float = 0.033) -> None:
-        self._q      = np.array([1., 0., 0., 0.], dtype=np.float64)
-        self._beta   = beta
-        self._t_prev: float | None = None
-
-    def update(self, gyro: np.ndarray, accel: np.ndarray, t: float) -> None:
-        if self._t_prev is None:
-            self._t_prev = t
-            return
-        dt = min(t - self._t_prev, 0.1)
-        self._t_prev = t
-        if dt <= 0:
-            return
-        q0, q1, q2, q3 = self._q
-        gx, gy, gz = gyro.astype(np.float64)
-        a_n = np.linalg.norm(accel)
-        if a_n > 0.5:
-            ax, ay, az = accel.astype(np.float64) / a_n
-            f1 = 2*(q1*q3 - q0*q2) - ax
-            f2 = 2*(q0*q1 + q2*q3) - ay
-            f3 = 2*(0.5 - q1**2 - q2**2) - az
-            J  = np.array([
-                [-2*q2,  2*q3, -2*q0, 2*q1],
-                [ 2*q1,  2*q0,  2*q3, 2*q2],
-                [    0, -4*q1, -4*q2,    0],
-            ])
-            grad = J.T @ np.array([f1, f2, f3])
-            gn   = np.linalg.norm(grad)
-            if gn > 1e-9:
-                grad /= gn
-        else:
-            grad = np.zeros(4)
-        q_dot = 0.5 * np.array([
-            -q1*gx - q2*gy - q3*gz,
-             q0*gx + q2*gz - q3*gy,
-             q0*gy - q1*gz + q3*gx,
-             q0*gz + q1*gy - q2*gx,
-        ]) - self._beta * grad
-        self._q = self._q + q_dot * dt
-        self._q /= np.linalg.norm(self._q) + 1e-12
-
-    @property
-    def R(self) -> np.ndarray:
-        q0, q1, q2, q3 = self._q
-        return np.array([
-            [1-2*(q2**2+q3**2), 2*(q1*q2-q0*q3),   2*(q1*q3+q0*q2)  ],
-            [2*(q1*q2+q0*q3),   1-2*(q1**2+q3**2), 2*(q2*q3-q0*q1)  ],
-            [2*(q1*q3-q0*q2),   2*(q2*q3+q0*q1),   1-2*(q1**2+q2**2)],
-        ], dtype=np.float32)
-
-
-# ── Point-cloud odometry ──────────────────────────────────────────────────────
-
-class PointCloudOdometry:
-    """Rotation-decoupled ICP for translation t. Takes R from Madgwick, converges in 3-4 iters."""
-
-    ITERS    = 4
-    MAX_DIST = 0.40
-    N_SRC    = 1_500
-    N_DST    = 8_000
-    N_STORE  = 10_000
-
-    def __init__(self) -> None:
-        self._t          = np.zeros(3, dtype=np.float32)
-        self._lock       = threading.Lock()
-        self._prev_world: np.ndarray | None = None
-
-    @property
-    def t(self) -> np.ndarray:
-        with self._lock:
-            return self._t.copy()
-
-    def update(self, xyz_cam: np.ndarray, R: np.ndarray) -> np.ndarray:
-        pts_ga = (xyz_cam @ R.T).astype(np.float32)
-        with self._lock:
-            t_est = self._t.copy()
-        if self._prev_world is None or len(pts_ga) < 50:
-            t_new = t_est
-        else:
-            n_src = min(self.N_SRC, len(pts_ga))
-            n_dst = min(self.N_DST, len(self._prev_world))
-            src   = pts_ga[np.random.choice(len(pts_ga), n_src, replace=False)]
-            dst   = self._prev_world[np.random.choice(len(self._prev_world), n_dst, replace=False)]
-            tree  = cKDTree(dst)
-            for _ in range(self.ITERS):
-                dists, idx = tree.query(src + t_est, k=1, workers=1)
-                mask = dists < self.MAX_DIST
-                if mask.sum() < 30:
-                    break
-                delta = dst[idx[mask]].mean(axis=0) - (src[mask] + t_est).mean(axis=0)
-                t_est = (t_est + 0.7 * delta).astype(np.float32)
-            t_new = t_est
-        n_st  = min(self.N_STORE, len(pts_ga))
-        idx_s = np.random.choice(len(pts_ga), n_st, replace=False)
-        self._prev_world = (pts_ga[idx_s] + t_new).astype(np.float32)
-        with self._lock:
-            self._t = t_new
-        return t_new
-
-
-# ── Module ────────────────────────────────────────────────────────────────────
 
 class Config(ModuleConfig):
     min_depth: float          = 0.1

--- a/dimos/perception/stereo_point_cloud/module.py
+++ b/dimos/perception/stereo_point_cloud/module.py
@@ -49,6 +49,7 @@ class Config(ModuleConfig):
     gradient_threshold: float = 0.30
     vox_size: float           = 0.020
     global_vox_size: float    = 0.020
+    floor_margin: float       = 0.03
     global_floor_margin: float = 0.04
     max_global_pts: int       = 500_000
     publish_every: int        = 1
@@ -217,6 +218,13 @@ class StereoPointCloud(Module):
         cam_z     = float(t[2])
 
         self._floor_calib.update(xyz_cam)
+
+        # Per-frame floor filter disabled — calibration cuts obstacles at wrong height.
+        # Floor is removed by the global map filter below; frame cloud shows all points.
+        # if self._floor_calib.ready:
+        #     keep = xyz_cam[:, 2] > (self._floor_calib.floor_z + self.config.floor_margin)
+        # else:
+        #     keep = np.ones(len(xyz_cam), dtype=bool)
 
         xyz_world_kept = xyz_world
         xyz_cam_kept   = xyz_cam

--- a/dimos/perception/stereo_point_cloud/utils.py
+++ b/dimos/perception/stereo_point_cloud/utils.py
@@ -104,10 +104,8 @@ class _FloorCalibrator:
             return
         bins          = np.arange(lo, hi + self.BIN_M, self.BIN_M)
         counts, edges = np.histogram(z_floor, bins=bins)
-        significant   = np.where(counts >= self.FLOOR_MIN_PTS)[0]
-        if not len(significant):
-            return
-        self._samples.append(float(edges[significant[0]] + self.BIN_M / 2))
+        peak          = np.argmax(counts)
+        self._samples.append(float(edges[peak] + self.BIN_M / 2))
         if len(self._samples) >= self.CALIB_FRAMES:
             self.floor_z    = float(np.median(self._samples))
             self.cam_height = -self.floor_z

--- a/dimos/perception/stereo_point_cloud/utils.py
+++ b/dimos/perception/stereo_point_cloud/utils.py
@@ -104,8 +104,8 @@ class _FloorCalibrator:
             return
         bins          = np.arange(lo, hi + self.BIN_M, self.BIN_M)
         counts, edges = np.histogram(z_floor, bins=bins)
-        peak          = np.argmax(counts)
-        self._samples.append(float(edges[peak] + self.BIN_M / 2))
+        prominent     = np.where(counts >= counts.max() * 0.20)[0]
+        self._samples.append(float(edges[prominent[0]] + self.BIN_M / 2))
         if len(self._samples) >= self.CALIB_FRAMES:
             self.floor_z    = float(np.median(self._samples))
             self.cam_height = -self.floor_z

--- a/dimos/perception/stereo_point_cloud/utils.py
+++ b/dimos/perception/stereo_point_cloud/utils.py
@@ -104,8 +104,10 @@ class _FloorCalibrator:
             return
         bins          = np.arange(lo, hi + self.BIN_M, self.BIN_M)
         counts, edges = np.histogram(z_floor, bins=bins)
-        peak          = np.argmax(counts)
-        self._samples.append(float(edges[peak] + self.BIN_M / 2))
+        significant   = np.where(counts >= self.FLOOR_MIN_PTS)[0]
+        if not len(significant):
+            return
+        self._samples.append(float(edges[significant[0]] + self.BIN_M / 2))
         if len(self._samples) >= self.CALIB_FRAMES:
             self.floor_z    = float(np.median(self._samples))
             self.cam_height = -self.floor_z

--- a/dimos/perception/stereo_point_cloud/utils.py
+++ b/dimos/perception/stereo_point_cloud/utils.py
@@ -1,0 +1,105 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Map-building utilities: constants, voxel packing, floor calibration, raycasting."""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.ndimage import sobel
+
+from dimos.utils.logging_config import setup_logger
+
+logger = setup_logger()
+
+_VOFF  = np.int64(100_000)
+_VMASK = np.int64(0x3FFFF)
+
+# Optical frame (X=right, Y=down, Z=depth) → camera_link (X=fwd, Y=left, Z=up)
+_R_OPT_TO_LINK = np.array([[0, 0, 1], [-1, 0, 0], [0, -1, 0]], dtype=np.float32)
+
+
+def _pack(vkeys: np.ndarray) -> np.ndarray:
+    v = (vkeys.astype(np.int64) + _VOFF) & _VMASK
+    return (v[:, 0] << np.int64(36)) | (v[:, 1] << np.int64(18)) | v[:, 2]
+
+
+def _gradient_mask(depth: np.ndarray, threshold: float) -> np.ndarray:
+    valid   = np.isfinite(depth)
+    depth_f = np.where(valid, depth, 0.0).astype(np.float64)
+    grad    = np.hypot(sobel(depth_f, axis=1), sobel(depth_f, axis=0))
+    return valid & (grad < threshold)
+
+
+def _raycast_free_keys(surface_pts: np.ndarray, vox_size: float, n_rays: int = 400) -> np.ndarray:
+    """Free-space voxel keys on rays from camera origin (rotation-only frame) to surface_pts."""
+    origin = np.zeros(3, dtype=np.float32)
+    n = min(len(surface_pts), n_rays)
+    if n == 0:
+        return np.empty(0, dtype=np.int64)
+    idx   = np.random.choice(len(surface_pts), n, replace=False) if len(surface_pts) > n else np.arange(n)
+    pts   = surface_pts[idx]
+    vecs  = pts - origin
+    dists = np.linalg.norm(vecs, axis=1)
+    ok    = dists > vox_size * 2
+    vecs, dists = vecs[ok], dists[ok]
+    if not len(vecs):
+        return np.empty(0, dtype=np.int64)
+    dirs      = vecs / dists[:, None]
+    max_steps = int(np.ceil(dists.max() / vox_size))
+    t_vals    = np.arange(max_steps, dtype=np.float32) * vox_size
+    t_end     = (dists - vox_size * 1.5)[:, None]
+    valid_m   = (t_vals[None, :] >= 0) & (t_vals[None, :] < t_end)
+    ray_pts   = origin + dirs[:, None, :] * t_vals[None, :, None]
+    vk_flat   = np.floor(ray_pts.reshape(-1, 3) / vox_size).astype(np.int32)
+    return np.unique(_pack(vk_flat)[valid_m.ravel()])
+
+
+class _FloorCalibrator:
+    """Histogram-based one-shot floor height estimator in camera_link frame (Z=up)."""
+
+    SKIP_FRAMES  = 30
+    CALIB_FRAMES = 30
+    BIN_M        = 0.02
+
+    def __init__(self) -> None:
+        self._frame   = 0
+        self._samples: list[float] = []
+        self.floor_z:    float | None = None
+        self.cam_height: float | None = None
+
+    @property
+    def ready(self) -> bool:
+        return self.floor_z is not None
+
+    def update(self, xyz_cam: np.ndarray) -> None:
+        self._frame += 1
+        if self.ready or self._frame <= self.SKIP_FRAMES:
+            return
+        z    = xyz_cam[:, 2]
+        dist = np.linalg.norm(xyz_cam[:, :2], axis=1)
+        mask = (z < -0.30) & (dist < 4.0)
+        if mask.sum() < 200:
+            return
+        z_floor = z[mask]
+        lo, hi  = z_floor.min(), z_floor.max()
+        if hi - lo < self.BIN_M:
+            return
+        bins          = np.arange(lo, hi + self.BIN_M, self.BIN_M)
+        counts, edges = np.histogram(z_floor, bins=bins)
+        self._samples.append(float(edges[int(np.argmax(counts))] + self.BIN_M / 2))
+        if len(self._samples) >= self.CALIB_FRAMES:
+            self.floor_z    = float(np.median(self._samples))
+            self.cam_height = -self.floor_z
+            logger.info(f"StereoPointCloud: floor calibrated — camera {self.cam_height:.3f} m above floor")

--- a/dimos/perception/stereo_point_cloud/utils.py
+++ b/dimos/perception/stereo_point_cloud/utils.py
@@ -23,7 +23,7 @@ from dimos.utils.logging_config import setup_logger
 
 logger = setup_logger()
 
-_VOFF  = np.int64(100_000)
+_VOFF = np.int64(100_000)
 _VMASK = np.int64(0x3FFFF)
 
 # Optical frame (X=right, Y=down, Z=depth) → camera_link (X=fwd, Y=left, Z=up)
@@ -39,9 +39,9 @@ def _pack(vkeys: np.ndarray) -> np.ndarray:
 
 
 def _gradient_mask(depth: np.ndarray, threshold: float) -> np.ndarray:
-    valid   = np.isfinite(depth)
+    valid = np.isfinite(depth)
     depth_f = np.where(valid, depth, 0.0).astype(np.float64)
-    grad    = np.hypot(sobel(depth_f, axis=1), sobel(depth_f, axis=0))
+    grad = np.hypot(sobel(depth_f, axis=1), sobel(depth_f, axis=0))
     return valid & (grad < threshold)
 
 
@@ -51,39 +51,43 @@ def _raycast_free_keys(surface_pts: np.ndarray, vox_size: float, n_rays: int = 4
     n = min(len(surface_pts), n_rays)
     if n == 0:
         return np.empty(0, dtype=np.int64)
-    idx   = np.random.choice(len(surface_pts), n, replace=False) if len(surface_pts) > n else np.arange(n)
-    pts   = surface_pts[idx]
-    vecs  = pts - origin
+    idx = (
+        np.random.choice(len(surface_pts), n, replace=False)
+        if len(surface_pts) > n
+        else np.arange(n)
+    )
+    pts = surface_pts[idx]
+    vecs = pts - origin
     dists = np.linalg.norm(vecs, axis=1)
-    ok    = dists > vox_size * _RAYCAST_MIN_RAY_VOXELS
+    ok = dists > vox_size * _RAYCAST_MIN_RAY_VOXELS
     vecs, dists = vecs[ok], dists[ok]
     if not len(vecs):
         return np.empty(0, dtype=np.int64)
-    dirs      = vecs / dists[:, None]
+    dirs = vecs / dists[:, None]
     max_steps = int(np.ceil(dists.max() / vox_size))
-    t_vals    = np.arange(max_steps, dtype=np.float32) * vox_size
-    t_end     = (dists - vox_size * _RAYCAST_SURFACE_MARGIN)[:, None]
-    valid_m   = (t_vals[None, :] >= 0) & (t_vals[None, :] < t_end)
-    ray_pts   = origin + dirs[:, None, :] * t_vals[None, :, None]
-    vk_flat   = np.floor(ray_pts.reshape(-1, 3) / vox_size).astype(np.int32)
+    t_vals = np.arange(max_steps, dtype=np.float32) * vox_size
+    t_end = (dists - vox_size * _RAYCAST_SURFACE_MARGIN)[:, None]
+    valid_m = (t_vals[None, :] >= 0) & (t_vals[None, :] < t_end)
+    ray_pts = origin + dirs[:, None, :] * t_vals[None, :, None]
+    vk_flat = np.floor(ray_pts.reshape(-1, 3) / vox_size).astype(np.int32)
     return np.unique(_pack(vk_flat)[valid_m.ravel()])
 
 
 class _FloorCalibrator:
     """Histogram-based one-shot floor height estimator in camera_link frame (Z=up)."""
 
-    SKIP_FRAMES      = 30
-    CALIB_FRAMES     = 30
-    BIN_M            = 0.02
-    FLOOR_MAX_Z      = -0.30
-    FLOOR_MIN_Z      = -3.0
+    SKIP_FRAMES = 30
+    CALIB_FRAMES = 30
+    BIN_M = 0.02
+    FLOOR_MAX_Z = -0.30
+    FLOOR_MIN_Z = -3.0
     FLOOR_MAX_DIST_M = 4.0
-    FLOOR_MIN_PTS    = 200
+    FLOOR_MIN_PTS = 200
 
     def __init__(self) -> None:
-        self._frame   = 0
+        self._frame = 0
         self._samples: list[float] = []
-        self.floor_z:    float | None = None
+        self.floor_z: float | None = None
         self.cam_height: float | None = None
 
     @property
@@ -94,22 +98,24 @@ class _FloorCalibrator:
         self._frame += 1
         if self.ready or self._frame <= self.SKIP_FRAMES:
             return
-        z    = xyz_cam[:, 2]
+        z = xyz_cam[:, 2]
         dist = np.linalg.norm(xyz_cam[:, :2], axis=1)
         mask = (z < self.FLOOR_MAX_Z) & (z > self.FLOOR_MIN_Z) & (dist < self.FLOOR_MAX_DIST_M)
         if mask.sum() < self.FLOOR_MIN_PTS:
             return
         z_floor = z[mask]
-        lo, hi  = z_floor.min(), z_floor.max()
+        lo, hi = z_floor.min(), z_floor.max()
         if hi - lo < self.BIN_M:
             return
-        bins          = np.arange(lo, hi + self.BIN_M, self.BIN_M)
+        bins = np.arange(lo, hi + self.BIN_M, self.BIN_M)
         counts, edges = np.histogram(z_floor, bins=bins)
-        significant   = np.where(counts >= self.FLOOR_MIN_PTS)[0]
+        significant = np.where(counts >= self.FLOOR_MIN_PTS)[0]
         if not len(significant):
             return
         self._samples.append(float(edges[significant[0]] + self.BIN_M / 2))
         if len(self._samples) >= self.CALIB_FRAMES:
-            self.floor_z    = float(np.median(self._samples))
+            self.floor_z = float(np.median(self._samples))
             self.cam_height = -self.floor_z
-            logger.info(f"StereoPointCloud: floor calibrated — camera {self.cam_height:.3f} m above floor")
+            logger.info(
+                f"StereoPointCloud: floor calibrated — camera {self.cam_height:.3f} m above floor"
+            )

--- a/dimos/perception/stereo_point_cloud/utils.py
+++ b/dimos/perception/stereo_point_cloud/utils.py
@@ -75,7 +75,7 @@ class _FloorCalibrator:
     SKIP_FRAMES      = 30
     CALIB_FRAMES     = 30
     BIN_M            = 0.02
-    FLOOR_MAX_Z      = -0.30
+    FLOOR_MAX_Z      = -0.05
     FLOOR_MAX_DIST_M = 4.0
     FLOOR_MIN_PTS    = 200
 
@@ -104,8 +104,13 @@ class _FloorCalibrator:
             return
         bins          = np.arange(lo, hi + self.BIN_M, self.BIN_M)
         counts, edges = np.histogram(z_floor, bins=bins)
-        prominent     = np.where(counts >= counts.max() * 0.20)[0]
-        self._samples.append(float(edges[prominent[0]] + self.BIN_M / 2))
+        # Use absolute count threshold so a nearby chair with many points can't
+        # drown out a distant floor with fewer points — floor is always the lowest
+        # significant bin regardless of what dominates the histogram.
+        significant   = np.where(counts >= self.FLOOR_MIN_PTS)[0]
+        if not len(significant):
+            return
+        self._samples.append(float(edges[significant[0]] + self.BIN_M / 2))
         if len(self._samples) >= self.CALIB_FRAMES:
             self.floor_z    = float(np.median(self._samples))
             self.cam_height = -self.floor_z

--- a/dimos/perception/stereo_point_cloud/utils.py
+++ b/dimos/perception/stereo_point_cloud/utils.py
@@ -29,6 +29,9 @@ _VMASK = np.int64(0x3FFFF)
 # Optical frame (X=right, Y=down, Z=depth) → camera_link (X=fwd, Y=left, Z=up)
 _R_OPT_TO_LINK = np.array([[0, 0, 1], [-1, 0, 0], [0, -1, 0]], dtype=np.float32)
 
+_RAYCAST_MIN_RAY_VOXELS = 2
+_RAYCAST_SURFACE_MARGIN = 1.5
+
 
 def _pack(vkeys: np.ndarray) -> np.ndarray:
     v = (vkeys.astype(np.int64) + _VOFF) & _VMASK
@@ -52,14 +55,14 @@ def _raycast_free_keys(surface_pts: np.ndarray, vox_size: float, n_rays: int = 4
     pts   = surface_pts[idx]
     vecs  = pts - origin
     dists = np.linalg.norm(vecs, axis=1)
-    ok    = dists > vox_size * 2
+    ok    = dists > vox_size * _RAYCAST_MIN_RAY_VOXELS
     vecs, dists = vecs[ok], dists[ok]
     if not len(vecs):
         return np.empty(0, dtype=np.int64)
     dirs      = vecs / dists[:, None]
     max_steps = int(np.ceil(dists.max() / vox_size))
     t_vals    = np.arange(max_steps, dtype=np.float32) * vox_size
-    t_end     = (dists - vox_size * 1.5)[:, None]
+    t_end     = (dists - vox_size * _RAYCAST_SURFACE_MARGIN)[:, None]
     valid_m   = (t_vals[None, :] >= 0) & (t_vals[None, :] < t_end)
     ray_pts   = origin + dirs[:, None, :] * t_vals[None, :, None]
     vk_flat   = np.floor(ray_pts.reshape(-1, 3) / vox_size).astype(np.int32)
@@ -69,9 +72,12 @@ def _raycast_free_keys(surface_pts: np.ndarray, vox_size: float, n_rays: int = 4
 class _FloorCalibrator:
     """Histogram-based one-shot floor height estimator in camera_link frame (Z=up)."""
 
-    SKIP_FRAMES  = 30
-    CALIB_FRAMES = 30
-    BIN_M        = 0.02
+    SKIP_FRAMES      = 30
+    CALIB_FRAMES     = 30
+    BIN_M            = 0.02
+    FLOOR_MAX_Z      = -0.30
+    FLOOR_MAX_DIST_M = 4.0
+    FLOOR_MIN_PTS    = 200
 
     def __init__(self) -> None:
         self._frame   = 0
@@ -89,8 +95,8 @@ class _FloorCalibrator:
             return
         z    = xyz_cam[:, 2]
         dist = np.linalg.norm(xyz_cam[:, :2], axis=1)
-        mask = (z < -0.30) & (dist < 4.0)
-        if mask.sum() < 200:
+        mask = (z < self.FLOOR_MAX_Z) & (dist < self.FLOOR_MAX_DIST_M)
+        if mask.sum() < self.FLOOR_MIN_PTS:
             return
         z_floor = z[mask]
         lo, hi  = z_floor.min(), z_floor.max()

--- a/dimos/perception/stereo_point_cloud/utils.py
+++ b/dimos/perception/stereo_point_cloud/utils.py
@@ -76,6 +76,7 @@ class _FloorCalibrator:
     CALIB_FRAMES     = 30
     BIN_M            = 0.02
     FLOOR_MAX_Z      = -0.30
+    FLOOR_MIN_Z      = -3.0
     FLOOR_MAX_DIST_M = 4.0
     FLOOR_MIN_PTS    = 200
 
@@ -95,7 +96,7 @@ class _FloorCalibrator:
             return
         z    = xyz_cam[:, 2]
         dist = np.linalg.norm(xyz_cam[:, :2], axis=1)
-        mask = (z < self.FLOOR_MAX_Z) & (dist < self.FLOOR_MAX_DIST_M)
+        mask = (z < self.FLOOR_MAX_Z) & (z > self.FLOOR_MIN_Z) & (dist < self.FLOOR_MAX_DIST_M)
         if mask.sum() < self.FLOOR_MIN_PTS:
             return
         z_floor = z[mask]
@@ -104,8 +105,10 @@ class _FloorCalibrator:
             return
         bins          = np.arange(lo, hi + self.BIN_M, self.BIN_M)
         counts, edges = np.histogram(z_floor, bins=bins)
-        prominent     = np.where(counts >= counts.max() * 0.20)[0]
-        self._samples.append(float(edges[prominent[0]] + self.BIN_M / 2))
+        significant   = np.where(counts >= self.FLOOR_MIN_PTS)[0]
+        if not len(significant):
+            return
+        self._samples.append(float(edges[significant[0]] + self.BIN_M / 2))
         if len(self._samples) >= self.CALIB_FRAMES:
             self.floor_z    = float(np.median(self._samples))
             self.cam_height = -self.floor_z

--- a/dimos/perception/stereo_point_cloud/utils.py
+++ b/dimos/perception/stereo_point_cloud/utils.py
@@ -75,7 +75,7 @@ class _FloorCalibrator:
     SKIP_FRAMES      = 30
     CALIB_FRAMES     = 30
     BIN_M            = 0.02
-    FLOOR_MAX_Z      = -0.05
+    FLOOR_MAX_Z      = -0.30
     FLOOR_MAX_DIST_M = 4.0
     FLOOR_MIN_PTS    = 200
 
@@ -104,13 +104,8 @@ class _FloorCalibrator:
             return
         bins          = np.arange(lo, hi + self.BIN_M, self.BIN_M)
         counts, edges = np.histogram(z_floor, bins=bins)
-        # Use absolute count threshold so a nearby chair with many points can't
-        # drown out a distant floor with fewer points — floor is always the lowest
-        # significant bin regardless of what dominates the histogram.
-        significant   = np.where(counts >= self.FLOOR_MIN_PTS)[0]
-        if not len(significant):
-            return
-        self._samples.append(float(edges[significant[0]] + self.BIN_M / 2))
+        peak          = np.argmax(counts)
+        self._samples.append(float(edges[peak] + self.BIN_M / 2))
         if len(self._samples) >= self.CALIB_FRAMES:
             self.floor_z    = float(np.median(self._samples))
             self.cam_height = -self.floor_z

--- a/dimos/perception/stereo_point_cloud/utils.py
+++ b/dimos/perception/stereo_point_cloud/utils.py
@@ -104,7 +104,8 @@ class _FloorCalibrator:
             return
         bins          = np.arange(lo, hi + self.BIN_M, self.BIN_M)
         counts, edges = np.histogram(z_floor, bins=bins)
-        self._samples.append(float(edges[int(np.argmax(counts))] + self.BIN_M / 2))
+        prominent     = np.where(counts >= counts.max() * 0.20)[0]
+        self._samples.append(float(edges[prominent[0]] + self.BIN_M / 2))
         if len(self._samples) >= self.CALIB_FRAMES:
             self.floor_z    = float(np.median(self._samples))
             self.cam_height = -self.floor_z

--- a/dimos/perception/stereo_point_cloud/vio.py
+++ b/dimos/perception/stereo_point_cloud/vio.py
@@ -21,18 +21,17 @@ import threading
 import numpy as np
 from scipy.spatial import cKDTree
 
-
-_MAX_DT_S        = 0.1  # don't integrate more than 100ms at once — big gaps would blow up the filter
-_ACCEL_MIN_NORM  = 0.5  # skip accel correction if reading is basically zero (noise or free-fall)
-_MIN_ICP_INLIERS = 30   # need at least 30 matched point pairs to trust the ICP translation update
+_MAX_DT_S = 0.1  # don't integrate more than 100ms at once — big gaps would blow up the filter
+_ACCEL_MIN_NORM = 0.5  # skip accel correction if reading is basically zero (noise or free-fall)
+_MIN_ICP_INLIERS = 30  # need at least 30 matched point pairs to trust the ICP translation update
 
 
 class MadgwickFilter:
     """Gyro + accel → orientation R (camera_link → world, Z-up). beta=0.033."""
 
     def __init__(self, beta: float = 0.033) -> None:
-        self._q      = np.array([1., 0., 0., 0.], dtype=np.float64)
-        self._beta   = beta
+        self._q = np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float64)
+        self._beta = beta
         self._t_prev: float | None = None
 
     def update(self, gyro: np.ndarray, accel: np.ndarray, t: float) -> None:
@@ -48,52 +47,63 @@ class MadgwickFilter:
         a_n = np.linalg.norm(accel)
         if a_n > _ACCEL_MIN_NORM:
             ax, ay, az = accel.astype(np.float64) / a_n
-            f1 = 2*(q1*q3 - q0*q2) - ax
-            f2 = 2*(q0*q1 + q2*q3) - ay
-            f3 = 2*(0.5 - q1**2 - q2**2) - az
-            J  = np.array([
-                [-2*q2,  2*q3, -2*q0, 2*q1],
-                [ 2*q1,  2*q0,  2*q3, 2*q2],
-                [    0, -4*q1, -4*q2,    0],
-            ])
+            f1 = 2 * (q1 * q3 - q0 * q2) - ax
+            f2 = 2 * (q0 * q1 + q2 * q3) - ay
+            f3 = 2 * (0.5 - q1**2 - q2**2) - az
+            J = np.array(
+                [
+                    [-2 * q2, 2 * q3, -2 * q0, 2 * q1],
+                    [2 * q1, 2 * q0, 2 * q3, 2 * q2],
+                    [0, -4 * q1, -4 * q2, 0],
+                ]
+            )
             grad = J.T @ np.array([f1, f2, f3])
-            gn   = np.linalg.norm(grad)
+            gn = np.linalg.norm(grad)
             if gn > 1e-9:
                 grad /= gn
         else:
             grad = np.zeros(4)
-        q_dot = 0.5 * np.array([
-            -q1*gx - q2*gy - q3*gz,
-             q0*gx + q2*gz - q3*gy,
-             q0*gy - q1*gz + q3*gx,
-             q0*gz + q1*gy - q2*gx,
-        ]) - self._beta * grad
+        q_dot = (
+            0.5
+            * np.array(
+                [
+                    -q1 * gx - q2 * gy - q3 * gz,
+                    q0 * gx + q2 * gz - q3 * gy,
+                    q0 * gy - q1 * gz + q3 * gx,
+                    q0 * gz + q1 * gy - q2 * gx,
+                ]
+            )
+            - self._beta * grad
+        )
         self._q = self._q + q_dot * dt
         self._q /= np.linalg.norm(self._q) + 1e-12
 
     @property
     def R(self) -> np.ndarray:
         q0, q1, q2, q3 = self._q
-        return np.array([
-            [1-2*(q2**2+q3**2), 2*(q1*q2-q0*q3),   2*(q1*q3+q0*q2)  ],
-            [2*(q1*q2+q0*q3),   1-2*(q1**2+q3**2), 2*(q2*q3-q0*q1)  ],
-            [2*(q1*q3-q0*q2),   2*(q2*q3+q0*q1),   1-2*(q1**2+q2**2)],
-        ], dtype=np.float32)
+        return np.array(
+            [
+                [1 - 2 * (q2**2 + q3**2), 2 * (q1 * q2 - q0 * q3), 2 * (q1 * q3 + q0 * q2)],
+                [2 * (q1 * q2 + q0 * q3), 1 - 2 * (q1**2 + q3**2), 2 * (q2 * q3 - q0 * q1)],
+                [2 * (q1 * q3 - q0 * q2), 2 * (q2 * q3 + q0 * q1), 1 - 2 * (q1**2 + q2**2)],
+            ],
+            dtype=np.float32,
+        )
 
 
 class PointCloudOdometry:
     """Rotation-decoupled ICP for translation t. Takes R from Madgwick, converges in 3-4 iters."""
 
-    ITERS    = 4
+    ITERS = 4
     MAX_DIST = 0.40
-    MIN_PTS  = 50     # minimum points needed to run ICP at all
-    N_SRC    = 1_500
-    N_DST    = 8_000
-    N_STORE  = 10_000
+    MIN_PTS = 50  # minimum points needed to run ICP at all
+    N_SRC = 1_500
+    N_DST = 8_000
+    N_STORE = 10_000
 
     def __init__(self) -> None:
-        self._t          = np.zeros(3, dtype=np.float32)
-        self._lock       = threading.Lock()
+        self._t = np.zeros(3, dtype=np.float32)
+        self._lock = threading.Lock()
         self._prev_world: np.ndarray | None = None
 
     @property
@@ -110,9 +120,9 @@ class PointCloudOdometry:
         else:
             n_src = min(self.N_SRC, len(pts_ga))
             n_dst = min(self.N_DST, len(self._prev_world))
-            src   = pts_ga[np.random.choice(len(pts_ga), n_src, replace=False)]
-            dst   = self._prev_world[np.random.choice(len(self._prev_world), n_dst, replace=False)]
-            tree  = cKDTree(dst)
+            src = pts_ga[np.random.choice(len(pts_ga), n_src, replace=False)]
+            dst = self._prev_world[np.random.choice(len(self._prev_world), n_dst, replace=False)]
+            tree = cKDTree(dst)
             for _ in range(self.ITERS):
                 dists, idx = tree.query(src + t_est, k=1, workers=1)
                 mask = dists < self.MAX_DIST
@@ -121,7 +131,7 @@ class PointCloudOdometry:
                 delta = dst[idx[mask]].mean(axis=0) - (src[mask] + t_est).mean(axis=0)
                 t_est = (t_est + 0.7 * delta).astype(np.float32)
             t_new = t_est
-        n_st  = min(self.N_STORE, len(pts_ga))
+        n_st = min(self.N_STORE, len(pts_ga))
         idx_s = np.random.choice(len(pts_ga), n_st, replace=False)
         self._prev_world = (pts_ga[idx_s] + t_new).astype(np.float32)
         with self._lock:

--- a/dimos/perception/stereo_point_cloud/vio.py
+++ b/dimos/perception/stereo_point_cloud/vio.py
@@ -22,6 +22,11 @@ import numpy as np
 from scipy.spatial import cKDTree
 
 
+_MAX_DT_S        = 0.1  # don't integrate more than 100ms at once — big gaps would blow up the filter
+_ACCEL_MIN_NORM  = 0.5  # skip accel correction if reading is basically zero (noise or free-fall)
+_MIN_ICP_INLIERS = 30   # need at least 30 matched point pairs to trust the ICP translation update
+
+
 class MadgwickFilter:
     """Gyro + accel → orientation R (camera_link → world, Z-up). beta=0.033."""
 
@@ -34,14 +39,14 @@ class MadgwickFilter:
         if self._t_prev is None:
             self._t_prev = t
             return
-        dt = min(t - self._t_prev, 0.1)
+        dt = min(t - self._t_prev, _MAX_DT_S)
         self._t_prev = t
         if dt <= 0:
             return
         q0, q1, q2, q3 = self._q
         gx, gy, gz = gyro.astype(np.float64)
         a_n = np.linalg.norm(accel)
-        if a_n > 0.5:
+        if a_n > _ACCEL_MIN_NORM:
             ax, ay, az = accel.astype(np.float64) / a_n
             f1 = 2*(q1*q3 - q0*q2) - ax
             f2 = 2*(q0*q1 + q2*q3) - ay
@@ -81,6 +86,7 @@ class PointCloudOdometry:
 
     ITERS    = 4
     MAX_DIST = 0.40
+    MIN_PTS  = 50     # minimum points needed to run ICP at all
     N_SRC    = 1_500
     N_DST    = 8_000
     N_STORE  = 10_000
@@ -99,7 +105,7 @@ class PointCloudOdometry:
         pts_ga = (xyz_cam @ R.T).astype(np.float32)
         with self._lock:
             t_est = self._t.copy()
-        if self._prev_world is None or len(pts_ga) < 50:
+        if self._prev_world is None or len(pts_ga) < self.MIN_PTS:
             t_new = t_est
         else:
             n_src = min(self.N_SRC, len(pts_ga))
@@ -110,7 +116,7 @@ class PointCloudOdometry:
             for _ in range(self.ITERS):
                 dists, idx = tree.query(src + t_est, k=1, workers=1)
                 mask = dists < self.MAX_DIST
-                if mask.sum() < 30:
+                if mask.sum() < _MIN_ICP_INLIERS:
                     break
                 delta = dst[idx[mask]].mean(axis=0) - (src[mask] + t_est).mean(axis=0)
                 t_est = (t_est + 0.7 * delta).astype(np.float32)

--- a/dimos/perception/stereo_point_cloud/vio.py
+++ b/dimos/perception/stereo_point_cloud/vio.py
@@ -1,0 +1,123 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Visual-inertial odometry: Madgwick AHRS + rotation-decoupled ICP."""
+
+from __future__ import annotations
+
+import threading
+
+import numpy as np
+from scipy.spatial import cKDTree
+
+
+class MadgwickFilter:
+    """Gyro + accel → orientation R (camera_link → world, Z-up). beta=0.033."""
+
+    def __init__(self, beta: float = 0.033) -> None:
+        self._q      = np.array([1., 0., 0., 0.], dtype=np.float64)
+        self._beta   = beta
+        self._t_prev: float | None = None
+
+    def update(self, gyro: np.ndarray, accel: np.ndarray, t: float) -> None:
+        if self._t_prev is None:
+            self._t_prev = t
+            return
+        dt = min(t - self._t_prev, 0.1)
+        self._t_prev = t
+        if dt <= 0:
+            return
+        q0, q1, q2, q3 = self._q
+        gx, gy, gz = gyro.astype(np.float64)
+        a_n = np.linalg.norm(accel)
+        if a_n > 0.5:
+            ax, ay, az = accel.astype(np.float64) / a_n
+            f1 = 2*(q1*q3 - q0*q2) - ax
+            f2 = 2*(q0*q1 + q2*q3) - ay
+            f3 = 2*(0.5 - q1**2 - q2**2) - az
+            J  = np.array([
+                [-2*q2,  2*q3, -2*q0, 2*q1],
+                [ 2*q1,  2*q0,  2*q3, 2*q2],
+                [    0, -4*q1, -4*q2,    0],
+            ])
+            grad = J.T @ np.array([f1, f2, f3])
+            gn   = np.linalg.norm(grad)
+            if gn > 1e-9:
+                grad /= gn
+        else:
+            grad = np.zeros(4)
+        q_dot = 0.5 * np.array([
+            -q1*gx - q2*gy - q3*gz,
+             q0*gx + q2*gz - q3*gy,
+             q0*gy - q1*gz + q3*gx,
+             q0*gz + q1*gy - q2*gx,
+        ]) - self._beta * grad
+        self._q = self._q + q_dot * dt
+        self._q /= np.linalg.norm(self._q) + 1e-12
+
+    @property
+    def R(self) -> np.ndarray:
+        q0, q1, q2, q3 = self._q
+        return np.array([
+            [1-2*(q2**2+q3**2), 2*(q1*q2-q0*q3),   2*(q1*q3+q0*q2)  ],
+            [2*(q1*q2+q0*q3),   1-2*(q1**2+q3**2), 2*(q2*q3-q0*q1)  ],
+            [2*(q1*q3-q0*q2),   2*(q2*q3+q0*q1),   1-2*(q1**2+q2**2)],
+        ], dtype=np.float32)
+
+
+class PointCloudOdometry:
+    """Rotation-decoupled ICP for translation t. Takes R from Madgwick, converges in 3-4 iters."""
+
+    ITERS    = 4
+    MAX_DIST = 0.40
+    N_SRC    = 1_500
+    N_DST    = 8_000
+    N_STORE  = 10_000
+
+    def __init__(self) -> None:
+        self._t          = np.zeros(3, dtype=np.float32)
+        self._lock       = threading.Lock()
+        self._prev_world: np.ndarray | None = None
+
+    @property
+    def t(self) -> np.ndarray:
+        with self._lock:
+            return self._t.copy()
+
+    def update(self, xyz_cam: np.ndarray, R: np.ndarray) -> np.ndarray:
+        pts_ga = (xyz_cam @ R.T).astype(np.float32)
+        with self._lock:
+            t_est = self._t.copy()
+        if self._prev_world is None or len(pts_ga) < 50:
+            t_new = t_est
+        else:
+            n_src = min(self.N_SRC, len(pts_ga))
+            n_dst = min(self.N_DST, len(self._prev_world))
+            src   = pts_ga[np.random.choice(len(pts_ga), n_src, replace=False)]
+            dst   = self._prev_world[np.random.choice(len(self._prev_world), n_dst, replace=False)]
+            tree  = cKDTree(dst)
+            for _ in range(self.ITERS):
+                dists, idx = tree.query(src + t_est, k=1, workers=1)
+                mask = dists < self.MAX_DIST
+                if mask.sum() < 30:
+                    break
+                delta = dst[idx[mask]].mean(axis=0) - (src[mask] + t_est).mean(axis=0)
+                t_est = (t_est + 0.7 * delta).astype(np.float32)
+            t_new = t_est
+        n_st  = min(self.N_STORE, len(pts_ga))
+        idx_s = np.random.choice(len(pts_ga), n_st, replace=False)
+        self._prev_world = (pts_ga[idx_s] + t_new).astype(np.float32)
+        with self._lock:
+            self._t = t_new
+        return t_new

--- a/dimos/robot/all_blueprints.py
+++ b/dimos/robot/all_blueprints.py
@@ -26,6 +26,7 @@ all_blueprints = {
     "coordinator-flowbase": "dimos.control.blueprints.mobile:coordinator_flowbase",
     "coordinator-flowbase-keyboard-teleop": "dimos.control.blueprints.mobile:coordinator_flowbase_keyboard_teleop",
     "coordinator-flowbase-nav": "dimos.control.blueprints.mobile:coordinator_flowbase_nav",
+    "coordinator-flowbase-stereo-nav": "dimos.control.blueprints.mobile:coordinator_flowbase_stereo_nav",
     "coordinator-mobile-manip-mock": "dimos.control.blueprints.mobile:coordinator_mobile_manip_mock",
     "coordinator-mock": "dimos.robot.manipulators.common.mock:coordinator_mock",
     "coordinator-mock-twist-base": "dimos.control.blueprints.mobile:coordinator_mock_twist_base",


### PR DESCRIPTION
## Summary

- **`dimos/perception/stereo_point_cloud.py`** — new `StereoPointCloud` module: subscribes to depth image + camera info, runs gradient filter → pinhole backproject → floor removal → 2 cm voxel dedup → ray-cast ghost clearing → publishes `frame_cloud` and `global_map` as `PointCloud2`
- **`dimos/control/blueprints/mobile.py`** — adds `coordinator_flowbase_stereo_nav`: FlowBase + RealSense D435i + StereoPointCloud + CostMapper + MovementManager + ControlCoordinator

## Test plan

- [ ] `dimos run coordinator-flowbase-stereo-nav` with D435i connected — verify `frame_cloud` and `global_map` publish
- [ ] Confirm `CostMapper` receives `frame_cloud` and produces a navigable costmap
- [ ] Click-to-drive via Rerun web viewer