### PR TITLE
Add Galaxea A1Z arm in simulation

### DIFF
--- a/data/.lfs/a1z_description.tar.gz
+++ b/data/.lfs/a1z_description.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2b2b71a0062c9b4b16ecb9db3637398f291d48ec87dd62e331d3ba000f6c20f
+size 4554974

--- a/data/.lfs/a1z_description.tar.gz
+++ b/data/.lfs/a1z_description.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b2b2b71a0062c9b4b16ecb9db3637398f291d48ec87dd62e331d3ba000f6c20f
-size 4554974
+oid sha256:f6a327f324864abfc40e95346159dff6b1edbc306da0aa93f2f88a78e82b7fb9
+size 4543240

--- a/dimos/robot/all_blueprints.py
+++ b/dimos/robot/all_blueprints.py
@@ -16,7 +16,10 @@
 # Run `pytest dimos/robot/test_all_blueprints_generation.py` to regenerate.
 
 all_blueprints = {
+    "a1z-planner-coordinator": "dimos.robot.manipulators.a1z.blueprints.basic:a1z_planner_coordinator",
+    "a1z-planner-only": "dimos.robot.manipulators.a1z.blueprints.basic:a1z_planner_only",
     "alfred-nav": "dimos.robot.diy.alfred.blueprints.alfred_nav:alfred_nav",
+    "coordinator-a1z": "dimos.robot.manipulators.a1z.blueprints.basic:coordinator_a1z",
     "coordinator-basic": "dimos.control.blueprints.basic:coordinator_basic",
     "coordinator-cartesian-ik-mock": "dimos.robot.manipulators.piper.blueprints.teleop:coordinator_cartesian_ik_mock",
     "coordinator-cartesian-ik-piper": "dimos.robot.manipulators.piper.blueprints.teleop:coordinator_cartesian_ik_piper",
@@ -60,6 +63,7 @@ all_blueprints = {
     "drone-agentic": "dimos.robot.drone.blueprints.agentic.drone_agentic:drone_agentic",
     "drone-basic": "dimos.robot.drone.blueprints.basic.drone_basic:drone_basic",
     "dual-xarm6-planner": "dimos.robot.manipulators.xarm.blueprints.basic:dual_xarm6_planner",
+    "keyboard-teleop-a1z": "dimos.robot.manipulators.a1z.blueprints.teleop:keyboard_teleop_a1z",
     "keyboard-teleop-a750": "dimos.robot.manipulators.a750.blueprints.teleop:keyboard_teleop_a750",
     "keyboard-teleop-openarm": "dimos.robot.manipulators.openarm.blueprints.teleop:keyboard_teleop_openarm",
     "keyboard-teleop-openarm-mock": "dimos.robot.manipulators.openarm.blueprints.teleop:keyboard_teleop_openarm_mock",

--- a/dimos/robot/all_blueprints.py
+++ b/dimos/robot/all_blueprints.py
@@ -17,7 +17,6 @@
 
 all_blueprints = {
     "a1z-planner-coordinator": "dimos.robot.manipulators.a1z.blueprints.basic:a1z_planner_coordinator",
-    "a1z-planner-only": "dimos.robot.manipulators.a1z.blueprints.basic:a1z_planner_only",
     "alfred-nav": "dimos.robot.diy.alfred.blueprints.alfred_nav:alfred_nav",
     "coordinator-a1z": "dimos.robot.manipulators.a1z.blueprints.basic:coordinator_a1z",
     "coordinator-basic": "dimos.control.blueprints.basic:coordinator_basic",

--- a/dimos/robot/manipulators/a1z/blueprints/basic.py
+++ b/dimos/robot/manipulators/a1z/blueprints/basic.py
@@ -18,13 +18,8 @@ from __future__ import annotations
 
 from dimos.control.coordinator import ControlCoordinator
 from dimos.core.coordination.blueprints import autoconnect
-from dimos.manipulation.manipulation_module import ManipulationModule
 from dimos.robot.manipulators.a1z.config import make_a1z_hardware, make_a1z_model_config
 from dimos.robot.manipulators.common.blueprints import coordinator, planner, trajectory_task
-
-a1z_planner_only = ManipulationModule.blueprint(
-    robots=[make_a1z_model_config(name="arm")],
-)
 
 _a1z_planner_hw = make_a1z_hardware("arm")
 

--- a/dimos/robot/manipulators/a1z/blueprints/basic.py
+++ b/dimos/robot/manipulators/a1z/blueprints/basic.py
@@ -1,0 +1,44 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Basic Galaxea A1Z coordinator and planner blueprints."""
+
+from __future__ import annotations
+
+from dimos.control.coordinator import ControlCoordinator
+from dimos.core.coordination.blueprints import autoconnect
+from dimos.manipulation.manipulation_module import ManipulationModule
+from dimos.robot.manipulators.a1z.config import make_a1z_hardware, make_a1z_model_config
+from dimos.robot.manipulators.common.blueprints import coordinator, planner, trajectory_task
+
+a1z_planner_only = ManipulationModule.blueprint(
+    robots=[make_a1z_model_config(name="arm")],
+)
+
+_a1z_planner_hw = make_a1z_hardware("arm")
+
+a1z_planner_coordinator = autoconnect(
+    planner(robots=[make_a1z_model_config(name="arm")]),
+    coordinator(
+        hardware=[_a1z_planner_hw],
+        tasks=[trajectory_task(_a1z_planner_hw)],
+    ),
+)
+
+_coordinator_a1z_hw = make_a1z_hardware("arm")
+
+coordinator_a1z = ControlCoordinator.blueprint(
+    hardware=[_coordinator_a1z_hw],
+    tasks=[trajectory_task(_coordinator_a1z_hw)],
+)

--- a/dimos/robot/manipulators/a1z/blueprints/teleop.py
+++ b/dimos/robot/manipulators/a1z/blueprints/teleop.py
@@ -1,0 +1,43 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Galaxea A1Z teleop blueprints."""
+
+from __future__ import annotations
+
+from dimos.control.coordinator import ControlCoordinator
+from dimos.core.coordination.blueprints import autoconnect
+from dimos.manipulation.manipulation_module import ManipulationModule
+from dimos.robot.manipulators.a1z.config import (
+    A1Z_DOF,
+    A1Z_FK_MODEL,
+    make_a1z_hardware,
+    make_a1z_model_config,
+)
+from dimos.robot.manipulators.common.blueprints import eef_twist_task
+from dimos.teleop.keyboard.keyboard_teleop_module import KeyboardTeleopModule
+
+_a1z_keyboard_hw = make_a1z_hardware("arm")
+
+keyboard_teleop_a1z = autoconnect(
+    KeyboardTeleopModule.blueprint(),
+    ControlCoordinator.blueprint(
+        hardware=[_a1z_keyboard_hw],
+        tasks=[eef_twist_task(_a1z_keyboard_hw, model_path=A1Z_FK_MODEL, ee_joint_id=A1Z_DOF)],
+    ),
+    ManipulationModule.blueprint(
+        robots=[make_a1z_model_config()],
+        visualization={"backend": "viser"},
+    ),
+)

--- a/dimos/robot/manipulators/a1z/config.py
+++ b/dimos/robot/manipulators/a1z/config.py
@@ -84,7 +84,9 @@ def make_a1z_model_config(
         model_path=A1Z_G1Z_MODEL_PATH if has_gripper else A1Z_FLANGE_MODEL_PATH,
         base_pose=base_pose(),
         joint_names=joint_names(A1Z_DOF, prefix="arm_joint"),
-        end_effector_link="arm_link6",
+        end_effector_link=(
+            "gripper_finger_left_link" if has_gripper else "arm_link6"
+        ),
         base_link="base_link",
         package_paths=A1Z_PACKAGE_PATHS,
         auto_convert_meshes=True,

--- a/dimos/robot/manipulators/a1z/config.py
+++ b/dimos/robot/manipulators/a1z/config.py
@@ -1,0 +1,101 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Galaxea A1Z planning model configuration helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from dimos.control.components import HardwareComponent, HardwareType, make_joints
+from dimos.manipulation.planning.spec.config import RobotModelConfig
+from dimos.robot.manipulators._modeling import (
+    base_pose,
+    coordinator_joint_mapping,
+    joint_names,
+)
+from dimos.utils.data import LfsPath
+
+A1Z_DOF = 6
+
+# These non-adjacent link pairs overlap at the home pose, so planning fails
+# with COLLISION_AT_START unless they are excluded. Enumerated with Drake's
+# ComputePointPairPenetration, which checks the convex hulls Drake plans
+# against. The same pairs penetrate in both URDF variants.
+A1Z_COLLISION_EXCLUSIONS: list[tuple[str, str]] = [
+    ("arm_link2", "arm_link5"),
+    ("arm_link4", "arm_link6"),
+]
+
+A1Z_G1Z_MODEL_PATH = LfsPath("a1z_description") / "A1Z_G1Z/urdf/A1Z_G1Z.urdf"
+A1Z_FLANGE_MODEL_PATH = LfsPath("a1z_description") / "A1Z_Flange/urdf/A1Z_Flange.urdf"
+A1Z_FK_MODEL = A1Z_FLANGE_MODEL_PATH
+A1Z_PACKAGE_PATHS: dict[str, Path] = {
+    "A1Z_G1Z": LfsPath("a1z_description") / "A1Z_G1Z",
+    "A1Z_Flange": LfsPath("a1z_description") / "A1Z_Flange",
+}
+
+
+def make_a1z_hardware(
+    hw_id: str = "arm",
+    *,
+    adapter_type: str = "mock",
+    address: str | None = None,
+    has_gripper: bool = True,
+    auto_enable: bool = True,
+    home_joints: list[float] | None = None,
+) -> HardwareComponent:
+    adapter_kwargs: dict[str, object] = {}
+    if home_joints is not None:
+        adapter_kwargs["initial_positions"] = home_joints
+    return HardwareComponent(
+        hardware_id=hw_id,
+        hardware_type=HardwareType.MANIPULATOR,
+        joints=make_joints(hw_id, A1Z_DOF),
+        adapter_type=adapter_type,
+        address=address,
+        auto_enable=auto_enable,
+        gripper_joints=[f"{hw_id}/gripper"] if has_gripper else [],
+        adapter_kwargs=adapter_kwargs,
+    )
+
+
+def make_a1z_model_config(
+    name: str = "arm",
+    *,
+    has_gripper: bool = True,
+    joint_prefix: str | None = None,
+    coordinator_task_name: str | None = None,
+    home_joints: list[float] | None = None,
+) -> RobotModelConfig:
+    return RobotModelConfig(
+        name=name,
+        model_path=A1Z_G1Z_MODEL_PATH if has_gripper else A1Z_FLANGE_MODEL_PATH,
+        base_pose=base_pose(),
+        joint_names=joint_names(A1Z_DOF, prefix="arm_joint"),
+        end_effector_link="arm_link6",
+        base_link="base_link",
+        package_paths=A1Z_PACKAGE_PATHS,
+        auto_convert_meshes=True,
+        collision_exclusion_pairs=A1Z_COLLISION_EXCLUSIONS,
+        joint_name_mapping=coordinator_joint_mapping(
+            name,
+            A1Z_DOF,
+            joint_prefix=joint_prefix,
+            urdf_joint_prefix="arm_",
+        ),
+        coordinator_task_name=coordinator_task_name or f"traj_{name}",
+        gripper_hardware_id=name if has_gripper else None,
+        home_joints=home_joints or [0.0] * A1Z_DOF,
+    )

--- a/dimos/robot/manipulators/a1z/config.py
+++ b/dimos/robot/manipulators/a1z/config.py
@@ -84,7 +84,9 @@ def make_a1z_model_config(
         model_path=A1Z_G1Z_MODEL_PATH if has_gripper else A1Z_FLANGE_MODEL_PATH,
         base_pose=base_pose(),
         joint_names=joint_names(A1Z_DOF, prefix="arm_joint"),
-        end_effector_link=("gripper_finger_left_link" if has_gripper else "arm_link6"),
+        end_effector_link=(
+            "gripper_eef_link" if has_gripper else "arm_link6"
+        ),
         base_link="base_link",
         package_paths=A1Z_PACKAGE_PATHS,
         auto_convert_meshes=True,

--- a/dimos/robot/manipulators/a1z/config.py
+++ b/dimos/robot/manipulators/a1z/config.py
@@ -84,9 +84,7 @@ def make_a1z_model_config(
         model_path=A1Z_G1Z_MODEL_PATH if has_gripper else A1Z_FLANGE_MODEL_PATH,
         base_pose=base_pose(),
         joint_names=joint_names(A1Z_DOF, prefix="arm_joint"),
-        end_effector_link=(
-            "gripper_finger_left_link" if has_gripper else "arm_link6"
-        ),
+        end_effector_link=("gripper_finger_left_link" if has_gripper else "arm_link6"),
         base_link="base_link",
         package_paths=A1Z_PACKAGE_PATHS,
         auto_convert_meshes=True,

--- a/dimos/robot/manipulators/a1z/config.py
+++ b/dimos/robot/manipulators/a1z/config.py
@@ -84,9 +84,7 @@ def make_a1z_model_config(
         model_path=A1Z_G1Z_MODEL_PATH if has_gripper else A1Z_FLANGE_MODEL_PATH,
         base_pose=base_pose(),
         joint_names=joint_names(A1Z_DOF, prefix="arm_joint"),
-        end_effector_link=(
-            "gripper_eef_link" if has_gripper else "arm_link6"
-        ),
+        end_effector_link=("gripper_eef_link" if has_gripper else "arm_link6"),
         base_link="base_link",
         package_paths=A1Z_PACKAGE_PATHS,
         auto_convert_meshes=True,

--- a/dimos/robot/manipulators/a1z/config.py
+++ b/dimos/robot/manipulators/a1z/config.py
@@ -29,10 +29,6 @@ from dimos.utils.data import LfsPath
 
 A1Z_DOF = 6
 
-# These non-adjacent link pairs overlap at the home pose, so planning fails
-# with COLLISION_AT_START unless they are excluded. Enumerated with Drake's
-# ComputePointPairPenetration, which checks the convex hulls Drake plans
-# against. The same pairs penetrate in both URDF variants.
 A1Z_COLLISION_EXCLUSIONS: list[tuple[str, str]] = [
     ("arm_link2", "arm_link5"),
     ("arm_link4", "arm_link6"),

--- a/dimos/robot/manipulators/test_blueprints.py
+++ b/dimos/robot/manipulators/test_blueprints.py
@@ -21,6 +21,7 @@ from dimos.control.coordinator import ControlCoordinator, TaskConfig
 from dimos.core.coordination.blueprints import Blueprint
 from dimos.manipulation.manipulation_module import ManipulationModule, ManipulationModuleConfig
 from dimos.manipulation.visualization.config import NoManipulationVisualizationConfig
+from dimos.robot.manipulators.a1z.blueprints.teleop import keyboard_teleop_a1z
 from dimos.robot.manipulators.a750.blueprints.teleop import keyboard_teleop_a750
 from dimos.robot.manipulators.common.blueprints import eef_twist_task, planner
 from dimos.robot.manipulators.common.topics import EEF_TWIST_TASK_NAME
@@ -104,6 +105,7 @@ def test_eef_twist_task_helper_uses_hardware_joints_and_default_name() -> None:
         pytest.param(keyboard_teleop_openarm_mock, id="openarm-mock"),
         pytest.param(keyboard_teleop_openarm, id="openarm"),
         pytest.param(keyboard_teleop_a750, id="a750"),
+        pytest.param(keyboard_teleop_a1z, id="a1z"),
     ],
 )
 def test_manipulator_keyboard_blueprint_uses_eef_twist_and_light_keyboard_kwargs(


### PR DESCRIPTION
## Problem

dimos has no support for the Galaxea A1Z, a standalone 6 DOF arm with an optional G1Z parallel gripper.

Review of #2925 asked for the work to be split. This PR is the first half, the arm as a simulation and model integration. Hardware support (the CAN adapter and a setup guide) is deliberately deferred to a follow up PR, so the absence of an adapter here is intentional. This PR supersedes #2925.

## Solution

Adds the A1Z following the piper, xarm and a750 pattern.

* Asset: official A1Z URDF packages vendored as one LFS archive, both variants included.
* Config (`robot/manipulators/a1z/config.py`): a single `has_gripper` flag (default true) selects between the gripper model and the bare flange model and wires the gripper joint and hardware id from it.
* Collision exclusions: enumerated with Drake `ComputePointPairPenetration` against the convex hulls it plans with. Without them planning fails at the home pose.
* Blueprints: `a1z-planner-only`, `a1z-planner-coordinator`, `coordinator-a1z` and `keyboard-teleop-a1z`, all on the mock adapter. Teleop uses the viser backend.
* Tests: a1z case added to the parametrized keyboard teleop test, blueprint registry regenerated.

## How to Test

Sim only, no hardware needed.

Automated:

    pytest dimos/robot/manipulators/test_blueprints.py dimos/robot/test_all_blueprints_generation.py -q

Teleop with interactive viser UI:

    dimos run keyboard-teleop-a1z

Plan and execute (two terminals):

    dimos run a1z-planner-coordinator -o manipulationmodule.visualization.backend=meshcat
    python -i -m dimos.manipulation.planning.examples.manipulation_client
    # plan([0.3, 0.5, -0.5, 0.2, 0.3, 0.2]); preview(); execute()
    # plan([0.2]*6) is correctly rejected, joints 2 and 3 have one sided limits
    # gripper(0.5)

## Contributor License Agreement

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
