### PR TITLE
feat(control): declarative task binding cards in _registry manifests

### DIFF
--- a/dimos/control/routing.py
+++ b/dimos/control/routing.py
@@ -1,0 +1,72 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Declarative stream-binding cards for control tasks.
+
+Task manifests (``_registry.py``) stay import-free: they declare bindings as
+plain strings, and ``ControlTaskRegistry`` converts them to the typed forms
+here at load time. The coordinator does not consume these yet; a follow-up PR
+routes its input streams through them.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import Enum
+from types import MappingProxyType
+
+
+class Routing(str, Enum):
+    """How the coordinator matches an input message to a consuming task."""
+
+    CLAIM_OVERLAP = "claim_overlap"  # deliver when msg names joints the task claims
+    BY_TASK_NAME = "by_task_name"  # deliver when msg.frame_id == task.name
+    BROADCAST = "broadcast"  # deliver to every task consuming this stream
+
+
+CONSUMABLE_STREAMS = frozenset({"joint_command", "coordinator_cartesian_command", "teleop_buttons"})
+"""Coordinator input ports that cards may bind."""
+
+DEFERRED_STREAMS = frozenset({"twist_command"})
+"""Coordinator input ports that exist but are not card-routable yet."""
+
+
+@dataclass(frozen=True)
+class StreamBinding:
+    """One input stream a task consumes: coordinator port -> task handler.
+
+    ``handler`` names a method on the task instance with signature
+    ``(msg, t_now) -> Any``; the task receives the raw message and owns
+    digestion, the coordinator owns only routing.
+    """
+
+    stream: str
+    handler: str
+    routing: Routing
+
+
+_EMPTY_EXPOSES: Mapping[str, str] = MappingProxyType({})
+
+
+@dataclass(frozen=True)
+class TaskBindings:
+    """Declared input streams and commands for one task type.
+
+    ``exposes`` maps a command name to a ``"module:PydanticModel"``
+    argument-schema path; it is stored but not consumed yet.
+    """
+
+    consumes: tuple[StreamBinding, ...] = ()
+    exposes: Mapping[str, str] = _EMPTY_EXPOSES

--- a/dimos/control/tasks/cartesian_ik_task/_registry.py
+++ b/dimos/control/tasks/cartesian_ik_task/_registry.py
@@ -15,3 +15,9 @@
 TASK_FACTORIES = {
     "cartesian_ik": "dimos.control.tasks.cartesian_ik_task.cartesian_ik_task:create_task",
 }
+
+TASK_CONSUMES = {
+    "cartesian_ik": {
+        "coordinator_cartesian_command": ("on_cartesian_command", "by_task_name"),
+    },
+}

--- a/dimos/control/tasks/g1_groot_wbc_task/_registry.py
+++ b/dimos/control/tasks/g1_groot_wbc_task/_registry.py
@@ -15,3 +15,7 @@
 TASK_FACTORIES = {
     "g1_groot_wbc": "dimos.control.tasks.g1_groot_wbc_task.g1_groot_wbc_task:create_task",
 }
+
+TASK_CONSUMES: dict[str, dict[str, tuple[str, str]]] = {
+    "g1_groot_wbc": {},  # its twist input is wired to cards in a later PR
+}

--- a/dimos/control/tasks/registry.py
+++ b/dimos/control/tasks/registry.py
@@ -28,17 +28,30 @@ Usage:
 
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 import importlib
 import os
+from types import MappingProxyType
 from typing import TYPE_CHECKING, cast
 
+from dimos.control.routing import (
+    CONSUMABLE_STREAMS,
+    DEFERRED_STREAMS,
+    Routing,
+    StreamBinding,
+    TaskBindings,
+)
+
 if TYPE_CHECKING:
+    from types import ModuleType
+
     from dimos.control.coordinator import TaskConfig
     from dimos.control.hardware_interface import ConnectedHardware, ConnectedWholeBody
     from dimos.control.task import ControlTask
 
 TaskFactory = Callable[..., "ControlTask"]
+
+_EMPTY_BINDINGS = TaskBindings()
 
 
 class ControlTaskRegistry:
@@ -47,6 +60,8 @@ class ControlTaskRegistry:
     def __init__(self) -> None:
         self._factory_paths: dict[str, str] = {}
         self._factories: dict[str, TaskFactory] = {}
+        self._bindings: dict[str, TaskBindings] = {}
+        self._binding_sources: dict[str, str] = {}
         self.discover()
 
     def discover(self) -> None:
@@ -75,6 +90,7 @@ class ControlTaskRegistry:
                     if not isinstance(name, str) or not isinstance(factory_path, str):
                         raise TypeError(f"{module_name}.TASK_FACTORIES must map strings to strings")
                     self.register_path(name, factory_path)
+                self._load_manifest_bindings(module_name, module, task_factories)
 
     def register_path(self, name: str, factory_path: str) -> None:
         """Register a lazy task factory import path."""
@@ -85,6 +101,43 @@ class ControlTaskRegistry:
         if existing is not None and existing != factory_path:
             raise ValueError(f"Duplicate task type {key!r}: {existing!r} vs {factory_path!r}")
         self._factory_paths[key] = factory_path
+
+    def register_bindings(
+        self,
+        task_type: str,
+        *,
+        consumes: Mapping[str, tuple[str, str]] | None = None,
+        exposes: Mapping[str, str] | None = None,
+        source: str | None = None,
+    ) -> None:
+        """Register a task type's binding card; conflicting duplicates raise.
+
+        ``consumes`` maps a coordinator input stream name to a
+        ``(handler_method, routing)`` pair of strings; ``exposes`` maps a
+        command name to a ``"module:PydanticModel"`` argument-schema path
+        (stored only for now). ``source`` names the manifest for error
+        messages; runtime callers can omit it.
+        """
+        key = task_type.lower()
+        origin = source or "register_bindings()"
+        bindings = TaskBindings(
+            consumes=self._parse_consumes(key, consumes, origin),
+            exposes=self._parse_exposes(key, exposes, origin),
+        )
+        existing = self._bindings.get(key)
+        if existing is not None:
+            if existing != bindings:
+                raise ValueError(
+                    f"Duplicate bindings for task type {key!r}: {existing!r} "
+                    f"(from {self._binding_sources[key]}) vs {bindings!r} (from {origin})"
+                )
+            return
+        self._bindings[key] = bindings
+        self._binding_sources[key] = origin
+
+    def bindings_for(self, task_type: str) -> TaskBindings:
+        """Declared bindings for a task type; empty for unknown or card-less types."""
+        return self._bindings.get(task_type.lower(), _EMPTY_BINDINGS)
 
     def create(
         self,
@@ -105,10 +158,126 @@ class ControlTaskRegistry:
         """
         key = name.lower()
         factory = self._resolve_factory(key)
-        return factory(cfg=cfg, hardware=hardware or {})
+        task = factory(cfg=cfg, hardware=hardware or {})
+        self._validate_bound_handlers(key, task)
+        return task
 
     def available(self) -> list[str]:
         return sorted(self._factory_paths.keys())
+
+    def _load_manifest_bindings(
+        self, module_name: str, module: ModuleType, task_factories: Mapping[str, str]
+    ) -> None:
+        consumes_by_type = getattr(module, "TASK_CONSUMES", None)
+        exposes_by_type = getattr(module, "TASK_EXPOSES", None)
+        declared_types = {name.lower() for name in task_factories}
+        for label, per_type in (
+            ("TASK_CONSUMES", consumes_by_type),
+            ("TASK_EXPOSES", exposes_by_type),
+        ):
+            if per_type is None:
+                continue
+            if not isinstance(per_type, Mapping):
+                raise TypeError(f"{module_name}.{label} must be a mapping keyed by task type")
+            seen: set[str] = set()
+            for name in per_type:
+                if not isinstance(name, str):
+                    raise TypeError(f"{module_name}.{label} keys must be task-type strings")
+                if name.lower() in seen:
+                    raise ValueError(
+                        f"{module_name}.{label} declares task type {name!r} more than once"
+                    )
+                seen.add(name.lower())
+                if name.lower() not in declared_types:
+                    raise ValueError(
+                        f"{module_name}.{label} declares task type {name!r} "
+                        "not present in the same manifest's TASK_FACTORIES"
+                    )
+        consumes_by_key = {name.lower(): card for name, card in (consumes_by_type or {}).items()}
+        exposes_by_key = {name.lower(): card for name, card in (exposes_by_type or {}).items()}
+        for name in sorted({*consumes_by_key, *exposes_by_key}):
+            self.register_bindings(
+                name,
+                consumes=consumes_by_key.get(name),
+                exposes=exposes_by_key.get(name),
+                source=module_name,
+            )
+
+    def _parse_consumes(
+        self,
+        task_type: str,
+        consumes: Mapping[str, tuple[str, str]] | None,
+        source: str,
+    ) -> tuple[StreamBinding, ...]:
+        if consumes is None:
+            return ()
+        if not isinstance(consumes, Mapping):
+            raise TypeError(f"{source}: consumes for task type {task_type!r} must be a mapping")
+        bindings = []
+        for stream, spec in consumes.items():
+            where = f"{source}: task type {task_type!r}, stream {stream!r}"
+            if not isinstance(stream, str):
+                raise TypeError(f"{where}: stream name must be a string")
+            if stream in DEFERRED_STREAMS:
+                raise ValueError(
+                    f"{where}: not card-routable yet; the twist path is deliberately "
+                    "deferred to a later PR, so this restriction is temporary"
+                )
+            if stream not in CONSUMABLE_STREAMS:
+                raise ValueError(f"{where}: unknown stream; allowed: {sorted(CONSUMABLE_STREAMS)}")
+            if (
+                not isinstance(spec, Sequence)
+                or isinstance(spec, str)
+                or len(spec) != 2
+                or not all(isinstance(part, str) for part in spec)
+            ):
+                raise TypeError(f"{where}: binding must be a (handler, routing) pair of strings")
+            handler, routing_value = spec
+            try:
+                routing = Routing(routing_value)
+            except ValueError:
+                raise ValueError(
+                    f"{where}: unknown routing {routing_value!r}; "
+                    f"valid: {[r.value for r in Routing]}"
+                ) from None
+            bindings.append(StreamBinding(stream=stream, handler=handler, routing=routing))
+        return tuple(sorted(bindings, key=lambda binding: binding.stream))
+
+    def _parse_exposes(
+        self,
+        task_type: str,
+        exposes: Mapping[str, str] | None,
+        source: str,
+    ) -> Mapping[str, str]:
+        if exposes is None:
+            return MappingProxyType({})
+        if not isinstance(exposes, Mapping):
+            raise TypeError(f"{source}: exposes for task type {task_type!r} must be a mapping")
+        for command, schema_path in exposes.items():
+            if not isinstance(command, str) or not isinstance(schema_path, str):
+                raise TypeError(
+                    f"{source}: exposes for task type {task_type!r} must map strings to strings"
+                )
+            if ":" not in schema_path:
+                raise ValueError(
+                    f"{source}: task type {task_type!r} command {command!r} has invalid "
+                    f"argument-schema path {schema_path!r} (expected 'module:Model')"
+                )
+        return MappingProxyType(dict(exposes))
+
+    def _validate_bound_handlers(self, key: str, task: ControlTask) -> None:
+        bindings = self._bindings.get(key)
+        if bindings is None:
+            return
+        source = self._binding_sources.get(key, "register_bindings()")
+        for binding in bindings.consumes:
+            handler = getattr(task, binding.handler, None)
+            if not callable(handler):
+                raise TypeError(
+                    f"Task type {key!r} binds stream {binding.stream!r} to handler "
+                    f"{binding.handler!r} (declared in {source}), but the created "
+                    f"{type(task).__name__} has no callable {binding.handler!r}"
+                )
 
     def _resolve_factory(self, key: str) -> TaskFactory:
         if key in self._factories:

--- a/dimos/control/tasks/servo_task/_registry.py
+++ b/dimos/control/tasks/servo_task/_registry.py
@@ -15,3 +15,7 @@
 TASK_FACTORIES = {
     "servo": "dimos.control.tasks.servo_task.servo_task:create_task",
 }
+
+TASK_CONSUMES = {
+    "servo": {"joint_command": ("on_joint_command", "claim_overlap")},
+}

--- a/dimos/control/tasks/servo_task/servo_task.py
+++ b/dimos/control/tasks/servo_task/servo_task.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import threading
 import time
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from dimos.control.task import (
     BaseControlTask,
@@ -35,6 +35,9 @@ from dimos.control.task import (
 )
 from dimos.protocol.service.spec import BaseConfig
 from dimos.utils.logging_config import setup_logger
+
+if TYPE_CHECKING:
+    from dimos.msgs.sensor_msgs.JointState import JointState
 
 logger = setup_logger()
 
@@ -222,6 +225,12 @@ class JointServoTask(BaseControlTask):
             ordered.append(positions[name])
 
         return self.set_target(ordered, t_now)
+
+    def on_joint_command(self, msg: JointState, t_now: float) -> bool:
+        """Uniform stream handler: digest the position half of a joint_command."""
+        if not msg.position:
+            return False
+        return self.set_target_by_name(dict(zip(msg.name, msg.position, strict=False)), t_now)
 
     def start(self) -> None:
         """Activate the task (start accepting and outputting commands)."""

--- a/dimos/control/tasks/servo_task/test_servo_task.py
+++ b/dimos/control/tasks/servo_task/test_servo_task.py
@@ -1,0 +1,45 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Behavioral tests for the uniform ``(msg, t_now)`` joint_command handler."""
+
+from __future__ import annotations
+
+from dimos.control.task import CoordinatorState, JointStateSnapshot
+from dimos.control.tasks.servo_task.servo_task import JointServoTask, JointServoTaskConfig
+from dimos.msgs.sensor_msgs.JointState import JointState
+
+
+def _task() -> JointServoTask:
+    return JointServoTask("servo", JointServoTaskConfig(joint_names=["a/j1", "a/j2"]))
+
+
+def test_on_joint_command_sets_position_targets() -> None:
+    task = _task()
+    assert task.on_joint_command(JointState(name=["a/j1", "a/j2"], position=[0.1, 0.2]), 1.0)
+    out = task.compute(CoordinatorState(joints=JointStateSnapshot(), t_now=1.0))
+    assert out is not None
+    assert out.positions == [0.1, 0.2]
+
+
+def test_on_joint_command_ignores_messages_without_positions() -> None:
+    task = _task()
+    assert not task.on_joint_command(JointState(name=["a/j1", "a/j2"], velocity=[0.1, 0.2]), 1.0)
+    assert not task.is_active()
+
+
+def test_on_joint_command_requires_all_claimed_joints() -> None:
+    task = _task()
+    assert not task.on_joint_command(JointState(name=["a/j1"], position=[0.1]), 1.0)
+    assert not task.is_active()

--- a/dimos/control/tasks/teleop_task/_registry.py
+++ b/dimos/control/tasks/teleop_task/_registry.py
@@ -15,3 +15,10 @@
 TASK_FACTORIES = {
     "teleop_ik": "dimos.control.tasks.teleop_task.teleop_task:create_task",
 }
+
+TASK_CONSUMES = {
+    "teleop_ik": {
+        "coordinator_cartesian_command": ("on_cartesian_command", "by_task_name"),
+        "teleop_buttons": ("on_teleop_buttons", "broadcast"),
+    },
+}

--- a/dimos/control/tasks/teleop_task/teleop_task.py
+++ b/dimos/control/tasks/teleop_task/teleop_task.py
@@ -316,6 +316,10 @@ class TeleopIKTask(BaseControlTask):
 
         return True
 
+    def on_teleop_buttons(self, msg: Buttons, t_now: float) -> bool:
+        """Uniform stream handler; ``on_buttons`` predates the (msg, t_now) contract."""
+        return self.on_buttons(msg)
+
     def on_cartesian_command(self, pose: Pose | PoseStamped, t_now: float) -> bool:
         """Handle incoming cartesian command (delta pose from teleop)"""
         with self._lock:

--- a/dimos/control/tasks/teleop_task/test_teleop_task.py
+++ b/dimos/control/tasks/teleop_task/test_teleop_task.py
@@ -1,0 +1,37 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Behavioral test for the uniform ``(msg, t_now)`` teleop_buttons handler."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pinocchio")
+
+from dimos.control.tasks.teleop_task.teleop_task import TeleopIKTask
+
+
+def test_on_teleop_buttons_delegates_to_on_buttons() -> None:
+    task = TeleopIKTask.__new__(TeleopIKTask)
+    seen: list[object] = []
+
+    def fake_on_buttons(msg: object) -> bool:
+        seen.append(msg)
+        return True
+
+    task.on_buttons = fake_on_buttons  # type: ignore[method-assign]
+    sentinel = object()
+    assert task.on_teleop_buttons(sentinel, 0.0) is True  # type: ignore[arg-type]
+    assert seen == [sentinel]

--- a/dimos/control/tasks/teleop_task/test_teleop_task.py
+++ b/dimos/control/tasks/teleop_task/test_teleop_task.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import pytest
 
-pytest.importorskip("pinocchio")
 
 from dimos.control.tasks.teleop_task.teleop_task import TeleopIKTask
 

--- a/dimos/control/tasks/teleop_task/test_teleop_task.py
+++ b/dimos/control/tasks/teleop_task/test_teleop_task.py
@@ -27,7 +27,7 @@ def test_on_teleop_buttons_delegates_to_on_buttons() -> None:
         seen.append(msg)
         return True
 
-    task.on_buttons = fake_on_buttons  # type: ignore[method-assign]
+    task.on_buttons = fake_on_buttons
     sentinel = object()
-    assert task.on_teleop_buttons(sentinel, 0.0) is True  # type: ignore[arg-type]
+    assert task.on_teleop_buttons(sentinel, 0.0) is True
     assert seen == [sentinel]

--- a/dimos/control/tasks/teleop_task/test_teleop_task.py
+++ b/dimos/control/tasks/teleop_task/test_teleop_task.py
@@ -16,9 +16,6 @@
 
 from __future__ import annotations
 
-import pytest
-
-
 from dimos.control.tasks.teleop_task.teleop_task import TeleopIKTask
 
 

--- a/dimos/control/tasks/test_registry.py
+++ b/dimos/control/tasks/test_registry.py
@@ -182,7 +182,7 @@ def test_bindings_for_unknown_type_is_empty() -> None:
     assert bindings.consumes == ()
     assert not bindings.exposes
     with pytest.raises(TypeError):
-        bindings.exposes["poison"] = "x:Y"  # type: ignore[index]
+        bindings.exposes["poison"] = "x:Y"
 
 
 def test_register_bindings_runtime_and_conflict() -> None:
@@ -258,9 +258,9 @@ def test_create_fails_loudly_on_missing_handler() -> None:
     with pytest.raises(
         TypeError, match=r"fake_missing_handler.+on_joint_command.+fake_manifest\._registry"
     ):
-        reg.create("fake_missing_handler", None)  # type: ignore[arg-type]
+        reg.create("fake_missing_handler", None)
 
     reg.register_path("fake_with_handler", f"{__name__}:_make_handled_task")
     reg.register_bindings("fake_with_handler", consumes=card)
-    task = reg.create("fake_with_handler", None)  # type: ignore[arg-type]
+    task = reg.create("fake_with_handler", None)
     assert isinstance(task, _HandledTask)

--- a/dimos/control/tasks/test_registry.py
+++ b/dimos/control/tasks/test_registry.py
@@ -18,11 +18,17 @@ from __future__ import annotations
 
 import importlib
 import importlib.util
+import inspect
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
-from dimos.control.tasks.registry import control_task_registry
+from dimos.control.routing import CONSUMABLE_STREAMS, Routing, StreamBinding, TaskBindings
+from dimos.control.tasks.registry import ControlTaskRegistry, control_task_registry
+
+if TYPE_CHECKING:
+    from types import ModuleType
 
 # Heavy optional dependencies; a task factory failing on one of these still
 # passes IF the dependency is not installed. Anything else (path typo,
@@ -70,3 +76,191 @@ def test_declared_task_factory_paths_resolve() -> None:
         factory = getattr(module, attr, None)
         assert factory is not None, f"{name}: {module_name!r} has no attribute {attr!r}"
         assert callable(factory), f"{name}: {factory_path!r} is not callable"
+
+
+def _manifest_modules() -> list[ModuleType]:
+    pkg = importlib.import_module("dimos.control.tasks")
+    modules = []
+    for root in pkg.__path__:
+        for child in sorted(Path(root).iterdir()):
+            if not child.is_dir() or child.name.startswith(("_", ".")):
+                continue
+            if not (child / "_registry.py").exists():
+                continue
+            modules.append(importlib.import_module(f"dimos.control.tasks.{child.name}._registry"))
+    return modules
+
+
+def test_task_cards_are_well_formed() -> None:
+    checked = 0
+    for module in _manifest_modules():
+        factories = module.TASK_FACTORIES
+        consumes_by_type = getattr(module, "TASK_CONSUMES", {})
+        exposes_by_type = getattr(module, "TASK_EXPOSES", {})
+        for label, per_type in (
+            ("TASK_CONSUMES", consumes_by_type),
+            ("TASK_EXPOSES", exposes_by_type),
+        ):
+            unknown = set(per_type) - set(factories)
+            assert not unknown, (
+                f"{module.__name__}.{label} declares {sorted(unknown)} not in TASK_FACTORIES"
+            )
+        for task_type, streams in consumes_by_type.items():
+            for stream, spec in streams.items():
+                where = f"{module.__name__}: {task_type!r} stream {stream!r}"
+                assert stream in CONSUMABLE_STREAMS, (
+                    f"{where} not in allowed set {sorted(CONSUMABLE_STREAMS)}"
+                )
+                handler, routing = spec
+                assert isinstance(handler, str) and handler, f"{where}: bad handler {handler!r}"
+                Routing(routing)  # raises on unknown routing strings
+                checked += 1
+    assert checked > 0
+
+
+def test_seeded_cards_load_into_registry() -> None:
+    servo = control_task_registry.bindings_for("servo")
+    assert servo.consumes == (
+        StreamBinding("joint_command", "on_joint_command", Routing.CLAIM_OVERLAP),
+    )
+    velocity = control_task_registry.bindings_for("velocity")
+    assert velocity.consumes == (
+        StreamBinding("joint_command", "on_joint_command", Routing.CLAIM_OVERLAP),
+    )
+    cartesian = control_task_registry.bindings_for("cartesian_ik")
+    assert cartesian.consumes == (
+        StreamBinding(
+            "coordinator_cartesian_command", "on_cartesian_command", Routing.BY_TASK_NAME
+        ),
+    )
+    teleop = control_task_registry.bindings_for("teleop_ik")
+    assert teleop.consumes == (
+        StreamBinding(
+            "coordinator_cartesian_command", "on_cartesian_command", Routing.BY_TASK_NAME
+        ),
+        StreamBinding("teleop_buttons", "on_teleop_buttons", Routing.BROADCAST),
+    )
+    for empty_card in ("trajectory", "g1_groot_wbc"):
+        # Present in _bindings distinguishes a seeded empty card from no card at all.
+        assert empty_card in control_task_registry._bindings, f"{empty_card} card not seeded"
+        assert control_task_registry.bindings_for(empty_card) == TaskBindings()
+
+
+def test_declared_handlers_exist_on_task_classes() -> None:
+    checked = 0
+    for task_type, bindings in sorted(control_task_registry._bindings.items()):
+        if not bindings.consumes:
+            continue
+        factory_path = control_task_registry._factory_paths[task_type]
+        module_name, _ = factory_path.split(":", maxsplit=1)
+        try:
+            module = importlib.import_module(module_name)
+        except ModuleNotFoundError as exc:
+            root = (exc.name or "").partition(".")[0]
+            if root in OPTIONAL_TASK_MODULES and importlib.util.find_spec(root) is None:
+                continue
+            pytest.fail(f"{task_type}: importing {module_name!r} failed: {exc}")
+        task_classes = [
+            cls
+            for _, cls in inspect.getmembers(module, inspect.isclass)
+            if cls.__module__ == module.__name__
+            and all(hasattr(cls, attr) for attr in ("compute", "claim", "is_active"))
+        ]
+        assert task_classes, f"{task_type}: no task class found in {module_name!r}"
+        for binding in bindings.consumes:
+            assert any(callable(getattr(cls, binding.handler, None)) for cls in task_classes), (
+                f"{task_type}: no task class in {module_name!r} defines handler "
+                f"{binding.handler!r} declared for stream {binding.stream!r}"
+            )
+            checked += 1
+    assert checked > 0
+
+
+def test_bindings_for_unknown_type_is_empty() -> None:
+    bindings = control_task_registry.bindings_for("definitely_not_registered")
+    assert bindings == TaskBindings()
+    assert bindings.consumes == ()
+    assert not bindings.exposes
+    with pytest.raises(TypeError):
+        bindings.exposes["poison"] = "x:Y"  # type: ignore[index]
+
+
+def test_register_bindings_runtime_and_conflict() -> None:
+    reg = ControlTaskRegistry()
+    reg.register_bindings(
+        "fake_runtime", consumes={"joint_command": ("on_joint_command", "claim_overlap")}
+    )
+    assert reg.bindings_for("fake_runtime").consumes == (
+        StreamBinding("joint_command", "on_joint_command", Routing.CLAIM_OVERLAP),
+    )
+    # Identical re-registration is a no-op and keeps the original source attribution.
+    reg.register_bindings(
+        "fake_runtime", consumes={"joint_command": ("on_joint_command", "claim_overlap")}
+    )
+    reg.register_bindings(
+        "fake_runtime",
+        consumes={"joint_command": ("on_joint_command", "claim_overlap")},
+        source="other._registry",
+    )
+    assert reg._binding_sources["fake_runtime"] == "register_bindings()"
+    with pytest.raises(ValueError, match="fake_runtime"):
+        reg.register_bindings(
+            "fake_runtime", consumes={"joint_command": ("on_joint_command", "broadcast")}
+        )
+
+
+def test_register_bindings_rejects_bad_streams_and_routing() -> None:
+    reg = ControlTaskRegistry()
+    with pytest.raises(ValueError, match="later PR"):
+        reg.register_bindings("fake_twist", consumes={"twist_command": ("on_twist", "broadcast")})
+    with pytest.raises(ValueError, match="allowed"):
+        reg.register_bindings("fake_stream", consumes={"no_such_port": ("on_x", "broadcast")})
+    with pytest.raises(ValueError, match="routing"):
+        reg.register_bindings("fake_routing", consumes={"joint_command": ("on_x", "round_robin")})
+    with pytest.raises(ValueError, match="module:Model"):
+        reg.register_bindings("fake_exposes", exposes={"do_thing": "not_a_path"})
+
+
+class _HandlerlessTask:
+    name = "handlerless"
+
+    def claim(self) -> None:
+        raise NotImplementedError
+
+    def is_active(self) -> bool:
+        return False
+
+    def compute(self, state: Any) -> None:
+        return None
+
+
+class _HandledTask(_HandlerlessTask):
+    name = "handled"
+
+    def on_joint_command(self, msg: Any, t_now: float) -> bool:
+        return True
+
+
+def _make_handlerless_task(cfg: Any, hardware: Any) -> _HandlerlessTask:
+    return _HandlerlessTask()
+
+
+def _make_handled_task(cfg: Any, hardware: Any) -> _HandledTask:
+    return _HandledTask()
+
+
+def test_create_fails_loudly_on_missing_handler() -> None:
+    reg = ControlTaskRegistry()
+    card = {"joint_command": ("on_joint_command", "claim_overlap")}
+
+    reg.register_path("fake_missing_handler", f"{__name__}:_make_handlerless_task")
+    reg.register_bindings("fake_missing_handler", consumes=card, source="fake_manifest._registry")
+    with pytest.raises(
+        TypeError, match=r"fake_missing_handler.+on_joint_command.+fake_manifest\._registry"
+    ):
+        reg.create("fake_missing_handler", None)  # type: ignore[arg-type]
+
+    reg.register_path("fake_with_handler", f"{__name__}:_make_handled_task")
+    reg.register_bindings("fake_with_handler", consumes=card)
+    task = reg.create("fake_with_handler", None)  # type: ignore[arg-type]
+    assert isinstance(task, _HandledTask)

--- a/dimos/control/tasks/trajectory_task/_registry.py
+++ b/dimos/control/tasks/trajectory_task/_registry.py
@@ -15,3 +15,7 @@
 TASK_FACTORIES = {
     "trajectory": "dimos.control.tasks.trajectory_task.trajectory_task:create_task",
 }
+
+TASK_CONSUMES: dict[str, dict[str, tuple[str, str]]] = {
+    "trajectory": {},  # command-driven only; consumes no input streams
+}

--- a/dimos/control/tasks/velocity_task/_registry.py
+++ b/dimos/control/tasks/velocity_task/_registry.py
@@ -15,3 +15,7 @@
 TASK_FACTORIES = {
     "velocity": "dimos.control.tasks.velocity_task.velocity_task:create_task",
 }
+
+TASK_CONSUMES = {
+    "velocity": {"joint_command": ("on_joint_command", "claim_overlap")},
+}

--- a/dimos/control/tasks/velocity_task/test_velocity_task.py
+++ b/dimos/control/tasks/velocity_task/test_velocity_task.py
@@ -1,0 +1,47 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Behavioral tests for the uniform ``(msg, t_now)`` joint_command handler."""
+
+from __future__ import annotations
+
+from dimos.control.task import CoordinatorState, JointStateSnapshot
+from dimos.control.tasks.velocity_task.velocity_task import (
+    JointVelocityTask,
+    JointVelocityTaskConfig,
+)
+from dimos.msgs.sensor_msgs.JointState import JointState
+
+
+def _task() -> JointVelocityTask:
+    return JointVelocityTask("velocity", JointVelocityTaskConfig(joint_names=["a/j1", "a/j2"]))
+
+
+def test_on_joint_command_sets_velocities() -> None:
+    task = _task()
+    assert task.on_joint_command(JointState(name=["a/j1", "a/j2"], velocity=[0.3, -0.1]), 1.0)
+    out = task.compute(CoordinatorState(joints=JointStateSnapshot(), t_now=1.0))
+    assert out is not None
+    assert out.velocities == [0.3, -0.1]
+
+
+def test_on_joint_command_ignores_position_bearing_messages() -> None:
+    # Mirrors the coordinator's if-position-elif-velocity split: a message
+    # carrying positions must never drive the velocity task.
+    task = _task()
+    both = JointState(name=["a/j1", "a/j2"], position=[0.1, 0.2], velocity=[0.3, -0.1])
+    assert not task.on_joint_command(both, 1.0)
+    positions = JointState(name=["a/j1", "a/j2"], position=[0.1, 0.2])
+    assert not task.on_joint_command(positions, 1.0)
+    assert not task.is_active()

--- a/dimos/control/tasks/velocity_task/velocity_task.py
+++ b/dimos/control/tasks/velocity_task/velocity_task.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import threading
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from dimos.control.task import (
     BaseControlTask,
@@ -36,6 +36,9 @@ from dimos.control.task import (
 )
 from dimos.protocol.service.spec import BaseConfig
 from dimos.utils.logging_config import setup_logger
+
+if TYPE_CHECKING:
+    from dimos.msgs.sensor_msgs.JointState import JointState
 
 logger = setup_logger()
 
@@ -239,6 +242,14 @@ class JointVelocityTask(BaseControlTask):
             ordered.append(velocities[name])
 
         return self.set_velocities(ordered, t_now)
+
+    def on_joint_command(self, msg: JointState, t_now: float) -> bool:
+        """Uniform stream handler: digest the velocity half of a joint_command."""
+        # Position-bearing messages belong to the servo half (the coordinator
+        # routes position XOR velocity; positions win when both are present).
+        if msg.position or not msg.velocity:
+            return False
+        return self.set_velocities_by_name(dict(zip(msg.name, msg.velocity, strict=False)), t_now)
 
     def start(self) -> None:
         """Activate the task (start accepting and outputting commands)."""


### PR DESCRIPTION
## Problem

Tasks streams need to be added in the control coordinator main module. which is unscalable for all the variety of tests.

Closes DIM-XXX

## Solution

Each control-task type now declares which coordinator input streams it consumes (stream -> handler + routing rule) as plain data in its _registry.py manifest. The registry converts cards to typed TaskBindings at load, exposes register_bindings()/bindings_for(), and validates at create() that every declared handler exists on the instance. Servo, velocity, and teleop tasks gain uniform (msg, t_now) handlers replicating today's coordinator routing; they are unused until the follow-up PR routes the coordinator through the cards. Coordinator itself is untouched.


## Contributor License Agreement

- [x ] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
