### PR TITLE
Control task commands

### DIFF
--- a/dimos/control/coordinator.py
+++ b/dimos/control/coordinator.py
@@ -26,6 +26,7 @@ Features:
 """
 
 from dataclasses import dataclass, field
+import inspect
 import threading
 import time
 from typing import TYPE_CHECKING, Any
@@ -182,6 +183,10 @@ class ControlCoordinator(Module):
         # Card-declared stream routes: stream name -> (task, handler, routing).
         # Guarded by _task_lock; entries are added/pruned with their task.
         self._routes: dict[str, list[tuple[ControlTask, str, Routing]]] = {}
+
+        # Card-declared command names per task, keyed by task name.
+        # Guarded by _task_lock; added/pruned with their task.
+        self._task_commands: dict[TaskName, frozenset[str]] = {}
 
         # Tick loop (created on start)
         self._tick_loop: TickLoop | None = None
@@ -417,6 +422,9 @@ class ControlCoordinator(Module):
             self._tasks[task.name] = task
             if task_type is not None:
                 self._register_routes(task, task_type)
+                self._task_commands[task.name] = self._commands_for(task_type)
+            else:
+                self._task_commands[task.name] = frozenset()
             logger.info(f"Added task {task.name}")
         self._sync_stream_subscriptions()
         return True
@@ -430,6 +438,7 @@ class ControlCoordinator(Module):
                 return False
             for entries in self._routes.values():
                 entries[:] = [entry for entry in entries if entry[0] is not task]
+            self._task_commands.pop(task_name, None)
             logger.info(f"Removed task {task_name}")
         self._sync_stream_subscriptions()
         return True
@@ -449,6 +458,12 @@ class ControlCoordinator(Module):
             self._routes.setdefault(binding.stream, []).append(
                 (task, binding.handler, binding.routing)
             )
+
+    def _commands_for(self, task_type: str) -> frozenset[str]:
+        """The command names the task type declares in its TASK_EXPOSES card."""
+        from dimos.control.tasks.registry import control_task_registry
+
+        return control_task_registry.bindings_for(task_type).exposes
 
     def _sync_stream_subscriptions(self) -> None:
         """Subscribe streams that gained routes; drop those whose last consumer left."""
@@ -571,28 +586,28 @@ class ControlCoordinator(Module):
 
     @rpc
     def set_activated(self, engaged: bool) -> None:
-        """Arm/disarm every task exposing ``arm()`` / ``disarm()``."""
+        """Arm/disarm every task whose card declares ``arm`` / ``disarm``."""
+        method = "arm" if engaged else "disarm"
         with self._task_lock:
-            for task in self._tasks.values():
-                method_name = "arm" if engaged else "disarm"
-                handler = getattr(task, method_name, None)
-                if callable(handler):
-                    try:
-                        handler()
-                    except Exception:
-                        logger.exception(f"{method_name}() raised on task {task.name!r}")
+            for name, task in self._tasks.items():
+                if method not in self._task_commands.get(name, frozenset()):
+                    continue
+                try:
+                    self._invoke_declared(task, name, method, {})
+                except Exception:
+                    logger.exception(f"{method}() raised on task {name!r}")
 
     @rpc
     def set_dry_run(self, enabled: bool) -> None:
-        """Toggle dry-run on every task exposing ``set_dry_run``."""
+        """Toggle dry-run on every task whose card declares ``set_dry_run``."""
         with self._task_lock:
-            for task in self._tasks.values():
-                handler = getattr(task, "set_dry_run", None)
-                if callable(handler):
-                    try:
-                        handler(enabled)
-                    except Exception:
-                        logger.exception(f"set_dry_run() raised on task {task.name!r}")
+            for name, task in self._tasks.items():
+                if "set_dry_run" not in self._task_commands.get(name, frozenset()):
+                    continue
+                try:
+                    self._invoke_declared(task, name, "set_dry_run", {"enabled": enabled})
+                except Exception:
+                    logger.exception(f"set_dry_run() raised on task {name!r}")
 
     @rpc
     def reset_runtime_state(self, reactivate: bool | None = None) -> dict[str, bool]:
@@ -616,24 +631,93 @@ class ControlCoordinator(Module):
     def task_invoke(
         self, task_name: TaskName, method: str, kwargs: dict[str, Any] | None = None
     ) -> Any:
-        """Invoke a method on a task. Pass t_now=None to auto-inject current time."""
+        """Invoke a task command. Pass t_now=None to auto-inject current time.
+
+        Commands declared in the task's TASK_EXPOSES card are validated
+        against the method's own signature before dispatch; a bad kwarg name
+        or missing required argument raises to the caller. Undeclared methods
+        still dispatch exactly as before but log a nudge to declare them.
+        """
         with self._task_lock:
             task = self._tasks.get(task_name)
             if task is None:
                 logger.warning(f"Task {task_name} not found")
                 return None
 
-            if not hasattr(task, method):
-                logger.warning(f"Task {task_name} has no method {method}")
-                return None
-
-            kwargs = kwargs or {}
+            kwargs = dict(kwargs or {})
 
             # Auto-inject t_now if requested (None means "use current time")
             if "t_now" in kwargs and kwargs["t_now"] is None:
                 kwargs["t_now"] = time.perf_counter()
 
+            if method in self._task_commands.get(task_name, frozenset()):
+                return self._invoke_declared(task, task_name, method, kwargs)
+
+            logger.warning(
+                f"undeclared task_invoke {task_name}.{method} — declare it in TASK_EXPOSES"
+            )
+            if not hasattr(task, method):
+                logger.warning(f"Task {task_name} has no method {method}")
+                return None
             return getattr(task, method)(**kwargs)
+
+    def _invoke_declared(
+        self, task: ControlTask, task_name: TaskName, method: str, kwargs: dict[str, Any]
+    ) -> Any:
+        """Bind ``kwargs`` to the command's own signature, then dispatch.
+
+        Caller must hold ``_task_lock``. A bad kwarg name or missing required
+        argument raises a ``TypeError`` naming the task, command, and the
+        offending argument; it propagates to the RPC caller.
+        """
+        handler = getattr(task, method)
+        sig = inspect.signature(handler)
+        where = f"task_invoke({task_name!r}, {method!r})"
+        # ``bind`` reports a missing required arg before an unexpected one, so
+        # name unexpected kwargs explicitly — a typo'd kwarg must be visible.
+        accepts_var_kw = any(
+            p.kind is inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()
+        )
+        if not accepts_var_kw:
+            unexpected = [name for name in kwargs if name not in sig.parameters]
+            if unexpected:
+                raise TypeError(
+                    f"{where}: unexpected argument(s) {unexpected}; accepts {list(sig.parameters)}"
+                )
+        try:
+            bound = sig.bind(**kwargs)
+        except TypeError as exc:
+            raise TypeError(f"{where}: {exc}") from exc
+        return handler(*bound.args, **bound.kwargs)
+
+    @rpc
+    def describe_task(self, task_name: TaskName) -> dict[str, Any] | None:
+        """Describe a task's declared commands and stream routes.
+
+        Each declared command reports its live signature (rendered string
+        plus parameter names) — the method signature is the argument
+        contract. Returns ``{"task", "commands": {name: {"signature",
+        "params"}}, "streams": [(stream, routing), ...]}`` or ``None`` for
+        an unknown task.
+        """
+        with self._task_lock:
+            task = self._tasks.get(task_name)
+            if task is None:
+                return None
+            commands: dict[str, Any] = {}
+            for name in sorted(self._task_commands.get(task_name, frozenset())):
+                handler = getattr(task, name, None)
+                if not callable(handler):
+                    continue
+                sig = inspect.signature(handler)
+                commands[name] = {"signature": str(sig), "params": list(sig.parameters)}
+            streams = sorted(
+                (stream, routing.value)
+                for stream, entries in self._routes.items()
+                for entry_task, _handler, routing in entries
+                if entry_task is task
+            )
+            return {"task": task_name, "commands": commands, "streams": streams}
 
     @rpc
     def set_gripper_position(self, hardware_id: str, position: float) -> bool:
@@ -735,6 +819,7 @@ class ControlCoordinator(Module):
             self._stream_unsubs.clear()
         with self._task_lock:
             self._routes.clear()
+            self._task_commands.clear()
         if self._twist_command_unsub:
             self._twist_command_unsub()
             self._twist_command_unsub = None

--- a/dimos/control/coordinator.py
+++ b/dimos/control/coordinator.py
@@ -653,12 +653,14 @@ class ControlCoordinator(Module):
             if method in self._task_commands.get(task_name, frozenset()):
                 return self._invoke_declared(task, task_name, method, kwargs)
 
+            if not hasattr(task, method):
+                raise AttributeError(
+                    f"task_invoke({task_name!r}, {method!r}): task has no such method; "
+                    f"declared commands: {sorted(self._task_commands.get(task_name, frozenset()))}"
+                )
             logger.warning(
                 f"undeclared task_invoke {task_name}.{method} — declare it in TASK_EXPOSES"
             )
-            if not hasattr(task, method):
-                logger.warning(f"Task {task_name} has no method {method}")
-                return None
             return getattr(task, method)(**kwargs)
 
     def _invoke_declared(

--- a/dimos/control/coordinator.py
+++ b/dimos/control/coordinator.py
@@ -812,14 +812,12 @@ class ControlCoordinator(Module):
         """Stop the coordinator."""
         logger.info("Stopping ControlCoordinator...")
 
-        # Unsubscribe from streaming commands and drop the route table
+        # Route/command tables are kept: they track _tasks, which survives stop(),
+        # and add_task() skips known names so a restart would never rebuild them.
         with self._subscribe_lock:
             for unsub in self._stream_unsubs.values():
                 unsub()
             self._stream_unsubs.clear()
-        with self._task_lock:
-            self._routes.clear()
-            self._task_commands.clear()
         if self._twist_command_unsub:
             self._twist_command_unsub()
             self._twist_command_unsub = None

--- a/dimos/control/routing.py
+++ b/dimos/control/routing.py
@@ -22,10 +22,8 @@ them when tasks are registered.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import Enum
-from types import MappingProxyType
 
 
 class Routing(str, Enum):
@@ -64,16 +62,14 @@ class StreamBinding:
     routing: Routing
 
 
-_EMPTY_EXPOSES: Mapping[str, str] = MappingProxyType({})
-
-
 @dataclass(frozen=True)
 class TaskBindings:
     """Declared input streams and commands for one task type.
 
-    ``exposes`` maps a command name to a ``"module:PydanticModel"``
-    argument-schema path; it is stored but not consumed yet.
+    ``exposes`` is the set of command names the task accepts via
+    ``ControlCoordinator.task_invoke``; the task method's own signature
+    is the argument schema (validated at dispatch, not here).
     """
 
     consumes: tuple[StreamBinding, ...] = ()
-    exposes: Mapping[str, str] = _EMPTY_EXPOSES
+    exposes: frozenset[str] = frozenset()

--- a/dimos/control/tasks/g1_groot_wbc_task/_registry.py
+++ b/dimos/control/tasks/g1_groot_wbc_task/_registry.py
@@ -19,3 +19,7 @@ TASK_FACTORIES = {
 TASK_CONSUMES: dict[str, dict[str, tuple[str, str]]] = {
     "g1_groot_wbc": {},  # its twist input is wired to cards in a later PR
 }
+
+TASK_EXPOSES: dict[str, list[str]] = {
+    "g1_groot_wbc": ["arm", "disarm", "set_dry_run"],
+}

--- a/dimos/control/tasks/registry.py
+++ b/dimos/control/tasks/registry.py
@@ -31,7 +31,6 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping, Sequence
 import importlib
 import os
-from types import MappingProxyType
 from typing import TYPE_CHECKING, cast
 
 from dimos.control.routing import (
@@ -107,16 +106,17 @@ class ControlTaskRegistry:
         task_type: str,
         *,
         consumes: Mapping[str, tuple[str, str]] | None = None,
-        exposes: Mapping[str, str] | None = None,
+        exposes: Sequence[str] | None = None,
         source: str | None = None,
     ) -> None:
         """Register a task type's binding card; conflicting duplicates raise.
 
         ``consumes`` maps a coordinator input stream name to a
-        ``(handler_method, routing)`` pair of strings; ``exposes`` maps a
-        command name to a ``"module:PydanticModel"`` argument-schema path
-        (stored only for now). ``source`` names the manifest for error
-        messages; runtime callers can omit it.
+        ``(handler_method, routing)`` pair of strings. ``exposes`` is a
+        sequence of command names the task accepts via
+        ``ControlCoordinator.task_invoke``; the task method's own signature
+        is the argument schema, so no separate model is declared. ``source``
+        names the manifest for error messages; runtime callers can omit it.
         """
         key = task_type.lower()
         origin = source or "register_bindings()"
@@ -246,24 +246,30 @@ class ControlTaskRegistry:
     def _parse_exposes(
         self,
         task_type: str,
-        exposes: Mapping[str, str] | None,
+        exposes: Sequence[str] | None,
         source: str,
-    ) -> Mapping[str, str]:
+    ) -> frozenset[str]:
         if exposes is None:
-            return MappingProxyType({})
-        if not isinstance(exposes, Mapping):
-            raise TypeError(f"{source}: exposes for task type {task_type!r} must be a mapping")
-        for command, schema_path in exposes.items():
-            if not isinstance(command, str) or not isinstance(schema_path, str):
-                raise TypeError(
-                    f"{source}: exposes for task type {task_type!r} must map strings to strings"
-                )
-            if ":" not in schema_path:
+            return frozenset()
+        if isinstance(exposes, str) or not isinstance(exposes, Sequence):
+            raise TypeError(
+                f"{source}: exposes for task type {task_type!r} must be a sequence of "
+                "command-name strings"
+            )
+        commands: set[str] = set()
+        for command in exposes:
+            where = f"{source}: task type {task_type!r}"
+            if not isinstance(command, str) or not command:
+                raise TypeError(f"{where}: command names must be non-empty strings")
+            if command.startswith("_"):
                 raise ValueError(
-                    f"{source}: task type {task_type!r} command {command!r} has invalid "
-                    f"argument-schema path {schema_path!r} (expected 'module:Model')"
+                    f"{where}: command {command!r} is private; underscore-prefixed "
+                    "methods are not wire-callable"
                 )
-        return MappingProxyType(dict(exposes))
+            if command in commands:
+                raise ValueError(f"{where}: command {command!r} declared more than once")
+            commands.add(command)
+        return frozenset(commands)
 
     def _validate_bound_handlers(self, key: str, task: ControlTask) -> None:
         bindings = self._bindings.get(key)

--- a/dimos/control/tasks/test_registry.py
+++ b/dimos/control/tasks/test_registry.py
@@ -140,10 +140,38 @@ def test_seeded_cards_load_into_registry() -> None:
         ),
         StreamBinding("teleop_buttons", "on_teleop_buttons", Routing.BROADCAST),
     )
-    for empty_card in ("trajectory", "g1_groot_wbc"):
-        # Present in _bindings distinguishes a seeded empty card from no card at all.
-        assert empty_card in control_task_registry._bindings, f"{empty_card} card not seeded"
-        assert control_task_registry.bindings_for(empty_card) == TaskBindings()
+    trajectory = control_task_registry.bindings_for("trajectory")
+    assert trajectory.consumes == ()  # command-driven only
+    assert trajectory.exposes == frozenset({"execute", "cancel", "get_state"})
+    g1 = control_task_registry.bindings_for("g1_groot_wbc")
+    assert g1.consumes == ()  # its twist input is a later PR
+    assert g1.exposes == frozenset({"arm", "disarm", "set_dry_run"})
+
+
+def _scannable_task_classes(task_type: str) -> list[type] | None:
+    """Task-like classes defined in ``task_type``'s factory module.
+
+    Returns ``None`` when the module needs an optional dependency that is
+    not installed (the CI guard skips those); otherwise the non-empty list
+    of task classes (an empty list is a hard failure).
+    """
+    factory_path = control_task_registry._factory_paths[task_type]
+    module_name, _ = factory_path.split(":", maxsplit=1)
+    try:
+        module = importlib.import_module(module_name)
+    except ModuleNotFoundError as exc:
+        root = (exc.name or "").partition(".")[0]
+        if root in OPTIONAL_TASK_MODULES and importlib.util.find_spec(root) is None:
+            return None
+        pytest.fail(f"{task_type}: importing {module_name!r} failed: {exc}")
+    classes = [
+        cls
+        for _, cls in inspect.getmembers(module, inspect.isclass)
+        if cls.__module__ == module.__name__
+        and all(hasattr(cls, attr) for attr in ("compute", "claim", "is_active"))
+    ]
+    assert classes, f"{task_type}: no task class found in {module_name!r}"
+    return classes
 
 
 def test_declared_handlers_exist_on_task_classes() -> None:
@@ -151,38 +179,50 @@ def test_declared_handlers_exist_on_task_classes() -> None:
     for task_type, bindings in sorted(control_task_registry._bindings.items()):
         if not bindings.consumes:
             continue
-        factory_path = control_task_registry._factory_paths[task_type]
-        module_name, _ = factory_path.split(":", maxsplit=1)
-        try:
-            module = importlib.import_module(module_name)
-        except ModuleNotFoundError as exc:
-            root = (exc.name or "").partition(".")[0]
-            if root in OPTIONAL_TASK_MODULES and importlib.util.find_spec(root) is None:
-                continue
-            pytest.fail(f"{task_type}: importing {module_name!r} failed: {exc}")
-        task_classes = [
-            cls
-            for _, cls in inspect.getmembers(module, inspect.isclass)
-            if cls.__module__ == module.__name__
-            and all(hasattr(cls, attr) for attr in ("compute", "claim", "is_active"))
-        ]
-        assert task_classes, f"{task_type}: no task class found in {module_name!r}"
+        task_classes = _scannable_task_classes(task_type)
+        if task_classes is None:
+            continue
         for binding in bindings.consumes:
             assert any(callable(getattr(cls, binding.handler, None)) for cls in task_classes), (
-                f"{task_type}: no task class in {module_name!r} defines handler "
+                f"{task_type}: no task class defines handler "
                 f"{binding.handler!r} declared for stream {binding.stream!r}"
             )
             checked += 1
     assert checked > 0
 
 
+def test_declared_commands_exist_on_task_classes() -> None:
+    checked = 0
+    for task_type, bindings in sorted(control_task_registry._bindings.items()):
+        if not bindings.exposes:
+            continue
+        task_classes = _scannable_task_classes(task_type)
+        if task_classes is None:
+            continue
+        for command in sorted(bindings.exposes):
+            assert any(callable(getattr(cls, command, None)) for cls in task_classes), (
+                f"{task_type}: no task class defines command {command!r} declared in TASK_EXPOSES"
+            )
+            checked += 1
+    assert checked > 0
+
+
+def test_command_guard_flags_command_absent_from_task_class() -> None:
+    # Proves the guard above actually discriminates: a real command resolves
+    # to a callable on the task class, a bogus one does not.
+    task_classes = _scannable_task_classes("trajectory")
+    assert task_classes is not None
+    assert any(callable(getattr(cls, "execute", None)) for cls in task_classes)
+    assert not any(callable(getattr(cls, "no_such_command", None)) for cls in task_classes)
+
+
 def test_bindings_for_unknown_type_is_empty() -> None:
     bindings = control_task_registry.bindings_for("definitely_not_registered")
     assert bindings == TaskBindings()
     assert bindings.consumes == ()
-    assert not bindings.exposes
-    with pytest.raises(TypeError):
-        bindings.exposes["poison"] = "x:Y"
+    assert bindings.exposes == frozenset()
+    # exposes is an immutable frozenset; there is no add/mutate API.
+    assert not hasattr(bindings.exposes, "add")
 
 
 def test_register_bindings_runtime_and_conflict() -> None:
@@ -217,8 +257,19 @@ def test_register_bindings_rejects_bad_streams_and_routing() -> None:
         reg.register_bindings("fake_stream", consumes={"no_such_port": ("on_x", "broadcast")})
     with pytest.raises(ValueError, match="routing"):
         reg.register_bindings("fake_routing", consumes={"joint_command": ("on_x", "round_robin")})
-    with pytest.raises(ValueError, match="module:Model"):
-        reg.register_bindings("fake_exposes", exposes={"do_thing": "not_a_path"})
+
+
+def test_register_bindings_rejects_bad_exposes() -> None:
+    reg = ControlTaskRegistry()
+    with pytest.raises(TypeError, match="sequence"):
+        # A bare string is not a command-name sequence.
+        reg.register_bindings("fake_str_exposes", exposes="do_thing")
+    with pytest.raises(ValueError, match="private"):
+        reg.register_bindings("fake_private_exposes", exposes=["_do_thing"])
+    with pytest.raises(ValueError, match="more than once"):
+        reg.register_bindings("fake_dup_exposes", exposes=["do_thing", "do_thing"])
+    with pytest.raises(TypeError, match="non-empty strings"):
+        reg.register_bindings("fake_nonstr_exposes", exposes=[123])
 
 
 class _HandlerlessTask:

--- a/dimos/control/tasks/trajectory_task/_registry.py
+++ b/dimos/control/tasks/trajectory_task/_registry.py
@@ -19,3 +19,7 @@ TASK_FACTORIES = {
 TASK_CONSUMES: dict[str, dict[str, tuple[str, str]]] = {
     "trajectory": {},  # command-driven only; consumes no input streams
 }
+
+TASK_EXPOSES: dict[str, list[str]] = {
+    "trajectory": ["execute", "cancel", "get_state"],
+}

--- a/dimos/control/test_coordinator_commands.py
+++ b/dimos/control/test_coordinator_commands.py
@@ -196,3 +196,118 @@ class TestActivationFanOut:
 
         coordinator.set_dry_run(False)
         assert task.dry_run is False
+
+
+class TestValidatedDispatch:
+    """New behavior introduced by TASK_EXPOSES: validated, declared commands."""
+
+    def test_valid_execute_passes_trajectory_by_identity(self, coordinator):
+        task = CommandRecordingTask("traj_arm")
+        coordinator.add_task(task, task_type="trajectory")
+
+        traj = _trajectory()
+        assert coordinator.task_invoke("traj_arm", "execute", {"trajectory": traj}) is True
+        # The trajectory object reaches the task unchanged (kwargs go straight
+        # to the method; nothing copies or re-serializes it).
+        assert task.executed is traj
+
+    def test_typo_kwarg_raises_naming_task_command_and_kwarg(self, coordinator):
+        task = CommandRecordingTask("traj_arm")
+        coordinator.add_task(task, task_type="trajectory")
+
+        with pytest.raises(TypeError) as exc:
+            coordinator.task_invoke("traj_arm", "execute", {"trajectroy": _trajectory()})
+
+        message = str(exc.value)
+        assert "trajectroy" in message  # the offending kwarg is named
+        assert "traj_arm" in message and "execute" in message
+        assert task.executed is None  # binding failed before dispatch
+
+    def test_missing_required_kwarg_raises(self, coordinator):
+        task = CommandRecordingTask("traj_arm")
+        coordinator.add_task(task, task_type="trajectory")
+
+        with pytest.raises(TypeError) as exc:
+            coordinator.task_invoke("traj_arm", "execute", {})
+
+        assert "execute" in str(exc.value)
+        assert task.executed is None
+
+    def test_defaulted_param_can_be_omitted(self, coordinator):
+        task = CommandRecordingTask("g1")
+        coordinator.add_task(task, task_type="g1_groot_wbc")
+
+        # arm(ramp_seconds=None) — the defaulted param may be omitted entirely.
+        assert coordinator.task_invoke("g1", "arm", {}) is True
+        assert task.armed is True
+        assert task.arm_calls == [None]
+
+    def test_undeclared_existing_method_warns_but_dispatches(self, coordinator, mocker):
+        import dimos.control.coordinator as coord_mod
+
+        task = CommandRecordingTask("traj_arm")
+        coordinator.add_task(task, task_type="trajectory")
+        warn = mocker.patch.object(coord_mod.logger, "warning")
+
+        result = coordinator.task_invoke("traj_arm", "record_time", {"t_now": None})
+
+        assert isinstance(result, float)  # legacy dispatch still happened
+        assert task.t_now_seen == result
+        assert any("undeclared task_invoke" in str(c.args[0]) for c in warn.call_args_list)
+
+    def test_typo_method_warns_and_returns_none(self, coordinator, mocker):
+        import dimos.control.coordinator as coord_mod
+
+        task = CommandRecordingTask("traj_arm")
+        coordinator.add_task(task, task_type="trajectory")
+        warn = mocker.patch.object(coord_mod.logger, "warning")
+
+        # "exceute" is a typo of the declared "execute"; no such method exists.
+        assert coordinator.task_invoke("traj_arm", "exceute", {}) is None
+        assert warn.called
+
+    def test_shims_reach_only_declaring_tasks(self, coordinator):
+        declaring = CommandRecordingTask("g1")
+        coordinator.add_task(declaring, task_type="g1_groot_wbc")
+        # Bare add: has arm()/disarm()/set_dry_run() but declares no commands.
+        bare = CommandRecordingTask("bare")
+        coordinator.add_task(bare)
+
+        coordinator.set_activated(True)
+        coordinator.set_dry_run(True)
+
+        assert declaring.armed is True
+        assert declaring.arm_calls == [None]  # arm() called with defaulted ramp_seconds
+        assert declaring.dry_run is True
+        # The bare task is skipped even though it defines the methods.
+        assert bare.armed is None
+        assert bare.dry_run is None
+
+
+class TestDescribeTask:
+    def test_reports_command_signatures(self, coordinator):
+        task = CommandRecordingTask("traj_arm")
+        coordinator.add_task(task, task_type="trajectory")
+
+        desc = coordinator.describe_task("traj_arm")
+
+        assert desc["task"] == "traj_arm"
+        assert set(desc["commands"]) == {"execute", "cancel", "get_state"}
+        execute = desc["commands"]["execute"]
+        assert execute["params"] == ["trajectory"]
+        assert "trajectory" in execute["signature"]
+        assert desc["commands"]["cancel"]["params"] == []
+        assert desc["streams"] == []
+
+    def test_reports_stream_routes(self, coordinator):
+        # servo declares no commands but consumes joint_command.
+        task = CommandRecordingTask("servo1")
+        coordinator.add_task(task, task_type="servo")
+
+        desc = coordinator.describe_task("servo1")
+
+        assert desc["commands"] == {}
+        assert desc["streams"] == [("joint_command", "claim_overlap")]
+
+    def test_unknown_task_returns_none(self, coordinator):
+        assert coordinator.describe_task("nope") is None

--- a/dimos/control/test_coordinator_commands.py
+++ b/dimos/control/test_coordinator_commands.py
@@ -197,6 +197,18 @@ class TestActivationFanOut:
         coordinator.set_dry_run(False)
         assert task.dry_run is False
 
+    def test_restart_keeps_declared_commands_reachable(self, coordinator):
+        # add_task() skips known names, so a table cleared on stop() never rebuilds.
+        task = CommandRecordingTask("g1")
+        coordinator.add_task(task, task_type="g1_groot_wbc")
+
+        coordinator.start()
+        coordinator.stop()
+        coordinator.start()
+
+        coordinator.set_activated(True)
+        assert task.armed is True  # still declared after a stop/start cycle
+
 
 class TestValidatedDispatch:
     """New behavior introduced by TASK_EXPOSES: validated, declared commands."""

--- a/dimos/control/test_coordinator_commands.py
+++ b/dimos/control/test_coordinator_commands.py
@@ -76,11 +76,10 @@ class CommandRecordingTask(BaseControlTask):
         return False
 
     def compute(self, state: CoordinatorState) -> JointCommandOutput | None:
-        _ = state
         return None
 
     def on_preempted(self, by_task: str, joints: frozenset[str]) -> None:
-        _ = by_task, joints
+        pass
 
     # Trajectory commands
     def execute(self, trajectory: Any) -> bool:

--- a/dimos/control/test_coordinator_commands.py
+++ b/dimos/control/test_coordinator_commands.py
@@ -1,0 +1,198 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Characterization tests for coordinator task commands.
+
+These pin the observable behavior of ``task_invoke`` and the
+``set_activated`` / ``set_dry_run`` fan-outs so the TASK_EXPOSES
+card refactor can prove it preserves them. Tasks that declare their
+commands (via ``task_type``) keep the exact same observable outcomes
+after the refactor; only the mechanism underneath changes.
+
+The stubs are registered under real declaring task types
+(``trajectory`` for execute/cancel/get_state, ``g1_groot_wbc`` for
+arm/disarm/set_dry_run) so the same tests stay green before and after
+the command table exists.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from dimos.control.coordinator import ControlCoordinator
+from dimos.control.task import (
+    BaseControlTask,
+    CoordinatorState,
+    JointCommandOutput,
+    ResourceClaim,
+)
+from dimos.msgs.trajectory_msgs.JointTrajectory import JointTrajectory
+from dimos.msgs.trajectory_msgs.TrajectoryPoint import TrajectoryPoint
+
+ARM_JOINTS = frozenset({"arm/joint1", "arm/joint2"})
+
+
+class CommandRecordingTask(BaseControlTask):
+    """Stub task recording every command invocation.
+
+    Carries the trajectory-task commands (execute/cancel/get_state),
+    the g1 arming commands (arm/disarm/set_dry_run), plus an undeclared
+    ``record_time`` used to pin the ``t_now`` auto-injection contract.
+    """
+
+    def __init__(self, name: str, joints: frozenset[str] = ARM_JOINTS) -> None:
+        self._name = name
+        self._joints = frozenset(joints)
+        self.executed: Any = None
+        self.cancelled = False
+        self.armed: bool | None = None
+        self.arm_calls: list[float | None] = []
+        self.dry_run: bool | None = None
+        self.t_now_seen: float | None = None
+        self._state = "IDLE"
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def claim(self) -> ResourceClaim:
+        return ResourceClaim(joints=self._joints)
+
+    def is_active(self) -> bool:
+        return False
+
+    def compute(self, state: CoordinatorState) -> JointCommandOutput | None:
+        _ = state
+        return None
+
+    def on_preempted(self, by_task: str, joints: frozenset[str]) -> None:
+        _ = by_task, joints
+
+    # Trajectory commands
+    def execute(self, trajectory: Any) -> bool:
+        self.executed = trajectory
+        self._state = "EXECUTING"
+        return True
+
+    def cancel(self) -> bool:
+        self.cancelled = True
+        self._state = "ABORTED"
+        return True
+
+    def get_state(self) -> str:
+        return self._state
+
+    # g1 arming commands
+    def arm(self, ramp_seconds: float | None = None) -> bool:
+        self.armed = True
+        self.arm_calls.append(ramp_seconds)
+        return True
+
+    def disarm(self) -> bool:
+        self.armed = False
+        return True
+
+    def set_dry_run(self, enabled: bool) -> None:
+        self.dry_run = bool(enabled)
+
+    # Undeclared helper (never in any TASK_EXPOSES card)
+    def record_time(self, t_now: float | None = None) -> float | None:
+        self.t_now_seen = t_now
+        return t_now
+
+
+def _trajectory() -> JointTrajectory:
+    return JointTrajectory(
+        joint_names=["arm/joint1", "arm/joint2"],
+        points=[
+            TrajectoryPoint(time_from_start=0.0, positions=[0.0, 0.0]),
+            TrajectoryPoint(time_from_start=1.0, positions=[0.1, 0.2]),
+        ],
+    )
+
+
+@pytest.fixture
+def coordinator(mocker) -> Iterator[ControlCoordinator]:
+    """A coordinator with the tick loop stubbed; never started (RPCs are pure)."""
+    mocker.patch("dimos.control.coordinator.TickLoop")
+    coord = ControlCoordinator(publish_joint_state=False)
+    try:
+        yield coord
+    finally:
+        coord.stop()
+
+
+class TestTaskInvoke:
+    def test_execute_cancel_get_state_round_trip(self, coordinator):
+        task = CommandRecordingTask("traj_arm")
+        coordinator.add_task(task, task_type="trajectory")
+
+        traj = _trajectory()
+        assert coordinator.task_invoke("traj_arm", "execute", {"trajectory": traj}) is True
+        assert coordinator.task_invoke("traj_arm", "get_state") == "EXECUTING"
+        assert coordinator.task_invoke("traj_arm", "cancel") is True
+        assert coordinator.task_invoke("traj_arm", "get_state") == "ABORTED"
+        assert task.executed is traj
+
+    def test_injects_t_now_when_none(self, coordinator):
+        task = CommandRecordingTask("traj_arm")
+        coordinator.add_task(task, task_type="trajectory")
+
+        result = coordinator.task_invoke("traj_arm", "record_time", {"t_now": None})
+
+        assert isinstance(result, float)
+        assert task.t_now_seen == result
+
+    def test_unknown_task_warns_and_returns_none(self, coordinator, mocker):
+        import dimos.control.coordinator as coord_mod
+
+        warn = mocker.patch.object(coord_mod.logger, "warning")
+
+        assert coordinator.task_invoke("nope", "execute", {}) is None
+        assert warn.called
+
+    def test_unknown_method_warns_and_returns_none(self, coordinator, mocker):
+        import dimos.control.coordinator as coord_mod
+
+        task = CommandRecordingTask("traj_arm")
+        coordinator.add_task(task, task_type="trajectory")
+        warn = mocker.patch.object(coord_mod.logger, "warning")
+
+        assert coordinator.task_invoke("traj_arm", "no_such_method", {}) is None
+        assert warn.called
+
+
+class TestActivationFanOut:
+    def test_set_activated_arms_then_disarms_declaring_task(self, coordinator):
+        task = CommandRecordingTask("g1")
+        coordinator.add_task(task, task_type="g1_groot_wbc")
+
+        coordinator.set_activated(True)
+        assert task.armed is True
+
+        coordinator.set_activated(False)
+        assert task.armed is False
+
+    def test_set_dry_run_reaches_declaring_task(self, coordinator):
+        task = CommandRecordingTask("g1")
+        coordinator.add_task(task, task_type="g1_groot_wbc")
+
+        coordinator.set_dry_run(True)
+        assert task.dry_run is True
+
+        coordinator.set_dry_run(False)
+        assert task.dry_run is False

--- a/dimos/control/test_coordinator_commands.py
+++ b/dimos/control/test_coordinator_commands.py
@@ -165,15 +165,12 @@ class TestTaskInvoke:
         assert coordinator.task_invoke("nope", "execute", {}) is None
         assert warn.called
 
-    def test_unknown_method_warns_and_returns_none(self, coordinator, mocker):
-        import dimos.control.coordinator as coord_mod
-
+    def test_unknown_method_raises(self, coordinator):
         task = CommandRecordingTask("traj_arm")
         coordinator.add_task(task, task_type="trajectory")
-        warn = mocker.patch.object(coord_mod.logger, "warning")
 
-        assert coordinator.task_invoke("traj_arm", "no_such_method", {}) is None
-        assert warn.called
+        with pytest.raises(AttributeError, match=r"traj_arm.+no_such_method"):
+            coordinator.task_invoke("traj_arm", "no_such_method", {})
 
 
 class TestActivationFanOut:
@@ -267,16 +264,14 @@ class TestValidatedDispatch:
         assert task.t_now_seen == result
         assert any("undeclared task_invoke" in str(c.args[0]) for c in warn.call_args_list)
 
-    def test_typo_method_warns_and_returns_none(self, coordinator, mocker):
-        import dimos.control.coordinator as coord_mod
-
+    def test_typo_method_raises_and_names_declared_commands(self, coordinator):
         task = CommandRecordingTask("traj_arm")
         coordinator.add_task(task, task_type="trajectory")
-        warn = mocker.patch.object(coord_mod.logger, "warning")
 
         # "exceute" is a typo of the declared "execute"; no such method exists.
-        assert coordinator.task_invoke("traj_arm", "exceute", {}) is None
-        assert warn.called
+        with pytest.raises(AttributeError, match="exceute") as excinfo:
+            coordinator.task_invoke("traj_arm", "exceute", {})
+        assert "execute" in str(excinfo.value)  # the error points at the right name
 
     def test_shims_reach_only_declaring_tasks(self, coordinator):
         declaring = CommandRecordingTask("g1")


### PR DESCRIPTION
## Problem

RPC based tasks used a single @rpc task_invoke method, without any checking if task actually does support the rpc commands

Closes DIM-XXX

## Solution

Activates the commands half of the task binding card. A task type lists the command names it accepts; the method's own signature is the argument schema (`inspect.signature().bind()`), so there's no second schema to maintain and no new files. `task_invoke` keeps its exact wire signature.

## Contributor License Agreement

- [x ] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
