### PR TITLE
Control twist cards

### DIFF
--- a/dimos/control/coordinator.py
+++ b/dimos/control/coordinator.py
@@ -195,9 +195,12 @@ class ControlCoordinator(Module):
         self._stream_unsubs: dict[str, Callable[[], None]] = {}
         self._subscribe_lock = threading.Lock()
 
-        # The twist stream predates cards and keeps its own handle until
-        # its migration PR.
-        self._twist_command_unsub: Callable[[], None] | None = None
+        # Hardware-side hooks run on the raw stream callback before card
+        # dispatch. They must stay out of _dispatch: the twist mapper itself
+        # dispatches joint_command, and _task_lock is not reentrant.
+        self._stream_pre_hooks: dict[str, Callable[[Any], None]] = {
+            "twist_command": self._map_twist_to_base_joints,
+        }
 
         logger.info(f"ControlCoordinator initialized at {self.config.tick_rate}Hz")
 
@@ -350,7 +353,8 @@ class ControlCoordinator(Module):
             logger.info(
                 f"Added hardware {component.hardware_id} with joints: {connected.joint_names}"
             )
-            return True
+        self._sync_stream_subscriptions()
+        return True
 
     @rpc
     def remove_hardware(self, hardware_id: str) -> bool:
@@ -384,7 +388,8 @@ class ControlCoordinator(Module):
             interface.disconnect()
             del self._hardware[hardware_id]
             logger.info(f"Removed hardware {hardware_id}")
-            return True
+        self._sync_stream_subscriptions()
+        return True
 
     @rpc
     def list_hardware(self) -> list[str]:
@@ -466,11 +471,21 @@ class ControlCoordinator(Module):
         return control_task_registry.bindings_for(task_type).exposes
 
     def _sync_stream_subscriptions(self) -> None:
-        """Subscribe streams that gained routes; drop those whose last consumer left."""
+        """Subscribe streams that gained consumers; drop those whose last consumer left.
+
+        A consumer is a card-declared task route, or BASE hardware for
+        ``twist_command``. Locks are taken sequentially, never nested.
+        """
         if not (self._tick_loop and self._tick_loop.is_running):
             return
         with self._task_lock:
             active = {stream for stream, entries in self._routes.items() if entries}
+        with self._hardware_lock:
+            has_base = any(
+                hw.component.hardware_type == HardwareType.BASE for hw in self._hardware.values()
+            )
+        if has_base:
+            active.add("twist_command")
         with self._subscribe_lock:
             for stream in active - self._stream_unsubs.keys():
                 try:
@@ -488,7 +503,11 @@ class ControlCoordinator(Module):
                 logger.info(f"Unsubscribed from {stream}; last card-bound consumer removed")
 
     def _make_stream_cb(self, stream: str) -> "Callable[[Any], None]":
+        pre_hook = self._stream_pre_hooks.get(stream)
+
         def _on_message(msg: Any) -> None:
+            if pre_hook is not None:
+                pre_hook(msg)
             self._dispatch(stream, msg)
 
         return _on_message
@@ -548,12 +567,8 @@ class ControlCoordinator(Module):
                 else:
                     logger.warning(f"{stream} for unknown task: {frame_id}")
 
-    def _on_twist_command(self, msg: Twist) -> None:
-        """Convert Twist → virtual joint velocities and route via joint_command dispatch.
-
-        Maps Twist fields to virtual joints using suffix convention:
-        base_vx ← linear.x, base_vy ← linear.y, base_wz ← angular.z, etc.
-        """
+    def _map_twist_to_base_joints(self, msg: Twist) -> None:
+        """Map Twist onto BASE virtual joints (base/vx ← linear.x, ...) via joint_command."""
         names: list[str] = []
         velocities: list[float] = []
 
@@ -575,14 +590,6 @@ class ControlCoordinator(Module):
         if names:
             joint_state = JointState(name=names, velocity=velocities)
             self._dispatch("joint_command", joint_state)
-
-        # Velocity-capable tasks opt in with set_velocity_command().
-        t_now = time.perf_counter()
-        with self._task_lock:
-            for task in self._tasks.values():
-                set_vel = getattr(task, "set_velocity_command", None)
-                if set_vel is not None:
-                    set_vel(msg.linear.x, msg.linear.y, msg.angular.z, t_now)
 
     @rpc
     def set_activated(self, engaged: bool) -> None:
@@ -611,20 +618,27 @@ class ControlCoordinator(Module):
 
     @rpc
     def reset_runtime_state(self, reactivate: bool | None = None) -> dict[str, bool]:
-        """Reset transient state on tasks that expose ``reset_runtime_state``.
+        """Reset transient state on tasks whose card declares ``reset_runtime_state``.
 
         This is meant for simulation/runtime discontinuities such as MuJoCo
         respawn, where task histories and latched commands must be cleared
-        without tearing down the coordinator.
+        without tearing down the coordinator. The result covers declaring
+        tasks only.
         """
         results: dict[str, bool] = {}
         with self._task_lock:
-            for task in self._tasks.values():
+            for name, task in self._tasks.items():
+                if "reset_runtime_state" not in self._task_commands.get(name, frozenset()):
+                    continue
                 try:
-                    results[task.name] = bool(task.reset_runtime_state(reactivate=reactivate))
+                    results[name] = bool(
+                        self._invoke_declared(
+                            task, name, "reset_runtime_state", {"reactivate": reactivate}
+                        )
+                    )
                 except Exception:
-                    logger.exception(f"reset_runtime_state() raised on task {task.name!r}")
-                    results[task.name] = False
+                    logger.exception(f"reset_runtime_state() raised on task {name!r}")
+                    results[name] = False
         return results
 
     @rpc
@@ -784,26 +798,9 @@ class ControlCoordinator(Module):
         )
         self._tick_loop.start()
 
-        # Subscribe the streams that registered tasks' cards consume.
+        # Subscribe the streams that registered tasks' cards consume, plus
+        # twist_command when BASE hardware demands the twist mapping.
         self._sync_stream_subscriptions()
-
-        # Twist commands drive either base hardware or velocity-capable tasks.
-        # This stream predates cards and is migrated in a follow-up PR.
-        has_twist_base = any(c.hardware_type == HardwareType.BASE for c in self.config.hardware)
-        with self._task_lock:
-            has_velocity_task = any(
-                callable(getattr(task, "set_velocity_command", None))
-                for task in self._tasks.values()
-            )
-        if has_twist_base or has_velocity_task:
-            try:
-                self._twist_command_unsub = self.twist_command.subscribe(self._on_twist_command)
-                logger.info("Subscribed to twist_command for twist base / velocity-capable tasks")
-            except Exception:
-                logger.warning(
-                    "Twist base or velocity-capable task configured but could not subscribe "
-                    "to twist_command. Use task_invoke RPC or set transport via blueprint."
-                )
 
         # Arming + dry-run are RPC-only; no stream subscription here.
 
@@ -820,9 +817,6 @@ class ControlCoordinator(Module):
             for unsub in self._stream_unsubs.values():
                 unsub()
             self._stream_unsubs.clear()
-        if self._twist_command_unsub:
-            self._twist_command_unsub()
-            self._twist_command_unsub = None
 
         if self._tick_loop:
             self._tick_loop.stop()

--- a/dimos/control/routing.py
+++ b/dimos/control/routing.py
@@ -39,13 +39,11 @@ CONSUMABLE_STREAMS = frozenset(
         "joint_command",
         "coordinator_cartesian_command",
         "coordinator_ee_twist_command",
+        "twist_command",
         "teleop_buttons",
     }
 )
 """Coordinator input ports that cards may bind."""
-
-DEFERRED_STREAMS = frozenset({"twist_command"})
-"""Coordinator input ports that exist but are not card-routable yet."""
 
 
 @dataclass(frozen=True)

--- a/dimos/control/tasks/g1_groot_wbc_task/_registry.py
+++ b/dimos/control/tasks/g1_groot_wbc_task/_registry.py
@@ -17,9 +17,9 @@ TASK_FACTORIES = {
 }
 
 TASK_CONSUMES: dict[str, dict[str, tuple[str, str]]] = {
-    "g1_groot_wbc": {},  # its twist input is wired to cards in a later PR
+    "g1_groot_wbc": {"twist_command": ("on_twist_command", "broadcast")},
 }
 
 TASK_EXPOSES: dict[str, list[str]] = {
-    "g1_groot_wbc": ["arm", "disarm", "set_dry_run"],
+    "g1_groot_wbc": ["arm", "disarm", "set_dry_run", "reset_runtime_state"],
 }

--- a/dimos/control/tasks/g1_groot_wbc_task/g1_groot_wbc_task.py
+++ b/dimos/control/tasks/g1_groot_wbc_task/g1_groot_wbc_task.py
@@ -589,15 +589,14 @@ class G1GrootWBCTask(BaseControlTask):
             self._cmd[:] = [vx, vy, yaw_rate]
             self._last_cmd_time = t_now
 
-    def on_twist(self, msg: Twist, t_now: float) -> bool:
-        """Accept a Twist message, e.g. from an LCM cmd_vel transport."""
+    def on_twist_command(self, msg: Twist, t_now: float) -> None:
+        """Card-routed twist_command handler."""
         self.set_velocity_command(
             float(msg.linear.x),
             float(msg.linear.y),
             float(msg.angular.z),
             t_now,
         )
-        return True
 
     # Lifecycle
 

--- a/dimos/control/tasks/g1_groot_wbc_task/test_g1_groot_wbc_task.py
+++ b/dimos/control/tasks/g1_groot_wbc_task/test_g1_groot_wbc_task.py
@@ -37,6 +37,7 @@ from dimos.control.tasks.g1_groot_wbc_task.g1_groot_wbc_task import (
     G1GrootWBCTaskConfig,
 )
 from dimos.hardware.whole_body.spec import IMUState
+from dimos.msgs.geometry_msgs.Twist import Twist
 
 
 class _StubSession:
@@ -185,6 +186,13 @@ def test_nonzero_cmd_uses_walk_until_timeout(
         task.compute(_state_at(102.0, joints_29))
 
     assert patched_ort == ["walk", "balance"]
+
+
+def test_on_twist_command_sets_velocity_command(task: G1GrootWBCTask) -> None:
+    task.on_twist_command(Twist(linear=[0.5, 0.25, 0.0], angular=[0.0, 0.0, 0.3]), t_now=100.0)
+
+    assert list(task._cmd) == pytest.approx([0.5, 0.25, 0.3])
+    assert task._last_cmd_time == 100.0
 
 
 def test_observation_layout_matches_policy_contract(task: G1GrootWBCTask) -> None:

--- a/dimos/control/tasks/registry.py
+++ b/dimos/control/tasks/registry.py
@@ -35,7 +35,6 @@ from typing import TYPE_CHECKING, cast
 
 from dimos.control.routing import (
     CONSUMABLE_STREAMS,
-    DEFERRED_STREAMS,
     Routing,
     StreamBinding,
     TaskBindings,
@@ -218,11 +217,6 @@ class ControlTaskRegistry:
             where = f"{source}: task type {task_type!r}, stream {stream!r}"
             if not isinstance(stream, str):
                 raise TypeError(f"{where}: stream name must be a string")
-            if stream in DEFERRED_STREAMS:
-                raise ValueError(
-                    f"{where}: not card-routable yet; the twist path is deliberately "
-                    "deferred to a later PR, so this restriction is temporary"
-                )
             if stream not in CONSUMABLE_STREAMS:
                 raise ValueError(f"{where}: unknown stream; allowed: {sorted(CONSUMABLE_STREAMS)}")
             if (

--- a/dimos/control/tasks/test_registry.py
+++ b/dimos/control/tasks/test_registry.py
@@ -144,8 +144,8 @@ def test_seeded_cards_load_into_registry() -> None:
     assert trajectory.consumes == ()  # command-driven only
     assert trajectory.exposes == frozenset({"execute", "cancel", "get_state"})
     g1 = control_task_registry.bindings_for("g1_groot_wbc")
-    assert g1.consumes == ()  # its twist input is a later PR
-    assert g1.exposes == frozenset({"arm", "disarm", "set_dry_run"})
+    assert g1.consumes == (StreamBinding("twist_command", "on_twist_command", Routing.BROADCAST),)
+    assert g1.exposes == frozenset({"arm", "disarm", "set_dry_run", "reset_runtime_state"})
 
 
 def _scannable_task_classes(task_type: str) -> list[type] | None:
@@ -251,12 +251,21 @@ def test_register_bindings_runtime_and_conflict() -> None:
 
 def test_register_bindings_rejects_bad_streams_and_routing() -> None:
     reg = ControlTaskRegistry()
-    with pytest.raises(ValueError, match="later PR"):
-        reg.register_bindings("fake_twist", consumes={"twist_command": ("on_twist", "broadcast")})
     with pytest.raises(ValueError, match="allowed"):
         reg.register_bindings("fake_stream", consumes={"no_such_port": ("on_x", "broadcast")})
     with pytest.raises(ValueError, match="routing"):
         reg.register_bindings("fake_routing", consumes={"joint_command": ("on_x", "round_robin")})
+
+
+def test_register_bindings_accepts_twist_card() -> None:
+    # twist_command left DEFERRED_STREAMS in B3; a twist card now loads.
+    reg = ControlTaskRegistry()
+    reg.register_bindings(
+        "fake_twist", consumes={"twist_command": ("on_twist_command", "broadcast")}
+    )
+    assert reg.bindings_for("fake_twist").consumes == (
+        StreamBinding("twist_command", "on_twist_command", Routing.BROADCAST),
+    )
 
 
 def test_register_bindings_rejects_bad_exposes() -> None:

--- a/dimos/control/test_control.py
+++ b/dimos/control/test_control.py
@@ -279,7 +279,7 @@ class TestControlCoordinatorLifecycle:
         unsubscribe.assert_called_once_with()
         assert coordinator._stream_unsubs == {}
 
-    def test_on_twist_command_still_routes_planar_twist_to_base_and_velocity_tasks(
+    def test_map_twist_to_base_joints_routes_planar_twist_via_joint_command(
         self, make_coordinator, mocker
     ):
         coordinator = make_coordinator()
@@ -289,13 +289,12 @@ class TestControlCoordinatorLifecycle:
             joints=make_twist_base_joints("base"),
         )
         coordinator._hardware = {"base": ConnectedTwistBase(MagicMock(), component)}
-        velocity_task = MagicMock()
-        velocity_task.claim.return_value = ResourceClaim(frozenset())
-        coordinator._tasks = {"velocity": velocity_task}
         dispatch = mocker.patch.object(coordinator, "_dispatch")
 
         try:
-            coordinator._on_twist_command(Twist(linear=[1.0, 2.0, 0.0], angular=[0.0, 0.0, 3.0]))
+            coordinator._map_twist_to_base_joints(
+                Twist(linear=[1.0, 2.0, 0.0], angular=[0.0, 0.0, 3.0])
+            )
         finally:
             coordinator.stop()
 
@@ -304,10 +303,6 @@ class TestControlCoordinatorLifecycle:
         assert isinstance(joint_state, JointState)
         assert joint_state.name == ["base/vx", "base/vy", "base/wz"]
         assert joint_state.velocity == [1.0, 2.0, 3.0]
-        velocity_task.set_velocity_command.assert_called_once()
-        vx, vy, wz, t_now = velocity_task.set_velocity_command.call_args.args
-        assert (vx, vy, wz) == (1.0, 2.0, 3.0)
-        assert isinstance(t_now, float)
 
     def test_reset_runtime_state_calls_task_hooks(self):
         class ResettableTask(BaseControlTask):
@@ -338,7 +333,8 @@ class TestControlCoordinatorLifecycle:
         task = ResettableTask()
 
         try:
-            assert coordinator.add_task(task)
+            # reset_runtime_state is card-gated; g1_groot_wbc declares it.
+            assert coordinator.add_task(task, task_type="g1_groot_wbc")
 
             assert coordinator.reset_runtime_state(reactivate=True) == {"resettable": True}
             assert task.reset_reactivate_args == [True]

--- a/dimos/control/test_coordinator_commands.py
+++ b/dimos/control/test_coordinator_commands.py
@@ -62,6 +62,7 @@ class CommandRecordingTask(BaseControlTask):
         self.armed: bool | None = None
         self.arm_calls: list[float | None] = []
         self.dry_run: bool | None = None
+        self.reset_calls: list[bool | None] = []
         self.t_now_seen: float | None = None
         self._state = "IDLE"
 
@@ -107,6 +108,10 @@ class CommandRecordingTask(BaseControlTask):
 
     def set_dry_run(self, enabled: bool) -> None:
         self.dry_run = bool(enabled)
+
+    def reset_runtime_state(self, reactivate: bool | None = None) -> bool:
+        self.reset_calls.append(reactivate)
+        return True
 
     # Undeclared helper (never in any TASK_EXPOSES card)
     def record_time(self, t_now: float | None = None) -> float | None:
@@ -192,6 +197,20 @@ class TestActivationFanOut:
 
         coordinator.set_dry_run(False)
         assert task.dry_run is False
+
+    def test_reset_runtime_state_reaches_declaring_task(self, coordinator):
+        task = CommandRecordingTask("g1")
+        coordinator.add_task(task, task_type="g1_groot_wbc")
+
+        assert coordinator.reset_runtime_state(reactivate=True) == {"g1": True}
+        assert task.reset_calls == [True]
+
+    def test_reset_runtime_state_defaults_reactivate_to_none(self, coordinator):
+        task = CommandRecordingTask("g1")
+        coordinator.add_task(task, task_type="g1_groot_wbc")
+
+        assert coordinator.reset_runtime_state() == {"g1": True}
+        assert task.reset_calls == [None]
 
     def test_restart_keeps_declared_commands_reachable(self, coordinator):
         # add_task() skips known names, so a table cleared on stop() never rebuilds.

--- a/dimos/control/test_coordinator_commands.py
+++ b/dimos/control/test_coordinator_commands.py
@@ -291,6 +291,17 @@ class TestValidatedDispatch:
             coordinator.task_invoke("traj_arm", "exceute", {})
         assert "execute" in str(excinfo.value)  # the error points at the right name
 
+    def test_reset_runtime_state_covers_declaring_tasks_only(self, coordinator):
+        declaring = CommandRecordingTask("g1")
+        coordinator.add_task(declaring, task_type="g1_groot_wbc")
+        # Bare add: has reset_runtime_state() but declares no commands.
+        bare = CommandRecordingTask("bare")
+        coordinator.add_task(bare)
+
+        assert coordinator.reset_runtime_state(reactivate=False) == {"g1": True}
+        assert declaring.reset_calls == [False]
+        assert bare.reset_calls == []
+
     def test_shims_reach_only_declaring_tasks(self, coordinator):
         declaring = CommandRecordingTask("g1")
         coordinator.add_task(declaring, task_type="g1_groot_wbc")
@@ -336,3 +347,13 @@ class TestDescribeTask:
 
     def test_unknown_task_returns_none(self, coordinator):
         assert coordinator.describe_task("nope") is None
+
+    def test_g1_reports_twist_stream_and_reset_command(self, coordinator):
+        task = CommandRecordingTask("g1")
+        coordinator.add_task(task, task_type="g1_groot_wbc")
+
+        desc = coordinator.describe_task("g1")
+
+        assert ("twist_command", "broadcast") in desc["streams"]
+        assert "reset_runtime_state" in desc["commands"]
+        assert desc["commands"]["reset_runtime_state"]["params"] == ["reactivate"]

--- a/dimos/control/test_coordinator_routing.py
+++ b/dimos/control/test_coordinator_routing.py
@@ -25,6 +25,7 @@ avoid coordinator internals: messages enter through the ports'
 from __future__ import annotations
 
 from collections.abc import Callable, Iterator
+import threading
 from typing import Any
 
 import pytest
@@ -54,7 +55,7 @@ STREAMS = (
 
 
 class VelocityCapableTask(RecordingTask):
-    """Stub that opts into the twist fan-out via set_velocity_command."""
+    """Bare stub with set_velocity_command; card routing gives it nothing."""
 
     def __init__(self, name: str) -> None:
         super().__init__(name)
@@ -283,7 +284,7 @@ def _base_component() -> HardwareComponent:
 
 
 class TestTwistRouting:
-    """Twist stays on the legacy path until B3; these guard that seam."""
+    """Base virtual-joint mapping is hardware-side; the fan-out is card-routed."""
 
     def test_base_twist_maps_to_virtual_joint_velocities(self, make_coordinator):
         coordinator, taps = make_coordinator(
@@ -302,21 +303,6 @@ class TestTwistRouting:
 
         assert coordinator.get_task("basevel")._velocities == [1.0, 2.0, 3.0]
 
-    def test_twist_fans_out_to_velocity_capable_tasks(self, make_coordinator):
-        coordinator, taps = make_coordinator()
-        capable = VelocityCapableTask("capable")
-        plain = RecordingTask("plain")
-        coordinator.add_task(capable)
-        coordinator.add_task(plain)
-        coordinator.start()
-
-        taps["twist_command"].emit(Twist(linear=[1.0, 2.0, 0.0], angular=[0.0, 0.0, 3.0]))
-
-        assert len(capable.velocity_commands) == 1
-        vx, vy, wz, t_now = capable.velocity_commands[0]
-        assert (vx, vy, wz) == (1.0, 2.0, 3.0)
-        assert isinstance(t_now, float)
-
     def test_base_twist_both_maps_joints_and_fans_out(self, make_coordinator):
         coordinator, taps = make_coordinator(
             hardware=[_base_component()],
@@ -328,8 +314,8 @@ class TestTwistRouting:
                 )
             ],
         )
-        capable = VelocityCapableTask("capable")
-        coordinator.add_task(capable)
+        capable = G1ShapedVelocityTask("capable")
+        coordinator.add_task(capable, task_type="g1_groot_wbc")
         coordinator.start()
 
         taps["twist_command"].emit(Twist(linear=[1.0, 2.0, 0.0], angular=[0.0, 0.0, 3.0]))
@@ -339,13 +325,6 @@ class TestTwistRouting:
 
     def test_twist_subscribed_for_base_hardware_without_tasks(self, make_coordinator):
         coordinator, taps = make_coordinator(hardware=[_base_component()])
-        coordinator.start()
-
-        assert taps["twist_command"].subscribed
-
-    def test_twist_subscribed_for_velocity_capable_task_without_base(self, make_coordinator):
-        coordinator, taps = make_coordinator()
-        coordinator.add_task(VelocityCapableTask("capable"))
         coordinator.start()
 
         assert taps["twist_command"].subscribed
@@ -438,6 +417,79 @@ class TestTwistRouting:
         vx, vy, wz, t_now = task.velocity_commands[0]
         assert (vx, vy, wz) == (1.0, 2.0, 3.0)
         assert isinstance(t_now, float)
+
+
+class TestTwistCardContract:
+    """Contract introduced by the twist migration: intentional deltas and new seams."""
+
+    def test_card_routed_twist_delivers_raw_msg_to_on_twist_command(self, make_coordinator):
+        coordinator, taps = make_coordinator()
+        task = G1ShapedVelocityTask("g1")
+        coordinator.add_task(task, task_type="g1_groot_wbc")
+        coordinator.start()
+
+        msg = Twist(linear=[1.0, 2.0, 0.0], angular=[0.0, 0.0, 3.0])
+        taps["twist_command"].emit(msg)
+
+        assert len(task.twist_msgs) == 1
+        assert task.twist_msgs[0] is msg  # the raw message, not a digest
+
+    def test_bare_set_velocity_command_stub_gets_nothing(self, make_coordinator):
+        # Intentional delta: the fan-out narrowed to card-declared consumers.
+        coordinator, taps = make_coordinator(hardware=[_base_component()])
+        bare = VelocityCapableTask("bare")
+        coordinator.add_task(bare)
+        coordinator.start()
+        assert taps["twist_command"].subscribed  # the base keeps the stream alive
+
+        taps["twist_command"].emit(Twist(linear=[1.0, 2.0, 0.0], angular=[0.0, 0.0, 3.0]))
+
+        assert bare.velocity_commands == []
+
+    def test_runtime_base_add_remove_toggles_twist_subscription(self, make_coordinator):
+        from dimos.hardware.drive_trains.registry import twist_base_adapter_registry
+
+        coordinator, taps = make_coordinator()
+        coordinator.start()
+        assert not taps["twist_command"].subscribed
+
+        component = _base_component()
+        adapter = twist_base_adapter_registry.create(
+            "mock_twist_base", dof=len(component.joints), hardware_id="base"
+        )
+        assert adapter.connect()
+        assert coordinator.add_hardware(adapter, component)
+        assert taps["twist_command"].subscribed
+
+        assert coordinator.remove_hardware("base")
+        taps["twist_command"].unsub.assert_called_once()
+
+    def test_twist_delivery_concurrent_with_remove_hardware(self, make_coordinator):
+        coordinator, taps = make_coordinator(hardware=[_base_component()])
+        coordinator.start()
+        assert taps["twist_command"].subscribed
+
+        msg = Twist(linear=[1.0, 0.0, 0.0], angular=[0.0, 0.0, 0.5])
+        stop = threading.Event()
+
+        def pump() -> None:
+            while not stop.is_set():
+                taps["twist_command"].emit(msg)
+
+        removed: list[bool] = []
+        pumper = threading.Thread(target=pump, daemon=True)
+        remover = threading.Thread(
+            target=lambda: removed.append(coordinator.remove_hardware("base")), daemon=True
+        )
+        pumper.start()
+        remover.start()
+        remover.join(timeout=5.0)
+        stop.set()
+        pumper.join(timeout=5.0)
+
+        assert not remover.is_alive(), "remove_hardware deadlocked against twist delivery"
+        assert not pumper.is_alive(), "twist delivery deadlocked against remove_hardware"
+        assert removed == [True]
 
 
 class TestSubscriptionLifecycle:

--- a/dimos/control/test_coordinator_routing.py
+++ b/dimos/control/test_coordinator_routing.py
@@ -64,6 +64,20 @@ class VelocityCapableTask(RecordingTask):
         self.velocity_commands.append((vx, vy, wz, t_now))
 
 
+class G1ShapedVelocityTask(VelocityCapableTask):
+    """Stub carrying g1_groot_wbc's twist surface, registered under its type."""
+
+    def __init__(self, name: str) -> None:
+        super().__init__(name)
+        self.twist_msgs: list[Any] = []
+
+    def on_twist_command(self, msg: Any, t_now: float) -> None:
+        # Mirrors G1GrootWBCTask: the uniform handler delegates to
+        # set_velocity_command.
+        self.twist_msgs.append(msg)
+        self.set_velocity_command(msg.linear.x, msg.linear.y, msg.angular.z, t_now)
+
+
 class PortTap:
     """Captures subscribe() on one coordinator port and replays messages."""
 
@@ -343,6 +357,87 @@ class TestTwistRouting:
         coordinator.start()
 
         assert not taps["twist_command"].subscribed
+
+    def test_base_suffix_subset_maps_only_declared_joints(self, make_coordinator):
+        carlike_joints = make_twist_base_joints("base", ["vx", "wz"])
+        coordinator, taps = make_coordinator(
+            hardware=[
+                HardwareComponent(
+                    hardware_id="base",
+                    hardware_type=HardwareType.BASE,
+                    joints=carlike_joints,
+                    adapter_type="mock_twist_base",
+                )
+            ],
+            tasks=[TaskConfig(name="basevel", type="velocity", joint_names=carlike_joints)],
+        )
+        coordinator.start()
+
+        taps["twist_command"].emit(Twist(linear=[1.0, 2.0, 0.0], angular=[0.0, 0.0, 3.0]))
+
+        assert coordinator.get_task("basevel")._velocities == [1.0, 3.0]
+
+    def test_base_full_6d_twist_maps_all_axes(self, make_coordinator):
+        # Drones and such: a base may declare all six twist axes.
+        drone_joints = make_twist_base_joints("base", ["vx", "vy", "vz", "wx", "wy", "wz"])
+        coordinator, taps = make_coordinator(
+            hardware=[
+                HardwareComponent(
+                    hardware_id="base",
+                    hardware_type=HardwareType.BASE,
+                    joints=drone_joints,
+                    adapter_type="mock_twist_base",
+                )
+            ],
+            tasks=[TaskConfig(name="basevel", type="velocity", joint_names=drone_joints)],
+        )
+        coordinator.start()
+
+        taps["twist_command"].emit(Twist(linear=[1.0, 2.0, 3.0], angular=[4.0, 5.0, 6.0]))
+
+        assert coordinator.get_task("basevel")._velocities == [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+
+    def test_twist_mapping_ignores_non_base_hardware(self, make_coordinator):
+        # A manipulator joint named like a twist axis must not be mapped.
+        coordinator, taps = make_coordinator(
+            hardware=[
+                _base_component(),
+                HardwareComponent(
+                    hardware_id="arm",
+                    hardware_type=HardwareType.MANIPULATOR,
+                    joints=["arm/vx"],
+                    adapter_type="mock",
+                ),
+            ],
+            tasks=[
+                TaskConfig(
+                    name="basevel",
+                    type="velocity",
+                    joint_names=make_twist_base_joints("base"),
+                ),
+                TaskConfig(name="armvel", type="velocity", joint_names=["arm/vx"]),
+            ],
+        )
+        coordinator.start()
+
+        taps["twist_command"].emit(Twist(linear=[1.0, 2.0, 0.0], angular=[0.0, 0.0, 3.0]))
+
+        assert coordinator.get_task("basevel")._velocities == [1.0, 2.0, 3.0]
+        assert coordinator.get_task("armvel")._velocities is None
+
+    def test_twist_reaches_declaring_velocity_task_without_base(self, make_coordinator):
+        coordinator, taps = make_coordinator()
+        task = G1ShapedVelocityTask("g1")
+        coordinator.add_task(task, task_type="g1_groot_wbc")
+        coordinator.start()
+
+        assert taps["twist_command"].subscribed
+        taps["twist_command"].emit(Twist(linear=[1.0, 2.0, 0.0], angular=[0.0, 0.0, 3.0]))
+
+        assert len(task.velocity_commands) == 1
+        vx, vy, wz, t_now = task.velocity_commands[0]
+        assert (vx, vy, wz) == (1.0, 2.0, 3.0)
+        assert isinstance(t_now, float)
 
 
 class TestSubscriptionLifecycle:


### PR DESCRIPTION
## Problem

`twist_command` was the last coordinator input still wired by hand: one fused handler doing two unrelated jobs, gated by hardcoded subscription logic and `getattr` probes for `set_velocity_command`. The coordinator still had to know task types by name.


## Solution

Split the fused handler. The Twist → base virtual-joint mapping stays coordinator-side as `_map_twist_to_base_joints` (it depends on hardware config, not tasks) and runs as a pre-dispatch hook — it can't be a route, because `_dispatch` holds the non-reentrant `_task_lock` and the mapper dispatches `joint_command` itself.

## Contributor License Agreement

- [x ] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
