### PR TITLE
feat: local relay

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,11 +311,12 @@ jobs:
         with:
           allow-prereleases: true
           python-version: ${{ matrix.pyver }}
-      - name: Install dependency for pyaudio (Ubuntu)
+      # pyaudio needs portaudio; the relay bridge tests encode JPEG via PyTurboJPEG.
+      - name: Install system dependencies (Ubuntu)
         if: startsWith(matrix.os, 'ubuntu')
         run: |
           sudo apt-get update
-          sudo apt-get install -y portaudio19-dev
+          sudo apt-get install -y portaudio19-dev libturbojpeg
       - name: Install dependency for pyaudio (macOS)
         if: startsWith(matrix.os, 'macos')
         run: brew install portaudio

--- a/dimos/core/global_config.py
+++ b/dimos/core/global_config.py
@@ -92,6 +92,8 @@ class GlobalConfig(BaseSettings):
     dimsim_scene: str = "apartment"
     dimsim_port: int = 8090
     dimsim_headless: bool = True
+    local_relay: bool = False
+    relay_url: str | None = None
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/dimos/memory2/codecs/test_codecs.py
+++ b/dimos/memory2/codecs/test_codecs.py
@@ -123,12 +123,18 @@ def _jpeg_eq(original: Any, decoded: Any) -> bool:
     return bool(np.mean(np.abs(decoded.data.astype(float) - expected.astype(float))) < 5)
 
 
-def _jpeg_case() -> Case | None:
+def _turbojpeg_available() -> bool:
     try:
         from turbojpeg import TurboJPEG
 
         TurboJPEG()  # fail fast if native lib is missing
     except (ImportError, RuntimeError):
+        return False
+    return True
+
+
+def _jpeg_case() -> Case | None:
+    if not _turbojpeg_available():
         return None
 
     from dimos.memory2.store.sqlite import SqliteStore
@@ -151,14 +157,33 @@ def _jpeg_case() -> Case | None:
     )
 
 
-testcases = [
-    c
-    for c in [_pickle_case(), _lcm_case(), _lz4_pickle_case(), _lz4_lcm_case(), _jpeg_case()]
-    if c is not None
-]
+_case_factories = {
+    "pickle": _pickle_case,
+    "lcm": _lcm_case,
+    "lz4+pickle": _lz4_pickle_case,
+    "lz4+lcm": _lz4_lcm_case,
+    "jpeg": _jpeg_case,
+}
+
+# The jpeg case reads frames from an 84 MB LFS database. Regular CI runners cap
+# LFS pulls at 1 MiB, and deselected tests still get collected (imported), so
+# the pull has to happen at test time (in the `case` fixture below) and the
+# case is marked self_hosted so only self-hosted runners and local machines
+# run it.
+case_params: list[Any] = ["pickle", "lcm", "lz4+pickle", "lz4+lcm"]
+if _turbojpeg_available():
+    case_params.append(pytest.param("jpeg", marks=pytest.mark.self_hosted))
 
 
-@pytest.mark.parametrize("case", testcases, ids=lambda c: c.name)
+@pytest.fixture
+def case(request: pytest.FixtureRequest) -> Case:
+    resolved = _case_factories[request.param]()
+    if resolved is None:
+        pytest.skip(f"no usable data for the {request.param} case")
+    return resolved
+
+
+@pytest.mark.parametrize("case", case_params, indirect=True)
 class TestCodecRoundtrip:
     """Every codec must perfectly roundtrip its values."""
 

--- a/dimos/robot/all_blueprints.py
+++ b/dimos/robot/all_blueprints.py
@@ -264,6 +264,7 @@ all_modules = {
     "receiver-module": "dimos.utils.demo_image_encoding.ReceiverModule",
     "recorder": "dimos.memory2.module.Recorder",
     "reid-module": "dimos.perception.detection.reid.module.ReidModule",
+    "relay-bridge-module": "dimos.web.relay_bridge.relay_bridge_module.RelayBridgeModule",
     "relocalization-module": "dimos.mapping.relocalization.module.RelocalizationModule",
     "replanning-a-star-planner": "dimos.navigation.replanning_a_star.module.ReplanningAStarPlanner",
     "rerun-bridge-module": "dimos.visualization.rerun.bridge.RerunBridgeModule",

--- a/dimos/robot/cli/dimos.py
+++ b/dimos/robot/cli/dimos.py
@@ -282,7 +282,12 @@ def _get_default_value(defaults: object, key: str, fallback: Any) -> Any:
     return fallback
 
 
-def load_config_args(config: type[BaseModel], args: Iterable[str], path: Path) -> dict[str, Any]:
+def load_config_args(
+    config: type[BaseModel],
+    args: Iterable[str],
+    path: Path,
+    cli_g_overrides: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     try:
         kwargs = json.loads(path.read_text())
     except (OSError, json.JSONDecodeError):
@@ -307,11 +312,31 @@ def load_config_args(config: type[BaseModel], args: Iterable[str], path: Path) -
             d = d.setdefault(p, {})
         d[parts[-1]] = v
 
+    if cli_g_overrides:
+        # Explicit CLI flags (--transport, --local-relay, ...) win for their
+        # own keys but must not wipe the rest of the g subtree built above.
+        kwargs.setdefault("g", {}).update(cli_g_overrides)
+
     # We don't need this config, but this atleast validates the user input first.
     # This will help catch misspellings and similar mistakes.
     config(**kwargs)
 
     return kwargs  # type: ignore[no-any-return]
+
+
+def _with_relay_bridge(blueprint: Blueprint) -> Blueprint:
+    """Append one relay bridge to an enabled CLI run after blueprint resolution."""
+    if not (global_config.local_relay or global_config.relay_url):
+        return blueprint
+
+    try:
+        from dimos.web.relay_bridge.relay_bridge_module import with_relay_bridge
+    except ImportError as e:
+        raise RuntimeError(
+            "--local-relay/--relay-url need the web extra: `uv sync --extra web --inexact`"
+        ) from e
+
+    return with_relay_bridge(blueprint)
 
 
 @main.command()
@@ -323,6 +348,14 @@ def run(
     blueprint_args: list[str] = typer.Option((), "--option", "-o"),
     config_path: Path = typer.Option(
         CONFIG_DIR / "dimos", "--config", "-c", help="Path to config file"
+    ),
+    local_relay: bool | None = typer.Option(
+        None,
+        "--local-relay/--no-local-relay",
+        help="Spawn a local cockpit relay and bridge this robot to it",
+    ),
+    relay_url: str | None = typer.Option(
+        None, "--relay-url", help="Bridge this robot to a running relay (wtUrl)"
     ),
     show_help: bool = typer.Option(False, "--help"),
 ) -> None:
@@ -346,6 +379,16 @@ def run(
     setup_exception_handler()
 
     cli_config_overrides: dict[str, Any] = ctx.obj
+
+    # These flags are accepted on `run` itself, not just as global options.
+    run_overrides = {
+        name: value
+        for name, value in (("local_relay", local_relay), ("relay_url", relay_url))
+        if value is not None
+    }
+    if run_overrides:
+        cli_config_overrides.update(run_overrides)
+        global_config.update(**run_overrides)
 
     # Clean stale registry entries
     stale = cleanup_stale()
@@ -372,6 +415,8 @@ def run(
         )
         blueprint = blueprint.disabled_modules(*disabled_classes)
 
+    blueprint = _with_relay_bridge(blueprint)
+
     if show_help:
         print("Blueprint arguments:")
         print("  Override with --option/-o module.field=value.")
@@ -380,9 +425,7 @@ def run(
         return
 
     blueprint_config = blueprint.config()
-    kwargs = load_config_args(blueprint_config, blueprint_args, config_path)
-    if cli_config_overrides:
-        kwargs["g"] = cli_config_overrides
+    kwargs = load_config_args(blueprint_config, blueprint_args, config_path, cli_config_overrides)
 
     coordinator = ModuleCoordinator.build(blueprint, kwargs)
 

--- a/dimos/robot/cli/test_dimos.py
+++ b/dimos/robot/cli/test_dimos.py
@@ -24,7 +24,13 @@ import dimos.core.coordination.worker_manager_python as worker_manager_python
 from dimos.core.global_config import global_config
 from dimos.core.module import Module, ModuleConfig
 from dimos.robot import external_blueprints as external
-from dimos.robot.cli.dimos import _normalize_simulation_argv, arg_help, load_config_args, main
+from dimos.robot.cli.dimos import (
+    _normalize_simulation_argv,
+    _with_relay_bridge,
+    arg_help,
+    load_config_args,
+    main,
+)
 import dimos.utils.cli.spy.run_spy as run_spy
 
 
@@ -142,6 +148,48 @@ def test_blueprint_arg_help_extra_args():
         "      * testmoduleb.ip: str (default: 1.1.1.1)",
         "",
     ]
+
+
+def test_load_config_args_merges_cli_g_overrides(tmp_path):
+    """CLI flags (--transport, --local-relay, ...) must merge into the g
+    subtree built from config file / G__* env / -o g.* args, not replace it:
+    a replace silently reverts every other g.* key to its default."""
+
+    class Config(ModuleConfig):
+        pass
+
+    class TestModuleG(Module):
+        config: Config
+
+    blueprint = TestModuleG.blueprint()
+    kwargs = load_config_args(
+        blueprint.config(),
+        ["g.robot_id=go2-lab", "g.local_relay=false"],
+        tmp_path / "config.json",
+        cli_g_overrides={"local_relay": True},
+    )
+    assert kwargs["g"]["robot_id"] == "go2-lab"  # survives the CLI overrides
+    assert kwargs["g"]["local_relay"] is True  # the explicit flag wins its own key
+
+
+def test_run_composition_leaves_blueprint_alone_when_relay_disabled() -> None:
+    class Config(ModuleConfig):
+        pass
+
+    class TestModule(Module):
+        config: Config
+
+    original_local_relay = global_config.local_relay
+    original_relay_url = global_config.relay_url
+    global_config.update(local_relay=False, relay_url=None)
+    try:
+        source = TestModule.blueprint()
+        assert _with_relay_bridge(source) is source
+    finally:
+        global_config.update(
+            local_relay=original_local_relay,
+            relay_url=original_relay_url,
+        )
 
 
 def test_blueprint_arg_help_required():

--- a/dimos/simulation/dimsim/dimsim_process.py
+++ b/dimos/simulation/dimsim/dimsim_process.py
@@ -16,7 +16,6 @@ import os
 from pathlib import Path
 import subprocess
 import threading
-import time
 from typing import IO
 
 from dimos.constants import DIMOS_PROJECT_ROOT
@@ -47,7 +46,6 @@ class DimSimProcess:
 
         if headless:
             ensure_playwright_chromium(deno_path)
-        _kill_port_holder(port)
 
         render = os.environ.get("DIMSIM_RENDER", "").strip()
         if not render:
@@ -111,25 +109,6 @@ class DimSimProcess:
         ]:
             t = threading.Thread(target=_reader, args=(stream, label), daemon=True)
             t.start()
-
-
-def _kill_port_holder(port: int) -> None:
-    """Kill any process listening on the given port."""
-    try:
-        result = subprocess.run(
-            ["lsof", "-ti", f":{port}"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-        pids = result.stdout.strip()
-        if pids:
-            for pid in pids.splitlines():
-                logger.info(f"Killing stale process {pid} on port {port}")
-                subprocess.run(["kill", pid], timeout=5)
-            time.sleep(0.5)
-    except Exception as e:
-        logger.warning(f"Failed to check/kill port {port}: {e}")
 
 
 def _deno_cmd(deno_path: str, repo_dir: Path) -> list[str]:

--- a/dimos/visualization/vis_module.py
+++ b/dimos/visualization/vis_module.py
@@ -61,7 +61,7 @@ def vis_module(
             rerun_config.setdefault("pubsubs", [LCM()])
             rerun_config.setdefault("rerun_open", global_config.rerun_open)
             rerun_config.setdefault("rerun_web", global_config.rerun_web)
-            return autoconnect(
+            bundle = autoconnect(
                 RerunBridgeModule.blueprint(
                     **rerun_config,
                 ),
@@ -69,7 +69,8 @@ def vis_module(
                 WebsocketVisModule.blueprint(),
             )
         case "none":
-            return autoconnect(WebsocketVisModule.blueprint())
+            bundle = autoconnect(WebsocketVisModule.blueprint())
         case _:
             valid = ", ".join(get_args(ViewerBackend))
             raise ValueError(f"Unknown viewer_backend {viewer_backend!r}. Expected one of: {valid}")
+    return bundle

--- a/dimos/web/relay_bridge/_wt_session.py
+++ b/dimos/web/relay_bridge/_wt_session.py
@@ -59,6 +59,11 @@ logger = setup_logger()
 # Received data frames waiting for the consumer; drop-oldest beyond this.
 _FRAME_QUEUE_MAX = 256
 
+# Relay-pushed control messages (subs snapshots, robots, manifest) waiting for
+# the consumer; drop-oldest beyond this. Snapshots are idempotent and resent,
+# so a dropped one heals on the next round.
+_CONTROL_QUEUE_MAX = 64
+
 # The relay's abort of its send half surfaces as a stream reset; also used
 # when this side resets a stale latest-wins stream.
 STALE_STREAM_ERROR_CODE = 0x01
@@ -92,6 +97,8 @@ class SessionProtocol(QuicConnectionProtocol):
         self.relay_error: Error | None = None
         self.frames: asyncio.Queue[DataFrame] = asyncio.Queue(maxsize=_FRAME_QUEUE_MAX)
         self.frames_dropped = 0
+        self.control_msgs: asyncio.Queue[Msg] = asyncio.Queue(maxsize=_CONTROL_QUEUE_MAX)
+        self.control_dropped = 0
         self.session_id: int | None = None
         self._pong_waiters: dict[int | float, asyncio.Future[Pong]] = {}
         self._frame_readers: dict[int, DataFrameReader | None] = {}
@@ -142,6 +149,13 @@ class SessionProtocol(QuicConnectionProtocol):
             waiter = self._pong_waiters.pop(msg.n, None)
             if waiter is not None and not waiter.done():
                 waiter.set_result(msg)
+        else:
+            # Session messages (subs snapshots, robots, manifest, ...) go to
+            # the consumer queue; see RelayClient.control_messages().
+            if self.control_msgs.full():
+                self.control_msgs.get_nowait()
+                self.control_dropped += 1
+            self.control_msgs.put_nowait(msg)
 
     def _stream_data_received(self, stream_id: int, data: bytes, ended: bool) -> None:
         # None marks a stream whose frame is already complete (the late FIN

--- a/dimos/web/relay_bridge/demo_smoke.py
+++ b/dimos/web/relay_bridge/demo_smoke.py
@@ -36,11 +36,28 @@ from urllib.parse import urlparse
 import cv2
 import numpy as np
 
-from dimos.web.relay_bridge.protocol import DataFrame
+from dimos.web.relay_bridge.protocol import (
+    ChannelSpec,
+    DataFrame,
+    Manifest,
+    RobotInfo,
+    RobotManifest,
+    Sub,
+    Subs,
+    Watch,
+)
 from dimos.web.relay_bridge.relay_process import RelayProcess
 from dimos.web.relay_bridge.wt_client import RelayClient
 
 WIDTH, HEIGHT = 640, 480
+
+ROBOT = RobotInfo(id="smoke", name="Smoke Demo", model="synthetic")
+MANIFEST = RobotManifest(
+    channels=[
+        ChannelSpec(ch="color_image", encoding="jpeg.v1", delivery="latest", maxHz=60.0),
+        ChannelSpec(ch="odom", encoding="pose.json.v1", delivery="reliable", maxHz=20.0),
+    ]
+)
 
 
 def make_jpeg(seq: int) -> bytes:
@@ -91,14 +108,60 @@ class ViewerStats:
         return " | ".join(parts) or "(nothing received yet)"
 
 
+async def _attach_viewer(viewer: RelayClient) -> None:
+    """watch the demo robot; the watch rides a lossy datagram, so it is
+    resent until the manifest reply proves it landed. Subs are driven by
+    _wait_subscribed, which resends them until the robot leg confirms."""
+    await viewer.hello()
+    deadline = time.monotonic() + 10
+    while True:
+        viewer.send_control(Watch(robotId=ROBOT.id))
+        with contextlib.suppress(asyncio.TimeoutError):
+            msg = await asyncio.wait_for(viewer._session.control_msgs.get(), 0.5)
+            while not isinstance(msg, Manifest):
+                msg = await asyncio.wait_for(viewer._session.control_msgs.get(), 0.5)
+            break
+        if time.monotonic() > deadline:
+            raise TimeoutError("viewer could not watch the demo robot")
+
+
+async def _wait_subscribed(robot: RelayClient, viewer: RelayClient, timeout: float = 10.0) -> None:
+    """Resend subs until the relay reports both channels wanted.
+
+    Subs ride lossy datagrams too, and the relay's subs snapshot to the robot
+    is the only proof of delivery: a one-shot Sub lost on a remote path would
+    never be healed. Polls the raw control queue - wait_for around the
+    control_messages() generator would close it permanently on timeout.
+    """
+    wanted = {spec.ch for spec in MANIFEST.channels}
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        for spec in MANIFEST.channels:
+            viewer.send_control(Sub(ch=spec.ch))
+        window = min(time.monotonic() + 0.5, deadline)
+        while time.monotonic() < window:
+            if robot.is_closed:
+                raise RuntimeError("relay session closed before viewers subscribed")
+            with contextlib.suppress(asyncio.TimeoutError):
+                msg = await asyncio.wait_for(
+                    robot._session.control_msgs.get(), window - time.monotonic()
+                )
+                if isinstance(msg, Subs) and wanted <= set(msg.chs):
+                    return
+    raise TimeoutError(
+        f"relay never reported viewers subscribed to {sorted(wanted)} within {timeout} s"
+    )
+
+
 async def run(url: str, secs: float) -> None:
     stats = ViewerStats()
     async with (
         await RelayClient.connect(url, "robot") as robot,
         await RelayClient.connect(url, "viewer") as viewer,
     ):
-        await robot.hello()
-        await viewer.hello()
+        await robot.hello(robot=ROBOT, manifest=MANIFEST)
+        await _attach_viewer(viewer)
+        await _wait_subscribed(robot, viewer)
         rtt = await viewer.ping()
         print(f"connected; datagram RTT {rtt * 1000:.1f} ms")
 

--- a/dimos/web/relay_bridge/e2e_support.py
+++ b/dimos/web/relay_bridge/e2e_support.py
@@ -1,0 +1,89 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared async helpers for relay end-to-end tests."""
+
+import asyncio
+from collections.abc import Callable, Sequence
+import time
+
+from dimos.web.relay_bridge.protocol import (
+    DataFrame,
+    Manifest,
+    Msg,
+    Sub,
+    Subs,
+    Watch,
+)
+from dimos.web.relay_bridge.wt_client import RelayClient
+
+
+async def next_control(client: RelayClient, timeout: float) -> Msg | None:
+    try:
+        return await asyncio.wait_for(client._session.control_msgs.get(), timeout)
+    except asyncio.TimeoutError:
+        return None
+
+
+async def attach_viewer(
+    viewer: RelayClient, robot_id: str, chs: Sequence[str], timeout: float = 10.0
+) -> None:
+    """Watch a robot and subscribe channels after the manifest confirms the watch."""
+    deadline = time.monotonic() + timeout
+    while True:
+        viewer.send_control(Watch(robotId=robot_id))
+        msg = await next_control(viewer, 0.5)
+        while msg is not None and not isinstance(msg, Manifest):
+            msg = await next_control(viewer, 0.5)
+        if isinstance(msg, Manifest):
+            break
+        if time.monotonic() >= deadline:
+            raise TimeoutError(f"no manifest for {robot_id} within {timeout} s")
+    for ch in chs:
+        viewer.send_control(Sub(ch=ch))
+
+
+async def wait_subs(
+    robot: RelayClient, chs: set[str], timeout: float = 10.0, *, exact: bool = False
+) -> None:
+    """Wait for a subscription snapshot covering, or exactly matching, ``chs``."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        msg = await next_control(robot, deadline - time.monotonic())
+        if not isinstance(msg, Subs):
+            continue
+        if set(msg.chs) == chs if exact else set(msg.chs) >= chs:
+            return
+    raise TimeoutError(f"no subs snapshot covering {chs} within {timeout} s")
+
+
+async def collect_until(
+    viewer: RelayClient,
+    done: Callable[[list[DataFrame]], bool],
+    timeout: float = 10.0,
+) -> list[DataFrame]:
+    """Consume viewer frames until ``done`` succeeds or the timeout expires."""
+    frames: list[DataFrame] = []
+
+    async def consume() -> None:
+        async for frame in viewer.frames():
+            frames.append(frame)
+            if done(frames):
+                return
+
+    try:
+        await asyncio.wait_for(consume(), timeout)
+    except asyncio.TimeoutError:
+        pass
+    return frames

--- a/dimos/web/relay_bridge/e2e_support.py
+++ b/dimos/web/relay_bridge/e2e_support.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Shared async helpers for relay end-to-end tests."""
+"""Shared helpers for relay bridge tests."""
 
 import asyncio
 from collections.abc import Callable, Sequence
@@ -26,7 +26,21 @@ from dimos.web.relay_bridge.protocol import (
     Subs,
     Watch,
 )
+from dimos.web.relay_bridge.relay_bridge_module import RelayBridgeModule
 from dimos.web.relay_bridge.wt_client import RelayClient
+
+
+def stop_module(module: RelayBridgeModule) -> None:
+    """module.stop(), then reap the loop's to_thread executor threads.
+
+    The framework never shuts down the loop's default executor, so tests that
+    drive a to_thread path (spawn/stop of a relay child) would trip the
+    conftest thread-leak check on the idle asyncio_* workers.
+    """
+    loop = module._loop
+    module.stop()
+    if loop is not None and not loop.is_closed():
+        loop.run_until_complete(loop.shutdown_default_executor())
 
 
 async def next_control(client: RelayClient, timeout: float) -> Msg | None:

--- a/dimos/web/relay_bridge/protocol.py
+++ b/dimos/web/relay_bridge/protocol.py
@@ -32,10 +32,19 @@ ProtocolError and kills only the affected stream.
 """
 
 from dataclasses import dataclass
+import json
 import struct
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, ValidationError
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    TypeAdapter,
+    ValidationError,
+    ValidationInfo,
+    field_validator,
+)
 
 from dimos.utils.logging_config import setup_logger
 
@@ -71,10 +80,50 @@ class _WireModel(BaseModel):
 # seq=1 as 1.0, breaking byte-exact encoding against the golden fixtures.
 
 
+class RobotInfo(_WireModel):
+    id: str
+    name: str
+    model: str
+
+
+class ChannelSpec(_WireModel):
+    """One robot->viewer stream (see ChannelSpec in protocol.ts).
+
+    Field names are the wire names, hence the camelCase.
+    """
+
+    ch: str
+    encoding: str
+    delivery: Delivery
+    maxHz: int | float
+
+
+class RobotManifest(_WireModel):
+    channels: list[ChannelSpec]
+
+
+# Sentinel validation context passed by every wire-decode path: lets Hello
+# tell wire input apart from local construction, mirroring `robot?: RobotInfo`
+# in protocol.ts -- absent is fine, but neither encoder ever emits null, so an
+# explicit null on the wire is a protocol violation. Locally, robot=None just
+# means absent (and encoders omit None fields).
+_WIRE_CTX: dict[str, Any] = {}
+
+
 class Hello(_WireModel):
     t: Literal["hello"] = "hello"
     v: int | float
     role: Role
+    # role=robot only: identity + channel manifest, registered by the relay.
+    robot: RobotInfo | None = None
+    manifest: RobotManifest | None = None
+
+    @field_validator("robot", "manifest", mode="before")
+    @classmethod
+    def _reject_wire_null(cls, value: Any, info: ValidationInfo) -> Any:
+        if value is None and info.context is _WIRE_CTX:
+            raise ValueError("explicit null (absent optional fields are omitted)")
+        return value
 
 
 class Welcome(_WireModel):
@@ -100,6 +149,47 @@ class Error(_WireModel):
     message: str
 
 
+# Session messages (T2): robot registration, viewer watch + per-channel
+# subscriptions, and the relay->robot subscription snapshot.
+class Robots(_WireModel):
+    t: Literal["robots"] = "robots"
+    robots: list[RobotInfo]
+
+
+class Watch(_WireModel):
+    t: Literal["watch"] = "watch"
+    robotId: str
+
+
+class Manifest(_WireModel):
+    t: Literal["manifest"] = "manifest"
+    robotId: str
+    channels: list[ChannelSpec]
+
+
+class Sub(_WireModel):
+    t: Literal["sub"] = "sub"
+    ch: str
+
+
+class Unsub(_WireModel):
+    t: Literal["unsub"] = "unsub"
+    ch: str
+
+
+class Subs(_WireModel):
+    """Relay->robot: the full set of channels with >= 1 subscribed viewer.
+
+    A snapshot (not a delta) because it rides lossy datagrams: any single
+    delivery heals the state. `n` is monotonic per robot; receivers ignore
+    stale/reordered snapshots.
+    """
+
+    t: Literal["subs"] = "subs"
+    chs: list[str]
+    n: int | float
+
+
 # Teleop datagrams (carried from T6 on; declared so the wire format is pinned
 # by fixtures from day one).
 class Twist(_WireModel):
@@ -116,7 +206,21 @@ class Stop(_WireModel):
     ts: int | float
 
 
-Msg = Hello | Welcome | Ping | Pong | Error | Twist | Stop
+Msg = (
+    Hello
+    | Welcome
+    | Ping
+    | Pong
+    | Error
+    | Robots
+    | Watch
+    | Manifest
+    | Sub
+    | Unsub
+    | Subs
+    | Twist
+    | Stop
+)
 
 # One pydantic-core pass takes raw peer bytes to a validated message: UTF-8
 # decoding, JSON parsing, and shape checks together, discriminated on "t".
@@ -126,8 +230,9 @@ _MSG_TA: TypeAdapter[Msg] = TypeAdapter(Annotated[Msg, Field(discriminator="t")]
 class FrameHeader(_WireModel):
     """Data-plane frame header.
 
-    `delivery` tells the relay how to forward without a manifest (T1 only; the
-    T2+ manifest replaces it). `meta` carries encoding-specific extras.
+    `delivery` tells the relay how to forward frames on channels the robot's
+    manifest does not declare (the manifest's delivery wins when present).
+    `meta` carries encoding-specific extras.
     """
 
     ch: str
@@ -144,21 +249,26 @@ class DataFrame:
 
 
 def msg_from_dict(data: dict[str, Any]) -> Msg:
+    # Through JSON, not validate_python: strict python-mode validation wants
+    # model instances for nested fields (hello.robot), but callers hold
+    # parsed-JSON dicts.
     try:
-        return _MSG_TA.validate_python(data)
+        return _MSG_TA.validate_json(json.dumps(data), context=_WIRE_CTX)
     except ValidationError as e:
         raise ProtocolError(f"invalid message: {e}") from e
 
 
 def _msg_from_json(data: bytes) -> Msg:
     try:
-        return _MSG_TA.validate_json(data)
+        return _MSG_TA.validate_json(data, context=_WIRE_CTX)
     except ValidationError as e:
         raise ProtocolError(f"invalid message: {e}") from e
 
 
 def encode_control_frame(msg: Msg) -> bytes:
-    body = msg.model_dump_json().encode()
+    # exclude_none: absent optional fields are omitted, matching
+    # JSON.stringify dropping undefined (no field is ever null on the wire).
+    body = msg.model_dump_json(exclude_none=True).encode()
     return struct.pack("<I", len(body)) + body
 
 
@@ -191,13 +301,13 @@ class ControlFrameReader:
 
 
 def encode_datagram(msg: Msg) -> bytes:
-    return msg.model_dump_json().encode()
+    return msg.model_dump_json(exclude_none=True).encode()
 
 
 def decode_datagram(data: bytes) -> Msg | None:
     """Returns None for datagrams that are not our JSON messages."""
     try:
-        return _MSG_TA.validate_json(data)
+        return _MSG_TA.validate_json(data, context=_WIRE_CTX)
     except ValidationError:
         return None
 

--- a/dimos/web/relay_bridge/relay_bridge_module.py
+++ b/dimos/web/relay_bridge/relay_bridge_module.py
@@ -1,0 +1,478 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""RelayBridgeModule: the robot side of the cockpit relay.
+
+Registers the robot (id + channel manifest) with a relay - spawned locally in
+--local-relay mode, or a remote one via relay_url - and forwards robot streams
+to it. Encoding is lazy: an input is subscribed, and frames are encoded, only
+while the relay reports at least one viewer subscribed to that channel, so a
+robot with no open cockpit does no encode work at all.
+
+Threading: input callbacks fire on the transport (LCM) thread, which gates on
+maxHz and encodes there (RerunBridge precedent, ~3 ms per JPEG), then hands
+the payload to the module event loop; all relay/session state lives on the
+loop. The supervisor task consumes relay subs snapshots and survives relay
+restarts (respawning the local child when it died).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Callable
+from dataclasses import dataclass, field
+import functools
+import json
+import socket
+import threading
+import time
+from typing import Any, TypeVar
+import webbrowser
+
+from pydantic import Field
+
+from dimos.core.coordination.blueprints import Blueprint, autoconnect
+from dimos.core.module import Module, ModuleConfig
+from dimos.core.stream import In
+from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
+from dimos.msgs.sensor_msgs.Image import Image
+from dimos.utils.logging_config import setup_logger
+from dimos.web.relay_bridge.protocol import (
+    ChannelSpec,
+    Delivery,
+    RobotInfo,
+    RobotManifest,
+    Subs,
+)
+from dimos.web.relay_bridge.relay_process import RelayProcess
+from dimos.web.relay_bridge.wt_client import (
+    RelayClient,
+    RelayRejectedError,
+    connect_with_backoff,
+)
+
+logger = setup_logger()
+
+_T = TypeVar("_T")
+_FrameMeta = dict[str, Any] | None
+_Sender = Callable[[bytes, _FrameMeta], None]
+
+_RECONNECT_PAUSE_S = 2.0
+
+# A SIGKILLed relay child sends no CONNECTION_CLOSE, so the QUIC session only
+# notices at idle timeout (tens of seconds). The child watchdog polls the
+# process instead and force-closes the session to trigger a prompt respawn.
+_CHILD_POLL_S = 1.0
+
+
+async def _blocking_call(func: Callable[..., _T], *args: Any) -> _T:
+    """Run blocking process work without abandoning its thread on cancellation."""
+    work = asyncio.create_task(asyncio.to_thread(func, *args))
+    cancelled: asyncio.CancelledError | None = None
+    while not work.done():
+        try:
+            await asyncio.shield(work)
+        except asyncio.CancelledError as exc:
+            cancelled = cancelled or exc
+        except BaseException:
+            break
+    try:
+        result = work.result()
+    except BaseException as exc:
+        if cancelled is not None:
+            raise cancelled from exc
+        raise
+    if cancelled is not None:
+        raise cancelled
+    return result
+
+
+async def _cancel_task(task: asyncio.Task[None] | None, name: str) -> None:
+    if task is None:
+        return
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    except Exception:
+        # A task that already died re-raises here; teardown must continue.
+        logger.exception(f"relay bridge {name} task failed during teardown")
+
+
+class RelayBridgeConfig(ModuleConfig):
+    relay_url: str | None = None
+    """Attach to a running relay (wtUrl). None: spawn a local one."""
+    local_port: int = 7780
+    """HTTP port of the spawned local relay; 0 picks an ephemeral port (tests)."""
+    open_browser: bool = True
+    """Open the local relay's page once it is up (local mode only)."""
+    robot_id: str = ""
+    """Relay identity; empty falls back to g.robot_id, then the hostname."""
+    robot_name: str = ""
+    """Display name; empty falls back to robot_id."""
+    jpeg_quality: int = 75
+    image_max_hz: float = Field(default=30.0, gt=0.0)
+    odom_max_hz: float = Field(default=20.0, gt=0.0)
+    available_channels: tuple[str, ...] | None = None
+    """Composition-provided channel allowlist; None derives from bound inputs."""
+
+
+def _encode_image(module: RelayBridgeModule, msg: Image) -> tuple[bytes, dict[str, Any] | None]:
+    # TurboJPEG via the message's own encoder (handles BGR/RGB/gray inputs).
+    return (
+        msg.to_jpeg_bytes(quality=module.config.jpeg_quality),
+        {"w": msg.width, "h": msg.height},
+    )
+
+
+def _encode_odom(
+    module: RelayBridgeModule, msg: PoseStamped
+) -> tuple[bytes, dict[str, Any] | None]:
+    pose = {
+        "x": msg.position.x,
+        "y": msg.position.y,
+        "z": msg.position.z,
+        "yaw": msg.yaw,
+        "ts": msg.ts,
+    }
+    return json.dumps(pose, separators=(",", ":")).encode(), None
+
+
+@dataclass(frozen=True)
+class ChannelDef:
+    ch: str
+    encoding: str
+    delivery: Delivery
+    max_hz: Callable[[RelayBridgeConfig], float]
+    encode: Callable[[RelayBridgeModule, Any], tuple[bytes, _FrameMeta]]
+
+
+@dataclass(slots=True)
+class _Session:
+    client: RelayClient
+    senders: dict[str, _Sender]
+    last_n: int | float = 0
+    unsubs: dict[str, Callable[[], None]] = field(default_factory=dict)
+    retired: threading.Event = field(default_factory=threading.Event)
+
+
+# The v0 channel table; every entry needs a matching `In` on the module.
+CHANNELS: tuple[ChannelDef, ...] = (
+    ChannelDef("color_image", "jpeg.v1", "latest", lambda c: c.image_max_hz, _encode_image),
+    ChannelDef("odom", "pose.json.v1", "reliable", lambda c: c.odom_max_hz, _encode_odom),
+)
+
+
+def build_manifest(config: RelayBridgeConfig, channels: tuple[ChannelDef, ...]) -> RobotManifest:
+    return RobotManifest(
+        channels=[
+            ChannelSpec(
+                ch=cd.ch, encoding=cd.encoding, delivery=cd.delivery, maxHz=cd.max_hz(config)
+            )
+            for cd in channels
+        ]
+    )
+
+
+def resolve_robot_info(config: RelayBridgeConfig) -> RobotInfo:
+    robot_id = config.robot_id or config.g.robot_id or socket.gethostname()
+    return RobotInfo(
+        id=robot_id,
+        name=config.robot_name or robot_id,
+        model=config.g.robot_model or "",
+    )
+
+
+class RelayBridgeModule(Module):
+    """Bridges robot streams to the relay; encodes only while viewers watch."""
+
+    config: RelayBridgeConfig
+    # Exact producer types (GO2Connection outputs) so autoconnect matches.
+    color_image: In[Image]
+    odom: In[PoseStamped]
+    # NEVER add handle_color_image/handle_odom methods here: _auto_bind_handlers
+    # subscribes any handle_<input> eagerly at start(), defeating lazy encode.
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._relay: RelayProcess | None = None
+        self._session: _Session | None = None
+        self._url: str | None = None
+        self._robot_info: RobotInfo | None = None
+        self._manifest: RobotManifest | None = None
+        self._channel_defs: tuple[ChannelDef, ...] = ()
+        self._min_interval: dict[str, float] = {}
+        self._last_input: dict[str, float] = {}
+        self.encoded: dict[str, int] = {cd.ch: 0 for cd in CHANNELS}
+
+    async def main(self) -> AsyncIterator[None]:
+        supervisor: asyncio.Task[None] | None = None
+        try:
+            self._robot_info = resolve_robot_info(self.config)
+            allowed = (
+                None
+                if self.config.available_channels is None
+                else frozenset(self.config.available_channels)
+            )
+            self._channel_defs = tuple(
+                cd
+                for cd in CHANNELS
+                if (allowed is None or cd.ch in allowed)
+                and self.inputs[cd.ch].transport is not None
+            )
+            self._min_interval = {cd.ch: 1.0 / cd.max_hz(self.config) for cd in self._channel_defs}
+            self._manifest = build_manifest(self.config, self._channel_defs)
+            self._url = self.config.relay_url or self.config.g.relay_url
+            if self._url is None:
+                self._url = await _blocking_call(self._spawn_relay, self.config.open_browser)
+            # The first connect fails fast: a relay that cannot be reached at
+            # startup should fail the module start visibly, not retry forever.
+            session = await self._connect_and_hello()
+            self._session = session
+            supervisor = asyncio.create_task(self._supervise(session))
+            logger.info(f"relay bridge up: robot={self._robot_info.id} relay={self._url}")
+            yield
+        finally:
+            try:
+                await _cancel_task(supervisor, "supervisor")
+                await self._disconnect()
+            finally:
+                if self._relay is not None:
+                    try:
+                        await _blocking_call(self._relay.stop)
+                    except Exception:
+                        # An orphaned Deno child would outlive this process holding
+                        # its port (it has no PDEATHSIG), so surface cleanup failure.
+                        logger.exception("relay bridge: stopping the local relay failed")
+
+    def _spawn_relay(self, open_browser: bool) -> str:
+        """Start a fresh local relay child (blocking; run via to_thread)."""
+        if self.config.local_port != 0:
+            try:
+                with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+                    probe.bind(("127.0.0.1", self.config.local_port))
+            except OSError as e:
+                raise RuntimeError(
+                    f"cannot start local relay: port {self.config.local_port} is unavailable"
+                ) from e
+        self._relay = RelayProcess(port=self.config.local_port)
+        info = self._relay.start()
+        logger.info(f"local relay ready: {info.debug_url}")
+        if open_browser:
+            webbrowser.open_new_tab(info.debug_url)
+        return info.wt_url
+
+    async def _connect_and_hello(self) -> _Session:
+        assert self._url is not None and self._robot_info is not None and self._manifest is not None
+        client = await connect_with_backoff(self._url, "robot", max_attempts=4)
+        try:
+            await client.hello(robot=self._robot_info, manifest=self._manifest)
+            senders = self._build_senders(client)
+        except BaseException:
+            try:
+                await client.close()
+            except Exception:
+                logger.exception("relay bridge: closing a failed relay session failed")
+            raise
+        return _Session(client, senders)
+
+    def _build_senders(self, client: RelayClient) -> dict[str, _Sender]:
+        senders: dict[str, _Sender] = {}
+        for cd in self._channel_defs:
+            if cd.delivery == "latest":
+                senders[cd.ch] = client.latest_writer(cd.ch).offer
+            else:
+                senders[cd.ch] = functools.partial(self._send_reliable, client, cd.ch)
+        return senders
+
+    def _send_reliable(
+        self, client: RelayClient, ch: str, payload: bytes, meta: dict[str, Any] | None
+    ) -> None:
+        client.send_frame(ch, payload, delivery="reliable", meta=meta)
+
+    async def _supervise(self, session: _Session) -> None:
+        """Consume subs snapshots; on session loss, reconnect (and respawn a
+        dead local relay child) until the module stops."""
+        watchdog: asyncio.Task[None] | None = None
+        try:
+            if self._relay is not None:
+                watchdog = asyncio.create_task(self._watch_child())
+            while True:
+                crashed = False
+                try:
+                    async for msg in session.client.control_messages():
+                        if isinstance(msg, Subs) and msg.n > session.last_n:
+                            session.last_n = msg.n
+                            self._reconcile(session, set(msg.chs))
+                    # The iterator only ends when the session closed.
+                except Exception:
+                    # An unguarded error here would silently end supervision while
+                    # the module stays "up" (never CancelledError: stop() cancels).
+                    crashed = True
+                    logger.exception("relay bridge supervisor error; recycling the relay session")
+                await self._disconnect(session)
+                if crashed:
+                    # Reconnect only pauses on FAILED connects; without this a
+                    # persistent reconcile error would recycle at handshake speed.
+                    await asyncio.sleep(_RECONNECT_PAUSE_S)
+                logger.warning("relay session lost; encoders stopped, reconnecting")
+                reconnected = await self._reconnect()
+                if reconnected is None:
+                    return
+                session = reconnected
+                self._session = session
+        finally:
+            await _cancel_task(watchdog, "watchdog")
+            await self._disconnect(session)
+
+    async def _watch_child(self) -> None:
+        """Close the session promptly when the local relay child dies (a kill
+        sends no CONNECTION_CLOSE; waiting for QUIC idle timeout is too slow).
+        The supervisor then respawns and reconnects."""
+        while True:
+            await asyncio.sleep(_CHILD_POLL_S)
+            relay, session = self._relay, self._session
+            if (
+                relay is not None
+                and not relay.is_running()
+                and session is not None
+                and not session.client.is_closed
+            ):
+                logger.warning("local relay child died; closing the session to reconnect")
+                await session.client.close()
+
+    async def _reconnect(self) -> _Session | None:
+        while True:
+            if self._relay is not None and not self._relay.is_running():
+                # The child is gone (crash, kill, or a previous respawn that
+                # failed): its QUIC port and cert die with it, so respawn and
+                # re-read the ready line. The browser page reconnects itself
+                # via the stable HTTP port. `not is_running()` rather than
+                # `poll() is not None`: a failed start leaves no process and
+                # poll() would read None forever, latching respawns off.
+                logger.warning("local relay child died; respawning")
+                try:
+                    await _blocking_call(self._relay.stop)
+                    self._url = await _blocking_call(self._spawn_relay, False)
+                except Exception:
+                    logger.exception("relay respawn failed; retrying")
+                    await asyncio.sleep(_RECONNECT_PAUSE_S)
+                    continue
+            try:
+                return await self._connect_and_hello()
+            except RelayRejectedError as e:
+                logger.error(f"relay rejected reconnect ({e.code}: {e.message}); not retrying")
+                return None
+            except Exception as e:
+                logger.warning(f"relay reconnect failed ({e}); retrying")
+                await asyncio.sleep(_RECONNECT_PAUSE_S)
+
+    def _reconcile(self, session: _Session, want: set[str]) -> None:
+        """Subscribe/unsubscribe inputs so exactly `want` is being encoded."""
+        for cd in self._channel_defs:
+            active = cd.ch in session.unsubs
+            should = cd.ch in want
+            if should and not active:
+                session.unsubs[cd.ch] = self.inputs[cd.ch].subscribe(
+                    functools.partial(self._on_input, session, cd, session.senders[cd.ch])
+                )
+                logger.info(f"relay bridge: viewer subscribed to {cd.ch}; encoding started")
+            elif active and not should:
+                unsubscribe = session.unsubs[cd.ch]
+                unsubscribe()
+                del session.unsubs[cd.ch]
+                logger.info(f"relay bridge: no viewers on {cd.ch}; encoding stopped")
+        unknown = want - {cd.ch for cd in self._channel_defs}
+        if unknown:
+            logger.debug(f"relay bridge: ignoring unknown channels {sorted(unknown)}")
+
+    def _on_input(self, session: _Session, cd: ChannelDef, sender: _Sender, msg: Any) -> None:
+        """Transport-thread callback: maxHz gate, encode, hand to the loop."""
+        if session.retired.is_set():
+            return
+        now = time.monotonic()
+        if now - self._last_input.get(cd.ch, 0.0) < self._min_interval[cd.ch]:
+            return
+        self._last_input[cd.ch] = now
+        try:
+            payload, meta = cd.encode(self, msg)
+        except Exception:
+            logger.exception(f"relay bridge: encoding {cd.ch} failed")
+            return
+        self.encoded[cd.ch] += 1
+        loop = self._loop
+        if loop is not None and loop.is_running():
+            loop.call_soon_threadsafe(self._offer, session, sender, payload, meta)
+
+    def _offer(self, session: _Session, sender: _Sender, payload: bytes, meta: _FrameMeta) -> None:
+        if session.retired.is_set() or self._session is not session:
+            return
+        try:
+            sender(payload, meta)
+        except Exception:
+            # Session mid-teardown (dead writer pump / closed connection): the
+            # supervisor is already reconnecting and will rebuild the senders.
+            return
+
+    async def _disconnect(self, session: _Session | None = None) -> None:
+        target = self._session if session is None else session
+        if target is None:
+            return
+        target.retired.set()
+        if self._session is target:
+            self._session = None
+        for ch, unsubscribe in tuple(target.unsubs.items()):
+            try:
+                unsubscribe()
+            except Exception:
+                logger.exception(f"relay bridge: unsubscribing {ch} failed")
+            finally:
+                target.unsubs.pop(ch, None)
+        try:
+            await target.client.close()
+        except Exception:
+            logger.exception("relay bridge: closing the relay session failed")
+
+
+def with_relay_bridge(blueprint: Blueprint) -> Blueprint:
+    """Append a relay bridge wired to the blueprint's channel producers."""
+    # An external or explicitly composed blueprint may already own a customized
+    # relay bridge. Preserve that atom rather than overriding its kwargs.
+    if any(atom.module is RelayBridgeModule for atom in blueprint.blueprints):
+        return blueprint
+
+    producer_keys: set[tuple[str, type]] = set()
+    for atom in blueprint.active_blueprints:
+        for stream in atom.streams:
+            if stream.direction != "out":
+                continue
+            effective_name = blueprint.remapping_map.get((atom.name, stream.name), stream.name)
+            if isinstance(effective_name, str):
+                producer_keys.add((effective_name, stream.type))
+
+    bridge_atom = RelayBridgeModule.blueprint().blueprints[0]
+    bridge_input_types = {
+        stream.name: stream.type for stream in bridge_atom.streams if stream.direction == "in"
+    }
+    available_channels = tuple(
+        channel.ch
+        for channel in CHANNELS
+        if (channel_type := bridge_input_types.get(channel.ch)) is not None
+        and (channel.ch, channel_type) in producer_keys
+    )
+    return autoconnect(
+        blueprint,
+        RelayBridgeModule.blueprint(available_channels=available_channels),
+    )

--- a/dimos/web/relay_bridge/relay_process.py
+++ b/dimos/web/relay_bridge/relay_process.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Spawn the Deno relay as a child process (used by tests and the smoke demo;
-T2 grows this into the RelayBridge module's managed relay process)."""
-
 from __future__ import annotations
 
 import collections
@@ -25,6 +22,7 @@ from pathlib import Path
 import queue
 import subprocess
 import threading
+import time
 from typing import IO
 
 from dimos.utils.deno import ensure_deno
@@ -85,19 +83,40 @@ class RelayProcess:
         ]
         for thread in self._threads:
             thread.start()
-        try:
-            self.info = self._ready_queue.get(timeout=self._timeout)
-        except queue.Empty:
-            code = self._process.poll()
-            self.stop()
-            stderr = "\n".join(self._stderr_tail)
-            state = f"exited with {code}" if code is not None else "still running"
-            raise RuntimeError(
-                f"relay produced no ready line within {self._timeout} s ({state}); "
-                f"stderr tail:\n{stderr}"
-            ) from None
+        deadline = time.monotonic() + self._timeout
+        while self.info is None:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                code = self._process.poll()
+                self.stop()
+                stderr = "\n".join(self._stderr_tail)
+                state = f"exited with {code}" if code is not None else "still running"
+                raise RuntimeError(
+                    f"relay produced no ready line within {self._timeout} s ({state}); "
+                    f"stderr tail:\n{stderr}"
+                )
+            try:
+                self.info = self._ready_queue.get(timeout=min(0.1, remaining))
+            except queue.Empty:
+                code = self._process.poll()
+                if code is None:
+                    continue
+                self.stop()
+                stderr = "\n".join(self._stderr_tail)
+                raise RuntimeError(
+                    f"relay exited with {code} before producing a ready line; "
+                    f"stderr tail:\n{stderr}"
+                ) from None
         logger.info(f"relay ready: {self.info}")
         return self.info
+
+    def poll(self) -> int | None:
+        """Child exit code; None while running (or after stop()/before start())."""
+        return None if self._process is None else self._process.poll()
+
+    def is_running(self) -> bool:
+        """True while a started child is alive."""
+        return self._process is not None and self._process.poll() is None
 
     def stop(self) -> None:
         if self._process is None:

--- a/dimos/web/relay_bridge/test_protocol.py
+++ b/dimos/web/relay_bridge/test_protocol.py
@@ -25,11 +25,16 @@ from dimos.web.relay_bridge.protocol import (
     MAX_DATA_FRAME_BYTES,
     MAX_HEADER_LEN,
     PROTOCOL_VERSION,
+    ChannelSpec,
     ControlFrameReader,
     DataFrameReader,
     FrameHeader,
+    Hello,
     Ping,
     ProtocolError,
+    RobotInfo,
+    RobotManifest,
+    Robots,
     decode_data_frame,
     decode_datagram,
     encode_control_frame,
@@ -190,6 +195,68 @@ def test_msg_from_dict_validates_types():
         msg_from_dict({"t": "bogus"})  # unknown type
     with pytest.raises(ProtocolError):
         msg_from_dict({"t": "ping", "n": True, "ts": 2.5})  # bool is not a number
+    # Mirrored-validator parity: protocol.ts must also reject prototype-chain
+    # keys instead of resolving them through Object.prototype (protocol_test.ts
+    # asserts the same three).
+    with pytest.raises(ProtocolError):
+        msg_from_dict({"t": "toString"})
+    with pytest.raises(ProtocolError):
+        msg_from_dict({"t": "constructor"})
+    with pytest.raises(ProtocolError):
+        msg_from_dict({"t": "hasOwnProperty"})
+
+
+def test_msg_from_dict_validates_nested_session_shapes():
+    robot = {"id": "go2-lab", "name": "Go2 Lab", "model": "unitree-go2"}
+    spec = {"ch": "odom", "encoding": "pose.json.v1", "delivery": "reliable", "maxHz": 20.5}
+    full = {"t": "hello", "v": 1, "role": "robot", "robot": robot, "manifest": {"channels": [spec]}}
+    assert msg_from_dict(full) == Hello(
+        v=1,
+        role="robot",
+        robot=RobotInfo(id="go2-lab", name="Go2 Lab", model="unitree-go2"),
+        manifest=RobotManifest(
+            channels=[
+                ChannelSpec(ch="odom", encoding="pose.json.v1", delivery="reliable", maxHz=20.5)
+            ]
+        ),
+    )
+    # hello stays valid without the optional robot/manifest (viewer form).
+    assert msg_from_dict({"t": "hello", "v": 1, "role": "viewer"}) == Hello(v=1, role="viewer")
+    bad = [
+        # Optional means absent-or-valid: explicit null is rejected on the
+        # wire (local construction with robot=None stays fine: absent).
+        {"t": "hello", "v": 1, "role": "robot", "robot": None},
+        {**full, "robot": {"id": 5, "name": "x", "model": "m"}},
+        {**full, "manifest": {"channels": [{**spec, "maxHz": "20"}]}},
+        {**full, "manifest": {"channels": [{**spec, "delivery": "bogus"}]}},
+        {**full, "manifest": {"channels": robot}},
+        {"t": "robots", "robots": {}},
+        {"t": "robots", "robots": [{"id": "a", "name": "b"}]},
+        {"t": "robots"},
+        {"t": "manifest", "channels": [spec]},
+        {"t": "watch"},
+        {"t": "subs", "chs": ["a", 5], "n": 1},
+        {"t": "subs", "chs": ["a"]},
+    ]
+    for data in bad:
+        with pytest.raises(ProtocolError):
+            msg_from_dict(data)
+
+
+def test_encode_omits_absent_optional_fields():
+    # A viewer hello must stay byte-identical to its T1 wire form: no
+    # "robot":null / "manifest":null keys (JSON.stringify omits undefined).
+    assert encode_datagram(Hello(v=1, role="viewer")) == b'{"t":"hello","v":1,"role":"viewer"}'
+
+
+def test_nested_roundtrip_returns_models():
+    msg = Robots(robots=[RobotInfo(id="a", name="A", model="m")])
+    decoded = decode_datagram(encode_datagram(msg))
+    assert decoded == msg
+    assert isinstance(decoded.robots[0], RobotInfo)
+    # Extra wire keys inside nested objects are ignored (forward compat).
+    extra = {"t": "watch", "robotId": "r", "later": 1}
+    assert msg_from_dict(extra) == msg_from_dict({"t": "watch", "robotId": "r"})
 
 
 def test_non_finite_numbers_rejected():

--- a/dimos/web/relay_bridge/test_relay_bridge_e2e.py
+++ b/dimos/web/relay_bridge/test_relay_bridge_e2e.py
@@ -1,0 +1,228 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end: a real RelayBridgeModule spawning a real relay child.
+
+The module runs standalone with hand-wired LCM transports (no coordinator);
+a Python viewer drives the full session flow: robots -> watch -> manifest ->
+sub -> decoded frames, plus lazy-encode stop on unsub and relay-child-death
+recovery. One file on purpose: --dist=loadfile keeps the module-scoped
+module + relay on a single xdist worker.
+
+Tests are sync and drive their viewer flows via asyncio.run: constructing a
+Module rebinds the constructing thread's current event loop (module.py
+get_loop), which corrupts pytest-asyncio's function-scoped loop teardown.
+"""
+
+import asyncio
+from collections.abc import Iterator
+import json
+import subprocess
+import sys
+import threading
+import time
+
+import numpy as np
+import pytest
+
+from dimos.core.transport import pLCMTransport
+from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
+from dimos.msgs.sensor_msgs.Image import Image
+from dimos.web.relay_bridge.e2e_support import attach_viewer, collect_until
+from dimos.web.relay_bridge.protocol import Unsub
+from dimos.web.relay_bridge.relay_bridge_module import RelayBridgeModule
+from dimos.web.relay_bridge.wt_client import RelayClient
+
+ROBOT_ID = "bridge-e2e"
+POSE = PoseStamped(ts=42.5, position=[1.5, -2.5, 0.25], orientation=[0.0, 0.0, 0.0, 1.0])
+_LISTENER = """
+import socket
+import time
+
+listener = socket.socket()
+listener.bind(("127.0.0.1", 0))
+listener.listen()
+print(listener.getsockname()[1], flush=True)
+time.sleep(60)
+"""
+
+
+class _Publisher:
+    """Publishes odom + color_image on their LCM topics from a daemon thread
+    (frames flow only once the bridge lazily subscribes, so a single publish
+    is never enough - keep them coming like a robot would)."""
+
+    def __init__(self) -> None:
+        self.odom = pLCMTransport("/rb_e2e/odom")
+        self.image = pLCMTransport("/rb_e2e/color_image")
+        self.stop = threading.Event()
+        arr = np.zeros((48, 64, 3), dtype=np.uint8)
+        arr[:, :, 1] = np.linspace(0, 255, 64, dtype=np.uint8)
+        self._image = Image.from_numpy(arr)
+        self._thread = threading.Thread(target=self._run, daemon=True)
+
+    def start(self) -> None:
+        self.odom.start()
+        self.image.start()
+        self._thread.start()
+
+    def _run(self) -> None:
+        while not self.stop.is_set():
+            self.odom.publish(POSE)
+            self.image.publish(self._image)
+            time.sleep(0.05)
+
+    def close(self) -> None:
+        self.stop.set()
+        self._thread.join(timeout=2)
+        self.odom.stop()
+        self.image.stop()
+
+
+@pytest.fixture(scope="module")
+def bridge() -> Iterator[RelayBridgeModule]:
+    module = RelayBridgeModule(local_port=0, open_browser=False, robot_id=ROBOT_ID)
+    odom_tr = pLCMTransport("/rb_e2e/odom")
+    image_tr = pLCMTransport("/rb_e2e/color_image")
+    odom_tr.start()
+    image_tr.start()
+    module.odom.transport = odom_tr
+    module.color_image.transport = image_tr
+    module.start()  # spawns the Deno relay, connects, registers
+    try:
+        yield module
+    finally:
+        module.stop()
+
+
+@pytest.fixture(scope="module")
+def publisher() -> Iterator[_Publisher]:
+    pub = _Publisher()
+    pub.start()
+    try:
+        yield pub
+    finally:
+        pub.close()
+
+
+def test_local_relay_port_collision_does_not_kill_listener() -> None:
+    listener = subprocess.Popen(
+        [sys.executable, "-c", _LISTENER],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    module: RelayBridgeModule | None = None
+    try:
+        assert listener.stdout is not None
+        port = int(listener.stdout.readline())
+        module = RelayBridgeModule(local_port=port, open_browser=False, robot_id="collision-test")
+
+        with pytest.raises(RuntimeError, match=rf"port {port} is unavailable"):
+            module._spawn_relay(False)
+
+        assert listener.poll() is None
+    finally:
+        if module is not None:
+            module.stop()
+        listener.terminate()
+        try:
+            listener.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            listener.kill()
+            listener.wait(timeout=5)
+        if listener.stdout is not None:
+            listener.stdout.close()
+
+
+def test_full_session_flow_and_lazy_encode(
+    bridge: RelayBridgeModule, publisher: _Publisher
+) -> None:
+    async def flow() -> None:
+        assert bridge._url is not None
+        async with await RelayClient.connect(bridge._url, "viewer") as viewer:
+            await viewer.hello()
+            # robots push carries the bridge's identity (drain until watch lands).
+            await attach_viewer(viewer, ROBOT_ID, ["odom", "color_image"])
+
+            frames = await collect_until(
+                viewer,
+                lambda fs: any(f.header.ch == "odom" for f in fs)
+                and any(f.header.ch == "color_image" for f in fs),
+                timeout=15.0,
+            )
+            odom = next(f for f in frames if f.header.ch == "odom")
+            pose = json.loads(odom.payload)
+            assert pose == {"x": 1.5, "y": -2.5, "z": 0.25, "yaw": 0.0, "ts": 42.5}
+            assert odom.header.delivery == "reliable"
+
+            image = next(f for f in frames if f.header.ch == "color_image")
+            assert bytes(image.payload[:2]) == b"\xff\xd8"  # real TurboJPEG output
+            assert image.header.meta == {"w": 64, "h": 48}
+            assert image.header.delivery == "latest"
+
+            # Unsub color_image: the bridge must stop encoding it entirely
+            # while odom (still subscribed) keeps flowing.
+            viewer.send_control(Unsub(ch="color_image"))
+            deadline = time.monotonic() + 10
+            while (
+                bridge._session is not None
+                and "color_image" in bridge._session.unsubs
+                and time.monotonic() < deadline
+            ):
+                await asyncio.sleep(0.05)
+            assert bridge._session is not None
+            assert "color_image" not in bridge._session.unsubs, "bridge never heard the unsub"
+
+            encoded_before = bridge.encoded["color_image"]
+            await asyncio.sleep(0.5)  # publisher keeps publishing the whole time
+            assert bridge.encoded["color_image"] == encoded_before
+            assert "odom" in bridge._session.unsubs
+
+    asyncio.run(flow())
+
+
+def test_relay_child_death_respawns_and_recovers(
+    bridge: RelayBridgeModule, publisher: _Publisher
+) -> None:
+    assert bridge._relay is not None and bridge._relay._process is not None
+    old_url = bridge._url
+    bridge._relay._process.kill()  # SIGKILL: no CONNECTION_CLOSE reaches the bridge
+
+    # The child watchdog notices, the supervisor respawns the relay (new QUIC
+    # port + cert) and reconnects.
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:
+        session = bridge._session
+        if (
+            bridge._url != old_url
+            and bridge._relay.poll() is None
+            and session is not None
+            and not session.client.is_closed
+        ):
+            break
+        time.sleep(0.1)
+    assert bridge._url != old_url, "relay child was never respawned"
+
+    async def flow() -> None:
+        # A fresh viewer attaches to the new relay and frames flow again.
+        assert bridge._url is not None
+        async with await RelayClient.connect(bridge._url, "viewer") as viewer:
+            await viewer.hello()
+            await attach_viewer(viewer, ROBOT_ID, ["odom"])
+            frames = await collect_until(
+                viewer, lambda fs: any(f.header.ch == "odom" for f in fs), timeout=15.0
+            )
+            assert any(f.header.ch == "odom" for f in frames)
+
+    asyncio.run(flow())

--- a/dimos/web/relay_bridge/test_relay_bridge_e2e.py
+++ b/dimos/web/relay_bridge/test_relay_bridge_e2e.py
@@ -18,7 +18,8 @@ The module runs standalone with hand-wired LCM transports (no coordinator);
 a Python viewer drives the full session flow: robots -> watch -> manifest ->
 sub -> decoded frames, plus lazy-encode stop on unsub and relay-child-death
 recovery. One file on purpose: --dist=loadfile keeps the module-scoped
-module + relay on a single xdist worker.
+module + relay on a single xdist worker. The child-kill test gets its own
+function-scoped bridge: it destroys the relay it is given.
 
 Tests are sync and drive their viewer flows via asyncio.run: constructing a
 Module rebinds the constructing thread's current event loop (module.py
@@ -39,7 +40,7 @@ import pytest
 from dimos.core.transport import pLCMTransport
 from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
 from dimos.msgs.sensor_msgs.Image import Image
-from dimos.web.relay_bridge.e2e_support import attach_viewer, collect_until
+from dimos.web.relay_bridge.e2e_support import attach_viewer, collect_until, stop_module
 from dimos.web.relay_bridge.protocol import Unsub
 from dimos.web.relay_bridge.relay_bridge_module import RelayBridgeModule
 from dimos.web.relay_bridge.wt_client import RelayClient
@@ -90,8 +91,7 @@ class _Publisher:
         self.image.stop()
 
 
-@pytest.fixture(scope="module")
-def bridge() -> Iterator[RelayBridgeModule]:
+def _start_bridge() -> tuple[RelayBridgeModule, pLCMTransport, pLCMTransport]:
     module = RelayBridgeModule(local_port=0, open_browser=False, robot_id=ROBOT_ID)
     odom_tr = pLCMTransport("/rb_e2e/odom")
     image_tr = pLCMTransport("/rb_e2e/color_image")
@@ -100,10 +100,34 @@ def bridge() -> Iterator[RelayBridgeModule]:
     module.odom.transport = odom_tr
     module.color_image.transport = image_tr
     module.start()  # spawns the Deno relay, connects, registers
+    return module, odom_tr, image_tr
+
+
+@pytest.fixture(scope="module")
+def bridge() -> Iterator[RelayBridgeModule]:
+    module, _, _ = _start_bridge()
     try:
         yield module
     finally:
         module.stop()
+
+
+@pytest.fixture
+def respawn_bridge() -> Iterator[RelayBridgeModule]:
+    """Function-scoped bridge for the relay-child-kill test.
+
+    The respawn creates a fresh relay child mid-test whose reader threads live
+    as long as the bridge, so a shared module-scoped bridge would trip the
+    conftest thread-leak check. Owning the bridge scopes those threads to the
+    test, with everything reaped here.
+    """
+    module, odom_tr, image_tr = _start_bridge()
+    try:
+        yield module
+    finally:
+        stop_module(module)
+        odom_tr.stop()
+        image_tr.stop()
 
 
 @pytest.fixture(scope="module")
@@ -193,8 +217,9 @@ def test_full_session_flow_and_lazy_encode(
 
 
 def test_relay_child_death_respawns_and_recovers(
-    bridge: RelayBridgeModule, publisher: _Publisher
+    respawn_bridge: RelayBridgeModule, publisher: _Publisher
 ) -> None:
+    bridge = respawn_bridge
     assert bridge._relay is not None and bridge._relay._process is not None
     old_url = bridge._url
     bridge._relay._process.kill()  # SIGKILL: no CONNECTION_CLOSE reaches the bridge

--- a/dimos/web/relay_bridge/test_relay_bridge_module.py
+++ b/dimos/web/relay_bridge/test_relay_bridge_module.py
@@ -40,6 +40,7 @@ from dimos.core.stream import Out
 from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
 from dimos.msgs.sensor_msgs.Image import Image
 from dimos.web.relay_bridge import relay_bridge_module
+from dimos.web.relay_bridge.e2e_support import stop_module
 from dimos.web.relay_bridge.protocol import Msg, RobotManifest, Subs
 from dimos.web.relay_bridge.relay_bridge_module import (
     CHANNELS,
@@ -160,19 +161,6 @@ class FakeRelay:
     def stop(self) -> None:
         self.stops += 1
         self.running = False
-
-
-def stop_module(module: RelayBridgeModule) -> None:
-    """module.stop(), then reap the loop's to_thread executor threads.
-
-    The framework never shuts down the loop's default executor, so tests that
-    drive a to_thread path (spawn/stop of a relay child) would trip the
-    conftest thread-leak check on the idle asyncio_* workers.
-    """
-    loop = module._loop
-    module.stop()
-    if loop is not None and not loop.is_closed():
-        loop.run_until_complete(loop.shutdown_default_executor())
 
 
 def wait_until(cond: Callable[[], bool], timeout: float = 5.0) -> bool:

--- a/dimos/web/relay_bridge/test_relay_bridge_module.py
+++ b/dimos/web/relay_bridge/test_relay_bridge_module.py
@@ -1,0 +1,708 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""RelayBridgeModule unit tests: no network, no Deno, no LCM.
+
+A fake relay client is injected under `connect_with_backoff` and fake
+transports under the module's `In` streams, so lazy subscribe/unsubscribe,
+the maxHz gate, the encode path, and reconnect are all observable directly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Callable
+from dataclasses import replace
+import json
+import socket
+import threading
+import time
+from typing import Any
+
+import numpy as np
+from pydantic import ValidationError
+import pytest
+
+from dimos.core.coordination.blueprints import autoconnect
+from dimos.core.module import Module, ModuleConfig
+from dimos.core.stream import Out
+from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
+from dimos.msgs.sensor_msgs.Image import Image
+from dimos.web.relay_bridge import relay_bridge_module
+from dimos.web.relay_bridge.protocol import Msg, RobotManifest, Subs
+from dimos.web.relay_bridge.relay_bridge_module import (
+    CHANNELS,
+    RelayBridgeConfig,
+    RelayBridgeModule,
+    build_manifest,
+    resolve_robot_info,
+    with_relay_bridge,
+)
+from dimos.web.relay_bridge.wt_client import RelayRejectedError
+
+
+class FakeWriter:
+    def __init__(self) -> None:
+        self.offers: list[tuple[bytes, dict[str, Any] | None]] = []
+
+    def offer(self, payload: bytes, meta: dict[str, Any] | None = None) -> None:
+        self.offers.append((payload, meta))
+
+
+class FakeClient:
+    """Duck-typed RelayClient: everything the module touches, nothing else."""
+
+    def __init__(self, hello_error: Exception | None = None) -> None:
+        self.hello_args: tuple[Any, Any] | None = None
+        self.hello_error = hello_error
+        self.control_msgs: asyncio.Queue[Msg] = asyncio.Queue()
+        self.closed = asyncio.Event()
+        self.writers: dict[str, FakeWriter] = {}
+        self.frames: list[tuple[str, bytes, str, dict[str, Any] | None]] = []
+        self.close_count = 0
+
+    async def hello(self, timeout: float = 5.0, *, robot: Any = None, manifest: Any = None) -> None:
+        self.hello_args = (robot, manifest)
+        if self.hello_error is not None:
+            raise self.hello_error
+
+    def latest_writer(self, ch: str, *, stale_after: float = 0.5) -> FakeWriter:
+        writer = FakeWriter()
+        self.writers[ch] = writer
+        return writer
+
+    def send_frame(
+        self,
+        ch: str,
+        payload: bytes,
+        *,
+        delivery: str = "reliable",
+        meta: dict[str, Any] | None = None,
+        ts: float | None = None,
+    ) -> int:
+        self.frames.append((ch, bytes(payload), delivery, meta))
+        return 1
+
+    async def control_messages(self) -> AsyncIterator[Msg]:
+        while True:
+            get = asyncio.ensure_future(self.control_msgs.get())
+            closed = asyncio.ensure_future(self.closed.wait())
+            try:
+                done, _ = await asyncio.wait({get, closed}, return_when=asyncio.FIRST_COMPLETED)
+            finally:
+                closed.cancel()
+                if not get.done():
+                    get.cancel()
+            if get in done:
+                yield get.result()
+                continue
+            return
+
+    async def close(self) -> None:
+        self.close_count += 1
+        self.closed.set()
+
+
+class FakeTransport:
+    """In-stream transport stub: counts subscribers, publishes synchronously
+    (the test thread plays the LCM callback thread)."""
+
+    def __init__(self) -> None:
+        self.subscribers: list[Callable[[Any], Any]] = []
+        self.unsubscribed = 0
+        self.unsubscribe_attempts = 0
+        self.unsubscribe_error: Exception | None = None
+
+    def subscribe(self, cb: Callable[[Any], Any], stream: Any = None) -> Callable[[], None]:
+        self.subscribers.append(cb)
+
+        def unsubscribe() -> None:
+            self.unsubscribe_attempts += 1
+            if self.unsubscribe_error is not None:
+                raise self.unsubscribe_error
+            self.subscribers.remove(cb)
+            self.unsubscribed += 1
+
+        return unsubscribe
+
+    def publish(self, msg: Any) -> None:
+        for cb in list(self.subscribers):
+            cb(msg)
+
+    def stop(self) -> None:  # called by In.stop() during module close
+        self.subscribers.clear()
+
+
+class FakeRelay:
+    """RelayProcess stand-in for the respawn/teardown paths."""
+
+    def __init__(self, running: bool) -> None:
+        self.running = running
+        self.stops = 0
+
+    def is_running(self) -> bool:
+        return self.running
+
+    def poll(self) -> int | None:
+        return None  # what a FAILED start reads: no process at all
+
+    def stop(self) -> None:
+        self.stops += 1
+        self.running = False
+
+
+def stop_module(module: RelayBridgeModule) -> None:
+    """module.stop(), then reap the loop's to_thread executor threads.
+
+    The framework never shuts down the loop's default executor, so tests that
+    drive a to_thread path (spawn/stop of a relay child) would trip the
+    conftest thread-leak check on the idle asyncio_* workers.
+    """
+    loop = module._loop
+    module.stop()
+    if loop is not None and not loop.is_closed():
+        loop.run_until_complete(loop.shutdown_default_executor())
+
+
+def wait_until(cond: Callable[[], bool], timeout: float = 5.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if cond():
+            return True
+        time.sleep(0.01)
+    return cond()
+
+
+def flush_loop(module: RelayBridgeModule) -> None:
+    """Wait until all callbacks already queued on the module loop have run."""
+    loop = module._loop
+    assert loop is not None
+    flushed = threading.Event()
+    loop.call_soon_threadsafe(flushed.set)
+    assert flushed.wait(timeout=5.0)
+
+
+def _make_bridge(
+    monkeypatch,
+    *,
+    wire: tuple[str, ...] = ("color_image", "odom"),
+    available_channels: tuple[str, ...] | None = None,
+    hello_errors: tuple[Exception | None, ...] = (),
+    relay: FakeRelay | None = None,
+) -> tuple[RelayBridgeModule, list[FakeClient]]:
+    clients: list[FakeClient] = []
+
+    async def fake_connect(url: str, role: str, **kwargs: Any) -> FakeClient:
+        error = hello_errors[len(clients)] if len(clients) < len(hello_errors) else None
+        clients.append(FakeClient(hello_error=error))
+        return clients[-1]
+
+    monkeypatch.setattr(relay_bridge_module, "connect_with_backoff", fake_connect)
+    module = RelayBridgeModule(
+        relay_url="https://127.0.0.1:1",
+        open_browser=False,
+        robot_id="unit-bot",
+        available_channels=available_channels,
+    )
+    module._relay = relay
+    for ch in wire:
+        getattr(module, ch).transport = FakeTransport()
+    module.start()
+    return module, clients
+
+
+@pytest.fixture
+def bridge(monkeypatch):
+    module, clients = _make_bridge(monkeypatch)
+    try:
+        yield module, clients
+    finally:
+        stop_module(module)
+
+
+def push(module: RelayBridgeModule, client: FakeClient, msg: Msg) -> None:
+    """Deliver a relay push onto the module's own event loop (queue affinity)."""
+    assert module._loop is not None
+    module._loop.call_soon_threadsafe(client.control_msgs.put_nowait, msg)
+
+
+def kill_session(module: RelayBridgeModule, client: FakeClient) -> None:
+    assert module._loop is not None
+    module._loop.call_soon_threadsafe(client.closed.set)
+
+
+def image_transport(module: RelayBridgeModule) -> FakeTransport:
+    transport = module.color_image.transport
+    assert isinstance(transport, FakeTransport)
+    return transport
+
+
+def odom_transport(module: RelayBridgeModule) -> FakeTransport:
+    transport = module.odom.transport
+    assert isinstance(transport, FakeTransport)
+    return transport
+
+
+def test_manifest_and_robot_info_content() -> None:
+    config = RelayBridgeConfig(robot_id="go2-lab", robot_name="Lab", image_max_hz=12.0)
+    manifest = build_manifest(config, CHANNELS)
+    assert [c.ch for c in manifest.channels] == ["color_image", "odom"]
+    image, odom = manifest.channels
+    assert (image.encoding, image.delivery, image.maxHz) == ("jpeg.v1", "latest", 12.0)
+    assert (odom.encoding, odom.delivery, odom.maxHz) == ("pose.json.v1", "reliable", 20.0)
+
+    info = resolve_robot_info(config)
+    assert (info.id, info.name) == ("go2-lab", "Lab")
+    # Fallback chain: explicit id -> global robot_id -> hostname.
+    fallback = resolve_robot_info(RelayBridgeConfig())
+    assert fallback.id == (RelayBridgeConfig().g.robot_id or socket.gethostname())
+    assert fallback.name == fallback.id
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("image_max_hz", 0.0),
+        ("image_max_hz", -1.0),
+        ("odom_max_hz", 0.0),
+        ("odom_max_hz", -1.0),
+    ],
+)
+def test_channel_rates_must_be_positive(field: str, value: float) -> None:
+    with pytest.raises(ValidationError):
+        RelayBridgeConfig(**{field: value})
+
+
+def test_start_registers_but_subscribes_nothing(bridge) -> None:
+    # Lazy-encode guard: if someone ever adds handle_color_image/handle_odom,
+    # _auto_bind_handlers would eagerly subscribe here and this fails.
+    module, clients = bridge
+    robot, manifest = clients[0].hello_args
+    assert robot.id == "unit-bot"
+    assert isinstance(manifest, RobotManifest) and len(manifest.channels) == 2
+    assert image_transport(module).subscribers == []
+    assert odom_transport(module).subscribers == []
+
+
+def test_subs_snapshot_toggles_subscriptions(bridge) -> None:
+    module, clients = bridge
+    push(module, clients[0], Subs(chs=["odom"], n=1))
+    assert wait_until(lambda: len(odom_transport(module).subscribers) == 1)
+    assert image_transport(module).subscribers == []
+
+    # A stale (already-seen n) snapshot must be ignored.
+    push(module, clients[0], Subs(chs=[], n=1))
+    time.sleep(0.1)
+    assert len(odom_transport(module).subscribers) == 1
+
+    push(module, clients[0], Subs(chs=[], n=2))
+    assert wait_until(lambda: odom_transport(module).subscribers == [])
+
+
+def test_unknown_channels_in_snapshot_are_ignored(bridge) -> None:
+    module, clients = bridge
+    push(module, clients[0], Subs(chs=["mystery", "odom"], n=1))
+    assert wait_until(lambda: len(odom_transport(module).subscribers) == 1)
+    assert image_transport(module).subscribers == []
+
+
+def test_encode_paths_and_max_hz_gate(bridge) -> None:
+    module, clients = bridge
+    client = clients[0]
+    push(module, client, Subs(chs=["color_image", "odom"], n=1))
+    assert wait_until(
+        lambda: image_transport(module).subscribers and odom_transport(module).subscribers
+    )
+
+    pose = PoseStamped(ts=42.5, position=[1.5, -2.5, 0.25], orientation=[0.0, 0.0, 0.0, 1.0])
+    odom_transport(module).publish(pose)
+    assert module.encoded["odom"] == 1
+    assert wait_until(lambda: len(client.frames) == 1)
+    ch, payload, delivery, _ = client.frames[0]
+    assert (ch, delivery) == ("odom", "reliable")
+    decoded = json.loads(payload)
+    assert decoded == {"x": 1.5, "y": -2.5, "z": 0.25, "yaw": 0.0, "ts": 42.5}
+
+    image = Image.from_numpy(np.zeros((8, 12, 3), dtype=np.uint8))
+    image_transport(module).publish(image)
+    assert module.encoded["color_image"] == 1
+    assert wait_until(lambda: client.writers["color_image"].offers)
+    jpeg, meta = client.writers["color_image"].offers[0]
+    assert jpeg[:2] == b"\xff\xd8"  # JPEG magic: TurboJPEG really encoded
+    assert meta == {"w": 12, "h": 8}
+
+    # maxHz gate: the first publish warmed the encode path (lazy imports cost
+    # ~250 ms), so this back-to-back pair reliably lands inside the 50 ms
+    # interval - exactly one of the two encodes.
+    time.sleep(0.06)
+    count = module.encoded["odom"]
+    odom_transport(module).publish(pose)
+    odom_transport(module).publish(pose)
+    assert module.encoded["odom"] == count + 1
+
+    # After the interval passes, encoding resumes.
+    time.sleep(0.06)
+    odom_transport(module).publish(pose)
+    assert wait_until(lambda: module.encoded["odom"] == count + 2)
+
+
+def test_session_loss_stops_encoders_and_reconnects(bridge) -> None:
+    module, clients = bridge
+    push(module, clients[0], Subs(chs=["odom"], n=5))
+    assert wait_until(lambda: odom_transport(module).subscribers)
+
+    kill_session(module, clients[0])
+    # Encoders stop the moment the session dies (no consumer = no work) ...
+    assert wait_until(lambda: odom_transport(module).subscribers == [])
+    # ... and the supervisor dials a fresh session with a reset n horizon,
+    # closing the dead client first (else its UDP socket leaks until GC).
+    assert wait_until(lambda: len(clients) == 2)
+    assert clients[0].close_count >= 1
+    push(module, clients[1], Subs(chs=["odom"], n=1))
+    assert wait_until(lambda: len(odom_transport(module).subscribers) == 1)
+
+
+def test_encode_started_in_old_session_is_not_sent_to_replacement(
+    monkeypatch,
+) -> None:
+    encode_started = threading.Event()
+    release_encode = threading.Event()
+
+    def blocking_encode(
+        module: RelayBridgeModule, msg: PoseStamped
+    ) -> tuple[bytes, dict[str, Any] | None]:
+        encode_started.set()
+        assert release_encode.wait(timeout=5.0)
+        return b"old-session-frame", None
+
+    odom = next(channel for channel in CHANNELS if channel.ch == "odom")
+    monkeypatch.setattr(
+        relay_bridge_module,
+        "CHANNELS",
+        tuple(
+            replace(channel, encode=blocking_encode) if channel.ch == "odom" else channel
+            for channel in CHANNELS
+        ),
+    )
+    module, clients = _make_bridge(monkeypatch)
+    publisher = threading.Thread(
+        target=odom_transport(module).publish,
+        args=(
+            PoseStamped(
+                ts=42.5,
+                position=[1.5, -2.5, 0.25],
+                orientation=[0.0, 0.0, 0.0, 1.0],
+            ),
+        ),
+    )
+    try:
+        push(module, clients[0], Subs(chs=[odom.ch], n=1))
+        assert wait_until(lambda: len(odom_transport(module).subscribers) == 1)
+
+        publisher.start()
+        assert encode_started.wait(timeout=5.0)
+        kill_session(module, clients[0])
+        assert wait_until(lambda: len(clients) == 2)
+        flush_loop(module)
+
+        release_encode.set()
+        publisher.join(timeout=5.0)
+        assert not publisher.is_alive()
+        flush_loop(module)
+
+        assert clients[1].frames == []
+    finally:
+        release_encode.set()
+        publisher.join(timeout=5.0)
+        stop_module(module)
+
+
+def test_stop_unsubscribes_and_closes(bridge) -> None:
+    module, clients = bridge
+    push(module, clients[0], Subs(chs=["color_image", "odom"], n=1))
+    assert wait_until(lambda: image_transport(module).subscribers)
+
+    image_tr, odom_tr = image_transport(module), odom_transport(module)
+    module.stop()
+    # The module's own teardown unsubscribed (not just the transports closing).
+    assert (image_tr.unsubscribed, odom_tr.unsubscribed) == (1, 1)
+    assert image_tr.subscribers == [] and odom_tr.subscribers == []
+    assert clients[0].close_count >= 1
+
+
+def test_failed_respawn_retries_until_success(bridge, monkeypatch) -> None:
+    # One failed respawn must not latch respawning off: the old gate read
+    # poll() - None after a failed start - and skipped the respawn branch
+    # forever, dialing the dead relay's old port instead.
+    module, clients = bridge
+    monkeypatch.setattr(relay_bridge_module, "_RECONNECT_PAUSE_S", 0.01)
+    spawns: list[int] = []
+
+    def fake_spawn(open_browser: bool) -> str:
+        spawns.append(1)
+        if len(spawns) == 1:
+            raise RuntimeError("ready-line timeout")
+        module._relay = FakeRelay(running=True)
+        return "https://127.0.0.1:2"
+
+    module._relay = FakeRelay(running=False)  # the post-failed-start poison
+    monkeypatch.setattr(module, "_spawn_relay", fake_spawn)
+    kill_session(module, clients[0])
+    assert wait_until(lambda: len(spawns) == 2)
+    assert wait_until(lambda: len(clients) == 2)
+
+
+def test_stop_waits_for_in_flight_respawn_and_stops_spawned_child(monkeypatch) -> None:
+    module, clients = _make_bridge(monkeypatch)
+    loop = module._loop
+    assert loop is not None
+    dead_relay = FakeRelay(running=False)
+    spawned_relay = FakeRelay(running=True)
+    spawn_started = threading.Event()
+    release_spawn = threading.Event()
+    spawn_completed = threading.Event()
+    stop_entered = threading.Event()
+    stop_returned = threading.Event()
+    stop_errors: list[BaseException] = []
+    stop_returned_before_spawn: list[bool] = []
+
+    def blocking_spawn(open_browser: bool) -> str:
+        spawn_started.set()
+        assert release_spawn.wait(timeout=5.0)
+        module._relay = spawned_relay
+        spawn_completed.set()
+        return "https://127.0.0.1:2"
+
+    real_stop_main = module._stop_main
+
+    def observed_stop_main() -> None:
+        stop_entered.set()
+        real_stop_main()
+
+    def stop() -> None:
+        try:
+            module.stop()
+            stop_returned_before_spawn.append(not spawn_completed.is_set())
+        except BaseException as error:
+            stop_errors.append(error)
+        finally:
+            stop_returned.set()
+
+    monkeypatch.setattr(module, "_spawn_relay", blocking_spawn)
+    monkeypatch.setattr(module, "_stop_main", observed_stop_main)
+    module._relay = dead_relay
+    kill_session(module, clients[0])
+    assert spawn_started.wait(timeout=5.0)
+
+    stopper = threading.Thread(target=stop)
+    stopper.start()
+    try:
+        assert stop_entered.wait(timeout=5.0)
+        assert not stop_returned.wait(timeout=0.25)
+    finally:
+        release_spawn.set()
+        stopper.join(timeout=5.0)
+        if module._loop is not None:
+            module.stop()
+        if not loop.is_closed():
+            loop.run_until_complete(loop.shutdown_default_executor())
+
+    assert not stopper.is_alive()
+    assert stop_errors == []
+    assert stop_returned_before_spawn == [False]
+    assert spawned_relay.stops >= 1
+    assert not spawned_relay.is_running()
+
+
+def test_stop_survives_dead_task(monkeypatch) -> None:
+    # A task that already died re-raises its exception when teardown awaits
+    # it; teardown must still unsubscribe inputs, close the client, and reach
+    # relay.stop() instead of aborting and orphaning everything.
+    crashed = threading.Event()
+
+    async def crash(module: RelayBridgeModule) -> None:
+        crashed.set()
+        raise RuntimeError("watchdog crashed earlier")
+
+    monkeypatch.setattr(RelayBridgeModule, "_watch_child", crash)
+    relay = FakeRelay(running=True)
+    module, clients = _make_bridge(monkeypatch, relay=relay)
+    try:
+        assert crashed.wait(timeout=5.0)
+        push(module, clients[0], Subs(chs=["color_image", "odom"], n=1))
+        assert wait_until(lambda: image_transport(module).subscribers)
+
+        image_tr, odom_tr = image_transport(module), odom_transport(module)
+        stop_module(module)
+        assert (image_tr.unsubscribed, odom_tr.unsubscribed) == (1, 1)
+        assert clients[0].close_count >= 1
+        assert relay.stops >= 1
+    finally:
+        stop_module(module)
+
+
+def test_unsubscribe_failure_does_not_skip_other_cleanup_or_leak_into_new_session(
+    bridge,
+) -> None:
+    module, clients = bridge
+    color = image_transport(module)
+    odom = odom_transport(module)
+    push(module, clients[0], Subs(chs=["color_image", "odom"], n=1))
+    assert wait_until(lambda: len(color.subscribers) == 1 and len(odom.subscribers) == 1)
+    old_session = module._session
+    assert old_session is not None
+    color.unsubscribe_error = RuntimeError("unsubscribe failed")
+
+    kill_session(module, clients[0])
+    assert wait_until(lambda: color.unsubscribe_attempts == 1)
+    assert wait_until(lambda: odom.unsubscribed == 1)
+    assert wait_until(lambda: len(clients) == 2)
+    assert old_session.unsubs == {}
+
+    color.publish(Image.from_numpy(np.zeros((8, 12, 3), dtype=np.uint8)))
+    flush_loop(module)
+
+    assert clients[1].writers["color_image"].offers == []
+
+
+def test_unwired_input_is_not_advertised_or_subscribed(monkeypatch) -> None:
+    module, clients = _make_bridge(monkeypatch, wire=("odom",))
+    try:
+        _, manifest = clients[0].hello_args
+        assert isinstance(manifest, RobotManifest)
+        assert [channel.ch for channel in manifest.channels] == ["odom"]
+
+        push(module, clients[0], Subs(chs=["color_image", "odom"], n=1))
+        assert wait_until(lambda: len(odom_transport(module).subscribers) == 1)
+        assert module._session is not None
+        assert "color_image" not in module._session.unsubs
+        assert len(clients) == 1  # supervisor alive, session not recycled
+        push(module, clients[0], Subs(chs=[], n=2))
+        assert wait_until(lambda: odom_transport(module).subscribers == [])
+    finally:
+        stop_module(module)
+
+
+def test_composition_channel_allowlist_filters_bound_inputs(monkeypatch) -> None:
+    module, clients = _make_bridge(monkeypatch, available_channels=("odom",))
+    try:
+        _, manifest = clients[0].hello_args
+        assert isinstance(manifest, RobotManifest)
+        assert [channel.ch for channel in manifest.channels] == ["odom"]
+
+        push(module, clients[0], Subs(chs=["color_image"], n=1))
+        assert wait_until(lambda: module._session is not None and module._session.last_n == 1)
+        assert image_transport(module).subscribers == []
+    finally:
+        stop_module(module)
+
+
+def test_relay_hello_rejection_stops_reconnect_attempts(monkeypatch) -> None:
+    conflict = RelayRejectedError("robot_id_conflict", "already connected")
+    module, clients = _make_bridge(monkeypatch, hello_errors=(None, conflict))
+    try:
+        kill_session(module, clients[0])
+        assert wait_until(lambda: len(clients) == 2)
+        flush_loop(module)
+        assert module._session is None
+        assert len(clients) == 2
+    finally:
+        stop_module(module)
+
+
+def test_supervisor_survives_reconcile_error(bridge, monkeypatch) -> None:
+    # An exception out of _reconcile must recycle the session (closing the old
+    # client), not silently end supervision with encoders latched on.
+    module, clients = bridge
+    monkeypatch.setattr(relay_bridge_module, "_RECONNECT_PAUSE_S", 0.01)
+    real = module._reconcile
+    calls: list[int] = []
+
+    def flaky(session: Any, want: set[str]) -> None:
+        calls.append(1)
+        if len(calls) == 1:
+            raise RuntimeError("boom")
+        real(session, want)
+
+    monkeypatch.setattr(module, "_reconcile", flaky)
+    push(module, clients[0], Subs(chs=["odom"], n=1))
+    assert wait_until(lambda: len(clients) == 2)
+    assert clients[0].close_count >= 1
+    push(module, clients[1], Subs(chs=["odom"], n=1))
+    assert wait_until(lambda: len(odom_transport(module).subscribers) == 1)
+
+
+def test_failed_start_stops_spawned_relay(monkeypatch) -> None:
+    # First-connect failure after a successful spawn happens before main yields;
+    # its unified finally must still reap the fresh child.
+    async def fail_connect(url: str, role: str, **kwargs: Any) -> FakeClient:
+        raise OSError("connect refused")
+
+    monkeypatch.setattr(relay_bridge_module, "connect_with_backoff", fail_connect)
+    module = RelayBridgeModule(local_port=0, open_browser=False, robot_id="unit-bot")
+    relay = FakeRelay(running=True)
+
+    def fake_spawn(open_browser: bool) -> str:
+        module._relay = relay
+        return "https://127.0.0.1:2"
+
+    monkeypatch.setattr(module, "_spawn_relay", fake_spawn)
+    with pytest.raises(OSError):
+        module.start()
+    stop_module(module)
+    assert relay.stops == 1
+
+
+# Composition helpers live at module level: under PEP 563 (`from __future__
+# import annotations`) a Module class defined inside a function loses its
+# streams, because its annotations cannot be resolved from module globals.
+class _EmptyConfig(ModuleConfig):
+    pass
+
+
+class _ImageProducer(Module):
+    config: _EmptyConfig
+    color_image: Out[Image]
+
+
+class _BareModule(Module):
+    config: _EmptyConfig
+
+
+def test_composition_adds_relay_to_non_visual_blueprint() -> None:
+    blueprint = with_relay_bridge(_ImageProducer.blueprint())
+    relay_atoms = [atom for atom in blueprint.blueprints if atom.module is RelayBridgeModule]
+
+    assert len(relay_atoms) == 1
+    assert relay_atoms[0].kwargs["available_channels"] == ("color_image",)
+
+
+def test_composition_ignores_disabled_producers() -> None:
+    source = _ImageProducer.blueprint().disabled_modules(_ImageProducer)
+    blueprint = with_relay_bridge(source)
+    relay_atom = next(atom for atom in blueprint.blueprints if atom.module is RelayBridgeModule)
+
+    assert relay_atom.kwargs["available_channels"] == ()
+
+
+def test_composition_preserves_existing_relay() -> None:
+    existing = RelayBridgeModule.blueprint(local_port=8899, available_channels=("odom",))
+    blueprint = with_relay_bridge(autoconnect(_BareModule.blueprint(), existing))
+    relay_atoms = [atom for atom in blueprint.blueprints if atom.module is RelayBridgeModule]
+
+    assert len(relay_atoms) == 1
+    assert relay_atoms[0].kwargs == {
+        "local_port": 8899,
+        "available_channels": ("odom",),
+    }

--- a/dimos/web/relay_bridge/test_relay_e2e.py
+++ b/dimos/web/relay_bridge/test_relay_e2e.py
@@ -19,7 +19,7 @@ single xdist worker.
 """
 
 import asyncio
-from collections.abc import AsyncIterator, Callable, Iterator
+from collections.abc import AsyncIterator, Iterator, Sequence
 import hashlib
 import json
 import statistics
@@ -28,9 +28,20 @@ import urllib.request
 
 import pytest
 
-from dimos.web.relay_bridge.protocol import DataFrame, FrameHeader
+from dimos.web.relay_bridge.e2e_support import attach_viewer, collect_until, wait_subs
+from dimos.web.relay_bridge.protocol import (
+    DataFrame,
+    FrameHeader,
+    RobotInfo,
+    Unsub,
+)
 from dimos.web.relay_bridge.relay_process import RelayProcess, RelayReadyInfo
-from dimos.web.relay_bridge.wt_client import RelayClient
+from dimos.web.relay_bridge.wt_client import RelayClient, RelayRejectedError
+
+# One robot identity for the whole module; function-scoped clients close before
+# the next test registers it. No manifest on purpose: undeclared channels take
+# the frame header's delivery, which is what these transport tests steer with.
+ROBOT = RobotInfo(id="e2e-bot", name="E2E Bot", model="test")
 
 
 @pytest.fixture(scope="module")
@@ -57,7 +68,7 @@ def own_relay() -> Iterator[RelayProcess]:
 async def robot(relay: RelayReadyInfo) -> AsyncIterator[RelayClient]:
     """A connected robot client with the hello handshake done."""
     async with await RelayClient.connect(relay.wt_url, "robot") as client:
-        await client.hello()
+        await client.hello(robot=ROBOT)
         yield client
 
 
@@ -69,25 +80,10 @@ async def viewer(relay: RelayReadyInfo) -> AsyncIterator[RelayClient]:
         yield client
 
 
-async def collect_until(
-    viewer: RelayClient,
-    done: Callable[[list[DataFrame]], bool],
-    timeout: float = 10.0,
-) -> list[DataFrame]:
-    """Consume viewer frames until `done(frames)` or `timeout` (returns what arrived)."""
-    frames: list[DataFrame] = []
-
-    async def _consume() -> None:
-        async for frame in viewer.frames():
-            frames.append(frame)
-            if done(frames):
-                return
-
-    try:
-        await asyncio.wait_for(_consume(), timeout)
-    except asyncio.TimeoutError:
-        pass
-    return frames
+async def attach(robot: RelayClient, viewer: RelayClient, chs: Sequence[str]) -> None:
+    """Standard preamble on top of the fixtures' hellos: viewer watch+sub, subs barrier."""
+    await attach_viewer(viewer, ROBOT.id, chs)
+    await wait_subs(robot, set(chs))
 
 
 async def fetch_stats(relay: RelayReadyInfo) -> dict:
@@ -108,14 +104,21 @@ def test_info_matches_ready_line(relay: RelayReadyInfo) -> None:
 async def test_robot_handshake_and_datagram_rtt(relay: RelayReadyInfo) -> None:
     # Connects manually: the hello handshake itself is under test here.
     async with await RelayClient.connect(relay.wt_url, "robot") as robot:
-        await robot.hello()
+        await robot.hello(robot=ROBOT)
         rtts = [await robot.ping() for _ in range(20)]
     assert statistics.median(rtts) < 0.1
+
+
+async def test_robot_hello_without_identity_is_rejected(relay: RelayReadyInfo) -> None:
+    async with await RelayClient.connect(relay.wt_url, "robot") as robot:
+        with pytest.raises(Exception, match="missing_robot_id"):
+            await robot.hello()
 
 
 async def test_reliable_channel_is_complete_and_intact(
     robot: RelayClient, viewer: RelayClient
 ) -> None:
+    await attach(robot, viewer, ["odom"])
     count = 100
     payloads = [seq.to_bytes(4, "little") * 256 for seq in range(count)]
     for seq, payload in enumerate(payloads):
@@ -135,6 +138,7 @@ async def test_reliable_channel_is_complete_and_intact(
 
 
 async def test_latest_channel_newest_wins(robot: RelayClient, viewer: RelayClient) -> None:
+    await attach(robot, viewer, ["cam"])
     writer = robot.latest_writer("cam")
     offered = 200
     for i in range(offered):
@@ -165,6 +169,7 @@ async def test_latest_channel_newest_wins(robot: RelayClient, viewer: RelayClien
 
 
 async def test_large_frame_1mib(robot: RelayClient, viewer: RelayClient) -> None:
+    await attach(robot, viewer, ["blob"])
     payload = bytes(range(256)) * 4096  # 1 MiB
     robot.send_frame("blob", payload, delivery="reliable")
     frames = await collect_until(viewer, lambda fs: any(f.header.ch == "blob" for f in fs))
@@ -175,6 +180,7 @@ async def test_large_frame_1mib(robot: RelayClient, viewer: RelayClient) -> None
 
 async def test_reset_stale_discards_partial_frame(robot: RelayClient, viewer: RelayClient) -> None:
     """A reset mid-frame must drop the partial on the relay and nothing else."""
+    await attach(robot, viewer, ["cam"])
     # 8 MiB cannot be flushed + ACKed within the same event-loop turn, so
     # the reset below reliably lands mid-transfer.
     big = robot.send_frame("cam", b"\xcd" * (8 * 1024 * 1024), delivery="latest")
@@ -200,6 +206,7 @@ async def test_reset_burst_does_not_wedge_robot_leg(
     used to silently end the robot stream loop. Bursting resets in the same
     event-loop turn as the sends makes that race near-certain.
     """
+    await attach(robot, viewer, ["cam"])
     for rnd in range(5):
         # The accept glue cannot have read all 50 preambles before the
         # resets land, so some streams are reset pre-acceptance.
@@ -222,14 +229,58 @@ async def test_reset_burst_does_not_wedge_robot_leg(
 async def test_stats_reflect_traffic(
     relay: RelayReadyInfo, robot: RelayClient, viewer: RelayClient
 ) -> None:
+    await attach(robot, viewer, ["odom"])
     robot.send_frame("odom", b"{}", delivery="reliable")
     await collect_until(viewer, lambda fs: len(fs) >= 1, timeout=5.0)
 
     stats = await fetch_stats(relay)
-    assert stats["robot"] is True
+    assert {"id": ROBOT.id, "name": ROBOT.name, "model": ROBOT.model} in stats["robots"]
     assert stats["viewers"] >= 1
-    assert stats["channels"]["odom"]["framesIn"] >= 1
-    assert stats["channels"]["odom"]["delivery"] == "reliable"
+    assert stats["perRobot"][ROBOT.id]["subs"] == ["odom"]
+    assert stats["perRobot"][ROBOT.id]["channels"]["odom"]["framesIn"] >= 1
+    assert stats["perRobot"][ROBOT.id]["channels"]["odom"]["delivery"] == "reliable"
+
+
+async def test_duplicate_robot_id_is_terminal_until_first_disconnects(
+    relay: RelayReadyInfo,
+) -> None:
+    async with await RelayClient.connect(relay.wt_url, "robot") as first:
+        await first.hello(robot=ROBOT)
+        async with await RelayClient.connect(relay.wt_url, "robot") as second:
+            with pytest.raises(RelayRejectedError) as exc_info:
+                await second.hello(robot=ROBOT)
+            assert exc_info.value.code == "robot_id_conflict"
+        assert not first.is_closed
+        assert await first.ping() < 5.0
+
+    deadline = time.monotonic() + 10.0
+    while time.monotonic() < deadline:
+        stats = await fetch_stats(relay)
+        if not stats["robots"]:
+            break
+        await asyncio.sleep(0.05)
+    assert (await fetch_stats(relay))["robots"] == []
+
+    async with await RelayClient.connect(relay.wt_url, "robot") as replacement:
+        await replacement.hello(robot=ROBOT)
+        assert await replacement.ping() < 5.0
+
+
+async def test_unsub_stops_forwarding_and_bridge_hears_it(
+    robot: RelayClient, viewer: RelayClient
+) -> None:
+    """Unsub drops the viewer's channel and the robot gets the shrunk snapshot."""
+    await attach(robot, viewer, ["cam", "odom"])
+    viewer.send_control(Unsub(ch="cam"))
+    # The snapshot shrinking to odom-only is both the assertion that the
+    # bridge hears the transition and the barrier that unsub was processed.
+    await wait_subs(robot, {"odom"}, exact=True)
+
+    robot.send_frame("cam", b"not-forwarded", delivery="latest")
+    robot.send_frame("odom", b"forwarded", delivery="reliable")
+    frames = await collect_until(viewer, lambda fs: any(f.header.ch == "odom" for f in fs))
+    assert [bytes(f.payload) for f in frames if f.header.ch == "odom"] == [b"forwarded"]
+    assert [f for f in frames if f.header.ch == "cam"] == []
 
 
 async def test_send_frame_paces_with_wait_delivered(robot: RelayClient) -> None:
@@ -243,6 +294,7 @@ async def test_malformed_robot_frame_is_dropped(
     relay: RelayReadyInfo, robot: RelayClient, viewer: RelayClient
 ) -> None:
     """A well-framed frame with an invalid header is dropped, not fatal."""
+    await attach(robot, viewer, ["cam"])
     before = (await fetch_stats(relay)).get("framesDropped", 0)
     # The client validates delivery, so model_construct skips it to put a
     # bogus value on the wire; the relay's validator must reject it.
@@ -269,6 +321,7 @@ async def test_malformed_robot_frame_is_dropped(
 
 async def test_latest_writer_resets_stale_stream(robot: RelayClient, viewer: RelayClient) -> None:
     """The writer auto-resets an in-flight stream when a newer frame is waiting."""
+    await attach(robot, viewer, ["cam"])
     writer = robot.latest_writer("cam", stale_after=0.02)
     # 8 MiB can't flush + ACK within stale_after, so it stays in flight.
     writer.offer(b"\xcd" * (8 * 1024 * 1024))
@@ -296,7 +349,7 @@ async def test_latest_writer_resets_stale_stream(robot: RelayClient, viewer: Rel
 async def test_close_signal_stops_writer_and_wakes_waiter(own_relay: RelayProcess) -> None:
     """Relay death terminates the connection, wakes wait_closed, stops the pump."""
     async with await RelayClient.connect(own_relay.info.wt_url, "robot") as robot:
-        await robot.hello()
+        await robot.hello(robot=ROBOT)
         writer = robot.latest_writer("cam")
         writer.offer(b"x" * 1000)
         await asyncio.sleep(0.1)  # let the pump start

--- a/dimos/web/relay_bridge/test_wt_client.py
+++ b/dimos/web/relay_bridge/test_wt_client.py
@@ -23,11 +23,19 @@ import asyncio
 import pytest
 
 from dimos.web.relay_bridge.protocol import (
+    ChannelSpec,
     DataFrame,
+    Error,
     FrameHeader,
+    Msg,
+    ProtocolError,
+    RobotInfo,
+    RobotManifest,
+    Role,
+    Subs,
     encode_data_frame,
 )
-from dimos.web.relay_bridge.wt_client import RelayClient
+from dimos.web.relay_bridge.wt_client import RelayClient, RelayRejectedError
 
 
 class StubSession:
@@ -35,8 +43,13 @@ class StubSession:
 
     def __init__(self) -> None:
         self.frames: asyncio.Queue[DataFrame] = asyncio.Queue()
+        self.control_msgs: asyncio.Queue[Msg] = asyncio.Queue()
         self.closed = asyncio.Event()
+        self.welcomed = asyncio.Event()
+        self.relay_error: Error | None = None
+        self.sent_msgs: list[Msg] = []
         self.frames_dropped = 0
+        self.control_dropped = 0
         self._next_id = 100
 
     def send_frame(self, header: FrameHeader, payload: bytes) -> int:
@@ -54,6 +67,9 @@ class StubSession:
 
     async def wait_closed(self) -> None:
         await self.closed.wait()
+
+    def send_msg(self, msg: Msg) -> None:
+        self.sent_msgs.append(msg)
 
 
 def _client(session: StubSession) -> RelayClient:
@@ -144,3 +160,123 @@ async def test_frames_drains_buffer_then_ends_on_close() -> None:
         seen.append(frame.header.seq)
     assert seen == [1, 2]
     assert client.is_closed
+
+
+async def test_control_messages_drain_then_end_on_close() -> None:
+    session = StubSession()
+    client = _client(session)
+    session.control_msgs.put_nowait(Subs(chs=["cam"], n=1))
+    session.control_msgs.put_nowait(Subs(chs=[], n=2))
+    session.closed.set()  # closed, but buffered snapshots must still drain
+
+    seen = [msg async for msg in client.control_messages()]
+    assert seen == [Subs(chs=["cam"], n=1), Subs(chs=[], n=2)]
+
+
+async def test_control_messages_wakes_on_late_push() -> None:
+    session = StubSession()
+    client = _client(session)
+
+    async def push_later() -> None:
+        await asyncio.sleep(0.02)
+        session.control_msgs.put_nowait(Subs(chs=["odom"], n=7))
+        await asyncio.sleep(0.02)
+        session.closed.set()
+
+    pusher = asyncio.ensure_future(push_later())
+    seen = [msg async for msg in client.control_messages()]
+    await pusher
+    assert seen == [Subs(chs=["odom"], n=7)]
+
+
+async def test_hello_oversized_datagram_refused() -> None:
+    # An unsendable datagram wedges aioquic's whole datagram queue, so an
+    # oversized hello must be refused before anything is queued. StubSession
+    # has no send_msg/welcomed: a guard placed after the first send would fail
+    # this test with AttributeError instead.
+    client = _client(StubSession())
+    manifest = RobotManifest(
+        channels=[
+            ChannelSpec(ch=f"channel_{i}", encoding="jpeg.v1", delivery="latest", maxHz=15.0)
+            for i in range(40)
+        ]
+    )
+    with pytest.raises(ProtocolError, match="hello datagram"):
+        await client.hello(robot=RobotInfo(id="r1", name="r1", model="test"), manifest=manifest)
+
+
+class FakeCtx:
+    def __init__(self) -> None:
+        self.exits = 0
+
+    async def __aexit__(self, *exc: object) -> None:
+        self.exits += 1
+        await asyncio.sleep(0)
+
+
+async def test_close_is_idempotent_and_concurrent_safe() -> None:
+    # Supervisor, watchdog, and teardown can all close the same client; a
+    # second __aexit__ entering the connect context manager while the first
+    # is still awaiting inside it would raise. Only the first may run.
+    ctx = FakeCtx()
+    client = RelayClient("https://127.0.0.1:1", "robot", StubSession(), ctx=ctx)
+    await asyncio.gather(client.close(), client.close())
+    await client.close()
+    assert ctx.exits == 1
+
+
+class BlockingCtx:
+    def __init__(self) -> None:
+        self.entered = asyncio.Event()
+        self.release = asyncio.Event()
+        self.exits = 0
+
+    async def __aexit__(self, *exc: object) -> None:
+        self.exits += 1
+        self.entered.set()
+        await self.release.wait()
+
+
+async def test_cancelled_close_waiter_does_not_cancel_shared_shutdown() -> None:
+    ctx = BlockingCtx()
+    client = RelayClient("https://127.0.0.1:1", "robot", StubSession(), ctx=ctx)
+
+    first = asyncio.create_task(client.close())
+    await asyncio.wait_for(ctx.entered.wait(), timeout=1.0)
+    first.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await first
+
+    second = asyncio.create_task(client.close())
+    await asyncio.sleep(0)
+    assert not second.done()
+
+    ctx.release.set()
+    await asyncio.wait_for(second, timeout=1.0)
+    assert ctx.exits == 1
+
+
+async def test_hello_rejection_preserves_error_code() -> None:
+    session = StubSession()
+    session.relay_error = Error(code="robot_id_conflict", message="already connected")
+    session.welcomed.set()
+    client = _client(session)
+
+    with pytest.raises(RelayRejectedError) as exc_info:
+        await client.hello(robot=RobotInfo(id="r1", name="r1", model="test"))
+
+    assert exc_info.value.code == "robot_id_conflict"
+    assert exc_info.value.message == "already connected"
+
+
+@pytest.mark.parametrize(
+    ("url", "role"),
+    [
+        ("https://127.0.0.1:1/viewer", "robot"),
+        ("https://127.0.0.1:1/robot", "viewer"),
+        ("https://127.0.0.1:1/unknown", "viewer"),
+    ],
+)
+async def test_connect_rejects_wrong_endpoint_path(url: str, role: Role) -> None:
+    with pytest.raises(ValueError, match="relay URL path"):
+        await RelayClient.connect(url, role)

--- a/dimos/web/relay_bridge/wt_client.py
+++ b/dimos/web/relay_bridge/wt_client.py
@@ -35,14 +35,34 @@ from dimos.web.relay_bridge.protocol import (
     Delivery,
     FrameHeader,
     Hello,
+    Msg,
     Ping,
     ProtocolError,
+    RobotInfo,
+    RobotManifest,
     Role,
+    encode_datagram,
 )
 
 logger = setup_logger()
 
 _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
+
+# aioquic never drops an unsendable datagram: max_datagram_size is fixed at
+# 1200 B (no PMTUD) and _write_application retries _datagrams_pending[0]
+# forever, so a datagram that cannot fit one packet (~1165 B encoded) wedges
+# every datagram queued behind it - hello resends, pings, all send_control.
+# Refuse to queue one; 1100 keeps margin under the real cliff.
+_HELLO_DATAGRAM_MAX_BYTES = 1100
+
+
+class RelayRejectedError(ProtocolError):
+    """The relay explicitly rejected this client's hello handshake."""
+
+    def __init__(self, code: str, message: str) -> None:
+        self.code = code
+        self.message = message
+        super().__init__(f"relay rejected hello: {code}: {message}")
 
 
 class RelayClient:
@@ -60,6 +80,7 @@ class RelayClient:
         self._ping_n = itertools.count(1)
         self._seq: dict[str, itertools.count[int]] = {}
         self._writers: list[LatestChannelWriter] = []
+        self._close_task: asyncio.Task[None] | None = None
 
     @classmethod
     async def connect(
@@ -86,7 +107,15 @@ class RelayClient:
             insecure = is_loopback
         if insecure and not is_loopback:
             raise ValueError(f"insecure=True is only allowed for loopback hosts, got {host!r}")
-        path = parsed.path if parsed.path not in ("", "/") else f"/{role}"
+        expected_path = f"/{role}"
+        if parsed.path in ("", "/"):
+            path = expected_path
+        elif parsed.path == expected_path:
+            path = parsed.path
+        else:
+            raise ValueError(
+                f"relay URL path must be {expected_path!r} for role={role}, got {parsed.path!r}"
+            )
 
         ctx = aioquic_connect(
             host,
@@ -116,30 +145,59 @@ class RelayClient:
         await self.close()
 
     async def close(self) -> None:
+        # Assign before the first await so concurrent watchdog/supervisor/
+        # teardown callers share one context-manager exit. Shielding keeps a
+        # cancelled caller from cancelling the shutdown itself; later callers
+        # still await its completion (or receive its exception).
+        if self._close_task is None:
+            self._close_task = asyncio.create_task(self._close())
+        await asyncio.shield(self._close_task)
+
+    async def _close(self) -> None:
         for writer in self._writers:
             writer.stop()
         self._writers.clear()
         await self._ctx.__aexit__(None, None, None)
 
-    async def hello(self, timeout: float = 5.0) -> None:
+    async def hello(
+        self,
+        timeout: float = 5.0,
+        *,
+        robot: RobotInfo | None = None,
+        manifest: RobotManifest | None = None,
+    ) -> None:
         """Send hello datagrams until the relay's welcome arrives.
 
-        Datagrams are lossy, so the hello is repeated every 200 ms. Raises
-        ProtocolError if the relay answers with an error (version mismatch),
-        TimeoutError if nothing answers within `timeout`.
+        Robot sessions carry their identity and channel manifest in the hello
+        (the relay registers the robot from it). Datagrams are lossy, so the
+        hello is repeated every 200 ms. Raises ProtocolError if the encoded
+        hello exceeds the datagram budget or the relay answers with an error
+        (version mismatch, missing robot id), TimeoutError if nothing answers
+        within `timeout`.
         """
+        msg = Hello(v=PROTOCOL_VERSION, role=self.role, robot=robot, manifest=manifest)
+        size = len(encode_datagram(msg))
+        if size > _HELLO_DATAGRAM_MAX_BYTES:
+            raise ProtocolError(
+                f"hello datagram is {size} B (limit {_HELLO_DATAGRAM_MAX_BYTES}); an "
+                "oversized datagram wedges aioquic's whole datagram queue - trim the manifest"
+            )
         deadline = time.monotonic() + timeout
         while True:
-            self._session.send_msg(Hello(v=PROTOCOL_VERSION, role=self.role))
+            self._session.send_msg(msg)
             with contextlib.suppress(asyncio.TimeoutError):
                 await asyncio.wait_for(self._session.welcomed.wait(), 0.2)
             if self._session.relay_error is not None:
                 err = self._session.relay_error
-                raise ProtocolError(f"relay rejected hello: {err.code}: {err.message}")
+                raise RelayRejectedError(err.code, err.message)
             if self._session.welcomed.is_set():
                 return
             if time.monotonic() >= deadline:
                 raise TimeoutError(f"no welcome from relay within {timeout} s")
+
+    def send_control(self, msg: Msg) -> None:
+        """Send one control message to the relay (datagram: lossy, ordered-less)."""
+        self._session.send_msg(msg)
 
     async def ping(self, timeout: float = 5.0) -> float:
         """Datagram ping; returns the round-trip time in seconds."""
@@ -217,10 +275,37 @@ class RelayClient:
         finally:
             closed.cancel()
 
+    async def control_messages(self) -> AsyncIterator[Msg]:
+        """Control messages pushed by the relay (subs snapshots, robots, ...).
+
+        Same contract as :meth:`frames`: buffered messages drain before the
+        close is honored, and cancelling the consumer never orphans the queue
+        getter. Ends when the session closes.
+        """
+        closed = asyncio.ensure_future(self._session.wait_closed())
+        try:
+            while True:
+                get = asyncio.ensure_future(self._session.control_msgs.get())
+                try:
+                    await asyncio.wait({get, closed}, return_when=asyncio.FIRST_COMPLETED)
+                    if not get.done():
+                        return
+                    msg = get.result()
+                finally:
+                    get.cancel()
+                yield msg
+        finally:
+            closed.cancel()
+
     @property
     def frames_dropped(self) -> int:
         """Frames dropped locally because the consumer lagged (drop-oldest)."""
         return self._session.frames_dropped
+
+    @property
+    def control_dropped(self) -> int:
+        """Control messages dropped locally under consumer lag (drop-oldest)."""
+        return self._session.control_dropped
 
 
 class LatestChannelWriter:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -529,6 +529,9 @@ ignore = [
 "dimos/models/Detic/*" = ["ALL"]
 # Naming needs to match the actual libraries.
 "stubs/*.pyi" = ["N801", "N802", "N803", "N815", "N816", "N818"]
+# Wire-protocol mirror: model field names are the wire names (camelCase,
+# pinned to protocol.ts by the golden fixtures).
+"dimos/web/relay_bridge/protocol.py" = ["N815"]
 # Polyfill module: re-exports ROS message types (with a dimos_lcm fallback).
 "dimos/types/ros_polyfill.py" = ["F401"]
 

--- a/web/relay/forward.ts
+++ b/web/relay/forward.ts
@@ -1,9 +1,11 @@
-// Robot->viewer forwarding: per-(viewer, channel) delivery policies over a
-// transport-blind ViewerSink, so the policy logic is unit-testable without
-// QUIC. The relay never parses payloads; it routes on the frame header only.
+// Robot->viewer forwarding primitives: per-(viewer, channel) delivery
+// policies over a transport-blind ViewerSink (unit-testable without QUIC),
+// plus the raw-QUIC robot stream readers. Routing lives in registry.ts; the
+// relay never parses payloads, only frame headers.
 import {
   concatBytes,
   type Delivery,
+  type FrameHeader,
   frameHeaderFromUnknown,
   peekDataFrameLengths,
 } from "@dimos/shared";
@@ -23,7 +25,7 @@ export interface ViewerSink {
   kick(reason: string): void;
 }
 
-interface ChannelPolicy {
+export interface ChannelPolicy {
   readonly delivery: Delivery;
   sent: number;
   dropped: number;
@@ -118,91 +120,19 @@ export class ReliableChannel implements ChannelPolicy {
   }
 }
 
-export interface ViewerHandle {
-  id: number;
-  sink: ViewerSink;
-  channels: Map<string, ChannelPolicy>;
-}
-
-interface ChannelInStats {
-  delivery: Delivery;
-  framesIn: number;
-  bytesIn: number;
-}
-
-/** Routes robot frames to every viewer through its per-channel policy. */
-export class Forwarder {
-  #viewers = new Set<ViewerHandle>();
-  #channelsIn = new Map<string, ChannelInStats>();
-  #nextViewerId = 1;
-  #framesDropped = 0;
-
-  addViewer(sink: ViewerSink): ViewerHandle {
-    const handle: ViewerHandle = { id: this.#nextViewerId++, sink, channels: new Map() };
-    this.#viewers.add(handle);
-    return handle;
-  }
-
-  removeViewer(handle: ViewerHandle): void {
-    this.#viewers.delete(handle);
-  }
-
-  get viewerCount(): number {
-    return this.#viewers.size;
-  }
-
-  /** Route one robot data frame (raw bytes, already length-complete). */
-  onRobotFrame(bytes: Uint8Array): void {
-    const lens = peekDataFrameLengths(bytes);
-    if (lens === null) return;
-    let header: ReturnType<typeof frameHeaderFromUnknown> = null;
-    try {
-      header = frameHeaderFromUnknown(
-        JSON.parse(headerDecoder.decode(bytes.subarray(8, 8 + lens.headerLen))),
-      );
-    } catch {
-      // bad UTF-8 or bad JSON: dropped below
-    }
-    if (header === null) {
-      this.#framesDropped++;
-      console.log("[relay] dropping robot frame with invalid header");
-      return;
-    }
-    const { ch, delivery } = header;
-
-    const stats = this.#channelsIn.get(ch) ?? { delivery, framesIn: 0, bytesIn: 0 };
-    stats.delivery = delivery;
-    stats.framesIn++;
-    stats.bytesIn += bytes.byteLength;
-    this.#channelsIn.set(ch, stats);
-
-    for (const viewer of this.#viewers) {
-      let policy = viewer.channels.get(ch);
-      if (policy === undefined || policy.delivery !== delivery) {
-        policy = delivery === "reliable"
-          ? new ReliableChannel(viewer.sink)
-          : new LatestChannel(viewer.sink);
-        viewer.channels.set(ch, policy);
-      }
-      policy.offer(bytes);
-    }
-  }
-
-  stats(): unknown {
-    return {
-      viewers: this.#viewers.size,
-      framesDropped: this.#framesDropped,
-      channels: Object.fromEntries(this.#channelsIn),
-      perViewer: [...this.#viewers].map((v) => ({
-        id: v.id,
-        channels: Object.fromEntries(
-          [...v.channels].map(([ch, p]) => [
-            ch,
-            { sent: p.sent, dropped: p.dropped, queued: p.queued() },
-          ]),
-        ),
-      })),
-    };
+/**
+ * Header of a length-complete robot data frame (raw bytes), or null if the
+ * header is truncated, malformed, or not valid UTF-8.
+ */
+export function parseRobotFrameHeader(bytes: Uint8Array): FrameHeader | null {
+  const lens = peekDataFrameLengths(bytes);
+  if (lens === null) return null;
+  try {
+    return frameHeaderFromUnknown(
+      JSON.parse(headerDecoder.decode(bytes.subarray(8, 8 + lens.headerLen))),
+    );
+  } catch {
+    return null; // bad UTF-8 or bad JSON
   }
 }
 

--- a/web/relay/forward_test.ts
+++ b/web/relay/forward_test.ts
@@ -1,8 +1,8 @@
-import { assert, assertEquals, assertRejects } from "@std/assert";
+import { assertEquals, assertRejects } from "@std/assert";
 import { encodeDataFrame, type FrameHeader } from "@dimos/shared";
 import {
-  Forwarder,
   LatestChannel,
+  parseRobotFrameHeader,
   readDataFrameBytes,
   readWebTransportPreamble,
   ReliableChannel,
@@ -113,56 +113,16 @@ Deno.test("reliable: queue overflow kicks the viewer", async () => {
   assertEquals(sink.kicked, "reliable channel overflow");
 });
 
-Deno.test("a slow viewer never delays another viewer", async () => {
-  const forwarder = new Forwarder();
-  const slow = new FakeSink(false);
-  const fast = new FakeSink();
-  forwarder.addViewer(slow);
-  forwarder.addViewer(fast);
-  for (let i = 0; i < 5; i++) forwarder.onRobotFrame(dataFrame("odom", i, "reliable"));
-  await tick();
-  assertEquals(fast.sent.length, 5);
-  assertEquals(slow.sent.length, 1); // stuck on its first write, rest queued
-  assertEquals(slow.kicked, null);
-});
-
-Deno.test("forwarder routes by header delivery and keeps channels independent", async () => {
-  const forwarder = new Forwarder();
-  const sink = new FakeSink(false);
-  const viewer = forwarder.addViewer(sink);
-  forwarder.onRobotFrame(dataFrame("color_image", 0, "latest"));
-  forwarder.onRobotFrame(dataFrame("color_image", 1, "latest"));
-  forwarder.onRobotFrame(dataFrame("color_image", 2, "latest"));
-  forwarder.onRobotFrame(dataFrame("odom", 0, "reliable"));
-  forwarder.onRobotFrame(dataFrame("odom", 1, "reliable"));
-  await tick();
-  assert(viewer.channels.get("color_image") instanceof LatestChannel);
-  assert(viewer.channels.get("odom") instanceof ReliableChannel);
-  // one color_image write in flight, newest pending, middle dropped
-  assertEquals(viewer.channels.get("color_image")!.dropped, 1);
-  // odom: one in flight, one queued, nothing dropped
-  assertEquals(viewer.channels.get("odom")!.dropped, 0);
-  assertEquals(viewer.channels.get("odom")!.queued(), 1);
-
-  const stats = forwarder.stats() as {
-    viewers: number;
-    channels: Record<string, { framesIn: number; bytesIn: number; delivery: string }>;
-  };
-  assertEquals(stats.viewers, 1);
-  assertEquals(stats.channels.color_image.framesIn, 3);
-  assertEquals(stats.channels.odom.framesIn, 2);
-  assertEquals(stats.channels.odom.delivery, "reliable");
-});
-
-Deno.test("junk frames are dropped without touching viewers", async () => {
-  const forwarder = new Forwarder();
-  const sink = new FakeSink();
-  forwarder.addViewer(sink);
-  forwarder.onRobotFrame(new Uint8Array([1, 2, 3])); // shorter than a header
-  const bad = new Uint8Array(16); // headerLen=0 -> JSON parse of "" fails
-  forwarder.onRobotFrame(bad);
-  await tick();
-  assertEquals(sink.sent.length, 0);
+Deno.test("parseRobotFrameHeader accepts valid frames and rejects junk", () => {
+  const good = dataFrame("odom", 4, "reliable");
+  assertEquals(parseRobotFrameHeader(good), { ch: "odom", seq: 4, ts: 4.5, delivery: "reliable" });
+  assertEquals(parseRobotFrameHeader(new Uint8Array([1, 2, 3])), null); // shorter than a header
+  assertEquals(parseRobotFrameHeader(new Uint8Array(16)), null); // headerLen=0 -> JSON.parse("")
+  const badDelivery = encodeDataFrame(
+    { ch: "cam", seq: 1, ts: 1.5, delivery: "bogus" } as unknown as FrameHeader,
+    new Uint8Array([7]),
+  );
+  assertEquals(parseRobotFrameHeader(badDelivery), null);
 });
 
 function byteStream(...chunks: Uint8Array[]): ReadableStream<Uint8Array> {
@@ -207,22 +167,4 @@ Deno.test("preamble: stream ending mid-preamble rejects", async () => {
     Error,
     "stream ended mid-preamble",
   );
-});
-
-Deno.test("a well-framed frame with an invalid header is dropped and counted", async () => {
-  const forwarder = new Forwarder();
-  const sink = new FakeSink();
-  forwarder.addViewer(sink);
-  // Parseable JSON header, but delivery is not a known value: must be rejected.
-  const badHeader = encodeDataFrame(
-    { ch: "cam", seq: 1, ts: 1.5, delivery: "bogus" } as unknown as FrameHeader,
-    new Uint8Array([7]),
-  );
-  forwarder.onRobotFrame(badHeader);
-  forwarder.onRobotFrame(new Uint8Array(16)); // headerLen=0 -> JSON.parse("") throws
-  forwarder.onRobotFrame(dataFrame("odom", 0, "reliable")); // valid -> routed
-  await tick();
-  assertEquals(sink.sent.length, 1);
-  const stats = forwarder.stats() as { framesDropped: number };
-  assertEquals(stats.framesDropped, 2);
 });

--- a/web/relay/registry.ts
+++ b/web/relay/registry.ts
@@ -1,0 +1,354 @@
+// Robot registry + subscription bookkeeping: robotId -> session, per-viewer
+// watch/sub state, and routing of robot frames to exactly the viewers that
+// asked for them. Transport-blind (sessions are peers behind small
+// interfaces) so every transition is unit-testable without QUIC.
+//
+// Subscription flow: viewers sub/unsub channels of their watched robot; after
+// every mutation the registry recomputes the active set (union over watchers)
+// and pushes a `subs` snapshot upstream when it changed. Snapshots ride lossy
+// datagrams, so server.ts also calls resendSnapshots() on an interval: any
+// single delivery heals bridge state (the bridge ignores stale `n`).
+
+import {
+  type ChannelSpec,
+  type Delivery,
+  encodeDatagram,
+  type Msg,
+  PROTOCOL_VERSION,
+  type RobotInfo,
+} from "@dimos/shared";
+
+import {
+  type ChannelPolicy,
+  LatestChannel,
+  parseRobotFrameHeader,
+  ReliableChannel,
+  type ViewerSink,
+} from "./forward.ts";
+
+// Subs snapshots ride a single QUIC datagram (~1200 B budget before QUIC
+// overhead); the Python bridge guards its hello the same way
+// (_HELLO_DATAGRAM_MAX_BYTES in wt_client.py).
+const DATAGRAM_BUDGET_BYTES = 1200;
+
+/** What the registry needs from a robot session. */
+export interface RobotPeer {
+  /** Set by the session once a valid robot hello arrived. */
+  readonly info: RobotInfo | null;
+  readonly channels: ChannelSpec[];
+  /** Close reason once closed; a closed session must never (re)register. */
+  readonly closed: string | null;
+  /** Control message upstream to the bridge (datagram: lossy, never blocks). */
+  sendMsg(msg: Msg): void;
+}
+
+/** What the registry needs from a viewer session (fakeable in tests). */
+export interface ViewerPeer {
+  readonly id: number;
+  watched: string | null;
+  readonly subs: Set<string>;
+  readonly policies: Map<string, ChannelPolicy>;
+  readonly sink: ViewerSink;
+  /** True once a valid hello arrived; robots pushes skip un-greeted viewers. */
+  greeted: boolean;
+  /** Push channel chosen at hello time (bidi stream or datagrams). */
+  sendMsg(msg: Msg): void;
+}
+
+interface ChannelInStats {
+  delivery: Delivery;
+  framesIn: number;
+  bytesIn: number;
+}
+
+interface RobotEntry {
+  peer: RobotPeer;
+  /** Manifest delivery per channel; frame-header delivery is the fallback. */
+  delivery: Map<string, Delivery>;
+  /** Snapshot counter, monotonic for this robot session's registration. */
+  n: number;
+  /** Last snapshot content, for change detection and periodic resend. */
+  lastChs: string[];
+  channelsIn: Map<string, ChannelInStats>;
+}
+
+export class Registry {
+  #robots = new Map<string, RobotEntry>();
+  #viewers = new Set<ViewerPeer>();
+  #framesDropped = 0;
+  #framesFromUnregistered = 0;
+
+  addViewer(viewer: ViewerPeer): void {
+    this.#viewers.add(viewer);
+  }
+
+  viewerClosed(viewer: ViewerPeer): void {
+    if (!this.#viewers.delete(viewer)) return;
+    if (viewer.watched !== null) this.#syncSubs(viewer.watched);
+  }
+
+  /**
+   * Register a robot session after its valid hello. Idempotent under hello
+   * resends. A different live peer with the same id is rejected so two bridges
+   * cannot continually displace one another.
+   */
+  registerRobot(peer: RobotPeer): boolean {
+    const info = peer.info;
+    if (info === null || peer.closed !== null) return false;
+    const entry = this.#robots.get(info.id);
+    if (entry !== undefined && entry.peer === peer) return true; // hello resend
+    if (entry !== undefined) {
+      console.log(`[relay] rejecting duplicate live robot id ${info.id}`);
+      return false;
+    }
+    const delivery = new Map(peer.channels.map((c) => [c.ch, c.delivery]));
+    this.#robots.set(info.id, {
+      peer,
+      delivery,
+      n: 0,
+      lastChs: [],
+      channelsIn: new Map(),
+    });
+    this.#pushRobots();
+    // Forced: gives a fresh bridge its baseline and reattaches surviving
+    // watchers after the old robot session has disconnected.
+    this.#syncSubs(info.id, true);
+    return true;
+  }
+
+  /** Session-closed hook; a no-op for an unregistered/rejected peer. */
+  robotClosed(peer: RobotPeer): void {
+    const id = peer.info?.id;
+    if (id === undefined) return;
+    const entry = this.#robots.get(id);
+    if (entry === undefined || entry.peer !== peer) return;
+    this.#robots.delete(id);
+    console.log(`[relay] robot ${id} disconnected`);
+    // Viewers keep watched/subs: a returning robot reattaches seamlessly.
+    this.#pushRobots();
+  }
+
+  /** Replies to viewer control messages; returns false if the session must close. */
+  onViewerMsg(viewer: ViewerPeer, msg: Msg, reply: (msg: Msg) => void): boolean {
+    if (msg.t !== "hello" && !viewer.greeted) {
+      reply({
+        t: "error",
+        code: "hello_required",
+        message: "send a valid role=viewer hello before viewer commands",
+      });
+      return false;
+    }
+    switch (msg.t) {
+      case "hello": {
+        if (msg.v !== PROTOCOL_VERSION) {
+          reply({
+            t: "error",
+            code: "version_mismatch",
+            message: `protocol v${PROTOCOL_VERSION} required, got v${msg.v}`,
+          });
+          return false;
+        }
+        if (msg.role !== "viewer") {
+          reply({
+            t: "error",
+            code: "role_mismatch",
+            message: "the /viewer endpoint requires role=viewer",
+          });
+          return false;
+        }
+        viewer.greeted = true;
+        // Repeat hellos repeat both replies: the Python viewer's control
+        // channel is datagrams, so this is its loss-healing path.
+        reply({ t: "welcome", v: PROTOCOL_VERSION });
+        reply(this.robotsMsg());
+        break;
+      }
+      case "ping":
+        reply({ t: "pong", n: msg.n, ts: msg.ts });
+        break;
+      case "watch": {
+        const entry = this.#robots.get(msg.robotId);
+        if (entry === undefined) {
+          reply({ t: "error", code: "unknown_robot", message: `no robot ${msg.robotId}` });
+          break;
+        }
+        const previous = viewer.watched;
+        if (previous !== null && previous !== msg.robotId) {
+          viewer.subs.clear();
+          viewer.policies.clear();
+        }
+        viewer.watched = msg.robotId;
+        if (previous !== null && previous !== msg.robotId) this.#syncSubs(previous);
+        this.#syncSubs(msg.robotId);
+        reply({ t: "manifest", robotId: msg.robotId, channels: entry.peer.channels });
+        break;
+      }
+      case "sub":
+      case "unsub": {
+        if (viewer.watched === null) {
+          reply({ t: "error", code: "no_watch", message: "watch a robot before sub/unsub" });
+          break;
+        }
+        if (msg.t === "sub") {
+          // Manifest-validated: unbounded ch strings would grow the subs
+          // snapshot past the datagram budget and silently freeze the
+          // robot's whole subscription control plane. A robot that declared
+          // no manifest at all (transport tests) has nothing to validate
+          // against and accepts any sub - production bridges always declare.
+          const entry = this.#robots.get(viewer.watched);
+          if (entry === undefined) {
+            reply({ t: "error", code: "unknown_robot", message: `no robot ${viewer.watched}` });
+            break;
+          }
+          if (entry.delivery.size > 0 && !entry.delivery.has(msg.ch)) {
+            reply({
+              t: "error",
+              code: "unknown_channel",
+              message: `no channel ${msg.ch.slice(0, 64)} on ${viewer.watched}`,
+            });
+            break;
+          }
+          viewer.subs.add(msg.ch);
+        } else {
+          viewer.subs.delete(msg.ch);
+        }
+        this.#syncSubs(viewer.watched);
+        break;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Route one robot data frame (raw bytes, already length-complete) to the
+   * viewers watching this robot and subscribed to its channel.
+   */
+  onRobotFrame(peer: RobotPeer, bytes: Uint8Array): void {
+    const id = peer.info?.id;
+    const entry = id === undefined ? undefined : this.#robots.get(id);
+    if (entry === undefined || entry.peer !== peer) {
+      // Frames race registration (the stream loop starts at accept time).
+      this.#framesFromUnregistered++;
+      return;
+    }
+    const header = parseRobotFrameHeader(bytes);
+    if (header === null) {
+      this.#framesDropped++;
+      console.log("[relay] dropping robot frame with invalid header");
+      return;
+    }
+    const ch = header.ch;
+    const delivery = entry.delivery.get(ch) ?? header.delivery;
+
+    const stats = entry.channelsIn.get(ch) ?? { delivery, framesIn: 0, bytesIn: 0 };
+    stats.delivery = delivery;
+    stats.framesIn++;
+    stats.bytesIn += bytes.byteLength;
+    entry.channelsIn.set(ch, stats);
+
+    for (const viewer of this.#viewers) {
+      if (viewer.watched !== id || !viewer.subs.has(ch)) continue;
+      let policy = viewer.policies.get(ch);
+      if (policy === undefined || policy.delivery !== delivery) {
+        policy = delivery === "reliable"
+          ? new ReliableChannel(viewer.sink)
+          : new LatestChannel(viewer.sink);
+        viewer.policies.set(ch, policy);
+      }
+      policy.offer(bytes);
+    }
+  }
+
+  /**
+   * Re-push every robot's current snapshot with a fresh `n` (called on an
+   * interval by server.ts). Content is unchanged, so a bridge that saw the
+   * previous snapshot reconciles to a no-op; one that missed it heals.
+   */
+  resendSnapshots(): void {
+    for (const entry of this.#robots.values()) {
+      entry.peer.sendMsg({ t: "subs", chs: entry.lastChs, n: ++entry.n });
+    }
+  }
+
+  robotsMsg(): Msg {
+    return { t: "robots", robots: this.#robotInfos() };
+  }
+
+  #robotInfos(): RobotInfo[] {
+    const robots: RobotInfo[] = [];
+    for (const entry of this.#robots.values()) {
+      if (entry.peer.info !== null) robots.push(entry.peer.info);
+    }
+    return robots;
+  }
+
+  stats(): unknown {
+    return {
+      robots: this.#robotInfos(),
+      viewers: this.#viewers.size,
+      framesDropped: this.#framesDropped,
+      framesFromUnregistered: this.#framesFromUnregistered,
+      perRobot: Object.fromEntries(
+        [...this.#robots].map(([id, e]) => [id, {
+          subs: e.lastChs,
+          channels: Object.fromEntries(e.channelsIn),
+        }]),
+      ),
+      perViewer: [...this.#viewers].map((v) => ({
+        id: v.id,
+        watched: v.watched,
+        subs: [...v.subs].sort(),
+        channels: Object.fromEntries(
+          [...v.policies].map(([ch, p]) => [
+            ch,
+            { sent: p.sent, dropped: p.dropped, queued: p.queued() },
+          ]),
+        ),
+      })),
+    };
+  }
+
+  /** Sorted union of the subs of every viewer watching `robotId`, kept to
+   * the current manifest when one was declared (a reconnect can shrink the
+   * manifest under surviving subs). */
+  #activeChs(robotId: string, delivery: Map<string, Delivery>): string[] {
+    const chs = new Set<string>();
+    for (const viewer of this.#viewers) {
+      if (viewer.watched !== robotId) continue;
+      for (const ch of viewer.subs) {
+        if (delivery.size === 0 || delivery.has(ch)) chs.add(ch);
+      }
+    }
+    return [...chs].sort();
+  }
+
+  /**
+   * Send a subs snapshot upstream iff the active set changed (or `force`).
+   * Recomputed from scratch on every mutation: no incremental refcounts to
+   * drift across watch switches, disconnects, and reconnects.
+   */
+  #syncSubs(robotId: string, force = false): void {
+    const entry = this.#robots.get(robotId);
+    if (entry === undefined) return;
+    const chs = this.#activeChs(robotId, entry.delivery);
+    if (!force && chs.join("\n") === entry.lastChs.join("\n")) return;
+    entry.lastChs = chs;
+    const msg: Msg = { t: "subs", chs, n: ++entry.n };
+    const size = encodeDatagram(msg).byteLength;
+    if (size > DATAGRAM_BUDGET_BYTES) {
+      // Unreachable while subs are manifest-validated (a manifest that fit
+      // its hello datagram implies a fitting snapshot). Loud if it ever
+      // happens: an oversized snapshot silently never reaches the robot.
+      console.error(`[relay] subs snapshot for ${robotId} is ${size} B (over datagram budget)`);
+    }
+    entry.peer.sendMsg(msg);
+    console.log(`[relay] robot ${robotId} active channels: [${chs.join(", ")}]`);
+  }
+
+  #pushRobots(): void {
+    const msg = this.robotsMsg();
+    for (const viewer of this.#viewers) {
+      if (viewer.greeted) viewer.sendMsg(msg);
+    }
+  }
+}

--- a/web/relay/registry_test.ts
+++ b/web/relay/registry_test.ts
@@ -1,0 +1,336 @@
+// Registry unit tests over fake peers: subscription snapshot transitions,
+// duplicate-id rejection, watch switching, robots pushes, and frame routing -
+// no QUIC.
+import { assert, assertEquals } from "@std/assert";
+import {
+  type ChannelSpec,
+  encodeDataFrame,
+  type FrameHeader,
+  type Msg,
+  PROTOCOL_VERSION,
+  type RobotInfo,
+  type SubsMsg,
+} from "@dimos/shared";
+import { type ChannelPolicy, LatestChannel, ReliableChannel, type ViewerSink } from "./forward.ts";
+import { Registry, type RobotPeer, type ViewerPeer } from "./registry.ts";
+
+class FakeSink implements ViewerSink {
+  sent: Uint8Array[] = [];
+  kicked: string | null = null;
+
+  sendFrame(bytes: Uint8Array): Promise<void> {
+    this.sent.push(bytes);
+    return Promise.resolve();
+  }
+
+  kick(reason: string): void {
+    this.kicked = reason;
+  }
+}
+
+class FakeRobot implements RobotPeer {
+  info: RobotInfo | null;
+  channels: ChannelSpec[];
+  msgs: Msg[] = [];
+  closed: string | null = null;
+
+  constructor(id: string, channels: ChannelSpec[] = []) {
+    this.info = { id, name: id, model: "test" };
+    this.channels = channels;
+  }
+
+  sendMsg(msg: Msg): void {
+    this.msgs.push(msg);
+  }
+
+  subs(): SubsMsg[] {
+    return this.msgs.filter((m): m is SubsMsg => m.t === "subs");
+  }
+
+  lastSubs(): SubsMsg {
+    const all = this.subs();
+    assert(all.length > 0, "expected at least one subs snapshot");
+    return all[all.length - 1];
+  }
+}
+
+class FakeViewer implements ViewerPeer {
+  static nextId = 1;
+  readonly id = FakeViewer.nextId++;
+  watched: string | null = null;
+  readonly subs = new Set<string>();
+  readonly policies = new Map<string, ChannelPolicy>();
+  readonly sink = new FakeSink();
+  greeted = false;
+  pushed: Msg[] = [];
+  replies: Msg[] = [];
+
+  sendMsg(msg: Msg): void {
+    this.pushed.push(msg);
+  }
+}
+
+function send(reg: Registry, viewer: FakeViewer, msg: Msg): boolean {
+  return reg.onViewerMsg(viewer, msg, (m) => viewer.replies.push(m));
+}
+
+/** hello -> watch -> sub for each channel; returns the greeted viewer. */
+function attach(reg: Registry, robotId: string, chs: string[]): FakeViewer {
+  const viewer = new FakeViewer();
+  reg.addViewer(viewer);
+  send(reg, viewer, { t: "hello", v: PROTOCOL_VERSION, role: "viewer" });
+  send(reg, viewer, { t: "watch", robotId });
+  for (const ch of chs) send(reg, viewer, { t: "sub", ch });
+  return viewer;
+}
+
+function frame(ch: string, seq: number, delivery: "latest" | "reliable" = "latest"): Uint8Array {
+  const header: FrameHeader = { ch, seq, ts: seq + 0.5, delivery };
+  return encodeDataFrame(header, new Uint8Array([seq]));
+}
+
+const SPECS: ChannelSpec[] = [
+  { ch: "color_image", encoding: "jpeg.v1", delivery: "latest", maxHz: 15 },
+  { ch: "odom", encoding: "pose.json.v1", delivery: "reliable", maxHz: 20 },
+];
+
+Deno.test("snapshots fire on 0->1 and ->0, not on redundant subs", () => {
+  const reg = new Registry();
+  const robot = new FakeRobot("r1", SPECS);
+  reg.registerRobot(robot);
+  assertEquals(robot.lastSubs(), { t: "subs", chs: [], n: 1 }); // forced baseline
+
+  const v1 = attach(reg, "r1", ["color_image"]);
+  assertEquals(robot.lastSubs(), { t: "subs", chs: ["color_image"], n: 2 });
+
+  const before = robot.subs().length;
+  const v2 = attach(reg, "r1", ["color_image"]); // same channel: set unchanged
+  assertEquals(robot.subs().length, before);
+
+  send(reg, v2, { t: "unsub", ch: "color_image" }); // still one subscriber
+  assertEquals(robot.subs().length, before);
+
+  send(reg, v1, { t: "unsub", ch: "color_image" }); // ->0
+  assertEquals(robot.lastSubs(), { t: "subs", chs: [], n: 3 });
+});
+
+Deno.test("viewer disconnect behaves like unsub", () => {
+  const reg = new Registry();
+  const robot = new FakeRobot("r1", SPECS);
+  reg.registerRobot(robot);
+  const viewer = attach(reg, "r1", ["odom", "color_image"]);
+  assertEquals(robot.lastSubs().chs, ["color_image", "odom"]);
+  reg.viewerClosed(viewer);
+  assertEquals(robot.lastSubs(), { t: "subs", chs: [], n: robot.subs().length });
+});
+
+Deno.test("watch switch moves subscriptions between robots", () => {
+  const reg = new Registry();
+  const r1 = new FakeRobot("r1", SPECS);
+  const r2 = new FakeRobot("r2", SPECS);
+  reg.registerRobot(r1);
+  reg.registerRobot(r2);
+  const viewer = attach(reg, "r1", ["odom"]);
+  assertEquals(r1.lastSubs().chs, ["odom"]);
+
+  send(reg, viewer, { t: "watch", robotId: "r2" }); // subs cleared on switch
+  assertEquals(r1.lastSubs().chs, []);
+  assertEquals(viewer.subs.size, 0);
+  send(reg, viewer, { t: "sub", ch: "color_image" });
+  assertEquals(r2.lastSubs().chs, ["color_image"]);
+});
+
+Deno.test("re-watching the same robot keeps subscriptions", () => {
+  const reg = new Registry();
+  const robot = new FakeRobot("r1", SPECS);
+  reg.registerRobot(robot);
+  const viewer = attach(reg, "r1", ["odom"]);
+  send(reg, viewer, { t: "watch", robotId: "r1" });
+  assertEquals(viewer.subs, new Set(["odom"]));
+  const manifests = viewer.replies.filter((m) => m.t === "manifest");
+  assertEquals(manifests.length, 2);
+  assertEquals((manifests[1] as { channels: ChannelSpec[] }).channels, SPECS);
+});
+
+Deno.test("duplicate live robot id is rejected; reconnect works after close", () => {
+  const reg = new Registry();
+  const first = new FakeRobot("r1", SPECS);
+  assertEquals(reg.registerRobot(first), true);
+  const watcher = attach(reg, "r1", ["odom"]);
+
+  const second = new FakeRobot("r1", SPECS);
+  assertEquals(reg.registerRobot(second), false);
+  assertEquals(first.closed, null);
+  assertEquals(second.subs(), []);
+  assertEquals(watcher.pushed, []);
+  assertEquals((reg.robotsMsg() as { robots: RobotInfo[] }).robots, [first.info!]);
+
+  reg.robotClosed(first);
+  assertEquals(reg.registerRobot(second), true);
+  // The returning robot reattaches the surviving viewer state and announces
+  // itself only after the old live registration is gone.
+  assertEquals(watcher.pushed, [
+    { t: "robots", robots: [] },
+    { t: "robots", robots: [second.info!] },
+  ]);
+  assertEquals(second.lastSubs(), { t: "subs", chs: ["odom"], n: 1 });
+});
+
+Deno.test("hello replies welcome + robots; register/close push robots", () => {
+  const reg = new Registry();
+  const viewer = new FakeViewer();
+  reg.addViewer(viewer);
+  send(reg, viewer, { t: "hello", v: PROTOCOL_VERSION, role: "viewer" });
+  assertEquals(viewer.replies[0], { t: "welcome", v: PROTOCOL_VERSION });
+  assertEquals(viewer.replies[1], { t: "robots", robots: [] });
+
+  const robot = new FakeRobot("r1", SPECS);
+  reg.registerRobot(robot);
+  assertEquals(viewer.pushed, [{ t: "robots", robots: [robot.info!] }]);
+
+  // A viewer that never helloed gets no pushes.
+  const silent = new FakeViewer();
+  reg.addViewer(silent);
+  reg.robotClosed(robot);
+  assertEquals(viewer.pushed[1], { t: "robots", robots: [] });
+  assertEquals(silent.pushed, []);
+});
+
+Deno.test("viewer hello rejects wrong version and role", () => {
+  const reg = new Registry();
+  const badVersion = new FakeViewer();
+  reg.addViewer(badVersion);
+  assertEquals(send(reg, badVersion, { t: "hello", v: 99, role: "viewer" }), false);
+  assertEquals((badVersion.replies[0] as { code: string }).code, "version_mismatch");
+  assertEquals(badVersion.greeted, false);
+
+  const badRole = new FakeViewer();
+  reg.addViewer(badRole);
+  assertEquals(
+    send(reg, badRole, { t: "hello", v: PROTOCOL_VERSION, role: "robot" }),
+    false,
+  );
+  assertEquals((badRole.replies[0] as { code: string }).code, "role_mismatch");
+  assertEquals(badRole.greeted, false);
+});
+
+Deno.test("viewer commands before hello are rejected without changing state", () => {
+  const reg = new Registry();
+  const robot = new FakeRobot("r1", SPECS);
+  reg.registerRobot(robot);
+  const viewer = new FakeViewer();
+  reg.addViewer(viewer);
+
+  assertEquals(send(reg, viewer, { t: "watch", robotId: "r1" }), false);
+  assertEquals((viewer.replies[0] as { code: string }).code, "hello_required");
+  assertEquals(viewer.watched, null);
+  assertEquals(viewer.subs, new Set());
+});
+
+Deno.test("frames route only to watching+subscribed viewers", () => {
+  const reg = new Registry();
+  const r1 = new FakeRobot("r1", SPECS);
+  const r2 = new FakeRobot("r2", SPECS);
+  reg.registerRobot(r1);
+  reg.registerRobot(r2);
+  const subscribed = attach(reg, "r1", ["odom"]);
+  const otherChannel = attach(reg, "r1", ["color_image"]);
+  const otherRobot = attach(reg, "r2", ["odom"]);
+  const noSub = attach(reg, "r1", []);
+
+  reg.onRobotFrame(r1, frame("odom", 1));
+  assertEquals(subscribed.sink.sent.length, 1);
+  assertEquals(otherChannel.sink.sent.length, 0);
+  assertEquals(otherRobot.sink.sent.length, 0);
+  assertEquals(noSub.sink.sent.length, 0);
+});
+
+Deno.test("manifest delivery wins over the frame header's", () => {
+  const reg = new Registry();
+  const robot = new FakeRobot("r1", SPECS); // odom declared reliable
+  reg.registerRobot(robot);
+  const viewer = attach(reg, "r1", ["odom"]);
+  reg.onRobotFrame(robot, frame("odom", 1, "latest")); // header says latest
+  assert(viewer.policies.get("odom") instanceof ReliableChannel);
+});
+
+Deno.test("sub to an undeclared channel is rejected", () => {
+  const reg = new Registry();
+  const robot = new FakeRobot("r1", SPECS);
+  reg.registerRobot(robot);
+  const viewer = attach(reg, "r1", []);
+  const before = robot.subs().length;
+  send(reg, viewer, { t: "sub", ch: "mystery" });
+  assertEquals((viewer.replies.at(-1) as { code: string }).code, "unknown_channel");
+  assertEquals(viewer.subs.size, 0);
+  assertEquals(robot.subs().length, before); // no new snapshot went out
+});
+
+Deno.test("a robot that declared no manifest accepts any sub", () => {
+  // The transport e2e tests hello without a manifest and steer delivery via
+  // frame headers; with nothing to validate against, subs pass through.
+  const reg = new Registry();
+  const robot = new FakeRobot("r1", []);
+  reg.registerRobot(robot);
+  const viewer = attach(reg, "r1", ["anything"]);
+  assertEquals(robot.lastSubs().chs, ["anything"]);
+  assertEquals(viewer.replies.filter((m) => m.t === "error"), []);
+});
+
+Deno.test("sub while the watched robot is offline is rejected", () => {
+  const reg = new Registry();
+  const robot = new FakeRobot("r1", SPECS);
+  reg.registerRobot(robot);
+  const viewer = attach(reg, "r1", []);
+  reg.robotClosed(robot);
+  send(reg, viewer, { t: "sub", ch: "odom" });
+  assertEquals((viewer.replies.at(-1) as { code: string }).code, "unknown_robot");
+  assertEquals(viewer.subs.size, 0);
+});
+
+Deno.test("reconnect-stale sub is filtered from snapshots, frames fall back to header delivery", () => {
+  const reg = new Registry();
+  const withMystery: ChannelSpec[] = [
+    ...SPECS,
+    { ch: "mystery", encoding: "x", delivery: "latest", maxHz: 1 },
+  ];
+  const first = new FakeRobot("r1", withMystery);
+  reg.registerRobot(first);
+  const viewer = attach(reg, "r1", ["mystery"]);
+  assertEquals(first.lastSubs().chs, ["mystery"]);
+
+  const second = new FakeRobot("r1", SPECS); // manifest shrank across restart
+  reg.robotClosed(first);
+  reg.registerRobot(second);
+  // The surviving sub is no longer in the manifest: snapshots must not carry
+  // it (an out-of-manifest union could outgrow the datagram budget) ...
+  assertEquals(second.lastSubs().chs, []);
+  // ... but if the robot still sends the channel, routing falls back to the
+  // frame header's delivery.
+  reg.onRobotFrame(second, frame("mystery", 1, "latest"));
+  assert(viewer.policies.get("mystery") instanceof LatestChannel);
+});
+
+Deno.test("invalid and unregistered frames are dropped and counted", () => {
+  const reg = new Registry();
+  const ghost = new FakeRobot("ghost", []);
+  reg.onRobotFrame(ghost, frame("odom", 1)); // never registered
+  const robot = new FakeRobot("r1", SPECS);
+  reg.registerRobot(robot);
+  const viewer = attach(reg, "r1", ["odom"]);
+  reg.onRobotFrame(robot, new Uint8Array(16)); // headerLen=0 -> invalid
+  assertEquals(viewer.sink.sent.length, 0);
+  const stats = reg.stats() as { framesDropped: number; framesFromUnregistered: number };
+  assertEquals(stats.framesDropped, 1);
+  assertEquals(stats.framesFromUnregistered, 1);
+});
+
+Deno.test("resendSnapshots repeats the last set with a fresh n", () => {
+  const reg = new Registry();
+  const robot = new FakeRobot("r1", SPECS);
+  reg.registerRobot(robot);
+  attach(reg, "r1", ["odom"]);
+  const last = robot.lastSubs();
+  reg.resendSnapshots();
+  assertEquals(robot.lastSubs(), { t: "subs", chs: last.chs, n: last.n + 1 });
+});

--- a/web/relay/server.ts
+++ b/web/relay/server.ts
@@ -1,28 +1,17 @@
 // The DimOS relay: QUIC/WebTransport listener (robot + viewer sessions) plus
 // a plain-HTTP side (static files, /api/info, /api/stats). Payload-blind:
-// all forwarding decisions come from frame headers (see forward.ts).
-//
-// Leg asymmetry, forced by upstream bugs (see web/README.md):
-// - Robot (aioquic): control = datagrams; data = one-shot bidi streams the
-//   relay never writes on (send half aborted with RESET, never FIN).
-// - Viewer (browser): control = viewer-opened bidi stream; data = relay-
-//   opened uni streams.
-import {
-  ControlFrameReader,
-  decodeDatagram,
-  encodeControlFrame,
-  encodeDatagram,
-  type Msg,
-  PROTOCOL_VERSION,
-} from "@dimos/shared";
+// all forwarding decisions come from frame headers and robot manifests.
+// Session/transport handling lives in session.ts, registration + routing in
+// registry.ts; this file owns the listeners and process-level wiring.
+import { PROTOCOL_VERSION } from "@dimos/shared";
 import { fileURLToPath } from "node:url";
 import { makeEphemeralCert } from "./cert.ts";
-import {
-  Forwarder,
-  readDataFrameBytes,
-  readWebTransportPreamble,
-  type ViewerSink,
-} from "./forward.ts";
+import { Registry } from "./registry.ts";
+import { RobotSession, ViewerSession } from "./session.ts";
+
+// Subs snapshots ride lossy datagrams; this resend interval is the loss- and
+// reorder-healing mechanism (bridges ignore stale `n`).
+const SNAPSHOT_RESEND_MS = 2_000;
 
 export interface RelayOptions {
   /** TCP port for the HTTP side. Default 7780; 0 picks an ephemeral port. */
@@ -83,183 +72,18 @@ export async function startRelay(options: RelayOptions = {}): Promise<RelayHandl
   const urlHost = host === "0.0.0.0" ? "127.0.0.1" : host;
   const wtUrl = `https://${urlHost}:${quicPort}`;
 
-  const forwarder = new Forwarder();
+  const registry = new Registry();
   const sessions = new Set<WebTransport>();
-  let robot: WebTransport | null = null;
+  let nextViewerId = 1;
 
   function track(wt: WebTransport): void {
     sessions.add(wt);
     wt.closed.catch(() => {}).finally(() => sessions.delete(wt));
   }
 
-  function sendControl(writer: WritableStreamDefaultWriter<Uint8Array>, msg: Msg): void {
-    writer.write(encodeControlFrame(msg)).catch(() => {});
-  }
-
-  function closeAfterFlush(wt: WebTransport, reason: string): void {
-    // Session close discards queued stream/datagram data, so give a just-sent
-    // reply (e.g. the version_mismatch error) a moment to reach the wire.
-    setTimeout(() => {
-      try {
-        wt.close({ closeCode: 1, reason });
-      } catch {
-        // already gone
-      }
-    }, 250);
-  }
-
-  function sendDatagram(writer: WritableStreamDefaultWriter<Uint8Array>, msg: Msg): void {
-    writer.write(encodeDatagram(msg)).catch(() => {});
-  }
-
-  /** Replies to hello/ping; returns false if the session must close (bad version). */
-  function handleControlMsg(msg: Msg, reply: (msg: Msg) => void): boolean {
-    if (msg.t === "hello") {
-      if (msg.v !== PROTOCOL_VERSION) {
-        reply({
-          t: "error",
-          code: "version_mismatch",
-          message: `protocol v${PROTOCOL_VERSION} required, got v${msg.v}`,
-        });
-        return false;
-      }
-      reply({ t: "welcome", v: PROTOCOL_VERSION });
-    } else if (msg.t === "ping") {
-      reply({ t: "pong", n: msg.n, ts: msg.ts });
-    }
-    return true;
-  }
-
-  function handleRobot(wt: WebTransport, conn: Deno.QuicConn): void {
-    if (robot) {
-      // Takeover: a restarted robot process must reattach without operator help.
-      console.log("[relay] robot takeover: closing previous robot session");
-      try {
-        robot.close({ closeCode: 0, reason: "replaced by new robot" });
-      } catch {
-        // already gone
-      }
-    }
-    robot = wt;
-    console.log("[relay] robot connected");
-    wt.closed
-      .catch(() => {})
-      .finally(() => {
-        if (robot === wt) robot = null;
-        console.log("[relay] robot disconnected");
-      });
-
-    const dgWriter = wt.datagrams.writable.getWriter();
-    (async () => {
-      // Robot-leg control rides datagrams: aioquic dies if the relay writes
-      // on robot-opened bidi streams, so hello/welcome/ping/pong live here.
-      for await (const dg of wt.datagrams.readable) {
-        const msg = decodeDatagram(dg);
-        if (msg === null) continue;
-        if (!handleControlMsg(msg, (m) => sendDatagram(dgWriter, m))) {
-          closeAfterFlush(wt, "version mismatch");
-          return;
-        }
-      }
-    })().catch(() => {});
-
-    (async () => {
-      // Data frames arrive on one-shot bidi streams (Deno never delivers
-      // incoming uni payloads), accepted at the QUIC level rather than via
-      // wt.incomingBidirectionalStreams: a reset racing that iterator's
-      // internal preamble read errors it permanently and would silently end
-      // this loop, while the raw accept only fails with the connection.
-      // Abort our send half: RESET is invisible to aioquic's h3 layer and
-      // releases stream credit; a FIN would kill it.
-      for await (const bidi of conn.incomingBidirectionalStreams) {
-        bidi.writable.abort().catch(() => {});
-        (async () => {
-          await readWebTransportPreamble(bidi.readable);
-          forwarder.onRobotFrame(await readDataFrameBytes(bidi.readable));
-        })().catch(() => {
-          // reset before/mid-frame (stale latest-wins write): drop the partial
-        });
-      }
-    })().catch((e) => {
-      console.log("[relay] robot stream loop ended:", (e as Error)?.message ?? e);
-    });
-  }
-
-  function handleViewer(wt: WebTransport): void {
-    let sendOrder = 1;
-    const sink: ViewerSink = {
-      async sendFrame(bytes: Uint8Array): Promise<void> {
-        // waitUntilAvailable: a slow page exhausts stream credit; without it
-        // this throws and we would drop a live viewer. Decreasing sendOrder
-        // keeps stream completions FIFO on the wire (quinn round-robins
-        // otherwise and frames complete in ~1 s waves).
-        const stream = await wt.createUnidirectionalStream({
-          waitUntilAvailable: true,
-          sendOrder: -(sendOrder++),
-        });
-        const writer = stream.getWriter();
-        await writer.write(bytes);
-        await writer.close();
-      },
-      kick(reason: string): void {
-        console.log(`[relay] kicking viewer: ${reason}`);
-        try {
-          wt.close({ closeCode: 1, reason });
-        } catch {
-          // already gone
-        }
-      },
-    };
-    const handle = forwarder.addViewer(sink);
-    console.log(`[relay] viewer ${handle.id} connected (${forwarder.viewerCount} total)`);
-    wt.closed
-      .catch(() => {})
-      .finally(() => {
-        forwarder.removeViewer(handle);
-        console.log(`[relay] viewer ${handle.id} disconnected`);
-      });
-
-    (async () => {
-      // Browser-leg control: viewer-opened bidi stream, replies on the same
-      // stream. Deno may write on viewer-initiated streams (browsers are not
-      // aioquic). wt.incomingBidirectionalStreams is safe here: unlike the
-      // robot leg, viewers never reset a stream racing its acceptance.
-      for await (const bidi of wt.incomingBidirectionalStreams) {
-        (async () => {
-          const writer = bidi.writable.getWriter();
-          const frames = new ControlFrameReader();
-          for await (const chunk of bidi.readable) {
-            for (const msg of frames.push(chunk)) {
-              if (!handleControlMsg(msg, (m) => sendControl(writer, m))) {
-                closeAfterFlush(wt, "version mismatch");
-                return;
-              }
-            }
-          }
-          writer.releaseLock();
-        })().catch((e) =>
-          console.log("[relay] viewer control stream ended:", (e as Error)?.message ?? e)
-        );
-      }
-    })().catch(() => {});
-
-    const dgWriter = wt.datagrams.writable.getWriter();
-    (async () => {
-      // Datagram control for viewers too: browsers use the bidi stream above,
-      // but the Python test viewer cannot receive replies on its own bidi
-      // streams (aioquic), so hello/ping work over datagrams on both legs.
-      // The relay answers pings itself (RTT works with no robot connected);
-      // teleop routing arrives in T6.
-      for await (const dg of wt.datagrams.readable) {
-        const msg = decodeDatagram(dg);
-        if (msg === null) continue;
-        if (!handleControlMsg(msg, (m) => sendDatagram(dgWriter, m))) {
-          closeAfterFlush(wt, "version mismatch");
-          return;
-        }
-      }
-    })().catch(() => {});
-  }
+  const resendTimer = setInterval(() => registry.resendSnapshots(), SNAPSHOT_RESEND_MS);
+  // A pending resend must not keep the Deno process alive after shutdown().
+  Deno.unrefTimer(resendTimer);
 
   (async () => {
     for await (const incoming of listener) {
@@ -269,8 +93,12 @@ export async function startRelay(options: RelayOptions = {}): Promise<RelayHandl
         await wt.ready;
         track(wt);
         const path = new URL(wt.url).pathname;
-        if (path === "/robot") handleRobot(wt, conn);
-        else handleViewer(wt);
+        if (path === "/robot") new RobotSession(wt, conn, registry).start();
+        else if (path === "/viewer") new ViewerSession(wt, nextViewerId++, registry).start();
+        else {
+          console.log(`[relay] rejecting unknown WebTransport endpoint ${path}`);
+          wt.close({ closeCode: 1, reason: "unknown WebTransport endpoint" });
+        }
       })().catch((e) => console.log("[relay] accept failed:", (e as Error)?.message ?? e));
     }
   })().catch(() => {
@@ -297,7 +125,7 @@ export async function startRelay(options: RelayOptions = {}): Promise<RelayHandl
       });
     }
     if (url.pathname === "/api/stats") {
-      return Response.json({ robot: robot !== null, ...(forwarder.stats() as object) });
+      return Response.json(registry.stats());
     }
     const name = url.pathname === "/" ? "debug.html" : url.pathname.slice(1);
     // Resolve the request to a real path and confirm it stays under the static
@@ -333,6 +161,7 @@ export async function startRelay(options: RelayOptions = {}): Promise<RelayHandl
     wtUrl,
     certHash: cert.certHashB64,
     async shutdown(): Promise<void> {
+      clearInterval(resendTimer);
       for (const wt of sessions) {
         try {
           wt.close({ closeCode: 0, reason: "relay shutdown" });

--- a/web/relay/server_test.ts
+++ b/web/relay/server_test.ts
@@ -4,6 +4,7 @@
 // only), so this covers the full forwarding path without a browser.
 import { assert, assertEquals } from "@std/assert";
 import {
+  type ChannelSpec,
   ControlFrameReader,
   decodeDatagram,
   encodeControlFrame,
@@ -12,9 +13,16 @@ import {
   type FrameHeader,
   type Msg,
   PROTOCOL_VERSION,
+  type RobotInfo,
 } from "@dimos/shared";
 import { readDataFrameBytes } from "./forward.ts";
 import { startRelay } from "./server.ts";
+
+const ROBOT: RobotInfo = { id: "deno-bot", name: "Deno Bot", model: "test" };
+const CHANNELS: ChannelSpec[] = [
+  { ch: "color_image", encoding: "jpeg.v1", delivery: "latest", maxHz: 15.5 },
+  { ch: "odom", encoding: "pose.json.v1", delivery: "reliable", maxHz: 20.5 },
+];
 
 function certOpts(hashB64: string): WebTransportOptions {
   return {
@@ -162,7 +170,7 @@ Deno.test({
   const controlWriter = control.writable.getWriter();
   const nextControl = controlQueue(control.readable);
 
-  await t.step("viewer control: hello -> welcome, ping -> pong", async () => {
+  await t.step("viewer control: hello -> welcome + robots, ping -> pong", async () => {
     await controlWriter.write(
       encodeControlFrame({ t: "hello", v: PROTOCOL_VERSION, role: "viewer" }),
     );
@@ -170,6 +178,7 @@ Deno.test({
       t: "welcome",
       v: PROTOCOL_VERSION,
     });
+    assertEquals(await within(nextControl(), "robots"), { t: "robots", robots: [] });
     await controlWriter.write(encodeControlFrame({ t: "ping", n: 1, ts: 123.5 }));
     assertEquals(await within(nextControl(), "pong"), { t: "pong", n: 1, ts: 123.5 });
   });
@@ -190,14 +199,56 @@ Deno.test({
   const robotDatagrams = datagramQueue(robot.datagrams.readable);
   const robotDgWriter = robot.datagrams.writable.getWriter();
 
-  await t.step("robot control rides datagrams: hello -> welcome", async () => {
+  await t.step("robot hello (identity + manifest) -> welcome + baseline subs", async () => {
     await robotDgWriter.write(
-      encodeDatagram({ t: "hello", v: PROTOCOL_VERSION, role: "robot" }),
+      encodeDatagram({
+        t: "hello",
+        v: PROTOCOL_VERSION,
+        role: "robot",
+        robot: ROBOT,
+        manifest: { channels: CHANNELS },
+      }),
     );
-    assertEquals(await within(robotDatagrams(), "robot welcome"), {
+    // Registration and welcome are separate datagrams, so their relative
+    // arrival is not a protocol guarantee.
+    const replies = [
+      await within(robotDatagrams(), "robot hello reply"),
+      await within(robotDatagrams(), "robot hello reply"),
+    ];
+    assertEquals(replies.find((msg) => msg.t === "welcome"), {
       t: "welcome",
       v: PROTOCOL_VERSION,
     });
+    assertEquals(replies.find((msg) => msg.t === "subs"), {
+      t: "subs",
+      chs: [],
+      n: 1,
+    });
+  });
+
+  await t.step("registration pushes robots to the greeted viewer", async () => {
+    assertEquals(await within(nextControl(), "robots push"), {
+      t: "robots",
+      robots: [ROBOT],
+    });
+  });
+
+  await t.step("watch -> manifest reply; subs snapshot reaches the robot", async () => {
+    await controlWriter.write(encodeControlFrame({ t: "watch", robotId: ROBOT.id }));
+    assertEquals(await within(nextControl(), "manifest"), {
+      t: "manifest",
+      robotId: ROBOT.id,
+      channels: CHANNELS,
+    });
+    await controlWriter.write(encodeControlFrame({ t: "sub", ch: "odom" }));
+    await controlWriter.write(encodeControlFrame({ t: "sub", ch: "color_image" }));
+    // One snapshot per sub message; skip ahead to the full set.
+    let subs: Msg;
+    do {
+      subs = await within(robotDatagrams(), "subs snapshot");
+    } while (subs.t === "subs" && subs.chs.length < 2);
+    assert(subs.t === "subs");
+    assertEquals(subs.chs, ["color_image", "odom"]);
   });
 
   await t.step("robot frames fan out to the viewer on uni streams", async () => {
@@ -233,13 +284,79 @@ Deno.test({
     assertEquals(got[1].payload, imagePayload);
   });
 
-  await t.step("/api/stats counted the traffic", async () => {
+  await t.step("a viewer that never subscribed receives nothing", async () => {
+    const idle = new WebTransport(`${relay.wtUrl}/viewer`, certOpts(relay.certHash));
+    await within(idle.ready, "idle viewer connect");
+    const idleStream = await idle.createBidirectionalStream();
+    const idleWriter = idleStream.writable.getWriter();
+    const idleControl = controlQueue(idleStream.readable);
+    await idleWriter.write(encodeControlFrame({ t: "hello", v: PROTOCOL_VERSION, role: "viewer" }));
+    await within(idleControl(), "idle welcome");
+
+    await sendRobotFrame(
+      robot,
+      { ch: "odom", seq: 3, ts: 12.5, delivery: "reliable" },
+      new Uint8Array([3]),
+    );
+    // The subscribed viewer's receipt proves routing ran with both present.
+    assertEquals((await within(viewerFrames(), "odom for subscriber")).header.seq, 3);
     const stats = await (await fetch(`${httpBase}/api/stats`)).json();
-    assertEquals(stats.robot, true);
+    const idleStats = stats.perViewer.find((v: { watched: string | null }) => v.watched === null);
+    assertEquals(idleStats.channels, {});
+    idle.close();
+  });
+
+  await t.step("unsub stops forwarding that channel", async () => {
+    await controlWriter.write(encodeControlFrame({ t: "unsub", ch: "color_image" }));
+    // Ordered control stream: the pong below proves the unsub was processed.
+    await controlWriter.write(encodeControlFrame({ t: "ping", n: 9, ts: 99.5 }));
+    assertEquals(await within(nextControl(), "pong after unsub"), { t: "pong", n: 9, ts: 99.5 });
+
+    await sendRobotFrame(
+      robot,
+      { ch: "color_image", seq: 4, ts: 13.5, delivery: "latest" },
+      new Uint8Array([4]),
+    );
+    await sendRobotFrame(
+      robot,
+      { ch: "odom", seq: 5, ts: 14.5, delivery: "reliable" },
+      new Uint8Array([5]),
+    );
+    // Only odom arrives; the image frame was not forwarded.
+    const got = await within(viewerFrames(), "odom after unsub");
+    assertEquals(got.header.ch, "odom");
+    assertEquals(got.header.seq, 5);
+  });
+
+  await t.step("/api/stats reflects sessions and traffic", async () => {
+    // The idle viewer's close is asynchronous on the relay side; poll it out.
+    let stats = await (await fetch(`${httpBase}/api/stats`)).json();
+    for (let i = 0; i < 80 && stats.viewers !== 1; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      stats = await (await fetch(`${httpBase}/api/stats`)).json();
+    }
+    assertEquals(stats.robots, [ROBOT]);
     assertEquals(stats.viewers, 1);
-    assertEquals(stats.channels.odom.framesIn, 1);
-    assertEquals(stats.channels.color_image.framesIn, 1);
-    assertEquals(stats.perViewer[0].channels.odom.sent, 1);
+    assertEquals(stats.perRobot[ROBOT.id].subs, ["odom"]);
+    assertEquals(stats.perRobot[ROBOT.id].channels.odom.framesIn, 3);
+    assertEquals(stats.perRobot[ROBOT.id].channels.odom.delivery, "reliable");
+    const viewerStats = stats.perViewer.find(
+      (v: { watched: string | null }) => v.watched === ROBOT.id,
+    );
+    assertEquals(viewerStats.subs, ["odom"]);
+    assertEquals(viewerStats.channels.odom.sent, 3);
+  });
+
+  await t.step("robot hello without robot{} -> missing_robot_id + close", async () => {
+    const bare = new WebTransport(`${relay.wtUrl}/robot`, certOpts(relay.certHash));
+    await within(bare.ready, "bare robot connect");
+    const bareDatagrams = datagramQueue(bare.datagrams.readable);
+    const bareWriter = bare.datagrams.writable.getWriter();
+    await bareWriter.write(encodeDatagram({ t: "hello", v: PROTOCOL_VERSION, role: "robot" }));
+    const err = await within(bareDatagrams(), "missing_robot_id error");
+    assertEquals(err.t, "error");
+    assertEquals((err as { code: string }).code, "missing_robot_id");
+    await within(bare.closed.catch(() => {}), "bare robot session close");
   });
 
   await t.step("hello with a wrong version -> error + close", async () => {
@@ -253,6 +370,47 @@ Deno.test({
     assertEquals(err.t, "error");
     assertEquals((err as { code: string }).code, "version_mismatch");
     await within(bad.closed.catch(() => {}), "bad-version session close");
+  });
+
+  await t.step("viewer commands before hello -> hello_required + close", async () => {
+    const ungreeted = new WebTransport(`${relay.wtUrl}/viewer`, certOpts(relay.certHash));
+    await within(ungreeted.ready, "ungreeted viewer connect");
+    const stream = await ungreeted.createBidirectionalStream();
+    const writer = stream.writable.getWriter();
+    const next = controlQueue(stream.readable);
+    await writer.write(encodeControlFrame({ t: "watch", robotId: ROBOT.id }));
+    const err = await within(next(), "hello_required error");
+    assertEquals(err.t, "error");
+    assertEquals((err as { code: string }).code, "hello_required");
+    await within(ungreeted.closed.catch(() => {}), "ungreeted viewer close");
+  });
+
+  await t.step("robot role on /viewer -> role_mismatch + close", async () => {
+    const wrongRole = new WebTransport(`${relay.wtUrl}/viewer`, certOpts(relay.certHash));
+    await within(wrongRole.ready, "wrong-role viewer connect");
+    const stream = await wrongRole.createBidirectionalStream();
+    const writer = stream.writable.getWriter();
+    const next = controlQueue(stream.readable);
+    await writer.write(
+      encodeControlFrame({
+        t: "hello",
+        v: PROTOCOL_VERSION,
+        role: "robot",
+        robot: { id: "wrong-leg", name: "Wrong Leg", model: "test" },
+      }),
+    );
+    const err = await within(next(), "role_mismatch error");
+    assertEquals(err.t, "error");
+    assertEquals((err as { code: string }).code, "role_mismatch");
+    await within(wrongRole.closed.catch(() => {}), "wrong-role viewer close");
+  });
+
+  await t.step("unknown WebTransport endpoint is rejected", async () => {
+    const unknown = new WebTransport(`${relay.wtUrl}/unknown`, certOpts(relay.certHash));
+    await within(unknown.closed.catch(() => {}), "unknown endpoint close");
+    const stats = await (await fetch(`${httpBase}/api/stats`)).json();
+    assertEquals(stats.robots, [ROBOT]);
+    assertEquals(stats.viewers, 1);
   });
 
   await t.step("a garbage control message is dropped, not fatal to the loop", async () => {

--- a/web/relay/session.ts
+++ b/web/relay/session.ts
@@ -1,0 +1,250 @@
+// Per-connection session objects: handshake, control loops, and (robot leg)
+// the raw-QUIC data stream loop. Sessions own transport quirks; all routing
+// and subscription policy lives in registry.ts.
+//
+// Leg asymmetry, forced by upstream bugs (see web/README.md):
+// - Robot (aioquic): control = datagrams both ways (the relay must never
+//   write on robot-opened bidi streams); data = one-shot bidi streams the
+//   relay never writes on (send half aborted with RESET, never FIN).
+// - Viewer (browser): control = viewer-opened bidi stream (replies + pushes
+//   on the same stream) or datagrams (Python test viewer); data = relay-
+//   opened uni streams.
+import {
+  type ChannelSpec,
+  ControlFrameReader,
+  decodeDatagram,
+  encodeControlFrame,
+  encodeDatagram,
+  type Msg,
+  PROTOCOL_VERSION,
+  type RobotInfo,
+} from "@dimos/shared";
+import {
+  type ChannelPolicy,
+  readDataFrameBytes,
+  readWebTransportPreamble,
+  type ViewerSink,
+} from "./forward.ts";
+import type { Registry, RobotPeer, ViewerPeer } from "./registry.ts";
+
+function closeAfterFlush(wt: WebTransport, reason: string): void {
+  // Session close discards queued stream/datagram data, so give a just-sent
+  // reply (e.g. the version_mismatch error) a moment to reach the wire.
+  setTimeout(() => {
+    try {
+      wt.close({ closeCode: 1, reason });
+    } catch {
+      // already gone
+    }
+  }, 250);
+}
+
+export class RobotSession implements RobotPeer {
+  info: RobotInfo | null = null;
+  channels: ChannelSpec[] = [];
+  /** Close reason; set before transport close so rejected hello resends
+   * cannot register this session. */
+  closed: string | null = null;
+  readonly #wt: WebTransport;
+  readonly #conn: Deno.QuicConn;
+  readonly #registry: Registry;
+  readonly #dgWriter: WritableStreamDefaultWriter<Uint8Array>;
+
+  constructor(wt: WebTransport, conn: Deno.QuicConn, registry: Registry) {
+    this.#wt = wt;
+    this.#conn = conn;
+    this.#registry = registry;
+    this.#dgWriter = wt.datagrams.writable.getWriter();
+  }
+
+  sendMsg(msg: Msg): void {
+    this.#dgWriter.write(encodeDatagram(msg)).catch(() => {});
+  }
+
+  #reject(code: string, message: string, reason: string): false {
+    this.sendMsg({ t: "error", code, message });
+    this.closed = reason;
+    closeAfterFlush(this.#wt, reason);
+    return false;
+  }
+
+  start(): void {
+    console.log("[relay] robot connected");
+    this.#wt.closed
+      .catch(() => {})
+      .finally(() => this.#registry.robotClosed(this));
+    this.#controlLoop();
+    this.#frameLoop();
+  }
+
+  #controlLoop(): void {
+    (async () => {
+      for await (const dg of this.#wt.datagrams.readable) {
+        const msg = decodeDatagram(dg);
+        if (msg === null) continue;
+        if (!this.#onControlMsg(msg)) return;
+      }
+    })().catch(() => {});
+  }
+
+  /** Replies to hello/ping; returns false once the session is being closed. */
+  #onControlMsg(msg: Msg): boolean {
+    if (msg.t === "hello") {
+      if (msg.v !== PROTOCOL_VERSION) {
+        return this.#reject(
+          "version_mismatch",
+          `protocol v${PROTOCOL_VERSION} required, got v${msg.v}`,
+          "version mismatch",
+        );
+      }
+      if (msg.role !== "robot") {
+        return this.#reject(
+          "role_mismatch",
+          "the /robot endpoint requires role=robot",
+          "role mismatch",
+        );
+      }
+      if (msg.robot === undefined) {
+        return this.#reject(
+          "missing_robot_id",
+          "robot hello must carry robot{id,name,model}",
+          "missing robot id",
+        );
+      }
+      // First hello wins; resends (the bridge repeats hello until welcome)
+      // must not mutate identity mid-session.
+      if (this.info === null) {
+        this.info = msg.robot;
+        this.channels = msg.manifest?.channels ?? [];
+      }
+      if (!this.#registry.registerRobot(this)) {
+        return this.#reject(
+          "robot_id_conflict",
+          `robot id ${msg.robot.id} already has a live session`,
+          "robot id conflict",
+        );
+      }
+      this.sendMsg({ t: "welcome", v: PROTOCOL_VERSION });
+    } else if (msg.t === "ping") {
+      this.sendMsg({ t: "pong", n: msg.n, ts: msg.ts });
+    }
+    return true;
+  }
+
+  #frameLoop(): void {
+    (async () => {
+      for await (const bidi of this.#conn.incomingBidirectionalStreams) {
+        bidi.writable.abort().catch(() => {});
+        (async () => {
+          await readWebTransportPreamble(bidi.readable);
+          this.#registry.onRobotFrame(this, await readDataFrameBytes(bidi.readable));
+        })().catch(() => {
+          // reset before/mid-frame (stale latest-wins write): drop the partial
+        });
+      }
+    })().catch((e) => {
+      console.log("[relay] robot stream loop ended:", (e as Error)?.message ?? e);
+    });
+  }
+}
+
+export class ViewerSession implements ViewerPeer {
+  readonly id: number;
+  watched: string | null = null;
+  readonly subs = new Set<string>();
+  readonly policies = new Map<string, ChannelPolicy>();
+  greeted = false;
+  readonly sink: ViewerSink;
+  readonly #wt: WebTransport;
+  readonly #registry: Registry;
+  /** Push channel for robots events, chosen by whichever leg carried hello. */
+  #push: ((msg: Msg) => void) | null = null;
+
+  constructor(wt: WebTransport, id: number, registry: Registry) {
+    this.#wt = wt;
+    this.id = id;
+    this.#registry = registry;
+    let sendOrder = 1;
+    this.sink = {
+      async sendFrame(bytes: Uint8Array): Promise<void> {
+        const stream = await wt.createUnidirectionalStream({
+          waitUntilAvailable: true,
+          sendOrder: -(sendOrder++),
+        });
+        const writer = stream.getWriter();
+        await writer.write(bytes);
+        await writer.close();
+      },
+      kick(reason: string): void {
+        console.log(`[relay] kicking viewer: ${reason}`);
+        try {
+          wt.close({ closeCode: 1, reason });
+        } catch {
+          // already gone
+        }
+      },
+    };
+  }
+
+  sendMsg(msg: Msg): void {
+    this.#push?.(msg);
+  }
+
+  start(): void {
+    this.#registry.addViewer(this);
+    console.log(`[relay] viewer ${this.id} connected`);
+    this.#wt.closed
+      .catch(() => {})
+      .finally(() => {
+        this.#registry.viewerClosed(this);
+        console.log(`[relay] viewer ${this.id} disconnected`);
+      });
+    this.#streamLoop();
+    this.#datagramLoop();
+  }
+
+  #dispatch(msg: Msg, reply: (msg: Msg) => void): boolean {
+    if (!this.#registry.onViewerMsg(this, msg, reply)) {
+      closeAfterFlush(this.#wt, "viewer handshake rejected");
+      return false;
+    }
+    if (msg.t === "hello" && this.greeted) this.#push = reply;
+    return true;
+  }
+
+  #streamLoop(): void {
+    (async () => {
+      for await (const bidi of this.#wt.incomingBidirectionalStreams) {
+        (async () => {
+          const writer = bidi.writable.getWriter();
+          const reply = (m: Msg) => {
+            writer.write(encodeControlFrame(m)).catch(() => {});
+          };
+          const frames = new ControlFrameReader();
+          for await (const chunk of bidi.readable) {
+            for (const msg of frames.push(chunk)) {
+              if (!this.#dispatch(msg, reply)) return;
+            }
+          }
+          writer.releaseLock();
+        })().catch((e) =>
+          console.log("[relay] viewer control stream ended:", (e as Error)?.message ?? e)
+        );
+      }
+    })().catch(() => {});
+  }
+
+  #datagramLoop(): void {
+    const dgWriter = this.#wt.datagrams.writable.getWriter();
+    (async () => {
+      const reply = (m: Msg) => {
+        dgWriter.write(encodeDatagram(m)).catch(() => {});
+      };
+      for await (const dg of this.#wt.datagrams.readable) {
+        const msg = decodeDatagram(dg);
+        if (msg === null) continue;
+        if (!this.#dispatch(msg, reply)) return;
+      }
+    })().catch(() => {});
+  }
+}

--- a/web/relay/static/debug.html
+++ b/web/relay/static/debug.html
@@ -73,6 +73,12 @@
         <div>round-trips</div>
         <pre id="rtt">control: -    datagram: -</pre>
       </div>
+      <div class="card">
+        <div>robots</div>
+        <pre id="robots">-</pre>
+        <div>manifest</div>
+        <pre id="manifest">-</pre>
+      </div>
     </div>
     <div class="card">
       <table id="stats">
@@ -273,6 +279,129 @@
         $("rtt").textContent = `control: ${rtts.control}    datagram: ${rtts.datagram}`;
       }
 
+      // Local auto-select policy lives here, not in the relay: watch the
+      // first listed robot (a robot picker is Cockpit/T12 territory).
+      let watched = null;
+      function renderRobots(robots) {
+        $("robots").textContent = robots.length
+          ? robots.map((r) => `${r.id === watched ? "> " : "  "}${r.id} (${r.model})`).join(
+            "\n",
+          )
+          : "none connected";
+      }
+
+      // One relay session: resolves when it closes (the caller reconnects).
+      async function connectOnce() {
+        const info = await (await fetch("/api/info")).json();
+        say(`connecting to ${info.wtUrl} ...`);
+        const opts = {};
+        if (info.certHash) {
+          opts.serverCertificateHashes = [{
+            algorithm: "sha-256",
+            value: Uint8Array.from(atob(info.certHash), (c) => c.charCodeAt(0)),
+          }];
+        }
+        const wt = new WebTransport(info.wtUrl, opts);
+        await wt.ready;
+        say(`connected to ${info.wtUrl} (protocol v${info.v})`, "ok");
+        wt.closed.then(
+          (i) => say(`session closed: ${JSON.stringify(i)}`, "bad"),
+          (e) => say(`session lost: ${e.message ?? e}`, "bad"),
+        );
+
+        const timers = [];
+        try {
+          // control stream: hello -> welcome + robots -> watch -> manifest ->
+          // sub every channel; ping every second
+          const control = await wt.createBidirectionalStream();
+          const cw = control.writable.getWriter();
+          const pending = new Map(); // n -> send time
+          let pingN = 0;
+          cw.write(encodeControlFrame({ t: "hello", v: info.v, role: "viewer" }));
+          (async () => {
+            const push = controlFrameReader();
+            for await (const chunk of control.readable) {
+              for (const msg of push(chunk)) {
+                if (msg.t === "welcome") {
+                  say(`connected, welcome received (protocol v${msg.v})`, "ok");
+                } else if (msg.t === "error") {
+                  say(`relay error: ${msg.code}: ${msg.message}`, "bad");
+                } else if (msg.t === "robots") {
+                  if (msg.robots.length && !msg.robots.some((r) => r.id === watched)) {
+                    watched = msg.robots[0].id;
+                  }
+                  renderRobots(msg.robots);
+                  // (Re-)watch: idempotent, refreshes the manifest, and after
+                  // a robot restart it reattaches this viewer's channels.
+                  if (msg.robots.length) {
+                    cw.write(encodeControlFrame({ t: "watch", robotId: watched })).catch(
+                      () => {},
+                    );
+                  }
+                } else if (msg.t === "manifest") {
+                  $("manifest").textContent = msg.channels.length
+                    ? msg.channels
+                      .map((c) => `${c.ch}  ${c.encoding} ${c.delivery} <=${c.maxHz} Hz`)
+                      .join("\n")
+                    : "no channels";
+                  for (const c of msg.channels) {
+                    cw.write(encodeControlFrame({ t: "sub", ch: c.ch })).catch(() => {});
+                  }
+                  say(`watching ${msg.robotId} (${msg.channels.length} channels)`, "ok");
+                } else if (msg.t === "pong" && pending.has(msg.n)) {
+                  rtts.control = `${
+                    (performance.now() - pending.get(msg.n)).toFixed(1)
+                  } ms`;
+                  pending.delete(msg.n);
+                  showRtt();
+                }
+              }
+            }
+          })().catch(() => {});
+          timers.push(setInterval(() => {
+            pending.set(++pingN, performance.now());
+            cw.write(encodeControlFrame({ t: "ping", n: pingN, ts: Date.now() / 1000 }))
+              .catch(() => {});
+          }, 1000));
+
+          // datagram ping every second (the relay answers these itself)
+          const dgw = wt.datagrams.writable.getWriter();
+          const dgPending = new Map();
+          let dgN = 0;
+          timers.push(setInterval(() => {
+            dgPending.set(++dgN, performance.now());
+            dgw.write(
+              enc.encode(JSON.stringify({ t: "ping", n: dgN, ts: Date.now() / 1000 })),
+            ).catch(() => {});
+          }, 1000));
+          (async () => {
+            for await (const d of wt.datagrams.readable) {
+              try {
+                const msg = JSON.parse(dec.decode(d));
+                if (msg.t === "pong" && dgPending.has(msg.n)) {
+                  rtts.datagram = `${
+                    (performance.now() - dgPending.get(msg.n)).toFixed(1)
+                  } ms`;
+                  dgPending.delete(msg.n);
+                  showRtt();
+                }
+              } catch { /* not JSON */ }
+            }
+          })().catch(() => {});
+
+          // data plane: one uni stream per frame; ends with the session
+          for await (const stream of wt.incomingUnidirectionalStreams) {
+            readDataFrame(stream).then(({ header, payload }) => onFrame(header, payload))
+              .catch(() => {});
+          }
+        } finally {
+          for (const t of timers) clearInterval(t);
+          try {
+            wt.close();
+          } catch { /* already gone */ }
+        }
+      }
+
       async function main() {
         if (!window.isSecureContext) {
           return say(
@@ -288,89 +417,20 @@
             "bad",
           );
         }
-        const info = await (await fetch("/api/info")).json();
-        say(`connecting to ${info.wtUrl} ...`);
-        const opts = {};
-        if (info.certHash) {
-          opts.serverCertificateHashes = [{
-            algorithm: "sha-256",
-            value: Uint8Array.from(atob(info.certHash), (c) => c.charCodeAt(0)),
-          }];
-        }
-        let wt;
-        try {
-          wt = new WebTransport(info.wtUrl, opts);
-          await wt.ready;
-        } catch (e) {
-          return say(
-            `WebTransport connect failed: ${e.message ?? e}<br>` +
-              "hints: relay running? firewall blocking UDP? cert older than its 10-day validity?",
-            "bad",
-          );
-        }
-        say(`connected to ${info.wtUrl} (protocol v${info.v})`, "ok");
-        wt.closed.then(
-          (i) => say(`session closed: ${JSON.stringify(i)}`, "bad"),
-          (e) => say(`session lost: ${e.message ?? e}`, "bad"),
-        );
-
-        // control stream: hello -> welcome, then ping every second
-        const control = await wt.createBidirectionalStream();
-        const cw = control.writable.getWriter();
-        const pending = new Map(); // n -> send time
-        let pingN = 0;
-        cw.write(encodeControlFrame({ t: "hello", v: info.v, role: "viewer" }));
-        (async () => {
-          const push = controlFrameReader();
-          for await (const chunk of control.readable) {
-            for (const msg of push(chunk)) {
-              if (msg.t === "welcome") {
-                say(`connected, welcome received (protocol v${msg.v})`, "ok");
-              } else if (msg.t === "error") {
-                say(`relay error: ${msg.code}: ${msg.message}`, "bad");
-              } else if (msg.t === "pong" && pending.has(msg.n)) {
-                rtts.control = `${(performance.now() - pending.get(msg.n)).toFixed(1)} ms`;
-                pending.delete(msg.n);
-                showRtt();
-              }
-            }
+        // Reconnect loop: survives relay/dimos restarts. The HTTP port is
+        // stable across restarts; the QUIC port + cert are re-read each time.
+        for (;;) {
+          try {
+            await connectOnce();
+            say("session closed - reconnecting...", "bad");
+          } catch (e) {
+            say(
+              `connect failed: ${e.message ?? e} - retrying<br>` +
+                "hints: relay running? firewall blocking UDP? cert older than its validity?",
+              "bad",
+            );
           }
-        })().catch(() => {});
-        setInterval(() => {
-          pending.set(++pingN, performance.now());
-          cw.write(encodeControlFrame({ t: "ping", n: pingN, ts: Date.now() / 1000 }))
-            .catch(() => {});
-        }, 1000);
-
-        // datagram ping every second (the relay answers these itself)
-        const dgw = wt.datagrams.writable.getWriter();
-        const dgPending = new Map();
-        let dgN = 0;
-        setInterval(() => {
-          dgPending.set(++dgN, performance.now());
-          dgw.write(
-            enc.encode(JSON.stringify({ t: "ping", n: dgN, ts: Date.now() / 1000 })),
-          ).catch(() => {});
-        }, 1000);
-        (async () => {
-          for await (const d of wt.datagrams.readable) {
-            try {
-              const msg = JSON.parse(dec.decode(d));
-              if (msg.t === "pong" && dgPending.has(msg.n)) {
-                rtts.datagram = `${
-                  (performance.now() - dgPending.get(msg.n)).toFixed(1)
-                } ms`;
-                dgPending.delete(msg.n);
-                showRtt();
-              }
-            } catch { /* not JSON */ }
-          }
-        })().catch(() => {});
-
-        // data plane: one uni stream per frame
-        for await (const stream of wt.incomingUnidirectionalStreams) {
-          readDataFrame(stream).then(({ header, payload }) => onFrame(header, payload))
-            .catch(() => {});
+          await new Promise((resolve) => setTimeout(resolve, 1000));
         }
       }
       main().catch((e) => say(`debug page failed: ${e.message ?? e}`, "bad"));

--- a/web/shared/fixtures/control_frames.json
+++ b/web/shared/fixtures/control_frames.json
@@ -5,9 +5,30 @@
       "message": {
         "t": "hello",
         "v": 1,
-        "role": "robot"
+        "role": "robot",
+        "robot": {
+          "id": "go2-lab",
+          "name": "Go2 Laborator β",
+          "model": "unitree-go2"
+        },
+        "manifest": {
+          "channels": [
+            {
+              "ch": "color_image",
+              "encoding": "jpeg.v1",
+              "delivery": "latest",
+              "maxHz": 15.5
+            },
+            {
+              "ch": "odom",
+              "encoding": "pose.json.v1",
+              "delivery": "reliable",
+              "maxHz": 20.5
+            }
+          ]
+        }
       },
-      "b64": "IgAAAHsidCI6ImhlbGxvIiwidiI6MSwicm9sZSI6InJvYm90In0="
+      "b64": "GwEAAHsidCI6ImhlbGxvIiwidiI6MSwicm9sZSI6InJvYm90Iiwicm9ib3QiOnsiaWQiOiJnbzItbGFiIiwibmFtZSI6IkdvMiBMYWJvcmF0b3IgzrIiLCJtb2RlbCI6InVuaXRyZWUtZ28yIn0sIm1hbmlmZXN0Ijp7ImNoYW5uZWxzIjpbeyJjaCI6ImNvbG9yX2ltYWdlIiwiZW5jb2RpbmciOiJqcGVnLnYxIiwiZGVsaXZlcnkiOiJsYXRlc3QiLCJtYXhIeiI6MTUuNX0seyJjaCI6Im9kb20iLCJlbmNvZGluZyI6InBvc2UuanNvbi52MSIsImRlbGl2ZXJ5IjoicmVsaWFibGUiLCJtYXhIeiI6MjAuNX1dfX0="
     },
     {
       "name": "hello_viewer",
@@ -52,6 +73,94 @@
         "message": "protocol v1 required, versiune neacceptată"
       },
       "b64": "XwAAAHsidCI6ImVycm9yIiwiY29kZSI6InZlcnNpb25fbWlzbWF0Y2giLCJtZXNzYWdlIjoicHJvdG9jb2wgdjEgcmVxdWlyZWQsIHZlcnNpdW5lIG5lYWNjZXB0YXTEgyJ9"
+    },
+    {
+      "name": "robots_two",
+      "message": {
+        "t": "robots",
+        "robots": [
+          {
+            "id": "go2-lab",
+            "name": "Go2 Laborator β",
+            "model": "unitree-go2"
+          },
+          {
+            "id": "arm-01",
+            "name": "Braț 01",
+            "model": "xarm7"
+          }
+        ]
+      },
+      "b64": "jAAAAHsidCI6InJvYm90cyIsInJvYm90cyI6W3siaWQiOiJnbzItbGFiIiwibmFtZSI6IkdvMiBMYWJvcmF0b3IgzrIiLCJtb2RlbCI6InVuaXRyZWUtZ28yIn0seyJpZCI6ImFybS0wMSIsIm5hbWUiOiJCcmHImyAwMSIsIm1vZGVsIjoieGFybTcifV19"
+    },
+    {
+      "name": "robots_empty",
+      "message": {
+        "t": "robots",
+        "robots": []
+      },
+      "b64": "GgAAAHsidCI6InJvYm90cyIsInJvYm90cyI6W119"
+    },
+    {
+      "name": "watch",
+      "message": {
+        "t": "watch",
+        "robotId": "go2-lab"
+      },
+      "b64": "IQAAAHsidCI6IndhdGNoIiwicm9ib3RJZCI6ImdvMi1sYWIifQ=="
+    },
+    {
+      "name": "manifest_reply",
+      "message": {
+        "t": "manifest",
+        "robotId": "go2-lab",
+        "channels": [
+          {
+            "ch": "odom",
+            "encoding": "pose.json.v1",
+            "delivery": "reliable",
+            "maxHz": 20.5
+          }
+        ]
+      },
+      "b64": "fAAAAHsidCI6Im1hbmlmZXN0Iiwicm9ib3RJZCI6ImdvMi1sYWIiLCJjaGFubmVscyI6W3siY2giOiJvZG9tIiwiZW5jb2RpbmciOiJwb3NlLmpzb24udjEiLCJkZWxpdmVyeSI6InJlbGlhYmxlIiwibWF4SHoiOjIwLjV9XX0="
+    },
+    {
+      "name": "sub",
+      "message": {
+        "t": "sub",
+        "ch": "color_image"
+      },
+      "b64": "HgAAAHsidCI6InN1YiIsImNoIjoiY29sb3JfaW1hZ2UifQ=="
+    },
+    {
+      "name": "unsub",
+      "message": {
+        "t": "unsub",
+        "ch": "color_image"
+      },
+      "b64": "IAAAAHsidCI6InVuc3ViIiwiY2giOiJjb2xvcl9pbWFnZSJ9"
+    },
+    {
+      "name": "subs_snapshot",
+      "message": {
+        "t": "subs",
+        "chs": [
+          "color_image",
+          "odom"
+        ],
+        "n": 3
+      },
+      "b64": "LwAAAHsidCI6InN1YnMiLCJjaHMiOlsiY29sb3JfaW1hZ2UiLCJvZG9tIl0sIm4iOjN9"
+    },
+    {
+      "name": "subs_empty",
+      "message": {
+        "t": "subs",
+        "chs": [],
+        "n": 4
+      },
+      "b64": "GwAAAHsidCI6InN1YnMiLCJjaHMiOltdLCJuIjo0fQ=="
     }
   ]
 }

--- a/web/shared/fixtures/datagrams.json
+++ b/web/shared/fixtures/datagrams.json
@@ -5,9 +5,30 @@
       "message": {
         "t": "hello",
         "v": 1,
-        "role": "robot"
+        "role": "robot",
+        "robot": {
+          "id": "go2-lab",
+          "name": "Go2 Laborator β",
+          "model": "unitree-go2"
+        },
+        "manifest": {
+          "channels": [
+            {
+              "ch": "color_image",
+              "encoding": "jpeg.v1",
+              "delivery": "latest",
+              "maxHz": 15.5
+            },
+            {
+              "ch": "odom",
+              "encoding": "pose.json.v1",
+              "delivery": "reliable",
+              "maxHz": 20.5
+            }
+          ]
+        }
       },
-      "b64": "eyJ0IjoiaGVsbG8iLCJ2IjoxLCJyb2xlIjoicm9ib3QifQ=="
+      "b64": "eyJ0IjoiaGVsbG8iLCJ2IjoxLCJyb2xlIjoicm9ib3QiLCJyb2JvdCI6eyJpZCI6ImdvMi1sYWIiLCJuYW1lIjoiR28yIExhYm9yYXRvciDOsiIsIm1vZGVsIjoidW5pdHJlZS1nbzIifSwibWFuaWZlc3QiOnsiY2hhbm5lbHMiOlt7ImNoIjoiY29sb3JfaW1hZ2UiLCJlbmNvZGluZyI6ImpwZWcudjEiLCJkZWxpdmVyeSI6ImxhdGVzdCIsIm1heEh6IjoxNS41fSx7ImNoIjoib2RvbSIsImVuY29kaW5nIjoicG9zZS5qc29uLnYxIiwiZGVsaXZlcnkiOiJyZWxpYWJsZSIsIm1heEh6IjoyMC41fV19fQ=="
     },
     {
       "name": "hello_viewer",
@@ -52,6 +73,94 @@
         "message": "protocol v1 required, versiune neacceptată"
       },
       "b64": "eyJ0IjoiZXJyb3IiLCJjb2RlIjoidmVyc2lvbl9taXNtYXRjaCIsIm1lc3NhZ2UiOiJwcm90b2NvbCB2MSByZXF1aXJlZCwgdmVyc2l1bmUgbmVhY2NlcHRhdMSDIn0="
+    },
+    {
+      "name": "robots_two",
+      "message": {
+        "t": "robots",
+        "robots": [
+          {
+            "id": "go2-lab",
+            "name": "Go2 Laborator β",
+            "model": "unitree-go2"
+          },
+          {
+            "id": "arm-01",
+            "name": "Braț 01",
+            "model": "xarm7"
+          }
+        ]
+      },
+      "b64": "eyJ0Ijoicm9ib3RzIiwicm9ib3RzIjpbeyJpZCI6ImdvMi1sYWIiLCJuYW1lIjoiR28yIExhYm9yYXRvciDOsiIsIm1vZGVsIjoidW5pdHJlZS1nbzIifSx7ImlkIjoiYXJtLTAxIiwibmFtZSI6IkJyYcibIDAxIiwibW9kZWwiOiJ4YXJtNyJ9XX0="
+    },
+    {
+      "name": "robots_empty",
+      "message": {
+        "t": "robots",
+        "robots": []
+      },
+      "b64": "eyJ0Ijoicm9ib3RzIiwicm9ib3RzIjpbXX0="
+    },
+    {
+      "name": "watch",
+      "message": {
+        "t": "watch",
+        "robotId": "go2-lab"
+      },
+      "b64": "eyJ0Ijoid2F0Y2giLCJyb2JvdElkIjoiZ28yLWxhYiJ9"
+    },
+    {
+      "name": "manifest_reply",
+      "message": {
+        "t": "manifest",
+        "robotId": "go2-lab",
+        "channels": [
+          {
+            "ch": "odom",
+            "encoding": "pose.json.v1",
+            "delivery": "reliable",
+            "maxHz": 20.5
+          }
+        ]
+      },
+      "b64": "eyJ0IjoibWFuaWZlc3QiLCJyb2JvdElkIjoiZ28yLWxhYiIsImNoYW5uZWxzIjpbeyJjaCI6Im9kb20iLCJlbmNvZGluZyI6InBvc2UuanNvbi52MSIsImRlbGl2ZXJ5IjoicmVsaWFibGUiLCJtYXhIeiI6MjAuNX1dfQ=="
+    },
+    {
+      "name": "sub",
+      "message": {
+        "t": "sub",
+        "ch": "color_image"
+      },
+      "b64": "eyJ0Ijoic3ViIiwiY2giOiJjb2xvcl9pbWFnZSJ9"
+    },
+    {
+      "name": "unsub",
+      "message": {
+        "t": "unsub",
+        "ch": "color_image"
+      },
+      "b64": "eyJ0IjoidW5zdWIiLCJjaCI6ImNvbG9yX2ltYWdlIn0="
+    },
+    {
+      "name": "subs_snapshot",
+      "message": {
+        "t": "subs",
+        "chs": [
+          "color_image",
+          "odom"
+        ],
+        "n": 3
+      },
+      "b64": "eyJ0Ijoic3VicyIsImNocyI6WyJjb2xvcl9pbWFnZSIsIm9kb20iXSwibiI6M30="
+    },
+    {
+      "name": "subs_empty",
+      "message": {
+        "t": "subs",
+        "chs": [],
+        "n": 4
+      },
+      "b64": "eyJ0Ijoic3VicyIsImNocyI6W10sIm4iOjR9"
     },
     {
       "name": "twist",

--- a/web/shared/fixtures/gen.ts
+++ b/web/shared/fixtures/gen.ts
@@ -24,7 +24,18 @@ function b64(bytes: Uint8Array): string {
 }
 
 const controlMsgs: Record<string, Msg> = {
-  hello_robot: { t: "hello", v: 1, role: "robot" },
+  hello_robot: {
+    t: "hello",
+    v: 1,
+    role: "robot",
+    robot: { id: "go2-lab", name: "Go2 Laborator β", model: "unitree-go2" },
+    manifest: {
+      channels: [
+        { ch: "color_image", encoding: "jpeg.v1", delivery: "latest", maxHz: 15.5 },
+        { ch: "odom", encoding: "pose.json.v1", delivery: "reliable", maxHz: 20.5 },
+      ],
+    },
+  },
   hello_viewer: { t: "hello", v: 1, role: "viewer" },
   welcome: { t: "welcome", v: 1 },
   ping: { t: "ping", n: 7, ts: 1752576000.5 },
@@ -34,6 +45,24 @@ const controlMsgs: Record<string, Msg> = {
     code: "version_mismatch",
     message: "protocol v1 required, versiune neacceptată",
   },
+  robots_two: {
+    t: "robots",
+    robots: [
+      { id: "go2-lab", name: "Go2 Laborator β", model: "unitree-go2" },
+      { id: "arm-01", name: "Braț 01", model: "xarm7" },
+    ],
+  },
+  robots_empty: { t: "robots", robots: [] },
+  watch: { t: "watch", robotId: "go2-lab" },
+  manifest_reply: {
+    t: "manifest",
+    robotId: "go2-lab",
+    channels: [{ ch: "odom", encoding: "pose.json.v1", delivery: "reliable", maxHz: 20.5 }],
+  },
+  sub: { t: "sub", ch: "color_image" },
+  unsub: { t: "unsub", ch: "color_image" },
+  subs_snapshot: { t: "subs", chs: ["color_image", "odom"], n: 3 },
+  subs_empty: { t: "subs", chs: [], n: 4 },
 };
 
 const teleopMsgs: Record<string, Msg> = {

--- a/web/shared/protocol.ts
+++ b/web/shared/protocol.ts
@@ -26,10 +26,33 @@ export const MAX_DATA_FRAME_BYTES = 64 * 1024 * 1024;
 export type Role = "robot" | "viewer";
 export type Delivery = "latest" | "reliable";
 
+export interface RobotInfo {
+  id: string;
+  name: string;
+  model: string;
+}
+
+// One robot->viewer stream: encoding names the payload format (e.g. jpeg.v1,
+// pose.json.v1), delivery picks the relay's forwarding policy, maxHz is the
+// bridge's advertised send cap (informational for viewers).
+export interface ChannelSpec {
+  ch: string;
+  encoding: string;
+  delivery: Delivery;
+  maxHz: number;
+}
+
+export interface RobotManifest {
+  channels: ChannelSpec[];
+}
+
 export interface HelloMsg {
   t: "hello";
   v: number;
   role: Role;
+  // role=robot only: identity + channel manifest, registered by the relay.
+  robot?: RobotInfo;
+  manifest?: RobotManifest;
 }
 
 export interface WelcomeMsg {
@@ -55,6 +78,44 @@ export interface ErrorMsg {
   message: string;
 }
 
+// Session messages (T2): robot registration, viewer watch + per-channel
+// subscriptions, and the relay->robot subscription snapshot.
+export interface RobotsMsg {
+  t: "robots";
+  robots: RobotInfo[];
+}
+
+export interface WatchMsg {
+  t: "watch";
+  robotId: string;
+}
+
+export interface ManifestMsg {
+  t: "manifest";
+  robotId: string;
+  channels: ChannelSpec[];
+}
+
+export interface SubMsg {
+  t: "sub";
+  ch: string;
+}
+
+export interface UnsubMsg {
+  t: "unsub";
+  ch: string;
+}
+
+// Relay->robot: the full set of channels with >= 1 subscribed viewer. A
+// snapshot (not a delta) because it rides lossy datagrams: any single delivery
+// heals the state. `n` is monotonic per robot; receivers ignore stale/reordered
+// snapshots.
+export interface SubsMsg {
+  t: "subs";
+  chs: string[];
+  n: number;
+}
+
 // Teleop datagrams (carried from T6 on; declared here so the wire format is
 // pinned by fixtures from day one).
 export interface TwistMsg {
@@ -72,12 +133,14 @@ export interface StopMsg {
 }
 
 export type ControlMsg = HelloMsg | WelcomeMsg | PingMsg | PongMsg | ErrorMsg;
+export type SessionMsg = RobotsMsg | WatchMsg | ManifestMsg | SubMsg | UnsubMsg | SubsMsg;
 export type TeleopMsg = TwistMsg | StopMsg;
-export type Msg = ControlMsg | TeleopMsg;
+export type Msg = ControlMsg | SessionMsg | TeleopMsg;
 
-// Data-plane frame header. `delivery` tells the relay how to forward the
-// frame without a manifest (T1 only; the T2+ manifest replaces it). `meta`
-// carries encoding-specific extras (e.g. {w, h} for images).
+// Data-plane frame header. `delivery` tells the relay how to forward frames
+// on channels the robot's manifest does not declare (the manifest's delivery
+// wins when present). `meta` carries encoding-specific extras (e.g. {w, h}
+// for images).
 export interface FrameHeader {
   ch: string;
   seq: number;
@@ -98,13 +161,20 @@ const dec = new TextDecoder("utf-8", { fatal: true });
 
 // Runtime field validation, mirrored by the pydantic models in protocol.py:
 // "string" is a JSON string, "number" any JSON number (booleans excluded by
-// typeof).
+// typeof). Structured fields (nested objects/arrays) are checked by
+// MSG_VALIDATORS below.
 const MSG_FIELDS: Record<string, Record<string, "string" | "number">> = {
   hello: { v: "number", role: "string" },
   welcome: { v: "number" },
   ping: { n: "number", ts: "number" },
   pong: { n: "number", ts: "number" },
   error: { code: "string", message: "string" },
+  robots: {},
+  watch: { robotId: "string" },
+  manifest: { robotId: "string" },
+  sub: { ch: "string" },
+  unsub: { ch: "string" },
+  subs: { n: "number" },
   twist: { vx: "number", wz: "number", seq: "number", ts: "number" },
   stop: { seq: "number", ts: "number" },
 };
@@ -113,15 +183,51 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function isRobotInfo(value: unknown): value is RobotInfo {
+  return (
+    isRecord(value) &&
+    typeof value.id === "string" &&
+    typeof value.name === "string" &&
+    typeof value.model === "string"
+  );
+}
+
+function isChannelSpec(value: unknown): value is ChannelSpec {
+  return (
+    isRecord(value) &&
+    typeof value.ch === "string" &&
+    typeof value.encoding === "string" &&
+    (value.delivery === "latest" || value.delivery === "reliable") &&
+    typeof value.maxHz === "number"
+  );
+}
+
+// Structural checks for nested fields, run after the flat MSG_FIELDS pass.
+// Optional fields (hello.robot/manifest) accept absent but reject null: JSON
+// encoders on both sides omit absent fields and never emit null.
+const MSG_VALIDATORS: Record<string, (value: Record<string, unknown>) => boolean> = {
+  hello: (v) =>
+    (v.robot === undefined || isRobotInfo(v.robot)) &&
+    (v.manifest === undefined ||
+      (isRecord(v.manifest) &&
+        Array.isArray(v.manifest.channels) &&
+        v.manifest.channels.every(isChannelSpec))),
+  robots: (v) => Array.isArray(v.robots) && v.robots.every(isRobotInfo),
+  manifest: (v) => Array.isArray(v.channels) && v.channels.every(isChannelSpec),
+  subs: (v) => Array.isArray(v.chs) && v.chs.every((c) => typeof c === "string"),
+};
+
 /** Validated message from parsed JSON; null for unknown or malformed ones. */
 export function msgFromUnknown(value: unknown): Msg | null {
   if (!isRecord(value) || typeof value.t !== "string") return null;
-  const fields = MSG_FIELDS[value.t];
+  const fields = Object.hasOwn(MSG_FIELDS, value.t) ? MSG_FIELDS[value.t] : undefined;
   if (fields === undefined) return null;
   for (const [name, kind] of Object.entries(fields)) {
     const actual = typeof value[name];
     if (actual !== kind) return null;
   }
+  const structural = Object.hasOwn(MSG_VALIDATORS, value.t) ? MSG_VALIDATORS[value.t] : undefined;
+  if (structural !== undefined && !structural(value)) return null;
   return value as unknown as Msg;
 }
 

--- a/web/shared/protocol_test.ts
+++ b/web/shared/protocol_test.ts
@@ -134,6 +134,42 @@ Deno.test("msgFromUnknown validates shape and rejects unknown/malformed", () => 
   assertEquals(msgFromUnknown({ t: "hello", v: 1 }), null); // missing role
   assertEquals(msgFromUnknown(null), null);
   assertEquals(msgFromUnknown([1, 2]), null);
+  // Prototype-chain keys must not resolve through Object.prototype (the
+  // mirrored protocol.py rejects these; test_protocol.py asserts the same).
+  assertEquals(msgFromUnknown({ t: "toString" }), null);
+  assertEquals(msgFromUnknown({ t: "constructor" }), null);
+  assertEquals(msgFromUnknown({ t: "hasOwnProperty" }), null);
+});
+
+Deno.test("msgFromUnknown validates nested session-message shapes", () => {
+  const robot = { id: "go2-lab", name: "Go2 Lab", model: "unitree-go2" };
+  const spec = { ch: "odom", encoding: "pose.json.v1", delivery: "reliable", maxHz: 20.5 };
+  // hello stays valid without the optional robot/manifest (viewer form).
+  assertEquals(msgFromUnknown({ t: "hello", v: 1, role: "viewer" }) !== null, true);
+  const full = { t: "hello", v: 1, role: "robot", robot, manifest: { channels: [spec] } };
+  assertEquals(msgFromUnknown(full) !== null, true);
+  // Optional means absent-or-valid: explicit null is rejected.
+  assertEquals(msgFromUnknown({ t: "hello", v: 1, role: "robot", robot: null }), null);
+  assertEquals(msgFromUnknown({ ...full, robot: { id: 5, name: "x", model: "m" } }), null);
+  assertEquals(
+    msgFromUnknown({ ...full, manifest: { channels: [{ ...spec, maxHz: "20" }] } }),
+    null,
+  );
+  assertEquals(
+    msgFromUnknown({ ...full, manifest: { channels: [{ ...spec, delivery: "bogus" }] } }),
+    null,
+  );
+  assertEquals(msgFromUnknown({ ...full, manifest: { channels: robot } }), null);
+  assertEquals(msgFromUnknown({ t: "robots", robots: [robot] }) !== null, true);
+  assertEquals(msgFromUnknown({ t: "robots", robots: {} }), null);
+  assertEquals(msgFromUnknown({ t: "robots", robots: [{ id: "a", name: "b" }] }), null);
+  assertEquals(msgFromUnknown({ t: "robots" }), null);
+  assertEquals(msgFromUnknown({ t: "manifest", robotId: "r", channels: [spec] }) !== null, true);
+  assertEquals(msgFromUnknown({ t: "manifest", channels: [spec] }), null);
+  assertEquals(msgFromUnknown({ t: "watch" }), null);
+  assertEquals(msgFromUnknown({ t: "subs", chs: ["a", "b"], n: 1 }) !== null, true);
+  assertEquals(msgFromUnknown({ t: "subs", chs: ["a", 5], n: 1 }), null);
+  assertEquals(msgFromUnknown({ t: "subs", chs: ["a"] }), null);
 });
 
 Deno.test("frameHeaderFromUnknown validates the header shape", () => {


### PR DESCRIPTION
* Use `--local-relay` to spawn a local relay.
* New messages which carry robot id, channel manifest, etc.
* Split `server.ts` into smaller files.
* Added `RelayBridgeModule`.
* `dimos run` automatically adds `RelayBridgeModule` if `--local-relay` is specified.

## How to Test

Run:

```
uv run python -m dimos.web.relay_bridge.demo_smoke
```

Go to http://127.0.0.1:45175/debug.html .

---

Run sim:

```
uv run dimos --simulation run --local-relay unitree-go2
```

Go to http://127.0.0.1:7780/debug.html

---

Closes DIM-1164

