### PR TITLE
feat: ban `__new__`

### DIFF
--- a/dimos/agents/mcp/test_mcp_client_unit.py
+++ b/dimos/agents/mcp/test_mcp_client_unit.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 from __future__ import annotations
 
+from collections.abc import Iterator
 import json
-from queue import Empty, Queue
+from queue import Empty
 from unittest.mock import MagicMock, patch
 
 from langchain_core.messages import HumanMessage
@@ -22,7 +23,6 @@ from langchain_core.messages.base import BaseMessage
 import pytest
 
 from dimos.agents.mcp.mcp_client import McpClient
-from dimos.utils.sequential_ids import SequentialIds
 
 
 def _mock_post(url: str, **kwargs: object) -> MagicMock:
@@ -95,19 +95,18 @@ def _mock_post(url: str, **kwargs: object) -> MagicMock:
 
 
 @pytest.fixture
-def mcp_client() -> McpClient:
+def mcp_client() -> Iterator[McpClient]:
     """Build an McpClient wired to the mock MCP post handler."""
     mock_http = MagicMock()
     mock_http.post.side_effect = _mock_post
 
     with patch("dimos.agents.mcp.mcp_client.httpx.Client", return_value=mock_http):
-        client = McpClient.__new__(McpClient)
+        client = McpClient(mcp_server_url="http://localhost:9990/mcp")
 
-    client._http_client = mock_http
-    client._seq_ids = SequentialIds()
-    client.config = MagicMock()
-    client.config.mcp_server_url = "http://localhost:9990/mcp"
-    return client
+    try:
+        yield client
+    finally:
+        client.stop()
 
 
 def test_fetch_tools_from_mcp_server(mcp_client: McpClient) -> None:
@@ -150,8 +149,6 @@ def test_mcp_request_error_propagation(mcp_client: McpClient) -> None:
 
 def test_tool_stream_notification_becomes_human_message(mcp_client: McpClient) -> None:
     """A `notifications/message` delivered over LCM becomes a HumanMessage."""
-    mcp_client._message_queue = Queue()
-
     notification = {
         "jsonrpc": "2.0",
         "method": "notifications/message",
@@ -172,8 +169,6 @@ def test_tool_stream_notification_becomes_human_message(mcp_client: McpClient) -
 def test_tool_stream_ignores_unrelated_frames(mcp_client: McpClient) -> None:
     """Unknown methods and empty bodies are dropped on the floor."""
 
-    mcp_client._message_queue = Queue()
-
     mcp_client._on_tool_stream_message({"jsonrpc": "2.0", "method": "notifications/other"})
     mcp_client._on_tool_stream_message(
         {"jsonrpc": "2.0", "method": "notifications/message", "params": {"data": ""}}
@@ -188,8 +183,6 @@ def test_tool_stream_ignores_unrelated_frames(mcp_client: McpClient) -> None:
 
 def test_tool_stream_progress_frame_becomes_human_message(mcp_client: McpClient) -> None:
     """A `notifications/progress` frame is routed as a HumanMessage."""
-
-    mcp_client._message_queue = Queue()
 
     progress_frame = {
         "jsonrpc": "2.0",

--- a/dimos/codebase_checks/test_no_dunder_new.py
+++ b/dimos/codebase_checks/test_no_dunder_new.py
@@ -1,0 +1,75 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ast
+from pathlib import Path
+
+from dimos.constants import DIMOS_PROJECT_ROOT
+
+# Calls that match but are legitimate. Last resort — construct the object
+# properly instead whenever possible.
+WHITELIST = [
+    # Pure threading-logic test; a real engine would need a MuJoCo model
+    # compile and the `mujoco` marker, dropping it from the default CI lane.
+    ("dimos/simulation/engines/test_mujoco_sim_module.py", "object.__new__(MujocoEngine)"),
+]
+
+
+def _is_whitelisted(rel_path: str, line: str) -> bool:
+    for allowed_path, allowed_substr in WHITELIST:
+        if rel_path == allowed_path and allowed_substr in line:
+            return True
+    return False
+
+
+def find_dunder_new_calls() -> list[tuple[Path, int, str]]:
+    """Return (file, line_number, line_text) for every `__new__` call in test files."""
+    dimos_dir = DIMOS_PROJECT_ROOT / "dimos"
+    hits: list[tuple[Path, int, str]] = []
+    for path in sorted(dimos_dir.rglob("*.py")):
+        if not (path.name.startswith("test_") or path.name == "conftest.py"):
+            continue
+        source = path.read_text(encoding="utf-8")
+        lines = source.splitlines()
+        rel_path = str(path.relative_to(DIMOS_PROJECT_ROOT))
+        for node in ast.walk(ast.parse(source)):
+            if not (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "__new__"
+            ):
+                continue
+            line = lines[node.lineno - 1]
+            if not _is_whitelisted(rel_path, line):
+                hits.append((path, node.lineno, line))
+    return hits
+
+
+def test_no_dunder_new() -> None:
+    """Fail if any test file calls `__new__` to bypass `__init__`."""
+    dimos_dir = DIMOS_PROJECT_ROOT / "dimos"
+    hits = find_dunder_new_calls()
+    if hits:
+        listing = "\n".join(
+            f"  - {p.relative_to(dimos_dir)}:{lineno}: {line.strip()}" for p, lineno, line in hits
+        )
+        raise AssertionError(
+            f"Found __new__ call(s) in test files:\n{listing}\n\n"
+            "Tests must construct objects with the real constructor: __init__ is "
+            "code under test too, and an object assembled by hand silently rots "
+            "when the constructor changes. If __init__ does heavy work, mock the "
+            "collaborators it needs instead of skipping it. Only if that is truly "
+            "impossible, add the call to the WHITELIST in "
+            "dimos/codebase_checks/test_no_dunder_new.py."
+        )

--- a/dimos/navigation/nav_3d/mls_planner/odom_body_frame.py
+++ b/dimos/navigation/nav_3d/mls_planner/odom_body_frame.py
@@ -14,6 +14,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from pydantic import Field
 from reactivex.disposable import Disposable
 
@@ -43,10 +45,13 @@ class OdomBodyFrame(Module):
     odometry: In[Odometry]
     body_odometry: Out[Odometry]
 
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._mount_inv = Quaternion(*self.config.mount_rotation).inverse()
+
     @rpc
     def start(self) -> None:
         super().start()
-        self._mount_inv = Quaternion(*self.config.mount_rotation).inverse()
         self.register_disposable(Disposable(self.odometry.subscribe(self._on_odometry)))
 
     def _on_odometry(self, msg: Odometry) -> None:

--- a/dimos/navigation/nav_3d/mls_planner/test_odom_body_frame.py
+++ b/dimos/navigation/nav_3d/mls_planner/test_odom_body_frame.py
@@ -12,39 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from types import SimpleNamespace
-
 from dimos.msgs.geometry_msgs.Pose import Pose
 from dimos.msgs.geometry_msgs.Quaternion import Quaternion
 from dimos.msgs.geometry_msgs.Vector3 import Vector3
 from dimos.msgs.nav_msgs.Odometry import Odometry
-from dimos.navigation.nav_3d.mls_planner.odom_body_frame import (
-    OdomBodyFrame,
-    OdomBodyFrameConfig,
-)
+from dimos.navigation.nav_3d.mls_planner.odom_body_frame import OdomBodyFrame
 
 
 def _level(mount_rotation, orientation):
-    """Run one odometry message through the handler and return the output.
-
-    Builds the module without its transport so no runtime threads spawn.
-    """
-    module = object.__new__(OdomBodyFrame)
-    module.config = OdomBodyFrameConfig(
-        mount_rotation=list(mount_rotation), body_frame_id="base_link"
-    )
-    module._mount_inv = Quaternion(*module.config.mount_rotation).inverse()
-    captured = []
-    module.body_odometry = SimpleNamespace(publish=captured.append)
-    module._on_odometry(
-        Odometry(
-            ts=1.0,
-            frame_id="odom",
-            child_frame_id="mid360_link",
-            pose=Pose(Vector3(1.0, 2.0, 3.0), orientation),
+    """Run one odometry message through the handler and return the output."""
+    module = OdomBodyFrame(mount_rotation=list(mount_rotation), body_frame_id="base_link")
+    try:
+        captured = []
+        module.body_odometry.subscribe(captured.append)
+        module._on_odometry(
+            Odometry(
+                ts=1.0,
+                frame_id="odom",
+                child_frame_id="mid360_link",
+                pose=Pose(Vector3(1.0, 2.0, 3.0), orientation),
+            )
         )
-    )
-    return captured[0]
+        return captured[0]
+    finally:
+        module.stop()
 
 
 def test_composes_out_the_mount_pitch():

--- a/dimos/protocol/service/test_lcmservice.py
+++ b/dimos/protocol/service/test_lcmservice.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pickle
 import threading
 import time
 from unittest.mock import MagicMock, create_autospec, patch
@@ -188,17 +189,13 @@ class TestLCMService:
             assert "_call_thread_pool" not in state
             assert "_call_thread_pool_lock" not in state
 
-    def test_setstate_reinitializes_runtime_attrs(self) -> None:
+    def test_unpickling_reinitializes_runtime_attrs(self) -> None:
         with patch("dimos.protocol.service.lcmservice.lcm_mod.LCM") as mock_lcm_class:
             mock_lcm_instance = create_autospec(LCM, spec_set=True, instance=True)
             mock_lcm_class.return_value = mock_lcm_instance
 
             service = LCMService()
-            state = service.__getstate__()
-
-            # Simulate unpickling
-            new_service = object.__new__(LCMService)
-            new_service.__setstate__(state)
+            new_service = pickle.loads(pickle.dumps(service))
 
             assert new_service.l is None
             assert isinstance(new_service._stop_event, threading.Event)
@@ -214,11 +211,7 @@ class TestLCMService:
             mock_lcm_class.return_value = mock_lcm_instance
 
             service = LCMService()
-            state = service.__getstate__()
-
-            # Simulate unpickling
-            new_service = object.__new__(LCMService)
-            new_service.__setstate__(state)
+            new_service = pickle.loads(pickle.dumps(service))
 
             # Start should reinitialize LCM
             new_service.start()

--- a/dimos/simulation/engines/test_mujoco_sim_module.py
+++ b/dimos/simulation/engines/test_mujoco_sim_module.py
@@ -19,13 +19,12 @@ from pathlib import Path
 import threading
 import time
 from typing import Any
-from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
 
 from dimos.simulation.engines.mujoco_engine import MujocoEngine
-from dimos.simulation.engines.mujoco_sim_module import MujocoSimModule, MujocoSimModuleConfig
+from dimos.simulation.engines.mujoco_sim_module import MujocoSimModule
 
 
 class _FakeData:
@@ -69,6 +68,9 @@ class _FakeRespawnEngine:
         }
         return True
 
+    def disconnect(self) -> None:
+        pass
+
 
 class _FakeSimHooks:
     def __init__(self) -> None:
@@ -80,15 +82,6 @@ class _FakeSimHooks:
 
 def test_ready_signal_happens_after_joint_state_and_imu_write() -> None:
     events: list[str] = []
-    module = object.__new__(MujocoSimModule)
-    module._shm_ready_signaled = False
-    module._root_base_qpos_adr = 0
-    module._imu_quat_slice = None
-    module._imu_base_qpos_slice = slice(3, 7)
-    module._imu_gyro_slice = slice(0, 3)
-    module._imu_accel_slice = slice(3, 6)
-    module.odom = MagicMock()
-    module.imu = MagicMock()
 
     class _FakeHooks:
         def post_step(self, engine: Any) -> None:
@@ -103,44 +96,64 @@ def test_ready_signal_happens_after_joint_state_and_imu_write() -> None:
             assert num_joints == 2
             events.append("ready")
 
-    module._sim_hooks = _FakeHooks()
-    module._shm = _FakeShm()
+        def signal_stop(self) -> None:
+            pass
 
-    module._publish_shm_and_lcm(_FakeEngine)
+        def cleanup(self) -> None:
+            pass
 
-    assert events == ["joint_state", "imu", "ready"]
+    module = MujocoSimModule()
+    try:
+        module._root_base_qpos_adr = 0
+        module._imu_base_qpos_slice = slice(3, 7)
+        module._imu_gyro_slice = slice(0, 3)
+        module._imu_accel_slice = slice(3, 6)
+        module._sim_hooks = _FakeHooks()
+        module._shm = _FakeShm()
+
+        module._publish_shm_and_lcm(_FakeEngine)
+
+        assert events == ["joint_state", "imu", "ready"]
+    finally:
+        module.stop()
 
 
 def test_reset_requests_engine_reset_and_clears_latched_commands() -> None:
-    module = object.__new__(MujocoSimModule)
     engine = _FakeRespawnEngine()
     hooks = _FakeSimHooks()
-    module._engine = engine
-    module._sim_hooks = hooks
+    module = MujocoSimModule()
+    try:
+        module._engine = engine
+        module._sim_hooks = hooks
 
-    assert module.reset() is True
+        assert module.reset() is True
 
-    assert engine.reset_requested is True
-    assert hooks.cleared is True
+        assert engine.reset_requested is True
+        assert hooks.cleared is True
+    finally:
+        module.stop()
 
 
 def test_respawn_at_uses_ground_height_plus_initial_root_clearance() -> None:
-    module = object.__new__(MujocoSimModule)
     engine = _FakeRespawnEngine(ground_z=0.08)
     hooks = _FakeSimHooks()
-    module._engine = engine
-    module._sim_hooks = hooks
-    module._root_spawn_clearance_z = 0.793
+    module = MujocoSimModule()
+    try:
+        module._engine = engine
+        module._sim_hooks = hooks
+        module._root_spawn_clearance_z = 0.793
 
-    assert module.respawn_at(2.6, 0.0, yaw=0.25) is True
+        assert module.respawn_at(2.6, 0.0, yaw=0.25) is True
 
-    assert engine.reset_to_kwargs == {
-        "spawn_xy": (2.6, 0.0),
-        "spawn_z": pytest.approx(0.873),
-        "spawn_yaw": 0.25,
-        "wait": True,
-    }
-    assert hooks.cleared is True
+        assert engine.reset_to_kwargs == {
+            "spawn_xy": (2.6, 0.0),
+            "spawn_z": pytest.approx(0.873),
+            "spawn_yaw": 0.25,
+            "wait": True,
+        }
+        assert hooks.cleared is True
+    finally:
+        module.stop()
 
 
 def test_reset_waiters_are_released_when_reset_requests_are_coalesced() -> None:
@@ -311,37 +324,38 @@ def test_compose_model_attaches_robot_before_scene_entities(tmp_path: Path) -> N
     _write_scene_xml(scene_xml)
     _write_robot_xml(robot_xml)
 
-    module = object.__new__(MujocoSimModule)
-    module.config = MujocoSimModuleConfig(
+    module = MujocoSimModule(
         scene_xml=scene_xml,
         robot_mjcf=robot_xml,
         scene_entities=[_scene_entity("chair_000")],
         spawn_xy=(0.25, -0.5),
         spawn_z=0.8,
     )
+    try:
+        model = module._compose_model()
 
-    model = MujocoSimModule._compose_model(module)
+        assert model.opt.timestep == pytest.approx(0.005)
+        assert mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_GEOM, "static_scene_box") >= 0
+        assert mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, "entity:chair_000") >= 0
 
-    assert model.opt.timestep == pytest.approx(0.005)
-    assert mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_GEOM, "static_scene_box") >= 0
-    assert mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, "entity:chair_000") >= 0
+        free_joints: list[tuple[str, int]] = []
+        for joint_id in range(model.njnt):
+            if int(model.jnt_type[joint_id]) != int(mujoco.mjtJoint.mjJNT_FREE):
+                continue
+            name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, joint_id) or ""
+            free_joints.append((name, int(model.jnt_qposadr[joint_id])))
 
-    free_joints: list[tuple[str, int]] = []
-    for joint_id in range(model.njnt):
-        if int(model.jnt_type[joint_id]) != int(mujoco.mjtJoint.mjJNT_FREE):
-            continue
-        name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, joint_id) or ""
-        free_joints.append((name, int(model.jnt_qposadr[joint_id])))
+        robot_free = next(item for item in free_joints if item[0].endswith("floating_base_joint"))
+        entity_free = next(item for item in free_joints if item[0] == "entity:chair_000:free")
+        assert robot_free[1] == 0
+        assert entity_free[1] > robot_free[1]
 
-    robot_free = next(item for item in free_joints if item[0].endswith("floating_base_joint"))
-    entity_free = next(item for item in free_joints if item[0] == "entity:chair_000:free")
-    assert robot_free[1] == 0
-    assert entity_free[1] > robot_free[1]
-
-    engine = MujocoEngine(config_path=robot_xml, headless=True, model=model)
-    assert engine.model is model
-    assert engine.root_qpos_adr == 0
-    assert any(name.endswith("hinge") for name in engine.joint_names)
+        engine = MujocoEngine(config_path=robot_xml, headless=True, model=model)
+        assert engine.model is model
+        assert engine.root_qpos_adr == 0
+        assert any(name.endswith("hinge") for name in engine.joint_names)
+    finally:
+        module.stop()
 
 
 @pytest.mark.mujoco
@@ -355,8 +369,7 @@ def test_compose_model_reuses_entity_mesh_assets(tmp_path: Path) -> None:
     _write_robot_xml(robot_xml)
     _write_hull_obj(hull_obj)
 
-    module = object.__new__(MujocoSimModule)
-    module.config = MujocoSimModuleConfig(
+    module = MujocoSimModule(
         scene_xml=scene_xml,
         robot_mjcf=robot_xml,
         scene_entities=[
@@ -365,12 +378,14 @@ def test_compose_model_reuses_entity_mesh_assets(tmp_path: Path) -> None:
         ],
         spawn_xy=(0.0, 0.0),
     )
+    try:
+        model = module._compose_model()
 
-    model = MujocoSimModule._compose_model(module)
-
-    assert mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, "entity:box_000") >= 0
-    assert mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, "entity:box_001") >= 0
-    assert model.nmesh == 1
+        assert mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, "entity:box_000") >= 0
+        assert mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, "entity:box_001") >= 0
+        assert model.nmesh == 1
+    finally:
+        module.stop()
 
 
 @pytest.fixture


### PR DESCRIPTION
## Contribution path

<!-- See CONTRIBUTING.md. Small, safe changes can skip the issue. -->

- [ ] Small, safe change that does not need a tracking issue
- [ ] Linked issue or discussion: DIM-XXX / #XXX / URL

## Problem

* We keep getting tests which use `object.__new__(SomeClass)` instead of using `SomeClass()`. This is usually to avoid calling `__init__`. But not calling `__init__` indicates a problem. Either we unnecessary leave `__init__` uncovered, or `__init__` cannot be ordinarily called because of the bad API design it uses.
* It also means `__init__` is often duplicate it test code. This will rarely be updated as the real `__init__` is changed.

## Solution

* Add a test which bans the use of `__new__`.

## How to Test

<!-- oneliner required to run the actual feature -->
<!-- blueprint for robot changes, benchmarks for transport changes etc -->

## AI assistance

<!-- Required by AI_POLICY.md. Name the tool and the model (e.g. "Claude Code with Opus 4.8") and how much they were involved. Write "None" if unassisted. -->

## Checklist

- [ ] This PR is scoped to one issue or clearly stated problem.
- [ ] I ran the relevant checks (`uv run pytest`, pre-commit) for the files I changed.
- [ ] I have reviewed and understood every line in this PR.
- [ ] I disclosed AI assistance above.
- [ ] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
