### PR TITLE
[Tests] Add unit tests for path_utils

### DIFF
--- a/dimos/utils/test_path_utils.py
+++ b/dimos/utils/test_path_utils.py
@@ -1,0 +1,26 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pathlib import Path
+
+from dimos.utils.path_utils import get_project_root
+
+
+def test_get_project_root_is_absolute_and_contains_dimos_package() -> None:
+    root = get_project_root()
+    assert isinstance(root, Path)
+    assert root.is_absolute()
+    assert root.is_dir()
+    # path_utils.py lives at <root>/dimos/utils/path_utils.py, so the
+    # returned project root must contain the dimos package and this file.
+    assert (root / "dimos" / "utils" / "path_utils.py").exists()


### PR DESCRIPTION
## Summary
- `dimos/utils/path_utils.py` (`get_project_root`) has no test coverage. This adds `dimos/utils/test_path_utils.py` asserting the returned path is absolute, is a directory, and contains the `dimos` package with this module (the real contract of "project root").

## Why
It is a tiny pure-pathlib helper; a cheap coverage win that matches the repo's per-module `test_*.py` convention.

## Test plan
- `uv run pytest dimos/utils/test_path_utils.py` (verified locally).

## AI disclosure
AI-assisted: drafted with WorkBuddy (Claude) and reviewed by a human before submission, per the AI Usage Policy.
