### PR TITLE
fix(memory2): recorder ingress reception_ts + poseless streams

### DIFF
--- a/dimos/memory2/module.py
+++ b/dimos/memory2/module.py
@@ -272,6 +272,8 @@ class RecorderConfig(MemoryModuleConfig):
     # read the active remappings from inside the module (AFAIK), so this config
     # arg does the per-stream rename directly.
     stream_remapping: dict[str, str] = Field(default_factory=dict)
+    # Port names that inherently have no pose to anchor (command streams, etc.).
+    poseless_streams: list[str] = Field(default_factory=list)
 
 
 PoseSetter = Callable[[Any], "Awaitable[Pose | None]"]
@@ -380,16 +382,17 @@ class Recorder(MemoryModule):
         """
 
         async def on_msg(msg: Any) -> None:
+            recv_ts = time.time()  # wall-clock at ingress
             ts = self._resolve_ts(name, msg)
             pose = await self._resolve_pose(name, msg, ts)
-            if not pose:
+            if not pose and name not in self.config.poseless_streams:
                 logger.warning(
                     "[%s] No pose for time %s (msg ts: %s), storing without pose",
                     name,
                     ts,
                     getattr(msg, "ts", None),
                 )
-            stream.append(msg, ts=ts, pose=pose)
+            stream.append(msg, ts=ts, pose=pose, tags={"reception_ts": recv_ts})
 
         self.process_observable(input_topic.pure_observable(), on_msg)
 

--- a/dimos/memory2/module.py
+++ b/dimos/memory2/module.py
@@ -24,6 +24,7 @@ import time
 from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
 
 from pydantic import Field, field_validator
+from reactivex import operators as ops
 from reactivex.disposable import Disposable
 
 from dimos.agents.annotation import skill
@@ -381,8 +382,8 @@ class Recorder(MemoryModule):
         and registers the subscription for cleanup on stop().
         """
 
-        async def on_msg(msg: Any) -> None:
-            recv_ts = time.time()  # wall-clock at ingress
+        async def on_msg(stamped: tuple[float, Any]) -> None:
+            recv_ts, msg = stamped
             ts = self._resolve_ts(name, msg)
             pose = await self._resolve_pose(name, msg, ts)
             if not pose and name not in self.config.poseless_streams:
@@ -394,7 +395,9 @@ class Recorder(MemoryModule):
                 )
             stream.append(msg, ts=ts, pose=pose, tags={"reception_ts": recv_ts})
 
-        self.process_observable(input_topic.pure_observable(), on_msg)
+        # Stamp arrival time before the coalescing dispatch queue.
+        stamped = input_topic.pure_observable().pipe(ops.map(lambda msg: (time.time(), msg)))
+        self.process_observable(stamped, on_msg)
 
     def _prepare_streams(self) -> None:
         """On APPEND, drop the streams this recorder is about to (re)write — the


### PR DESCRIPTION
## Problem

1. **No command-link latency captured.** Recorded observations only carried the sender's `msg.ts`. There was no record of *when the robot received* a command
2. **"No pose" log spam.** Streams that inherently have no pose to anchor (command streams like `cmd_vel_stamped`) logged a `warning` on every message, flooding the logs during recording.

Closes DIM-1040

## Solution

Two small, independent changes in `dimos/memory2/module.py`:

1. **Ingress `reception_ts` tag.** `Recorder.on_msg` stamps a wall-clock `time.time()` at ingress and attaches it as a `reception_ts` tag on the stored observation.

2. **`RecorderConfig.poseless_streams`.** Streams listed here record silently with no pose. Everything *not* listed still warns per-message — a missing tf on a sensor stream (camera, lidar) is a real data-collection error and must stay loud, not be swallowed. 
- Kept as a config list (matching `stream_remapping`) rather than downgrading/throttling the log, so genuine sensor tf loss is never hidden.

## How to Test

    blueprint.add(MyRecorder, poseless_streams=["cmd_vel_stamped"])

## Contributor License Agreement

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
