### PR TITLE
feat(control): removes frozen set of input streams - now Any Input stream can be routed to the control coordinator

### DIFF
--- a/dimos/control/coordinator.py
+++ b/dimos/control/coordinator.py
@@ -25,6 +25,7 @@ Features:
 - Aggregated preemption notifications
 """
 
+from contextlib import suppress
 from dataclasses import dataclass, field
 import inspect
 import threading
@@ -210,6 +211,7 @@ class ControlCoordinator(Module):
     def _setup_from_config(self) -> None:
         """Create hardware and tasks from config (called on start)."""
         hardware_added: list[str] = []
+        tasks_added: list[TaskName] = []
 
         try:
             for component in self.config.hardware:
@@ -218,19 +220,22 @@ class ControlCoordinator(Module):
 
             for task_cfg in self.config.tasks:
                 task = self._create_task_from_config(task_cfg)
-                self.add_task(task, task_type=task_cfg.type, stream_bind=task_cfg.stream_bind)
+                if self.add_task(task, task_type=task_cfg.type, stream_bind=task_cfg.stream_bind):
+                    tasks_added.append(task.name)
                 if task_cfg.auto_start:
                     start = getattr(task, "start", None)
                     if callable(start):
                         start()
 
         except Exception:
-            # Rollback: clean up all successfully added hardware
+            # Roll back everything this call added, tasks first: an active task
+            # blocks removal of the hardware whose joints it claims.
+            for task_name in tasks_added:
+                with suppress(Exception):
+                    self.remove_task(task_name)
             for hw_id in hardware_added:
-                try:
+                with suppress(Exception):
                     self.remove_hardware(hw_id)
-                except Exception:
-                    pass
             raise
 
     def _setup_hardware(self, component: HardwareComponent) -> None:

--- a/dimos/control/coordinator.py
+++ b/dimos/control/coordinator.py
@@ -81,6 +81,8 @@ class TaskConfig:
     priority: int = 10
     auto_start: bool = False
     params: dict[str, Any] = field(default_factory=dict)
+    # card input name -> the port this instance reads instead
+    stream_bind: dict[str, str] = field(default_factory=dict)
 
 
 class ControlCoordinatorConfig(ModuleConfig):
@@ -180,8 +182,9 @@ class ControlCoordinator(Module):
         self._tasks: dict[TaskName, ControlTask] = {}
         self._task_lock = threading.Lock()
 
-        # Card-declared stream routes: stream name -> (task, handler, routing).
-        # Guarded by _task_lock; entries are added/pruned with their task.
+        # Card-declared stream routes, keyed by the port stream_bind resolved to:
+        # port -> (task, handler, routing). Guarded by _task_lock; entries are
+        # added/pruned with their task.
         self._routes: dict[str, list[tuple[ControlTask, str, Routing]]] = {}
 
         # Card-declared command names per task, keyed by task name.
@@ -215,7 +218,7 @@ class ControlCoordinator(Module):
 
             for task_cfg in self.config.tasks:
                 task = self._create_task_from_config(task_cfg)
-                self.add_task(task, task_type=task_cfg.type)
+                self.add_task(task, task_type=task_cfg.type, stream_bind=task_cfg.stream_bind)
                 if task_cfg.auto_start:
                     start = getattr(task, "start", None)
                     if callable(start):
@@ -415,21 +418,34 @@ class ControlCoordinator(Module):
             return positions
 
     @rpc
-    def add_task(self, task: ControlTask, task_type: str | None = None) -> bool:
-        """Register a task; ``task_type`` binds its card's input streams (if any)."""
+    def add_task(
+        self,
+        task: ControlTask,
+        task_type: str | None = None,
+        stream_bind: dict[str, str] | None = None,
+    ) -> bool:
+        """Register a task; ``task_type`` binds its card's input streams (if any).
+
+        ``stream_bind`` remaps those inputs to other ports (see ``TaskConfig``).
+        """
         if not isinstance(task, ControlTask):
             raise TypeError("task must implement ControlTask")
+        if task_type is None and stream_bind:
+            raise ValueError(
+                f"task {task.name!r} was given stream_bind {sorted(stream_bind)} but no "
+                "task_type; the inputs it remaps come from the type's card, so pass task_type"
+            )
 
         with self._task_lock:
             if task.name in self._tasks:
                 logger.warning(f"Task {task.name} already registered")
                 return False
-            self._tasks[task.name] = task
             if task_type is not None:
-                self._register_routes(task, task_type)
+                self._register_routes(task, task_type, stream_bind)
                 self._task_commands[task.name] = self._commands_for(task_type)
             else:
                 self._task_commands[task.name] = frozenset()
+            self._tasks[task.name] = task
             logger.info(f"Added task {task.name}")
         self._sync_stream_subscriptions()
         return True
@@ -448,7 +464,9 @@ class ControlCoordinator(Module):
         self._sync_stream_subscriptions()
         return True
 
-    def _register_routes(self, task: ControlTask, task_type: str) -> None:
+    def _register_routes(
+        self, task: ControlTask, task_type: str, stream_bind: dict[str, str] | None = None
+    ) -> None:
         # Inline: importing the registry runs task-manifest discovery at import time.
         from dimos.control.tasks.registry import control_task_registry
 
@@ -462,10 +480,38 @@ class ControlCoordinator(Module):
                 task_name=task.name,
                 task_type=task_type,
             )
-        for binding in bindings.consumes:
-            self._routes.setdefault(binding.stream, []).append(
-                (task, binding.handler, binding.routing)
+
+        where = f"task {task.name!r} (type {task_type!r})"
+        binds = stream_bind or {}
+        inputs = {binding.stream for binding in bindings.consumes}
+        unknown = sorted(set(binds) - inputs)
+        if unknown:
+            raise ValueError(
+                f"{where}: stream_bind key(s) {unknown} are not card inputs {sorted(inputs)}"
             )
+
+        ports = {name: binds.get(name, name) for name in inputs}
+        # All ports first: one typo must not leave the task half-wired.
+        for port in ports.values():
+            if not isinstance(getattr(self, port, None), In):
+                raise ValueError(
+                    f"{where}: this coordinator has no input port {port!r} — add "
+                    f"`{port}: In[...]` to your coordinator subclass, or fix the stream_bind entry"
+                )
+
+        for binding in bindings.consumes:
+            port = ports[binding.stream]
+            if binding.routing is Routing.DIRECT:
+                sharing = [t.name for t, _h, r in self._routes.get(port, ()) if r is Routing.DIRECT]
+                if sharing:
+                    logger.warning(
+                        "Port already has a 'direct' task; both get every message. "
+                        "stream_bind can give them separate ports",
+                        stream=port,
+                        task_name=task.name,
+                        also_bound=sharing,
+                    )
+            self._routes.setdefault(port, []).append((task, binding.handler, binding.routing))
 
     def _commands_for(self, task_type: str) -> frozenset[str]:
         """The command names the task type declares in its TASK_EXPOSES card."""
@@ -544,7 +590,10 @@ class ControlCoordinator(Module):
             return [name for name, task in self._tasks.items() if task.is_active()]
 
     def _dispatch(self, stream: str, msg: Any) -> None:
-        """Deliver a stream message to its card-routed tasks per each entry's routing rule."""
+        """Deliver a stream message to its card-routed tasks per each entry's routing rule.
+
+        BROADCAST and DIRECT are ungated, so only the other two rules appear below.
+        """
         t_now = time.perf_counter()
         with self._task_lock:
             entries = self._routes.get(stream)

--- a/dimos/control/routing.py
+++ b/dimos/control/routing.py
@@ -14,10 +14,9 @@
 
 """Declarative stream-binding cards for control tasks.
 
-Task manifests (``_registry.py``) stay import-free: they declare bindings as
-plain strings, and ``ControlTaskRegistry`` converts them to the typed forms
-here at load time. ``ControlCoordinator`` builds its stream route table from
-them when tasks are registered.
+A card says which coordinator input a task reads, and which method gets it:
+
+    TASK_CONSUMES = {"servo": {"joint_command": ("on_joint_command", "claim_overlap")}}
 """
 
 from __future__ import annotations
@@ -32,27 +31,16 @@ class Routing(str, Enum):
     CLAIM_OVERLAP = "claim_overlap"  # deliver when msg names joints the task claims
     BY_TASK_NAME = "by_task_name"  # deliver when msg.frame_id == task.name
     BROADCAST = "broadcast"  # deliver to every task consuming this stream
-
-
-CONSUMABLE_STREAMS = frozenset(
-    {
-        "joint_command",
-        "coordinator_cartesian_command",
-        "coordinator_ee_twist_command",
-        "twist_command",
-        "teleop_buttons",
-    }
-)
-"""Coordinator input ports that cards may bind."""
+    DIRECT = "direct"  # like broadcast, but the port is meant to have one task on it
 
 
 @dataclass(frozen=True)
 class StreamBinding:
     """One input stream a task consumes: coordinator port -> task handler.
 
-    ``handler`` names a method on the task instance with signature
-    ``(msg, t_now) -> Any``; the task receives the raw message and owns
-    digestion, the coordinator owns only routing.
+    ``stream`` names the port, unless ``TaskConfig.stream_bind`` remaps it.
+    ``handler`` is a task method ``(msg, t_now) -> Any``: it gets the raw
+    message and owns digestion, the coordinator owns only routing.
     """
 
     stream: str

--- a/dimos/control/tasks/registry.py
+++ b/dimos/control/tasks/registry.py
@@ -34,7 +34,6 @@ import os
 from typing import TYPE_CHECKING, cast
 
 from dimos.control.routing import (
-    CONSUMABLE_STREAMS,
     Routing,
     StreamBinding,
     TaskBindings,
@@ -217,8 +216,13 @@ class ControlTaskRegistry:
             where = f"{source}: task type {task_type!r}, stream {stream!r}"
             if not isinstance(stream, str):
                 raise TypeError(f"{where}: stream name must be a string")
-            if stream not in CONSUMABLE_STREAMS:
-                raise ValueError(f"{where}: unknown stream; allowed: {sorted(CONSUMABLE_STREAMS)}")
+            # A subclassed coordinator can declare ports this registry never
+            # sees, so port existence is checked at add_task() time instead.
+            if not stream.isidentifier() or stream.startswith("_"):
+                raise ValueError(
+                    f"{where}: stream must name a coordinator input port "
+                    "(a non-underscore Python identifier)"
+                )
             if (
                 not isinstance(spec, Sequence)
                 or isinstance(spec, str)

--- a/dimos/control/tasks/test_registry.py
+++ b/dimos/control/tasks/test_registry.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 
-from dimos.control.routing import CONSUMABLE_STREAMS, Routing, StreamBinding, TaskBindings
+from dimos.control.routing import Routing, StreamBinding, TaskBindings
 from dimos.control.tasks.registry import ControlTaskRegistry, control_task_registry
 
 if TYPE_CHECKING:
@@ -128,8 +128,9 @@ def test_task_cards_are_well_formed() -> None:
         for task_type, streams in consumes_by_type.items():
             for stream, spec in streams.items():
                 where = f"{module.__name__}: {task_type!r} stream {stream!r}"
-                assert stream in CONSUMABLE_STREAMS, (
-                    f"{where} not in allowed set {sorted(CONSUMABLE_STREAMS)}"
+                # Which ports exist is the coordinator's check, not the card's.
+                assert stream.isidentifier() and not stream.startswith("_"), (
+                    f"{where} is not a usable port name"
                 )
                 handler, routing = spec
                 assert isinstance(handler, str) and handler, f"{where}: bad handler {handler!r}"
@@ -267,10 +268,21 @@ def test_register_bindings_runtime_and_conflict() -> None:
         )
 
 
+def test_register_bindings_accepts_any_port_name() -> None:
+    # No fixed set of ports: a coordinator subclass declares its own.
+    reg = ControlTaskRegistry()
+    reg.register_bindings("fake_custom_port", consumes={"wrench_command": ("on_wrench", "direct")})
+    assert reg.bindings_for("fake_custom_port").consumes == (
+        StreamBinding("wrench_command", "on_wrench", Routing.DIRECT),
+    )
+
+
 def test_register_bindings_rejects_bad_streams_and_routing() -> None:
     reg = ControlTaskRegistry()
-    with pytest.raises(ValueError, match="allowed"):
-        reg.register_bindings("fake_stream", consumes={"no_such_port": ("on_x", "broadcast")})
+    with pytest.raises(ValueError, match="input port"):
+        reg.register_bindings("fake_stream", consumes={"not a port": ("on_x", "broadcast")})
+    with pytest.raises(ValueError, match="input port"):
+        reg.register_bindings("fake_private_stream", consumes={"_private": ("on_x", "broadcast")})
     with pytest.raises(ValueError, match="routing"):
         reg.register_bindings("fake_routing", consumes={"joint_command": ("on_x", "round_robin")})
 

--- a/dimos/control/test_coordinator_routing.py
+++ b/dimos/control/test_coordinator_routing.py
@@ -821,6 +821,13 @@ class TestSubclassDeclaredStreams:
         assert taps["custom_in"].subscribed
 
 
+class ActiveProbeTask(ProbeTask):
+    """Probe that claims its joints for real, so remove_hardware can refuse it."""
+
+    def is_active(self) -> bool:
+        return True
+
+
 class TestStreamBind:
     """Per-instance remapping of a card's inputs onto other ports."""
 
@@ -879,6 +886,33 @@ class TestStreamBind:
 
         assert coordinator.get_task("a").probe_commands == []
         assert len(coordinator.get_task("b").probe_commands) == 1
+
+    def test_bad_task_config_rolls_back_the_whole_setup(self, make_coordinator, register_card):
+        card = self._fanout_card(register_card)
+        base_joints = make_twist_base_joints("base")
+        coordinator, _ = make_coordinator(
+            coordinator_cls=FanoutCoordinator,
+            hardware=[_base_component()],
+            tasks=[
+                TaskConfig(
+                    name="good",
+                    type=card,
+                    joint_names=base_joints,
+                    stream_bind={"sensor_in": "a_in"},
+                ),
+                TaskConfig(name="bad", type=card, stream_bind={"sensor_in": "no_such_port"}),
+            ],
+        )
+        coordinator._create_task_from_config = lambda cfg: ActiveProbeTask(
+            cfg.name, frozenset(cfg.joint_names)
+        )
+
+        with pytest.raises(ValueError, match="no_such_port"):
+            coordinator.start()
+
+        # Tasks go first, or "good" is active on the base joints and pins the hardware.
+        assert coordinator.list_tasks() == []
+        assert coordinator.list_hardware() == []
 
     def test_unknown_stream_bind_key_is_loud(self, make_coordinator, register_card):
         card = register_card(

--- a/dimos/control/test_coordinator_routing.py
+++ b/dimos/control/test_coordinator_routing.py
@@ -40,6 +40,7 @@ import dimos.control.coordinator as coord_mod
 from dimos.control.coordinator import ControlCoordinator, TaskConfig
 from dimos.control.tasks.registry import control_task_registry
 from dimos.control.tasks.servo_task.servo_task import JointServoTask, JointServoTaskConfig
+from dimos.core.stream import In
 from dimos.hardware.drive_trains.registry import twist_base_adapter_registry
 from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
 from dimos.msgs.geometry_msgs.Twist import Twist
@@ -118,18 +119,20 @@ def make_coordinator(
 
     def make(
         *,
+        coordinator_cls: type[ControlCoordinator] = ControlCoordinator,
         stub_task_types: bool = False,
         fail_streams: tuple[str, ...] = (),
         **kwargs: Any,
     ) -> tuple[ControlCoordinator, dict[str, PortTap]]:
-        coordinator = ControlCoordinator(publish_joint_state=False, **kwargs)
+        coordinator = coordinator_cls(publish_joint_state=False, **kwargs)
         if stub_task_types:
             coordinator._create_task_from_config = lambda cfg: RecordingTask(
                 cfg.name, frozenset(cfg.joint_names)
             )
+        # Every declared input, so a subclass's own ports are tapped too.
         taps = {
-            stream: PortTap(mocker, getattr(coordinator, stream), fail=stream in fail_streams)
-            for stream in STREAMS
+            stream: PortTap(mocker, port, fail=stream in fail_streams)
+            for stream, port in coordinator.inputs.items()
         }
         coordinators.append(coordinator)
         return coordinator, taps
@@ -706,6 +709,14 @@ class TestCardRoutingContract:
         assert any("srvo" in str(c) for c in warn.call_args_list)
         assert not taps["joint_command"].subscribed
 
+    def test_no_stream_bind_keeps_card_named_ports(self, make_coordinator):
+        # The default path: routes are keyed by the card's own stream name.
+        coordinator, _ = _streaming_coordinator(make_coordinator)
+
+        assert coordinator.describe_task("servo1")["streams"] == [
+            ("joint_command", "claim_overlap")
+        ]
+
     def test_cardless_known_type_does_not_warn(self, make_coordinator, mocker):
         warn = mocker.patch.object(coord_mod.logger, "warning")
         coordinator, _ = make_coordinator()
@@ -716,3 +727,225 @@ class TestCardRoutingContract:
         coordinator.add_task(RecordingTask("traj", frozenset(ARM_JOINTS)), task_type="trajectory")
 
         assert not any("unknown task_type" in str(c.args[0]) for c in warn.call_args_list)
+
+
+class SubclassedCoordinator(ControlCoordinator):
+    """How a deployment adds its own input: one annotation, no coordinator edits."""
+
+    custom_in: In[JointState]
+
+
+class FanoutCoordinator(ControlCoordinator):
+    """One port per task instance, for the stream_bind tests."""
+
+    a_in: In[JointState]
+    b_in: In[JointState]
+
+
+@pytest.fixture
+def register_card() -> Iterator[Callable[[str, dict[str, tuple[str, str]]], str]]:
+    """Register throwaway task cards; drop them on teardown."""
+    registered: list[str] = []
+
+    def register(task_type: str, consumes: dict[str, tuple[str, str]]) -> str:
+        control_task_registry.register_bindings(task_type, consumes=consumes)
+        registered.append(task_type)
+        return task_type
+
+    try:
+        yield register
+    finally:
+        for task_type in registered:
+            control_task_registry._bindings.pop(task_type, None)
+            control_task_registry._binding_sources.pop(task_type, None)
+
+
+class TestSubclassDeclaredStreams:
+    """Cards can bind ports a coordinator subclass declares."""
+
+    def test_subclass_port_routes_with_zero_coordinator_edits(
+        self, make_coordinator, register_card
+    ):
+        card = register_card("subclass_probe_task", {"custom_in": ("on_probe_command", "direct")})
+        coordinator, taps = make_coordinator(coordinator_cls=SubclassedCoordinator)
+        coordinator.start()
+        probe = ProbeTask("probe1", frozenset(ARM_JOINTS))
+        assert coordinator.add_task(probe, task_type=card)
+
+        assert taps["custom_in"].subscribed
+        msg = JointState(name=ARM_JOINTS, position=[0.1, 0.2])
+        taps["custom_in"].emit(msg)
+
+        assert len(probe.probe_commands) == 1
+        assert probe.probe_commands[0][0] is msg
+
+    def test_direct_routing_delivers_without_a_claim_gate(self, make_coordinator, register_card):
+        card = register_card("direct_probe_task", {"custom_in": ("on_probe_command", "direct")})
+        coordinator, taps = make_coordinator(coordinator_cls=SubclassedCoordinator)
+        coordinator.start()
+        probe = ProbeTask("probe1", frozenset(ARM_JOINTS))
+        assert coordinator.add_task(probe, task_type=card)
+
+        # Joints the task does not claim, and no frame_id: neither gate applies.
+        taps["custom_in"].emit(JointState(name=["other/joint9"], position=[1.0]))
+
+        assert len(probe.probe_commands) == 1
+
+    def test_missing_port_error_names_the_annotation_to_add(self, make_coordinator, register_card):
+        card = register_card("admittance_probe", {"wrench_command": ("on_probe_command", "direct")})
+        coordinator, _ = make_coordinator()
+        coordinator.start()
+
+        with pytest.raises(ValueError) as excinfo:
+            coordinator.add_task(ProbeTask("adm"), task_type=card)
+
+        message = str(excinfo.value)
+        assert "adm" in message
+        assert card in message
+        assert "wrench_command: In[...]" in message
+        assert coordinator.list_tasks() == []  # nothing half-registered
+
+    def test_subclass_port_is_rejected_by_a_plain_coordinator(
+        self, make_coordinator, register_card
+    ):
+        # Same card, two deployments: it binds only where the port is declared.
+        card = register_card("subclass_only_probe", {"custom_in": ("on_probe_command", "direct")})
+        plain, _ = make_coordinator()
+        plain.start()
+        with pytest.raises(ValueError, match="custom_in"):
+            plain.add_task(ProbeTask("probe1"), task_type=card)
+
+        subclassed, taps = make_coordinator(coordinator_cls=SubclassedCoordinator)
+        subclassed.start()
+        assert subclassed.add_task(ProbeTask("probe1"), task_type=card)
+        assert taps["custom_in"].subscribed
+
+
+class TestStreamBind:
+    """Per-instance remapping of a card's inputs onto other ports."""
+
+    @staticmethod
+    def _fanout_card(register_card) -> str:
+        return register_card("fanout_probe_task", {"sensor_in": ("on_probe_command", "direct")})
+
+    def test_two_instances_read_separate_ports(self, make_coordinator, register_card):
+        card = self._fanout_card(register_card)
+        coordinator, taps = make_coordinator(coordinator_cls=FanoutCoordinator)
+        coordinator.start()
+        a = ProbeTask("a", frozenset(ARM_JOINTS))
+        b = ProbeTask("b", frozenset(ARM_JOINTS))
+        assert coordinator.add_task(a, task_type=card, stream_bind={"sensor_in": "a_in"})
+        assert coordinator.add_task(b, task_type=card, stream_bind={"sensor_in": "b_in"})
+
+        taps["a_in"].emit(JointState(name=ARM_JOINTS, position=[0.1, 0.2]))
+
+        assert len(a.probe_commands) == 1
+        assert b.probe_commands == []
+
+        taps["b_in"].emit(JointState(name=ARM_JOINTS, position=[0.3, 0.4]))
+
+        assert len(a.probe_commands) == 1
+        assert len(b.probe_commands) == 1
+
+    def test_logical_name_is_not_subscribed_when_remapped(self, make_coordinator, register_card):
+        # "sensor_in" is not a port on this coordinator at all; only a_in is.
+        card = self._fanout_card(register_card)
+        coordinator, taps = make_coordinator(coordinator_cls=FanoutCoordinator)
+        coordinator.start()
+        assert coordinator.add_task(
+            ProbeTask("a", frozenset(ARM_JOINTS)), task_type=card, stream_bind={"sensor_in": "a_in"}
+        )
+
+        assert taps["a_in"].subscribed
+        assert not taps["b_in"].subscribed
+        assert coordinator.describe_task("a")["streams"] == [("a_in", "direct")]
+
+    def test_stream_bind_from_task_config(self, make_coordinator, register_card):
+        # The deployment path: stream_bind arrives in the blueprint's TaskConfig.
+        card = self._fanout_card(register_card)
+        coordinator, taps = make_coordinator(
+            coordinator_cls=FanoutCoordinator,
+            tasks=[
+                TaskConfig(name="a", type=card, stream_bind={"sensor_in": "a_in"}),
+                TaskConfig(name="b", type=card, stream_bind={"sensor_in": "b_in"}),
+            ],
+        )
+        coordinator._create_task_from_config = lambda cfg: ProbeTask(
+            cfg.name, frozenset(cfg.joint_names)
+        )
+        coordinator.start()
+
+        taps["b_in"].emit(JointState(name=ARM_JOINTS, position=[0.1, 0.2]))
+
+        assert coordinator.get_task("a").probe_commands == []
+        assert len(coordinator.get_task("b").probe_commands) == 1
+
+    def test_unknown_stream_bind_key_is_loud(self, make_coordinator, register_card):
+        card = register_card(
+            "typo_probe_task", {"joint_command": ("on_probe_command", "claim_overlap")}
+        )
+        coordinator, _ = make_coordinator()
+        coordinator.start()
+
+        with pytest.raises(ValueError) as excinfo:
+            coordinator.add_task(
+                ProbeTask("probe1", frozenset(ARM_JOINTS)),
+                task_type=card,
+                stream_bind={"joint_comand": "joint_command"},
+            )
+
+        message = str(excinfo.value)
+        assert "joint_comand" in message  # the typo'd key
+        assert "joint_command" in message  # what the card does declare
+        assert coordinator.list_tasks() == []
+
+    def test_stream_bind_onto_missing_port_is_loud(self, make_coordinator, register_card):
+        card = register_card(
+            "misbound_probe_task", {"joint_command": ("on_probe_command", "claim_overlap")}
+        )
+        coordinator, _ = make_coordinator()
+        coordinator.start()
+
+        with pytest.raises(ValueError, match="no_such_port: In"):
+            coordinator.add_task(
+                ProbeTask("probe1", frozenset(ARM_JOINTS)),
+                task_type=card,
+                stream_bind={"joint_command": "no_such_port"},
+            )
+
+    def test_stream_bind_without_task_type_is_loud(self, make_coordinator):
+        # No card means nothing to remap; dropping it silently would hide a bug.
+        coordinator, _ = make_coordinator()
+        coordinator.start()
+
+        with pytest.raises(ValueError, match="task_type"):
+            coordinator.add_task(
+                ProbeTask("probe1", frozenset(ARM_JOINTS)),
+                stream_bind={"joint_command": "joint_command"},
+            )
+
+        assert coordinator.list_tasks() == []
+
+    def test_direct_cross_talk_warns_naming_both_tasks(
+        self, make_coordinator, register_card, mocker
+    ):
+        card = register_card("shared_probe_task", {"custom_in": ("on_probe_command", "direct")})
+        coordinator, taps = make_coordinator(coordinator_cls=SubclassedCoordinator)
+        coordinator.start()
+        first = ProbeTask("first", frozenset(ARM_JOINTS))
+        second = ProbeTask("second", frozenset(ARM_JOINTS))
+
+        warn = mocker.patch.object(coord_mod.logger, "warning")
+        assert coordinator.add_task(first, task_type=card)
+        assert not warn.called  # one task on the port is not cross-talk
+
+        assert coordinator.add_task(second, task_type=card)  # allowed, just noisy
+
+        assert warn.called
+        logged = str(warn.call_args)
+        assert "first" in logged and "second" in logged
+        assert "stream_bind" in logged
+
+        taps["custom_in"].emit(JointState(name=ARM_JOINTS, position=[0.1, 0.2]))
+        assert len(first.probe_commands) == 1
+        assert len(second.probe_commands) == 1


### PR DESCRIPTION
## Problem

Task cards could only bind five hardcoded coordinator inputs (`CONSUMABLE_STREAMS`), so a deployment could not add a stream of its own, and two instances of one task type were stuck reading the same source.

Issue: follows #2959, supersedes withdrawn #2981

---

## Solution

A deployment now subclasses `ControlCoordinator` and declares extra inputs as normal annotations (`wrench: In[WrenchStamped]`). The allowed-set is deleted: the registry only checks the card names a valid identifier, and the coordinator checks the port exists on itself when the task is registered, naming the annotation to add if not.

`TaskConfig.stream_bind` maps a card input to the port one instance reads, so instances can fan out over separate ports. New `direct` routing rule delivers unconditionally and warns when two instances land on one port. Empty `stream_bind` behaves exactly as before.

---

## Breaking Changes

None

---

## How to Test

1. `uv run pytest dimos/control -m 'not (tool or self_hosted or mujoco or self_hosted_large)'`
2. Subclass the coordinator with `custom_in: In[JointState]`, bind it from a card, confirm the handler fires.
3. Register two instances with different `stream_bind`, emit on one port, confirm only that instance fires.

## Checklist

- [x ] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
