### PR TITLE
style(docs): fix trailing whitespace breaking lint on main

### DIFF
--- a/docs/capabilities/teleoperation/hosted.md
+++ b/docs/capabilities/teleoperation/hosted.md
@@ -40,7 +40,7 @@ All broker-facing modules share a single broker session, so there's exactly
 one video track and one control plane per robot — see
 [How it connects](#how-it-connects) for the channel-level detail.
 
-How low is the latency in practice? With the World Cup on, four Dimensional teammates across the globe; San Francisco, Bangalore, Buenos Aires, and Shanghai played soccer with Go2s hosted in SF, over the public internet. 
+How low is the latency in practice? With the World Cup on, four Dimensional teammates across the globe; San Francisco, Bangalore, Buenos Aires, and Shanghai played soccer with Go2s hosted in SF, over the public internet.
 
 Below are the latencies recorded:
 


### PR DESCRIPTION
`docs/capabilities/teleoperation/hosted.md` line 43 has a trailing space, introduced by e7df6f683 (#2982). The lint job runs `pre-commit --all-files`, so this fails on main and on every open PR that inherits it (e.g. #2984).

One character. Verified locally with pre-commit 4.6.0 (same version CI uses): reproduces on clean main, passes after the fix.

Note: #2984 carries the same one-line fix to unblock itself. Whichever merges first, the other becomes a no-op — the change is byte-identical, so no conflict.