### PR TITLE
fix(config): merge nested module overrides

### DIFF
--- a/dimos/core/coordination/test_worker.py
+++ b/dimos/core/coordination/test_worker.py
@@ -14,16 +14,14 @@
 
 from typing import TYPE_CHECKING
 
-from pydantic import Field
 import pytest
 
-from dimos.core.coordination.worker_manager_python import WorkerManagerPython, _merge_config_kwargs
+from dimos.core.coordination.worker_manager_python import WorkerManagerPython
 from dimos.core.core import rpc
 from dimos.core.global_config import GlobalConfig, global_config
-from dimos.core.module import Module, ModuleConfig
+from dimos.core.module import Module
 from dimos.core.stream import In, Out
 from dimos.msgs.geometry_msgs.Vector3 import Vector3
-from dimos.protocol.service.spec import BaseConfig
 
 if TYPE_CHECKING:
     from dimos.core.resource_monitor.stats import WorkerStats
@@ -81,15 +79,6 @@ class ThirdModule(Module):
     @rpc
     def get_multiplier(self) -> int:
         return self.multiplier
-
-
-class NestedConfig(BaseConfig):
-    a: int = 0
-    b: int = 2
-
-
-class ModuleWithNestedConfig(ModuleConfig):
-    sub: NestedConfig = Field(default_factory=lambda: NestedConfig(a=10, b=20))
 
 
 class HeavyModule(Module):
@@ -198,17 +187,6 @@ def test_worker_manager_parallel_deployment(create_worker_manager):
     module1.stop()
     module2.stop()
     module3.stop()
-
-
-def test_nested_blueprint_config_defaults_survive_cli_override():
-    blueprint_kwargs = {"sub": NestedConfig(a=10, b=20)}
-    cli_kwargs = {"sub": {"a": "1"}}
-
-    merged = _merge_config_kwargs(blueprint_kwargs, cli_kwargs)
-    config = ModuleWithNestedConfig(**merged)
-
-    assert config.sub.a == 1
-    assert config.sub.b == 20
 
 
 @pytest.mark.skipif_macos_bug

--- a/dimos/core/coordination/test_worker.py
+++ b/dimos/core/coordination/test_worker.py
@@ -14,14 +14,16 @@
 
 from typing import TYPE_CHECKING
 
+from pydantic import Field
 import pytest
 
-from dimos.core.coordination.worker_manager_python import WorkerManagerPython
+from dimos.core.coordination.worker_manager_python import WorkerManagerPython, _merge_config_kwargs
 from dimos.core.core import rpc
 from dimos.core.global_config import GlobalConfig, global_config
-from dimos.core.module import Module
+from dimos.core.module import Module, ModuleConfig
 from dimos.core.stream import In, Out
 from dimos.msgs.geometry_msgs.Vector3 import Vector3
+from dimos.protocol.service.spec import BaseConfig
 
 if TYPE_CHECKING:
     from dimos.core.resource_monitor.stats import WorkerStats
@@ -79,6 +81,15 @@ class ThirdModule(Module):
     @rpc
     def get_multiplier(self) -> int:
         return self.multiplier
+
+
+class NestedConfig(BaseConfig):
+    a: int = 0
+    b: int = 2
+
+
+class ModuleWithNestedConfig(ModuleConfig):
+    sub: NestedConfig = Field(default_factory=lambda: NestedConfig(a=10, b=20))
 
 
 class HeavyModule(Module):
@@ -187,6 +198,17 @@ def test_worker_manager_parallel_deployment(create_worker_manager):
     module1.stop()
     module2.stop()
     module3.stop()
+
+
+def test_nested_blueprint_config_defaults_survive_cli_override():
+    blueprint_kwargs = {"sub": NestedConfig(a=10, b=20)}
+    cli_kwargs = {"sub": {"a": "1"}}
+
+    merged = _merge_config_kwargs(blueprint_kwargs, cli_kwargs)
+    config = ModuleWithNestedConfig(**merged)
+
+    assert config.sub.a == 1
+    assert config.sub.b == 20
 
 
 @pytest.mark.skipif_macos_bug

--- a/dimos/core/coordination/worker_manager_python.py
+++ b/dimos/core/coordination/worker_manager_python.py
@@ -17,8 +17,6 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping
 from typing import TYPE_CHECKING, Any
 
-from pydantic import BaseModel
-
 from dimos.core.coordination.python_worker import PythonWorker
 from dimos.core.global_config import GlobalConfig
 from dimos.core.module import ModuleBase, ModuleSpec
@@ -42,9 +40,6 @@ def _merge_config_kwargs(base: Mapping[str, Any], overrides: Mapping[str, Any]) 
 def _merge_config_value(base_value: Any, override_value: Any) -> Any:
     if not isinstance(override_value, Mapping):
         return override_value
-
-    if isinstance(base_value, BaseModel):
-        base_value = base_value.model_dump(mode="python")
 
     if not isinstance(base_value, Mapping):
         return dict(override_value)

--- a/dimos/core/coordination/worker_manager_python.py
+++ b/dimos/core/coordination/worker_manager_python.py
@@ -49,14 +49,7 @@ def _merge_config_value(base_value: Any, override_value: Any) -> Any:
     if not isinstance(base_value, Mapping):
         return dict(override_value)
 
-    if _changes_backend(base_value, override_value):
-        return dict(override_value)
-
     return _merge_config_kwargs(base_value, override_value)
-
-
-def _changes_backend(base: Mapping[str, Any], overrides: Mapping[str, Any]) -> bool:
-    return "backend" in base and "backend" in overrides and base["backend"] != overrides["backend"]
 
 
 class WorkerManagerPython:

--- a/dimos/core/coordination/worker_manager_python.py
+++ b/dimos/core/coordination/worker_manager_python.py
@@ -33,18 +33,12 @@ logger = setup_logger()
 def _merge_config_kwargs(base: Mapping[str, Any], overrides: Mapping[str, Any]) -> dict[str, Any]:
     merged = dict(base)
     for key, override_value in overrides.items():
-        merged[key] = _merge_config_value(merged.get(key), override_value)
+        base_value = merged.get(key)
+        if isinstance(base_value, Mapping) and isinstance(override_value, Mapping):
+            merged[key] = _merge_config_kwargs(base_value, override_value)
+        else:
+            merged[key] = override_value
     return merged
-
-
-def _merge_config_value(base_value: Any, override_value: Any) -> Any:
-    if not isinstance(override_value, Mapping):
-        return override_value
-
-    if not isinstance(base_value, Mapping):
-        return dict(override_value)
-
-    return _merge_config_kwargs(base_value, override_value)
 
 
 class WorkerManagerPython:

--- a/dimos/core/coordination/worker_manager_python.py
+++ b/dimos/core/coordination/worker_manager_python.py
@@ -183,11 +183,7 @@ class WorkerManagerPython:
             module_class, _, kwargs = specs[i]
             worker = self._select_worker(dedicated=module_class.dedicated_worker)
             worker.reserve_slot()
-            specs[i] = (
-                specs[i][0],
-                specs[i][1],
-                _merge_config_kwargs(kwargs, blueprint_args.get(module_class.name, {})),
-            )
+            kwargs.update(_merge_config_kwargs(kwargs, blueprint_args.get(module_class.name, {})))
             workers_by_index[i] = worker
 
         assignments = [(workers_by_index[i], specs[i]) for i in range(len(specs))]

--- a/dimos/core/coordination/worker_manager_python.py
+++ b/dimos/core/coordination/worker_manager_python.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping
 from typing import TYPE_CHECKING, Any
 
+from pydantic import BaseModel
+
 from dimos.core.coordination.python_worker import PythonWorker
 from dimos.core.global_config import GlobalConfig
 from dimos.core.module import ModuleBase, ModuleSpec
@@ -28,6 +30,33 @@ if TYPE_CHECKING:
     from dimos.core.resource_monitor.monitor import StatsMonitor
 
 logger = setup_logger()
+
+
+def _merge_config_kwargs(base: Mapping[str, Any], overrides: Mapping[str, Any]) -> dict[str, Any]:
+    merged = dict(base)
+    for key, override_value in overrides.items():
+        merged[key] = _merge_config_value(merged.get(key), override_value)
+    return merged
+
+
+def _merge_config_value(base_value: Any, override_value: Any) -> Any:
+    if not isinstance(override_value, Mapping):
+        return override_value
+
+    if isinstance(base_value, BaseModel):
+        base_value = base_value.model_dump(mode="python")
+
+    if not isinstance(base_value, Mapping):
+        return dict(override_value)
+
+    if _changes_backend(base_value, override_value):
+        return dict(override_value)
+
+    return _merge_config_kwargs(base_value, override_value)
+
+
+def _changes_backend(base: Mapping[str, Any], overrides: Mapping[str, Any]) -> bool:
+    return "backend" in base and "backend" in overrides and base["backend"] != overrides["backend"]
 
 
 class WorkerManagerPython:
@@ -161,7 +190,11 @@ class WorkerManagerPython:
             module_class, _, kwargs = specs[i]
             worker = self._select_worker(dedicated=module_class.dedicated_worker)
             worker.reserve_slot()
-            kwargs.update(blueprint_args.get(module_class.name, {}))
+            specs[i] = (
+                specs[i][0],
+                specs[i][1],
+                _merge_config_kwargs(kwargs, blueprint_args.get(module_class.name, {})),
+            )
             workers_by_index[i] = worker
 
         assignments = [(workers_by_index[i], specs[i]) for i in range(len(specs))]

--- a/dimos/robot/cli/test_dimos.py
+++ b/dimos/robot/cli/test_dimos.py
@@ -20,9 +20,10 @@ import pytest
 from typer.testing import CliRunner
 
 from dimos.core.coordination.blueprints import autoconnect
+import dimos.core.coordination.worker_manager_python as worker_manager_python
 from dimos.core.global_config import global_config
 from dimos.core.module import Module, ModuleConfig
-from dimos.robot.cli.dimos import _normalize_simulation_argv, arg_help, main
+from dimos.robot.cli.dimos import _normalize_simulation_argv, arg_help, load_config_args, main
 import dimos.utils.cli.spy.run_spy as run_spy
 
 
@@ -259,3 +260,46 @@ def test_blueprint_arg_help_uses_nested_backend_defaults():
         in output
     )
     assert "        * testmodule.nested.level: int (default: 3)" in output
+
+
+def test_nested_blueprint_config_defaults_survive_cli_override(tmp_path, monkeypatch):
+    class NestedConfig(BaseModel):
+        enabled: bool = True
+        mode: str = "auto"
+
+    class Config(ModuleConfig):
+        nested: NestedConfig = Field(default_factory=NestedConfig)
+
+    class TestModule(Module):
+        config: Config
+
+    class FakeWorker:
+        dedicated = False
+        module_count = 0
+
+        def reserve_slot(self):
+            self.module_count += 1
+
+        def deploy_module(self, _module_class, _global_config, kwargs):
+            return kwargs
+
+    monkeypatch.setattr(worker_manager_python, "RPCClient", lambda actor, _module_class: actor)
+
+    blueprint = TestModule.blueprint(nested=NestedConfig(mode="manual"))
+    blueprint_args = load_config_args(
+        blueprint.config(),
+        ["testmodule.nested.enabled=false"],
+        tmp_path / "config.json",
+    )
+    worker_manager = worker_manager_python.WorkerManagerPython(global_config)
+    worker_manager._started = True
+    worker_manager._workers = [FakeWorker()]
+
+    deployed_configs = worker_manager.deploy_parallel(
+        [(TestModule, global_config, blueprint.blueprints[0].kwargs.copy())],
+        blueprint_args,
+    )
+    config = Config(**deployed_configs[0])
+
+    assert config.nested.enabled is False
+    assert config.nested.mode == "manual"

--- a/dimos/robot/cli/test_dimos.py
+++ b/dimos/robot/cli/test_dimos.py
@@ -285,7 +285,7 @@ def test_nested_blueprint_config_defaults_survive_cli_override(tmp_path, monkeyp
 
     monkeypatch.setattr(worker_manager_python, "RPCClient", lambda actor, _module_class: actor)
 
-    blueprint = TestModule.blueprint(nested=NestedConfig(mode="manual"))
+    blueprint = TestModule.blueprint(nested={"mode": "manual"})
     blueprint_args = load_config_args(
         blueprint.config(),
         ["testmodule.nested.enabled=false"],


### PR DESCRIPTION
## Problem

Nested Pydantic blueprint config objects are replaced by partial dotted CLI override dicts because deployment used a shallow `dict.update`. That drops blueprint-provided nested defaults.

Closes: N/A

## Solution

Recursively merge module deployment kwargs before Python module deployment. Non-mapping overrides still replace the existing value.

## How to Test

```bash
uv run pytest dimos/robot/cli/test_dimos.py -k 'nested_blueprint_config_defaults_survive_cli_override or blueprint_arg_help_nested_config_paths or blueprint_arg_help_uses_nested_backend_defaults'
uv run pytest dimos/core/coordination/test_worker.py -k worker_manager_parallel_deployment
uv run ruff check dimos/core/coordination/worker_manager_python.py dimos/core/coordination/test_worker.py dimos/robot/cli/test_dimos.py
```

## Contributor License Agreement

- [ ] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
