### PR TITLE
Remove the dimos_time rerun timeline

### DIFF
--- a/dimos/visualization/rerun/bridge.py
+++ b/dimos/visualization/rerun/bridge.py
@@ -136,12 +136,6 @@ def _hex_to_rgba(hex_color: str) -> int:
     return int(h[:8], 16)
 
 
-def _set_rerun_message_time(msg: Any) -> None:
-    ts = getattr(msg, "ts", None)
-    if isinstance(ts, (int, float)) and ts > 0:
-        rr.set_time("dimos_time", timestamp=float(ts))
-
-
 def _with_graph_tab(bp: Blueprint) -> Blueprint:
     """Add a Graph tab alongside the existing viewer layout without changing it."""
 
@@ -344,8 +338,6 @@ class RerunBridgeModule(Module):
 
         if not rerun_data:
             return
-
-        _set_rerun_message_time(msg)
 
         # TFMessage for example returns list of (entity_path, archetype) tuples
         if is_rerun_multi(rerun_data):


### PR DESCRIPTION
## Problem

Since #2594, `uv run dimos --replay run unitree-go2` shows the robot box updating once per second (reported by @leshy, alternative fix by @paul-nechifor in #2809).

Root cause: #2594 added a helper that set a custom `dimos_time` timeline from `msg.ts` before each rerun log. Two problems combined:

- `rr.set_time` is sticky per thread: anything logged without announcing its own time gets filed at the last announced time.
- The helper only announced a time for messages with `ts > 0`, and `TFMessage` has no `ts` attribute at all.

So in the go2 replay every `/tf` pose got filed at the last `camera_info` stamp, which ticks at 1 Hz. The viewer auto-selects the custom timeline when one exists, so playback followed the barely-ticking clock.

The timeline itself came out of a June debugging session chasing G1 viewer jitter, which it did not fix (the actual fix was the sim arm hold task). Nothing else uses it.

## Solution

Delete the helper instead of completing it (#2809). Without a custom timeline the viewer is back on rerun's default arrival-time clock, which was already correct: the replayer paces messages at their recorded rhythm, and live data arrives in order. If we later want data-time scrubbing across topics, we can reintroduce it deliberately — with a `ts` on every message and an always-stamp contract, i.e. #2809 is the right shape for that.

## How to Test

`uv run dimos --replay run unitree-go2` — robot box, global map and camera all update smoothly.
`uv run dimos --simulation mujoco --scene-package office --viewer rerun --n-workers 12 run unitree-g1-groot-wbc -o mujocosimmodule.headless=true` — G1 animation unaffected.

## Contributor License Agreement

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)