### PR TITLE
feat(web): PR 2 - Relay

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -1,13 +1,14 @@
 # DimOS web
 
 Deno workspace for the robot web stack. `shared/` holds the wire protocol and its golden vectors;
-the WebTransport relay (`relay/`, with `deno task dev`), its Python mirror + client
-(`dimos/web/relay_bridge/`), and the Cockpit browser app arrive in follow-up PRs.
+`relay/` is the WebTransport relay. The Python mirror + client (`dimos/web/relay_bridge/`) and the
+Cockpit browser app arrive in follow-up PRs.
 
 Everything runs on Deno 2.6.10, pinned in `dimos/utils/deno.py` (CI reads the pin from there).
 
 ```bash
-deno task test           # unit tests
+deno task dev            # relay on http://127.0.0.1:7780 (debug page at /debug.html)
+deno task test           # unit + loopback e2e tests
 deno task check          # type-check; deno fmt + deno lint for style
 ```
 

--- a/web/deno.json
+++ b/web/deno.json
@@ -1,5 +1,6 @@
 {
   "workspace": [
+    "./relay",
     "./shared"
   ],
   "unstable": [
@@ -11,6 +12,7 @@
     "@std/cli": "jsr:@std/cli@^1"
   },
   "tasks": {
+    "dev": "deno run --allow-net --allow-read relay/main.ts",
     "test": "deno test --allow-net --allow-read",
     "check": "deno check ."
   },

--- a/web/deno.lock
+++ b/web/deno.lock
@@ -3,7 +3,9 @@
   "specifiers": {
     "jsr:@std/assert@1": "1.0.19",
     "jsr:@std/cli@1": "1.0.28",
-    "jsr:@std/internal@^1.0.12": "1.0.12"
+    "jsr:@std/internal@^1.0.12": "1.0.12",
+    "npm:@peculiar/x509@2": "2.0.0",
+    "npm:reflect-metadata@0.2": "0.2.2"
   },
   "jsr": {
     "@std/assert@1.0.19": {
@@ -22,10 +24,169 @@
       "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
     }
   },
+  "npm": {
+    "@peculiar/asn1-cms@2.8.0": {
+      "integrity": "sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA==",
+      "dependencies": [
+        "@peculiar/asn1-schema",
+        "@peculiar/asn1-x509",
+        "@peculiar/asn1-x509-attr",
+        "asn1js",
+        "tslib@2.8.1"
+      ]
+    },
+    "@peculiar/asn1-csr@2.8.0": {
+      "integrity": "sha512-akbF8+uvleHs8sejNPQxwmVFuInAg6FMNHOwMILXfP518YfFJwdR3jr6oNUPOaEJfuEhn/vkNOCIT6ASUd4mbg==",
+      "dependencies": [
+        "@peculiar/asn1-schema",
+        "@peculiar/asn1-x509",
+        "asn1js",
+        "tslib@2.8.1"
+      ]
+    },
+    "@peculiar/asn1-ecc@2.8.0": {
+      "integrity": "sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ==",
+      "dependencies": [
+        "@peculiar/asn1-schema",
+        "@peculiar/asn1-x509",
+        "asn1js",
+        "tslib@2.8.1"
+      ]
+    },
+    "@peculiar/asn1-pfx@2.8.0": {
+      "integrity": "sha512-5yof1ytoB++RQtaFbqSUJ8pxDJtZT6vbVqZ8XoJ61ph7UjNVvfFwAilnCodqkNsAodpy13gDhoxZXw00pghnyg==",
+      "dependencies": [
+        "@peculiar/asn1-cms",
+        "@peculiar/asn1-pkcs8",
+        "@peculiar/asn1-rsa",
+        "@peculiar/asn1-schema",
+        "asn1js",
+        "tslib@2.8.1"
+      ]
+    },
+    "@peculiar/asn1-pkcs8@2.8.0": {
+      "integrity": "sha512-qAKXtLpBEw9LqhKpjw3ajZSXlBur+ipW+y2ivVBQAG6F6qRx94yO+1ZR4mvw+YaCfKSaOzLeYEzsPaBp4SJELA==",
+      "dependencies": [
+        "@peculiar/asn1-schema",
+        "@peculiar/asn1-x509",
+        "asn1js",
+        "tslib@2.8.1"
+      ]
+    },
+    "@peculiar/asn1-pkcs9@2.8.0": {
+      "integrity": "sha512-b5nDWCnkV60+cQ141D6sVVwK9nz64R5n3zSVnklGd+ECdkW2Ol3U1a6yYFlalpSOaD557yuJB64A+q42jG7lUQ==",
+      "dependencies": [
+        "@peculiar/asn1-cms",
+        "@peculiar/asn1-pfx",
+        "@peculiar/asn1-pkcs8",
+        "@peculiar/asn1-schema",
+        "@peculiar/asn1-x509",
+        "@peculiar/asn1-x509-attr",
+        "asn1js",
+        "tslib@2.8.1"
+      ]
+    },
+    "@peculiar/asn1-rsa@2.8.0": {
+      "integrity": "sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg==",
+      "dependencies": [
+        "@peculiar/asn1-schema",
+        "@peculiar/asn1-x509",
+        "asn1js",
+        "tslib@2.8.1"
+      ]
+    },
+    "@peculiar/asn1-schema@2.8.0": {
+      "integrity": "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==",
+      "dependencies": [
+        "@peculiar/utils",
+        "asn1js",
+        "tslib@2.8.1"
+      ]
+    },
+    "@peculiar/asn1-x509-attr@2.8.0": {
+      "integrity": "sha512-tHjkfS/qhMnmrlB2J9NhflQlQ7In3khO3CfmVrriOlpTeErY9ZIKOso1hQ5JQiyrJ7ShvqVPk7E5fQmbclkSKA==",
+      "dependencies": [
+        "@peculiar/asn1-schema",
+        "@peculiar/asn1-x509",
+        "asn1js",
+        "tslib@2.8.1"
+      ]
+    },
+    "@peculiar/asn1-x509@2.8.0": {
+      "integrity": "sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg==",
+      "dependencies": [
+        "@peculiar/asn1-schema",
+        "@peculiar/utils",
+        "asn1js",
+        "tslib@2.8.1"
+      ]
+    },
+    "@peculiar/utils@2.0.3": {
+      "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+      "dependencies": [
+        "tslib@2.8.1"
+      ]
+    },
+    "@peculiar/x509@2.0.0": {
+      "integrity": "sha512-r10lkuy6BNfRmyYdRAfgu6dq0HOmyIV2OLhXWE3gDEPBdX1b8miztJVyX/UxWhLwemNyDP3CLZHpDxDwSY0xaA==",
+      "dependencies": [
+        "@peculiar/asn1-cms",
+        "@peculiar/asn1-csr",
+        "@peculiar/asn1-ecc",
+        "@peculiar/asn1-pkcs9",
+        "@peculiar/asn1-rsa",
+        "@peculiar/asn1-schema",
+        "@peculiar/asn1-x509",
+        "pvtsutils",
+        "tslib@2.8.1",
+        "tsyringe"
+      ]
+    },
+    "asn1js@3.0.10": {
+      "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+      "dependencies": [
+        "pvtsutils",
+        "pvutils",
+        "tslib@2.8.1"
+      ]
+    },
+    "pvtsutils@1.3.6": {
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "dependencies": [
+        "tslib@2.8.1"
+      ]
+    },
+    "pvutils@1.1.5": {
+      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA=="
+    },
+    "reflect-metadata@0.2.2": {
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="
+    },
+    "tslib@1.14.1": {
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "tslib@2.8.1": {
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "tsyringe@4.10.0": {
+      "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+      "dependencies": [
+        "tslib@1.14.1"
+      ]
+    }
+  },
   "workspace": {
     "dependencies": [
       "jsr:@std/assert@1",
       "jsr:@std/cli@1"
-    ]
+    ],
+    "members": {
+      "relay": {
+        "dependencies": [
+          "npm:@peculiar/x509@2",
+          "npm:reflect-metadata@0.2"
+        ]
+      }
+    }
   }
 }

--- a/web/relay/cert.ts
+++ b/web/relay/cert.ts
@@ -1,0 +1,41 @@
+// Ephemeral self-signed certificate for WebTransport serverCertificateHashes.
+// Chrome's constraints for hash-pinned certs: ECDSA P-256 and validity under
+// 14 days. The browser pins the SHA-256 of the DER cert (via /api/info) and
+// skips normal chain/hostname verification entirely.
+import "reflect-metadata"; // @peculiar/x509 2.x needs the polyfill (tsyringe)
+import * as x509 from "@peculiar/x509";
+
+export interface EphemeralCert {
+  certPem: string;
+  keyPem: string;
+  /** base64 SHA-256 of the DER cert, served via /api/info. */
+  certHashB64: string;
+}
+
+export async function makeEphemeralCert(): Promise<EphemeralCert> {
+  const alg = { name: "ECDSA", namedCurve: "P-256", hash: "SHA-256" };
+  const keys = await crypto.subtle.generateKey(alg, true, ["sign", "verify"]);
+  const cert = await x509.X509CertificateGenerator.createSelfSigned({
+    serialNumber: Date.now().toString(16),
+    name: "CN=localhost",
+    notBefore: new Date(Date.now() - 3600_000), // 1 h clock-skew slack
+    notAfter: new Date(Date.now() + 9 * 86400_000), // 9 days, under Chrome's 14-day cap
+    signingAlgorithm: alg,
+    keys,
+    extensions: [
+      new x509.SubjectAlternativeNameExtension([
+        { type: "dns", value: "localhost" },
+        { type: "ip", value: "127.0.0.1" },
+      ]),
+      new x509.BasicConstraintsExtension(false, undefined, true),
+    ],
+  });
+  const der = new Uint8Array(cert.rawData);
+  const hash = new Uint8Array(await crypto.subtle.digest("SHA-256", der));
+  const pkcs8 = await crypto.subtle.exportKey("pkcs8", keys.privateKey);
+  return {
+    certPem: cert.toString("pem"),
+    keyPem: x509.PemConverter.encode(pkcs8, "PRIVATE KEY"),
+    certHashB64: btoa(String.fromCharCode(...hash)),
+  };
+}

--- a/web/relay/cert_test.ts
+++ b/web/relay/cert_test.ts
@@ -1,0 +1,31 @@
+import { assert, assertEquals } from "@std/assert";
+import "reflect-metadata"; // must precede @peculiar/x509 (tsyringe polyfill)
+import * as x509 from "@peculiar/x509";
+import { makeEphemeralCert } from "./cert.ts";
+
+Deno.test("ephemeral cert: P-256, short validity, SANs, matching hash", async () => {
+  const cert = await makeEphemeralCert();
+  const parsed = new x509.X509Certificate(cert.certPem);
+
+  const alg = parsed.publicKey.algorithm as { name: string; namedCurve?: string };
+  assertEquals(alg.name, "ECDSA");
+  assertEquals(alg.namedCurve, "P-256");
+
+  // Chrome accepts serverCertificateHashes only for certs valid < 14 days.
+  const validityDays = (parsed.notAfter.getTime() - parsed.notBefore.getTime()) / 86400_000;
+  assert(validityDays < 14, `validity ${validityDays} days`);
+  assert(parsed.notBefore.getTime() <= Date.now() - 3599_000, "clock-skew slack missing");
+  assert(parsed.notAfter.getTime() > Date.now() + 8 * 86400_000, "expires too soon");
+
+  const san = parsed.getExtension(x509.SubjectAlternativeNameExtension);
+  const sanEntries = san ? san.names.items.map((n) => `${n.type}:${n.value}`) : [];
+  assert(sanEntries.includes("dns:localhost"), sanEntries.join(","));
+  assert(sanEntries.includes("ip:127.0.0.1"), sanEntries.join(","));
+
+  const hash = new Uint8Array(
+    await crypto.subtle.digest("SHA-256", new Uint8Array(parsed.rawData)),
+  );
+  assertEquals(btoa(String.fromCharCode(...hash)), cert.certHashB64);
+  assertEquals(cert.certHashB64.length, 44);
+  assert(cert.keyPem.includes("PRIVATE KEY"));
+});

--- a/web/relay/deno.json
+++ b/web/relay/deno.json
@@ -1,0 +1,11 @@
+{
+  "name": "@dimos/relay",
+  "version": "0.0.0",
+  "exports": {
+    ".": "./server.ts"
+  },
+  "imports": {
+    "@peculiar/x509": "npm:@peculiar/x509@^2.0",
+    "reflect-metadata": "npm:reflect-metadata@^0.2"
+  }
+}

--- a/web/relay/forward.ts
+++ b/web/relay/forward.ts
@@ -1,0 +1,285 @@
+// Robot->viewer forwarding: per-(viewer, channel) delivery policies over a
+// transport-blind ViewerSink, so the policy logic is unit-testable without
+// QUIC. The relay never parses payloads; it routes on the frame header only.
+import {
+  concatBytes,
+  type Delivery,
+  frameHeaderFromUnknown,
+  peekDataFrameLengths,
+} from "@dimos/shared";
+
+// Reliable channels: a viewer this far behind is dead weight; kick it so it
+// reconnects with a clean slate (T5 hardens and tunes these).
+const RELIABLE_MAX_QUEUE = 64;
+const RELIABLE_MAX_BYTES = 16 * 1024 * 1024;
+
+// One decoder for every robot frame header (fatal so corrupt UTF-8 drops the
+// frame rather than routing a mangled channel name).
+const headerDecoder = new TextDecoder("utf-8", { fatal: true });
+
+/** Transport surface a policy writes to: one uni stream per sendFrame call. */
+export interface ViewerSink {
+  sendFrame(bytes: Uint8Array): Promise<void>;
+  kick(reason: string): void;
+}
+
+interface ChannelPolicy {
+  readonly delivery: Delivery;
+  sent: number;
+  dropped: number;
+  queued(): number;
+  offer(bytes: Uint8Array): void;
+}
+
+/**
+ * Latest-wins: a 1-slot pending buffer. A frame arriving while a write is in
+ * flight replaces the pending one (newest wins); the final frame is always
+ * eventually delivered. A slow viewer sheds its own frames and nothing else.
+ */
+export class LatestChannel implements ChannelPolicy {
+  readonly delivery: Delivery = "latest";
+  sent = 0;
+  dropped = 0;
+  #pending: Uint8Array | null = null;
+  #writing = false;
+
+  constructor(readonly sink: ViewerSink) {}
+
+  queued(): number {
+    return this.#pending ? 1 : 0;
+  }
+
+  offer(bytes: Uint8Array): void {
+    if (this.#pending) this.dropped++;
+    this.#pending = bytes;
+    this.#drain();
+  }
+
+  #drain(): void {
+    if (this.#writing) return;
+    this.#writing = true;
+    (async () => {
+      while (this.#pending) {
+        const bytes = this.#pending;
+        this.#pending = null;
+        await this.sink.sendFrame(bytes);
+        this.sent++;
+      }
+    })()
+      .catch(() => this.sink.kick("write failed"))
+      .finally(() => {
+        this.#writing = false;
+      });
+  }
+}
+
+/**
+ * Reliable: bounded per-viewer FIFO, no drops, delivery order preserved. On
+ * overflow the viewer is kicked (better a visible reconnect than silent loss).
+ */
+export class ReliableChannel implements ChannelPolicy {
+  readonly delivery: Delivery = "reliable";
+  sent = 0;
+  dropped = 0;
+  #fifo: Uint8Array[] = [];
+  #bytes = 0;
+  #writing = false;
+
+  constructor(readonly sink: ViewerSink) {}
+
+  queued(): number {
+    return this.#fifo.length;
+  }
+
+  offer(bytes: Uint8Array): void {
+    this.#fifo.push(bytes);
+    this.#bytes += bytes.byteLength;
+    if (this.#fifo.length > RELIABLE_MAX_QUEUE || this.#bytes > RELIABLE_MAX_BYTES) {
+      this.sink.kick("reliable channel overflow");
+      return;
+    }
+    this.#drain();
+  }
+
+  #drain(): void {
+    if (this.#writing) return;
+    this.#writing = true;
+    (async () => {
+      for (let bytes = this.#fifo.shift(); bytes; bytes = this.#fifo.shift()) {
+        this.#bytes -= bytes.byteLength;
+        await this.sink.sendFrame(bytes);
+        this.sent++;
+      }
+    })()
+      .catch(() => this.sink.kick("write failed"))
+      .finally(() => {
+        this.#writing = false;
+      });
+  }
+}
+
+export interface ViewerHandle {
+  id: number;
+  sink: ViewerSink;
+  channels: Map<string, ChannelPolicy>;
+}
+
+interface ChannelInStats {
+  delivery: Delivery;
+  framesIn: number;
+  bytesIn: number;
+}
+
+/** Routes robot frames to every viewer through its per-channel policy. */
+export class Forwarder {
+  #viewers = new Set<ViewerHandle>();
+  #channelsIn = new Map<string, ChannelInStats>();
+  #nextViewerId = 1;
+  #framesDropped = 0;
+
+  addViewer(sink: ViewerSink): ViewerHandle {
+    const handle: ViewerHandle = { id: this.#nextViewerId++, sink, channels: new Map() };
+    this.#viewers.add(handle);
+    return handle;
+  }
+
+  removeViewer(handle: ViewerHandle): void {
+    this.#viewers.delete(handle);
+  }
+
+  get viewerCount(): number {
+    return this.#viewers.size;
+  }
+
+  /** Route one robot data frame (raw bytes, already length-complete). */
+  onRobotFrame(bytes: Uint8Array): void {
+    const lens = peekDataFrameLengths(bytes);
+    if (lens === null) return;
+    let header: ReturnType<typeof frameHeaderFromUnknown> = null;
+    try {
+      header = frameHeaderFromUnknown(
+        JSON.parse(headerDecoder.decode(bytes.subarray(8, 8 + lens.headerLen))),
+      );
+    } catch {
+      // bad UTF-8 or bad JSON: dropped below
+    }
+    if (header === null) {
+      this.#framesDropped++;
+      console.log("[relay] dropping robot frame with invalid header");
+      return;
+    }
+    const { ch, delivery } = header;
+
+    const stats = this.#channelsIn.get(ch) ?? { delivery, framesIn: 0, bytesIn: 0 };
+    stats.delivery = delivery;
+    stats.framesIn++;
+    stats.bytesIn += bytes.byteLength;
+    this.#channelsIn.set(ch, stats);
+
+    for (const viewer of this.#viewers) {
+      let policy = viewer.channels.get(ch);
+      if (policy === undefined || policy.delivery !== delivery) {
+        policy = delivery === "reliable"
+          ? new ReliableChannel(viewer.sink)
+          : new LatestChannel(viewer.sink);
+        viewer.channels.set(ch, policy);
+      }
+      policy.offer(bytes);
+    }
+  }
+
+  stats(): unknown {
+    return {
+      viewers: this.#viewers.size,
+      framesDropped: this.#framesDropped,
+      channels: Object.fromEntries(this.#channelsIn),
+      perViewer: [...this.#viewers].map((v) => ({
+        id: v.id,
+        channels: Object.fromEntries(
+          [...v.channels].map(([ch, p]) => [
+            ch,
+            { sent: p.sent, dropped: p.dropped, queued: p.queued() },
+          ]),
+        ),
+      })),
+    };
+  }
+}
+
+// First varint of a WebTransport bidi data stream (the preamble is stream
+// type + session id, both QUIC varints).
+const WT_BIDI_STREAM_TYPE = 0x41;
+
+/**
+ * Consume the WebTransport preamble of a raw incoming QUIC bidi stream, then
+ * release the lock so readDataFrameBytes can take over. Robot streams are
+ * accepted at the QUIC level because a reset racing the preamble read inside
+ * wt.incomingBidirectionalStreams errors that stream permanently (rejected
+ * pull) and kills the whole accept loop. Throws on a non-WebTransport type or
+ * a stream reset/ended mid-preamble; the session id's value is not checked (a
+ * robot connection carries exactly one WT session).
+ */
+export async function readWebTransportPreamble(rs: ReadableStream<Uint8Array>): Promise<number> {
+  const reader = rs.getReader({ mode: "byob" });
+  try {
+    const type = await readVarint(reader);
+    if (type !== WT_BIDI_STREAM_TYPE) {
+      throw new Error(`not a WebTransport data stream (type ${type})`);
+    }
+    return await readVarint(reader);
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+async function readVarint(reader: ReadableStreamBYOBReader): Promise<number> {
+  const first = await readByte(reader);
+  const size = 1 << (first >> 6);
+  let value = first & 0x3f;
+  for (let i = 1; i < size; i++) {
+    value = value * 256 + (await readByte(reader));
+  }
+  return value;
+}
+
+async function readByte(reader: ReadableStreamBYOBReader): Promise<number> {
+  const { value, done } = await reader.read(new Uint8Array(1));
+  if (done || value === undefined || value.byteLength !== 1) {
+    throw new Error("stream ended mid-preamble");
+  }
+  return value[0];
+}
+
+/**
+ * Read one length-prefixed data frame from a robot stream, stopping at the
+ * frame's byte count - never at EOF (Deno 2.6.x delays FIN by up to ~1 s, and
+ * a reset-stale writer may never send one). BYOB reader: default readers were
+ * observed to never deliver on Deno 2.6.10 incoming WT streams.
+ */
+export async function readDataFrameBytes(rs: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+  const reader = rs.getReader({ mode: "byob" });
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  let total: number | null = null;
+  try {
+    while (total === null || size < total) {
+      const { value, done } = await reader.read(new Uint8Array(64 * 1024));
+      if (value && value.byteLength) {
+        chunks.push(value);
+        size += value.byteLength;
+        if (total === null && size >= 8) {
+          // peekDataFrameLengths throws on an oversize total (MAX_DATA_FRAME_BYTES).
+          const lens = peekDataFrameLengths(concatBytes(chunks, 8));
+          if (lens !== null) total = lens.total;
+        }
+      }
+      if (done) break;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  if (total === null || size < total) {
+    throw new Error(`robot stream ended mid-frame (${size} bytes)`);
+  }
+  return concatBytes(chunks, total);
+}

--- a/web/relay/forward_test.ts
+++ b/web/relay/forward_test.ts
@@ -1,0 +1,228 @@
+import { assert, assertEquals, assertRejects } from "@std/assert";
+import { encodeDataFrame, type FrameHeader } from "@dimos/shared";
+import {
+  Forwarder,
+  LatestChannel,
+  readDataFrameBytes,
+  readWebTransportPreamble,
+  ReliableChannel,
+  type ViewerSink,
+} from "./forward.ts";
+
+class FakeSink implements ViewerSink {
+  sent: Uint8Array[] = [];
+  kicked: string | null = null;
+  auto: boolean;
+  #waiters: (() => void)[] = [];
+
+  constructor(auto = true) {
+    this.auto = auto;
+  }
+
+  sendFrame(bytes: Uint8Array): Promise<void> {
+    this.sent.push(bytes);
+    if (this.auto) return Promise.resolve();
+    return new Promise<void>((resolve) => this.#waiters.push(resolve));
+  }
+
+  release(n = 1): void {
+    while (n-- > 0) this.#waiters.shift()?.();
+  }
+
+  kick(reason: string): void {
+    this.kicked = reason;
+  }
+}
+
+function tick(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function frame(n: number): Uint8Array {
+  return new Uint8Array([n]);
+}
+
+function dataFrame(ch: string, seq: number, delivery: "latest" | "reliable"): Uint8Array {
+  const header: FrameHeader = { ch, seq, ts: seq + 0.5, delivery };
+  return encodeDataFrame(header, new Uint8Array([seq]));
+}
+
+Deno.test("latest: newest replaces pending while a write is in flight", async () => {
+  const sink = new FakeSink(false);
+  const ch = new LatestChannel(sink);
+  ch.offer(frame(1)); // begins writing
+  ch.offer(frame(2)); // parked in the pending slot
+  ch.offer(frame(3)); // replaces frame 2
+  await tick();
+  assertEquals(sink.sent.length, 1);
+  sink.release();
+  await tick();
+  assertEquals(sink.sent, [frame(1), frame(3)]);
+  sink.release();
+  await tick();
+  assertEquals(ch.sent, 2);
+  assertEquals(ch.dropped, 1);
+  assertEquals(ch.queued(), 0);
+  assertEquals(sink.kicked, null);
+});
+
+Deno.test("latest: the final frame is always eventually delivered", async () => {
+  const sink = new FakeSink(false);
+  const ch = new LatestChannel(sink);
+  for (let i = 0; i < 100; i++) ch.offer(frame(i));
+  sink.release(100);
+  await tick();
+  sink.release(100);
+  await tick();
+  assertEquals(sink.sent.length, 2); // first + newest, everything between dropped
+  assertEquals(sink.sent[1], frame(99));
+  assertEquals(ch.dropped, 98);
+});
+
+Deno.test("latest: fast sink delivers everything", async () => {
+  const sink = new FakeSink();
+  const ch = new LatestChannel(sink);
+  for (let i = 0; i < 5; i++) {
+    ch.offer(frame(i));
+    await tick();
+  }
+  assertEquals(sink.sent.length, 5);
+  assertEquals(ch.dropped, 0);
+});
+
+Deno.test("reliable: FIFO order, zero drops", async () => {
+  const sink = new FakeSink(false);
+  const ch = new ReliableChannel(sink);
+  for (let i = 0; i < 10; i++) ch.offer(frame(i));
+  for (let i = 0; i < 10; i++) {
+    sink.release();
+    await tick();
+  }
+  assertEquals(sink.sent, Array.from({ length: 10 }, (_, i) => frame(i)));
+  assertEquals(ch.sent, 10);
+  assertEquals(ch.dropped, 0);
+  assertEquals(sink.kicked, null);
+});
+
+Deno.test("reliable: queue overflow kicks the viewer", async () => {
+  const sink = new FakeSink(false);
+  const ch = new ReliableChannel(sink);
+  // 1 in flight + 64 queued is accepted; the next one overflows.
+  for (let i = 0; i < 66 && sink.kicked === null; i++) ch.offer(frame(i));
+  await tick();
+  assertEquals(sink.kicked, "reliable channel overflow");
+});
+
+Deno.test("a slow viewer never delays another viewer", async () => {
+  const forwarder = new Forwarder();
+  const slow = new FakeSink(false);
+  const fast = new FakeSink();
+  forwarder.addViewer(slow);
+  forwarder.addViewer(fast);
+  for (let i = 0; i < 5; i++) forwarder.onRobotFrame(dataFrame("odom", i, "reliable"));
+  await tick();
+  assertEquals(fast.sent.length, 5);
+  assertEquals(slow.sent.length, 1); // stuck on its first write, rest queued
+  assertEquals(slow.kicked, null);
+});
+
+Deno.test("forwarder routes by header delivery and keeps channels independent", async () => {
+  const forwarder = new Forwarder();
+  const sink = new FakeSink(false);
+  const viewer = forwarder.addViewer(sink);
+  forwarder.onRobotFrame(dataFrame("color_image", 0, "latest"));
+  forwarder.onRobotFrame(dataFrame("color_image", 1, "latest"));
+  forwarder.onRobotFrame(dataFrame("color_image", 2, "latest"));
+  forwarder.onRobotFrame(dataFrame("odom", 0, "reliable"));
+  forwarder.onRobotFrame(dataFrame("odom", 1, "reliable"));
+  await tick();
+  assert(viewer.channels.get("color_image") instanceof LatestChannel);
+  assert(viewer.channels.get("odom") instanceof ReliableChannel);
+  // one color_image write in flight, newest pending, middle dropped
+  assertEquals(viewer.channels.get("color_image")!.dropped, 1);
+  // odom: one in flight, one queued, nothing dropped
+  assertEquals(viewer.channels.get("odom")!.dropped, 0);
+  assertEquals(viewer.channels.get("odom")!.queued(), 1);
+
+  const stats = forwarder.stats() as {
+    viewers: number;
+    channels: Record<string, { framesIn: number; bytesIn: number; delivery: string }>;
+  };
+  assertEquals(stats.viewers, 1);
+  assertEquals(stats.channels.color_image.framesIn, 3);
+  assertEquals(stats.channels.odom.framesIn, 2);
+  assertEquals(stats.channels.odom.delivery, "reliable");
+});
+
+Deno.test("junk frames are dropped without touching viewers", async () => {
+  const forwarder = new Forwarder();
+  const sink = new FakeSink();
+  forwarder.addViewer(sink);
+  forwarder.onRobotFrame(new Uint8Array([1, 2, 3])); // shorter than a header
+  const bad = new Uint8Array(16); // headerLen=0 -> JSON parse of "" fails
+  forwarder.onRobotFrame(bad);
+  await tick();
+  assertEquals(sink.sent.length, 0);
+});
+
+function byteStream(...chunks: Uint8Array[]): ReadableStream<Uint8Array> {
+  // type "bytes" so BYOB readers work, like a real QUIC receive stream.
+  return new ReadableStream({
+    type: "bytes",
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk);
+      controller.close();
+    },
+  });
+}
+
+// Stream type 0x41 exceeds the 1-byte varint range, so on the wire it is the
+// 2-byte varint [0x40, 0x41] (what aioquic sends).
+
+Deno.test("preamble: consumed so the data frame parses from the remainder", async () => {
+  const frame = dataFrame("cam", 3, "latest");
+  // enqueue a copy: the byte stream detaches the chunk's buffer on read
+  const rs = byteStream(new Uint8Array([0x40, 0x41, 0x00]), frame.slice());
+  assertEquals(await readWebTransportPreamble(rs), 0);
+  assertEquals(await readDataFrameBytes(rs), frame);
+});
+
+Deno.test("preamble: multi-byte varint session id", async () => {
+  // session id 0x14c as a 2-byte varint (0x40 | 0x01, 0x4c)
+  const rs = byteStream(new Uint8Array([0x40, 0x41, 0x41, 0x4c]));
+  assertEquals(await readWebTransportPreamble(rs), 0x14c);
+});
+
+Deno.test("preamble: non-WebTransport stream type rejects", async () => {
+  await assertRejects(
+    () => readWebTransportPreamble(byteStream(new Uint8Array([0x17, 0x00]))),
+    Error,
+    "not a WebTransport data stream",
+  );
+});
+
+Deno.test("preamble: stream ending mid-preamble rejects", async () => {
+  await assertRejects(
+    () => readWebTransportPreamble(byteStream(new Uint8Array([0x40, 0x41]))),
+    Error,
+    "stream ended mid-preamble",
+  );
+});
+
+Deno.test("a well-framed frame with an invalid header is dropped and counted", async () => {
+  const forwarder = new Forwarder();
+  const sink = new FakeSink();
+  forwarder.addViewer(sink);
+  // Parseable JSON header, but delivery is not a known value: must be rejected.
+  const badHeader = encodeDataFrame(
+    { ch: "cam", seq: 1, ts: 1.5, delivery: "bogus" } as unknown as FrameHeader,
+    new Uint8Array([7]),
+  );
+  forwarder.onRobotFrame(badHeader);
+  forwarder.onRobotFrame(new Uint8Array(16)); // headerLen=0 -> JSON.parse("") throws
+  forwarder.onRobotFrame(dataFrame("odom", 0, "reliable")); // valid -> routed
+  await tick();
+  assertEquals(sink.sent.length, 1);
+  const stats = forwarder.stats() as { framesDropped: number };
+  assertEquals(stats.framesDropped, 2);
+});

--- a/web/relay/main.ts
+++ b/web/relay/main.ts
@@ -1,0 +1,50 @@
+// Relay CLI. Run from web/:  deno task dev  (or --port/--host/--static-dir).
+// Prints a single JSON ready line on stdout for parent processes to parse;
+// everything else logs to stderr-adjacent console lines prefixed [relay].
+import { parseArgs } from "@std/cli";
+import { PROTOCOL_VERSION } from "@dimos/shared";
+import { startRelay } from "./server.ts";
+
+const args = parseArgs(Deno.args, {
+  string: ["host", "static-dir"],
+  default: { port: 7780, host: "127.0.0.1" },
+});
+
+const host = args.host as string;
+if (host !== "127.0.0.1" && host !== "localhost") {
+  // serverCertificateHashes only works from secure contexts; http://<lan-ip>
+  // pages are not one. Remote access needs the cloud relay + real TLS (T12).
+  console.log(
+    `[relay] warning: binding ${host} - browsers will not treat http://${host} as a ` +
+      "secure context, so WebTransport will be unavailable there; this is only useful " +
+      "behind your own TLS setup",
+  );
+}
+
+const relay = await startRelay({
+  port: Number(args.port),
+  host,
+  staticDir: args["static-dir"],
+});
+
+console.log(JSON.stringify({
+  event: "ready",
+  httpPort: relay.httpPort,
+  wtUrl: relay.wtUrl,
+  certHash: relay.certHash,
+  v: PROTOCOL_VERSION,
+}));
+const pageHost = host === "0.0.0.0" ? "127.0.0.1" : host;
+console.log(`[relay] debug page: http://${pageHost}:${relay.httpPort}/debug.html`);
+
+for (const signal of ["SIGINT", "SIGTERM"] as const) {
+  try {
+    Deno.addSignalListener(signal, async () => {
+      console.log(`[relay] ${signal}, shutting down`);
+      await relay.shutdown();
+      Deno.exit(0);
+    });
+  } catch {
+    // not supported on this platform (e.g. SIGTERM on Windows)
+  }
+}

--- a/web/relay/server.ts
+++ b/web/relay/server.ts
@@ -1,0 +1,348 @@
+// The DimOS relay: QUIC/WebTransport listener (robot + viewer sessions) plus
+// a plain-HTTP side (static files, /api/info, /api/stats). Payload-blind:
+// all forwarding decisions come from frame headers (see forward.ts).
+//
+// Leg asymmetry, forced by upstream bugs (see web/README.md):
+// - Robot (aioquic): control = datagrams; data = one-shot bidi streams the
+//   relay never writes on (send half aborted with RESET, never FIN).
+// - Viewer (browser): control = viewer-opened bidi stream; data = relay-
+//   opened uni streams.
+import {
+  ControlFrameReader,
+  decodeDatagram,
+  encodeControlFrame,
+  encodeDatagram,
+  type Msg,
+  PROTOCOL_VERSION,
+} from "@dimos/shared";
+import { fileURLToPath } from "node:url";
+import { makeEphemeralCert } from "./cert.ts";
+import {
+  Forwarder,
+  readDataFrameBytes,
+  readWebTransportPreamble,
+  type ViewerSink,
+} from "./forward.ts";
+
+export interface RelayOptions {
+  /** TCP port for the HTTP side. Default 7780; 0 picks an ephemeral port. */
+  port?: number;
+  /** Bind host for both listeners. The default is the only secure-context-friendly choice. */
+  host?: string;
+  /** Directory served over HTTP. Defaults to ./static next to this module. */
+  staticDir?: string;
+}
+
+export interface RelayHandle {
+  httpPort: number;
+  quicPort: number;
+  /** Base WebTransport URL (no path); clients append /robot or /viewer. */
+  wtUrl: string;
+  certHash: string;
+  shutdown(): Promise<void>;
+}
+
+const MIME: Record<string, string> = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "application/javascript",
+  ".css": "text/css",
+  ".json": "application/json",
+  ".svg": "image/svg+xml",
+  ".png": "image/png",
+};
+
+export function installUnhandledRejectionGuard(): void {
+  // deno#28406: WT sessions leak unhandled rejections on disconnect/idle
+  // timeout; without this guard the relay dies ~30 s after a tab closes.
+  if ((globalThis as { __dimosRejectionGuard?: boolean }).__dimosRejectionGuard) return;
+  (globalThis as { __dimosRejectionGuard?: boolean }).__dimosRejectionGuard = true;
+  globalThis.addEventListener("unhandledrejection", (e) => {
+    console.log("[relay] unhandled rejection (ignored):", (e.reason as Error)?.message ?? e.reason);
+    e.preventDefault();
+  });
+}
+
+export async function startRelay(options: RelayOptions = {}): Promise<RelayHandle> {
+  installUnhandledRejectionGuard();
+  const host = options.host ?? "127.0.0.1";
+  const cert = await makeEphemeralCert();
+
+  // QUIC always binds an ephemeral port; clients discover it via the ready
+  // line or /api/info, so --port stays a single HTTP-facing knob.
+  const endpoint = new Deno.QuicEndpoint({ hostname: host, port: 0 });
+  const listener = endpoint.listen({
+    cert: cert.certPem,
+    key: cert.keyPem,
+    alpnProtocols: ["h3"],
+    maxIdleTimeout: 30_000,
+    keepAliveInterval: 4_000,
+  });
+  const quicPort = endpoint.addr.port;
+  // 127.0.0.1 rather than localhost: Chrome resolves localhost to ::1 first
+  // and the endpoint binds IPv4. Hash pinning replaces hostname verification.
+  const urlHost = host === "0.0.0.0" ? "127.0.0.1" : host;
+  const wtUrl = `https://${urlHost}:${quicPort}`;
+
+  const forwarder = new Forwarder();
+  const sessions = new Set<WebTransport>();
+  let robot: WebTransport | null = null;
+
+  function track(wt: WebTransport): void {
+    sessions.add(wt);
+    wt.closed.catch(() => {}).finally(() => sessions.delete(wt));
+  }
+
+  function sendControl(writer: WritableStreamDefaultWriter<Uint8Array>, msg: Msg): void {
+    writer.write(encodeControlFrame(msg)).catch(() => {});
+  }
+
+  function closeAfterFlush(wt: WebTransport, reason: string): void {
+    // Session close discards queued stream/datagram data, so give a just-sent
+    // reply (e.g. the version_mismatch error) a moment to reach the wire.
+    setTimeout(() => {
+      try {
+        wt.close({ closeCode: 1, reason });
+      } catch {
+        // already gone
+      }
+    }, 250);
+  }
+
+  function sendDatagram(writer: WritableStreamDefaultWriter<Uint8Array>, msg: Msg): void {
+    writer.write(encodeDatagram(msg)).catch(() => {});
+  }
+
+  /** Replies to hello/ping; returns false if the session must close (bad version). */
+  function handleControlMsg(msg: Msg, reply: (msg: Msg) => void): boolean {
+    if (msg.t === "hello") {
+      if (msg.v !== PROTOCOL_VERSION) {
+        reply({
+          t: "error",
+          code: "version_mismatch",
+          message: `protocol v${PROTOCOL_VERSION} required, got v${msg.v}`,
+        });
+        return false;
+      }
+      reply({ t: "welcome", v: PROTOCOL_VERSION });
+    } else if (msg.t === "ping") {
+      reply({ t: "pong", n: msg.n, ts: msg.ts });
+    }
+    return true;
+  }
+
+  function handleRobot(wt: WebTransport, conn: Deno.QuicConn): void {
+    if (robot) {
+      // Takeover: a restarted robot process must reattach without operator help.
+      console.log("[relay] robot takeover: closing previous robot session");
+      try {
+        robot.close({ closeCode: 0, reason: "replaced by new robot" });
+      } catch {
+        // already gone
+      }
+    }
+    robot = wt;
+    console.log("[relay] robot connected");
+    wt.closed
+      .catch(() => {})
+      .finally(() => {
+        if (robot === wt) robot = null;
+        console.log("[relay] robot disconnected");
+      });
+
+    const dgWriter = wt.datagrams.writable.getWriter();
+    (async () => {
+      // Robot-leg control rides datagrams: aioquic dies if the relay writes
+      // on robot-opened bidi streams, so hello/welcome/ping/pong live here.
+      for await (const dg of wt.datagrams.readable) {
+        const msg = decodeDatagram(dg);
+        if (msg === null) continue;
+        if (!handleControlMsg(msg, (m) => sendDatagram(dgWriter, m))) {
+          closeAfterFlush(wt, "version mismatch");
+          return;
+        }
+      }
+    })().catch(() => {});
+
+    (async () => {
+      // Data frames arrive on one-shot bidi streams (Deno never delivers
+      // incoming uni payloads), accepted at the QUIC level rather than via
+      // wt.incomingBidirectionalStreams: a reset racing that iterator's
+      // internal preamble read errors it permanently and would silently end
+      // this loop, while the raw accept only fails with the connection.
+      // Abort our send half: RESET is invisible to aioquic's h3 layer and
+      // releases stream credit; a FIN would kill it.
+      for await (const bidi of conn.incomingBidirectionalStreams) {
+        bidi.writable.abort().catch(() => {});
+        (async () => {
+          await readWebTransportPreamble(bidi.readable);
+          forwarder.onRobotFrame(await readDataFrameBytes(bidi.readable));
+        })().catch(() => {
+          // reset before/mid-frame (stale latest-wins write): drop the partial
+        });
+      }
+    })().catch((e) => {
+      console.log("[relay] robot stream loop ended:", (e as Error)?.message ?? e);
+    });
+  }
+
+  function handleViewer(wt: WebTransport): void {
+    let sendOrder = 1;
+    const sink: ViewerSink = {
+      async sendFrame(bytes: Uint8Array): Promise<void> {
+        // waitUntilAvailable: a slow page exhausts stream credit; without it
+        // this throws and we would drop a live viewer. Decreasing sendOrder
+        // keeps stream completions FIFO on the wire (quinn round-robins
+        // otherwise and frames complete in ~1 s waves).
+        const stream = await wt.createUnidirectionalStream({
+          waitUntilAvailable: true,
+          sendOrder: -(sendOrder++),
+        });
+        const writer = stream.getWriter();
+        await writer.write(bytes);
+        await writer.close();
+      },
+      kick(reason: string): void {
+        console.log(`[relay] kicking viewer: ${reason}`);
+        try {
+          wt.close({ closeCode: 1, reason });
+        } catch {
+          // already gone
+        }
+      },
+    };
+    const handle = forwarder.addViewer(sink);
+    console.log(`[relay] viewer ${handle.id} connected (${forwarder.viewerCount} total)`);
+    wt.closed
+      .catch(() => {})
+      .finally(() => {
+        forwarder.removeViewer(handle);
+        console.log(`[relay] viewer ${handle.id} disconnected`);
+      });
+
+    (async () => {
+      // Browser-leg control: viewer-opened bidi stream, replies on the same
+      // stream. Deno may write on viewer-initiated streams (browsers are not
+      // aioquic). wt.incomingBidirectionalStreams is safe here: unlike the
+      // robot leg, viewers never reset a stream racing its acceptance.
+      for await (const bidi of wt.incomingBidirectionalStreams) {
+        (async () => {
+          const writer = bidi.writable.getWriter();
+          const frames = new ControlFrameReader();
+          for await (const chunk of bidi.readable) {
+            for (const msg of frames.push(chunk)) {
+              if (!handleControlMsg(msg, (m) => sendControl(writer, m))) {
+                closeAfterFlush(wt, "version mismatch");
+                return;
+              }
+            }
+          }
+          writer.releaseLock();
+        })().catch((e) =>
+          console.log("[relay] viewer control stream ended:", (e as Error)?.message ?? e)
+        );
+      }
+    })().catch(() => {});
+
+    const dgWriter = wt.datagrams.writable.getWriter();
+    (async () => {
+      // Datagram control for viewers too: browsers use the bidi stream above,
+      // but the Python test viewer cannot receive replies on its own bidi
+      // streams (aioquic), so hello/ping work over datagrams on both legs.
+      // The relay answers pings itself (RTT works with no robot connected);
+      // teleop routing arrives in T6.
+      for await (const dg of wt.datagrams.readable) {
+        const msg = decodeDatagram(dg);
+        if (msg === null) continue;
+        if (!handleControlMsg(msg, (m) => sendDatagram(dgWriter, m))) {
+          closeAfterFlush(wt, "version mismatch");
+          return;
+        }
+      }
+    })().catch(() => {});
+  }
+
+  (async () => {
+    for await (const incoming of listener) {
+      (async () => {
+        const conn = await incoming.accept();
+        const wt = await Deno.upgradeWebTransport(conn);
+        await wt.ready;
+        track(wt);
+        const path = new URL(wt.url).pathname;
+        if (path === "/robot") handleRobot(wt, conn);
+        else handleViewer(wt);
+      })().catch((e) => console.log("[relay] accept failed:", (e as Error)?.message ?? e));
+    }
+  })().catch(() => {
+    // listener stopped (shutdown)
+  });
+
+  const staticRoot = options.staticDir
+    ? new URL(
+      options.staticDir.endsWith("/") ? options.staticDir : options.staticDir + "/",
+      `file://${Deno.cwd()}/`,
+    )
+    : new URL("./static/", import.meta.url);
+  // Resolved filesystem prefix every served path must stay under (href ends
+  // with "/", so the path does too).
+  const staticRootPath = fileURLToPath(staticRoot);
+
+  async function handleHttp(req: Request): Promise<Response> {
+    const url = new URL(req.url);
+    if (url.pathname === "/api/info") {
+      return Response.json({
+        wtUrl: `${wtUrl}/viewer`,
+        certHash: cert.certHashB64,
+        v: PROTOCOL_VERSION,
+      });
+    }
+    if (url.pathname === "/api/stats") {
+      return Response.json({ robot: robot !== null, ...(forwarder.stats() as object) });
+    }
+    const name = url.pathname === "/" ? "debug.html" : url.pathname.slice(1);
+    // Resolve the request to a real path and confirm it stays under the static
+    // root. A leading "/" or "\" makes `new URL(name, root)` jump to the
+    // filesystem root; fileURLToPath additionally throws on encoded slashes.
+    let filePath: string;
+    try {
+      filePath = fileURLToPath(new URL(name, staticRoot));
+    } catch {
+      return new Response("bad path", { status: 400 });
+    }
+    if (!filePath.startsWith(staticRootPath)) return new Response("bad path", { status: 400 });
+    try {
+      const data = await Deno.readFile(filePath);
+      const ext = name.slice(name.lastIndexOf("."));
+      return new Response(data, {
+        headers: { "content-type": MIME[ext] ?? "application/octet-stream" },
+      });
+    } catch {
+      return new Response("not found", { status: 404 });
+    }
+  }
+
+  const httpServer = Deno.serve(
+    { hostname: host, port: options.port ?? 7780, onListen: () => {} },
+    handleHttp,
+  );
+  const httpPort = (httpServer.addr as Deno.NetAddr).port;
+
+  return {
+    httpPort,
+    quicPort,
+    wtUrl,
+    certHash: cert.certHashB64,
+    async shutdown(): Promise<void> {
+      for (const wt of sessions) {
+        try {
+          wt.close({ closeCode: 0, reason: "relay shutdown" });
+        } catch {
+          // already gone
+        }
+      }
+      listener.stop();
+      endpoint.close({ closeCode: 0, reason: "relay shutdown" });
+      await httpServer.shutdown();
+    },
+  };
+}

--- a/web/relay/server_test.ts
+++ b/web/relay/server_test.ts
@@ -1,0 +1,270 @@
+// In-process loopback e2e: startRelay + Deno's own WebTransport client as
+// both robot and viewer. Deno's client CAN receive relay-initiated uni
+// streams (verified; the 2.6.10 incoming-uni bug is server-side receive
+// only), so this covers the full forwarding path without a browser.
+import { assert, assertEquals } from "@std/assert";
+import {
+  ControlFrameReader,
+  decodeDatagram,
+  encodeControlFrame,
+  encodeDataFrame,
+  encodeDatagram,
+  type FrameHeader,
+  type Msg,
+  PROTOCOL_VERSION,
+} from "@dimos/shared";
+import { readDataFrameBytes } from "./forward.ts";
+import { startRelay } from "./server.ts";
+
+function certOpts(hashB64: string): WebTransportOptions {
+  return {
+    serverCertificateHashes: [{
+      algorithm: "sha-256",
+      value: Uint8Array.from(atob(hashB64), (c) => c.charCodeAt(0)),
+    }],
+  };
+}
+
+function within<T>(promise: Promise<T>, what: string, ms = 8000): Promise<T> {
+  let timer: number;
+  const timeout = new Promise<T>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`${what} timed out after ${ms} ms`)), ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
+/** Pull-based message queue over a stream of control frames (BYOB reads). */
+function controlQueue(readable: ReadableStream<Uint8Array>): () => Promise<Msg> {
+  const queue: Msg[] = [];
+  const waiters: ((msg: Msg) => void)[] = [];
+  (async () => {
+    const frames = new ControlFrameReader();
+    const reader = readable.getReader({ mode: "byob" });
+    while (true) {
+      const { value, done } = await reader.read(new Uint8Array(8 * 1024));
+      if (value && value.byteLength) {
+        for (const msg of frames.push(value)) {
+          const waiter = waiters.shift();
+          if (waiter) waiter(msg);
+          else queue.push(msg);
+        }
+      }
+      if (done) break;
+    }
+  })().catch(() => {});
+  return () => {
+    const msg = queue.shift();
+    if (msg) return Promise.resolve(msg);
+    return new Promise<Msg>((resolve) => waiters.push(resolve));
+  };
+}
+
+/** Pull-based message queue over incoming datagrams (junk skipped). */
+function datagramQueue(readable: ReadableStream<Uint8Array>): () => Promise<Msg> {
+  const queue: Msg[] = [];
+  const waiters: ((msg: Msg) => void)[] = [];
+  (async () => {
+    for await (const dg of readable) {
+      const msg = decodeDatagram(dg);
+      if (msg === null) continue;
+      const waiter = waiters.shift();
+      if (waiter) waiter(msg);
+      else queue.push(msg);
+    }
+  })().catch(() => {});
+  return () => {
+    const msg = queue.shift();
+    if (msg) return Promise.resolve(msg);
+    return new Promise<Msg>((resolve) => waiters.push(resolve));
+  };
+}
+
+/** Collect forwarded data frames arriving on relay-initiated uni streams. */
+function frameQueue(
+  wt: WebTransport,
+): () => Promise<{ header: FrameHeader; payload: Uint8Array }> {
+  const queue: { header: FrameHeader; payload: Uint8Array }[] = [];
+  const waiters: ((f: { header: FrameHeader; payload: Uint8Array }) => void)[] = [];
+  (async () => {
+    for await (const stream of wt.incomingUnidirectionalStreams) {
+      readDataFrameBytes(stream)
+        .then((bytes) => {
+          const headerLen = new DataView(bytes.buffer, bytes.byteOffset).getUint32(0, true);
+          const header = JSON.parse(
+            new TextDecoder().decode(bytes.subarray(8, 8 + headerLen)),
+          ) as FrameHeader;
+          const payload = bytes.subarray(8 + headerLen);
+          const waiter = waiters.shift();
+          if (waiter) waiter({ header, payload });
+          else queue.push({ header, payload });
+        })
+        .catch(() => {});
+    }
+  })().catch(() => {});
+  return () => {
+    const frame = queue.shift();
+    if (frame) return Promise.resolve(frame);
+    return new Promise((resolve) => waiters.push(resolve));
+  };
+}
+
+async function sendRobotFrame(robot: WebTransport, header: FrameHeader, payload: Uint8Array) {
+  const stream = await robot.createBidirectionalStream();
+  const writer = stream.writable.getWriter();
+  await writer.write(encodeDataFrame(header, payload));
+  await writer.close(); // FIN is delayed by Deno (bug 2); the relay reads by byte count
+}
+
+Deno.test({
+  name: "relay loopback e2e",
+  // QUIC endpoint + WT sessions keep background ops alive past shutdown();
+  // their teardown is asynchronous in Deno 2.6.
+  sanitizeOps: false,
+  sanitizeResources: false,
+}, async (t) => {
+  const relay = await startRelay({ port: 0 });
+  const httpBase = `http://127.0.0.1:${relay.httpPort}`;
+
+  await t.step("/api/info matches the handle and the debug page serves", async () => {
+    const info = await (await fetch(`${httpBase}/api/info`)).json();
+    assertEquals(info, {
+      wtUrl: `${relay.wtUrl}/viewer`,
+      certHash: relay.certHash,
+      v: PROTOCOL_VERSION,
+    });
+    assert(relay.wtUrl.startsWith("https://127.0.0.1:"), relay.wtUrl);
+    const page = await (await fetch(`${httpBase}/debug.html`)).text();
+    assert(page.includes("DimOS relay debug"));
+    const index = await (await fetch(`${httpBase}/`)).text();
+    assert(index.includes("DimOS relay debug"));
+    // Traversal probes. The client/URL parser normalizes these two away from
+    // the tree before the guard sees them, so they 404 on absence.
+    for (const path of ["/../etc/passwd", "/%2e%2e/etc/passwd"]) {
+      const res = await fetch(`${httpBase}${path}`);
+      await res.body?.cancel();
+      assertEquals(res.status, 404, path);
+    }
+    // These survive normalization and must be rejected by the containment
+    // check: a leading "//" makes new URL() jump to the filesystem root, and
+    // encoded slashes let a "../" escape reassemble after decoding.
+    for (const path of ["//etc/passwd", "/..%2f..%2f..%2f..%2fetc%2fpasswd"]) {
+      const res = await fetch(`${httpBase}${path}`);
+      await res.body?.cancel();
+      assertEquals(res.status, 400, path);
+    }
+  });
+
+  const viewer = new WebTransport(`${relay.wtUrl}/viewer`, certOpts(relay.certHash));
+  await within(viewer.ready, "viewer connect");
+  const viewerFrames = frameQueue(viewer);
+  const viewerDatagrams = datagramQueue(viewer.datagrams.readable);
+  const control = await within(viewer.createBidirectionalStream(), "control stream");
+  const controlWriter = control.writable.getWriter();
+  const nextControl = controlQueue(control.readable);
+
+  await t.step("viewer control: hello -> welcome, ping -> pong", async () => {
+    await controlWriter.write(
+      encodeControlFrame({ t: "hello", v: PROTOCOL_VERSION, role: "viewer" }),
+    );
+    assertEquals(await within(nextControl(), "welcome"), {
+      t: "welcome",
+      v: PROTOCOL_VERSION,
+    });
+    await controlWriter.write(encodeControlFrame({ t: "ping", n: 1, ts: 123.5 }));
+    assertEquals(await within(nextControl(), "pong"), { t: "pong", n: 1, ts: 123.5 });
+  });
+
+  await t.step("viewer datagram ping -> pong (relay answers itself)", async () => {
+    const dgWriter = viewer.datagrams.writable.getWriter();
+    await dgWriter.write(encodeDatagram({ t: "ping", n: 2, ts: 124.5 }));
+    assertEquals(await within(viewerDatagrams(), "datagram pong"), {
+      t: "pong",
+      n: 2,
+      ts: 124.5,
+    });
+    dgWriter.releaseLock();
+  });
+
+  const robot = new WebTransport(`${relay.wtUrl}/robot`, certOpts(relay.certHash));
+  await within(robot.ready, "robot connect");
+  const robotDatagrams = datagramQueue(robot.datagrams.readable);
+  const robotDgWriter = robot.datagrams.writable.getWriter();
+
+  await t.step("robot control rides datagrams: hello -> welcome", async () => {
+    await robotDgWriter.write(
+      encodeDatagram({ t: "hello", v: PROTOCOL_VERSION, role: "robot" }),
+    );
+    assertEquals(await within(robotDatagrams(), "robot welcome"), {
+      t: "welcome",
+      v: PROTOCOL_VERSION,
+    });
+  });
+
+  await t.step("robot frames fan out to the viewer on uni streams", async () => {
+    const odomPayload = new TextEncoder().encode('{"x":1.5,"yaw":0.25}');
+    await sendRobotFrame(
+      robot,
+      { ch: "odom", seq: 1, ts: 10.5, delivery: "reliable" },
+      odomPayload,
+    );
+    const imagePayload = new Uint8Array(100_000);
+    imagePayload.fill(7);
+    await sendRobotFrame(
+      robot,
+      { ch: "color_image", seq: 2, ts: 11.5, delivery: "latest", meta: { w: 320, h: 240 } },
+      imagePayload,
+    );
+
+    const got = [
+      await within(viewerFrames(), "first forwarded frame"),
+      await within(viewerFrames(), "second forwarded frame"),
+    ];
+    // one-stream-per-message may arrive out of order; sort by seq
+    got.sort((a, b) => a.header.seq - b.header.seq);
+    assertEquals(got[0].header, { ch: "odom", seq: 1, ts: 10.5, delivery: "reliable" });
+    assertEquals(got[0].payload, odomPayload);
+    assertEquals(got[1].header, {
+      ch: "color_image",
+      seq: 2,
+      ts: 11.5,
+      delivery: "latest",
+      meta: { w: 320, h: 240 },
+    });
+    assertEquals(got[1].payload, imagePayload);
+  });
+
+  await t.step("/api/stats counted the traffic", async () => {
+    const stats = await (await fetch(`${httpBase}/api/stats`)).json();
+    assertEquals(stats.robot, true);
+    assertEquals(stats.viewers, 1);
+    assertEquals(stats.channels.odom.framesIn, 1);
+    assertEquals(stats.channels.color_image.framesIn, 1);
+    assertEquals(stats.perViewer[0].channels.odom.sent, 1);
+  });
+
+  await t.step("hello with a wrong version -> error + close", async () => {
+    const bad = new WebTransport(`${relay.wtUrl}/viewer`, certOpts(relay.certHash));
+    await within(bad.ready, "bad-version viewer connect");
+    const stream = await bad.createBidirectionalStream();
+    const writer = stream.writable.getWriter();
+    const next = controlQueue(stream.readable);
+    await writer.write(encodeControlFrame({ t: "hello", v: 99, role: "viewer" }));
+    const err = await within(next(), "version error");
+    assertEquals(err.t, "error");
+    assertEquals((err as { code: string }).code, "version_mismatch");
+    await within(bad.closed.catch(() => {}), "bad-version session close");
+  });
+
+  await t.step("a garbage control message is dropped, not fatal to the loop", async () => {
+    // A well-framed but invalid body (JSON null) must not kill the viewer's
+    // control loop: a following ping still gets a pong.
+    const junk = encodeControlFrame(null as unknown as Msg);
+    await controlWriter.write(junk);
+    await controlWriter.write(encodeControlFrame({ t: "ping", n: 7, ts: 77.5 }));
+    assertEquals(await within(nextControl(), "pong after junk"), { t: "pong", n: 7, ts: 77.5 });
+  });
+
+  viewer.close();
+  robot.close();
+  await relay.shutdown();
+});

--- a/web/relay/static/debug.html
+++ b/web/relay/static/debug.html
@@ -1,0 +1,379 @@
+<!DOCTYPE html>
+<html lang="en">
+  <!-- No-build diagnostic page for the relay (T1). It is NOT the Cockpit and
+     never grows panels; it exists so backend work is demoable and debuggable
+     with zero frontend tooling. It duplicates ~40 lines of framing JS from
+     web/shared/protocol.ts on purpose. -->
+  <head>
+    <meta charset="utf-8">
+    <title>DimOS relay debug</title>
+    <style>
+      body {
+        font: 13px/1.5 ui-monospace, monospace;
+        background: #14161a;
+        color: #d7dae0;
+        margin: 1.2rem;
+      }
+      h1 {
+        font-size: 15px;
+        margin: 0 0 0.6rem;
+        color: #8ab4f8;
+      }
+      .row {
+        display: flex;
+        gap: 1.2rem;
+        flex-wrap: wrap;
+        align-items: flex-start;
+      }
+      .card {
+        background: #1d2026;
+        border: 1px solid #2a2e36;
+        border-radius: 6px;
+        padding: 0.7rem 0.9rem;
+        margin-bottom: 1rem;
+      }
+      #status {
+        white-space: pre-wrap;
+      }
+      .ok {
+        color: #7ee787;
+      }
+      .bad {
+        color: #ff7b72;
+      }
+      canvas {
+        background: #000;
+        border: 1px solid #2a2e36;
+        max-width: 480px;
+      }
+      table {
+        border-collapse: collapse;
+      }
+      td, th {
+        padding: 0.1rem 0.6rem;
+        text-align: right;
+        border-bottom: 1px solid #2a2e36;
+      }
+      th:first-child, td:first-child {
+        text-align: left;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>DimOS relay debug</h1>
+    <div class="card" id="status">checking WebTransport support...</div>
+    <div class="row">
+      <div class="card">
+        <div>color_image</div>
+        <canvas id="image" width="480" height="360"></canvas>
+      </div>
+      <div class="card">
+        <div>odom</div>
+        <pre id="odom">-</pre>
+        <div>round-trips</div>
+        <pre id="rtt">control: -    datagram: -</pre>
+      </div>
+    </div>
+    <div class="card">
+      <table id="stats">
+        <thead>
+          <tr>
+            <th>channel</th>
+            <th>frames</th>
+            <th>Hz</th>
+            <th>KB/s</th>
+            <th>span loss</th>
+            <th>out of order</th>
+            <th>last seq</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </div>
+
+    <script>
+      "use strict";
+      const $ = (id) => document.getElementById(id);
+      const enc = new TextEncoder();
+      const dec = new TextDecoder();
+
+      function say(html, cls) {
+        $("status").innerHTML = cls ? `<span class="${cls}">${html}</span>` : html;
+      }
+
+      // ---- framing (mirrors web/shared/protocol.ts) ----
+      function encodeControlFrame(msg) {
+        const body = enc.encode(JSON.stringify(msg));
+        const out = new Uint8Array(4 + body.length);
+        new DataView(out.buffer).setUint32(0, body.length, true);
+        out.set(body, 4);
+        return out;
+      }
+
+      function controlFrameReader() {
+        let buf = new Uint8Array(0);
+        return (chunk) => {
+          const merged = new Uint8Array(buf.length + chunk.length);
+          merged.set(buf, 0);
+          merged.set(chunk, buf.length);
+          buf = merged;
+          const msgs = [];
+          while (buf.length >= 4) {
+            const len = new DataView(buf.buffer, buf.byteOffset).getUint32(0, true);
+            if (buf.length < 4 + len) break;
+            msgs.push(JSON.parse(dec.decode(buf.subarray(4, 4 + len))));
+            buf = buf.subarray(4 + len);
+          }
+          return msgs;
+        };
+      }
+
+      // Read one data frame by byte count; never wait for EOF (the relay's FIN can
+      // arrive up to ~1 s late on Deno 2.6.x).
+      async function readDataFrame(stream) {
+        const reader = stream.getReader();
+        const chunks = [];
+        let size = 0;
+        let total = null;
+        let head = new Uint8Array(0);
+        try {
+          while (total === null || size < total) {
+            const { value, done } = await reader.read();
+            if (value && value.byteLength) {
+              chunks.push(value);
+              size += value.byteLength;
+              if (total === null) {
+                const merged = new Uint8Array(Math.min(size, 8));
+                let off = 0;
+                for (const c of chunks) {
+                  for (let i = 0; i < c.byteLength && off < 8; i++) merged[off++] = c[i];
+                }
+                head = merged;
+                if (size >= 8) {
+                  const dv = new DataView(head.buffer);
+                  total = 8 + dv.getUint32(0, true) + dv.getUint32(4, true);
+                }
+              }
+            }
+            if (done) break;
+          }
+        } finally {
+          reader.releaseLock(); // no cancel: the late FIN closes the stream
+        }
+        if (total === null || size < total) throw new Error("stream ended mid-frame");
+        const buf = new Uint8Array(size);
+        let off = 0;
+        for (const c of chunks) {
+          buf.set(c, off);
+          off += c.byteLength;
+        }
+        const hlen = new DataView(buf.buffer).getUint32(0, true);
+        return {
+          header: JSON.parse(dec.decode(buf.subarray(8, 8 + hlen))),
+          payload: buf.subarray(8 + hlen, total),
+        };
+      }
+
+      // ---- per-channel stats ----
+      const chans = new Map();
+      function chan(ch) {
+        let c = chans.get(ch);
+        if (!c) {
+          c = {
+            frames: 0,
+            bytes: 0,
+            winFrames: 0,
+            winBytes: 0,
+            hz: 0,
+            kbps: 0,
+            minSeq: Infinity,
+            maxSeq: -1,
+            lastSeq: -1,
+            ooo: 0,
+            seen: 0,
+          };
+          chans.set(ch, c);
+        }
+        return c;
+      }
+      function onFrame(header, payload) {
+        const c = chan(header.ch);
+        c.frames++;
+        c.winFrames++;
+        c.bytes += payload.byteLength;
+        c.winBytes += payload.byteLength;
+        c.seen++;
+        if (header.seq < c.lastSeq) c.ooo++;
+        c.lastSeq = Math.max(c.lastSeq, header.seq);
+        c.minSeq = Math.min(c.minSeq, header.seq);
+        c.maxSeq = Math.max(c.maxSeq, header.seq);
+        if (header.ch === "color_image") latestImage = payload;
+        else if (header.ch === "odom") latestOdom = { header, payload };
+      }
+      setInterval(() => {
+        const rows = [];
+        for (const [ch, c] of chans) {
+          c.hz = c.winFrames / 2;
+          c.kbps = c.winBytes / 2048;
+          c.winFrames = 0;
+          c.winBytes = 0;
+          const span = c.maxSeq >= 0 ? c.maxSeq - c.minSeq + 1 : 0;
+          const loss = span - c.seen; // span-based: streams arrive out of order
+          rows.push(
+            `<tr><td>${ch}</td><td>${c.frames}</td><td>${c.hz.toFixed(1)}</td>` +
+              `<td>${
+                c.kbps.toFixed(0)
+              }</td><td>${loss}</td><td>${c.ooo}</td><td>${c.lastSeq}</td></tr>`,
+          );
+        }
+        document.querySelector("#stats tbody").innerHTML = rows.join("");
+      }, 2000);
+
+      // ---- rendering: rAF draws the latest frame, never per-arrival ----
+      let latestImage = null;
+      let latestOdom = null;
+      let decoding = false;
+      const ctx = $("image").getContext("2d");
+      function raf() {
+        if (latestImage && !decoding) {
+          const payload = latestImage;
+          latestImage = null;
+          decoding = true;
+          createImageBitmap(new Blob([payload], { type: "image/jpeg" }))
+            .then((bmp) => {
+              if ($("image").width !== bmp.width) {
+                $("image").width = bmp.width;
+                $("image").height = bmp.height;
+              }
+              ctx.drawImage(bmp, 0, 0);
+            })
+            .catch(() => {}) // not a decodable image (e.g. synthetic bytes): counted in stats only
+            .finally(() => {
+              decoding = false;
+            });
+        }
+        if (latestOdom) {
+          const p = latestOdom;
+          latestOdom = null;
+          let text;
+          try {
+            text = JSON.stringify(JSON.parse(dec.decode(p.payload)), null, 1);
+          } catch {
+            text = `${p.payload.byteLength} B`;
+          }
+          $("odom").textContent = `seq ${p.header.seq}\n${text}`;
+        }
+        requestAnimationFrame(raf);
+      }
+      requestAnimationFrame(raf);
+
+      // ---- connection ----
+      const rtts = { control: "-", datagram: "-" };
+      function showRtt() {
+        $("rtt").textContent = `control: ${rtts.control}    datagram: ${rtts.datagram}`;
+      }
+
+      async function main() {
+        if (!window.isSecureContext) {
+          return say(
+            "this page is not a secure context - open it via http://localhost:PORT or " +
+              "http://127.0.0.1:PORT (not a LAN IP); WebTransport is unavailable otherwise",
+            "bad",
+          );
+        }
+        if (typeof WebTransport === "undefined") {
+          return say(
+            "this browser has no WebTransport support (Chrome and Firefox work; Safari " +
+              "ships it behind a feature flag and is not a target yet)",
+            "bad",
+          );
+        }
+        const info = await (await fetch("/api/info")).json();
+        say(`connecting to ${info.wtUrl} ...`);
+        const opts = {};
+        if (info.certHash) {
+          opts.serverCertificateHashes = [{
+            algorithm: "sha-256",
+            value: Uint8Array.from(atob(info.certHash), (c) => c.charCodeAt(0)),
+          }];
+        }
+        let wt;
+        try {
+          wt = new WebTransport(info.wtUrl, opts);
+          await wt.ready;
+        } catch (e) {
+          return say(
+            `WebTransport connect failed: ${e.message ?? e}<br>` +
+              "hints: relay running? firewall blocking UDP? cert older than its 10-day validity?",
+            "bad",
+          );
+        }
+        say(`connected to ${info.wtUrl} (protocol v${info.v})`, "ok");
+        wt.closed.then(
+          (i) => say(`session closed: ${JSON.stringify(i)}`, "bad"),
+          (e) => say(`session lost: ${e.message ?? e}`, "bad"),
+        );
+
+        // control stream: hello -> welcome, then ping every second
+        const control = await wt.createBidirectionalStream();
+        const cw = control.writable.getWriter();
+        const pending = new Map(); // n -> send time
+        let pingN = 0;
+        cw.write(encodeControlFrame({ t: "hello", v: info.v, role: "viewer" }));
+        (async () => {
+          const push = controlFrameReader();
+          for await (const chunk of control.readable) {
+            for (const msg of push(chunk)) {
+              if (msg.t === "welcome") {
+                say(`connected, welcome received (protocol v${msg.v})`, "ok");
+              } else if (msg.t === "error") {
+                say(`relay error: ${msg.code}: ${msg.message}`, "bad");
+              } else if (msg.t === "pong" && pending.has(msg.n)) {
+                rtts.control = `${(performance.now() - pending.get(msg.n)).toFixed(1)} ms`;
+                pending.delete(msg.n);
+                showRtt();
+              }
+            }
+          }
+        })().catch(() => {});
+        setInterval(() => {
+          pending.set(++pingN, performance.now());
+          cw.write(encodeControlFrame({ t: "ping", n: pingN, ts: Date.now() / 1000 }))
+            .catch(() => {});
+        }, 1000);
+
+        // datagram ping every second (the relay answers these itself)
+        const dgw = wt.datagrams.writable.getWriter();
+        const dgPending = new Map();
+        let dgN = 0;
+        setInterval(() => {
+          dgPending.set(++dgN, performance.now());
+          dgw.write(
+            enc.encode(JSON.stringify({ t: "ping", n: dgN, ts: Date.now() / 1000 })),
+          ).catch(() => {});
+        }, 1000);
+        (async () => {
+          for await (const d of wt.datagrams.readable) {
+            try {
+              const msg = JSON.parse(dec.decode(d));
+              if (msg.t === "pong" && dgPending.has(msg.n)) {
+                rtts.datagram = `${
+                  (performance.now() - dgPending.get(msg.n)).toFixed(1)
+                } ms`;
+                dgPending.delete(msg.n);
+                showRtt();
+              }
+            } catch { /* not JSON */ }
+          }
+        })().catch(() => {});
+
+        // data plane: one uni stream per frame
+        for await (const stream of wt.incomingUnidirectionalStreams) {
+          readDataFrame(stream).then(({ header, payload }) => onFrame(header, payload))
+            .catch(() => {});
+        }
+      }
+      main().catch((e) => say(`debug page failed: ${e.message ?? e}`, "bad"));
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
* Added the code for an initial relay, which handles connections from the robot (DimOS) and the frontend (cockpit).
* This is just a start. I definitely want to break up `web/relay/server.ts` into smaller more cohesive parts.
* Added a cockpit stub in a single file: `web/relay/static/debug.html`. This will be replaced.