### PR TITLE
fix(memory2): drain recorder callbacks before store close

### DIFF
--- a/dimos/memory2/module.py
+++ b/dimos/memory2/module.py
@@ -19,7 +19,7 @@ import enum
 import inspect
 import os
 from pathlib import Path
-import sqlite3
+import threading
 import time
 from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
 
@@ -28,7 +28,7 @@ from reactivex import operators as ops
 from reactivex.disposable import Disposable
 
 from dimos.agents.annotation import skill
-from dimos.constants import DIMOS_PROJECT_ROOT
+from dimos.constants import DEFAULT_THREAD_JOIN_TIMEOUT, DIMOS_PROJECT_ROOT
 from dimos.core.core import rpc
 from dimos.core.module import Module, ModuleConfig
 from dimos.core.stream import In
@@ -56,6 +56,108 @@ logger = setup_logger()
 T = TypeVar("T")
 TIn = TypeVar("TIn")
 TOut = TypeVar("TOut")
+
+_RECORDER_DRAIN_TIMEOUT_SECONDS: float = DEFAULT_THREAD_JOIN_TIMEOUT
+_RECORDER_DRAIN_LOG_INTERVAL_SECONDS: float = 0.1
+
+
+class _RecorderDrainError(RuntimeError):
+    pass
+
+
+class _RecorderCallbacks:
+    def __init__(self) -> None:
+        self._state = threading.Condition()
+        self._accepting = True
+        self._active = 0
+        self._subscriptions: list[DisposableBase] = []
+        self._dispatchers: list[DisposableBase] = []
+        self._stopped = False
+
+    def begin(self) -> bool:
+        with self._state:
+            if not self._accepting:
+                return False
+            self._active += 1
+            return True
+
+    def finish(self) -> None:
+        with self._state:
+            self._active -= 1
+            if self._active == 0:
+                self._state.notify_all()
+
+    def register(
+        self,
+        subscription: DisposableBase,
+        dispatcher: DisposableBase | None = None,
+    ) -> None:
+        with self._state:
+            if self._accepting:
+                self._subscriptions.append(subscription)
+                if dispatcher is not None:
+                    self._dispatchers.append(dispatcher)
+                return
+
+        subscription.dispose()
+        if dispatcher is not None:
+            dispatcher.dispose()
+        raise RuntimeError("Recorder is stopping or stopped")
+
+    def stop(self) -> None:
+        with self._state:
+            if self._stopped:
+                return
+            self._accepting = False
+            subscriptions, self._subscriptions = self._subscriptions, []
+            dispatchers = list(self._dispatchers)
+
+        first_error: BaseException | None = None
+        for subscription in subscriptions:
+            try:
+                subscription.dispose()
+            except BaseException as exc:
+                if first_error is None:
+                    first_error = exc
+
+        started = time.monotonic()
+        deadline = started + _RECORDER_DRAIN_TIMEOUT_SECONDS
+        while True:
+            with self._state:
+                if self._active == 0:
+                    break
+                active = self._active
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise _RecorderDrainError(
+                        f"Timed out waiting for {active} recorder callback(s)"
+                    ) from first_error
+                self._state.wait(timeout=min(_RECORDER_DRAIN_LOG_INTERVAL_SECONDS, remaining))
+                if self._active == 0:
+                    break
+
+            try:
+                logger.warning(
+                    "Still waiting for recorder callbacks",
+                    active_callbacks=active,
+                    elapsed_seconds=time.monotonic() - started,
+                )
+            except Exception:
+                pass
+
+        for dispatcher in dispatchers:
+            try:
+                dispatcher.dispose()
+            except BaseException as exc:
+                if first_error is None:
+                    first_error = exc
+
+        if first_error is not None:
+            raise first_error
+
+        with self._state:
+            self._dispatchers.clear()
+            self._stopped = True
 
 
 def stream_to_port(stream: Stream[T], out: Out[T]) -> DisposableBase:
@@ -325,8 +427,51 @@ class Recorder(MemoryModule):
 
     _pose_setters: dict[str, Any] = {}
 
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._init_recorder_runtime()
+
+    def _init_recorder_runtime(self) -> None:
+        self._recorder_stop_lock = threading.RLock()
+        self._recorder_callbacks = _RecorderCallbacks()
+        self._recorder_teardown_error: BaseException | None = None
+        self.register_disposable(Disposable(self._recorder_callbacks.stop))
+
+    def __getstate__(self) -> dict[str, Any]:
+        # ModuleBase.__getstate__ is untyped.
+        state: dict[str, Any] = super().__getstate__()  # type: ignore[no-untyped-call]
+        state.pop("_recorder_stop_lock", None)
+        state.pop("_recorder_callbacks", None)
+        state.pop("_recorder_teardown_error", None)
+        return state
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        super().__setstate__(state)
+        self._init_recorder_runtime()
+
+    @rpc
+    def stop(self) -> None:
+        with self._recorder_stop_lock:
+            if self._recorder_teardown_error is not None:
+                raise RuntimeError(
+                    "Recorder teardown previously failed; refusing to close the store"
+                ) from self._recorder_teardown_error
+            # Run the retryable callback barrier before the one-shot composite
+            # teardown. A drain timeout therefore leaves the store registered
+            # and allows a later stop() to finish once callbacks have returned.
+            self._recorder_callbacks.stop()
+            try:
+                super().stop()
+            except BaseException as exc:
+                self._recorder_teardown_error = exc
+                raise
+
     @rpc
     def start(self) -> None:
+        with self._recorder_stop_lock:
+            self._start_recorder()
+
+    def _start_recorder(self) -> None:
         super().start()
 
         if self.config.g.replay:
@@ -387,27 +532,39 @@ class Recorder(MemoryModule):
         already in world coords) fall back to ``config.default_frame_id`` —
         so every observation gets a robot-pose anchor when tf is publishing.
 
-        Each port is recorded by an async callback dispatched on the module's
-        event loop via :meth:`process_observable`, which serialises invocations
-        and registers the subscription for cleanup on stop().
+        Each port uses a LATEST-coalescing async dispatcher on the module's event
+        loop. The recorder callback barrier owns the subscription and dispatcher
+        so stop() can block new writes, unsubscribe, and drain admitted callbacks
+        before the store closes.
         """
 
         async def on_msg(stamped: tuple[float, Any]) -> None:
-            recv_ts, msg = stamped
-            ts = self._resolve_ts(name, msg)
-            pose = await self._resolve_pose(name, msg, ts)
-            if not pose and name not in self.config.poseless_streams:
-                logger.warning(
-                    "[%s] No pose for time %s (msg ts: %s), storing without pose",
-                    name,
-                    ts,
-                    getattr(msg, "ts", None),
-                )
-            stream.append(msg, ts=ts, pose=pose, tags={"reception_ts": recv_ts})
+            if not self._recorder_callbacks.begin():
+                return
+            try:
+                recv_ts, msg = stamped
+                ts = self._resolve_ts(name, msg)
+                pose = await self._resolve_pose(name, msg, ts)
+                if not pose and name not in self.config.poseless_streams:
+                    logger.warning(
+                        "[%s] No pose for time %s (msg ts: %s), storing without pose",
+                        name,
+                        ts,
+                        getattr(msg, "ts", None),
+                    )
+                stream.append(msg, ts=ts, pose=pose, tags={"reception_ts": recv_ts})
+            finally:
+                self._recorder_callbacks.finish()
 
         # Stamp arrival time before the coalescing dispatch queue.
         stamped = input_topic.pure_observable().pipe(ops.map(lambda msg: (time.time(), msg)))
-        self.process_observable(stamped, on_msg)
+        on_next, dispatcher = self._make_async_dispatch(on_msg)
+        try:
+            subscription = stamped.subscribe(on_next)
+        except BaseException:
+            dispatcher.dispose()
+            raise
+        self._recorder_callbacks.register(subscription, dispatcher)
 
     def _prepare_streams(self) -> None:
         """On APPEND, drop the streams this recorder is about to (re)write — the
@@ -457,11 +614,12 @@ class Recorder(MemoryModule):
         tf_stream = self.store.stream("tf", TFMessage)
 
         def on_tf(msg: TFMessage) -> None:
+            if not self._recorder_callbacks.begin():
+                return
             try:
                 for transform in msg.transforms:
                     tf_stream.append(TFMessage(transform), ts=transform.ts, pose=None)
-            except sqlite3.ProgrammingError:
-                # A late LCM callback raced teardown and hit the closed store.
-                pass
+            finally:
+                self._recorder_callbacks.finish()
 
-        self.register_disposable(Disposable(self.tf.subscribe(on_tf)))
+        self._recorder_callbacks.register(Disposable(self.tf.subscribe(on_tf)))

--- a/dimos/memory2/test_recorder_shutdown.py
+++ b/dimos/memory2/test_recorder_shutdown.py
@@ -1,0 +1,343 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from concurrent.futures import Future, ThreadPoolExecutor, TimeoutError as FutureTimeoutError
+from pathlib import Path
+import threading
+from types import SimpleNamespace
+from typing import Any, overload
+from unittest.mock import MagicMock
+
+import pytest
+from reactivex import operators as ops
+from reactivex.subject import Subject
+
+from dimos.core.stream import In
+from dimos.memory2 import module as memory_module
+from dimos.memory2.module import Recorder
+from dimos.memory2.store.sqlite import SqliteStore
+from dimos.memory2.stream import Stream
+from dimos.msgs.geometry_msgs.Transform import Transform
+from dimos.msgs.tf2_msgs.TFMessage import TFMessage
+from dimos.protocol.rpc.spec import Args, RPCSpec
+
+SYNC_TIMEOUT: float = 2.0
+
+
+class _TestRPC(RPCSpec):
+    def __init__(self, **_kwargs: Any) -> None:
+        pass
+
+    def serve_rpc(self, _f: Callable[..., Any], _name: str) -> Callable[[], None]:
+        return lambda: None
+
+    @overload
+    def call(self, _name: str, _arguments: Args, _cb: None) -> None: ...
+
+    @overload
+    def call(
+        self,
+        _name: str,
+        _arguments: Args,
+        _cb: Callable[[Any], None],
+    ) -> Callable[[], Any]: ...
+
+    def call(
+        self,
+        _name: str,
+        _arguments: Args,
+        _cb: Callable[[Any], None] | None,
+    ) -> Callable[[], Any] | None:
+        return None if _cb is None else lambda: None
+
+    def call_nowait(self, _name: str, _arguments: Args) -> None:
+        pass
+
+
+def _recorder(tmp_path: Path, store: MagicMock) -> Recorder:
+    module = Recorder(
+        db_path=tmp_path / "recording.db",
+        record_tf=False,
+        rpc_transport=_TestRPC,
+    )
+    module._store = store
+    module.register_disposable(store)
+    return module
+
+
+def _store() -> tuple[MagicMock, threading.Event]:
+    store = MagicMock(spec=SqliteStore)
+    stopped = threading.Event()
+
+    def dispose() -> None:
+        store.stop()
+        stopped.set()
+
+    store.dispose.side_effect = dispose
+    return store, stopped
+
+
+def test_stop_waits_for_active_input_before_closing_store(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    store, store_stopped = _store()
+    stream = MagicMock(spec=Stream)
+    input_topic = MagicMock(spec=In)
+    subject: Subject[Any] = Subject()
+    unsubscribed = threading.Event()
+    input_topic.pure_observable.return_value = subject.pipe(ops.finally_action(unsubscribed.set))
+    module = _recorder(tmp_path, store)
+    append_started = threading.Event()
+    append_release = threading.Event()
+    append_finished = threading.Event()
+
+    async def resolve_pose(_name: str, _msg: Any, _ts: float) -> None:
+        return None
+
+    def append(*_args: Any, **_kwargs: Any) -> None:
+        append_started.set()
+        assert append_release.wait(timeout=SYNC_TIMEOUT)
+        append_finished.set()
+
+    def stop_store() -> None:
+        assert append_finished.is_set()
+
+    monkeypatch.setattr(module, "_resolve_pose", resolve_pose)
+    stream.append.side_effect = append
+    store.stop.side_effect = stop_store
+    module._port_to_stream("color_image", input_topic, stream)
+
+    try:
+        subject.on_next(SimpleNamespace(ts=1.0))
+        assert append_started.wait(timeout=SYNC_TIMEOUT)
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            stop_future = pool.submit(module.stop)
+            try:
+                assert unsubscribed.wait(timeout=SYNC_TIMEOUT)
+                assert not store_stopped.is_set()
+                assert not stop_future.done()
+            finally:
+                append_release.set()
+            stop_future.result(timeout=SYNC_TIMEOUT)
+    finally:
+        append_release.set()
+        module.stop()
+
+    assert store_stopped.is_set()
+    store.stop.assert_called_once_with()
+
+
+def test_stop_waits_for_active_tf_before_closing_store(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    store, store_stopped = _store()
+    tf_stream = MagicMock(spec=Stream)
+    store.stream.return_value = tf_stream
+    module = _recorder(tmp_path, store)
+    callback: list[Callable[[TFMessage], None]] = []
+    unsubscribed = threading.Event()
+    tf_port = MagicMock(spec=In)
+    tf_port._transport = MagicMock()
+
+    def subscribe(cb: Callable[[TFMessage], None]) -> Callable[[], None]:
+        callback.append(cb)
+        return unsubscribed.set
+
+    tf_port.subscribe.side_effect = subscribe
+    module.tf = tf_port
+    append_started = threading.Event()
+    append_release = threading.Event()
+    append_finished = threading.Event()
+
+    def append(*_args: Any, **_kwargs: Any) -> None:
+        append_started.set()
+        assert append_release.wait(timeout=SYNC_TIMEOUT)
+        append_finished.set()
+
+    def stop_store() -> None:
+        assert append_finished.is_set()
+
+    tf_stream.append.side_effect = append
+    store.stop.side_effect = stop_store
+    module._record_tf()
+
+    try:
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            callback_future = pool.submit(
+                callback[0], TFMessage(Transform(ts=1.0, frame_id="world"))
+            )
+            assert append_started.wait(timeout=SYNC_TIMEOUT)
+            stop_future = pool.submit(module.stop)
+            try:
+                assert unsubscribed.wait(timeout=SYNC_TIMEOUT)
+                assert not store_stopped.is_set()
+                assert not stop_future.done()
+            finally:
+                append_release.set()
+            callback_future.result(timeout=SYNC_TIMEOUT)
+            stop_future.result(timeout=SYNC_TIMEOUT)
+    finally:
+        append_release.set()
+        module.stop()
+
+    assert store_stopped.is_set()
+    store.stop.assert_called_once_with()
+
+
+def test_late_tf_callback_is_ignored_after_stop(tmp_path: Path) -> None:
+    store, _ = _store()
+    tf_stream = MagicMock(spec=Stream)
+    store.stream.return_value = tf_stream
+    module = _recorder(tmp_path, store)
+    callback: list[Callable[[TFMessage], None]] = []
+    tf_port = MagicMock(spec=In)
+    tf_port._transport = MagicMock()
+
+    def subscribe(cb: Callable[[TFMessage], None]) -> Callable[[], None]:
+        callback.append(cb)
+        return lambda: None
+
+    tf_port.subscribe.side_effect = subscribe
+    module.tf = tf_port
+    module._record_tf()
+    module.stop()
+
+    callback[0](TFMessage(Transform(ts=1.0, frame_id="world")))
+
+    tf_stream.append.assert_not_called()
+
+
+def test_concurrent_stop_waits_for_active_teardown(tmp_path: Path) -> None:
+    store, _ = _store()
+    module = _recorder(tmp_path, store)
+    store_stop_started = threading.Event()
+    store_stop_release = threading.Event()
+    second_stop_started = threading.Event()
+
+    def stop_store() -> None:
+        store_stop_started.set()
+        assert store_stop_release.wait(timeout=SYNC_TIMEOUT)
+
+    def stop_again() -> None:
+        second_stop_started.set()
+        module.stop()
+
+    store.stop.side_effect = stop_store
+    first_stop: Future[None] | None = None
+    second_stop: Future[None] | None = None
+    try:
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            first_stop = pool.submit(module.stop)
+            assert store_stop_started.wait(timeout=SYNC_TIMEOUT)
+            second_stop = pool.submit(stop_again)
+            assert second_stop_started.wait(timeout=SYNC_TIMEOUT)
+            assert not module._module_closed
+            with pytest.raises(FutureTimeoutError):
+                second_stop.result(timeout=0.05)
+            store_stop_release.set()
+            first_stop.result(timeout=SYNC_TIMEOUT)
+            second_stop.result(timeout=SYNC_TIMEOUT)
+    finally:
+        store_stop_release.set()
+        if first_stop is not None:
+            first_stop.result(timeout=SYNC_TIMEOUT)
+        if second_stop is not None:
+            second_stop.result(timeout=SYNC_TIMEOUT)
+
+    store.stop.assert_called_once_with()
+
+
+def test_stop_can_retry_after_drain_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    store, store_stopped = _store()
+    stream = MagicMock(spec=Stream)
+    input_topic = MagicMock(spec=In)
+    subject: Subject[Any] = Subject()
+    input_topic.pure_observable.return_value = subject
+    module = _recorder(tmp_path, store)
+    append_started = threading.Event()
+    append_release = threading.Event()
+    append_finished = threading.Event()
+    callback_threads: list[threading.Thread] = []
+
+    async def resolve_pose(_name: str, _msg: Any, _ts: float) -> None:
+        return None
+
+    def append(*_args: Any, **_kwargs: Any) -> None:
+        append_started.set()
+        assert append_release.wait(timeout=SYNC_TIMEOUT)
+        append_finished.set()
+
+    monkeypatch.setattr(module, "_resolve_pose", resolve_pose)
+    monkeypatch.setattr(
+        memory_module,
+        "_RECORDER_DRAIN_TIMEOUT_SECONDS",
+        0.01,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        memory_module,
+        "_RECORDER_DRAIN_LOG_INTERVAL_SECONDS",
+        0.005,
+        raising=False,
+    )
+
+    def make_dispatch(
+        async_callback: Callable[[Any], Any],
+    ) -> tuple[Callable[[Any], None], MagicMock]:
+        dispatcher = MagicMock()
+
+        def on_next(msg: Any) -> None:
+            thread = threading.Thread(target=lambda: asyncio.run(async_callback(msg)))
+            callback_threads.append(thread)
+            thread.start()
+
+        return on_next, dispatcher
+
+    monkeypatch.setattr(module, "_make_async_dispatch", make_dispatch)
+    stream.append.side_effect = append
+    module._port_to_stream("color_image", input_topic, stream)
+
+    try:
+        subject.on_next(SimpleNamespace(ts=1.0))
+        assert append_started.wait(timeout=SYNC_TIMEOUT)
+        with pytest.raises(RuntimeError, match="Timed out waiting for 1 recorder callback"):
+            module.stop()
+        assert not store_stopped.is_set()
+        assert not module._module_closed
+
+        append_release.set()
+        assert append_finished.wait(timeout=SYNC_TIMEOUT)
+        for thread in callback_threads:
+            thread.join(timeout=SYNC_TIMEOUT)
+
+        module.stop()
+    finally:
+        append_release.set()
+        for thread in callback_threads:
+            thread.join(timeout=SYNC_TIMEOUT)
+        if not module._module_closed:
+            module.stop()
+
+    assert store_stopped.is_set()
+    assert module._module_closed
+    store.stop.assert_called_once_with()

--- a/dimos/teleop/utils/recorder.py
+++ b/dimos/teleop/utils/recorder.py
@@ -60,6 +60,10 @@ class TeleopRecorder(Recorder):
 
     @rpc
     def start(self) -> None:
+        with self._recorder_stop_lock:
+            self._start_teleop_recorder()
+
+    def _start_teleop_recorder(self) -> None:
         if self.config.g.replay:
             super().start()
             return


### PR DESCRIPTION
## Contribution path

- [ ] Small, safe change that does not need a tracking issue
- [x] Linked issue: #2572

## Problem

Recorder registers SQLite before its input and TF subscriptions. During shutdown, the store can close while an admitted callback is still resolving a pose or writing. Canceling the handler task does not wait for an active synchronous SQLite write.

## Solution

Register a callback barrier before the store. Stop blocks new writes, unsubscribes input and TF sources, and waits up to two seconds for admitted callbacks before closing SQLite.

If the drain times out, the store and runtime stay open. A later stop retries after the callback finishes.

Start and stop are serialized, including `TeleopRecorder` setup. Recording contents, timestamps, poses, and robot control are unchanged.

## How to Test

```bash
uv run pytest -q dimos/memory2/test_recorder_shutdown.py
uv run pytest -q dimos/memory2 dimos/teleop
```

Validated locally:

- shutdown regressions: 5 passed
- Memory2 and teleop: 437 passed, 126 skipped
- Ruff, mypy, pre-commit, and `git diff --check`: passed
- SQLite reopen and integrity check: passed

## AI assistance

Used GPT-5 for implementation and tests. Claude and Qodo reviewed the change.

## Checklist

- [x] I have reviewed and understood every line in this PR.
- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
