### PR TITLE
docs: add Sphinx documentation renderer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,27 @@ jobs:
       #   working-directory: docs
       #   run: npm run validate
 
+  docs-build:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read  # For checkout
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          lfs: false
+      - name: Fetch documentation LFS assets
+        run: git lfs pull --include="docs/**" --exclude=""
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+      - name: Install documentation dependencies
+        run: uv sync --no-install-project --only-group docs --frozen
+      - name: Build Sphinx documentation
+        run: uv run --no-sync sphinx-build -W --keep-going -b html docs docs/_build/html
+
   tests:
     timeout-minutes: 20
     strategy:
@@ -733,6 +754,7 @@ jobs:
     - rust
     - md-babel
     - docs-validate
+    - docs-build
     - tests
     - cmu-nav-natives
     - self-hosted-tests

--- a/docs/_static/dimensional.css
+++ b/docs/_static/dimensional.css
@@ -1,0 +1,384 @@
+/* DimOS presentation layer: a quiet, dark documentation shell with a
+   cyan technical accent. Furo supplies the responsive structure; these rules
+   tune its proportions toward the public Dimensional docs. */
+:root {
+  --dimos-teal: #159bbd;
+  --dimos-cyan: #39c7e7;
+  --dimos-ink: #e9eef0;
+  --dimos-muted: #9aa6ab;
+  --dimos-panel: #101416;
+  --dimos-line: #252d31;
+}
+
+body {
+  background: #080a0b;
+}
+
+/* Keep both color modes intentional instead of letting the theme's blue
+   defaults compete with the DimOS teal. */
+body[data-theme="dark"],
+body[data-theme="auto"] {
+  --color-background-primary: #080a0b;
+  --color-background-secondary: #0d1113;
+  --color-background-hover: #141a1d;
+  --color-foreground-primary: var(--dimos-ink);
+  --color-foreground-secondary: var(--dimos-muted);
+  --color-foreground-muted: #748187;
+  --color-background-border: var(--dimos-line);
+  --color-brand-primary: var(--dimos-cyan);
+  --color-brand-content: var(--dimos-cyan);
+}
+
+/* Slim the announcement into the compact promo strip used by the hosted
+   docs, without removing its text or keyboard accessibility. */
+.announcement {
+  display: none;
+}
+
+.announcement-content {
+  max-width: 72rem;
+  margin-inline: auto;
+}
+
+.page {
+  width: 100%;
+  max-width: 84rem;
+  margin-inline: auto;
+  margin-top: 3.25rem;
+  min-height: calc(100vh - 3.25rem);
+}
+
+.dimos-topnav {
+  position: fixed;
+  z-index: 20;
+  top: 0;
+  right: 0;
+  left: 0;
+  height: 3.25rem;
+  border-bottom: 1px solid var(--dimos-line);
+  background: rgba(8, 10, 11, .96);
+  backdrop-filter: blur(12px);
+}
+
+.dimos-topnav-inner {
+  display: flex;
+  align-items: center;
+  gap: 1.2rem;
+  width: min(84rem, 100%);
+  height: 100%;
+  margin-inline: auto;
+  padding-inline: 1rem;
+}
+
+.dimos-topnav-logo {
+  display: inline-flex;
+  align-items: center;
+  width: 8.5rem;
+  color: #dceef2;
+  font-size: .78rem;
+  font-weight: 750;
+  letter-spacing: .12em;
+  text-decoration: none;
+}
+
+.dimos-topnav-logo img {
+  width: 8.5rem;
+  max-height: 2rem;
+  object-fit: contain;
+}
+
+.dimos-topnav-search {
+  display: flex;
+  align-items: center;
+  width: min(22rem, 42vw);
+  margin-inline: auto;
+  padding: .42rem .7rem;
+  border: 1px solid #1d262a;
+  border-radius: 999px;
+  background: #111619;
+}
+
+.dimos-topnav-search input {
+  min-width: 0;
+  flex: 1;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--dimos-ink);
+  font: inherit;
+  font-size: .8rem;
+}
+
+.dimos-topnav-search input::placeholder { color: #7e8b90; }
+.dimos-topnav-search kbd { color: #758187; font-size: .68rem; }
+
+.dimos-topnav-link {
+  color: #dce5e8;
+  font-size: .78rem;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.dimos-topnav-link:hover { color: var(--dimos-cyan); }
+
+.dimos-topnav-cta {
+  padding: .43rem .8rem;
+  border-radius: .55rem;
+  background: var(--dimos-teal);
+  color: white;
+  font-weight: 650;
+}
+
+.dimos-topnav-cta:hover { color: white; background: #20a9c8; }
+
+.sidebar-drawer {
+  width: 17rem;
+  border-right: 1px solid var(--dimos-line);
+}
+
+.sidebar-container {
+  background: #0b0e10;
+}
+
+.sidebar-brand {
+  display: none;
+}
+
+.sidebar-logo-container {
+  max-width: 8.5rem;
+}
+
+.sidebar-logo { max-height: 2.1rem; }
+.sidebar-brand-text { display: none; }
+.sidebar-search-container { display: none; }
+
+/* Furo's native sidebars are sticky to the viewport. Offset both scroll
+   regions by the same compact header height so neither can slide beneath it. */
+.sidebar-sticky,
+.toc-sticky {
+  top: 3.25rem;
+  height: calc(100vh - 3.25rem);
+}
+
+.sidebar-tree {
+  padding: 1rem .85rem 2rem;
+  font-size: .84rem;
+}
+
+.sidebar-tree .toctree-l1 > a {
+  color: #dce5e8;
+  font-weight: 650;
+  letter-spacing: .01em;
+}
+
+.sidebar-tree .toctree-l1.current > a,
+.sidebar-tree a.current,
+.sidebar-tree a:hover {
+  color: var(--dimos-cyan);
+}
+
+/* The source page outline belongs in the right-hand TOC, not in the global
+   catalog sidebar. Page links still remain visible because they have no # in
+   their URL. :has() is supported by current evergreen browsers and leaves the
+   semantic navigation intact for non-CSS users. */
+.sidebar-tree li:has(> a[href*="#"]):not(.current-page) { display: none; }
+
+.main {
+  background: radial-gradient(circle at 85% 0%, rgba(21, 155, 189, .07), transparent 32rem);
+}
+
+.content {
+  flex: 1 1 auto;
+  width: auto;
+  min-width: 0;
+  max-width: none;
+  padding-inline: 2rem;
+}
+
+.article-container {
+  max-width: 42rem;
+  margin-inline: auto;
+}
+
+.content h1 {
+  margin-top: 1.25rem;
+  color: var(--dimos-ink);
+  font-size: clamp(2rem, 3.2vw, 2.25rem);
+  line-height: 1.12;
+  letter-spacing: -.035em;
+  font-weight: 720;
+}
+
+.content h2 {
+  margin-top: 2.8rem;
+  color: var(--dimos-ink);
+  font-size: 1.55rem;
+  letter-spacing: -.02em;
+}
+
+.content p,
+.content li {
+  color: #aeb8bc;
+  line-height: 1.65;
+}
+
+.toc-drawer {
+  width: 13rem;
+}
+
+/* Do not reserve a desktop grid track for pages with no page outline. */
+.toc-drawer.no-toc { display: none; }
+
+/* The rail is content-sized; the border should not run down an empty column. */
+.toc-drawer:not(.no-toc) {
+  align-self: start;
+  padding-inline-start: 1.1rem;
+}
+
+.toc-drawer:not(.no-toc) .toc-sticky {
+  height: auto;
+  max-height: calc(100vh - 4.5rem);
+  overflow-y: auto;
+  padding: .85rem 0 1rem 1rem;
+  border-left: 1px solid var(--dimos-line);
+}
+
+.toc-title {
+  display: block;
+  margin-bottom: .65rem;
+  color: #dce5e8;
+  font-size: .7rem;
+  font-weight: 700;
+  letter-spacing: .1em;
+  line-height: 1.3;
+  text-transform: uppercase;
+}
+
+.toc-tree {
+  font-size: .82rem;
+}
+
+.toc-tree ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.toc-tree ul ul {
+  margin: .2rem 0 .25rem .45rem;
+  padding-left: .55rem;
+  border-left: 1px solid #1c272b;
+}
+
+.toc-tree a {
+  display: block;
+  padding: .25rem .45rem;
+  border-radius: .3rem;
+  color: #8f9da2;
+  line-height: 1.4;
+  text-decoration: none;
+}
+
+.toc-tree > ul > li > a,
+.toc-tree li.active > a,
+.toc-tree a.current,
+.toc-tree a[aria-current="true"],
+.toc-tree a[aria-current="location"] {
+  color: var(--dimos-ink);
+  font-weight: 650;
+}
+
+.toc-tree li.active > a,
+.toc-tree a.current,
+.toc-tree a[aria-current="true"],
+.toc-tree a[aria-current="location"],
+.toc-tree a:hover {
+  background: rgba(57, 199, 231, .08);
+  color: var(--dimos-cyan);
+}
+
+/* The page outline is intentionally deferred to a dedicated Sphinx plugin.
+   Remove the drawer and both Furo toggle affordances at every breakpoint so
+   the article reclaims the full main column without an empty rail. */
+.toc-drawer,
+.toc-overlay-icon,
+.toc-content-icon,
+.toc-header-icon {
+  display: none !important;
+}
+
+.sd-card {
+  position: relative;
+  min-height: 10rem;
+  border: 1px solid #283237;
+  border-radius: .8rem;
+  background: rgba(15, 19, 21, .72);
+  box-shadow: none;
+  transition: transform .18s ease, border-color .18s ease, background .18s ease;
+}
+
+.sd-card:hover {
+  border-color: #347f91;
+  background: #11191c;
+  transform: translateY(-2px);
+}
+
+.sd-card-body {
+  padding: 1.25rem 1.2rem 1.15rem 1.2rem;
+}
+
+.sd-card-title {
+  color: #f0f5f6;
+  font-size: 1rem;
+  letter-spacing: -.01em;
+}
+
+.dimos-card .sd-card-title::before {
+  display: block;
+  margin-bottom: .85rem;
+  color: var(--dimos-cyan);
+  font-size: 1.35rem;
+  line-height: 1;
+  font-weight: 400;
+}
+
+.dimos-icon-map .sd-card-title::before { content: "⌁"; }
+.dimos-icon-eye .sd-card-title::before { content: "⊙"; }
+.dimos-icon-robot .sd-card-title::before { content: "♙"; }
+.dimos-icon-brain .sd-card-title::before { content: "◌"; }
+.dimos-icon-rocket .sd-card-title::before { content: "↗"; }
+.dimos-icon-microchip .sd-card-title::before { content: "▦"; }
+.dimos-icon-diagram-project .sd-card-title::before { content: "⌘"; }
+.dimos-icon-bolt .sd-card-title::before { content: "ϟ"; }
+.dimos-icon-spark .sd-card-title::before { content: "◇"; }
+
+.sd-card p,
+.sd-card li {
+  margin-bottom: 0;
+  color: #aab5b9;
+  line-height: 1.45;
+}
+
+.sd-card strong { color: #f0f5f6; }
+.sd-card .highlight { overflow: visible; }
+.sd-card pre { white-space: normal; overflow: visible; }
+
+@media (max-width: 70rem) {
+  .article-container { max-width: 38rem; }
+}
+
+@media (max-width: 50rem) {
+  .page { margin-top: 3.25rem; }
+  .content { padding-inline: 1rem; }
+  .sidebar-drawer { width: min(17rem, 86vw); }
+  .toc-drawer,
+  .toc-drawer:not(.no-toc) { display: none; }
+  .dimos-topnav-link { display: none; }
+  .dimos-topnav-search { width: auto; flex: 1; margin-inline: 0; }
+  .dimos-topnav-cta { display: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sd-card { transition: none; }
+  .sd-card:hover { transform: none; }
+}

--- a/docs/_static/searchtools-root.js
+++ b/docs/_static/searchtools-root.js
@@ -1,0 +1,29 @@
+/* Keep Sphinx's native search, but make its directory-style result links root-relative. */
+(function () {
+  "use strict";
+
+  const normalizeSearchLinks = () => {
+    const contentRoot = document.documentElement.dataset.content_root || "./";
+    document.querySelectorAll("#search-results a[href]").forEach((link) => {
+      const href = link.getAttribute("href");
+      if (!href || href.startsWith("/") || href.startsWith("#") || /^[a-z][a-z0-9+.-]*:/i.test(href)) {
+        return;
+      }
+      const [path, fragment = ""] = href.split("#", 2);
+      const canonicalPath = path.endsWith("/index/")
+        ? path.slice(0, -6)
+        : path === "index/"
+          ? ""
+          : path;
+      const target = new URL(contentRoot + canonicalPath, document.baseURI);
+      target.hash = fragment;
+      link.href = target.href;
+    });
+  };
+
+  normalizeSearchLinks();
+  new MutationObserver(normalizeSearchLinks).observe(document.body, {
+    childList: true,
+    subtree: true,
+  });
+})();

--- a/docs/_templates/sidebar/brand.html
+++ b/docs/_templates/sidebar/brand.html
@@ -1,0 +1,23 @@
+<div class="dimos-topnav" role="navigation" aria-label="Primary navigation">
+  <div class="dimos-topnav-inner">
+    <a class="dimos-topnav-logo" href="{{ pathto(master_doc) }}" aria-label="Dimensional home">
+      {% if logo_url %}<img src="{{ logo_url }}" alt="Dimensional"/>{% else %}DIMENSIONAL{% endif %}
+    </a>
+    <form class="dimos-topnav-search" method="get" action="{{ pathto('search') }}" role="search">
+      <span aria-hidden="true">⌕</span>
+      <input name="q" type="search" placeholder="Search docs" aria-label="Search documentation"/>
+      <kbd>Ctrl K</kbd>
+    </form>
+    <a class="dimos-topnav-link" href="https://github.com/dimensionalOS/dimos">dimensionalOS/dimos</a>
+    <a class="dimos-topnav-link dimos-topnav-cta" href="https://dimensionalos.com/prototype">Get started</a>
+  </div>
+</div>
+<script>
+  // Keep the public catalog's first level open while leaving every nested
+  // disclosure keyboard-toggleable through Furo's native checkboxes.
+  document.addEventListener("DOMContentLoaded", function () {
+    document.querySelectorAll(
+      ".sidebar-tree > ul > li.toctree-l1.has-children > input.toctree-checkbox"
+    ).forEach(function (toggle) { toggle.checked = true; });
+  });
+</script>

--- a/docs/capabilities.rst
+++ b/docs/capabilities.rst
@@ -1,0 +1,13 @@
+Capabilities
+============
+
+.. toctree::
+   :maxdepth: 1
+   :titlesonly:
+
+   Agents <capabilities/agents>
+   Manipulation <capabilities/manipulation>
+   Memory <capabilities/memory>
+   Navigation <capabilities/navigation>
+   Perception <capabilities/perception>
+   Teleoperation <capabilities/teleoperation>

--- a/docs/capabilities/agents.rst
+++ b/docs/capabilities/agents.rst
@@ -1,0 +1,12 @@
+Agents
+======
+
+.. include:: agents/index.md
+   :parser: myst_parser.sphinx_
+   :body-only:
+   :relative-images:
+   :relative-docs: .
+
+.. toctree::
+   :maxdepth: 1
+   :titlesonly:

--- a/docs/capabilities/manipulation.rst
+++ b/docs/capabilities/manipulation.rst
@@ -14,3 +14,4 @@ Manipulation
    manipulation/adding_a_custom_arm
    manipulation/openarm_integration
    manipulation/a750
+   manipulation/agentic

--- a/docs/capabilities/manipulation.rst
+++ b/docs/capabilities/manipulation.rst
@@ -1,0 +1,16 @@
+Manipulation
+============
+
+.. include:: manipulation/index.md
+   :parser: myst_parser.sphinx_
+   :body-only:
+   :relative-images:
+   :relative-docs: .
+
+.. toctree::
+   :maxdepth: 1
+   :titlesonly:
+
+   manipulation/adding_a_custom_arm
+   manipulation/openarm_integration
+   manipulation/a750

--- a/docs/capabilities/memory.rst
+++ b/docs/capabilities/memory.rst
@@ -1,0 +1,15 @@
+Memory
+======
+
+.. include:: memory/index.md
+   :parser: myst_parser.sphinx_
+   :body-only:
+   :relative-images:
+   :relative-docs: .
+
+.. toctree::
+   :maxdepth: 1
+   :titlesonly:
+
+   memory/algo_comparison
+   memory/plot

--- a/docs/capabilities/navigation.rst
+++ b/docs/capabilities/navigation.rst
@@ -1,0 +1,15 @@
+Navigation
+==========
+
+.. include:: navigation/index.md
+   :parser: myst_parser.sphinx_
+   :body-only:
+   :relative-images:
+   :relative-docs: .
+
+.. toctree::
+   :maxdepth: 1
+   :titlesonly:
+
+   navigation/deep_dive
+   navigation/relocalization

--- a/docs/capabilities/perception.rst
+++ b/docs/capabilities/perception.rst
@@ -1,0 +1,12 @@
+Perception
+==========
+
+.. include:: perception/index.md
+   :parser: myst_parser.sphinx_
+   :body-only:
+   :relative-images:
+   :relative-docs: .
+
+.. toctree::
+   :maxdepth: 1
+   :titlesonly:

--- a/docs/capabilities/teleoperation.rst
+++ b/docs/capabilities/teleoperation.rst
@@ -1,0 +1,8 @@
+Teleoperation
+=============
+
+.. toctree::
+   :maxdepth: 1
+   :titlesonly:
+
+   teleoperation/hosted

--- a/docs/coding-agents.rst
+++ b/docs/coding-agents.rst
@@ -18,5 +18,3 @@ Coding agent notes
    coding-agents/docs/index
    coding-agents/docs/codeblocks
    coding-agents/docs/doclinks
-   agents/domain
-   agents/issue-tracker

--- a/docs/coding-agents.rst
+++ b/docs/coding-agents.rst
@@ -1,0 +1,22 @@
+Coding agent notes
+==================
+
+.. include:: coding-agents/index.md
+   :parser: myst_parser.sphinx_
+   :body-only:
+   :relative-images:
+   :relative-docs: .
+
+.. toctree::
+   :maxdepth: 1
+   :titlesonly:
+
+   coding-agents/style
+   coding-agents/testing
+   coding-agents/worktrees
+   coding-agents/code-quality-rules
+   coding-agents/docs/index
+   coding-agents/docs/codeblocks
+   coding-agents/docs/doclinks
+   agents/domain
+   agents/issue-tracker

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,14 +8,12 @@ of Mintlify components used by the introduction and quickstart pages.
 from __future__ import annotations
 
 import os
-import re
-import shutil
 from pathlib import Path
+import re
 
 from docutils.parsers.rst import directives
-from sphinx.directives.other import Include
 from myst_parser.parsers.sphinx_ import MystParser
-
+from sphinx.directives.other import Include
 
 project = "Dimensional"
 copyright = "2026, Dimensional Team"
@@ -88,9 +86,14 @@ _COMPONENT_OPEN = re.compile(
     r"^(?P<indent>\s*)<(?P<name>Columns|CardGroup|Card)\b(?P<attrs>[^>]*)>\s*$"
 )
 _COMPONENT_CLOSE = re.compile(r"^\s*</(?P<name>Columns|CardGroup|Card)>\s*$")
-_ATTRIBUTE = re.compile(r"(?P<key>title|href|cols|icon)=[{]?(?:\"(?P<quoted>[^\"]*)\"|(?P<braced>[^}\s]+))[}]?")
+_ATTRIBUTE = re.compile(
+    r"(?P<key>title|href|cols|icon)=[{]?(?:\"(?P<quoted>[^\"]*)\"|(?P<braced>[^}\s]+))[}]?"
+)
 _ICON = re.compile(r"<Icon\b[^>]*/>")
-_LEGACY_LEXERS = re.compile(r"^(?P<indent>\s*)(?P<fence>`{3,}|~{3,})(?P<lexer>results|pikchr|node|diagon)(?P<rest>.*)$", re.MULTILINE)
+_LEGACY_LEXERS = re.compile(
+    r"^(?P<indent>\s*)(?P<fence>`{3,}|~{3,})(?P<lexer>results|pikchr|node|diagon)(?P<rest>.*)$",
+    re.MULTILINE,
+)
 _IMAGE = re.compile(r"!\[(?P<alt>[^]]*)\]\((?P<path>[^)]+)\)")
 _MINTLIFY_DOC_LINK = re.compile(
     r"(?P<opening>\()(?P<path>/docs/[^)#\s]+)\.md(?P<anchor>#[^)\s]+)?(?P<closing>\))"
@@ -154,7 +157,9 @@ def _mintlify_components(text: str) -> str:
                 href = _attribute(attrs, "href")
                 icon = _attribute(attrs, "icon") or "spark"
                 output.append(f":::\u007bgrid-item-card\u007d {title}")
-                output.append(f":class-card: dimos-card dimos-icon-{re.sub(r'[^a-z0-9-]', '-', icon.lower())}")
+                output.append(
+                    f":class-card: dimos-card dimos-icon-{re.sub(r'[^a-z0-9-]', '-', icon.lower())}"
+                )
                 if href:
                     output.append(f":link: {_canonical_card_route(href)}")
                 output.append("")
@@ -241,8 +246,8 @@ def _strip_frontmatter_title(text: str) -> str:
         end = next(index for index, line in enumerate(lines[1:], 1) if line.strip() == "---")
     except StopIteration:
         return text
-    lines = lines[:end + 1]
-    body = text.splitlines(keepends=True)[end + 1:]
+    lines = lines[: end + 1]
+    body = text.splitlines(keepends=True)[end + 1 :]
     frontmatter = [line for line in lines[1:-1] if not re.match(r"^\s*title\s*:", line)]
     if not frontmatter:
         return "".join(body)
@@ -254,7 +259,9 @@ def _coding_agents_landing(text: str) -> str:
 
     if not text.startswith(_CODING_AGENTS_LANDING):
         return text
-    return _CODING_AGENTS_LANDING + """
+    return (
+        _CODING_AGENTS_LANDING
+        + """
 The coding-agent notes are organized as a small toolkit: start with the
 workflow guides, then use the documentation utilities when you are changing
 the docs themselves.
@@ -294,6 +301,7 @@ Executable code blocks, doc links, and diagrams for writing docs.
 :::
 ::::
 """
+    )
 
 
 def _normalise_markdown_source(text: str, source_path: Path) -> str:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,421 @@
+"""Sphinx configuration for the DimOS documentation.
+
+The Markdown and MDX files remain the source of truth.  This file only adds
+the Sphinx presentation layer and a small compatibility pass for the handful
+of Mintlify components used by the introduction and quickstart pages.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+from pathlib import Path
+
+from docutils.parsers.rst import directives
+from sphinx.directives.other import Include
+from myst_parser.parsers.sphinx_ import MystParser
+
+
+project = "Dimensional"
+copyright = "2026, Dimensional Team"
+author = "Dimensional Team"
+release = ""
+
+extensions = [
+    "myst_parser",
+    "sphinx_design",
+]
+
+# Keep the existing Markdown/MDX source directly renderable, and register the
+# small non-Markdown Sphinx entry point used by ``master_doc``.
+source_suffix = {".md": "markdown", ".mdx": "markdown", ".rst": "restructuredtext"}
+master_doc = "index"
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "node_modules"]
+
+# The legacy Markdown corpus intentionally contains heading jumps.  Suppress
+# only the known legacy-source diagnostics below. Strict builds still surface
+# broken links, missing documents, and all unrelated Sphinx/MyST warnings.
+suppress_warnings = [
+    "myst.header",
+    "myst.xref_missing",  # repository links intentionally point to GitHub
+]
+
+myst_enable_extensions = [
+    "colon_fence",
+    "deflist",
+    "fieldlist",
+    "linkify",
+    "strikethrough",
+    "substitution",
+    "tasklist",
+]
+myst_heading_anchors = 3
+myst_title_to_header = True
+
+html_theme = "furo"
+html_title = "Dimensional · DimOS"
+html_file_suffix = "/index.html"
+html_link_suffix = "/"
+html_logo = "assets/dimensional-logo-master-transparent.png"
+html_favicon = "assets/favicon.png"
+html_static_path = ["_static"]
+html_css_files = ["dimensional.css"]
+templates_path = ["_templates"]
+html_theme_options = {
+    "announcement": "DimOS documentation — build physical applications in Python.",
+    "source_repository": "https://github.com/dimensionalOS/dimos",
+    "source_branch": "main",
+    "source_directory": "docs/",
+    "sidebar_hide_name": True,
+    "light_css_variables": {
+        "color-brand-primary": "#1682a3",
+        "color-brand-content": "#08708f",
+        "color-brand-visited": "#7358a6",
+    },
+    "dark_css_variables": {
+        "color-brand-primary": "#50c5df",
+        "color-brand-content": "#68d4e9",
+        "color-brand-visited": "#c3a9ff",
+    },
+}
+
+nitpicky = False
+nitpick_ignore = [("py:class", "Dimos")]
+
+
+_COMPONENT_OPEN = re.compile(
+    r"^(?P<indent>\s*)<(?P<name>Columns|CardGroup|Card)\b(?P<attrs>[^>]*)>\s*$"
+)
+_COMPONENT_CLOSE = re.compile(r"^\s*</(?P<name>Columns|CardGroup|Card)>\s*$")
+_ATTRIBUTE = re.compile(r"(?P<key>title|href|cols|icon)=[{]?(?:\"(?P<quoted>[^\"]*)\"|(?P<braced>[^}\s]+))[}]?")
+_ICON = re.compile(r"<Icon\b[^>]*/>")
+_LEGACY_LEXERS = re.compile(r"^(?P<indent>\s*)(?P<fence>`{3,}|~{3,})(?P<lexer>results|pikchr|node|diagon)(?P<rest>.*)$", re.MULTILINE)
+_IMAGE = re.compile(r"!\[(?P<alt>[^]]*)\]\((?P<path>[^)]+)\)")
+_MINTLIFY_DOC_LINK = re.compile(
+    r"(?P<opening>\()(?P<path>/docs/[^)#\s]+)\.md(?P<anchor>#[^)\s]+)?(?P<closing>\))"
+)
+_ROOT_RELATIVE_ATTRIBUTE = re.compile(
+    r"(?P<prefix>\b(?:href|src|action|poster)=['\"])(?P<relative>(?:\.\./)+)(?P<path>[^'\"]*)"
+)
+_CODING_AGENTS_LANDING = '---\ntitle: "For Agents"\n---\n'
+_INCLUDED_SOURCES: dict[Path, str] = {}
+_DOCS_DIR = Path(__file__).parent.resolve()
+_SYNTHETIC_TITLES = {
+    "capabilities/memory/algo_comparison.md": "Algorithm comparison",
+    "capabilities/memory/plot.md": "Plot",
+    "development/conventions.md": "Conventions",
+}
+
+
+def _attribute(attrs: str, key: str) -> str | None:
+    for match in _ATTRIBUTE.finditer(attrs):
+        if match.group("key") == key:
+            return match.group("quoted") or match.group("braced")
+    return None
+
+
+def _mintlify_components(text: str) -> str:
+    """Translate the small Mintlify JSX subset into sphinx-design directives.
+
+    Only lines outside fenced code blocks are changed.  This keeps examples
+    such as ``export ROBOT_IP=<YOUR_ROBOT_IP>`` completely untouched.
+    """
+
+    output: list[str] = []
+    in_fence = False
+    inside_card = False
+    for line in text.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("```") or stripped.startswith("~~~"):
+            in_fence = not in_fence
+            output.append(line)
+            continue
+        if in_fence:
+            output.append(line)
+            continue
+
+        close = _COMPONENT_CLOSE.match(line)
+        if close:
+            if close.group("name") == "Card":
+                inside_card = False
+            output.append("::::" if close.group("name") in {"Columns", "CardGroup"} else ":::")
+            continue
+
+        open_match = _COMPONENT_OPEN.match(line)
+        if open_match:
+            name = open_match.group("name")
+            attrs = open_match.group("attrs")
+            if name in {"Columns", "CardGroup"}:
+                cols = _attribute(attrs, "cols") or "2"
+                output.append(f"::::{{grid}} 1 1 {cols} {cols}")
+            else:
+                title = _attribute(attrs, "title") or ""
+                href = _attribute(attrs, "href")
+                icon = _attribute(attrs, "icon") or "spark"
+                output.append(f":::\u007bgrid-item-card\u007d {title}")
+                output.append(f":class-card: dimos-card dimos-icon-{re.sub(r'[^a-z0-9-]', '-', icon.lower())}")
+                if href:
+                    output.append(f":link: {_canonical_card_route(href)}")
+                output.append("")
+                inside_card = True
+            continue
+
+        if inside_card:
+            # Mintlify indents Card bodies for JSX readability. That
+            # indentation becomes a literal code block in MyST; remove it so
+            # prose, emphasis, and inline links are parsed normally.
+            output.append(line.lstrip())
+            continue
+
+        output.append(_ICON.sub("", line))
+    return "\n".join(output)
+
+
+def _canonical_card_route(href: str) -> str:
+    """Keep external Card links intact and make internal links site-rooted."""
+
+    if not href.startswith("/") or href.startswith("//"):
+        return href
+    route = href
+    if route.startswith("/docs/"):
+        route = route.removeprefix("/docs")
+    route = route.removesuffix(".md")
+    if route == "/index":
+        return "/"
+    route = route.removesuffix("/index")
+    return f"{route.rstrip('/')}/"
+
+
+def _normalise_legacy_source(text: str, source_path: Path) -> str:
+    """Make known legacy-only syntax safe for the Sphinx renderer."""
+
+    # These fences are valid in the repository's Markdown tooling but are not
+    # Pygments lexers. Rendering them as plain text preserves the examples and
+    # avoids hiding highlighting failures for every other language.
+    text = _LEGACY_LEXERS.sub(
+        lambda match: f"{match.group('indent')}{match.group('fence')}text{match.group('rest')}",
+        text,
+    )
+
+    # This one pip requirement is intentionally written in install syntax,
+    # not TOML string syntax. Keep the displayed command unchanged while
+    # asking Pygments to render the fence as plain text.
+    if source_path.as_posix().endswith("capabilities/manipulation/a750.md"):
+        text = re.sub(r"^(\s*)(`{3,}|~{3,})toml\s*$", r"\1\2text", text, flags=re.MULTILINE)
+
+    # A few code-authoring examples intentionally reference generated assets
+    # that are not checked into this repository. Replace only those missing
+    # local images with an honest inline note; available assets still render.
+    if "coding-agents/docs/" in source_path.as_posix():
+        parent = source_path.parent
+
+        def image_or_note(match: re.Match[str]) -> str:
+            image = (parent / match.group("path")).resolve()
+            if image.is_file():
+                return match.group(0)
+            return f"*Image unavailable in this checkout: {match.group('alt')}*"
+
+        text = _IMAGE.sub(image_or_note, text)
+    return text
+
+
+def _normalise_mintlify_links(text: str) -> str:
+    """Map Mintlify absolute Markdown links to Sphinx directory routes."""
+
+    def route(match: re.Match[str]) -> str:
+        path = match.group("path").removeprefix("/docs")
+        anchor = match.group("anchor") or ""
+        return f"{match.group('opening')}{path}/{anchor}{match.group('closing')}"
+
+    return _MINTLIFY_DOC_LINK.sub(route, text)
+
+
+def _strip_frontmatter_title(text: str) -> str:
+    """Remove only a Markdown frontmatter title for an RST-owned wrapper."""
+
+    lines = text.splitlines(keepends=True)
+    if not lines or lines[0].strip() != "---":
+        return text
+    try:
+        end = next(index for index, line in enumerate(lines[1:], 1) if line.strip() == "---")
+    except StopIteration:
+        return text
+    lines = lines[:end + 1]
+    body = text.splitlines(keepends=True)[end + 1:]
+    frontmatter = [line for line in lines[1:-1] if not re.match(r"^\s*title\s*:", line)]
+    if not frontmatter:
+        return "".join(body)
+    return "".join([lines[0], *frontmatter, lines[-1], *body])
+
+
+def _coding_agents_landing(text: str) -> str:
+    """Replace only the legacy coding-agent tree with a navigable catalog."""
+
+    if not text.startswith(_CODING_AGENTS_LANDING):
+        return text
+    return _CODING_AGENTS_LANDING + """
+The coding-agent notes are organized as a small toolkit: start with the
+workflow guides, then use the documentation utilities when you are changing
+the docs themselves.
+
+## Agent toolkit
+
+::::{grid} 1 1 2 2
+:::{grid-item-card} Worktrees
+:class-card: dimos-card dimos-icon-spark
+:link: /coding-agents/worktrees/
+
+Create and use provisioned worktrees with `bin/worktree`.
+:::
+:::{grid-item-card} Style guidelines
+:class-card: dimos-card dimos-icon-spark
+:link: /coding-agents/style/
+
+Code style and conventions for DimOS contributions.
+:::
+:::{grid-item-card} Code quality rules
+:class-card: dimos-card dimos-icon-spark
+:link: /coding-agents/code-quality-rules/
+
+Rules that agents scan and fix during coding work.
+:::
+:::{grid-item-card} Testing guidelines
+:class-card: dimos-card dimos-icon-spark
+:link: /coding-agents/testing/
+
+How to write and run the project test suite.
+:::
+:::{grid-item-card} Documentation guides
+:class-card: dimos-card dimos-icon-spark
+:link: /coding-agents/docs/index/
+
+Executable code blocks, doc links, and diagrams for writing docs.
+:::
+::::
+"""
+
+
+def _normalise_markdown_source(text: str, source_path: Path) -> str:
+    """Apply the Markdown compatibility passes exactly once per parse."""
+
+    text = _normalise_mintlify_links(text)
+    if source_path.as_posix().endswith("docs/coding-agents/index.md"):
+        text = _coding_agents_landing(text)
+    text = _normalise_legacy_source(text, source_path)
+    if source_path.suffix == ".mdx":
+        text = _mintlify_components(text)
+    key = source_path.relative_to(_DOCS_DIR).as_posix()
+    if key in _SYNTHETIC_TITLES and not re.match(r"^\s*#\s", text):
+        title = _SYNTHETIC_TITLES[key]
+        text = f"{title}\n{'=' * len(title)}\n\n{text}"
+    return text
+
+
+def _relativise_included_images(text: str, source_path: Path, parent_path: Path) -> str:
+    """Resolve included Markdown images from the including RST document."""
+
+    source_dir = source_path.parent
+    parent_dir = parent_path.parent
+
+    def image_path(match: re.Match[str]) -> str:
+        path = match.group("path")
+        if path.startswith(("/", "#", "data:", "http://", "https://")):
+            return match.group(0)
+        resolved = os.path.relpath(source_dir / path, parent_dir)
+        return match.group(0).replace(path, resolved, 1)
+
+    return _IMAGE.sub(image_path, text)
+
+
+def _prepare_source(app, docname: str, source: list[str]) -> None:
+    source_path = (Path(app.srcdir) / app.env.doc2path(docname)).resolve()
+    # Mintlify links are rooted at /docs, while Sphinx serves docs at /. Only
+    # normalize Markdown/MDX content; the RST root legitimately contains the
+    # literal ``coding-agents/docs/...`` document names.
+    if source_path.suffix in {".md", ".mdx"}:
+        source[0] = _normalise_markdown_source(source[0], source_path)
+
+
+def _prepare_included_source(app, relative_path, parent_docname: str, source: list[str]) -> None:
+    """Apply Markdown compatibility passes to parser-qualified RST includes."""
+
+    source_path = (Path(app.srcdir) / relative_path).resolve()
+    if source_path.suffix in {".md", ".mdx"}:
+        source[0] = _normalise_markdown_source(source[0], source_path)
+        parent_path = (Path(app.srcdir) / app.env.doc2path(parent_docname)).resolve()
+        source[0] = _relativise_included_images(source[0], source_path, parent_path)
+
+
+class _IncludedMystParser(MystParser):
+    """Feed include-read's transformed source to a parser-qualified include."""
+
+    def parse(self, inputstring, document) -> None:
+        source_path = Path(document["source"]).resolve()
+        super().parse(_INCLUDED_SOURCES.get(source_path, inputstring), document)
+
+
+class _IncludeWithReadEvent(Include):
+    """Make Sphinx's parser-qualified include emit its normal include event."""
+
+    def run(self):
+        parser = self.options.get("parser")
+        if parser is MystParser and self.arguments[0].lower().endswith((".md", ".mdx")):
+            _relative_path, filename = self.env.relfn2path(self.arguments[0])
+            source_path = Path(filename).resolve()
+            text = source_path.read_text(encoding=self.state.document.settings.input_encoding)
+            if "body-only" in self.options:
+                text = _strip_frontmatter_title(text)
+            arg = [text]
+            relative_path = Path(os.path.relpath(source_path, self.env.srcdir))
+            self.env.app.events.emit("include-read", relative_path, self.env.docname, arg)
+            _INCLUDED_SOURCES[source_path] = arg[0]
+            self.options["parser"] = _IncludedMystParser
+            try:
+                return super().run()
+            finally:
+                self.options["parser"] = parser
+                _INCLUDED_SOURCES.pop(source_path, None)
+        return super().run()
+
+
+def _publish_root_index(app, exception) -> None:
+    """Expose the master document at ``/`` as well as ``/index/``."""
+
+    if exception is None:
+        generated = Path(app.outdir) / "index" / "index.html"
+        root = Path(app.outdir) / "index.html"
+        if generated.is_file():
+            rendered = generated.read_text(encoding="utf-8")
+            # The master document is rendered in /index/, so Sphinx emits
+            # ../-relative URLs. Once copied to /index.html those escape the
+            # site root. Rewrite only URL-bearing HTML attributes; external
+            # URLs and fragments are unaffected.
+            rendered = _ROOT_RELATIVE_ATTRIBUTE.sub(
+                lambda match: f"{match.group('prefix')}/{match.group('path')}",
+                rendered,
+            )
+            root.write_text(rendered, encoding="utf-8")
+
+
+def _trim_markdown_tocs(app, env) -> None:
+    """Keep Markdown page titles, not their body headings, in Furo's tree."""
+
+    for docname, toc in env.tocs.items():
+        source_path = (Path(app.srcdir) / env.doc2path(docname)).resolve()
+        if source_path.suffix in {".md", ".mdx"} and toc.children:
+            toc.children[:] = toc.children[:1]
+
+
+def setup(app):
+    # The parser-qualified Docutils include uses Sphinx's outer RST directive;
+    # expose MyST's include options there as well.
+    Include.option_spec["relative-images"] = directives.flag
+    Include.option_spec["relative-docs"] = directives.path
+    Include.option_spec["body-only"] = directives.flag
+    directives.register_directive("include", _IncludeWithReadEvent)
+    app.connect("source-read", _prepare_source)
+    app.connect("include-read", _prepare_included_source)
+    app.connect("env-updated", _trim_markdown_tocs)
+    app.connect("build-finished", _publish_root_index)
+    return {"version": "1", "parallel_read_safe": True}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,6 +59,7 @@ html_logo = "assets/dimensional-logo-master-transparent.png"
 html_favicon = "assets/favicon.png"
 html_static_path = ["_static"]
 html_css_files = ["dimensional.css"]
+html_js_files = ["searchtools-root.js"]
 templates_path = ["_templates"]
 html_theme_options = {
     "announcement": "DimOS documentation — build physical applications in Python.",

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -1,0 +1,15 @@
+Development
+===========
+
+.. toctree::
+   :maxdepth: 1
+   :titlesonly:
+
+   development/conventions
+   development/testing
+   development/docker
+   development/grid_testing
+   development/large_file_management
+   development/profiling_dimos
+   development/releasing
+   development/writing_docs

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -1,0 +1,10 @@
+Getting Started
+===============
+
+.. toctree::
+   :maxdepth: 1
+   :titlesonly:
+
+   Introduction <introduction>
+   Quickstart <quickstart>
+   System Requirements <requirements>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,8 +1,11 @@
-Dimensional
-===========
+Welcome to Dimensional
+======================
 
-Build physical applications in Python with the modern operating system for
-generalist robotics.
+.. include:: introduction.mdx
+   :parser: myst_parser.sphinx_
+   :body-only:
+   :relative-images:
+   :relative-docs: .
 
 .. toctree::
    :maxdepth: 1

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,21 @@
+Dimensional
+===========
+
+Build physical applications in Python with the modern operating system for
+generalist robotics.
+
+.. toctree::
+   :maxdepth: 1
+   :titlesonly:
+
+   Getting Started <getting-started>
+   Installation <installation>
+   Usage <usage>
+   Capabilities <capabilities>
+   Platforms <platforms>
+   Development <development>
+
+.. toctree::
+   :hidden:
+
+   Coding agent notes <coding-agents>

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,0 +1,10 @@
+Installation
+============
+
+.. toctree::
+   :maxdepth: 1
+   :titlesonly:
+
+   Ubuntu <installation/ubuntu>
+   macOS <installation/osx>
+   Nix <installation/nix>

--- a/docs/platforms.rst
+++ b/docs/platforms.rst
@@ -1,0 +1,9 @@
+Platforms
+=========
+
+.. toctree::
+   :maxdepth: 1
+   :titlesonly:
+
+   Quadruped <platforms/quadruped>
+   Humanoid <platforms/humanoid>

--- a/docs/platforms/humanoid.rst
+++ b/docs/platforms/humanoid.rst
@@ -1,0 +1,8 @@
+Humanoid
+========
+
+.. toctree::
+   :maxdepth: 1
+   :titlesonly:
+
+   humanoid/g1/index

--- a/docs/platforms/quadruped.rst
+++ b/docs/platforms/quadruped.rst
@@ -1,0 +1,8 @@
+Quadruped
+=========
+
+.. toctree::
+   :maxdepth: 1
+   :titlesonly:
+
+   Unitree Go2 <quadruped/go2>

--- a/docs/platforms/quadruped/go2.rst
+++ b/docs/platforms/quadruped/go2.rst
@@ -1,0 +1,15 @@
+Unitree Go2
+===========
+
+.. include:: go2/index.md
+   :parser: myst_parser.sphinx_
+   :body-only:
+   :relative-images:
+   :relative-docs: .
+
+.. toctree::
+   :maxdepth: 1
+   :titlesonly:
+
+   go2/setup
+   go2/simulation

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -11,7 +11,6 @@ Usage
    :maxdepth: 1
    :titlesonly:
 
-   Concepts <usage/index>
    Modules <usage/modules>
    Blueprints <usage/blueprints>
    Configuration <usage/configuration>
@@ -26,3 +25,8 @@ Usage
    Data streams <usage/data-streams>
    Sensor streams <usage/sensor-streams>
    Transports <usage/transports>
+
+.. toctree::
+   :hidden:
+
+   usage/index

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,0 +1,28 @@
+Usage
+=====
+
+.. include:: usage/index.md
+   :parser: myst_parser.sphinx_
+   :body-only:
+   :relative-images:
+   :relative-docs: .
+
+.. toctree::
+   :maxdepth: 1
+   :titlesonly:
+
+   Concepts <usage/index>
+   Modules <usage/modules>
+   Blueprints <usage/blueprints>
+   Configuration <usage/configuration>
+   LCM <usage/lcm>
+   Transforms <usage/transforms>
+   Visualization <usage/visualization>
+   CLI <usage/cli>
+   Python API <usage/python-api>
+   Camera Calibration <usage/camera_calibration>
+   Native Modules <usage/native_modules>
+   Tool Streams <usage/tool_streams>
+   Data streams <usage/data-streams>
+   Sensor streams <usage/sensor-streams>
+   Transports <usage/transports>

--- a/docs/usage/data-streams.rst
+++ b/docs/usage/data-streams.rst
@@ -1,0 +1,18 @@
+Data streams
+============
+
+.. include:: data_streams/index.md
+   :parser: myst_parser.sphinx_
+   :body-only:
+   :relative-images:
+   :relative-docs: .
+
+.. toctree::
+   :maxdepth: 1
+   :titlesonly:
+
+   data_streams/advanced_streams
+   data_streams/quality_filter
+   data_streams/reactivex
+   data_streams/storage_replay
+   data_streams/temporal_alignment

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Concepts"
+title: "Usage"
 ---
 
 This page explains general concepts.

--- a/docs/usage/sensor-streams.rst
+++ b/docs/usage/sensor-streams.rst
@@ -1,0 +1,18 @@
+Sensor streams
+==============
+
+.. include:: sensor_streams/index.md
+   :parser: myst_parser.sphinx_
+   :body-only:
+   :relative-images:
+   :relative-docs: .
+
+.. toctree::
+   :maxdepth: 1
+   :titlesonly:
+
+   sensor_streams/advanced_streams
+   sensor_streams/quality_filter
+   sensor_streams/reactivex
+   sensor_streams/storage_replay
+   sensor_streams/temporal_alignment

--- a/docs/usage/transports.rst
+++ b/docs/usage/transports.rst
@@ -1,0 +1,14 @@
+Transports
+==========
+
+.. include:: transports/index.md
+   :parser: myst_parser.sphinx_
+   :body-only:
+   :relative-images:
+   :relative-docs: .
+
+.. toctree::
+   :maxdepth: 1
+   :titlesonly:
+
+   transports/dds

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -362,6 +362,15 @@ all = [
 # For autofix.yml
 autofix = ["ruff==0.14.3"]
 
+# Dependencies for the Sphinx documentation build.
+docs = [
+    "sphinx>=7.4,<8",
+    "myst-parser>=3,<4",
+    "linkify-it-py>=2,<3",
+    "furo>=2024.8.6,<2026",
+    "sphinx-design>=0.6,<1",
+]
+
 # Project deps shared by `tests` and `lint`.
 project-deps = [
     "dimos[web,visualization,webrtc]",

--- a/uv.lock
+++ b/uv.lock
@@ -82,6 +82,18 @@ wheels = [
 ]
 
 [[package]]
+name = "accessible-pygments"
+version = "0.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c1/bbac6a50d02774f91572938964c582fff4270eee73ab822a4aeea4d8b11b/accessible_pygments-0.0.5.tar.gz", hash = "sha256:40918d3e6a2b619ad424cb91e556bd3bd8865443d9f22f1dcdf79e33c8046872", size = 1377899, upload-time = "2024-05-10T11:23:10.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/3f/95338030883d8c8b91223b4e21744b04d11b161a3ef117295d8241f50ab4/accessible_pygments-0.0.5-py3-none-any.whl", hash = "sha256:88ae3211e68a1d0b011504b2ffc1691feafce124b845bd072ab6f9f66f34d4b7", size = 1395903, upload-time = "2024-05-10T11:23:08.421Z" },
+]
+
+[[package]]
 name = "addict"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -239,6 +251,15 @@ wheels = [
 ]
 
 [[package]]
+name = "alabaster"
+version = "0.7.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/3e/13dd8e5ed9094e734ac430b5d0eb4f2bb001708a8b7856cbf8e084e001ba/alabaster-0.7.16.tar.gz", hash = "sha256:75a8b99c28a5dad50dd7f8ccdd447a121ddb3892da9e53d1ca5cca3106d58d65", size = 23776, upload-time = "2024-01-10T00:56:10.189Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/34/d4e1c02d3bee589efb5dfa17f88ea08bdb3e3eac12bc475462aec52ed223/alabaster-0.7.16-py3-none-any.whl", hash = "sha256:b46733c07dce03ae4e150330b975c75737fa60f0a7c591b6c8bf4928a28e2c92", size = 13511, upload-time = "2024-01-10T00:56:08.388Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -373,6 +394,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8e/ac/d90df7f1e3b97fc5554cf45076df5045f1e0a6adf13899e10121229b826c/av-16.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8cf065f9d438e1921dc31fc7aa045790b58aee71736897866420d80b5450f62a", size = 40817720, upload-time = "2026-01-11T09:57:39.039Z" },
     { url = "https://files.pythonhosted.org/packages/80/6f/13c3a35f9dbcebafd03fe0c4cbd075d71ac8968ec849a3cfce406c35a9d2/av-16.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a345877a9d3cc0f08e2bc4ec163ee83176864b92587afb9d08dff50f37a9a829", size = 42267396, upload-time = "2026-01-11T09:57:42.115Z" },
     { url = "https://files.pythonhosted.org/packages/c8/b9/275df9607f7fb44317ccb1d4be74827185c0d410f52b6e2cd770fe209118/av-16.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:f49243b1d27c91cd8c66fdba90a674e344eb8eb917264f36117bf2b6879118fd", size = 31752045, upload-time = "2026-01-11T09:57:45.106Z" },
+]
+
+[[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
 ]
 
 [[package]]
@@ -1846,6 +1876,14 @@ webrtc = [
 autofix = [
     { name = "ruff" },
 ]
+docs = [
+    { name = "furo" },
+    { name = "linkify-it-py" },
+    { name = "myst-parser" },
+    { name = "sphinx" },
+    { name = "sphinx-design", version = "0.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx-design", version = "0.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
 lint = [
     { name = "aiortc" },
     { name = "chromadb" },
@@ -2127,6 +2165,13 @@ provides-extras = ["misc", "visualization", "learning", "agents", "web", "percep
 
 [package.metadata.requires-dev]
 autofix = [{ name = "ruff", specifier = "==0.14.3" }]
+docs = [
+    { name = "furo", specifier = ">=2024.8.6,<2026" },
+    { name = "linkify-it-py", specifier = ">=2,<3" },
+    { name = "myst-parser", specifier = ">=3,<4" },
+    { name = "sphinx", specifier = ">=7.4,<8" },
+    { name = "sphinx-design", specifier = ">=0.6,<1" },
+]
 lint = [
     { name = "aiortc", specifier = ">=1.14.0" },
     { name = "chromadb", specifier = ">=1.0.0" },
@@ -2356,6 +2401,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/52/d8/8abe80d62c5dce1075578031bcfde07e735bcf0afe2886dd48b470162ab4/docstring_to_markdown-0.17.tar.gz", hash = "sha256:df72a112294c7492487c9da2451cae0faeee06e86008245c188c5761c9590ca3", size = 32260, upload-time = "2025-05-02T15:09:07.932Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/7b/af3d0da15bed3a8665419bb3a630585756920f4ad67abfdfef26240ebcc0/docstring_to_markdown-0.17-py3-none-any.whl", hash = "sha256:fd7d5094aa83943bf5f9e1a13701866b7c452eac19765380dead666e36d3711c", size = 23479, upload-time = "2025-05-02T15:09:06.676Z" },
+]
+
+[[package]]
+name = "docutils"
+version = "0.21.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/ed/aefcc8cd0ba62a0560c3c18c33925362d46c6075480bfa4df87b28e169a9/docutils-0.21.2.tar.gz", hash = "sha256:3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f", size = 2204444, upload-time = "2024-04-23T18:57:18.24Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl", hash = "sha256:dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2", size = 587408, upload-time = "2024-04-23T18:57:14.835Z" },
 ]
 
 [[package]]
@@ -2973,6 +3027,22 @@ wheels = [
 ]
 
 [[package]]
+name = "furo"
+version = "2025.12.19"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "accessible-pygments" },
+    { name = "beautifulsoup4" },
+    { name = "pygments" },
+    { name = "sphinx" },
+    { name = "sphinx-basic-ng" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/20/5f5ad4da6a5a27c80f2ed2ee9aee3f9e36c66e56e21c00fde467b2f8f88f/furo-2025.12.19.tar.gz", hash = "sha256:188d1f942037d8b37cd3985b955839fea62baa1730087dc29d157677c857e2a7", size = 1661473, upload-time = "2025-12-19T17:34:40.889Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/b2/50e9b292b5cac13e9e81272c7171301abc753a60460d21505b606e15cf21/furo-2025.12.19-py3-none-any.whl", hash = "sha256:bb0ead5309f9500130665a26bee87693c41ce4dbdff864dbfb6b0dae4673d24f", size = 339262, upload-time = "2025-12-19T17:34:38.905Z" },
+]
+
+[[package]]
 name = "future"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3333,6 +3403,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/84/93bcd1300216ea50811cee96873b84a1bebf8d0489ffaf7f2a3756bab866/imageio-2.37.3.tar.gz", hash = "sha256:bbb37efbfc4c400fcd534b367b91fcd66d5da639aaa138034431a1c5e0a41451", size = 389673, upload-time = "2026-03-09T11:31:12.573Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/fa/391e437a34e55095173dca5f24070d89cbc233ff85bf1c29c93248c6588d/imageio-2.37.3-py3-none-any.whl", hash = "sha256:46f5bb8522cd421c0f5ae104d8268f569d856b29eb1a13b92829d1970f32c9f0", size = 317646, upload-time = "2026-03-09T11:31:10.771Z" },
+]
+
+[[package]]
+name = "imagesize"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/e6/7bf14eeb8f8b7251141944835abd42eb20a658d89084b7e1f3e5fe394090/imagesize-2.0.0.tar.gz", hash = "sha256:8e8358c4a05c304f1fccf7ff96f036e7243a189e9e42e90851993c558cfe9ee3", size = 1773045, upload-time = "2026-03-03T14:18:29.941Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/53/fb7122b71361a0d121b669dcf3d31244ef75badbbb724af388948de543e2/imagesize-2.0.0-py2.py3-none-any.whl", hash = "sha256:5667c5bbb57ab3f1fa4bc366f4fbc971db3d5ed011fd2715fd8001f782718d96", size = 9441, upload-time = "2026-03-03T14:18:27.892Z" },
 ]
 
 [[package]]
@@ -4445,14 +4524,14 @@ wheels = [
 
 [[package]]
 name = "markdown-it-py"
-version = "4.0.0"
+version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mdurl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528, upload-time = "2023-06-03T06:41:11.019Z" },
 ]
 
 [package.optional-dependencies]
@@ -5057,6 +5136,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "myst-parser"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "jinja2" },
+    { name = "markdown-it-py" },
+    { name = "mdit-py-plugins" },
+    { name = "pyyaml" },
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/64/e2f13dac02f599980798c01156393b781aec983b52a6e4057ee58f07c43a/myst_parser-3.0.1.tar.gz", hash = "sha256:88f0cb406cb363b077d176b51c476f62d60604d68a8dcdf4832e080441301a87", size = 92392, upload-time = "2024-04-28T20:22:42.116Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/de/21aa8394f16add8f7427f0a1326ccd2b3a2a8a3245c9252bc5ac034c6155/myst_parser-3.0.1-py3-none-any.whl", hash = "sha256:6457aaa33a5d474aca678b8ead9b3dc298e89c68e67012e73146ea6fd54babf1", size = 83163, upload-time = "2024-04-28T20:22:39.985Z" },
 ]
 
 [[package]]
@@ -8235,6 +8331,150 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
+]
+
+[[package]]
+name = "sphinx"
+version = "7.4.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils" },
+    { name = "imagesize" },
+    { name = "importlib-metadata" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/be/50e50cb4f2eff47df05673d361095cafd95521d2a22521b920c67a372dcb/sphinx-7.4.7.tar.gz", hash = "sha256:242f92a7ea7e6c5b406fdc2615413890ba9f699114a9c09192d7dfead2ee9cfe", size = 8067911, upload-time = "2024-07-20T14:46:56.059Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/ef/153f6803c5d5f8917dbb7f7fcf6d34a871ede3296fa89c2c703f5f8a6c8e/sphinx-7.4.7-py3-none-any.whl", hash = "sha256:c2419e2135d11f1951cd994d6eb18a1835bd8fdd8429f9ca375dc1f3281bd239", size = 3401624, upload-time = "2024-07-20T14:46:52.142Z" },
+]
+
+[[package]]
+name = "sphinx-basic-ng"
+version = "1.0.0b2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/0b/a866924ded68efec7a1759587a4e478aec7559d8165fac8b2ad1c0e774d6/sphinx_basic_ng-1.0.0b2.tar.gz", hash = "sha256:9ec55a47c90c8c002b5960c57492ec3021f5193cb26cebc2dc4ea226848651c9", size = 20736, upload-time = "2023-07-08T18:40:54.166Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/dd/018ce05c532a22007ac58d4f45232514cd9d6dd0ee1dc374e309db830983/sphinx_basic_ng-1.0.0b2-py3-none-any.whl", hash = "sha256:eb09aedbabfb650607e9b4b68c9d240b90b1e1be221d6ad71d61c52e29f7932b", size = 22496, upload-time = "2023-07-08T18:40:52.659Z" },
+]
+
+[[package]]
+name = "sphinx-design"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "sphinx", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2b/69/b34e0cb5336f09c6866d53b4a19d76c227cdec1bbc7ac4de63ca7d58c9c7/sphinx_design-0.6.1.tar.gz", hash = "sha256:b44eea3719386d04d765c1a8257caca2b3e6f8421d7b3a5e742c0fd45f84e632", size = 2193689, upload-time = "2024-08-02T13:48:44.277Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/43/65c0acbd8cc6f50195a3a1fc195c404988b15c67090e73c7a41a9f57d6bd/sphinx_design-0.6.1-py3-none-any.whl", hash = "sha256:b11f37db1a802a183d61b159d9a202314d4d2fe29c163437001324fe2f19549c", size = 2215338, upload-time = "2024-08-02T13:48:42.106Z" },
+]
+
+[[package]]
+name = "sphinx-design"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
+    "python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'darwin'",
+    "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "sphinx", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/7b/804f311da4663a4aecc6cf7abd83443f3d4ded970826d0c958edc77d4527/sphinx_design-0.7.0.tar.gz", hash = "sha256:d2a3f5b19c24b916adb52f97c5f00efab4009ca337812001109084a740ec9b7a", size = 2203582, upload-time = "2026-01-19T13:12:53.297Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/cf/45dd359f6ca0c3762ce0490f681da242f0530c49c81050c035c016bfdd3a/sphinx_design-0.7.0-py3-none-any.whl", hash = "sha256:f82bf179951d58f55dca78ab3706aeafa496b741a91b1911d371441127d64282", size = 2220350, upload-time = "2026-01-19T13:12:51.077Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-applehelp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/6e/b837e84a1a704953c62ef8776d45c3e8d759876b4a84fe14eba2859106fe/sphinxcontrib_applehelp-2.0.0.tar.gz", hash = "sha256:2f29ef331735ce958efa4734873f084941970894c6090408b079c61b2e1c06d1", size = 20053, upload-time = "2024-07-29T01:09:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/85/9ebeae2f76e9e77b952f4b274c27238156eae7979c5421fba91a28f4970d/sphinxcontrib_applehelp-2.0.0-py3-none-any.whl", hash = "sha256:4cd3f0ec4ac5dd9c17ec65e9ab272c9b867ea77425228e68ecf08d6b28ddbdb5", size = 119300, upload-time = "2024-07-29T01:08:58.99Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-devhelp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/d2/5beee64d3e4e747f316bae86b55943f51e82bb86ecd325883ef65741e7da/sphinxcontrib_devhelp-2.0.0.tar.gz", hash = "sha256:411f5d96d445d1d73bb5d52133377b4248ec79db5c793ce7dbe59e074b4dd1ad", size = 12967, upload-time = "2024-07-29T01:09:23.417Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/7a/987e583882f985fe4d7323774889ec58049171828b58c2217e7f79cdf44e/sphinxcontrib_devhelp-2.0.0-py3-none-any.whl", hash = "sha256:aefb8b83854e4b0998877524d1029fd3e6879210422ee3780459e28a1f03a8a2", size = 82530, upload-time = "2024-07-29T01:09:21.945Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-htmlhelp"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/93/983afd9aa001e5201eab16b5a444ed5b9b0a7a010541e0ddfbbfd0b2470c/sphinxcontrib_htmlhelp-2.1.0.tar.gz", hash = "sha256:c9e2916ace8aad64cc13a0d233ee22317f2b9025b9cf3295249fa985cc7082e9", size = 22617, upload-time = "2024-07-29T01:09:37.889Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/7b/18a8c0bcec9182c05a0b3ec2a776bba4ead82750a55ff798e8d406dae604/sphinxcontrib_htmlhelp-2.1.0-py3-none-any.whl", hash = "sha256:166759820b47002d22914d64a075ce08f4c46818e17cfc9470a9786b759b19f8", size = 98705, upload-time = "2024-07-29T01:09:36.407Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-jsmath"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/e8/9ed3830aeed71f17c026a07a5097edcf44b692850ef215b161b8ad875729/sphinxcontrib-jsmath-1.0.1.tar.gz", hash = "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8", size = 5787, upload-time = "2019-01-21T16:10:16.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl", hash = "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178", size = 5071, upload-time = "2019-01-21T16:10:14.333Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-qthelp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/bc/9104308fc285eb3e0b31b67688235db556cd5b0ef31d96f30e45f2e51cae/sphinxcontrib_qthelp-2.0.0.tar.gz", hash = "sha256:4fe7d0ac8fc171045be623aba3e2a8f613f8682731f9153bb2e40ece16b9bbab", size = 17165, upload-time = "2024-07-29T01:09:56.435Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/83/859ecdd180cacc13b1f7e857abf8582a64552ea7a061057a6c716e790fce/sphinxcontrib_qthelp-2.0.0-py3-none-any.whl", hash = "sha256:b18a828cdba941ccd6ee8445dbe72ffa3ef8cbe7505d8cd1fa0d42d3f2d5f3eb", size = 88743, upload-time = "2024-07-29T01:09:54.885Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-serializinghtml"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/44/6716b257b0aa6bfd51a1b31665d1c205fb12cb5ad56de752dfa15657de2f/sphinxcontrib_serializinghtml-2.0.0.tar.gz", hash = "sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d", size = 16080, upload-time = "2024-07-29T01:10:09.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl", hash = "sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331", size = 92072, upload-time = "2024-07-29T01:10:08.203Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- render the existing documentation corpus with Sphinx, MyST, and the Furo theme
- serve the existing Introduction content at `/`, while retaining `/introduction/` as a compatibility route
- use native Sphinx wrappers for canonical folder routes and hierarchical catalog navigation; align Usage with the Manipulation catalog
- rename the legacy `usage/index.md` title from “Concepts” to “Usage” so the source and catalog agree
- repair directory-style Sphinx search results so nested pages resolve from the site root
- add a Dimensional-styled shell and strict documentation build in CI

## Preview locally
```sh
git lfs pull --include="docs/**" --exclude=""
uv run --no-sync sphinx-build -E -W --keep-going -b html docs /tmp/dimos-sphinx-final
uv run --no-sync python -m http.server --directory /tmp/dimos-sphinx-final 8000
```
Open http://127.0.0.1:8000/.

## Validation
- `git lfs pull --include="docs/**" --exclude="" && uv run --no-sync sphinx-build -E -W --keep-going -b html docs /tmp/dimos-sphinx-search-verified`
- search result links from `/search/` resolve to their canonical root routes, including `/capabilities/manipulation/`
- root output contains the existing Welcome to Dimensional content
- Usage catalog has no visible `usage/index` leaf; nested stream guides remain under their wrapper pages
- `git diff --check`
- `uv lock --check`