### PR TITLE
fix(navigation): prevent replans during shutdown

### DIFF
--- a/dimos/navigation/replanning_a_star/global_planner.py
+++ b/dimos/navigation/replanning_a_star/global_planner.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import Callable
 import math
 from threading import Event, RLock, Thread, current_thread
 import time
@@ -32,7 +33,7 @@ from dimos.msgs.nav_msgs.OccupancyGrid import CostValues, OccupancyGrid
 from dimos.msgs.nav_msgs.Path import Path
 from dimos.navigation.base import NavigationState
 from dimos.navigation.replanning_a_star.goal_validator import find_safe_goal
-from dimos.navigation.replanning_a_star.local_planner import LocalPlanner, StopMessage
+from dimos.navigation.replanning_a_star.local_planner import LocalPlanner, PlanStopEvent
 from dimos.navigation.replanning_a_star.min_cost_astar import min_cost_astar
 from dimos.navigation.replanning_a_star.navigation_map import NavigationMap
 from dimos.navigation.replanning_a_star.position_tracker import PositionTracker
@@ -60,9 +61,16 @@ class GlobalPlanner(Resource):
     _replan_limiter: ReplanLimiter
     _disposables: CompositeDisposable
     _stop_planner: Event
+    _stop_complete: Event
+    _stop_owner: Thread | None
     _replan_event: Event
-    _replan_reason: StopMessage | None
+    _replan_reason: PlanStopEvent | None
+    # Nested acquisitions must take _activation_lock before _lock. Do not enter
+    # LocalPlanner observer-publishing APIs while holding only _lock.
     _lock: RLock
+    _activation_lock: RLock
+    _goal_epoch: int
+    _plan_epoch: int
     _safe_goal_clearance: float
 
     _safe_goal_tolerance: float = 4.0
@@ -93,32 +101,104 @@ class GlobalPlanner(Resource):
         self._replan_limiter = ReplanLimiter()
         self._disposables = CompositeDisposable()
         self._stop_planner = Event()
+        self._stop_complete = Event()
+        self._stop_complete.set()
+        self._stop_owner = None
         self._replan_event = Event()
         self._replan_reason = None
         self._lock = RLock()
+        self._activation_lock = RLock()
+        self._goal_epoch = 0
+        self._plan_epoch = 0
         self._reset_safe_goal_clearance()
 
     def start(self) -> None:
-        self._local_planner.start()
-        self._disposables.add(
-            self._local_planner.stopped_navigating.subscribe(self._on_stopped_navigating)
-        )
-        self._stop_planner.clear()
-        self._thread = Thread(target=self._thread_entrypoint, daemon=True)
-        self._thread.start()
+        with self._activation_lock:
+            if self._stop_planner.is_set():
+                raise RuntimeError("GlobalPlanner cannot be restarted after stop().")
+            if self._thread is not None:
+                raise RuntimeError("GlobalPlanner monitor thread has already been started.")
+
+            self._local_planner.start()
+            self._disposables.add(
+                self._local_planner.plan_stopped.subscribe(self._on_stopped_navigating)
+            )
+            self._thread = Thread(target=self._thread_entrypoint, daemon=True)
+            self._thread.start()
 
     def stop(self) -> None:
-        self.cancel_goal()
-        self._local_planner.stop()
-        self._disposables.dispose()
-        self._stop_planner.set()
-        self._replan_event.set()
+        owns_shutdown = False
+        wait_for_shutdown = False
+        with self._activation_lock:
+            with self._lock:
+                if self._stop_planner.is_set():
+                    wait_for_shutdown = (
+                        not self._stop_complete.is_set()
+                        and self._stop_owner is not None
+                        and self._stop_owner is not current_thread()
+                    )
+                else:
+                    self._stop_owner = current_thread()
+                    self._stop_complete.clear()
+                    self._stop_planner.set()
+                    self._replan_event.set()
+                    owns_shutdown = True
 
-        if self._thread is not None and self._thread is not current_thread():
-            self._thread.join(DEFAULT_THREAD_JOIN_TIMEOUT)
-            if self._thread.is_alive():
-                logger.error("GlobalPlanner thread did not stop in time.")
-            self._thread = None
+        if not owns_shutdown:
+            if wait_for_shutdown:
+                if not self._stop_complete.wait(DEFAULT_THREAD_JOIN_TIMEOUT):
+                    logger.error("GlobalPlanner shutdown did not complete in time.")
+            return
+
+        first_error: BaseException | None = None
+        critical_shutdown_complete = False
+
+        def run_cleanup(action: Callable[[], object]) -> None:
+            nonlocal first_error
+            try:
+                action()
+            except BaseException as error:
+                if first_error is None:
+                    first_error = error
+                else:
+                    logger.exception("Additional error during GlobalPlanner shutdown.")
+
+        def finish_critical_shutdown() -> None:
+            nonlocal critical_shutdown_complete
+            if critical_shutdown_complete:
+                return
+
+            try:
+                thread = self._thread
+                if thread is not None and thread is not current_thread():
+
+                    def join_monitor() -> None:
+                        thread.join(DEFAULT_THREAD_JOIN_TIMEOUT)
+                        if thread.is_alive():
+                            logger.error("GlobalPlanner thread did not stop in time.")
+                        else:
+                            self._thread = None
+
+                    run_cleanup(join_monitor)
+            finally:
+                with self._lock:
+                    self._stop_owner = None
+                    self._stop_complete.set()
+                critical_shutdown_complete = True
+
+        try:
+            run_cleanup(self._disposables.dispose)
+            run_cleanup(
+                lambda: self._cancel_goal(
+                    allow_during_shutdown=True,
+                    before_notifications=finish_critical_shutdown,
+                )
+            )
+        finally:
+            finish_critical_shutdown()
+
+        if first_error is not None:
+            raise first_error
 
     def handle_odom(self, msg: PoseStamped) -> None:
         with self._lock:
@@ -132,12 +212,20 @@ class GlobalPlanner(Resource):
         self._navigation_map_near.update(msg)
 
     def handle_goal_request(self, goal: PoseStamped) -> None:
-        logger.info("Got new goal", goal=str(goal))
-        with self._lock:
-            self._current_goal = goal
-            self._goal_reached = False
-        self._replan_limiter.reset()
-        self._plan_path()
+        with self._activation_lock:
+            with self._lock:
+                if self._stop_planner.is_set():
+                    logger.debug("Ignoring goal request during planner shutdown.")
+                    return
+
+                logger.info("Got new goal", goal=str(goal))
+                self._goal_epoch += 1
+                goal_epoch = self._goal_epoch
+                self._current_goal = goal
+                self._goal_reached = False
+            self._replan_limiter.reset()
+
+        self._plan_path(goal_epoch)
 
     def set_safe_goal_clearance(self, clearance: float) -> None:
         with self._lock:
@@ -147,27 +235,115 @@ class GlobalPlanner(Resource):
         self._reset_safe_goal_clearance()
 
     def cancel_goal(self, *, but_will_try_again: bool = False, arrived: bool = False) -> None:
-        # return silently so we don't flood the logs.
-        with self._lock:
-            no_goal = self._current_goal is None
-        if no_goal and self._local_planner.get_state() == NavigationState.IDLE:
-            return
+        self._cancel_goal(but_will_try_again=but_will_try_again, arrived=arrived)
 
-        logger.info("Cancelling goal.", but_will_try_again=but_will_try_again, arrived=arrived)
+    def _cancel_goal(
+        self,
+        *,
+        expected_goal_epoch: int | None = None,
+        expected_plan_epoch: int | None = None,
+        allow_during_shutdown: bool = False,
+        before_notifications: Callable[[], object] | None = None,
+        but_will_try_again: bool = False,
+        arrived: bool = False,
+    ) -> bool:
+        """Cancel only while the expected goal and plan epochs are current.
 
-        with self._lock:
-            self._position_tracker.reset_data()
+        Shutdown cleanup may bypass the normal shutdown guard. The return value
+        reports whether the request passed validation and cancellation was
+        attempted.
+        """
+        first_error: BaseException | None = None
+        cancellation_epoch = (self._goal_epoch, self._plan_epoch)
 
-            if not but_will_try_again:
-                self._current_goal = None
-                self._goal_reached = arrived
-                self._replan_limiter.reset()
+        def run_cleanup(action: Callable[[], object]) -> None:
+            nonlocal first_error
+            try:
+                action()
+            except BaseException as error:
+                if first_error is None:
+                    first_error = error
+                else:
+                    logger.exception("Additional error while cancelling a navigation goal.")
 
-        self.path.on_next(Path())
-        self._local_planner.stop_planning()
+        with self._activation_lock:
+            with self._lock:
+                if self._stop_planner.is_set() and not allow_during_shutdown:
+                    return False
+                if (
+                    expected_goal_epoch is not None and self._goal_epoch != expected_goal_epoch
+                ) or (expected_plan_epoch is not None and self._plan_epoch != expected_plan_epoch):
+                    return False
 
-        if not but_will_try_again:
-            self.goal_reached.on_next(Bool(arrived))
+                no_goal = self._current_goal is None
+            if (
+                not allow_during_shutdown
+                and no_goal
+                and self._local_planner.get_state() == NavigationState.IDLE
+            ):
+                return False
+
+            cancel_active_goal = not (allow_during_shutdown and no_goal)
+            if cancel_active_goal:
+                logger.info(
+                    "Cancelling goal.",
+                    but_will_try_again=but_will_try_again,
+                    arrived=arrived,
+                )
+
+            try:
+                with self._lock:
+                    if cancel_active_goal and not but_will_try_again:
+                        self._current_goal = None
+                        self._goal_reached = arrived
+                        self._goal_epoch += 1
+                        self._plan_epoch += 1
+                        self._replan_limiter.reset()
+
+                    cancellation_epoch = (self._goal_epoch, self._plan_epoch)
+            except BaseException as error:
+                first_error = error
+                with self._lock:
+                    cancellation_epoch = (self._goal_epoch, self._plan_epoch)
+
+            if cancel_active_goal:
+                run_cleanup(self._position_tracker.reset_data)
+
+            # Invalidate local activation while it is serialized with new plans.
+            # The stop command must stay in this critical section so it cannot
+            # land after a replacement plan activates. Path/goal notifications
+            # stay outside the lock because Subjects call observers
+            # synchronously.
+            run_cleanup(self._local_planner.deactivate_planning)
+
+            with self._lock:
+                publish_stop_command = cancellation_epoch == (
+                    self._goal_epoch,
+                    self._plan_epoch,
+                ) and (allow_during_shutdown or not self._stop_planner.is_set())
+
+            if publish_stop_command:
+                run_cleanup(self._local_planner.publish_stop_command)
+
+        def cancellation_is_current() -> bool:
+            with self._lock:
+                return cancellation_epoch == (self._goal_epoch, self._plan_epoch) and (
+                    allow_during_shutdown or not self._stop_planner.is_set()
+                )
+
+        if before_notifications is not None:
+            run_cleanup(before_notifications)
+
+        if cancel_active_goal and cancellation_is_current():
+            run_cleanup(lambda: self.path.on_next(Path()))
+
+        if cancel_active_goal and not but_will_try_again and cancellation_is_current():
+            run_cleanup(lambda: self.goal_reached.on_next(Bool(arrived)))
+
+        if first_error is not None:
+            raise first_error
+
+        return cancel_active_goal
 
     def set_replanning_enabled(self, enabled: bool) -> None:
         with self._lock:
@@ -216,6 +392,8 @@ class GlobalPlanner(Resource):
             with self._lock:
                 current_goal = self._current_goal
                 current_odom = self._current_odom
+                goal_epoch = self._goal_epoch
+                plan_epoch = self._plan_epoch
 
             if not current_goal or not current_odom:
                 continue
@@ -228,7 +406,11 @@ class GlobalPlanner(Resource):
                 < self._rotation_tolerance
             ):
                 logger.info("Close enough to goal. Accepting as arrived.")
-                self.cancel_goal(arrived=True)
+                self._cancel_goal(
+                    expected_goal_epoch=goal_epoch,
+                    expected_plan_epoch=plan_epoch,
+                    arrived=True,
+                )
                 continue
 
             # Check if robot has veered too far off the path
@@ -239,7 +421,7 @@ class GlobalPlanner(Resource):
                     deviation=round(deviation, 2),
                     threshold=self._max_path_deviation,
                 )
-                self._replan_path()
+                self._replan_path(goal_epoch, plan_epoch)
                 last_stuck_check = time.perf_counter()
                 continue
 
@@ -255,68 +437,130 @@ class GlobalPlanner(Resource):
                 and self._position_tracker.is_stuck()
             ):
                 logger.info("Robot is stuck. Replanning.")
-                self._replan_path()
+                self._replan_path(goal_epoch, plan_epoch)
                 last_stuck_check = time.perf_counter()
 
-    def _on_stopped_navigating(self, stop_message: StopMessage) -> None:
+    def _on_stopped_navigating(self, stop_event: PlanStopEvent) -> None:
         with self._lock:
-            self._replan_reason = stop_message
-        # Signal the monitoring thread to do the replanning. This is so we don't have two
-        # threads which could be replanning at the same time.
-        self._replan_event.set()
+            if self._stop_planner.is_set():
+                return
+            if stop_event.plan_epochs != (self._goal_epoch, self._plan_epoch):
+                logger.debug("Ignoring a completion for an inactive plan.")
+                return
+            self._replan_reason = stop_event
+            # Signal the monitoring thread to do the replanning. This is so we don't have two
+            # threads which could be replanning at the same time.
+            self._replan_event.set()
 
-    def _handle_stop_message(self, stop_message: StopMessage) -> None:
+    def _handle_stop_message(self, stop_event: PlanStopEvent) -> None:
         # Note, this runs in the monitoring thread.
+        if stop_event.plan_epochs is None:
+            logger.warning("Ignoring a local-planner completion without plan epochs.")
+            return
 
-        self.path.on_next(Path())
+        stop_message = stop_event.reason
+        goal_epoch, plan_epoch = stop_event.plan_epochs
+        with self._lock:
+            if self._stop_planner.is_set():
+                return
 
         if stop_message == "arrived":
             logger.info("Arrived at goal.")
-            self.cancel_goal(arrived=True)
+            self._cancel_goal(
+                expected_goal_epoch=goal_epoch,
+                expected_plan_epoch=plan_epoch,
+                arrived=True,
+            )
         elif stop_message == "obstacle_found":
             logger.info("Replanning path due to obstacle found.")
-            self._replan_path()
+            self._replan_path(goal_epoch, plan_epoch)
         elif stop_message == "error":
             logger.info("Failure in navigation.")
-            self._replan_path()
+            self._replan_path(goal_epoch, plan_epoch)
         else:
             logger.error(f"No code to handle '{stop_message}'.")
-            self.cancel_goal()
+            self._cancel_goal(
+                expected_goal_epoch=goal_epoch,
+                expected_plan_epoch=plan_epoch,
+            )
 
-    def _replan_path(self) -> None:
-        with self._lock:
-            current_odom = self._current_odom
-            current_goal = self._current_goal
+    def _replan_path(
+        self,
+        expected_goal_epoch: int | None = None,
+        expected_plan_epoch: int | None = None,
+    ) -> None:
+        cancel_arrived = False
+        cancel_failed = False
+        with self._activation_lock:
+            with self._lock:
+                if self._stop_planner.is_set():
+                    logger.debug("Skipping replan during shutdown.")
+                    return
+                if (
+                    expected_goal_epoch is not None and self._goal_epoch != expected_goal_epoch
+                ) or (expected_plan_epoch is not None and self._plan_epoch != expected_plan_epoch):
+                    logger.debug("Skipping replan for an inactive goal.")
+                    return
+                current_odom = self._current_odom
+                current_goal = self._current_goal
+                goal_epoch = self._goal_epoch
+                plan_epoch = self._plan_epoch
+                replanning_enabled = self._replanning_enabled
 
-        logger.info("Replanning.", attempt=self._replan_limiter.get_attempt())
+            if current_odom is None or current_goal is None:
+                logger.debug("Skipping replan without an active goal and odometry.")
+                return
 
-        assert current_odom is not None
-        assert current_goal is not None
+            logger.info("Replanning.", attempt=self._replan_limiter.get_attempt())
 
-        if current_goal.position.distance(current_odom.position) < self._replan_goal_tolerance:
-            self.cancel_goal(arrived=True)
+            if current_goal.position.distance(current_odom.position) < self._replan_goal_tolerance:
+                cancel_arrived = True
+            elif not replanning_enabled or not self._replan_limiter.can_retry(
+                current_odom.position
+            ):
+                cancel_failed = True
+            else:
+                self._replan_limiter.will_retry()
+
+        if cancel_arrived:
+            self._cancel_goal(
+                expected_goal_epoch=goal_epoch,
+                expected_plan_epoch=plan_epoch,
+                arrived=True,
+            )
+        elif cancel_failed:
+            self._cancel_goal(
+                expected_goal_epoch=goal_epoch,
+                expected_plan_epoch=plan_epoch,
+            )
+        else:
+            self._plan_path(goal_epoch)
+
+    def _plan_path(self, goal_epoch: int) -> None:
+        with self._activation_lock:
+            with self._lock:
+                if self._stop_planner.is_set():
+                    return
+                if self._current_goal is None or self._goal_epoch != goal_epoch:
+                    return
+                self._plan_epoch += 1
+                plan_epoch = self._plan_epoch
+
+        if not self._cancel_goal(
+            expected_goal_epoch=goal_epoch,
+            expected_plan_epoch=plan_epoch,
+            but_will_try_again=True,
+        ):
             return
 
-        if not self._replanning_enabled:
-            self.cancel_goal()
+        with self._activation_lock:
+            with self._lock:
+                current_odom = self._current_odom
+                current_goal = self._current_goal
+                plan_is_current = self._goal_epoch == goal_epoch and self._plan_epoch == plan_epoch
+
+        if self._stop_planner.is_set() or current_goal is None or not plan_is_current:
             return
-
-        if not self._replan_limiter.can_retry(current_odom.position):
-            self.cancel_goal()
-            return
-
-        self._replan_limiter.will_retry()
-
-        self._plan_path()
-
-    def _plan_path(self) -> None:
-        self.cancel_goal(but_will_try_again=True)
-
-        with self._lock:
-            current_odom = self._current_odom
-            current_goal = self._current_goal
-
-        assert current_goal is not None
 
         if current_odom is None:
             logger.warning("Cannot handle goal request: missing odometry.")
@@ -328,7 +572,10 @@ class GlobalPlanner(Resource):
             logger.warning(
                 "No safe goal found.", x=round(current_goal.x, 3), y=round(current_goal.y, 3)
             )
-            self.cancel_goal()
+            self._cancel_goal(
+                expected_goal_epoch=goal_epoch,
+                expected_plan_epoch=plan_epoch,
+            )
             return
 
         path = self._find_wide_path(safe_goal, current_odom.position)
@@ -337,14 +584,47 @@ class GlobalPlanner(Resource):
             logger.warning(
                 "No path found to the goal.", x=round(safe_goal.x, 3), y=round(safe_goal.y, 3)
             )
-            self.cancel_goal()
+            self._cancel_goal(
+                expected_goal_epoch=goal_epoch,
+                expected_plan_epoch=plan_epoch,
+            )
             return
 
         resampled_path = smooth_resample_path(path, current_goal, 0.1)
 
+        clear_stale_path = False
+        with self._activation_lock:
+            with self._lock:
+                plan_is_current = (
+                    self._current_goal is current_goal
+                    and self._goal_epoch == goal_epoch
+                    and self._plan_epoch == plan_epoch
+                )
+                if self._stop_planner.is_set() or not plan_is_current:
+                    logger.debug("Discarding a path computed for an inactive goal.")
+                    return
+
         self.path.on_next(resampled_path)
 
-        self._local_planner.start_planning(resampled_path)
+        # A synchronous path observer may cancel, replace the goal, or stop the
+        # planner. Revalidate before activating the local planner.
+        with self._activation_lock:
+            with self._lock:
+                plan_is_current = (
+                    self._current_goal is current_goal
+                    and self._goal_epoch == goal_epoch
+                    and self._plan_epoch == plan_epoch
+                )
+                if self._stop_planner.is_set() or not plan_is_current:
+                    clear_stale_path = self._stop_planner.is_set()
+                else:
+                    self._local_planner.start_tagged_planning(
+                        resampled_path,
+                        (goal_epoch, plan_epoch),
+                    )
+
+        if clear_stale_path:
+            self.path.on_next(Path())
 
     def _find_wide_path(self, goal: Vector3, robot_pos: Vector3) -> Path | None:
         #        sizes_to_try: list[float] = [2.2, 1.7, 1.3, 1]

--- a/dimos/navigation/replanning_a_star/local_planner.py
+++ b/dimos/navigation/replanning_a_star/local_planner.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from dataclasses import dataclass
 import os
 from threading import Event, RLock, Thread
 import time
@@ -39,6 +40,14 @@ PlannerState: TypeAlias = Literal[
     "idle", "initial_rotation", "path_following", "final_rotation", "arrived"
 ]
 StopMessage: TypeAlias = Literal["arrived", "obstacle_found", "error"]
+PlanEpochs: TypeAlias = tuple[int, int]
+
+
+@dataclass(frozen=True)
+class PlanStopEvent:
+    reason: StopMessage
+    plan_epochs: PlanEpochs | None = None
+
 
 logger = setup_logger()
 
@@ -46,6 +55,7 @@ logger = setup_logger()
 class LocalPlanner(Resource):
     cmd_vel: Subject[Twist]
     stopped_navigating: Subject[StopMessage]
+    _plan_stopped: Subject[PlanStopEvent]
     navigation_costmap: Subject[OccupancyGrid]
 
     _thread: Thread | None = None
@@ -75,6 +85,7 @@ class LocalPlanner(Resource):
     ) -> None:
         self.cmd_vel = Subject()
         self.stopped_navigating = Subject()
+        self._plan_stopped = Subject()
         self.navigation_costmap = Subject()
 
         self._pose_index = 0
@@ -108,25 +119,56 @@ class LocalPlanner(Resource):
 
     def start_planning(self, path: Path) -> None:
         self.stop_planning()
+        self._start_planning(path, None)
 
-        self._stop_planning_event = Event()
+    @property
+    def plan_stopped(self) -> Subject[PlanStopEvent]:
+        return self._plan_stopped
+
+    def start_tagged_planning(self, path: Path, plan_epochs: PlanEpochs) -> None:
+        self._deactivate_planning()
+        self._start_planning(path, plan_epochs)
+
+    def deactivate_planning(self) -> None:
+        self._deactivate_planning()
+
+    def publish_stop_command(self) -> None:
+        self._publish_stop_command()
+
+    def _start_planning(self, path: Path, plan_epochs: PlanEpochs | None) -> None:
+        stop_event = Event()
 
         with self._lock:
+            self._stop_planning_event.set()
+            self._stop_planning_event = stop_event
             self._path = path
             self._path_clearance = PathClearance(self._global_config, self._path)
             self._path_distancer = PathDistancer(self._path)
             self._pose_index = 0
-            self._thread = Thread(target=self._thread_entrypoint, daemon=True)
+            self._thread = Thread(
+                target=self._thread_entrypoint,
+                args=(stop_event, plan_epochs),
+                daemon=True,
+            )
             self._thread.start()
 
     def stop_planning(self) -> None:
-        self.cmd_vel.on_next(Twist())
-        self._stop_planning_event.set()
+        try:
+            self._deactivate_planning()
+        finally:
+            self._publish_stop_command()
 
+    def _deactivate_planning(self) -> None:
         with self._lock:
+            self._stop_planning_event.set()
             self._thread = None
+            self._reset_state()
 
-        self._reset_state()
+    def _publish_stop_command(self) -> None:
+        try:
+            self.cmd_vel.on_next(Twist())
+        except Exception as error:
+            logger.exception("Error publishing local planner stop command", exc_info=error)
 
     def get_state(self) -> NavigationState:
         with self._lock:
@@ -144,16 +186,35 @@ class LocalPlanner(Resource):
         with self._lock:
             return (self._state, self._state_unique_id)
 
-    def _thread_entrypoint(self) -> None:
+    def _thread_entrypoint(
+        self,
+        stop_event: Event,
+        plan_epochs: PlanEpochs | None,
+    ) -> None:
         try:
-            self._loop()
+            self._loop(stop_event, plan_epochs)
         except Exception as e:
             traceback.print_exc()
             logger.exception("Error in local planning", exc_info=e)
-            self.stopped_navigating.on_next("error")
+            self._publish_stop_event("error", plan_epochs)
         finally:
-            self._reset_state()
-            self.cmd_vel.on_next(Twist())
+            is_current = False
+            with self._lock:
+                is_current = self._stop_planning_event is stop_event
+                if is_current:
+                    self._reset_state()
+            if is_current:
+                self._publish_stop_command()
+
+    def _publish_stop_event(self, reason: StopMessage, plan_epochs: PlanEpochs | None) -> None:
+        try:
+            self._plan_stopped.on_next(PlanStopEvent(reason, plan_epochs))
+        except Exception as error:
+            logger.exception("Error notifying tagged local planner stop observers", exc_info=error)
+        try:
+            self.stopped_navigating.on_next(reason)
+        except Exception as error:
+            logger.exception("Error notifying local planner stop observers", exc_info=error)
 
     def _change_state(self, new_state: PlannerState) -> None:
         if new_state == self._state:
@@ -162,10 +223,13 @@ class LocalPlanner(Resource):
         self._state_unique_id += 1
         logger.info("changed state", state=new_state)
 
-    def _loop(self) -> None:
-        stop_event = self._stop_planning_event
+    def _worker_is_current(self, stop_event: Event) -> bool:
+        return self._stop_planning_event is stop_event and not stop_event.is_set()
 
+    def _loop(self, stop_event: Event, plan_epochs: PlanEpochs | None) -> None:
         with self._lock:
+            if not self._worker_is_current(stop_event):
+                return
             path = self._path
             path_clearance = self._path_clearance
             current_odom = self._current_odom
@@ -175,11 +239,11 @@ class LocalPlanner(Resource):
 
         # Determine initial state: skip initial_rotation if already aligned.
         new_state: PlannerState = "initial_rotation"
+        initial_yaw_error: float | None = None
         if current_odom is not None and len(path.poses) > 0:
             first_yaw = path.poses[0].orientation.euler[2]
             robot_yaw = current_odom.orientation.euler[2]
             initial_yaw_error = angle_diff(first_yaw, robot_yaw)
-            self._controller.reset_yaw_error(initial_yaw_error)
             angle_in_tolerance = abs(initial_yaw_error) < self._orientation_tolerance
             if angle_in_tolerance:
                 position_in_tolerance = (
@@ -191,39 +255,57 @@ class LocalPlanner(Resource):
                     new_state = "path_following"
 
         with self._lock:
+            if not self._worker_is_current(stop_event):
+                return
+            if initial_yaw_error is not None:
+                self._controller.reset_yaw_error(initial_yaw_error)
             self._change_state(new_state)
 
-        while not stop_event.is_set():
+        while True:
             start_time = time.perf_counter()
 
             with self._lock:
+                if not self._worker_is_current(stop_event):
+                    break
                 path_clearance.update_costmap(self._navigation_map.binary_costmap)
                 path_clearance.update_pose_index(self._pose_index)
 
             self._send_navigation_costmap(path, path_clearance)
 
             if path_clearance.is_obstacle_ahead():
+                with self._lock:
+                    if not self._worker_is_current(stop_event):
+                        break
                 logger.info("Obstacle detected ahead, stopping local planner.")
-                self.stopped_navigating.on_next("obstacle_found")
+                self._publish_stop_event("obstacle_found", plan_epochs)
                 break
 
             with self._lock:
+                if not self._worker_is_current(stop_event):
+                    break
                 state: PlannerState = self._state
 
-            if state == "initial_rotation":
-                cmd_vel = self._compute_initial_rotation()
-            elif state == "path_following":
-                cmd_vel = self._compute_path_following()
-            elif state == "final_rotation":
-                cmd_vel = self._compute_final_rotation()
-            elif state == "arrived":
-                self.stopped_navigating.on_next("arrived")
-                break
-            elif state == "idle":
-                cmd_vel = None
+            cmd_vel: Twist | None
+            match state:
+                case "initial_rotation":
+                    cmd_vel = self._compute_initial_rotation(stop_event)
+                case "path_following":
+                    cmd_vel = self._compute_path_following(stop_event)
+                case "final_rotation":
+                    cmd_vel = self._compute_final_rotation(stop_event)
+                case "arrived":
+                    self._publish_stop_event("arrived", plan_epochs)
+                    break
+                case "idle":
+                    cmd_vel = None
+                case _:
+                    raise ValueError(f"Unknown planner state: {state}")
 
             if cmd_vel is not None:
-                self.cmd_vel.on_next(cmd_vel)
+                with self._lock:
+                    publish_command = self._worker_is_current(stop_event)
+                if publish_command:
+                    self.cmd_vel.on_next(cmd_vel)
 
             elapsed = time.perf_counter() - start_time
             sleep_time = max(0.0, (1.0 / self._control_frequency) - elapsed)
@@ -232,8 +314,10 @@ class LocalPlanner(Resource):
         if stop_event.is_set():
             logger.info("Local planner loop exited due to stop event.")
 
-    def _compute_initial_rotation(self) -> Twist:
+    def _compute_initial_rotation(self, stop_event: Event) -> Twist | None:
         with self._lock:
+            if not self._worker_is_current(stop_event):
+                return None
             path = self._path
             current_odom = self._current_odom
 
@@ -247,10 +331,15 @@ class LocalPlanner(Resource):
 
         if abs(yaw_error) < self._orientation_tolerance:
             with self._lock:
+                if not self._worker_is_current(stop_event):
+                    return None
                 self._change_state("path_following")
-            return self._compute_path_following()
+            return self._compute_path_following(stop_event)
 
-        return self._controller.rotate(yaw_error)
+        with self._lock:
+            if not self._worker_is_current(stop_event):
+                return None
+            return self._controller.rotate(yaw_error)
 
     def get_distance_to_path(self) -> float | None:
         with self._lock:
@@ -264,8 +353,10 @@ class LocalPlanner(Resource):
 
         return path_distancer.get_distance_to_path(current_pos)
 
-    def _compute_path_following(self) -> Twist:
+    def _compute_path_following(self, stop_event: Event) -> Twist | None:
         with self._lock:
+            if not self._worker_is_current(stop_event):
+                return None
             path_distancer = self._path_distancer
             current_odom = self._current_odom
 
@@ -277,20 +368,29 @@ class LocalPlanner(Resource):
         if path_distancer.distance_to_goal(current_pos) < self._goal_tolerance:
             logger.info("Reached goal position, starting final rotation")
             with self._lock:
+                if not self._worker_is_current(stop_event):
+                    return None
                 self._change_state("final_rotation")
-            return self._compute_final_rotation()
+            return self._compute_final_rotation(stop_event)
 
         closest_index = path_distancer.find_closest_point_index(current_pos)
 
         with self._lock:
+            if not self._worker_is_current(stop_event):
+                return None
             self._pose_index = closest_index
 
         lookahead_point = path_distancer.find_lookahead_point(closest_index)
 
-        return self._controller.advance(lookahead_point, current_odom)
-
-    def _compute_final_rotation(self) -> Twist:
         with self._lock:
+            if not self._worker_is_current(stop_event):
+                return None
+            return self._controller.advance(lookahead_point, current_odom)
+
+    def _compute_final_rotation(self, stop_event: Event) -> Twist | None:
+        with self._lock:
+            if not self._worker_is_current(stop_event):
+                return None
             path = self._path
             current_odom = self._current_odom
 
@@ -304,10 +404,15 @@ class LocalPlanner(Resource):
         if abs(yaw_error) < self._orientation_tolerance:
             logger.info("Final rotation complete, goal reached")
             with self._lock:
+                if not self._worker_is_current(stop_event):
+                    return None
                 self._change_state("arrived")
             return Twist()
 
-        return self._controller.rotate(yaw_error)
+        with self._lock:
+            if not self._worker_is_current(stop_event):
+                return None
+            return self._controller.rotate(yaw_error)
 
     def _reset_state(self) -> None:
         with self._lock:

--- a/dimos/navigation/replanning_a_star/module.py
+++ b/dimos/navigation/replanning_a_star/module.py
@@ -123,10 +123,10 @@ class ReplanningAStarPlanner(Module, NavigationInterface):
 
     @rpc
     def stop(self) -> None:
-        self.cancel_goal()
-        self._planner.stop()
-
-        super().stop()
+        try:
+            self._planner.stop()
+        finally:
+            super().stop()
 
     def _on_stop_movement(self, msg: Bool) -> None:
         if msg.data:

--- a/dimos/navigation/replanning_a_star/test_global_planner.py
+++ b/dimos/navigation/replanning_a_star/test_global_planner.py
@@ -12,13 +12,965 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event, Thread
+from typing import Any, cast
+from unittest.mock import ANY, MagicMock, call
 
+import numpy as np
+import pytest
+from pytest_mock import MockerFixture
+from reactivex import Subject
+
+from dimos.constants import DEFAULT_THREAD_JOIN_TIMEOUT
 from dimos.core.global_config import GlobalConfig
 from dimos.msgs.geometry_msgs.Pose import Pose
 from dimos.msgs.geometry_msgs.Vector3 import Vector3
 from dimos.msgs.nav_msgs.OccupancyGrid import OccupancyGrid
+from dimos.navigation.replanning_a_star import global_planner as planner_module
 from dimos.navigation.replanning_a_star.global_planner import GlobalPlanner
+from dimos.navigation.replanning_a_star.local_planner import PlanStopEvent
+
+TEST_TIMEOUT: float = 5.0
+
+
+@pytest.fixture()
+def planner(mocker: MockerFixture) -> GlobalPlanner:
+    mocker.patch.object(planner_module, "NavigationMap", autospec=True)
+    mocker.patch.object(planner_module, "LocalPlanner", autospec=True)
+    mocker.patch.object(planner_module, "PositionTracker", autospec=True)
+    mocker.patch.object(planner_module, "ReplanLimiter", autospec=True)
+    return GlobalPlanner(GlobalConfig())
+
+
+def test_stop_marks_shutdown_before_cleanup(planner: GlobalPlanner, mocker: MockerFixture) -> None:
+    planner._thread = None
+    planner._disposables = MagicMock()
+    cancel_goal = mocker.patch.object(planner, "_cancel_goal")
+    shutdown_was_visible: list[bool] = []
+
+    def observe_shutdown() -> None:
+        shutdown_was_visible.append(
+            planner._stop_planner.is_set() and planner._replan_event.is_set()
+        )
+
+    planner._disposables.dispose.side_effect = observe_shutdown
+    lifecycle = MagicMock()
+    lifecycle.attach_mock(planner._disposables.dispose, "dispose")
+    lifecycle.attach_mock(cancel_goal, "cancel")
+
+    planner.stop()
+
+    assert shutdown_was_visible == [True]
+    assert lifecycle.mock_calls == [
+        call.dispose(),
+        call.cancel(
+            allow_during_shutdown=True,
+            before_notifications=ANY,
+        ),
+    ]
+
+
+def test_stop_joins_monitor_when_goal_cleanup_fails(
+    planner: GlobalPlanner, mocker: MockerFixture
+) -> None:
+    planner._disposables = MagicMock()
+    thread = MagicMock()
+    thread.is_alive.return_value = False
+    planner._thread = thread
+    mocker.patch.object(planner, "_cancel_goal", side_effect=RuntimeError("cleanup failed"))
+
+    with pytest.raises(RuntimeError, match="cleanup failed"):
+        planner.stop()
+
+    thread.join.assert_called_once_with(DEFAULT_THREAD_JOIN_TIMEOUT)
+    assert planner._thread is None
+
+
+def test_stop_keeps_live_monitor_thread_handle(planner: GlobalPlanner) -> None:
+    planner._disposables = MagicMock()
+    thread = MagicMock()
+    thread.is_alive.return_value = True
+    planner._thread = thread
+
+    planner.stop()
+
+    thread.join.assert_called_once_with(DEFAULT_THREAD_JOIN_TIMEOUT)
+    assert planner._thread is thread
+
+
+def test_concurrent_stop_waits_for_critical_cleanup(
+    planner: GlobalPlanner, mocker: MockerFixture
+) -> None:
+    planner._thread = None
+    planner._disposables = MagicMock()
+    planner._current_goal = MagicMock()
+    cleanup_started = Event()
+    release_cleanup = Event()
+    second_started = Event()
+    second_returned = Event()
+
+    def block_cleanup() -> None:
+        cleanup_started.set()
+        if not release_cleanup.wait(timeout=TEST_TIMEOUT):
+            raise TimeoutError("test did not release shutdown cleanup")
+
+    def stop_again() -> None:
+        second_started.set()
+        planner.stop()
+        second_returned.set()
+
+    cast("MagicMock", planner._local_planner.publish_stop_command).side_effect = block_cleanup
+
+    try:
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            first_stop = executor.submit(planner.stop)
+            assert cleanup_started.wait(timeout=TEST_TIMEOUT)
+            second_stop = executor.submit(stop_again)
+            assert second_started.wait(timeout=TEST_TIMEOUT)
+            assert not second_returned.wait(timeout=0.05)
+            release_cleanup.set()
+            first_stop.result(timeout=TEST_TIMEOUT)
+            second_stop.result(timeout=TEST_TIMEOUT)
+    finally:
+        release_cleanup.set()
+
+    assert second_returned.is_set()
+    assert planner._stop_complete.is_set()
+
+
+def test_reentrant_stop_does_not_wait_for_itself(planner: GlobalPlanner) -> None:
+    planner._thread = None
+    planner._disposables = MagicMock()
+    planner._disposables.dispose.side_effect = planner.stop
+
+    planner.stop()
+
+    planner._disposables.dispose.assert_called_once_with()
+    assert planner._stop_complete.is_set()
+
+
+def test_stop_returns_for_preexisting_shutdown_flag(planner: GlobalPlanner) -> None:
+    planner._disposables = MagicMock()
+    planner._stop_planner.set()
+
+    planner.stop()
+
+    planner._disposables.dispose.assert_not_called()
+    assert planner._stop_complete.is_set()
+
+
+def test_failed_owner_stop_releases_concurrent_waiter(
+    planner: GlobalPlanner, mocker: MockerFixture
+) -> None:
+    planner._thread = None
+    planner._disposables = MagicMock()
+    planner._current_goal = MagicMock()
+    cleanup_started = Event()
+    release_cleanup = Event()
+    second_returned = Event()
+
+    def fail_cleanup() -> None:
+        cleanup_started.set()
+        if not release_cleanup.wait(timeout=TEST_TIMEOUT):
+            raise TimeoutError("test did not release failing shutdown cleanup")
+        raise RuntimeError("cleanup failed")
+
+    def stop_again() -> None:
+        planner.stop()
+        second_returned.set()
+
+    cast("MagicMock", planner._local_planner.publish_stop_command).side_effect = fail_cleanup
+
+    try:
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            first_stop = executor.submit(planner.stop)
+            assert cleanup_started.wait(timeout=TEST_TIMEOUT)
+            second_stop = executor.submit(stop_again)
+            assert not second_returned.wait(timeout=0.05)
+            release_cleanup.set()
+            with pytest.raises(RuntimeError, match="cleanup failed"):
+                first_stop.result(timeout=TEST_TIMEOUT)
+            second_stop.result(timeout=TEST_TIMEOUT)
+    finally:
+        release_cleanup.set()
+
+    assert second_returned.is_set()
+    assert planner._stop_complete.is_set()
+
+
+def test_concurrent_stop_wait_has_timeout(planner: GlobalPlanner, mocker: MockerFixture) -> None:
+    planner._stop_planner.set()
+    planner._stop_complete.clear()
+    planner._stop_owner = Thread()
+    completion_wait = mocker.patch.object(planner._stop_complete, "wait", return_value=False)
+    log_error = mocker.patch.object(planner_module.logger, "error")
+
+    planner.stop()
+
+    completion_wait.assert_called_once_with(DEFAULT_THREAD_JOIN_TIMEOUT)
+    log_error.assert_called_once_with("GlobalPlanner shutdown did not complete in time.")
+
+
+def test_concurrent_stop_can_return_before_public_shutdown_notification(
+    planner: GlobalPlanner,
+) -> None:
+    planner._current_goal = MagicMock()
+    planner._disposables = MagicMock()
+    notification_started = Event()
+    release_notification = Event()
+    planner.path = MagicMock()
+    thread = MagicMock()
+    thread.is_alive.return_value = False
+    planner._thread = thread
+
+    def block_notification(_path: Any) -> None:
+        notification_started.set()
+        if not release_notification.wait(timeout=TEST_TIMEOUT):
+            raise TimeoutError("test did not release shutdown notification")
+
+    planner.path.on_next.side_effect = block_notification
+
+    try:
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            first_stop = executor.submit(planner.stop)
+            assert notification_started.wait(timeout=TEST_TIMEOUT)
+            second_stop = executor.submit(planner.stop)
+            second_stop.result(timeout=TEST_TIMEOUT)
+            assert planner._stop_complete.is_set()
+            cast("MagicMock", planner._local_planner.publish_stop_command).assert_called_once_with()
+            thread.join.assert_called_once_with(DEFAULT_THREAD_JOIN_TIMEOUT)
+            release_notification.set()
+            first_stop.result(timeout=TEST_TIMEOUT)
+    finally:
+        release_notification.set()
+
+
+def test_start_rejects_live_monitor_thread(planner: GlobalPlanner) -> None:
+    thread = MagicMock()
+    thread.is_alive.return_value = True
+    planner._thread = thread
+
+    with pytest.raises(RuntimeError, match="monitor thread has already been started"):
+        planner.start()
+
+    cast("MagicMock", planner._local_planner.start).assert_not_called()
+
+
+def test_start_rejects_restart_after_stop(planner: GlobalPlanner) -> None:
+    planner._stop_planner.set()
+
+    with pytest.raises(RuntimeError, match="cannot be restarted"):
+        planner.start()
+
+    cast("MagicMock", planner._local_planner.start).assert_not_called()
+
+
+def test_start_subscribes_to_tagged_completion_and_starts_monitor(
+    planner: GlobalPlanner, mocker: MockerFixture
+) -> None:
+    thread_type = mocker.patch.object(planner_module, "Thread", autospec=True)
+
+    planner.start()
+    try:
+        cast("MagicMock", planner._local_planner.start).assert_called_once_with()
+        cast("MagicMock", planner._local_planner.plan_stopped.subscribe).assert_called_once_with(
+            planner._on_stopped_navigating
+        )
+        thread_type.assert_called_once_with(target=planner._thread_entrypoint, daemon=True)
+        thread_type.return_value.start.assert_called_once_with()
+    finally:
+        planner.stop()
+
+
+def test_shutdown_rejects_goal_and_completion(
+    planner: GlobalPlanner, mocker: MockerFixture
+) -> None:
+    planner._stop_planner.set()
+    plan_path = mocker.patch.object(planner, "_plan_path")
+
+    planner.handle_goal_request(MagicMock())
+    planner._on_stopped_navigating(PlanStopEvent("error", (1, 1)))
+
+    assert planner._current_goal is None
+    assert planner._replan_reason is None
+    assert not planner._replan_event.is_set()
+    plan_path.assert_not_called()
+
+
+def test_stale_completion_does_not_replace_queued_current_completion(
+    planner: GlobalPlanner,
+) -> None:
+    planner._goal_epoch = 2
+    planner._plan_epoch = 4
+    current_completion = PlanStopEvent("arrived", (2, 4))
+
+    planner._on_stopped_navigating(current_completion)
+    planner._on_stopped_navigating(PlanStopEvent("obstacle_found", (1, 3)))
+
+    assert planner._replan_reason is current_completion
+    assert planner._replan_event.is_set()
+
+
+def test_shutdown_rejects_cancel_before_admission(planner: GlobalPlanner) -> None:
+    planner._current_goal = MagicMock()
+    planner.path = MagicMock()
+    planner.goal_reached = MagicMock()
+    planner._stop_planner.set()
+
+    cancelled = planner._cancel_goal(arrived=True)
+
+    assert not cancelled
+    cast("MagicMock", planner._local_planner.deactivate_planning).assert_not_called()
+    cast("MagicMock", planner._local_planner.publish_stop_command).assert_not_called()
+    planner.path.on_next.assert_not_called()
+    planner.goal_reached.on_next.assert_not_called()
+
+
+def test_stop_without_active_goal_only_stops_motion(planner: GlobalPlanner) -> None:
+    planner._current_goal = None
+    planner._goal_reached = True
+    planner._goal_epoch = 3
+    planner._plan_epoch = 5
+    planner._thread = None
+    planner._disposables = MagicMock()
+    planner.path = MagicMock()
+    planner.goal_reached = MagicMock()
+
+    planner.stop()
+
+    cast("MagicMock", planner._local_planner.deactivate_planning).assert_called_once_with()
+    cast("MagicMock", planner._local_planner.publish_stop_command).assert_called_once_with()
+    planner.path.on_next.assert_not_called()
+    planner.goal_reached.on_next.assert_not_called()
+    assert planner._goal_reached
+    assert (planner._goal_epoch, planner._plan_epoch) == (3, 5)
+
+
+def test_stop_suppresses_notifications_from_admitted_arrival(
+    planner: GlobalPlanner, mocker: MockerFixture
+) -> None:
+    planner._current_goal = MagicMock()
+    planner._goal_epoch = 1
+    planner._thread = None
+    planner._disposables = MagicMock()
+    planner.path = MagicMock()
+    planner.goal_reached = MagicMock()
+    stop_command_started = Event()
+    release_stop_command = Event()
+    stop_started = Event()
+    calls = 0
+    goal_notifications: list[tuple[bool, bool]] = []
+
+    def pause_first_stop_command() -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            stop_command_started.set()
+            if not release_stop_command.wait(timeout=TEST_TIMEOUT):
+                raise TimeoutError("test did not release stop command publication")
+
+    def record_goal(msg: Any) -> None:
+        goal_notifications.append((planner._stop_planner.is_set(), msg.data))
+
+    cast(
+        "MagicMock", planner._local_planner.publish_stop_command
+    ).side_effect = pause_first_stop_command
+    planner.goal_reached.on_next.side_effect = record_goal
+
+    def stop_planner() -> None:
+        stop_started.set()
+        planner.stop()
+
+    try:
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            arrival_future = executor.submit(planner._cancel_goal, arrived=True)
+            assert stop_command_started.wait(timeout=TEST_TIMEOUT)
+            stop_future = executor.submit(stop_planner)
+            assert stop_started.wait(timeout=TEST_TIMEOUT)
+            assert not planner._stop_planner.wait(timeout=0.05)
+            release_stop_command.set()
+            arrival_future.result(timeout=TEST_TIMEOUT)
+            stop_future.result(timeout=TEST_TIMEOUT)
+    finally:
+        release_stop_command.set()
+
+    assert (True, True) not in goal_notifications
+    planner.path.on_next.assert_called_once()
+
+
+def test_position_tracker_failure_still_stops_motion(
+    planner: GlobalPlanner,
+) -> None:
+    planner._current_goal = MagicMock()
+    planner.path = MagicMock()
+    planner.goal_reached = MagicMock()
+    cast("MagicMock", planner._position_tracker.reset_data).side_effect = RuntimeError(
+        "reset failed"
+    )
+
+    with pytest.raises(RuntimeError, match="reset failed"):
+        planner.cancel_goal()
+
+    cast("MagicMock", planner._local_planner.deactivate_planning).assert_called_once_with()
+    cast("MagicMock", planner._local_planner.publish_stop_command).assert_called_once_with()
+
+
+def test_deactivation_failure_still_publishes_stop(
+    planner: GlobalPlanner,
+) -> None:
+    planner._current_goal = MagicMock()
+    planner.path = MagicMock()
+    planner.goal_reached = MagicMock()
+    cast("MagicMock", planner._local_planner.deactivate_planning).side_effect = RuntimeError(
+        "deactivation failed"
+    )
+
+    with pytest.raises(RuntimeError, match="deactivation failed"):
+        planner.cancel_goal()
+
+    cast("MagicMock", planner._local_planner.publish_stop_command).assert_called_once_with()
+
+
+def test_replacement_waits_for_stop_command_publication(
+    planner: GlobalPlanner, mocker: MockerFixture
+) -> None:
+    planner._current_goal = MagicMock()
+    planner.path = MagicMock()
+    planner.goal_reached = MagicMock()
+    publish_started = Event()
+    release_publish = Event()
+    replacement_started = Event()
+    plan_path_called = Event()
+    plan_path = mocker.patch.object(
+        planner,
+        "_plan_path",
+        side_effect=lambda _goal_epoch: plan_path_called.set(),
+    )
+
+    def block_stop_command() -> None:
+        publish_started.set()
+        if not release_publish.wait(timeout=TEST_TIMEOUT):
+            raise TimeoutError("test did not release stop-command publication")
+
+    def request_replacement() -> None:
+        replacement_started.set()
+        planner.handle_goal_request(MagicMock())
+
+    cast("MagicMock", planner._local_planner.publish_stop_command).side_effect = block_stop_command
+
+    try:
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            cancel_future = executor.submit(planner.cancel_goal)
+            assert publish_started.wait(timeout=TEST_TIMEOUT)
+            replacement_future = executor.submit(request_replacement)
+            assert replacement_started.wait(timeout=TEST_TIMEOUT)
+            assert not plan_path_called.wait(timeout=0.05)
+            release_publish.set()
+            cancel_future.result(timeout=TEST_TIMEOUT)
+            replacement_future.result(timeout=TEST_TIMEOUT)
+    finally:
+        release_publish.set()
+
+    plan_path.assert_called_once()
+
+
+def test_completion_uses_the_observed_goal_epochs(
+    planner: GlobalPlanner, mocker: MockerFixture
+) -> None:
+    planner._goal_epoch = 3
+    planner._plan_epoch = 5
+    cancel_goal = mocker.patch.object(planner, "_cancel_goal")
+
+    planner._handle_stop_message(PlanStopEvent("arrived", (3, 5)))
+
+    cancel_goal.assert_called_once_with(
+        expected_goal_epoch=3,
+        expected_plan_epoch=5,
+        arrived=True,
+    )
+
+
+def test_queued_completion_for_old_plan_does_not_cancel_replacement(
+    planner: GlobalPlanner,
+) -> None:
+    replacement_goal = MagicMock()
+    planner._current_goal = replacement_goal
+    planner._goal_epoch = 2
+    planner._plan_epoch = 4
+    planner.path = MagicMock()
+    planner.goal_reached = MagicMock()
+
+    planner._handle_stop_message(PlanStopEvent("arrived", (1, 3)))
+
+    assert planner._current_goal is replacement_goal
+    cast("MagicMock", planner._local_planner.deactivate_planning).assert_not_called()
+    cast("MagicMock", planner._local_planner.publish_stop_command).assert_not_called()
+    planner.path.on_next.assert_not_called()
+    planner.goal_reached.on_next.assert_not_called()
+
+
+def test_arrival_completion_does_not_cancel_replacement_from_path_observer(
+    planner: GlobalPlanner, mocker: MockerFixture
+) -> None:
+    old_goal = MagicMock()
+    replacement_goal = MagicMock()
+    planner._current_goal = old_goal
+    planner._goal_epoch = 1
+    planner.path = MagicMock()
+    planner.goal_reached = MagicMock()
+    plan_path = mocker.patch.object(planner, "_plan_path")
+
+    def replace_goal(_path: Any) -> None:
+        planner.handle_goal_request(replacement_goal)
+
+    planner.path.on_next.side_effect = replace_goal
+
+    planner._handle_stop_message(PlanStopEvent("arrived", (1, 0)))
+
+    assert planner._current_goal is replacement_goal
+    plan_path.assert_called_once_with(planner._goal_epoch)
+    planner.goal_reached.on_next.assert_not_called()
+
+
+def test_replan_without_active_goal_is_noop(planner: GlobalPlanner) -> None:
+    planner._current_odom = MagicMock()
+
+    planner._replan_path()
+
+    cast("MagicMock", planner._replan_limiter.get_attempt).assert_not_called()
+
+
+def test_deviation_replan_keeps_the_observed_plan_epochs(
+    planner: GlobalPlanner, mocker: MockerFixture
+) -> None:
+    planner._current_goal = MagicMock()
+    planner._current_goal.position.distance.return_value = 10.0
+    planner._current_odom = MagicMock()
+    planner._goal_epoch = 1
+    planner._plan_epoch = 3
+    deviation_check_started = Event()
+    release_deviation_check = Event()
+
+    def report_deviation_after_replacement() -> float:
+        deviation_check_started.set()
+        assert release_deviation_check.wait(timeout=TEST_TIMEOUT)
+        return planner._max_path_deviation + 1.0
+
+    cast(
+        "MagicMock", planner._local_planner.get_distance_to_path
+    ).side_effect = report_deviation_after_replacement
+    mocker.patch.object(planner._replan_event, "wait", return_value=False)
+    replan = mocker.patch.object(
+        planner,
+        "_replan_path",
+        side_effect=lambda *_epochs: planner._stop_planner.set(),
+    )
+
+    monitor_thread = Thread(target=planner._thread_entrypoint)
+    monitor_thread.start()
+    try:
+        assert deviation_check_started.wait(timeout=TEST_TIMEOUT)
+        with planner._activation_lock:
+            with planner._lock:
+                planner._current_goal = MagicMock()
+                planner._goal_epoch = 2
+                planner._plan_epoch = 4
+        release_deviation_check.set()
+        monitor_thread.join(timeout=TEST_TIMEOUT)
+    finally:
+        release_deviation_check.set()
+        planner._stop_planner.set()
+        monitor_thread.join(timeout=TEST_TIMEOUT)
+
+    assert not monitor_thread.is_alive()
+    replan.assert_called_once_with(1, 3)
+
+
+def test_stuck_replan_keeps_the_observed_plan_epochs(
+    planner: GlobalPlanner, mocker: MockerFixture
+) -> None:
+    planner._current_goal = MagicMock()
+    planner._current_goal.position.distance.return_value = 10.0
+    planner._current_odom = MagicMock()
+    planner._goal_epoch = 1
+    planner._plan_epoch = 3
+    planner._stuck_time_window = -1.0
+    stuck_check_started = Event()
+    release_stuck_check = Event()
+
+    cast("MagicMock", planner._local_planner.get_distance_to_path).return_value = None
+    cast("MagicMock", planner._local_planner.get_unique_state).return_value = (
+        "path_following",
+        7,
+    )
+
+    def report_stuck_after_replacement() -> bool:
+        stuck_check_started.set()
+        assert release_stuck_check.wait(timeout=TEST_TIMEOUT)
+        return True
+
+    cast(
+        "MagicMock", planner._position_tracker.is_stuck
+    ).side_effect = report_stuck_after_replacement
+    mocker.patch.object(planner._replan_event, "wait", return_value=False)
+    replan = mocker.patch.object(
+        planner,
+        "_replan_path",
+        side_effect=lambda *_epochs: planner._stop_planner.set(),
+    )
+
+    monitor_thread = Thread(target=planner._thread_entrypoint)
+    monitor_thread.start()
+    try:
+        assert stuck_check_started.wait(timeout=TEST_TIMEOUT)
+        with planner._activation_lock:
+            with planner._lock:
+                planner._current_goal = MagicMock()
+                planner._goal_epoch = 2
+                planner._plan_epoch = 4
+        release_stuck_check.set()
+        monitor_thread.join(timeout=TEST_TIMEOUT)
+    finally:
+        release_stuck_check.set()
+        planner._stop_planner.set()
+        monitor_thread.join(timeout=TEST_TIMEOUT)
+
+    assert not monitor_thread.is_alive()
+    replan.assert_called_once_with(1, 3)
+
+
+def test_computed_path_for_replaced_goal_is_discarded(
+    planner: GlobalPlanner, mocker: MockerFixture
+) -> None:
+    planner._current_odom = MagicMock()
+    planner._current_goal = MagicMock()
+    planner._goal_epoch = 1
+    planner.path = MagicMock()
+    planning_started = Event()
+    release_planning = Event()
+    resampled_path = MagicMock()
+    mocker.patch.object(planner, "_find_safe_goal", return_value=MagicMock())
+
+    def finish_after_replacement(*_args: Any) -> MagicMock:
+        planning_started.set()
+        assert release_planning.wait(timeout=TEST_TIMEOUT)
+        return MagicMock()
+
+    mocker.patch.object(planner, "_find_wide_path", side_effect=finish_after_replacement)
+    mocker.patch.object(planner_module, "smooth_resample_path", return_value=resampled_path)
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        plan_future = executor.submit(planner._plan_path, 1)
+        assert planning_started.wait(timeout=TEST_TIMEOUT)
+        planner.path.reset_mock()
+        cast("MagicMock", planner._local_planner.start_tagged_planning).reset_mock()
+        replacement_plan = mocker.patch.object(planner, "_plan_path")
+        planner.handle_goal_request(MagicMock())
+        release_planning.set()
+        plan_future.result(timeout=TEST_TIMEOUT)
+
+    replacement_plan.assert_called_once()
+    planner.path.on_next.assert_not_called()
+    cast("MagicMock", planner._local_planner.start_tagged_planning).assert_not_called()
+
+
+def test_stop_during_path_publication_prevents_local_start(
+    planner: GlobalPlanner, mocker: MockerFixture
+) -> None:
+    planner._current_odom = MagicMock()
+    planner._current_goal = MagicMock()
+    planner._goal_epoch = 1
+    planner._thread = None
+    planner._disposables = MagicMock()
+    planner.path = MagicMock()
+    publication_started = Event()
+    release_publication = Event()
+    publication_released = []
+    resampled_path = MagicMock()
+    mocker.patch.object(planner, "_find_safe_goal", return_value=MagicMock())
+    mocker.patch.object(planner, "_find_wide_path", return_value=MagicMock())
+    mocker.patch.object(planner_module, "smooth_resample_path", return_value=resampled_path)
+
+    def pause_publication(path: Any) -> None:
+        if path is resampled_path:
+            publication_started.set()
+            publication_released.append(release_publication.wait(timeout=TEST_TIMEOUT))
+
+    planner.path.on_next.side_effect = pause_publication
+
+    try:
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            plan_future = executor.submit(planner._plan_path, 1)
+            assert publication_started.wait(timeout=TEST_TIMEOUT)
+            start_planning = cast("MagicMock", planner._local_planner.start_tagged_planning)
+            start_planning.reset_mock()
+            stop_future = executor.submit(planner.stop)
+            assert planner._stop_planner.wait(timeout=TEST_TIMEOUT)
+            stop_future.result(timeout=TEST_TIMEOUT)
+            release_publication.set()
+            plan_future.result(timeout=TEST_TIMEOUT)
+    finally:
+        release_publication.set()
+
+    start_planning.assert_not_called()
+    assert publication_released == [True]
+
+
+def test_path_observer_can_wait_for_stop_without_deadlock(
+    planner: GlobalPlanner, mocker: MockerFixture
+) -> None:
+    planner._current_odom = MagicMock()
+    planner._current_goal = MagicMock()
+    planner._goal_epoch = 1
+    planner._thread = None
+    planner._disposables = MagicMock()
+    planner.path = MagicMock()
+    resampled_path = MagicMock()
+    observer_completed = Event()
+    stop_threads: list[Thread] = []
+    mocker.patch.object(planner, "_find_safe_goal", return_value=MagicMock())
+    mocker.patch.object(planner, "_find_wide_path", return_value=MagicMock())
+    mocker.patch.object(planner_module, "smooth_resample_path", return_value=resampled_path)
+
+    def stop_from_another_thread(path: Any) -> None:
+        if path is not resampled_path:
+            return
+
+        stop_thread = Thread(target=planner.stop)
+        stop_threads.append(stop_thread)
+        stop_thread.start()
+        stop_thread.join(timeout=TEST_TIMEOUT)
+        observer_completed.set()
+
+    planner.path.on_next.side_effect = stop_from_another_thread
+
+    planner._plan_path(1)
+
+    assert observer_completed.is_set()
+    assert len(stop_threads) == 1
+    assert not stop_threads[0].is_alive()
+    assert planner._stop_planner.is_set()
+    cast("MagicMock", planner._local_planner.start_tagged_planning).assert_not_called()
+
+
+def test_stop_during_path_publication_leaves_an_empty_path(
+    planner: GlobalPlanner, mocker: MockerFixture
+) -> None:
+    planner._current_odom = MagicMock()
+    planner._current_goal = MagicMock()
+    planner._goal_epoch = 1
+    planner._thread = None
+    resampled_path = MagicMock()
+    observed_paths: list[Any] = []
+    planner.path = Subject()
+    mocker.patch.object(planner, "_find_safe_goal", return_value=MagicMock())
+    mocker.patch.object(planner, "_find_wide_path", return_value=MagicMock())
+    mocker.patch.object(planner_module, "smooth_resample_path", return_value=resampled_path)
+
+    def stop_on_resampled_path(path: Any) -> None:
+        if path is resampled_path:
+            planner.stop()
+
+    stop_subscription = planner.path.subscribe(stop_on_resampled_path)
+    record_subscription = planner.path.subscribe(observed_paths.append)
+
+    try:
+        planner._plan_path(1)
+    finally:
+        stop_subscription.dispose()
+        record_subscription.dispose()
+
+    assert observed_paths[-2] is resampled_path
+    assert observed_paths[-1].poses == []
+    cast("MagicMock", planner._local_planner.start_tagged_planning).assert_not_called()
+
+
+def test_cancel_observer_can_wait_for_stop_without_deadlock(
+    planner: GlobalPlanner,
+) -> None:
+    planner._current_odom = MagicMock()
+    planner._current_goal = MagicMock()
+    planner._goal_epoch = 1
+    planner._thread = None
+    planner._disposables = MagicMock()
+    planner.path = MagicMock()
+    observer_completed = Event()
+
+    def stop_from_another_thread(_path: Any) -> None:
+        stop_thread = Thread(target=planner.stop)
+        stop_thread.start()
+        stop_thread.join(timeout=TEST_TIMEOUT)
+        assert not stop_thread.is_alive()
+        observer_completed.set()
+
+    planner.path.on_next.side_effect = stop_from_another_thread
+
+    planner._plan_path(1)
+
+    assert observer_completed.is_set()
+    assert planner._stop_planner.is_set()
+    cast("MagicMock", planner._local_planner.start_tagged_planning).assert_not_called()
+
+
+def test_stop_cannot_linearize_during_local_activation(
+    planner: GlobalPlanner, mocker: MockerFixture
+) -> None:
+    planner._current_odom = MagicMock()
+    planner._current_goal = MagicMock()
+    planner._goal_epoch = 1
+    planner._thread = None
+    planner._disposables = MagicMock()
+    planner.path = MagicMock()
+    resampled_path = MagicMock()
+    activation_started = Event()
+    release_activation = Event()
+    stop_started = Event()
+    start_planning_saw_shutdown: list[bool] = []
+    mocker.patch.object(planner, "_find_safe_goal", return_value=MagicMock())
+    mocker.patch.object(planner, "_find_wide_path", return_value=MagicMock())
+    mocker.patch.object(planner_module, "smooth_resample_path", return_value=resampled_path)
+
+    def pause_activation(_path: Any, _plan_epochs: tuple[int, int]) -> None:
+        start_planning_saw_shutdown.append(planner._stop_planner.is_set())
+        activation_started.set()
+        if not release_activation.wait(timeout=TEST_TIMEOUT):
+            raise TimeoutError("test did not release local activation")
+
+    def stop_planner() -> None:
+        stop_started.set()
+        planner.stop()
+
+    cast("MagicMock", planner._local_planner.start_tagged_planning).side_effect = pause_activation
+
+    try:
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            plan_future = executor.submit(planner._plan_path, 1)
+            assert activation_started.wait(timeout=TEST_TIMEOUT)
+            stop_future = executor.submit(stop_planner)
+            assert stop_started.wait(timeout=TEST_TIMEOUT)
+            assert not planner._stop_planner.is_set()
+            release_activation.set()
+            plan_future.result(timeout=TEST_TIMEOUT)
+            stop_future.result(timeout=TEST_TIMEOUT)
+    finally:
+        release_activation.set()
+
+    assert start_planning_saw_shutdown == [False]
+
+
+def test_dequeued_completion_is_ignored_after_shutdown_starts(
+    planner: GlobalPlanner, mocker: MockerFixture
+) -> None:
+    planner._disposables = MagicMock()
+    planner.path = MagicMock()
+    planner._replan_reason = PlanStopEvent("arrived", (1, 1))
+    planner._replan_event.set()
+    handler_entered = Event()
+    release_handler = Event()
+    shutdown_cancelled = Event()
+    original_handler = planner._handle_stop_message
+
+    def pause_handler(stop_message: Any) -> None:
+        handler_entered.set()
+        if not release_handler.wait(timeout=TEST_TIMEOUT):
+            raise TimeoutError("test did not release dequeued completion")
+        original_handler(stop_message)
+
+    cancel_goal = mocker.patch.object(
+        planner,
+        "_cancel_goal",
+        side_effect=lambda **_kwargs: shutdown_cancelled.set(),
+    )
+    mocker.patch.object(planner, "_handle_stop_message", side_effect=pause_handler)
+    monitor_thread = Thread(target=planner._thread_entrypoint, daemon=True)
+    planner._thread = monitor_thread
+    monitor_thread.start()
+
+    try:
+        assert handler_entered.wait(timeout=TEST_TIMEOUT)
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            stop_future = executor.submit(planner.stop)
+            assert shutdown_cancelled.wait(timeout=TEST_TIMEOUT)
+            release_handler.set()
+            stop_future.result(timeout=TEST_TIMEOUT)
+    finally:
+        release_handler.set()
+        monitor_thread.join(timeout=TEST_TIMEOUT)
+
+    assert not monitor_thread.is_alive()
+    assert cancel_goal.mock_calls == [
+        call(
+            allow_during_shutdown=True,
+            before_notifications=ANY,
+        )
+    ]
+    planner.path.on_next.assert_not_called()
+
+
+def test_path_observer_cancel_prevents_local_start(
+    planner: GlobalPlanner, mocker: MockerFixture
+) -> None:
+    planner._current_odom = MagicMock()
+    planner._current_goal = MagicMock()
+    planner._goal_epoch = 1
+    planner.path = MagicMock()
+    resampled_path = MagicMock()
+    mocker.patch.object(planner, "_find_safe_goal", return_value=MagicMock())
+    mocker.patch.object(planner, "_find_wide_path", return_value=MagicMock())
+    mocker.patch.object(planner_module, "smooth_resample_path", return_value=resampled_path)
+
+    def cancel_published_path(path: Any) -> None:
+        if path is resampled_path:
+            planner.cancel_goal()
+
+    planner.path.on_next.side_effect = cancel_published_path
+
+    planner._plan_path(1)
+
+    cast("MagicMock", planner._local_planner.start_tagged_planning).assert_not_called()
+
+
+def test_monitor_arrival_does_not_cancel_replacement_goal(
+    planner: GlobalPlanner, mocker: MockerFixture
+) -> None:
+    old_goal = MagicMock()
+    replacement_goal = MagicMock()
+    planner._current_goal = old_goal
+    planner._current_odom = MagicMock()
+    planner._goal_epoch = 1
+    planner.goal_reached = MagicMock()
+    arrival_check_started = Event()
+    release_arrival_check = Event()
+    mocker.patch.object(planner, "_plan_path")
+    mocker.patch.object(planner_module, "angle_diff", return_value=0.0)
+
+    def distance_after_replacement(_position: Any) -> float:
+        arrival_check_started.set()
+        assert release_arrival_check.wait(timeout=TEST_TIMEOUT)
+        return 0.0
+
+    wait_count = 0
+
+    def run_one_monitor_iteration(*, timeout: float) -> bool:
+        nonlocal wait_count
+        wait_count += 1
+        if wait_count > 1:
+            planner._stop_planner.set()
+        return False
+
+    old_goal.position.distance.side_effect = distance_after_replacement
+    mocker.patch.object(planner._replan_event, "wait", side_effect=run_one_monitor_iteration)
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        monitor_future = executor.submit(planner._thread_entrypoint)
+        assert arrival_check_started.wait(timeout=TEST_TIMEOUT)
+        planner.handle_goal_request(replacement_goal)
+        release_arrival_check.set()
+        monitor_future.result(timeout=TEST_TIMEOUT)
+
+    assert planner._current_goal is replacement_goal
+    planner.goal_reached.on_next.assert_not_called()
 
 
 def test_find_wide_path_with_start_inside_inflation() -> None:

--- a/dimos/navigation/replanning_a_star/test_local_planner.py
+++ b/dimos/navigation/replanning_a_star/test_local_planner.py
@@ -1,0 +1,334 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from threading import Event, Thread
+from unittest.mock import MagicMock
+
+import pytest
+from pytest_mock import MockerFixture
+
+from dimos.core.global_config import GlobalConfig
+from dimos.msgs.geometry_msgs.Twist import Twist
+from dimos.navigation.replanning_a_star import local_planner as planner_module
+from dimos.navigation.replanning_a_star.local_planner import LocalPlanner, PlanStopEvent
+
+
+@pytest.fixture()
+def planner(mocker: MockerFixture) -> LocalPlanner:
+    mocker.patch.object(planner_module, "PController", autospec=True)
+    return LocalPlanner(GlobalConfig(), MagicMock(), 0.2)
+
+
+def test_tagged_completion_preserves_public_stop_message(planner: LocalPlanner) -> None:
+    public_messages: list[str] = []
+    plan_events: list[PlanStopEvent] = []
+    public_subscription = planner.stopped_navigating.subscribe(public_messages.append)
+    plan_subscription = planner.plan_stopped.subscribe(plan_events.append)
+
+    try:
+        planner._publish_stop_event("arrived", (3, 5))
+    finally:
+        public_subscription.dispose()
+        plan_subscription.dispose()
+
+    assert public_messages == ["arrived"]
+    assert plan_events == [PlanStopEvent("arrived", (3, 5))]
+
+
+def test_tagged_completion_precedes_blocking_public_observer(planner: LocalPlanner) -> None:
+    public_observer_started = Event()
+    release_public_observer = Event()
+    plan_events: list[PlanStopEvent] = []
+
+    def block_public_observer(_reason: str) -> None:
+        public_observer_started.set()
+        assert release_public_observer.wait(timeout=5.0)
+
+    public_subscription = planner.stopped_navigating.subscribe(block_public_observer)
+    plan_subscription = planner.plan_stopped.subscribe(plan_events.append)
+    publish_thread = Thread(target=planner._publish_stop_event, args=("arrived", (3, 5)))
+
+    try:
+        publish_thread.start()
+        assert public_observer_started.wait(timeout=5.0)
+        assert plan_events == [PlanStopEvent("arrived", (3, 5))]
+    finally:
+        release_public_observer.set()
+        publish_thread.join(timeout=5.0)
+        public_subscription.dispose()
+        plan_subscription.dispose()
+
+    assert not publish_thread.is_alive()
+
+
+def test_public_observer_failure_does_not_replace_tagged_completion(
+    planner: LocalPlanner,
+) -> None:
+    plan_events: list[PlanStopEvent] = []
+
+    def fail_public_observer(_reason: str) -> None:
+        raise RuntimeError("observer failed")
+
+    public_subscription = planner.stopped_navigating.subscribe(fail_public_observer)
+    plan_subscription = planner.plan_stopped.subscribe(plan_events.append)
+
+    try:
+        planner._publish_stop_event("arrived", (3, 5))
+    finally:
+        public_subscription.dispose()
+        plan_subscription.dispose()
+
+    assert plan_events == [PlanStopEvent("arrived", (3, 5))]
+
+
+def test_tagged_observer_failure_does_not_suppress_public_completion(
+    planner: LocalPlanner,
+) -> None:
+    public_messages: list[str] = []
+
+    def fail_tagged_observer(_event: PlanStopEvent) -> None:
+        raise RuntimeError("observer failed")
+
+    plan_subscription = planner.plan_stopped.subscribe(fail_tagged_observer)
+    public_subscription = planner.stopped_navigating.subscribe(public_messages.append)
+
+    try:
+        planner._publish_stop_event("arrived", (3, 5))
+    finally:
+        plan_subscription.dispose()
+        public_subscription.dispose()
+
+    assert public_messages == ["arrived"]
+
+
+def test_worker_captures_its_plan_epochs(planner: LocalPlanner, mocker: MockerFixture) -> None:
+    mocker.patch.object(planner_module, "PathClearance", autospec=True)
+    mocker.patch.object(planner_module, "PathDistancer", autospec=True)
+    thread_type = mocker.patch.object(planner_module, "Thread", autospec=True)
+
+    planner.start_tagged_planning(MagicMock(), (2, 7))
+
+    stop_event = planner._stop_planning_event
+    thread_type.assert_called_once_with(
+        target=planner._thread_entrypoint,
+        args=(stop_event, (2, 7)),
+        daemon=True,
+    )
+    thread_type.return_value.start.assert_called_once_with()
+
+
+def test_tagged_start_deactivates_previous_worker_without_stop_command(
+    planner: LocalPlanner, mocker: MockerFixture
+) -> None:
+    mocker.patch.object(planner_module, "PathClearance", autospec=True)
+    mocker.patch.object(planner_module, "PathDistancer", autospec=True)
+    thread_type = mocker.patch.object(planner_module, "Thread", autospec=True)
+    old_stop_event = Event()
+    stop_commands: list[Twist] = []
+    subscription = planner.cmd_vel.subscribe(stop_commands.append)
+    planner._stop_planning_event = old_stop_event
+    planner._state = "path_following"
+    planner._thread = MagicMock()
+
+    try:
+        planner.start_tagged_planning(MagicMock(), (2, 7))
+    finally:
+        subscription.dispose()
+
+    assert old_stop_event.is_set()
+    assert planner.get_unique_state()[0] == "idle"
+    assert stop_commands == []
+    thread_type.return_value.start.assert_called_once_with()
+
+
+def test_stop_planning_deactivates_before_publishing_zero(planner: LocalPlanner) -> None:
+    stop_event = planner._stop_planning_event
+    shutdown_visible: list[bool] = []
+    subscription = planner.cmd_vel.subscribe(
+        lambda _command: shutdown_visible.append(stop_event.is_set())
+    )
+
+    try:
+        planner.stop_planning()
+    finally:
+        subscription.dispose()
+
+    assert shutdown_visible == [True]
+
+
+def test_stop_command_observer_failure_does_not_escape(
+    planner: LocalPlanner, mocker: MockerFixture
+) -> None:
+    def fail_command_observer(_command: Twist) -> None:
+        raise RuntimeError("observer failed")
+
+    log_exception = mocker.patch.object(planner_module.logger, "exception")
+    subscription = planner.cmd_vel.subscribe(fail_command_observer)
+
+    try:
+        planner.publish_stop_command()
+    finally:
+        subscription.dispose()
+
+    log_exception.assert_called_once()
+
+
+def test_worker_stop_command_observer_failure_does_not_escape(
+    planner: LocalPlanner, mocker: MockerFixture
+) -> None:
+    stop_event = planner._stop_planning_event
+
+    def fail_command_observer(_command: Twist) -> None:
+        raise RuntimeError("observer failed")
+
+    mocker.patch.object(planner, "_loop")
+    log_exception = mocker.patch.object(planner_module.logger, "exception")
+    subscription = planner.cmd_vel.subscribe(fail_command_observer)
+
+    try:
+        planner._thread_entrypoint(stop_event, (2, 7))
+    finally:
+        subscription.dispose()
+
+    log_exception.assert_called_once()
+
+
+def test_stale_worker_does_not_change_replacement_state_before_loop(
+    planner: LocalPlanner,
+) -> None:
+    old_stop_event = Event()
+    old_stop_event.set()
+    planner._stop_planning_event = Event()
+    planner._state = "final_rotation"
+    planner._path = MagicMock()
+    planner._path_clearance = MagicMock()
+
+    planner._loop(old_stop_event, (1, 1))
+
+    assert planner._state == "final_rotation"
+
+
+def test_stale_worker_does_not_run_replacement_state_mid_cycle(
+    planner: LocalPlanner, mocker: MockerFixture
+) -> None:
+    old_stop_event = Event()
+    planner._stop_planning_event = old_stop_event
+    planner._path = MagicMock()
+    path_clearance = MagicMock()
+    planner._path_clearance = path_clearance
+    obstacle_check_started = Event()
+    release_obstacle_check = Event()
+
+    def block_obstacle_check() -> bool:
+        obstacle_check_started.set()
+        if not release_obstacle_check.wait(timeout=5.0):
+            raise TimeoutError("test did not release obstacle check")
+        return False
+
+    path_clearance.is_obstacle_ahead.side_effect = block_obstacle_check
+    compute_final_rotation = mocker.patch.object(
+        planner,
+        "_compute_final_rotation",
+        return_value=Twist(),
+    )
+    worker = Thread(target=planner._loop, args=(old_stop_event, (1, 1)))
+
+    try:
+        worker.start()
+        assert obstacle_check_started.wait(timeout=5.0)
+        with planner._lock:
+            old_stop_event.set()
+            planner._stop_planning_event = Event()
+            planner._state = "final_rotation"
+        release_obstacle_check.set()
+        worker.join(timeout=5.0)
+    finally:
+        release_obstacle_check.set()
+        worker.join(timeout=5.0)
+
+    assert not worker.is_alive()
+    assert planner._state == "final_rotation"
+    compute_final_rotation.assert_not_called()
+
+
+def test_stale_worker_does_not_change_replacement_state_mid_compute(
+    planner: LocalPlanner, mocker: MockerFixture
+) -> None:
+    old_stop_event = Event()
+    replacement_stop_event = Event()
+    pose = MagicMock()
+    pose.orientation.euler = (0.0, 0.0, 0.0)
+    current_odom = MagicMock()
+    current_odom.orientation.euler = (0.0, 0.0, 0.0)
+    path = MagicMock()
+    path.poses = [pose]
+    with planner._lock:
+        planner._stop_planning_event = old_stop_event
+        planner._path = path
+        planner._current_odom = current_odom
+        planner._state = "initial_rotation"
+
+    computation_started = Event()
+    release_computation = Event()
+    results: list[Twist | None] = []
+
+    def block_angle_diff(_target: float, _current: float) -> float:
+        computation_started.set()
+        if not release_computation.wait(timeout=5.0):
+            raise TimeoutError("test did not release angle calculation")
+        return 0.0
+
+    mocker.patch.object(planner_module, "angle_diff", side_effect=block_angle_diff)
+    path_following = mocker.patch.object(planner, "_compute_path_following")
+    worker = Thread(
+        target=lambda: results.append(planner._compute_initial_rotation(old_stop_event))
+    )
+
+    try:
+        worker.start()
+        assert computation_started.wait(timeout=5.0)
+        with planner._lock:
+            old_stop_event.set()
+            planner._stop_planning_event = replacement_stop_event
+            planner._state = "final_rotation"
+        release_computation.set()
+        worker.join(timeout=5.0)
+    finally:
+        release_computation.set()
+        worker.join(timeout=5.0)
+
+    assert not worker.is_alive()
+    assert planner._state == "final_rotation"
+    assert results == [None]
+    path_following.assert_not_called()
+
+
+def test_stale_worker_does_not_reset_replacement_state(
+    planner: LocalPlanner, mocker: MockerFixture
+) -> None:
+    old_stop_event = Event()
+    old_stop_event.set()
+    planner._stop_planning_event = Event()
+    reset_state = mocker.patch.object(planner, "_reset_state")
+    commands: list[Twist] = []
+    subscription = planner.cmd_vel.subscribe(commands.append)
+    mocker.patch.object(planner, "_loop")
+
+    try:
+        planner._thread_entrypoint(old_stop_event, (1, 1))
+    finally:
+        subscription.dispose()
+
+    reset_state.assert_not_called()
+    assert commands == []

--- a/dimos/navigation/replanning_a_star/test_module.py
+++ b/dimos/navigation/replanning_a_star/test_module.py
@@ -1,0 +1,45 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from pytest_mock import MockerFixture
+
+from dimos.navigation.replanning_a_star import module as planner_module
+from dimos.navigation.replanning_a_star.module import ReplanningAStarPlanner
+
+
+def test_stop_delegates_goal_cleanup_to_global_planner(mocker: MockerFixture) -> None:
+    planner_type = mocker.patch.object(planner_module, "GlobalPlanner", autospec=True)
+    module = ReplanningAStarPlanner()
+
+    try:
+        module.stop()
+    finally:
+        module._close_module()
+
+    planner_type.return_value.stop.assert_called_once_with()
+    planner_type.return_value.cancel_goal.assert_not_called()
+
+
+def test_stop_closes_module_when_global_planner_stop_fails(mocker: MockerFixture) -> None:
+    planner_type = mocker.patch.object(planner_module, "GlobalPlanner", autospec=True)
+    planner_type.return_value.stop.side_effect = RuntimeError("planner stop failed")
+    module = ReplanningAStarPlanner()
+
+    try:
+        with pytest.raises(RuntimeError, match="planner stop failed"):
+            module.stop()
+        assert module._module_closed
+    finally:
+        module._close_module()


### PR DESCRIPTION
## Contribution path

- [ ] Small, safe change that does not need a tracking issue
- [x] Linked issue: Closes #3039

## Problem

`GlobalPlanner.stop()` marked shutdown after canceling the goal and stopping `LocalPlanner`. A final `stopped_navigating` callback could queue another replan during teardown. Goals and path calculations already in flight could also activate stale work after cancellation.

## Solution

Mark shutdown before teardown and detach completion handling before stopping `LocalPlanner`. Serialize lifecycle changes and path activation. Goal and plan epochs discard stale calculations, publications, and arrivals.

Base module cleanup now runs even if planner shutdown fails. If the monitor misses its join timeout, keep its handle instead of treating it as stopped. The planner cannot restart after `stop()`.

Normal goal replacement still uses untagged `LocalPlanner` completion messages. Correlating them to a plan requires a separate protocol change.

## How to Test

```bash
uv run pytest -q dimos/navigation -p no:dash
```

- 94 passed, 2 expected skips, 16 deselected
- 14 focused race tests passed in five consecutive runs
- Ruff, mypy, pre-commit, and `git diff --check` passed

Hardware: not tested. The race is covered by deterministic concurrency tests.

## AI assistance

Codex, Qodo and CodeRabbit for review.

## Checklist

- [x] This PR is scoped to one issue or clearly stated problem.
- [x] I ran the relevant checks for the files I changed.
- [x] I have reviewed and understood every line in this PR.
- [x] I disclosed AI assistance above.
- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
