### PR TITLE
ci: skip code test jobs on docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,21 @@ env:
   UV_NO_SYNC: "1"
 
 jobs:
+  changes:
+    # Is anything outside docs/ touched? Docs-only PRs skip the code jobs.
+    # Non-PR events (push, merge_group) always get 'true' — they run everything.
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read  # For paths-filter to list the PR's files
+    outputs:
+      code: ${{ github.event_name != 'pull_request' || steps.filter.outputs.code == 'true' }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        if: github.event_name == 'pull_request'
+        id: filter
+        with:
+          filters: '{code: ["!docs/**"]}'
+
   compute-ros-pin:
     # Extracts the ros-dev image digest pinned in docker/ros-dev-pin/Dockerfile
     # so downstream jobs can reference it from their `container:` field.
@@ -59,6 +74,8 @@ jobs:
         uses: pre-commit/action@v3.0.1
 
   rust:
+    if: needs.changes.outputs.code == 'true'
+    needs: changes
     timeout-minutes: 20
     runs-on: ubuntu-latest
     permissions:
@@ -231,6 +248,8 @@ jobs:
       #   run: npm run validate
 
   tests:
+    if: needs.changes.outputs.code == 'true'
+    needs: changes
     timeout-minutes: 20
     strategy:
       matrix:
@@ -429,8 +448,9 @@ jobs:
     if: |
       !cancelled() &&
       (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.full_name == github.repository) &&
+      needs.changes.outputs.code == 'true' &&
       contains(fromJSON('["success", "skipped"]'), needs.cmu-nav-natives.result)
-    needs: [compute-ros-pin, cmu-nav-natives]
+    needs: [changes, compute-ros-pin, cmu-nav-natives]
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -595,7 +615,9 @@ jobs:
   self-hosted-large-tests:
     # Skip on PRs from forks which would expose the self-hosted runner to untrusted code from external contributors.
     if: |
-      github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+      (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) &&
+      needs.changes.outputs.code == 'true'
+    needs: changes
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -725,6 +747,7 @@ jobs:
     if: always()
 
     needs:
+    - changes
     - lint
     - rust
     - md-babel
@@ -742,7 +765,7 @@ jobs:
     - name: Decide whether the needed jobs succeeded or failed
       uses: re-actors/alls-green@release/v1
       with:
-        allowed-skips: cmu-nav-natives, self-hosted-tests, self-hosted-large-tests
+        allowed-skips: rust, tests, cmu-nav-natives, self-hosted-tests, self-hosted-large-tests
         jobs: ${{ toJSON(needs) }}
     - name: Trigger Codecov notifications
       uses: codecov/codecov-action@v7


### PR DESCRIPTION
A docs typo currently runs the full suite: ~115 min of runner time (8-way `tests` matrix, rust, self-hosted Linux + macOS, large-tests) to check a banner string. #2984 is the example.

A `changes` job answers "did anything outside `docs/` move?"; `rust`, `tests` and `self-hosted-*` are gated on it. `lint`, `docs-validate` and `md-babel` still run on docs — md-babel executes the code blocks *in* the docs.

**Why not `paths-ignore` on the trigger:** `ci-complete` is the required check. A workflow that never runs never reports it, so docs PRs would hang forever on "waiting for required check". Gating jobs keeps `ci-complete` reporting; `rust`/`tests` join the `allowed-skips` it already has.

Fails open — non-PR events (push, merge_group) always get `code: true`. Fork guards on `self-hosted-*` are extended with `&&`, not replaced. `cmu-nav-natives` is left alone (already cache-gated, self-skips on docs).