### PR TITLE
docs(teleop): rename Hosted Teleop page to Remote Teleop

### DIFF
--- a/docs/capabilities/teleoperation/hosted.md
+++ b/docs/capabilities/teleoperation/hosted.md
@@ -1,5 +1,5 @@
 ---
-title: "Hosted Teleop"
+title: "Remote Teleop"
 ---
 
 Operate a DimOS robot remotely from any browser or Quest headset over WebRTC.


### PR DESCRIPTION
Renames the teleoperation capability page from **Hosted Teleop** to **Remote Teleop**.

### What changed
- `docs/capabilities/teleoperation/hosted.md` frontmatter `title` → `"Remote Teleop"` (also updates the Mintlify sidebar label, which derives from the title).

### What deliberately did **not** change
- **Code identifiers** — `HostedTeleopModule`, `HostedTwistTeleopModule`, `HostedArmTeleopModule`, `HostedTeleopConfig`, blueprints `teleop-hosted-go2` / `teleop-hosted-xarm7`, and `TELEOP_*` env vars — these match the shipped code, so renaming them in docs would point readers at symbols that do not exist.
- **URL slug** stays `/capabilities/teleoperation/hosted` — no broken inbound links, no redirect needed.

Single-line content change; scope intentionally limited to the product-facing name.