### PR TITLE
Velocity API

### DIFF
--- a/dimos/experimental/arduino/test_arduino_module.py
+++ b/dimos/experimental/arduino/test_arduino_module.py
@@ -389,10 +389,13 @@ def test_registry_matches_main_cpp_hash_registry() -> None:
 
 
 class _FakeTransport:
-    """Transport stand-in: carries a topic; ``stop()`` is a no-op."""
+    """Transport stand-in: carries a channel; ``stop()`` is a no-op.
 
-    def __init__(self, topic: str) -> None:
-        self.topic = topic
+    ``NativeModule._collect_topics`` reads ``transport.channel``.
+    """
+
+    def __init__(self, channel: str) -> None:
+        self.channel = channel
 
     def stop(self) -> None:
         pass
@@ -400,8 +403,8 @@ class _FakeTransport:
 
 def _with_topics(mod, topics):
     """Attach fake transports to the module's real streams via ``set_transport``."""
-    for name, topic in topics.items():
-        mod.set_transport(name, _FakeTransport(topic))
+    for name, channel in topics.items():
+        mod.set_transport(name, _FakeTransport(channel))
     return mod
 
 

--- a/dimos/robot/unitree/connection.py
+++ b/dimos/robot/unitree/connection.py
@@ -26,6 +26,7 @@ from reactivex import operators as ops
 from reactivex.observable import Observable
 from reactivex.subject import Subject
 from unitree_webrtc_connect.constants import (
+    DATA_CHANNEL_TYPE,
     RTC_TOPIC,
     SPORT_CMD,
     VUI_COLOR,
@@ -52,6 +53,7 @@ from dimos.types.timestamped import Timestamped
 from dimos.utils.decorators.decorators import simple_mcache
 from dimos.utils.logging_config import setup_logger
 from dimos.utils.reactive import backpressure, callback_to_observable
+from dimos.utils.sequential_ids import SequentialIds
 
 VideoMessage: TypeAlias = NDArray[np.uint8]  # Shape: (height, width, 3)
 
@@ -97,11 +99,19 @@ class SerializableVideoFrame:
 class UnitreeWebRTCConnection(Resource):
     _SPORT_API_ID_RAGEMODE: int = 2059
 
-    def __init__(self, ip: str, mode: str = "ai", aes_128_key: str | None = None) -> None:
+    def __init__(
+        self,
+        ip: str,
+        mode: str = "ai",
+        aes_128_key: str | None = None,
+        velocity_api: bool = False,
+    ) -> None:
         self.ip = ip
         self.mode = mode
         self.stop_timer: threading.Timer | None = None
         self.cmd_vel_timeout = 0.2
+        self._velocity_api = velocity_api
+        self._move_ids = SequentialIds()
         # Per-device AES-128 key for new Unitree firmware (data2=3 handshake); omitted when unset.
         self.conn = LegionConnection(
             WebRTCConnectionMethod.LocalSTA, ip=self.ip, aes_128_key=aes_128_key
@@ -147,11 +157,7 @@ class UnitreeWebRTCConnection(Resource):
 
         async def async_disconnect() -> None:
             try:
-                # Send stop command directly since we're already in the event loop.
-                self.conn.datachannel.pub_sub.publish_without_callback(
-                    RTC_TOPIC["WIRELESS_CONTROLLER"],
-                    data={"lx": 0, "ly": 0, "rx": 0, "ry": 0},
-                )
+                self._publish_movement(0, 0, 0)
                 await self.conn.disconnect()
             except Exception:
                 pass
@@ -164,11 +170,33 @@ class UnitreeWebRTCConnection(Resource):
         if self.thread.is_alive():
             self.thread.join(timeout=DEFAULT_THREAD_JOIN_TIMEOUT)
 
+    def _publish_movement(self, x: float, y: float, yaw: float) -> None:
+        if self._velocity_api:
+            self.conn.datachannel.pub_sub.publish_without_callback(
+                RTC_TOPIC["SPORT_MOD"],
+                data={
+                    "header": {
+                        "identity": {
+                            "id": self._move_ids.next() + 1,
+                            "api_id": SPORT_CMD["Move"],
+                        }
+                    },
+                    "parameter": json.dumps({"x": x, "y": y, "z": yaw}),
+                },
+                msg_type=DATA_CHANNEL_TYPE["REQUEST"],
+            )
+            return
+
+        self.conn.datachannel.pub_sub.publish_without_callback(
+            RTC_TOPIC["WIRELESS_CONTROLLER"],
+            data={"lx": -y, "ly": x, "rx": -yaw, "ry": 0},
+        )
+
     def move(self, twist: Twist, duration: float = 0.0) -> bool:
-        """Send movement command to the robot using Twist commands.
+        """Send a body-frame movement command using the configured wire API.
 
         Args:
-            twist: Twist message with linear and angular velocities
+            twist: Linear x/y and angular z command
             duration: How long to move (seconds). If 0, command is continuous
 
         Returns:
@@ -176,15 +204,8 @@ class UnitreeWebRTCConnection(Resource):
         """
         x, y, yaw = twist.linear.x, twist.linear.y, twist.angular.z
 
-        # WebRTC coordinate mapping:
-        # x - Positive right, negative left
-        # y - positive forward, negative backwards
-        # yaw - Positive rotate right, negative rotate left
         async def async_move() -> None:
-            self.conn.datachannel.pub_sub.publish_without_callback(
-                RTC_TOPIC["WIRELESS_CONTROLLER"],
-                data={"lx": -y, "ly": x, "rx": -yaw, "ry": 0},
-            )
+            self._publish_movement(x, y, yaw)
 
         async def async_move_duration() -> None:
             """Send movement commands continuously for the specified duration."""

--- a/dimos/robot/unitree/go2/connection.py
+++ b/dimos/robot/unitree/go2/connection.py
@@ -66,6 +66,7 @@ class ConnectionConfig(ModuleConfig):
     mode: Go2Mode = Go2Mode.DEFAULT
     lidar: bool = True
     camera: bool = True
+    velocity_api: bool = False
     # "mcf" for stair traversal, "normal" for basic, None to leave it as is
     motion_mode: str | None = None
     # Per-device AES-128 key (Go2 fw >=1.1.15); defaults from GlobalConfig.
@@ -122,6 +123,7 @@ def make_connection(
     ip: str | None,
     cfg: GlobalConfig,
     aes_128_key: str | None = None,
+    velocity_api: bool = False,
 ) -> Go2ConnectionProtocol:
     connection_type = cfg.unitree_connection_type.lower()
 
@@ -138,7 +140,11 @@ def make_connection(
         return DimSimConnection(cfg)
     elif connection_type == "webrtc":
         assert ip is not None, "IP address must be provided"
-        return UnitreeWebRTCConnection(ip, aes_128_key=aes_128_key)
+        return UnitreeWebRTCConnection(
+            ip,
+            aes_128_key=aes_128_key,
+            velocity_api=velocity_api,
+        )
     else:
         raise ValueError(f"Unknown simulator {cfg.simulation!r}. Choose from: mujoco, dimsim")
 
@@ -262,7 +268,10 @@ class GO2Connection(Module, Camera, Pointcloud):
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.connection = make_connection(
-            self.config.ip, self.config.g, aes_128_key=self.config.aes_128_key
+            self.config.ip,
+            self.config.g,
+            aes_128_key=self.config.aes_128_key,
+            velocity_api=self.config.velocity_api,
         )
 
         if hasattr(self.connection, "camera_info_static"):

--- a/dimos/robot/unitree/go2/test_connection.py
+++ b/dimos/robot/unitree/go2/test_connection.py
@@ -41,7 +41,11 @@ def test_make_connection_webrtc_forwards_aes_128_key(stub_webrtc: MagicMock) -> 
     """Webrtc branch forwards aes_128_key as a kwarg to UnitreeWebRTCConnection."""
     cfg = SimpleNamespace(unitree_connection_type="webrtc")
     go2_conn.make_connection("192.168.123.161", cfg, aes_128_key="cafe" * 8)
-    stub_webrtc.assert_called_once_with("192.168.123.161", aes_128_key="cafe" * 8)
+    stub_webrtc.assert_called_once_with(
+        "192.168.123.161",
+        aes_128_key="cafe" * 8,
+        velocity_api=False,
+    )
 
 
 def test_connection_config_aes_key_defaults_from_global_config() -> None:

--- a/dimos/robot/unitree/test_connection.py
+++ b/dimos/robot/unitree/test_connection.py
@@ -14,17 +14,21 @@
 
 """Unit tests for UnitreeWebRTCConnection.
 
-Pure-Python — no hardware, no network. Covers connect() error propagation,
+Pure-Python test suite with no hardware or network. Covers connect() error propagation,
 aes_128_key forwarding, and the UNITREE_AES_128_KEY env var via GlobalConfig.
 """
 
+import json
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import ANY, AsyncMock, MagicMock, call
 
 import pytest
+from unitree_webrtc_connect.constants import DATA_CHANNEL_TYPE, RTC_TOPIC, SPORT_CMD
 
 from dimos.constants import DEFAULT_THREAD_JOIN_TIMEOUT
 from dimos.core.global_config import GlobalConfig
+from dimos.msgs.geometry_msgs.Twist import Twist
+from dimos.msgs.geometry_msgs.Vector3 import Vector3
 from dimos.robot.unitree import connection as conn_mod
 from dimos.robot.unitree.connection import UnitreeWebRTCConnection
 
@@ -69,6 +73,59 @@ def test_connect_success_completes_setup(built_connection: Any) -> None:
 
     driver.connect.assert_awaited_once()
     driver.datachannel.pub_sub.publish_request_new.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    ("connection_options", "expected_call"),
+    [
+        pytest.param(
+            {},
+            call(
+                RTC_TOPIC["WIRELESS_CONTROLLER"],
+                data={"lx": 0.4, "ly": 1.5, "rx": -0.8, "ry": 0},
+            ),
+            id="joystick",
+        ),
+        pytest.param(
+            {"velocity_api": True},
+            call(
+                RTC_TOPIC["SPORT_MOD"],
+                data={
+                    "header": {
+                        "identity": {
+                            "id": ANY,
+                            "api_id": SPORT_CMD["Move"],
+                        }
+                    },
+                    "parameter": json.dumps({"x": 1.5, "y": -0.4, "z": 0.8}),
+                },
+                msg_type=DATA_CHANNEL_TYPE["REQUEST"],
+            ),
+            id="velocity",
+        ),
+    ],
+)
+def test_move_api_toggle_sends_selected_wire_command(
+    monkeypatch: pytest.MonkeyPatch,
+    connection_options: dict[str, bool],
+    expected_call: Any,
+) -> None:
+    driver = _stub_driver()
+    monkeypatch.setattr(conn_mod, "LegionConnection", MagicMock(return_value=driver))
+    twist = Twist(
+        linear=Vector3(1.5, -0.4, 0.0),
+        angular=Vector3(0.0, 0.0, 0.8),
+    )
+
+    connection = UnitreeWebRTCConnection(ip="10.0.0.99", **connection_options)
+    try:
+        driver.datachannel.pub_sub.publish_without_callback.reset_mock()
+        assert connection.move(twist)
+        assert driver.datachannel.pub_sub.publish_without_callback.call_args == expected_call
+    finally:
+        connection.stop_movement()
+        connection.loop.call_soon_threadsafe(connection.loop.stop)
+        connection.thread.join(timeout=DEFAULT_THREAD_JOIN_TIMEOUT)
 
 
 @pytest.fixture


### PR DESCRIPTION
Currently Go2 twist values are  written directly to `WIRELESS_CONTROLLER` stick axes so values such as 1.5 are not transmitted as meters per second. 

- Added `velocity_api: bool = False` to `dimos/robot/unitree/go2/connection.py:64`.
- Added Sport Move API 1008 with unchanged body-frame metric velocities in dimos/robot/unitree/connection.py:173.
- Kept `WIRELESS_CONTROLLER` as the default.

Any Go2 blueprint can opt in with `GO2Connection.blueprint(velocity_api=True)` or `-o go2connection.velocity_api=true`.