### PR TITLE
fix choppiness in rerun

### DIFF
--- a/dimos/msgs/tf2_msgs/TFMessage.py
+++ b/dimos/msgs/tf2_msgs/TFMessage.py
@@ -100,6 +100,11 @@ class TFMessage:
 
         return cls(*transforms)
 
+    @property
+    def ts(self) -> float:
+        """Latest transform timestamp, 0.0 when empty."""
+        return max((t.ts for t in self.transforms), default=0.0)
+
     def __len__(self) -> int:
         """Return number of transforms."""
         return len(self.transforms)

--- a/dimos/visualization/rerun/bridge.py
+++ b/dimos/visualization/rerun/bridge.py
@@ -137,9 +137,12 @@ def _hex_to_rgba(hex_color: str) -> int:
 
 
 def _set_rerun_message_time(msg: Any) -> None:
+    # set_time is sticky per-thread, so always stamp: a message without a
+    # usable ts must not inherit the previous message's timestamp.
     ts = getattr(msg, "ts", None)
-    if isinstance(ts, (int, float)) and ts > 0:
-        rr.set_time("dimos_time", timestamp=float(ts))
+    if not (isinstance(ts, (int, float)) and ts > 0):
+        ts = time.time()
+    rr.set_time("dimos_time", timestamp=float(ts))
 
 
 def _with_graph_tab(bp: Blueprint) -> Blueprint:


### PR DESCRIPTION
## Problem

Since https://github.com/dimensionalOS/dimos/pull/2594/changes , running `uv run dimos --replay run unitree-go2` produced choppy updates for the robot's position.

Closes DIM-XXX

## Solution

<!-- What you changed and why this approach -->
<!-- Key design decisions / tradeoffs -->
<!-- Keep it high-signal; deep planning belongs in the issue. -->

## How to Test

<!-- oneliner required to run the actual feature -->
<!-- blueprint for robot changes, benchmarks for transport changes etc -->

## Contributor License Agreement

- [ ] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
