### PR TITLE
chore(ci): GC persistent Nix store after self-hosted tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -569,6 +569,21 @@ jobs:
         if: failure()
         run: |
           df -h
+      - name: Garbage-collect the persistent Nix store
+        # /nix is bind-mounted from the runner host's /var/cache/dimos-nix
+        # (see this job's container.volumes) so module closures survive between
+        # jobs. But every run also imports a fresh `…-source` closure of the
+        # tree — including the large data/.lfs recordings — and nothing ever
+        # reclaims them, so the store grows unbounded until jobs fail with
+        # "No space left on device". GC after each run keeps the last few days
+        # (module closures fetched from Cachix stay warm; stale source closures
+        # are freed). Runs on the Linux entry, the only one that mounts /nix and
+        # puts nix on PATH (Install Nix step above).
+        if: ${{ always() && contains(matrix.markers, 'skipif_no_ros') }}
+        run: |
+          df -h /nix || true
+          nix-collect-garbage --delete-older-than 3d || true
+          df -h /nix || true
 
   self-hosted-large-tests:
     # Skip on PRs from forks which would expose the self-hosted runner to untrusted code from external contributors.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -582,7 +582,7 @@ jobs:
         if: ${{ always() && contains(matrix.markers, 'skipif_no_ros') }}
         run: |
           df -h /nix || true
-          nix-collect-garbage --delete-older-than 3d || true
+          nix-collect-garbage --delete-older-than 3d
           df -h /nix || true
 
   self-hosted-large-tests:


### PR DESCRIPTION
## Problem

Self-hosted runners have been failing at `Set up job` with **`No space left on device`** (e.g. `dimos-self-hosted-22.04-08`). Root cause: the persistent per-runner Nix store at `/var/cache/dimos-nix` had grown to **~162GB (56% of the 291GB disk)**, dominated by ~129GB of duplicated Git-LFS blobs (`drone.tar.gz` 710MB ×38 copies, `go2_bigoffice.db` 196MB, …).

This started with **#2470** ("Build/cache native modules", 2026-07-01), which introduced the nix native-module build. The `self-hosted-tests` job bind-mounts `/nix` from the host's `/var/cache/dimos-nix` (see the job's `container.volumes`) so module closures survive between jobs — but every run *also* imports a fresh `…-source` closure of the working tree (including the large `data/.lfs` recordings), and **nothing ever garbage-collected them**. Each push adds a fresh multi-hundred-MB source path, per runner, forever.

The host-side disk-cleanup cron only prunes Docker + checkouts, so it never reclaimed the Nix store and the disk ratcheted to 100%.

## Fix

Add a `nix-collect-garbage --delete-older-than 3d` step at the end of `self-hosted-tests` (Linux entry only — the only one that mounts `/nix` and puts nix on PATH). It runs `if: always()` so the store is trimmed even when tests fail. Recent module closures fetched from Cachix stay warm; stale source closures are freed.

Scope check: `self-hosted-large-tests` runs directly on the host (no `container:`, no `/nix` mount), so it doesn't accumulate a Nix store and needs no GC. `cmu-nav-natives` runs on GitHub-hosted `ubuntu-latest` with an ephemeral `/nix`.

Retention (`3d`) is easily tunable if the store still trends high.

## Follow-ups (not in this PR)
- Exclude `data/`/LFS from the nix `src` closure so builds stop copying ~0.7GB of recordings per commit.
- Extend the host `runner-disk-cleanup.sh` cron with a nix-GC safety net (`docker image prune -a`, plus GC via the ros-dev image).