### PR TITLE
Add blueprint smoke/performance logging tool

### DIFF
--- a/dimos/robot/test_tool_blueprint_perf.py
+++ b/dimos/robot/test_tool_blueprint_perf.py
@@ -223,6 +223,29 @@ def test_negative_tail_count_parse_error(flag: str) -> None:
         parse_args([flag, "-1"])
 
 
+@pytest.mark.parametrize(
+    ("flag", "value"),
+    [
+        ("--duration-seconds", "-1"),
+        ("--duration-seconds", "0"),
+        ("--duration-seconds", "nan"),
+        ("--duration-seconds", "inf"),
+        ("--duration-seconds", "-inf"),
+        ("--warmup-seconds", "-1"),
+        ("--warmup-seconds", "nan"),
+        ("--warmup-seconds", "inf"),
+        ("--warmup-seconds", "-inf"),
+        ("--command-timeout-seconds", "-1"),
+        ("--command-timeout-seconds", "nan"),
+        ("--command-timeout-seconds", "inf"),
+        ("--command-timeout-seconds", "-inf"),
+    ],
+)
+def test_invalid_runtime_float_parse_error(flag: str, value: str) -> None:
+    with pytest.raises(SystemExit, match="2"):
+        parse_args([flag, value])
+
+
 def test_main_returns_nonzero_on_startup_failure(tmp_path: Path, mocker) -> None:
     mocker.patch(
         "dimos.robot.tool_blueprint_perf.run_blueprint_perf",

--- a/dimos/robot/test_tool_blueprint_perf.py
+++ b/dimos/robot/test_tool_blueprint_perf.py
@@ -17,13 +17,17 @@ from __future__ import annotations
 from pathlib import Path
 import sys
 
-from dimos.robot.tool_blueprint_perf import ToolArgs, build_command, main, run_blueprint_perf
+import psutil
+import pytest
+
+from dimos.robot.tool_blueprint_perf import ToolArgs, build_command, main, parse_args, run_blueprint_perf
 
 
 def _make_args(tmp_path: Path, **kwargs: object) -> ToolArgs:
     return ToolArgs(
         blueprint=kwargs.get("blueprint", "unitree-go2"),  # type: ignore[arg-type]
         mode=kwargs.get("mode", "replay"),  # type: ignore[arg-type]
+        simulation_backend=kwargs.get("simulation_backend", "mujoco"),  # type: ignore[arg-type]
         viewer=kwargs.get("viewer", "none"),  # type: ignore[arg-type]
         duration_seconds=kwargs.get("duration_seconds", 0.2),  # type: ignore[arg-type]
         warmup_seconds=kwargs.get("warmup_seconds", 0.05),  # type: ignore[arg-type]
@@ -35,7 +39,9 @@ def _make_args(tmp_path: Path, **kwargs: object) -> ToolArgs:
 
 
 def test_build_command_replay() -> None:
-    assert build_command(blueprint="unitree-go2", mode="replay", viewer="none") == [
+    assert build_command(
+        blueprint="unitree-go2", mode="replay", simulation_backend="mujoco", viewer="none"
+    ) == [
         sys.executable,
         "-m",
         "dimos.robot.cli.dimos",
@@ -47,11 +53,16 @@ def test_build_command_replay() -> None:
 
 
 def test_build_command_simulation() -> None:
-    assert build_command(blueprint="unitree-g1-basic-sim", mode="simulation", viewer="rerun") == [
+    assert build_command(
+        blueprint="unitree-g1-basic-sim",
+        mode="simulation",
+        simulation_backend="mujoco",
+        viewer="rerun",
+    ) == [
         sys.executable,
         "-m",
         "dimos.robot.cli.dimos",
-        "--simulation=true",
+        "--simulation=mujoco",
         "--viewer=rerun",
         "run",
         "unitree-g1-basic-sim",
@@ -59,7 +70,9 @@ def test_build_command_simulation() -> None:
 
 
 def test_build_command_normal() -> None:
-    assert build_command(blueprint="unitree-go2", mode="normal", viewer="none") == [
+    assert build_command(
+        blueprint="unitree-go2", mode="normal", simulation_backend="mujoco", viewer="none"
+    ) == [
         sys.executable,
         "-m",
         "dimos.robot.cli.dimos",
@@ -92,6 +105,20 @@ def test_json_schema_shape(tmp_path: Path, mocker) -> None:
     assert "stdout" in result["logs"]
     assert "stderr" in result["logs"]
     assert args.output.exists()
+
+
+def test_json_output_creates_nested_parent_directory(tmp_path: Path, mocker) -> None:
+    code = "import time; print('ok'); time.sleep(0.1)"
+    mocker.patch(
+        "dimos.robot.tool_blueprint_perf.build_command",
+        return_value=[sys.executable, "-c", code],
+    )
+    output = tmp_path / "nested" / "dir" / "result.json"
+
+    result = run_blueprint_perf(_make_args(tmp_path, output=output))
+
+    assert result["run"]["blueprint"] == "unitree-go2"
+    assert output.exists()
 
 
 def test_log_tail_truncation(tmp_path: Path, mocker) -> None:
@@ -133,6 +160,46 @@ def test_startup_success_heuristic_for_bounded_run(tmp_path: Path, mocker) -> No
     assert result["run"]["returncode"] is not None
 
 
+def test_cpu_metrics_preserved_from_last_valid_sample(tmp_path: Path, mocker) -> None:
+    class FakeCpuTimes:
+        def __init__(self, user: float, system: float) -> None:
+            self.user = user
+            self.system = system
+
+    class FakePsProcess:
+        def __init__(self, _pid: int) -> None:
+            self._samples = [
+                FakeCpuTimes(1.0, 2.0),
+                FakeCpuTimes(3.5, 5.0),
+                FakeCpuTimes(4.0, 6.5),
+            ]
+            self._index = 0
+
+        def cpu_times(self):
+            if self._index >= len(self._samples):
+                raise psutil.NoSuchProcess(pid=123)
+            sample = self._samples[self._index]
+            self._index += 1
+            if isinstance(sample, Exception):
+                raise sample
+            return sample
+
+        def memory_info(self):
+            return mocker.Mock(rss=1234)
+
+    code = "import time; time.sleep(0.2)"
+    mocker.patch(
+        "dimos.robot.tool_blueprint_perf.build_command",
+        return_value=[sys.executable, "-c", code],
+    )
+    mocker.patch("dimos.robot.tool_blueprint_perf.psutil.Process", FakePsProcess)
+
+    result = run_blueprint_perf(_make_args(tmp_path, duration_seconds=0.1, warmup_seconds=0.05))
+
+    assert result["performance"]["cpu_user_seconds"] == 3.0
+    assert result["performance"]["cpu_system_seconds"] == 4.5
+
+
 def test_process_failure_before_warmup(tmp_path: Path, mocker) -> None:
     code = "import sys; print('boom', file=sys.stderr); sys.exit(7)"
     mocker.patch(
@@ -148,6 +215,12 @@ def test_process_failure_before_warmup(tmp_path: Path, mocker) -> None:
     assert result["run"]["exit_reason"] == "exited_before_warmup"
     assert result["run"]["returncode"] == 7
     assert "boom" in result["logs"]["stderr"]["tail_lines"]
+
+
+@pytest.mark.parametrize("flag", ["--stdout-tail-lines", "--stderr-tail-lines"])
+def test_negative_tail_count_parse_error(flag: str) -> None:
+    with pytest.raises(SystemExit, match="2"):
+        parse_args([flag, "-1"])
 
 
 def test_main_returns_nonzero_on_startup_failure(tmp_path: Path, mocker) -> None:

--- a/dimos/robot/test_tool_blueprint_perf.py
+++ b/dimos/robot/test_tool_blueprint_perf.py
@@ -1,0 +1,173 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+from dimos.robot.tool_blueprint_perf import ToolArgs, build_command, main, run_blueprint_perf
+
+
+def _make_args(tmp_path: Path, **kwargs: object) -> ToolArgs:
+    return ToolArgs(
+        blueprint=kwargs.get("blueprint", "unitree-go2"),  # type: ignore[arg-type]
+        mode=kwargs.get("mode", "replay"),  # type: ignore[arg-type]
+        viewer=kwargs.get("viewer", "none"),  # type: ignore[arg-type]
+        duration_seconds=kwargs.get("duration_seconds", 0.2),  # type: ignore[arg-type]
+        warmup_seconds=kwargs.get("warmup_seconds", 0.05),  # type: ignore[arg-type]
+        output=kwargs.get("output", tmp_path / "result.json"),  # type: ignore[arg-type]
+        command_timeout_seconds=kwargs.get("command_timeout_seconds", 0.2),  # type: ignore[arg-type]
+        stdout_tail_lines=kwargs.get("stdout_tail_lines", 10),  # type: ignore[arg-type]
+        stderr_tail_lines=kwargs.get("stderr_tail_lines", 10),  # type: ignore[arg-type]
+    )
+
+
+def test_build_command_replay() -> None:
+    assert build_command(blueprint="unitree-go2", mode="replay", viewer="none") == [
+        sys.executable,
+        "-m",
+        "dimos.robot.cli.dimos",
+        "--replay",
+        "--viewer=none",
+        "run",
+        "unitree-go2",
+    ]
+
+
+def test_build_command_simulation() -> None:
+    assert build_command(blueprint="unitree-g1-basic-sim", mode="simulation", viewer="rerun") == [
+        sys.executable,
+        "-m",
+        "dimos.robot.cli.dimos",
+        "--simulation=true",
+        "--viewer=rerun",
+        "run",
+        "unitree-g1-basic-sim",
+    ]
+
+
+def test_build_command_normal() -> None:
+    assert build_command(blueprint="unitree-go2", mode="normal", viewer="none") == [
+        sys.executable,
+        "-m",
+        "dimos.robot.cli.dimos",
+        "--viewer=none",
+        "run",
+        "unitree-go2",
+    ]
+
+
+def test_json_schema_shape(tmp_path: Path, mocker) -> None:
+    code = "import sys, time; print('ok'); print('warn', file=sys.stderr); time.sleep(0.2)"
+    mocker.patch(
+        "dimos.robot.tool_blueprint_perf.build_command",
+        return_value=[sys.executable, "-c", code],
+    )
+    args = _make_args(
+        tmp_path,
+        blueprint="unitree-go2",
+        mode="normal",
+        duration_seconds=0.2,
+        warmup_seconds=0.05,
+    )
+
+    result = run_blueprint_perf(args)
+
+    assert set(result) == {"metadata", "run", "performance", "logs"}
+    assert result["run"]["blueprint"] == "unitree-go2"
+    assert result["run"]["mode"] == "normal"
+    assert "wall_clock_seconds" in result["performance"]
+    assert "stdout" in result["logs"]
+    assert "stderr" in result["logs"]
+    assert args.output.exists()
+
+
+def test_log_tail_truncation(tmp_path: Path, mocker) -> None:
+    code = (
+        "import sys, time\n"
+        "for i in range(6):\n"
+        "    print(f'out-{i}')\n"
+        "    print(f'err-{i}', file=sys.stderr)\n"
+        "    sys.stdout.flush()\n"
+        "    sys.stderr.flush()\n"
+        "time.sleep(0.2)\n"
+    )
+    mocker.patch(
+        "dimos.robot.tool_blueprint_perf.build_command",
+        return_value=[sys.executable, "-c", code],
+    )
+    args = _make_args(tmp_path, stdout_tail_lines=3, stderr_tail_lines=2)
+
+    result = run_blueprint_perf(args)
+
+    assert result["logs"]["stdout"]["tail_lines"] == ["out-3", "out-4", "out-5"]
+    assert result["logs"]["stdout"]["truncated"] is True
+    assert result["logs"]["stderr"]["tail_lines"] == ["err-4", "err-5"]
+    assert result["logs"]["stderr"]["truncated"] is True
+
+
+def test_startup_success_heuristic_for_bounded_run(tmp_path: Path, mocker) -> None:
+    code = "import time; print('started'); time.sleep(0.3)"
+    mocker.patch(
+        "dimos.robot.tool_blueprint_perf.build_command",
+        return_value=[sys.executable, "-c", code],
+    )
+    args = _make_args(tmp_path, duration_seconds=0.15, warmup_seconds=0.05)
+
+    result = run_blueprint_perf(args)
+
+    assert result["run"]["startup_succeeded"] is True
+    assert result["run"]["completed_bounded_run"] is True
+    assert result["run"]["returncode"] is not None
+
+
+def test_process_failure_before_warmup(tmp_path: Path, mocker) -> None:
+    code = "import sys; print('boom', file=sys.stderr); sys.exit(7)"
+    mocker.patch(
+        "dimos.robot.tool_blueprint_perf.build_command",
+        return_value=[sys.executable, "-c", code],
+    )
+    args = _make_args(tmp_path, duration_seconds=0.3, warmup_seconds=0.2)
+
+    result = run_blueprint_perf(args)
+
+    assert result["run"]["startup_succeeded"] is False
+    assert result["run"]["completed_bounded_run"] is False
+    assert result["run"]["exit_reason"] == "exited_before_warmup"
+    assert result["run"]["returncode"] == 7
+    assert "boom" in result["logs"]["stderr"]["tail_lines"]
+
+
+def test_main_returns_nonzero_on_startup_failure(tmp_path: Path, mocker) -> None:
+    mocker.patch(
+        "dimos.robot.tool_blueprint_perf.run_blueprint_perf",
+        return_value={
+            "metadata": {},
+            "run": {"startup_succeeded": False},
+            "performance": {},
+            "logs": {},
+        },
+    )
+
+    rc = main(
+        [
+            "--blueprint",
+            "unitree-go2",
+            "--output",
+            str(tmp_path / "result.json"),
+        ]
+    )
+
+    assert rc == 1

--- a/dimos/robot/tool_blueprint_perf.py
+++ b/dimos/robot/tool_blueprint_perf.py
@@ -47,6 +47,7 @@ DEFAULT_OUTPUT = Path("blueprint_perf.json")
 class ToolArgs:
     blueprint: str
     mode: Mode
+    simulation_backend: str
     viewer: str
     duration_seconds: float
     warmup_seconds: float
@@ -76,15 +77,22 @@ class LineTail:
         }
 
 
-def build_command(*, blueprint: str, mode: Mode, viewer: str) -> list[str]:
+def build_command(*, blueprint: str, mode: Mode, simulation_backend: str, viewer: str) -> list[str]:
     cmd = [sys.executable, "-m", "dimos.robot.cli.dimos"]
     if mode == "replay":
         cmd.extend(["--replay", f"--viewer={viewer}", "run", blueprint])
     elif mode == "simulation":
-        cmd.extend(["--simulation=true", f"--viewer={viewer}", "run", blueprint])
+        cmd.extend([f"--simulation={simulation_backend}", f"--viewer={viewer}", "run", blueprint])
     else:
         cmd.extend([f"--viewer={viewer}", "run", blueprint])
     return cmd
+
+
+def _nonnegative_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 0:
+        raise ValueError("must be >= 0")
+    return parsed
 
 
 def parse_args(argv: Sequence[str] | None = None) -> ToolArgs:
@@ -99,6 +107,11 @@ def parse_args(argv: Sequence[str] | None = None) -> ToolArgs:
         choices=("replay", "simulation", "normal"),
         default=DEFAULT_MODE,
         help="How to construct the DimOS command.",
+    )
+    parser.add_argument(
+        "--simulation-backend",
+        default="mujoco",
+        help="Simulation backend name to pass when --mode=simulation.",
     )
     parser.add_argument("--viewer", default=DEFAULT_VIEWER, help="Viewer mode to pass to DimOS.")
     parser.add_argument(
@@ -127,21 +140,25 @@ def parse_args(argv: Sequence[str] | None = None) -> ToolArgs:
     )
     parser.add_argument(
         "--stdout-tail-lines",
-        type=int,
+        type=_nonnegative_int,
         default=DEFAULT_STDOUT_TAIL_LINES,
         help="How many stdout lines to keep in the JSON tail.",
     )
     parser.add_argument(
         "--stderr-tail-lines",
-        type=int,
+        type=_nonnegative_int,
         default=DEFAULT_STDERR_TAIL_LINES,
         help="How many stderr lines to keep in the JSON tail.",
     )
 
-    ns = parser.parse_args(argv)
+    try:
+        ns = parser.parse_args(argv)
+    except ValueError as exc:
+        parser.error(str(exc))
     return ToolArgs(
         blueprint=ns.blueprint,
         mode=ns.mode,
+        simulation_backend=ns.simulation_backend,
         viewer=ns.viewer,
         duration_seconds=ns.duration_seconds,
         warmup_seconds=ns.warmup_seconds,
@@ -180,7 +197,12 @@ def _tail_file(stream: Any, max_lines: int) -> dict[str, Any]:
 
 
 def run_blueprint_perf(args: ToolArgs) -> dict[str, Any]:
-    command = build_command(blueprint=args.blueprint, mode=args.mode, viewer=args.viewer)
+    command = build_command(
+        blueprint=args.blueprint,
+        mode=args.mode,
+        simulation_backend=args.simulation_backend,
+        viewer=args.viewer,
+    )
     started_at = datetime.now(UTC)
     monotonic_start = time.monotonic()
     with (
@@ -196,6 +218,8 @@ def run_blueprint_perf(args: ToolArgs) -> dict[str, Any]:
     ):
         ps_proc = psutil.Process(proc.pid)
         cpu_user_start, cpu_system_start = _safe_cpu_times(ps_proc)
+        last_cpu_user = cpu_user_start
+        last_cpu_system = cpu_system_start
         peak_rss_bytes = 0
         survived_past_warmup = False
         warmup_reached_at: float | None = None
@@ -226,8 +250,18 @@ def run_blueprint_perf(args: ToolArgs) -> dict[str, Any]:
                     peak_rss_bytes = max(peak_rss_bytes, rss)
                 except (psutil.Error, OSError):
                     pass
+                cpu_user_sample, cpu_system_sample = _safe_cpu_times(ps_proc)
+                if cpu_user_sample is not None:
+                    last_cpu_user = cpu_user_sample
+                if cpu_system_sample is not None:
+                    last_cpu_system = cpu_system_sample
 
                 if elapsed >= args.duration_seconds:
+                    cpu_user_sample, cpu_system_sample = _safe_cpu_times(ps_proc)
+                    if cpu_user_sample is not None:
+                        last_cpu_user = cpu_user_sample
+                    if cpu_system_sample is not None:
+                        last_cpu_system = cpu_system_sample
                     exit_reason, escalated_to_kill = _terminate_process(
                         proc, args.command_timeout_seconds
                     )
@@ -237,16 +271,30 @@ def run_blueprint_perf(args: ToolArgs) -> dict[str, Any]:
                 time.sleep(0.05)
         finally:
             if proc.poll() is None:
+                cpu_user_sample, cpu_system_sample = _safe_cpu_times(ps_proc)
+                if cpu_user_sample is not None:
+                    last_cpu_user = cpu_user_sample
+                if cpu_system_sample is not None:
+                    last_cpu_system = cpu_system_sample
                 exit_reason, escalated_to_kill = _terminate_process(
                     proc, args.command_timeout_seconds
                 )
                 terminated = True
             else:
+                cpu_user_sample, cpu_system_sample = _safe_cpu_times(ps_proc)
+                if cpu_user_sample is not None:
+                    last_cpu_user = cpu_user_sample
+                if cpu_system_sample is not None:
+                    last_cpu_system = cpu_system_sample
                 proc.wait()
 
         ended_at = datetime.now(UTC)
         wall_clock_seconds = time.monotonic() - monotonic_start
         cpu_user_end, cpu_system_end = _safe_cpu_times(ps_proc)
+        if cpu_user_end is None:
+            cpu_user_end = last_cpu_user
+        if cpu_system_end is None:
+            cpu_system_end = last_cpu_system
         pid = proc.pid
         returncode = proc.returncode
         stdout_snapshot = _tail_file(stdout_file, args.stdout_tail_lines)
@@ -273,6 +321,7 @@ def run_blueprint_perf(args: ToolArgs) -> dict[str, Any]:
             "command": command,
             "blueprint": args.blueprint,
             "mode": args.mode,
+            "simulation_backend": args.simulation_backend,
             "viewer": args.viewer,
             "pid": pid,
             "started_at": started_at.isoformat(),
@@ -299,6 +348,7 @@ def run_blueprint_perf(args: ToolArgs) -> dict[str, Any]:
             "stderr": stderr_snapshot,
         },
     }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(json.dumps(result, indent=2) + "\n")
     return result
 

--- a/dimos/robot/tool_blueprint_perf.py
+++ b/dimos/robot/tool_blueprint_perf.py
@@ -21,6 +21,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 import json
+import math
 from pathlib import Path
 import subprocess
 import sys
@@ -95,6 +96,20 @@ def _nonnegative_int(value: str) -> int:
     return parsed
 
 
+def _positive_finite_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed) or parsed <= 0:
+        raise ValueError("must be finite and > 0")
+    return parsed
+
+
+def _nonnegative_finite_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed) or parsed < 0:
+        raise ValueError("must be finite and >= 0")
+    return parsed
+
+
 def parse_args(argv: Sequence[str] | None = None) -> ToolArgs:
     import argparse
 
@@ -116,13 +131,13 @@ def parse_args(argv: Sequence[str] | None = None) -> ToolArgs:
     parser.add_argument("--viewer", default=DEFAULT_VIEWER, help="Viewer mode to pass to DimOS.")
     parser.add_argument(
         "--duration-seconds",
-        type=float,
+        type=_positive_finite_float,
         default=DEFAULT_DURATION_SECONDS,
         help="How long to let the command run before terminating it.",
     )
     parser.add_argument(
         "--warmup-seconds",
-        type=float,
+        type=_nonnegative_finite_float,
         default=DEFAULT_WARMUP_SECONDS,
         help="How long the process must stay alive to count startup as successful.",
     )
@@ -134,7 +149,7 @@ def parse_args(argv: Sequence[str] | None = None) -> ToolArgs:
     )
     parser.add_argument(
         "--command-timeout-seconds",
-        type=float,
+        type=_nonnegative_finite_float,
         default=DEFAULT_COMMAND_TIMEOUT_SECONDS,
         help="How long to wait after terminate() before escalating to kill().",
     )

--- a/dimos/robot/tool_blueprint_perf.py
+++ b/dimos/robot/tool_blueprint_perf.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import time
+from typing import Any, Literal
+
+import psutil
+
+Mode = Literal["replay", "simulation", "normal"]
+
+DEFAULT_BLUEPRINT = "unitree-go2"
+DEFAULT_MODE: Mode = "replay"
+DEFAULT_VIEWER = "none"
+DEFAULT_DURATION_SECONDS = 10.0
+DEFAULT_WARMUP_SECONDS = 3.0
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 10.0
+DEFAULT_STDOUT_TAIL_LINES = 50
+DEFAULT_STDERR_TAIL_LINES = 50
+DEFAULT_OUTPUT = Path("blueprint_perf.json")
+
+
+@dataclass(frozen=True)
+class ToolArgs:
+    blueprint: str
+    mode: Mode
+    viewer: str
+    duration_seconds: float
+    warmup_seconds: float
+    output: Path
+    command_timeout_seconds: float
+    stdout_tail_lines: int
+    stderr_tail_lines: int
+
+
+class LineTail:
+    """Keep only the most recent lines from a stream."""
+
+    def __init__(self, max_lines: int) -> None:
+        self._max_lines = max_lines
+        self._lines: deque[str] = deque(maxlen=max_lines)
+        self._total_lines = 0
+    def add(self, line: str) -> None:
+        self._total_lines += 1
+        self._lines.append(line.rstrip("\n"))
+
+    def snapshot(self) -> dict[str, Any]:
+        return {
+            "tail_lines": list(self._lines),
+            "tail_line_count": len(self._lines),
+            "total_line_count": self._total_lines,
+            "truncated": self._total_lines > self._max_lines,
+        }
+
+
+def build_command(*, blueprint: str, mode: Mode, viewer: str) -> list[str]:
+    cmd = [sys.executable, "-m", "dimos.robot.cli.dimos"]
+    if mode == "replay":
+        cmd.extend(["--replay", f"--viewer={viewer}", "run", blueprint])
+    elif mode == "simulation":
+        cmd.extend(["--simulation=true", f"--viewer={viewer}", "run", blueprint])
+    else:
+        cmd.extend([f"--viewer={viewer}", "run", blueprint])
+    return cmd
+
+
+def parse_args(argv: Sequence[str] | None = None) -> ToolArgs:
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Run a bounded DimOS blueprint CLI smoke/performance subprocess."
+    )
+    parser.add_argument("--blueprint", default=DEFAULT_BLUEPRINT, help="Blueprint to run.")
+    parser.add_argument(
+        "--mode",
+        choices=("replay", "simulation", "normal"),
+        default=DEFAULT_MODE,
+        help="How to construct the DimOS command.",
+    )
+    parser.add_argument("--viewer", default=DEFAULT_VIEWER, help="Viewer mode to pass to DimOS.")
+    parser.add_argument(
+        "--duration-seconds",
+        type=float,
+        default=DEFAULT_DURATION_SECONDS,
+        help="How long to let the command run before terminating it.",
+    )
+    parser.add_argument(
+        "--warmup-seconds",
+        type=float,
+        default=DEFAULT_WARMUP_SECONDS,
+        help="How long the process must stay alive to count startup as successful.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help="Where to write the structured JSON result.",
+    )
+    parser.add_argument(
+        "--command-timeout-seconds",
+        type=float,
+        default=DEFAULT_COMMAND_TIMEOUT_SECONDS,
+        help="How long to wait after terminate() before escalating to kill().",
+    )
+    parser.add_argument(
+        "--stdout-tail-lines",
+        type=int,
+        default=DEFAULT_STDOUT_TAIL_LINES,
+        help="How many stdout lines to keep in the JSON tail.",
+    )
+    parser.add_argument(
+        "--stderr-tail-lines",
+        type=int,
+        default=DEFAULT_STDERR_TAIL_LINES,
+        help="How many stderr lines to keep in the JSON tail.",
+    )
+
+    ns = parser.parse_args(argv)
+    return ToolArgs(
+        blueprint=ns.blueprint,
+        mode=ns.mode,
+        viewer=ns.viewer,
+        duration_seconds=ns.duration_seconds,
+        warmup_seconds=ns.warmup_seconds,
+        output=ns.output,
+        command_timeout_seconds=ns.command_timeout_seconds,
+        stdout_tail_lines=ns.stdout_tail_lines,
+        stderr_tail_lines=ns.stderr_tail_lines,
+    )
+
+
+def _terminate_process(proc: subprocess.Popen[str], timeout_seconds: float) -> tuple[str, bool]:
+    proc.terminate()
+    try:
+        proc.wait(timeout=timeout_seconds)
+        return ("terminated", False)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+        return ("killed_after_timeout", True)
+
+
+def _safe_cpu_times(proc: psutil.Process) -> tuple[float | None, float | None]:
+    try:
+        cpu = proc.cpu_times()
+    except (psutil.Error, OSError):
+        return (None, None)
+    return (cpu.user, cpu.system)
+
+
+def _tail_file(stream: Any, max_lines: int) -> dict[str, Any]:
+    tail = LineTail(max_lines)
+    stream.seek(0)
+    for line in stream:
+        tail.add(line)
+    return tail.snapshot()
+
+
+def run_blueprint_perf(args: ToolArgs) -> dict[str, Any]:
+    command = build_command(blueprint=args.blueprint, mode=args.mode, viewer=args.viewer)
+    started_at = datetime.now(UTC)
+    monotonic_start = time.monotonic()
+    with (
+        tempfile.TemporaryFile(mode="w+t") as stdout_file,
+        tempfile.TemporaryFile(mode="w+t") as stderr_file,
+        subprocess.Popen(
+            command,
+            stdout=stdout_file,
+            stderr=stderr_file,
+            stdin=subprocess.DEVNULL,
+            text=True,
+        ) as proc,
+    ):
+        ps_proc = psutil.Process(proc.pid)
+        cpu_user_start, cpu_system_start = _safe_cpu_times(ps_proc)
+        peak_rss_bytes = 0
+        survived_past_warmup = False
+        warmup_reached_at: float | None = None
+        exit_reason = "completed_bounded_duration"
+        terminated = False
+        escalated_to_kill = False
+
+        try:
+            while True:
+                elapsed = time.monotonic() - monotonic_start
+                returncode = proc.poll()
+
+                if returncode is not None:
+                    if elapsed < args.warmup_seconds:
+                        exit_reason = "exited_before_warmup"
+                    else:
+                        survived_past_warmup = True
+                        warmup_reached_at = args.warmup_seconds
+                        exit_reason = "exited_after_warmup"
+                    break
+
+                if not survived_past_warmup and elapsed >= args.warmup_seconds:
+                    survived_past_warmup = True
+                    warmup_reached_at = elapsed
+
+                try:
+                    rss = ps_proc.memory_info().rss
+                    peak_rss_bytes = max(peak_rss_bytes, rss)
+                except (psutil.Error, OSError):
+                    pass
+
+                if elapsed >= args.duration_seconds:
+                    exit_reason, escalated_to_kill = _terminate_process(
+                        proc, args.command_timeout_seconds
+                    )
+                    terminated = True
+                    break
+
+                time.sleep(0.05)
+        finally:
+            if proc.poll() is None:
+                exit_reason, escalated_to_kill = _terminate_process(
+                    proc, args.command_timeout_seconds
+                )
+                terminated = True
+            else:
+                proc.wait()
+
+        ended_at = datetime.now(UTC)
+        wall_clock_seconds = time.monotonic() - monotonic_start
+        cpu_user_end, cpu_system_end = _safe_cpu_times(ps_proc)
+        pid = proc.pid
+        returncode = proc.returncode
+        stdout_snapshot = _tail_file(stdout_file, args.stdout_tail_lines)
+        stderr_snapshot = _tail_file(stderr_file, args.stderr_tail_lines)
+
+    startup_succeeded = survived_past_warmup
+    completed_bounded_run = survived_past_warmup and terminated
+
+    cpu_user_seconds = None
+    if cpu_user_start is not None and cpu_user_end is not None:
+        cpu_user_seconds = max(0.0, cpu_user_end - cpu_user_start)
+
+    cpu_system_seconds = None
+    if cpu_system_start is not None and cpu_system_end is not None:
+        cpu_system_seconds = max(0.0, cpu_system_end - cpu_system_start)
+
+    result = {
+        "metadata": {
+            "tool": "dimos.robot.tool_blueprint_perf",
+            "generated_at": ended_at.isoformat(),
+            "python_executable": sys.executable,
+        },
+        "run": {
+            "command": command,
+            "blueprint": args.blueprint,
+            "mode": args.mode,
+            "viewer": args.viewer,
+            "pid": pid,
+            "started_at": started_at.isoformat(),
+            "ended_at": ended_at.isoformat(),
+            "duration_seconds": args.duration_seconds,
+            "warmup_seconds": args.warmup_seconds,
+            "command_timeout_seconds": args.command_timeout_seconds,
+            "returncode": returncode,
+            "exit_reason": exit_reason,
+            "startup_succeeded": startup_succeeded,
+            "completed_bounded_run": completed_bounded_run,
+            "survived_past_warmup": survived_past_warmup,
+            "warmup_reached_at_seconds": warmup_reached_at,
+            "escalated_to_kill": escalated_to_kill,
+        },
+        "performance": {
+            "wall_clock_seconds": wall_clock_seconds,
+            "peak_rss_bytes": peak_rss_bytes,
+            "cpu_user_seconds": cpu_user_seconds,
+            "cpu_system_seconds": cpu_system_seconds,
+        },
+        "logs": {
+            "stdout": stdout_snapshot,
+            "stderr": stderr_snapshot,
+        },
+    }
+    args.output.write_text(json.dumps(result, indent=2) + "\n")
+    return result
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    result = run_blueprint_perf(args)
+    print(json.dumps(result["run"], indent=2))
+    return 0 if result["run"]["startup_succeeded"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/development/profiling_dimos.md
+++ b/docs/development/profiling_dimos.md
@@ -9,3 +9,11 @@ uv run py-spy record --format speedscope --subprocesses -o profile.speedscope.js
 ```
 
 Hit `Ctrl+C` when you're done. It will write a `profile.speedscope.json` file which you can upload to [speedscope.app](https://www.speedscope.app/) to visualize it.
+
+Before using `py-spy`, it is often useful to first run the bounded subprocess smoke/perf harness in [dimos/robot/tool_blueprint_perf.py](/dimos/robot/tool_blueprint_perf.py). That gives you a cheap way to confirm that a blueprint starts at all, survives warmup, and captures basic CPU/memory signals plus bounded stdout/stderr tails.
+
+```bash
+uv run python -m dimos.robot.tool_blueprint_perf --blueprint unitree-go2 --mode replay --viewer none --output /tmp/unitree-go2.json
+```
+
+Use that tool to identify which blueprint or mode is slow or unstable first. Then switch to `py-spy` for deeper profiling of the specific command you care about.

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -179,6 +179,13 @@ pytest -s dimos/path/to/tool_file.py
 
 (`-s` keeps stdout/stdin open for prints and interactive input; add `--timeout=0` for long-running or interactive ones.)
 
+One useful example is [dimos/robot/tool_blueprint_perf.py](/dimos/robot/tool_blueprint_perf.py), a dev-only full-blueprint smoke/perf harness that exercises the real user CLI path in a subprocess for a bounded duration and writes structured JSON. It is intentionally separate from normal pytest collection.
+
+```bash
+uv run python -m dimos.robot.tool_blueprint_perf
+uv run python -m dimos.robot.tool_blueprint_perf --blueprint unitree-go2 --mode replay --viewer none --output /tmp/unitree-go2.json
+```
+
 ## Markers
 
 We have a few markers in use now.


### PR DESCRIPTION
## Summary

Adds a lightweight dev-only tool for bounded full-blueprint smoke/performance runs.

The tool exercises the real DimOS CLI path in a subprocess, for example:

```bash
uv run python -m dimos.robot.tool_blueprint_perf \
  --blueprint unitree-go2 \
  --mode replay \
  --viewer none \
  --duration-seconds 20 \
  --output /tmp/unitree-go2-blueprint-perf.json