### PR TITLE
fix(unitree): marshal stop_movement zero-twist onto the loop thread

### DIFF
--- a/dimos/robot/unitree/connection.py
+++ b/dimos/robot/unitree/connection.py
@@ -502,7 +502,16 @@ class UnitreeWebRTCConnection(Resource):
         if self.stop_timer:
             self.stop_timer.cancel()
             self.stop_timer = None
-        self._publish_movement(0, 0, 0)
+
+        async def async_stop() -> None:
+            self._publish_movement(0, 0, 0)
+
+        if not self.loop.is_running():
+            return
+        try:
+            asyncio.run_coroutine_threadsafe(async_stop(), self.loop).result(timeout=1.0)
+        except Exception as e:
+            logger.warning("Failed to publish stop twist: %s", e)
 
     def disconnect(self) -> None:
         """Disconnect from the robot and clean up resources."""


### PR DESCRIPTION
## Problem

`stop_movement` called `_publish_movement(0,0,0)` directly from non-loop threads

## Solution

Marshal the send onto the connection's event loop via `asyncio.run_coroutine_threadsafe`, matching the existing pattern in `publish_request` and `move()`. 

## How to Test
```
dimos run teleop-hosted-go2-multicam
```

## Contributor License Agreement

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
