### PR TITLE
Add backport label to Dependabot PRs and check docker weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,7 +29,7 @@ updates:
   - package-ecosystem: "docker"
     directories: ["/docker/*/"]
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     # https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns
     cooldown:
       default-days: 7

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -20,13 +20,3 @@ jobs:
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - name: Approve a PR
-        run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - name: Enable auto-merge for Dependabot PRs
-        run: gh pr merge --auto --squash "$PR_URL"
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -15,6 +15,11 @@ jobs:
         uses: dependabot/fetch-metadata@v3
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Add backport:skip label
+        run: gh pr edit --add-label "backport:skip" "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Approve a PR
         run: gh pr review --approve "$PR_URL"
         env:


### PR DESCRIPTION
Also drop auto-approve and auto-merge, as these don't actually achieve anything currently.