### PR TITLE
fix(teleop): support keyboard strafing and arrow keys

### DIFF
--- a/dimos/control/examples/twist_base_keyboard_teleop.py
+++ b/dimos/control/examples/twist_base_keyboard_teleop.py
@@ -19,9 +19,9 @@ WASD keys publish Twist → coordinator's twist_command port → virtual joints
 → tick loop → MockTwistBaseAdapter.
 
 Controls:
-    W/S: Forward/backward (linear.x)
-    Q/E: Strafe left/right (linear.y)
-    A/D: Turn left/right (angular.z)
+    W/S or Up/Down: Forward/backward (linear.x)
+    Q/E or Alt + turn keys: Strafe left/right (linear.y)
+    A/D or Left/Right: Turn left/right (angular.z)
     Shift: 2x boost
     Ctrl: 0.5x slow
     Space: Emergency stop

--- a/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_keyboard_teleop.py
+++ b/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_keyboard_teleop.py
@@ -15,7 +15,10 @@
 
 """Unitree Go2 keyboard teleop via ControlCoordinator (DDS/SDK2 path).
 
-WASD keys -> Twist -> coordinator twist_command -> UnitreeGo2TwistAdapter (DDS).
+Keyboard input -> Twist -> coordinator twist_command -> UnitreeGo2TwistAdapter (DDS).
+
+Use W/S or Up/Down to move, A/D or Left/Right to turn, and Q/E or
+Alt plus the turn keys to strafe.
 
 Usage:
     dimos run unitree-go2-keyboard-teleop

--- a/dimos/robot/unitree/keyboard_teleop.py
+++ b/dimos/robot/unitree/keyboard_teleop.py
@@ -18,6 +18,7 @@ import threading
 from typing import Any
 
 import pygame
+from pygame.constants import K_DOWN, K_LALT, K_LEFT, K_RALT, K_RIGHT, K_UP
 
 from dimos.constants import DEFAULT_THREAD_JOIN_TIMEOUT
 
@@ -52,6 +53,45 @@ _CONTROL_RATE_HZ = 50
 _BACKGROUND_COLOR = (30, 30, 30)
 _HELP_TEXT_COLOR = (150, 150, 150)
 _INDICATOR_RADIUS = 15
+
+
+def twist_from_keys(
+    keys: set[int],
+    linear_speed: float,
+    angular_speed: float,
+    boost_multiplier: float,
+    slow_multiplier: float,
+) -> Twist:
+    """Build a velocity command from the currently held keyboard keys."""
+    twist = Twist()
+
+    forward = pygame.K_w in keys or K_UP in keys
+    backward = pygame.K_s in keys or K_DOWN in keys
+    if forward != backward:
+        twist.linear.x = linear_speed if forward else -linear_speed
+
+    alt_held = K_LALT in keys or K_RALT in keys
+    strafe_left = pygame.K_q in keys or (alt_held and (pygame.K_a in keys or K_LEFT in keys))
+    strafe_right = pygame.K_e in keys or (alt_held and (pygame.K_d in keys or K_RIGHT in keys))
+    if strafe_left != strafe_right:
+        twist.linear.y = linear_speed if strafe_left else -linear_speed
+
+    if not alt_held:
+        turn_left = pygame.K_a in keys or K_LEFT in keys
+        turn_right = pygame.K_d in keys or K_RIGHT in keys
+        if turn_left != turn_right:
+            twist.angular.z = angular_speed if turn_left else -angular_speed
+
+    speed_multiplier = 1.0
+    if pygame.K_LSHIFT in keys or pygame.K_RSHIFT in keys:
+        speed_multiplier = boost_multiplier
+    elif pygame.K_LCTRL in keys or pygame.K_RCTRL in keys:
+        speed_multiplier = slow_multiplier
+
+    twist.linear.x *= speed_multiplier
+    twist.linear.y *= speed_multiplier
+    twist.angular.z *= speed_multiplier
+    return twist
 
 
 class KeyboardTeleop(Module):
@@ -179,43 +219,17 @@ class KeyboardTeleop(Module):
                 elif event.type == pygame.KEYUP:
                     self._keys_held.discard(event.key)
 
-            # Generate Twist message from held keys
-            twist = Twist()
-            twist.linear = Vector3(0, 0, 0)
-            twist.angular = Vector3(0, 0, 0)
-
-            # Movement keys (WASD/QE) — guarded by disable_movement so the
-            # window can run as a pure e_max slider (0-9 keys stay live in
-            # the KEYDOWN handler above).
-            if not self.disable_movement:
-                # Forward/backward (W/S)
-                if pygame.K_w in self._keys_held:
-                    twist.linear.x = self.linear_speed
-                if pygame.K_s in self._keys_held:
-                    twist.linear.x = -self.linear_speed
-
-                # Strafe left/right (Q/E)
-                if pygame.K_q in self._keys_held:
-                    twist.linear.y = self.linear_speed
-                if pygame.K_e in self._keys_held:
-                    twist.linear.y = -self.linear_speed
-
-                # Turning (A/D)
-                if pygame.K_a in self._keys_held:
-                    twist.angular.z = self.angular_speed
-                if pygame.K_d in self._keys_held:
-                    twist.angular.z = -self.angular_speed
-
-            # Apply speed modifiers (Shift = boost, Ctrl = slow)
-            speed_multiplier = 1.0
-            if pygame.K_LSHIFT in self._keys_held or pygame.K_RSHIFT in self._keys_held:
-                speed_multiplier = self.boost_multiplier
-            elif pygame.K_LCTRL in self._keys_held or pygame.K_RCTRL in self._keys_held:
-                speed_multiplier = self.slow_multiplier
-
-            twist.linear.x *= speed_multiplier
-            twist.linear.y *= speed_multiplier
-            twist.angular.z *= speed_multiplier
+            twist = (
+                Twist()
+                if self.disable_movement
+                else twist_from_keys(
+                    self._keys_held,
+                    self.linear_speed,
+                    self.angular_speed,
+                    self.boost_multiplier,
+                    self.slow_multiplier,
+                )
+            )
 
             if self.publish_only_when_active:
                 active = twist.linear.x != 0 or twist.linear.y != 0 or twist.angular.z != 0
@@ -259,7 +273,10 @@ class KeyboardTeleop(Module):
             f"Linear Y (Strafe L/R): {twist.linear.y:+.2f} m/s",
             f"Angular Z (Turn L/R): {twist.angular.z:+.2f} rad/s",
             "",
-            "Keys: " + ", ".join([pygame.key.name(k).upper() for k in self._keys_held if k < 256]),
+            "Keys: "
+            + ", ".join(
+                pygame.key.name(key).upper() for key in sorted(self._keys_held) if key < 256
+            ),
         ]
 
         for i, text in enumerate(texts):
@@ -274,7 +291,7 @@ class KeyboardTeleop(Module):
         else:
             pygame.draw.circle(self._screen, (0, 255, 0), (450, 30), _INDICATOR_RADIUS)
 
-        y_pos = 280
+        y_pos = 250
         if self.disable_movement:
             help_texts = [
                 "Movement disabled (e_max slider mode)",
@@ -284,9 +301,10 @@ class KeyboardTeleop(Module):
             ]
         else:
             help_texts = [
-                "WS: Move | AD: Turn | QE: Strafe",
-                "Shift: Boost | Ctrl: Slow",
-                "Space: E-Stop | ESC: Quit",
+                "W/S or Up/Down: Move",
+                "A/D or Left/Right: Turn",
+                "Q/E or Alt + turn keys: Strafe",
+                "Shift: Boost | Ctrl: Slow | Space: E-Stop | ESC: Quit",
                 "Enter: Advance | K: Skip | Backspace: Quit (tools)",
                 "0-9: e_max corridor (0.0-0.9 m, for RG)",
             ]

--- a/dimos/robot/unitree/keyboard_teleop.py
+++ b/dimos/robot/unitree/keyboard_teleop.py
@@ -18,7 +18,6 @@ import threading
 from typing import Any
 
 import pygame
-from pygame.constants import K_DOWN, K_LALT, K_LEFT, K_RALT, K_RIGHT, K_UP
 
 from dimos.constants import DEFAULT_THREAD_JOIN_TIMEOUT
 
@@ -65,20 +64,22 @@ def twist_from_keys(
     """Build a velocity command from the currently held keyboard keys."""
     twist = Twist()
 
-    forward = pygame.K_w in keys or K_UP in keys
-    backward = pygame.K_s in keys or K_DOWN in keys
+    forward = pygame.K_w in keys or pygame.K_UP in keys
+    backward = pygame.K_s in keys or pygame.K_DOWN in keys
     if forward != backward:
         twist.linear.x = linear_speed if forward else -linear_speed
 
-    alt_held = K_LALT in keys or K_RALT in keys
-    strafe_left = pygame.K_q in keys or (alt_held and (pygame.K_a in keys or K_LEFT in keys))
-    strafe_right = pygame.K_e in keys or (alt_held and (pygame.K_d in keys or K_RIGHT in keys))
+    alt_held = pygame.K_LALT in keys or pygame.K_RALT in keys
+    strafe_left = pygame.K_q in keys or (alt_held and (pygame.K_a in keys or pygame.K_LEFT in keys))
+    strafe_right = pygame.K_e in keys or (
+        alt_held and (pygame.K_d in keys or pygame.K_RIGHT in keys)
+    )
     if strafe_left != strafe_right:
         twist.linear.y = linear_speed if strafe_left else -linear_speed
 
     if not alt_held:
-        turn_left = pygame.K_a in keys or K_LEFT in keys
-        turn_right = pygame.K_d in keys or K_RIGHT in keys
+        turn_left = pygame.K_a in keys or pygame.K_LEFT in keys
+        turn_right = pygame.K_d in keys or pygame.K_RIGHT in keys
         if turn_left != turn_right:
             twist.angular.z = angular_speed if turn_left else -angular_speed
 
@@ -275,7 +276,9 @@ class KeyboardTeleop(Module):
             "",
             "Keys: "
             + ", ".join(
-                pygame.key.name(key).upper() for key in sorted(self._keys_held) if key < 256
+                pygame.key.name(key).upper()
+                for key in sorted(self._keys_held)
+                if key < 256 or key in {pygame.K_UP, pygame.K_DOWN, pygame.K_LEFT, pygame.K_RIGHT}
             ),
         ]
 

--- a/dimos/robot/unitree/test_keyboard_teleop.py
+++ b/dimos/robot/unitree/test_keyboard_teleop.py
@@ -1,0 +1,76 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pygame
+import pytest
+
+from dimos.robot.unitree.keyboard_teleop import twist_from_keys
+
+
+@pytest.mark.parametrize(
+    ("keys", "expected"),
+    [
+        pytest.param({pygame.K_w}, (0.5, 0.0, 0.0), id="w-forward"),
+        pytest.param({pygame.K_UP}, (0.5, 0.0, 0.0), id="up-forward"),
+        pytest.param({pygame.K_s}, (-0.5, 0.0, 0.0), id="s-backward"),
+        pytest.param({pygame.K_DOWN}, (-0.5, 0.0, 0.0), id="down-backward"),
+        pytest.param({pygame.K_a}, (0.0, 0.0, 0.8), id="a-turn-left"),
+        pytest.param({pygame.K_LEFT}, (0.0, 0.0, 0.8), id="left-turn-left"),
+        pytest.param({pygame.K_d}, (0.0, 0.0, -0.8), id="d-turn-right"),
+        pytest.param({pygame.K_RIGHT}, (0.0, 0.0, -0.8), id="right-turn-right"),
+        pytest.param({pygame.K_q}, (0.0, 0.5, 0.0), id="q-strafe-left"),
+        pytest.param({pygame.K_e}, (0.0, -0.5, 0.0), id="e-strafe-right"),
+        pytest.param(
+            {pygame.K_LALT, pygame.K_a},
+            (0.0, 0.5, 0.0),
+            id="alt-a-strafe-left",
+        ),
+        pytest.param(
+            {pygame.K_RALT, pygame.K_RIGHT},
+            (0.0, -0.5, 0.0),
+            id="alt-right-strafe-right",
+        ),
+        pytest.param({pygame.K_w, pygame.K_s}, (0.0, 0.0, 0.0), id="forward-opposites-cancel"),
+        pytest.param({pygame.K_q, pygame.K_e}, (0.0, 0.0, 0.0), id="strafe-opposites-cancel"),
+        pytest.param({pygame.K_a, pygame.K_d}, (0.0, 0.0, 0.0), id="turn-opposites-cancel"),
+        pytest.param(
+            {pygame.K_LALT, pygame.K_a, pygame.K_d},
+            (0.0, 0.0, 0.0),
+            id="alt-strafe-opposites-cancel",
+        ),
+    ],
+)
+def test_twist_from_movement_keys(keys: set[int], expected: tuple[float, float, float]) -> None:
+    twist = twist_from_keys(keys, 0.5, 0.8, 2.0, 0.5)
+    assert (twist.linear.x, twist.linear.y, twist.angular.z) == expected
+
+
+@pytest.mark.parametrize(
+    ("keys", "expected"),
+    [
+        pytest.param({pygame.K_w, pygame.K_LSHIFT}, (1.0, 0.0, 0.0), id="shift-boosts-move"),
+        pytest.param({pygame.K_q, pygame.K_RCTRL}, (0.0, 0.25, 0.0), id="ctrl-slows-strafe"),
+        pytest.param({pygame.K_d, pygame.K_RSHIFT}, (0.0, 0.0, -1.6), id="shift-boosts-turn"),
+        pytest.param(
+            {pygame.K_w, pygame.K_LSHIFT, pygame.K_LCTRL},
+            (1.0, 0.0, 0.0),
+            id="shift-takes-precedence",
+        ),
+    ],
+)
+def test_twist_from_keys_applies_speed_modifier(
+    keys: set[int], expected: tuple[float, float, float]
+) -> None:
+    twist = twist_from_keys(keys, 0.5, 0.8, 2.0, 0.5)
+    assert (twist.linear.x, twist.linear.y, twist.angular.z) == expected

--- a/dimos/robot/unitree/test_keyboard_teleop.py
+++ b/dimos/robot/unitree/test_keyboard_teleop.py
@@ -12,10 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest.mock import MagicMock, patch
+
 import pygame
 import pytest
 
-from dimos.robot.unitree.keyboard_teleop import twist_from_keys
+from dimos.msgs.geometry_msgs.Twist import Twist
+from dimos.robot.unitree.keyboard_teleop import KeyboardTeleop, twist_from_keys
 
 
 @pytest.mark.parametrize(
@@ -74,3 +77,27 @@ def test_twist_from_keys_applies_speed_modifier(
 ) -> None:
     twist = twist_from_keys(keys, 0.5, 0.8, 2.0, 0.5)
     assert (twist.linear.x, twist.linear.y, twist.angular.z) == expected
+
+
+def test_display_lists_arrow_and_strafe_controls() -> None:
+    teleop = MagicMock(spec=KeyboardTeleop)
+    teleop._screen = MagicMock()
+    teleop._font = MagicMock()
+    teleop._keys_held = {pygame.K_UP}
+    teleop._window_title = "Keyboard Teleop"
+    teleop.boost_multiplier = 2.0
+    teleop.slow_multiplier = 0.5
+    teleop.disable_movement = False
+
+    with (
+        patch.object(pygame.key, "name", return_value="up"),
+        patch.object(pygame.draw, "circle"),
+        patch.object(pygame.display, "flip"),
+    ):
+        KeyboardTeleop._update_display(teleop, Twist())
+
+    rendered_text = [call.args[0] for call in teleop._font.render.call_args_list]
+    assert "Keys: UP" in rendered_text
+    assert "W/S or Up/Down: Move" in rendered_text
+    assert "A/D or Left/Right: Turn" in rendered_text
+    assert "Q/E or Alt + turn keys: Strafe" in rendered_text

--- a/stubs/pygame/__init__.pyi
+++ b/stubs/pygame/__init__.pyi
@@ -57,12 +57,18 @@ K_SPACE: int
 K_ESCAPE: int
 K_RETURN: int
 K_BACKSPACE: int
+K_DOWN: int
 K_LCTRL: int
+K_LALT: int
+K_LEFT: int
 K_LSHIFT: int
+K_RALT: int
 K_RCTRL: int
+K_RIGHT: int
 K_RSHIFT: int
 K_LEFTBRACKET: int
 K_RIGHTBRACKET: int
+K_UP: int
 
 # --- submodules --------------------------------------------------------
 


### PR DESCRIPTION
## Contribution path

- [ ] Small, safe change that does not need a tracking issue
- [x] Linked issue or discussion: Closes #1957

## Problem

Keyboard teleop supports W/S movement, A/D turning, and Q/E strafing, but it lacks the arrow-key aliases and Alt-modified strafing requested in #1957.

## Solution

- Map Up/Down to forward/backward movement and Left/Right to turning.
- Map Alt+A/D and Alt+Left/Right to strafing while preserving Q/E.
- Apply the existing Shift/Ctrl speed modifiers to every commanded axis.
- Cancel opposite inputs on each axis and test the key-to-`Twist` mapping directly.
- Update the mock example, Go2 blueprint documentation, and pygame help display.

The deprecated web command-center extension remains unchanged, following the maintainer direction on #2028.

## How to Test

```bash
uv run --no-sync pytest -q dimos/robot/unitree dimos/codebase_checks/test_no_underscore_assign.py
uv sync --only-group lint --frozen
uv run mypy
pre-commit run --files \
  dimos/control/examples/twist_base_keyboard_teleop.py \
  dimos/robot/unitree/go2/blueprints/basic/unitree_go2_keyboard_teleop.py \
  dimos/robot/unitree/keyboard_teleop.py \
  dimos/robot/unitree/test_keyboard_teleop.py
```

Results on macOS arm64 with Python 3.12:

- 56 relevant tests passed; 11 hardware-dependent tests were deselected
- full-repository mypy passed: 866 source files
- all hooks applicable to the changed files passed
- Greptile review: 5/5, no blocking issues

Interactive verification on a system with X11 and repository LFS access:

```bash
uv run python -m dimos.control.examples.twist_base_keyboard_teleop
```

The interactive mock example was not run locally because its shared mobile-blueprint import requires a private LFS asset and this host has no X11 display. No robot hardware was used or tested.

## AI assistance

OpenAI Codex with GPT-5 was heavily involved in repository analysis, implementation, tests, and PR preparation. The contributor reviewed the complete diff, understands its behavior and limitations, and stands behind the submitted changes.

## Checklist

- [x] This PR is scoped to one issue or clearly stated problem.
- [x] I ran the relevant checks (`uv run pytest`, pre-commit) for the files I changed.
- [x] I have reviewed and understood every line in this PR.
- [x] I disclosed AI assistance above.
- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
