### PR TITLE
feat(manipulation): formal time-parameterization stage, preserve planner timestamps (#2540)

### DIFF
--- a/dimos/manipulation/manipulation_module.py
+++ b/dimos/manipulation/manipulation_module.py
@@ -658,8 +658,6 @@ class ManipulationModule(Module):
         except ValueError as exc:
             # A bad planner timeline must not strand the module, nor leave a
             # stale trajectory from a previous plan that execute() could pick up.
-        except ValueError as exc:
-            # A bad planner timeline must not strand the module in PLANNING.
             self._planned_paths.pop(robot_name, None)
             self._planned_trajectories.pop(robot_name, None)
             return self._fail(f"Time-parameterization failed: {exc}")

--- a/dimos/manipulation/manipulation_module.py
+++ b/dimos/manipulation/manipulation_module.py
@@ -658,6 +658,8 @@ class ManipulationModule(Module):
         except ValueError as exc:
             # A bad planner timeline must not strand the module, nor leave a
             # stale trajectory from a previous plan that execute() could pick up.
+        except ValueError as exc:
+            # A bad planner timeline must not strand the module in PLANNING.
             self._planned_paths.pop(robot_name, None)
             self._planned_trajectories.pop(robot_name, None)
             return self._fail(f"Time-parameterization failed: {exc}")

--- a/dimos/manipulation/manipulation_module.py
+++ b/dimos/manipulation/manipulation_module.py
@@ -656,7 +656,10 @@ class ManipulationModule(Module):
         try:
             traj = time_parameterizer.parameterize(result)
         except ValueError as exc:
-            # A bad planner timeline must not strand the module in PLANNING.
+            # A bad planner timeline must not strand the module, nor leave a
+            # stale trajectory from a previous plan that execute() could pick up.
+            self._planned_paths.pop(robot_name, None)
+            self._planned_trajectories.pop(robot_name, None)
             return self._fail(f"Time-parameterization failed: {exc}")
         self._planned_trajectories[robot_name] = traj
         logger.info(f"Trajectory: {traj.duration:.3f}s")

--- a/dimos/manipulation/manipulation_module.py
+++ b/dimos/manipulation/manipulation_module.py
@@ -63,6 +63,9 @@ from dimos.manipulation.planning.spec.protocols import KinematicsSpec, PlannerSp
 from dimos.manipulation.planning.trajectory_generator.joint_trajectory_generator import (
     JointTrajectoryGenerator,
 )
+from dimos.manipulation.planning.trajectory_generator.time_parameterizer import (
+    TrapezoidalTimeParameterizer,
+)
 from dimos.manipulation.skill_errors import ManipulationSkillError
 from dimos.manipulation.visualization.config import (
     ManipulationVisualizationConfig,
@@ -647,8 +650,10 @@ class ManipulationModule(Module):
         self._planned_paths[robot_name] = result.path
 
         _, _, traj_gen = self._robots[robot_name]
-        # Convert JointState path to list of position lists for trajectory generator
-        traj = traj_gen.generate([list(state.position) for state in result.path])
+        # Time-parameterize the geometric path into an executable trajectory.
+        # Honors planner-provided timestamps; else synthesizes a trapezoidal profile.
+        time_parameterizer = TrapezoidalTimeParameterizer(traj_gen)
+        traj = time_parameterizer.parameterize(result)
         self._planned_trajectories[robot_name] = traj
         logger.info(f"Trajectory: {traj.duration:.3f}s")
 

--- a/dimos/manipulation/manipulation_module.py
+++ b/dimos/manipulation/manipulation_module.py
@@ -653,7 +653,11 @@ class ManipulationModule(Module):
         # Time-parameterize the geometric path into an executable trajectory.
         # Honors planner-provided timestamps; else synthesizes a trapezoidal profile.
         time_parameterizer = TrapezoidalTimeParameterizer(traj_gen)
-        traj = time_parameterizer.parameterize(result)
+        try:
+            traj = time_parameterizer.parameterize(result)
+        except ValueError as exc:
+            # A bad planner timeline must not strand the module in PLANNING.
+            return self._fail(f"Time-parameterization failed: {exc}")
         self._planned_trajectories[robot_name] = traj
         logger.info(f"Trajectory: {traj.duration:.3f}s")
 

--- a/dimos/manipulation/planning/trajectory_generator/test_time_parameterizer.py
+++ b/dimos/manipulation/planning/trajectory_generator/test_time_parameterizer.py
@@ -101,3 +101,12 @@ def test_negative_timestamps_raise() -> None:
     result = PlanningResult(status=PlanningStatus.SUCCESS, path=_path(), timestamps=[-1.0, 1.0, 2.0])
     with pytest.raises(ValueError):
         stage.parameterize(result)
+
+
+def test_non_finite_timestamps_raise() -> None:
+    """NaN or infinite timestamps are rejected (they would break the controller)."""
+    stage, _ = _stage()
+    for bad in ([0.0, float("inf"), 2.0], [0.0, float("nan"), 2.0]):
+        result = PlanningResult(status=PlanningStatus.SUCCESS, path=_path(), timestamps=bad)
+        with pytest.raises(ValueError):
+            stage.parameterize(result)

--- a/dimos/manipulation/planning/trajectory_generator/test_time_parameterizer.py
+++ b/dimos/manipulation/planning/trajectory_generator/test_time_parameterizer.py
@@ -110,3 +110,11 @@ def test_non_finite_timestamps_raise() -> None:
         result = PlanningResult(status=PlanningStatus.SUCCESS, path=_path(), timestamps=bad)
         with pytest.raises(ValueError):
             stage.parameterize(result)
+
+
+def test_empty_timestamps_and_empty_path_raises() -> None:
+    """Both empty: must raise ValueError, not IndexError from indexing an empty list."""
+    stage, _ = _stage()
+    result = PlanningResult(status=PlanningStatus.SUCCESS, path=[], timestamps=[])
+    with pytest.raises(ValueError):
+        stage.parameterize(result)

--- a/dimos/manipulation/planning/trajectory_generator/test_time_parameterizer.py
+++ b/dimos/manipulation/planning/trajectory_generator/test_time_parameterizer.py
@@ -1,0 +1,78 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the formal time-parameterization stage."""
+
+import pytest
+
+from dimos.manipulation.planning.spec.enums import PlanningStatus
+from dimos.manipulation.planning.spec.models import PlanningResult
+from dimos.manipulation.planning.trajectory_generator.joint_trajectory_generator import (
+    JointTrajectoryGenerator,
+)
+from dimos.manipulation.planning.trajectory_generator.time_parameterizer import (
+    TrapezoidalTimeParameterizer,
+)
+from dimos.msgs.sensor_msgs.JointState import JointState
+
+NAMES = ["joint_a", "joint_b"]
+
+
+def _path() -> list[JointState]:
+    return [
+        JointState(name=NAMES, position=[0.0, 0.0]),
+        JointState(name=NAMES, position=[0.5, 0.3]),
+        JointState(name=NAMES, position=[1.0, 0.6]),
+    ]
+
+
+def _stage() -> tuple[TrapezoidalTimeParameterizer, JointTrajectoryGenerator]:
+    gen = JointTrajectoryGenerator(num_joints=2, max_velocity=1.0, max_acceleration=2.0)
+    return TrapezoidalTimeParameterizer(gen), gen
+
+
+def test_untimed_path_falls_back_to_trapezoidal() -> None:
+    """An untimed planner (no timestamps) gets the trapezoidal profile -- unchanged behavior."""
+    stage, gen = _stage()
+    result = PlanningResult(status=PlanningStatus.SUCCESS, path=_path(), timestamps=None)
+
+    traj = stage.parameterize(result)
+    expected = gen.generate([list(s.position) for s in result.path])
+
+    assert traj.duration == pytest.approx(expected.duration)
+    assert traj.duration > 0.0
+
+
+def test_planner_timestamps_are_preserved() -> None:
+    """Planner-provided timing is honored exactly, not re-synthesized (the bug fix)."""
+    stage, _ = _stage()
+    timestamps = [0.0, 3.0, 6.0]
+    result = PlanningResult(status=PlanningStatus.SUCCESS, path=_path(), timestamps=timestamps)
+
+    traj = stage.parameterize(result)
+
+    assert traj.duration == pytest.approx(6.0)
+    assert [p.time_from_start for p in traj.points] == pytest.approx(timestamps)
+    assert traj.points[0].positions == [0.0, 0.0]
+    assert traj.points[-1].positions == [1.0, 0.6]
+
+
+def test_timestamp_path_length_mismatch_raises() -> None:
+    """A timestamp/waypoint count mismatch is a hard error, not a silent bug."""
+    stage, _ = _stage()
+    result = PlanningResult(
+        status=PlanningStatus.SUCCESS, path=_path(), timestamps=[0.0, 1.0]  # 2 vs 3 waypoints
+    )
+    with pytest.raises(ValueError):
+        stage.parameterize(result)

--- a/dimos/manipulation/planning/trajectory_generator/test_time_parameterizer.py
+++ b/dimos/manipulation/planning/trajectory_generator/test_time_parameterizer.py
@@ -76,3 +76,28 @@ def test_timestamp_path_length_mismatch_raises() -> None:
     )
     with pytest.raises(ValueError):
         stage.parameterize(result)
+
+
+def test_empty_timestamps_for_nonempty_path_raises() -> None:
+    """An empty timestamp list for a non-empty path is a mismatch, not 'untimed'."""
+    stage, _ = _stage()
+    result = PlanningResult(status=PlanningStatus.SUCCESS, path=_path(), timestamps=[])
+    with pytest.raises(ValueError):
+        stage.parameterize(result)
+
+
+def test_non_monotonic_timestamps_raise() -> None:
+    """A zero-duration or out-of-order timeline is rejected up front."""
+    stage, _ = _stage()
+    for bad in ([0.0, 0.0, 0.0], [0.0, 2.0, 1.0]):
+        result = PlanningResult(status=PlanningStatus.SUCCESS, path=_path(), timestamps=bad)
+        with pytest.raises(ValueError):
+            stage.parameterize(result)
+
+
+def test_negative_timestamps_raise() -> None:
+    """A negative timeline is rejected."""
+    stage, _ = _stage()
+    result = PlanningResult(status=PlanningStatus.SUCCESS, path=_path(), timestamps=[-1.0, 1.0, 2.0])
+    with pytest.raises(ValueError):
+        stage.parameterize(result)

--- a/dimos/manipulation/planning/trajectory_generator/time_parameterizer.py
+++ b/dimos/manipulation/planning/trajectory_generator/time_parameterizer.py
@@ -53,38 +53,27 @@ class TrapezoidalTimeParameterizer:
     def parameterize(self, result: PlanningResult) -> JointTrajectory:
         waypoints = [list(state.position) for state in result.path]
 
-        # Only a genuinely absent timeline (None) means "untimed" -> synthesize a
-        # trapezoidal profile. An empty list for a non-empty path is a mismatch,
-        # caught by the length check below (not silently re-timed).
+        # A genuinely absent timeline (None) means "untimed" -> synthesize a
+        # trapezoidal profile. Everything else is a supplied timeline we validate.
         if result.timestamps is None:
             return self._generator.generate(waypoints)
 
-        # Planner supplied a timeline: it must line up with the waypoints...
-        if len(result.timestamps) != len(waypoints):
-            raise ValueError(
-                f"timestamps ({len(result.timestamps)}) and path "
-                f"({len(waypoints)}) length mismatch"
-            )
-        # ...and be a valid, executable timeline. NaN/inf slip past ordinary
-        # comparisons (any comparison with NaN is False; inf gives an infinite
-        # duration the controller never completes), so require finite first.
-        if any(not math.isfinite(t) for t in result.timestamps):
-            raise ValueError(
-                f"timestamps must all be finite, got {result.timestamps}"
-            )
-        # ...non-negative and strictly increasing (a zero-duration or
-        # non-monotonic timeline is rejected by the controller at execution).
-        if result.timestamps[0] < 0.0:
-            raise ValueError(
-                f"timestamps must be non-negative, got {result.timestamps[0]}"
-            )
-        if any(b <= a for a, b in zip(result.timestamps, result.timestamps[1:])):
-            raise ValueError(
-                f"timestamps must be strictly increasing, got {result.timestamps}"
-            )
+        ts = result.timestamps
+        # Guard order matters: reject empty BEFORE indexing, and reject
+        # non-finite BEFORE the numeric comparisons (NaN slips past all of them).
+        if not ts:
+            raise ValueError("timestamps must not be empty when supplied")
+        if len(ts) != len(waypoints):
+            raise ValueError(f"timestamps ({len(ts)}) and path ({len(waypoints)}) length mismatch")
+        if any(not math.isfinite(t) for t in ts):
+            raise ValueError(f"timestamps must all be finite, got {ts}")
+        if ts[0] < 0.0:
+            raise ValueError(f"timestamps must be non-negative, got {ts[0]}")
+        if any(b <= a for a, b in zip(ts, ts[1:])):
+            raise ValueError(f"timestamps must be strictly increasing, got {ts}")
 
         points = [
             TrajectoryPoint(time_from_start=t, positions=list(p))
-            for t, p in zip(result.timestamps, waypoints)
+            for t, p in zip(ts, waypoints)
         ]
         return JointTrajectory(points=points)

--- a/dimos/manipulation/planning/trajectory_generator/time_parameterizer.py
+++ b/dimos/manipulation/planning/trajectory_generator/time_parameterizer.py
@@ -15,9 +15,7 @@
 """Formal time-parameterization stage for manipulation planning.
 
 Turns a geometric joint-space path (a ``PlanningResult`` whose ``path`` is
-untimed joint waypoints) into a time-parameterized ``JointTrajectory``. This is
-the explicit boundary between geometric planning and execution: planners produce
-geometry, this stage produces time.
+untimed joint waypoints) into a time-parameterized ``JointTrajectory``.
 """
 
 from __future__ import annotations
@@ -54,16 +52,30 @@ class TrapezoidalTimeParameterizer:
     def parameterize(self, result: PlanningResult) -> JointTrajectory:
         waypoints = [list(state.position) for state in result.path]
 
-        # Untimed planner: synthesize timing with a trapezoidal profile.
-        if not result.timestamps:
+        # Only a genuinely absent timeline (None) means "untimed" -> synthesize a
+        # trapezoidal profile. An empty list for a non-empty path is a mismatch,
+        # caught by the length check below (not silently re-timed).
+        if result.timestamps is None:
             return self._generator.generate(waypoints)
 
-        # Planner supplied timing: preserve it exactly.
+        # Planner supplied a timeline: it must line up with the waypoints...
         if len(result.timestamps) != len(waypoints):
             raise ValueError(
                 f"timestamps ({len(result.timestamps)}) and path "
                 f"({len(waypoints)}) length mismatch"
             )
+        # ...and be a valid, executable timeline: non-negative and strictly
+        # increasing. A zero-duration or non-monotonic timeline is rejected by
+        # the controller at execution, so fail fast here instead.
+        if result.timestamps and result.timestamps[0] < 0.0:
+            raise ValueError(
+                f"timestamps must be non-negative, got {result.timestamps[0]}"
+            )
+        if any(b <= a for a, b in zip(result.timestamps, result.timestamps[1:])):
+            raise ValueError(
+                f"timestamps must be strictly increasing, got {result.timestamps}"
+            )
+
         points = [
             TrajectoryPoint(time_from_start=t, positions=list(p))
             for t, p in zip(result.timestamps, waypoints)

--- a/dimos/manipulation/planning/trajectory_generator/time_parameterizer.py
+++ b/dimos/manipulation/planning/trajectory_generator/time_parameterizer.py
@@ -1,0 +1,71 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Formal time-parameterization stage for manipulation planning.
+
+Turns a geometric joint-space path (a ``PlanningResult`` whose ``path`` is
+untimed joint waypoints) into a time-parameterized ``JointTrajectory``. This is
+the explicit boundary between geometric planning and execution: planners produce
+geometry, this stage produces time.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from dimos.manipulation.planning.spec.models import PlanningResult
+from dimos.manipulation.planning.trajectory_generator.joint_trajectory_generator import (
+    JointTrajectoryGenerator,
+)
+from dimos.msgs.trajectory_msgs.JointTrajectory import JointTrajectory
+from dimos.msgs.trajectory_msgs.TrajectoryPoint import TrajectoryPoint
+
+
+@runtime_checkable
+class TimeParameterizer(Protocol):
+    """Converts a geometric planning result into a timed trajectory."""
+
+    def parameterize(self, result: PlanningResult) -> JointTrajectory: ...
+
+
+class TrapezoidalTimeParameterizer:
+    """Default time-parameterization stage.
+
+    - Planner-provided timestamps (from optimization-based planners) are honored
+      exactly, preserving the planner's timing.
+    - Untimed geometric planners (e.g. RRT) get a trapezoidal velocity profile
+      synthesized via ``JointTrajectoryGenerator``.
+    """
+
+    def __init__(self, generator: JointTrajectoryGenerator) -> None:
+        self._generator = generator
+
+    def parameterize(self, result: PlanningResult) -> JointTrajectory:
+        waypoints = [list(state.position) for state in result.path]
+
+        # Untimed planner: synthesize timing with a trapezoidal profile.
+        if not result.timestamps:
+            return self._generator.generate(waypoints)
+
+        # Planner supplied timing: preserve it exactly.
+        if len(result.timestamps) != len(waypoints):
+            raise ValueError(
+                f"timestamps ({len(result.timestamps)}) and path "
+                f"({len(waypoints)}) length mismatch"
+            )
+        points = [
+            TrajectoryPoint(time_from_start=t, positions=list(p))
+            for t, p in zip(result.timestamps, waypoints)
+        ]
+        return JointTrajectory(points=points)

--- a/dimos/manipulation/planning/trajectory_generator/time_parameterizer.py
+++ b/dimos/manipulation/planning/trajectory_generator/time_parameterizer.py
@@ -20,6 +20,7 @@ untimed joint waypoints) into a time-parameterized ``JointTrajectory``.
 
 from __future__ import annotations
 
+import math
 from typing import Protocol, runtime_checkable
 
 from dimos.manipulation.planning.spec.models import PlanningResult
@@ -64,10 +65,16 @@ class TrapezoidalTimeParameterizer:
                 f"timestamps ({len(result.timestamps)}) and path "
                 f"({len(waypoints)}) length mismatch"
             )
-        # ...and be a valid, executable timeline: non-negative and strictly
-        # increasing. A zero-duration or non-monotonic timeline is rejected by
-        # the controller at execution, so fail fast here instead.
-        if result.timestamps and result.timestamps[0] < 0.0:
+        # ...and be a valid, executable timeline. NaN/inf slip past ordinary
+        # comparisons (any comparison with NaN is False; inf gives an infinite
+        # duration the controller never completes), so require finite first.
+        if any(not math.isfinite(t) for t in result.timestamps):
+            raise ValueError(
+                f"timestamps must all be finite, got {result.timestamps}"
+            )
+        # ...non-negative and strictly increasing (a zero-duration or
+        # non-monotonic timeline is rejected by the controller at execution).
+        if result.timestamps[0] < 0.0:
             raise ValueError(
                 f"timestamps must be non-negative, got {result.timestamps[0]}"
             )


### PR DESCRIPTION
## Problem

Time-parameterization — turning a geometric joint path into a timed, executable trajectory — isn't a formal planning stage. It's done ad-hoc inside `ManipulationModule.execute_plan` as a single inline `traj_gen.generate(...)` call. Two consequences:

- The boundary between geometric planning and timed execution is implicit and lives in execution glue, so planner output / preview / execution timing can drift apart.
- **Latent bug:** the inline call ignores `PlanningResult.timestamps`, so timing supplied by optimization-based planners is silently discarded and re-synthesized from generic velocity limits. In practice a planner that intends a 6.0 s motion gets re-timed to ~2.0 s — the arm moves ~3× faster than intended, discarding whatever the planner accounted for (payload, obstacle proximity, dual-arm coordination).

Closes #2540

## Solution

Add an explicit time-parameterization stage with one job: `PlanningResult` (geometric) → `JointTrajectory` (timed).

- New `dimos/manipulation/planning/trajectory_generator/time_parameterizer.py`:
  - `TimeParameterizer` protocol (the formal stage interface).
  - `TrapezoidalTimeParameterizer` implementation:
    - Planner-provided `timestamps` are **honored exactly** (fixes the latent bug).
    - Untimed planners (e.g. RRT) fall back to the existing trapezoidal `JointTrajectoryGenerator` — behavior unchanged.
    - Length-mismatched timestamps raise `ValueError` instead of silently mis-timing.
- `execute_plan` now delegates to the stage instead of calling `generate(...)` inline. Preview and execution already read the single stored `_planned_trajectories` artifact, so they now share the formally time-parameterized result.

Concrete effect (baked into the tests): a planner intending a 6.0 s motion was previously re-timed to 2.0 s; it is now preserved at 6.0 s. Untimed planners are unchanged.

**Acceptance criteria**
- [x] Explicit time-parameterization API (`TimeParameterizer`).
- [x] `ManipulationModule` no longer owns ad-hoc path-to-trajectory timing.
- [x] Preview and execution use the same time-parameterized artifact (`_planned_trajectories`).
- [x] Data model distinguishes geometric path (`PlanningResult.path`) from timed trajectory (`JointTrajectory`); tests distinguish them.
- [x] Untimed planner outputs and planner-provided timestamps are both covered by tests.

## How to Test
```
pytest dimos/manipulation/planning/trajectory_generator/test_time_parameterizer.py -q
```

Three tests: untimed path → trapezoidal profile (no regression), planner timestamps → preserved exactly (the fix), timestamp/waypoint length mismatch → `ValueError`.

**Open question for reviewers:** I placed the `TimeParameterizer` protocol in the new stage module for a self-contained change. Per the `spec/protocols.py` convention, it may belong in the spec instead — happy to move it if you'd prefer.

## Contributor License Agreement
- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).