### PR TITLE
fix(arduino): give _FakeTransport the channel property _collect_topics reads

### DIFF
--- a/dimos/experimental/arduino/test_arduino_module.py
+++ b/dimos/experimental/arduino/test_arduino_module.py
@@ -394,6 +394,10 @@ class _FakeTransport:
     def __init__(self, topic: str) -> None:
         self.topic = topic
 
+    @property
+    def channel(self) -> str:
+        return str(self.topic)
+
     def stop(self) -> None:
         pass
 


### PR DESCRIPTION
#2753 switched `NativeModule._collect_topics` to read `transport.channel`; the arduino tests (#1879) were developed against the older `.topic` attribute and merged after, so `_FakeTransport` resolves to an empty topic map — 3 tests red on main, blocking every PR's CI.

One-line fix: mirror `PubSubTransport.channel` on the fake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)