### PR TITLE
Auto-fixes for control-card-routing

### DIFF
--- a/dimos/control/_control_test_helpers.py
+++ b/dimos/control/_control_test_helpers.py
@@ -1,0 +1,76 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared control-task stubs for tests.
+
+Not named ``test_*``/``*_test`` so pytest does not collect it; both
+``test_control.py`` and ``test_coordinator_routing.py`` import ``RecordingTask``
+from here rather than reaching into each other's test modules.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from dimos.control.task import (
+    BaseControlTask,
+    CoordinatorState,
+    JointCommandOutput,
+    ResourceClaim,
+)
+
+
+class RecordingTask(BaseControlTask):
+    """Stub task that records every stream handler invocation."""
+
+    def __init__(self, name: str, joints: frozenset[str] = frozenset()) -> None:
+        self._name = name
+        self._joints = frozenset(joints)
+        self.cartesian_calls: list[tuple[Any, float]] = []
+        self.ee_twist_calls: list[tuple[Any, float]] = []
+        self.buttons_calls: list[Any] = []
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def claim(self) -> ResourceClaim:
+        return ResourceClaim(joints=self._joints)
+
+    def is_active(self) -> bool:
+        return False
+
+    def compute(self, state: CoordinatorState) -> JointCommandOutput | None:
+        _ = state
+        return None
+
+    def on_preempted(self, by_task: str, joints: frozenset[str]) -> None:
+        _ = by_task, joints
+
+    def on_cartesian_command(self, pose: Any, t_now: float) -> bool:
+        self.cartesian_calls.append((pose, t_now))
+        return True
+
+    def on_ee_twist_command(self, twist: Any, t_now: float) -> bool:
+        self.ee_twist_calls.append((twist, t_now))
+        return True
+
+    def on_buttons(self, msg: Any) -> bool:
+        self.buttons_calls.append(msg)
+        return True
+
+    def on_teleop_buttons(self, msg: Any, t_now: float) -> bool:
+        # Mirrors TeleopIKTask: the uniform handler delegates to on_buttons.
+        _ = t_now
+        return self.on_buttons(msg)

--- a/dimos/control/tasks/servo_task/servo_task.py
+++ b/dimos/control/tasks/servo_task/servo_task.py
@@ -230,7 +230,7 @@ class JointServoTask(BaseControlTask):
         """Uniform stream handler: digest the position half of a joint_command."""
         if not msg.position:
             return False
-        return self.set_target_by_name(dict(zip(msg.name, msg.position, strict=False)), t_now)
+        return self.set_target_by_name(dict(zip(msg.name, msg.position, strict=True)), t_now)
 
     def start(self) -> None:
         """Activate the task (start accepting and outputting commands)."""

--- a/dimos/control/tasks/teleop_task/test_teleop_task.py
+++ b/dimos/control/tasks/teleop_task/test_teleop_task.py
@@ -19,15 +19,9 @@ from __future__ import annotations
 from dimos.control.tasks.teleop_task.teleop_task import TeleopIKTask
 
 
-def test_on_teleop_buttons_delegates_to_on_buttons() -> None:
-    task = TeleopIKTask.__new__(TeleopIKTask)
-    seen: list[object] = []
-
-    def fake_on_buttons(msg: object) -> bool:
-        seen.append(msg)
-        return True
-
-    task.on_buttons = fake_on_buttons
+def test_on_teleop_buttons_delegates_to_on_buttons(mocker) -> None:
+    mock_self = mocker.Mock()
+    mock_self.on_buttons.return_value = True
     sentinel = object()
-    assert task.on_teleop_buttons(sentinel, 0.0) is True
-    assert seen == [sentinel]
+    assert TeleopIKTask.on_teleop_buttons(mock_self, sentinel, 0.0) is True
+    mock_self.on_buttons.assert_called_once_with(sentinel)

--- a/dimos/control/tasks/velocity_task/velocity_task.py
+++ b/dimos/control/tasks/velocity_task/velocity_task.py
@@ -249,7 +249,7 @@ class JointVelocityTask(BaseControlTask):
         # routes position XOR velocity; positions win when both are present).
         if msg.position or not msg.velocity:
             return False
-        return self.set_velocities_by_name(dict(zip(msg.name, msg.velocity, strict=False)), t_now)
+        return self.set_velocities_by_name(dict(zip(msg.name, msg.velocity, strict=True)), t_now)
 
     def start(self) -> None:
         """Activate the task (start accepting and outputting commands)."""

--- a/dimos/control/test_control.py
+++ b/dimos/control/test_control.py
@@ -24,6 +24,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from dimos.control._control_test_helpers import RecordingTask
 from dimos.control.components import (
     HardwareComponent,
     HardwareType,
@@ -45,7 +46,6 @@ from dimos.control.tasks.trajectory_task.trajectory_task import (
     JointTrajectoryTask,
     JointTrajectoryTaskConfig,
 )
-from dimos.control.test_coordinator_routing import RecordingTask
 from dimos.control.tick_loop import TickLoop
 from dimos.hardware.manipulators.spec import ManipulatorAdapter
 from dimos.msgs.geometry_msgs.Twist import Twist

--- a/dimos/control/test_coordinator_routing.py
+++ b/dimos/control/test_coordinator_routing.py
@@ -29,18 +29,13 @@ from typing import Any
 
 import pytest
 
+from dimos.control._control_test_helpers import RecordingTask
 from dimos.control.components import (
     HardwareComponent,
     HardwareType,
     make_twist_base_joints,
 )
 from dimos.control.coordinator import ControlCoordinator, TaskConfig
-from dimos.control.task import (
-    BaseControlTask,
-    CoordinatorState,
-    JointCommandOutput,
-    ResourceClaim,
-)
 from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
 from dimos.msgs.geometry_msgs.Twist import Twist
 from dimos.msgs.geometry_msgs.TwistStamped import TwistStamped
@@ -56,51 +51,6 @@ STREAMS = (
     "twist_command",
     "teleop_buttons",
 )
-
-
-class RecordingTask(BaseControlTask):
-    """Stub task that records every stream handler invocation."""
-
-    def __init__(self, name: str, joints: frozenset[str] = frozenset()) -> None:
-        self._name = name
-        self._joints = frozenset(joints)
-        self.cartesian_calls: list[tuple[Any, float]] = []
-        self.ee_twist_calls: list[tuple[Any, float]] = []
-        self.buttons_calls: list[Any] = []
-
-    @property
-    def name(self) -> str:
-        return self._name
-
-    def claim(self) -> ResourceClaim:
-        return ResourceClaim(joints=self._joints)
-
-    def is_active(self) -> bool:
-        return False
-
-    def compute(self, state: CoordinatorState) -> JointCommandOutput | None:
-        _ = state
-        return None
-
-    def on_preempted(self, by_task: str, joints: frozenset[str]) -> None:
-        _ = by_task, joints
-
-    def on_cartesian_command(self, pose: Any, t_now: float) -> bool:
-        self.cartesian_calls.append((pose, t_now))
-        return True
-
-    def on_ee_twist_command(self, twist: Any, t_now: float) -> bool:
-        self.ee_twist_calls.append((twist, t_now))
-        return True
-
-    def on_buttons(self, msg: Any) -> bool:
-        self.buttons_calls.append(msg)
-        return True
-
-    def on_teleop_buttons(self, msg: Any, t_now: float) -> bool:
-        # Mirrors TeleopIKTask: the uniform handler delegates to on_buttons.
-        _ = t_now
-        return self.on_buttons(msg)
 
 
 class VelocityCapableTask(RecordingTask):


### PR DESCRIPTION
These are automated fixes. Each fix is a separate commit. Use `git rebase -i` to drop any you disagree with.