### PR TITLE
ci: skip experimental arduino tests in CI test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,13 +281,13 @@ jobs:
       - name: Install dependencies
         run: uv sync --group tests --frozen
       - name: Run tests
-        run: uv run pytest --numprocesses=3 --cov=dimos/ --junitxml=junit.xml -m 'not (self_hosted or mujoco or self_hosted_large)'
+        run: uv run pytest --numprocesses=3 --cov=dimos/ --junitxml=junit.xml --ignore=dimos/experimental/arduino -m 'not (self_hosted or mujoco or self_hosted_large)'
       - name: Re-run the failing tests with maximum verbosity
         if: failure()
         env:
           COLOR: yes
         run: >-  # `exit 1` makes sure that the job remains red with flaky runs
-          uv run pytest --no-cov -vvvvv --lf  -m 'not (self_hosted or mujoco or self_hosted_large)' && exit 1
+          uv run pytest --no-cov -vvvvv --lf  --ignore=dimos/experimental/arduino -m 'not (self_hosted or mujoco or self_hosted_large)' && exit 1
         shell: bash
       - name: Turn coverage into xml
         run: uv run python -m coverage xml


### PR DESCRIPTION
Exclude `dimos/experimental/arduino` from CI