### PR TITLE
fix: remove removed cibuildwheel enable group breaking release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,6 @@ jobs:
       id-token: write      # For attest-build-provenance's OIDC sigstore signing
       attestations: write  # For uploading the SLSA build-provenance attestation
     env:
-      CIBW_ENABLE: "cpython-freethreading"
       CIBW_ARCHS: ${{ matrix.arch }}
       # Skip musllinux (Alpine) — Pinocchio's build ecosystem (pin/coal/cmeel-*)
       # is glibc-only; cmeel-assimp >= 6.0.5 has no musllinux wheels.


### PR DESCRIPTION
The release run on release/0.0.14b1 failed all three build-wheels jobs with:

    cibuildwheel: Failed to parse enable group. Unknown enable group: cpython-freethreading.

- #2728 bumped pypa/cibuildwheel v3.4.1 -> v4.1.0, which removed the \`cpython-freethreading\` enable group (free-threaded builds are default-on since 3.2).
- The flag was a no-op for us anyway: \`requires-python = ">=3.10,<3.13"\` excludes 3.13+, and free-threading only exists from 3.13.
- Release workflow is dispatch-only, so the break sat dormant since the bump merged.

Needs backport to release/0.0.14b1 to unblock the in-flight release.