### PR TITLE
feat(webrtc): real-SCTP loopback provider + typed msg transforms

### DIFF
--- a/dimos/core/test_transform.py
+++ b/dimos/core/test_transform.py
@@ -1,0 +1,98 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import pickle
+from typing import Any
+
+import numpy as np
+
+from dimos.core.stream import Out, Stream, Transport
+from dimos.core.transform import ResizeImage, Throttle, TransformTransport, VoxelDownsample
+from dimos.msgs.sensor_msgs.Image import Image, ImageFormat
+
+
+class RecordingTransport(Transport[Any]):
+    """Records broadcasts; subscribe hands back a marker unsubscribe."""
+
+    def __init__(self) -> None:
+        self.broadcasts: list[Any] = []
+        self.started = False
+
+    def broadcast(self, selfstream: Out[Any] | None, value: Any) -> None:
+        self.broadcasts.append(value)
+
+    def subscribe(
+        self, callback: Callable[[Any], Any], selfstream: Stream[Any] | None = None
+    ) -> Callable[[], None]:
+        return lambda: None
+
+    def start(self) -> None:
+        self.started = True
+
+    def stop(self) -> None:
+        self.started = False
+
+
+def add_one(msg: int) -> int:
+    return msg + 1
+
+
+def drop_odd(msg: int) -> int | None:
+    return None if msg % 2 else msg
+
+
+def test_transforms_apply_in_order() -> None:
+    inner = RecordingTransport()
+    transport = TransformTransport(inner, add_one, drop_odd)
+    transport.publish(1)  # 1 -> 2 -> kept
+    transport.publish(2)  # 2 -> 3 -> dropped
+    assert inner.broadcasts == [2]
+
+
+def test_none_drops_before_later_transforms() -> None:
+    inner = RecordingTransport()
+    transport = TransformTransport(inner, drop_odd, add_one)
+    transport.publish(3)
+    assert inner.broadcasts == []
+
+
+def test_lifecycle_and_subscribe_passthrough() -> None:
+    inner = RecordingTransport()
+    transport = TransformTransport(inner, add_one)
+    transport.start()
+    assert inner.started
+    assert callable(transport.subscribe(lambda msg: None))
+    transport.stop()
+    assert not inner.started
+
+
+def test_throttle_keeps_first_of_interval() -> None:
+    throttle = Throttle(max_hz=1000.0)
+    assert throttle("a") == "a"
+    assert throttle("b") is None  # within the 1ms interval
+
+
+def test_resize_image() -> None:
+    image = Image(data=np.zeros((1000, 2000, 3), dtype=np.uint8), format=ImageFormat.RGB)
+    resized = ResizeImage(max_width=640, max_height=480)(image)
+    assert (resized.width, resized.height) == (640, 320)
+
+
+def test_pickle_roundtrip() -> None:
+    transport = TransformTransport(RecordingTransport(), add_one, VoxelDownsample(0.05))
+    restored = pickle.loads(pickle.dumps(transport))
+    assert restored._transforms[1] == VoxelDownsample(0.05)

--- a/dimos/core/transform.py
+++ b/dimos/core/transform.py
@@ -1,0 +1,126 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Typed per-message transforms, composable with any transport.
+
+A transform is a callable ``(A) -> B | None`` applied to the typed message
+before it reaches the wire; returning ``None`` drops the message. Transforms
+are plain picklable values (frozen dataclasses), so a blueprint can pin them
+per stream and they survive into worker processes like the transports they
+wrap:
+
+    blueprint.transports({
+        ("lidar", PointCloud2): TransformTransport(
+            ZenohTransport("lidar", PointCloud2), VoxelDownsample(0.05)
+        ),
+        ("color_image", Image): TransformTransport(
+            WebRTCTransport("color_image", Image), Throttle(5.0), ResizeImage(640, 480)
+        ),
+    })
+
+This keeps bandwidth policy (decimation, throttling) out of the individual
+transport backends: the same transform runs unchanged over LCM, Zenoh, SHM,
+ROS, or WebRTC, and the wire layer only ever sees the reduced message.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+import time
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from dimos.core.stream import Out, Stream, Transport
+
+if TYPE_CHECKING:
+    from dimos.msgs.sensor_msgs.Image import Image
+    from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
+
+A = TypeVar("A")
+
+# A transform maps a typed message to a (possibly different) message, or None
+# to drop it. Must be picklable — module-level functions or dataclasses, not
+# lambdas — because transports (and their transforms) pickle into workers.
+MsgTransform = Callable[[Any], Any]
+
+
+@dataclass(frozen=True)
+class VoxelDownsample:
+    """Voxel-grid downsample a PointCloud2 before it reaches the wire."""
+
+    voxel_size: float = 0.1
+
+    def __call__(self, msg: PointCloud2) -> PointCloud2:
+        return msg.voxel_downsample(self.voxel_size)
+
+
+@dataclass(frozen=True)
+class ResizeImage:
+    """Scale an Image down to fit the given bounds (aspect ratio preserved)."""
+
+    max_width: int = 640
+    max_height: int = 480
+
+    def __call__(self, msg: Image) -> Image:
+        resized, _ = msg.resize_to_fit(self.max_width, self.max_height)
+        return resized
+
+
+@dataclass
+class Throttle:
+    """Drop messages arriving faster than ``max_hz``, keeping the first of
+    each interval. Per-process state: after pickling into a worker the rate
+    cap restarts there, which is the correct behavior for a publisher-side
+    cap."""
+
+    max_hz: float
+    _last: float = field(default=0.0, repr=False, compare=False)
+
+    def __call__(self, msg: A) -> A | None:
+        now = time.monotonic()
+        if now - self._last < 1.0 / self.max_hz:
+            return None
+        self._last = now
+        return msg
+
+
+class TransformTransport(Transport[A]):
+    """Applies transforms, in order, before the wrapped transport broadcasts.
+
+    A transform returning None drops the message. Subscribing and lifecycle
+    are pass-through, so this composes with any Transport backend.
+    """
+
+    def __init__(self, transport: Transport[Any], *transforms: MsgTransform) -> None:
+        self._transport = transport
+        self._transforms = transforms
+
+    def broadcast(self, selfstream: Out[A] | None, value: A) -> None:
+        out: Any = value
+        for transform in self._transforms:
+            out = transform(out)
+            if out is None:
+                return
+        self._transport.broadcast(selfstream, out)
+
+    def subscribe(
+        self, callback: Callable[[A], Any], selfstream: Stream[A] | None = None
+    ) -> Callable[[], None]:
+        return self._transport.subscribe(callback, selfstream)
+
+    def start(self) -> None:
+        self._transport.start()
+
+    def stop(self) -> None:
+        self._transport.stop()

--- a/dimos/protocol/pubsub/benchmark/testdata.py
+++ b/dimos/protocol/pubsub/benchmark/testdata.py
@@ -551,6 +551,35 @@ if WEBRTC_AVAILABLE:
         )
     )
 
+    # Real-SCTP loopback: full aiortc stack (DTLS, SCTP, localhost UDP), still
+    # keyless. This row is the actual WebRTC link ceiling; read the in-memory
+    # WebrtcLoopback row above as pure stack overhead.
+    from dimos.protocol.pubsub.impl.webrtc.providers.loopback import (
+        MAX_MSG_SIZE as SCTP_MAX_MSG_SIZE,
+        LoopbackConfig,
+    )
+
+    @contextmanager
+    def webrtc_sctp_pubsub_channel() -> Generator[WebRTCPubSub, None, None]:
+        pubsub = WebRTCPubSub(provider=LoopbackConfig().provider())
+        pubsub.start()
+        try:
+            yield pubsub
+        finally:
+            pubsub.stop()
+
+    def webrtc_sctp_msggen(size: int) -> tuple[str, bytes]:
+        if size > SCTP_MAX_MSG_SIZE:
+            pytest.skip(f"{size}B exceeds the negotiated SCTP message limit")
+        return ("benchmark/webrtc_sctp", make_data_bytes(size))
+
+    testcases.append(
+        Case(
+            pubsub_context=webrtc_sctp_pubsub_channel,
+            msg_gen=webrtc_sctp_msggen,
+        )
+    )
+
 
 if WEBRTC_AVAILABLE and os.environ.get("CF_TELEOP_APP_ID"):
 

--- a/dimos/protocol/pubsub/impl/webrtc/providers/loopback.py
+++ b/dimos/protocol/pubsub/impl/webrtc/providers/loopback.py
@@ -1,0 +1,201 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""In-process WebRTC loopback: two peer connections over localhost UDP.
+
+Unlike the in-memory mock providers (dict dispatch, no network), this runs
+the full aiortc stack — DTLS crypto, SCTP framing, localhost UDP — so it
+measures and tests what a real DataChannel link does, keyless and offline.
+Host candidates only: no STUN, no TURN, no signaling server (the SDP
+offer/answer is exchanged directly between the two in-process peers).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from dimos.protocol.pubsub.impl.webrtc.providers.spec import (
+    WEBRTC_AVAILABLE,
+    AsyncProviderBase,
+    Provider,
+    ProviderConfig,
+    wait_connected,
+    wait_open,
+)
+from dimos.utils.logging_config import setup_logger
+
+if TYPE_CHECKING:
+    from aiortc import RTCDataChannel, RTCPeerConnection
+
+logger = setup_logger()
+
+# aiortc's SDP-negotiated SCTP max-message-size. Larger sends raise in the
+# SCTP stack; chunking above this limit is a framing-layer concern.
+MAX_MSG_SIZE = 64 * 1024
+
+
+class LoopbackConfig(ProviderConfig):
+    """Loopback link settings. Defaults are ordered+reliable so the contract
+    grid and benchmark measure the link, not message loss."""
+
+    ordered: bool = True
+    max_retransmits: int | None = None
+
+    def _create(self) -> Provider:
+        return LoopbackProvider(self)
+
+
+class LoopbackProvider(AsyncProviderBase):
+    """One sender and one receiver RTCPeerConnection in the same process.
+
+    Topics map to lazily-created negotiated DataChannel pairs (same id on
+    both peers, allocated locally — both ends are ours, so no signaling is
+    needed after the initial offer/answer). Traffic direction is send-side →
+    recv-side, mirroring the Cloudflare loopback pair.
+    """
+
+    def __init__(self, config: LoopbackConfig | None = None) -> None:
+        if not WEBRTC_AVAILABLE:
+            raise RuntimeError("aiortc required: pip install dimos[webrtc]")
+        super().__init__()
+        self._config = config or LoopbackConfig()
+        self._send_pc: RTCPeerConnection | None = None
+        self._recv_pc: RTCPeerConnection | None = None
+        self._channel_lock: asyncio.Lock | None = None
+        self._next_dc_id = 1  # id 0 is the pre-offer placeholder
+
+        # Guarded by self._lock (from the base); never held across an await.
+        self._channels: dict[str, RTCDataChannel] = {}
+        self._callbacks: dict[str, list[Callable[[bytes, str], None]]] = defaultdict(list)
+
+    # ─── Connect / Disconnect (loop thread) ──────────────────────────
+
+    async def _connect(self) -> None:
+        from aiortc import RTCConfiguration, RTCPeerConnection
+
+        self._channel_lock = asyncio.Lock()
+        self._next_dc_id = 1
+        # Empty iceServers: host candidates only. aiortc's default config
+        # queries Google STUN, stalling gathering ~5s per peer when blocked.
+        ice = RTCConfiguration(iceServers=[])
+        self._send_pc = RTCPeerConnection(configuration=ice)
+        self._recv_pc = RTCPeerConnection(configuration=ice)
+
+        # A pre-offer channel puts the SCTP m-line in the SDP; per-topic
+        # channels are then negotiated additions needing no renegotiation.
+        self._send_pc.createDataChannel("_init", negotiated=True, id=0)
+        self._recv_pc.createDataChannel("_init", negotiated=True, id=0)
+
+        offer = await self._send_pc.createOffer()
+        await self._send_pc.setLocalDescription(offer)  # gathers host candidates
+        await self._recv_pc.setRemoteDescription(self._send_pc.localDescription)
+        answer = await self._recv_pc.createAnswer()
+        await self._recv_pc.setLocalDescription(answer)
+        await self._send_pc.setRemoteDescription(self._recv_pc.localDescription)
+
+        await wait_connected(self._send_pc)
+        await wait_connected(self._recv_pc)
+
+    async def _disconnect(self) -> None:
+        if self._send_pc:
+            await self._send_pc.close()
+            self._send_pc = None
+        if self._recv_pc:
+            await self._recv_pc.close()
+            self._recv_pc = None
+        with self._lock:
+            self._channels.clear()
+
+    # ─── Channel management (loop thread) ────────────────────────────
+
+    async def _ensure_channel(self, topic: str) -> RTCDataChannel:
+        assert self._channel_lock and self._send_pc and self._recv_pc
+        async with self._channel_lock:
+            with self._lock:
+                ch = self._channels.get(topic)
+            if ch is not None:
+                return ch
+            dc_id = self._next_dc_id
+            self._next_dc_id += 1
+            options: dict[str, Any] = {
+                "negotiated": True,
+                "id": dc_id,
+                "ordered": self._config.ordered,
+                "maxRetransmits": self._config.max_retransmits,
+            }
+            send_ch = self._send_pc.createDataChannel(topic, **options)
+            recv_ch = self._recv_pc.createDataChannel(topic, **options)
+
+            @recv_ch.on("message")
+            def _on_msg(payload: Any) -> None:
+                if isinstance(payload, str):
+                    payload = payload.encode()
+                with self._lock:
+                    callbacks = list(self._callbacks.get(topic, ()))
+                for cb in callbacks:
+                    try:
+                        cb(payload, topic)
+                    except Exception:
+                        logger.exception("WebRTC subscriber callback error")
+
+            await wait_open(send_ch)
+            await wait_open(recv_ch)
+            with self._lock:
+                self._channels[topic] = send_ch
+            return send_ch
+
+    # ─── Public API (Provider) ───────────────────────────────────────
+
+    def publish(self, topic: str, data: bytes) -> None:
+        if not self.is_connected:
+            self.start()
+        if isinstance(data, (bytearray, memoryview)):
+            data = bytes(data)
+        if len(data) > MAX_MSG_SIZE:
+            logger.warning("WebRTC msg on %r exceeds %d bytes", topic, MAX_MSG_SIZE)
+        with self._lock:
+            ch = self._channels.get(topic)
+        if ch is None:
+            ch = self._run_sync(self._ensure_channel(topic))
+        with self._lock:
+            if not self._started or self._loop is None:
+                return
+            self._loop.call_soon_threadsafe(ch.send, data)
+
+    def subscribe(self, topic: str, callback: Callable[[bytes, str], None]) -> Callable[[], None]:
+        if not self.is_connected:
+            self.start()
+        with self._lock:
+            self._callbacks[topic].append(callback)
+        try:
+            self._run_sync(self._ensure_channel(topic))
+        except BaseException:
+            # Failed subscribe returns no unsub handle — deregister, or the
+            # callback would start firing once a later subscribe succeeds.
+            with self._lock:
+                if callback in self._callbacks[topic]:
+                    self._callbacks[topic].remove(callback)
+            raise
+
+        def _unsub() -> None:
+            with self._lock:
+                try:
+                    self._callbacks[topic].remove(callback)
+                except ValueError:
+                    pass
+
+        return _unsub

--- a/dimos/protocol/pubsub/impl/webrtc/test_loopback.py
+++ b/dimos/protocol/pubsub/impl/webrtc/test_loopback.py
@@ -1,0 +1,111 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Loopback provider tests — real aiortc SCTP over localhost, keyless."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+import threading
+
+import pytest
+
+from dimos.protocol.pubsub.impl.webrtc.providers.spec import WEBRTC_AVAILABLE
+
+if not WEBRTC_AVAILABLE:
+    pytest.skip("aiortc not installed", allow_module_level=True)
+
+from dimos.protocol.pubsub.impl.webrtc.providers.loopback import LoopbackConfig, LoopbackProvider
+
+TIMEOUT = 10.0
+
+
+@pytest.fixture
+def provider() -> Iterator[LoopbackProvider]:
+    p = LoopbackProvider()
+    p.start()
+    yield p
+    p.stop()
+
+
+class Collector:
+    """Thread-safe callback sink with event-based waiting (no sleeps)."""
+
+    def __init__(self) -> None:
+        self.messages: list[tuple[bytes, str]] = []
+        self._event = threading.Event()
+
+    def __call__(self, data: bytes, topic: str) -> None:
+        self.messages.append((data, topic))
+        self._event.set()
+
+    def wait(self, count: int = 1) -> list[tuple[bytes, str]]:
+        while len(self.messages) < count:
+            assert self._event.wait(TIMEOUT), f"got {len(self.messages)}/{count} messages"
+            self._event.clear()
+        return self.messages
+
+
+def test_roundtrip(provider: LoopbackProvider) -> None:
+    got = Collector()
+    provider.subscribe("test/topic", got)
+    provider.publish("test/topic", b"hello")
+    assert got.wait() == [(b"hello", "test/topic")]
+
+
+def test_topics_are_isolated(provider: LoopbackProvider) -> None:
+    got_a, got_b = Collector(), Collector()
+    provider.subscribe("test/a", got_a)
+    provider.subscribe("test/b", got_b)
+    provider.publish("test/a", b"for-a")
+    provider.publish("test/b", b"for-b")
+    assert got_a.wait() == [(b"for-a", "test/a")]
+    assert got_b.wait() == [(b"for-b", "test/b")]
+
+
+def test_large_message(provider: LoopbackProvider) -> None:
+    got = Collector()
+    provider.subscribe("test/large", got)
+    payload = bytes(range(256)) * 128  # 32 KiB through real SCTP fragmentation
+    provider.publish("test/large", payload)
+    assert got.wait() == [(payload, "test/large")]
+
+
+def test_unsubscribe_stops_delivery(provider: LoopbackProvider) -> None:
+    dropped, kept = Collector(), Collector()
+    unsub = provider.subscribe("test/topic", dropped)
+    provider.subscribe("test/topic", kept)
+    unsub()
+    provider.publish("test/topic", b"after-unsub")
+    kept.wait()
+    assert dropped.messages == []
+
+
+def test_restart_after_stop() -> None:
+    provider = LoopbackConfig().provider()
+    provider.start()
+    provider.stop()
+    provider.start()
+    try:
+        got = Collector()
+        provider.subscribe("test/restart", got)
+        provider.publish("test/restart", b"alive")
+        assert got.wait() == [(b"alive", "test/restart")]
+    finally:
+        provider.stop()
+
+
+def test_config_singleton() -> None:
+    assert LoopbackConfig().provider() is LoopbackConfig().provider()
+    assert LoopbackConfig(ordered=False).provider() is not LoopbackConfig().provider()

--- a/dimos/protocol/pubsub/test_spec.py
+++ b/dimos/protocol/pubsub/test_spec.py
@@ -169,6 +169,27 @@ testdata.append(
 )
 
 
+from dimos.protocol.pubsub.impl.webrtc.providers.spec import WEBRTC_AVAILABLE
+
+if WEBRTC_AVAILABLE:
+    from dimos.protocol.pubsub.impl.webrtc.providers.loopback import LoopbackConfig
+
+    @contextmanager
+    def webrtc_sctp_context() -> Generator[WebRTCPubSub, None, None]:
+        pubsub = WebRTCPubSub(provider=LoopbackConfig().provider())
+        pubsub.start()
+        yield pubsub
+        pubsub.stop()
+
+    testdata.append(
+        (
+            webrtc_sctp_context,
+            "test/sctp_topic",
+            [b"webrtc_sctp_value1", b"webrtc_sctp_value2", b"webrtc_sctp_value3"],
+        )
+    )
+
+
 @contextmanager
 def zenoh_lcm_context() -> Generator[Zenoh, None, None]:
     pool = ZenohSessionPool()


### PR DESCRIPTION
first chunk of the webrtc-as-full-transport-backend work. two peices, can split the transforms commit out if prefered.

**loopback provider** — keyless real-SCTP link for tests + benchmarks. full aiortc stack (dtls, sctp, localhost udp), no signaling server, no CF creds. unlike the in-memory mock this measures what a real datachannel actually does:

```
LoopbackConfig(ProviderConfig)              # frozen, picklable, singelton per process
  -> LoopbackProvider(AsyncProviderBase)
       _connect():
         pc_a, pc_b = RTCPeerConnection(iceServers=[])   # empty! aiortc defualt queries google stun -> exactly 5s stall per peer when blocked
         both.createDataChannel("_init", negotiated, id=0)   # forces the sctp m-line pre-offer
         offer/answer exchanged directly in process, host candidates only
       publish(topic, data):
         ch = channels[topic] or ensure_channel(topic)   # lazy negotiated pair, same id on both pcs
         loop.call_soon_threadsafe(ch.send, data)
       subscribe(topic, cb):
         callbacks[topic] += cb                          # recv-side pc dispatches on("message")
```

benchmarked (new WebrtcSctp row, keyless, runs anywhere): ~3.7k msg/s small msgs, ~20 MiB/s at 16-64KiB, 0% loss once the send queue drains. so raw Image/PointCloud2 over datachannels is dead — decimation / video track routing it is. thats the decision gate this was built to answer.

**transforms** — decimation/throttling as typed picklable callables that compose around *any* transport, not webrtc specific:

```
MsgTransform = (A) -> B | None          # None = drop the message
TransformTransport(inner, *fns)         # broadcast() applies fns in order, then delegates

("lidar", PointCloud2): TransformTransport(ZenohTransport(...), VoxelDownsample(0.05))
("color_image", Image): TransformTransport(WebRTCTransport(...), Throttle(5.0), ResizeImage(640, 480))
```

tests: 6 loopback units (event driven, no sleeps), real-sctp row in the shared pubsub contract grid, 6 transform units. full suite green locally (2510 passed). loopback tests add ~0.5s to CI.
