### PR TITLE
Auto Tune module

### DIFF
--- a/dimos/control/autotune/README.md
+++ b/dimos/control/autotune/README.md
@@ -1,0 +1,46 @@
+# dimos.control.autotune
+
+Characterize a mobile base's velocity plant and emit tuned controller gains from
+a declared robot profile. Supersedes `dimos/utils/characterization` and
+`dimos/utils/benchmarking` for plant identification and PI tuning; those trees
+are deprecated pending parity.
+
+User guide: [docs/capabilities/control-autotune.md](../../../docs/capabilities/control-autotune.md).
+
+## Layout
+
+| File | Role |
+|---|---|
+| `profile.py` | `RobotProfile` — declared inputs + measured-properties slot |
+| `probe.py` | passive stream timing/noise probe (advisory; no motion) |
+| `excitation.py` | step / ramp / deadzone signal generators + batteries |
+| `drive.py` | sequencer: one excitation run = one episode (protocol-based) |
+| `live.py` | live adapters binding the sequencer to coordinator + recorder |
+| `fit/` | velocity + pose FOPDT fitters + synthetic ground truth |
+| `properties.py` | direction asymmetry, gain schedule, coupling, deadzone |
+| `bandwidth.py` | bandwidth + Bode + pole-zero from the fit (no python-control) |
+| `tune.py` | lambda-PI tuning, closed-loop scoring, robustness sweep, verdict |
+| `report.py` | tuned artifact (task `from_artifact` shape) + characterization report |
+| `runner.py` | offline pipeline: episodes → fit → bandwidth → tune → emit |
+
+## Property triage
+
+Measured: FOPDT `K/tau/L` per axis, bandwidth, saturation, gain-vs-amplitude
+nonlinearity, direction asymmetry, cross-axis coupling, deadzone, stream rate /
+jitter / noise floor.
+
+Deliberately **not** measured (marginal benefit): isolated measurement latency
+(lumped into `L`), hysteresis, and automatic controller-structure selection.
+
+## Notes for contributors
+
+- The FOPDT fitters and the lambda-tune math were ported from the
+  characterization/benchmark branches and made robot-agnostic: Go2-specific
+  constants (saturation limits, control rate, cost weights, verdict thresholds)
+  are parameters or named module constants, not baked-in values.
+- The tuned artifact's `vx/vy/wz` slots are a fixed contract the consuming task
+  reads. `report.py` projects the channel-list profile onto those slots and
+  rejects channels outside `{vx, vy, wz}`.
+- The closed-loop scorer is O(n²) by construction (re-simulates the full command
+  history each control tick), preserved exactly from the source. Vectorizing it
+  is a future optimization, not a behavior change.

--- a/dimos/control/autotune/bandwidth.py
+++ b/dimos/control/autotune/bandwidth.py
@@ -1,0 +1,191 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Frequency-domain views of a fitted FOPDT plant: bandwidth, Bode, pole-zero.
+
+All three are closed-form from the fitted ``(K, tau, L)`` - no chirp, no
+swept-sine, and no ``python-control`` dependency (scipy/matplotlib are already
+deps; control is not, and for a FOPDT it would only obscure the deadtime
+approximation we deliberately label).
+
+FOPDT transfer function:
+
+    G(s) = K * exp(-L s) / (tau s + 1)
+
+  * magnitude  |G(jw)| = K / sqrt(1 + (w tau)^2)
+  * phase      arg G(jw) = -atan(w tau) - w L      (deadtime = linear phase ramp)
+
+The only physical pole is at s = -1/tau; there are NO finite zeros. The
+deadtime exp(-L s) is non-rational, so the pole-zero MAP uses a first-order
+Pade approximation,
+
+    exp(-L s) ~= (1 - L s / 2) / (1 + L s / 2),
+
+which introduces ONE extra pole at s = -2/L and ONE right-half-plane zero at
+s = +2/L. These are approximation artifacts, flagged as such so they are never
+read as physical plant roots.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import numpy as np
+
+# Bandwidth is only meaningful for a trustworthy fit. Gate on this R^2 unless
+# the caller overrides; below it, bandwidth is withheld.
+DEFAULT_FIT_QUALITY_GATE = 0.8
+
+
+def fopdt_response(
+    K: float, tau: float, L: float, omega: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]:
+    """Complex magnitude and phase (rad) of the FOPDT at angular freqs ``omega``."""
+    if tau <= 0:
+        raise ValueError("tau must be > 0")
+    jw_tau = omega * tau
+    mag = abs(K) / np.sqrt(1.0 + jw_tau**2)
+    phase = -np.arctan(jw_tau) - omega * L
+    return mag, phase
+
+
+def bandwidth_hz(
+    K: float,
+    tau: float,
+    L: float,
+    *,
+    r2: float | None = None,
+    quality_gate: float = DEFAULT_FIT_QUALITY_GATE,
+) -> float | None:
+    """Open-loop -3 dB bandwidth (Hz) of the FOPDT, or ``None`` if the fit is
+    too poor to trust.
+
+    For a first-order lag the -3 dB magnitude point is w = 1/tau, independent of
+    the (all-pass) deadtime - deadtime adds phase lag, not magnitude rolloff. So
+    the bandwidth is ``1 / (2*pi*tau)``. ``L`` is accepted for signature
+    symmetry and to make the deadtime's effect on achievable *closed-loop*
+    bandwidth explicit to callers (it caps it well below this open-loop number).
+    """
+    if r2 is not None and r2 < quality_gate:
+        return None
+    if tau <= 0:
+        return None
+    return float(1.0 / (2.0 * np.pi * tau))
+
+
+@dataclass(frozen=True)
+class PoleZero:
+    """A pole or zero on the s-plane, tagged by origin so Pade artifacts are
+    never confused with the physical plant root."""
+
+    s: complex
+    kind: str  # "pole" | "zero"
+    origin: str  # "physical" | "pade_pole" | "pade_zero_rhp"
+
+
+def pole_zero_map(K: float, tau: float, L: float) -> list[PoleZero]:
+    """Pole-zero list for the FOPDT with a 1st-order Pade deadtime.
+
+    Physical: one pole at -1/tau, no finite zeros.
+    Pade artifacts (only when ``L`` > 0): a pole at -2/L and an RHP zero at
+    +2/L, both labeled as approximation artifacts.
+    """
+    if tau <= 0:
+        raise ValueError("tau must be > 0")
+    out = [PoleZero(s=complex(-1.0 / tau, 0.0), kind="pole", origin="physical")]
+    if L > 0:
+        out.append(PoleZero(s=complex(-2.0 / L, 0.0), kind="pole", origin="pade_pole"))
+        out.append(PoleZero(s=complex(+2.0 / L, 0.0), kind="zero", origin="pade_zero_rhp"))
+    return out
+
+
+@dataclass
+class FrequencyPlots:
+    """Paths of emitted per-axis Bode and pole-zero figures."""
+
+    bode_paths: dict[str, str] = field(default_factory=dict)
+    pole_zero_paths: dict[str, str] = field(default_factory=dict)
+
+
+def _decade_grid(tau: float, L: float, n: int = 400) -> np.ndarray:
+    """Log-spaced angular-frequency grid spanning two decades either side of the
+    corner 1/tau (and the deadtime corner if faster)."""
+    corner = 1.0 / tau
+    hi_feature = max(corner, (2.0 / L) if L > 0 else corner)
+    return np.logspace(np.log10(corner / 100.0), np.log10(hi_feature * 100.0), n)
+
+
+def plot_bode(K: float, tau: float, L: float, out_path: str, title: str = "") -> str:
+    """Write a Bode magnitude/phase figure for one axis. Returns ``out_path``."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    omega = _decade_grid(tau, L)
+    mag, phase = fopdt_response(K, tau, L, omega)
+    f_hz = omega / (2.0 * np.pi)
+
+    fig, (ax_mag, ax_ph) = plt.subplots(2, 1, sharex=True, figsize=(7, 6))
+    ax_mag.semilogx(f_hz, 20.0 * np.log10(np.maximum(mag, 1e-12)))
+    ax_mag.axhline(20.0 * np.log10(abs(K) / np.sqrt(2.0)), ls=":", color="gray", lw=1)
+    ax_mag.axvline(1.0 / (2.0 * np.pi * tau), ls="--", color="C3", lw=1, label="-3 dB (1/tau)")
+    ax_mag.set_ylabel("magnitude (dB)")
+    ax_mag.legend(loc="best", fontsize=8)
+    ax_mag.grid(True, which="both", alpha=0.3)
+    ax_ph.semilogx(f_hz, np.degrees(phase))
+    ax_ph.set_ylabel("phase (deg)")
+    ax_ph.set_xlabel("frequency (Hz)")
+    ax_ph.grid(True, which="both", alpha=0.3)
+    fig.suptitle(title or f"Bode - K={K:.3g} tau={tau:.3g}s L={L:.3g}s")
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=110)
+    plt.close(fig)
+    return out_path
+
+
+def plot_pole_zero(K: float, tau: float, L: float, out_path: str, title: str = "") -> str:
+    """Write a pole-zero figure for one axis, styling physical vs Pade-artifact
+    roots distinctly. Returns ``out_path``."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    pzs = pole_zero_map(K, tau, L)
+    fig, ax = plt.subplots(figsize=(6, 6))
+    styles = {
+        "physical": dict(marker="x", color="C0", s=90, label="physical pole (-1/tau)"),
+        "pade_pole": dict(marker="x", color="0.6", s=70, label="Pade pole (artifact)"),
+        "pade_zero_rhp": dict(
+            marker="o", color="0.6", s=70, facecolors="none", label="Pade RHP zero (artifact)"
+        ),
+    }
+    seen: set[str] = set()
+    for pz in pzs:
+        st = dict(styles[pz.origin])
+        label = st.pop("label")
+        ax.scatter(pz.s.real, pz.s.imag, label=label if label not in seen else None, **st)
+        seen.add(label)
+    ax.axhline(0, color="k", lw=0.5)
+    ax.axvline(0, color="k", lw=0.5)
+    ax.set_xlabel("Re(s)")
+    ax.set_ylabel("Im(s)")
+    ax.legend(loc="best", fontsize=8)
+    ax.grid(True, alpha=0.3)
+    ax.set_title(title or f"Pole-Zero (1st-order Pade deadtime) - tau={tau:.3g}s L={L:.3g}s")
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=110)
+    plt.close(fig)
+    return out_path

--- a/dimos/control/autotune/drive.py
+++ b/dimos/control/autotune/drive.py
@@ -1,0 +1,133 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Drive the excitation battery through the coordinator, segmenting episodes.
+
+The sequencer is the autotune-side piece that meets the live system. It plays
+each :class:`ExcitationRun` as ONE episode:
+
+    episode start  ->  play signal at tick rate for the run duration  ->  zero
+    command  ->  episode save
+
+Episode transitions are driven PROGRAMMATICALLY (the excitation sequencer knows
+exactly when each run begins and ends), not by teleop keypresses - but the
+recorded ``EpisodeStatus`` stream is the same one ``EpisodeMonitor`` emits, so
+the learning recorder segments autotune runs exactly as it segments teleop
+episodes. We do not fork ``EpisodeMonitor`` semantics; we just emit the same
+events on a known schedule.
+
+Everything here is defined against small Protocols so the sequencer is fully
+unit-testable against mocks. The live adapters (publish a Twist on the
+coordinator's ``twist_command``, publish ``EpisodeStatus``, real wall clock) are
+thin wrappers - they cannot be validated without a running coordinator, but the
+ordering/segmentation logic they depend on is pinned by the mock tests.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Protocol, runtime_checkable
+
+from dimos.control.autotune.excitation import ExcitationRun
+
+
+@runtime_checkable
+class CommandSink(Protocol):
+    """Accepts a per-channel command and turns it into a robot command (e.g. a
+    Twist on the coordinator). ``stop`` commands all channels to zero."""
+
+    def send(self, channel_values: dict[str, float]) -> None: ...
+    def stop(self) -> None: ...
+
+
+@runtime_checkable
+class EpisodeSink(Protocol):
+    """Programmatic episode segmentation: emit start/save on the same
+    ``EpisodeStatus`` timeline the recorder reads."""
+
+    def start_episode(self, label: str) -> None: ...
+    def save_episode(self) -> None: ...
+
+
+@runtime_checkable
+class Clock(Protocol):
+    """Monotonic clock + sleep, injectable so tests run in virtual time."""
+
+    def now(self) -> float: ...
+    def sleep(self, seconds: float) -> None: ...
+
+
+def play_run(
+    run: ExcitationRun,
+    sink: CommandSink,
+    episodes: EpisodeSink,
+    clock: Clock,
+    *,
+    tick_hz: float,
+) -> int:
+    """Play one excitation run as one episode. Returns the number of command
+    ticks emitted.
+
+    The excited channel is commanded by ``run.signal(t)``; all other channels
+    are implicitly zero (the sink only receives the excited channel). On exit the
+    sink is stopped (zeroed) and the episode is saved, even if the body raised -
+    we never leave the base commanded."""
+    if tick_hz <= 0:
+        raise ValueError("tick_hz must be > 0")
+    dt = 1.0 / tick_hz
+    n_ticks = max(1, round(run.duration_s * tick_hz))
+    episodes.start_episode(run.label)
+    emitted = 0
+    try:
+        t0 = clock.now()
+        for i in range(n_ticks):
+            t = i * dt
+            sink.send({run.channel: run.signal(t)})
+            emitted += 1
+            # Pace to the tick boundary relative to the run start.
+            target = t0 + (i + 1) * dt
+            remaining = target - clock.now()
+            if remaining > 0:
+                clock.sleep(remaining)
+    finally:
+        sink.stop()
+        episodes.save_episode()
+    return emitted
+
+
+def run_battery(
+    runs: Sequence[ExcitationRun],
+    sink: CommandSink,
+    episodes: EpisodeSink,
+    clock: Clock,
+    *,
+    tick_hz: float,
+    settle_s: float = 1.0,
+) -> int:
+    """Play a whole battery: each run is its own episode, with a settle dwell
+    (zeroed command) between runs so the base returns to rest before the next
+    excitation. Returns the number of episodes played.
+
+    The base is NOT repositioned automatically - the operator does that between
+    runs in the existing playbook (teleop during the dwell). ``settle_s`` only
+    guarantees a commanded-zero rest, not a returned-to-origin pose."""
+    played = 0
+    for run in runs:
+        play_run(run, sink, episodes, clock, tick_hz=tick_hz)
+        played += 1
+        # Inter-run settle: hold zero so transients die before the next episode.
+        if settle_s > 0:
+            sink.stop()
+            clock.sleep(settle_s)
+    return played

--- a/dimos/control/autotune/excitation.py
+++ b/dimos/control/autotune/excitation.py
@@ -1,0 +1,152 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Excitation signal generators.
+
+Pure ``(t) -> command`` functions that the drive layer plays through the
+coordinator. They carry NO recording concern (capture is the learning
+recorder's job) and NO timing concern beyond the signal shape. One excited
+channel at a time; the value is the command for that channel (other channels
+are commanded zero by the driver).
+
+Amplitudes are profile-driven (fractions of the channel envelope) and applied
+in both directions, so the same battery scales to any robot and exposes
+direction asymmetry. A run is one ``ExcitationRun`` = one episode.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from dimos.control.autotune.profile import RobotProfile
+
+SignalFn = Callable[[float], float]
+"""Time (s, relative to run start) -> command value for the excited channel."""
+
+
+def step(amplitude: float, t_start: float = 0.5) -> SignalFn:
+    """Zero until ``t_start``, then constant ``amplitude``. The canonical FOPDT
+    excitation; the pre-step dwell gives a clean baseline."""
+
+    def _fn(t: float) -> float:
+        return amplitude if t >= t_start else 0.0
+
+    return _fn
+
+
+def ramp(amplitude: float, duration_s: float, t_start: float = 0.5) -> SignalFn:
+    """Linear rise from 0 to ``amplitude`` over ``duration_s`` after ``t_start``,
+    then hold. Used for rate-limit probing and as the deadzone sweep base."""
+    if duration_s <= 0:
+        raise ValueError("duration_s must be > 0")
+
+    def _fn(t: float) -> float:
+        if t < t_start:
+            return 0.0
+        frac = (t - t_start) / duration_s
+        if frac >= 1.0:
+            return amplitude
+        return amplitude * frac
+
+    return _fn
+
+
+def deadzone_ramp(amplitude: float, duration_s: float, t_start: float = 0.5) -> SignalFn:
+    """Slow ramp from 0 to ``amplitude`` to find the minimum command that moves
+    the base. Identical shape to :func:`ramp`; named distinctly because the
+    intent (and the slow rate) differ — keep ``duration_s`` long so the deadzone
+    crossing is well resolved."""
+    return ramp(amplitude, duration_s, t_start)
+
+
+@dataclass(frozen=True)
+class ExcitationRun:
+    """One excitation episode: which channel, signed amplitude, signal, repeat
+    index, and how long to play it."""
+
+    channel: str
+    amplitude: float
+    direction: int  # +1 or -1
+    repeat: int
+    signal: SignalFn
+    duration_s: float
+    kind: str  # "step" | "ramp" | "deadzone_ramp"
+
+    @property
+    def label(self) -> str:
+        sign = "fwd" if self.direction >= 0 else "rev"
+        return f"{self.kind}_{self.channel}_{abs(self.amplitude):.3g}_{sign}_r{self.repeat}"
+
+
+def step_battery(
+    profile: RobotProfile,
+    *,
+    duration_s: float = 4.0,
+    t_start: float = 0.5,
+    bidirectional: bool = True,
+) -> list[ExcitationRun]:
+    """Build the step battery for every channel: each profile amplitude, both
+    directions (to expose asymmetry), repeated ``profile.battery.repeats`` times.
+
+    Order is channel-major then amplitude then direction then repeat; the driver
+    may randomize this to decorrelate drift."""
+    runs: list[ExcitationRun] = []
+    directions = (1, -1) if bidirectional else (1,)
+    for ch in profile.channel_names:
+        for amp in profile.battery_amplitudes(ch):
+            for direction in directions:
+                signed = direction * amp
+                for rep in range(profile.battery.repeats):
+                    runs.append(
+                        ExcitationRun(
+                            channel=ch,
+                            amplitude=signed,
+                            direction=direction,
+                            repeat=rep,
+                            signal=step(signed, t_start),
+                            duration_s=duration_s,
+                            kind="step",
+                        )
+                    )
+    return runs
+
+
+def deadzone_battery(
+    profile: RobotProfile,
+    *,
+    duration_s: float = 8.0,
+    t_start: float = 0.5,
+    bidirectional: bool = True,
+) -> list[ExcitationRun]:
+    """One slow ramp to full ``vmax`` per channel per direction. Long duration so
+    the deadzone crossing is well sampled."""
+    runs: list[ExcitationRun] = []
+    directions = (1, -1) if bidirectional else (1,)
+    for ch in profile.channel_names:
+        vmax = profile.channel(ch).vmax
+        for direction in directions:
+            signed = direction * vmax
+            runs.append(
+                ExcitationRun(
+                    channel=ch,
+                    amplitude=signed,
+                    direction=direction,
+                    repeat=0,
+                    signal=deadzone_ramp(signed, duration_s - t_start, t_start),
+                    duration_s=duration_s,
+                    kind="deadzone_ramp",
+                )
+            )
+    return runs

--- a/dimos/control/autotune/fit/pose_fopdt.py
+++ b/dimos/control/autotune/fit/pose_fopdt.py
@@ -1,0 +1,311 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pose-domain (output-error) FOPDT fitter.
+
+Fits the FOPDT against raw pose without ever differentiating the measurement.
+At low odom rate the velocity-domain fitter's smoothing window is longer than
+tau, which flattens the step and inflates tau, and co-fitting L with tau is
+degenerate. This fitter forward-models pose a candidate (K, tau, L) would
+produce and fits to raw pose (simulation-error identification).
+
+Forward model for one step segment (axis excited alone, from rest, signed
+amplitude ``amp``, ``t`` relative to the step edge):
+
+    velocity:  v(t) = K*amp*(1 - exp(-(t-L)/tau))            for t >= L, else 0
+    position:  p(t) = p0 + drift*t
+                      + K*amp*[(t-L) - tau*(1 - exp(-(t-L)/tau))]   for t >= L
+
+``p0`` (start offset) and ``drift`` (constant-velocity odom slip) are fit as
+nuisance parameters so they cannot bias K/tau. L is fixed per fit;
+:func:`estimate_deadtime` chooses it by profiling, decoupling it from tau.
+
+Ported from the characterization harness; bounds default to values suited to a
+legged base with slow odom but are parameters, not baked-in constants.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+import numpy as np
+
+K_ABS_MAX = 5.0
+# Defaults tuned for a slow-odom legged base; override per robot.
+DEFAULT_TAU_BOUNDS = (0.03, 0.6)
+DEFAULT_L_BOUNDS = (0.05, 0.30)
+
+
+@dataclass
+class PoseFopdtParams:
+    """Result of a pose-domain FOPDT fit. ``r_squared``/``rmse`` are on POSE
+    (the fitted quantity), not a differentiated velocity. ``valid`` is the
+    plausibility gate: ``False`` means the fit landed outside physical bounds
+    and must not be tuned from."""
+
+    K: float
+    tau: float
+    L: float  # fixed input, echoed for the record
+    p0: float
+    drift: float
+    rmse: float
+    r_squared: float
+    n_samples: int
+    valid: bool
+    converged: bool
+    reason: str | None = None
+    bounds: dict[str, tuple[float, float]] = field(default_factory=dict)
+
+    def asdict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def pose_step_response(t_rel: np.ndarray, K: float, tau: float, L: float, amp: float) -> np.ndarray:
+    """Position of a from-rest FOPDT step, ``t_rel`` relative to the step edge.
+
+    Closed-form integral of the FOPDT velocity step - no differentiation, no
+    discretization. Excludes ``p0``/``drift`` (added by the fit)."""
+    t_rel = np.asarray(t_rel, dtype=float)
+    out = np.zeros_like(t_rel)
+    if tau <= 0.0:
+        return out
+    mask = t_rel >= L
+    s = t_rel[mask] - L
+    out[mask] = K * amp * (s - tau * (1.0 - np.exp(-s / tau)))
+    return out
+
+
+def _nan_result(n: int, reason: str, l_fixed: float) -> PoseFopdtParams:
+    nan = float("nan")
+    return PoseFopdtParams(
+        K=nan,
+        tau=nan,
+        L=l_fixed,
+        p0=nan,
+        drift=nan,
+        rmse=nan,
+        r_squared=nan,
+        n_samples=n,
+        valid=False,
+        converged=False,
+        reason=reason,
+    )
+
+
+def fit_pose_fopdt(
+    t_rel: np.ndarray,
+    p_meas: np.ndarray,
+    amp: float,
+    l_fixed: float,
+    *,
+    tau_bounds: tuple[float, float] = DEFAULT_TAU_BOUNDS,
+    l_bounds: tuple[float, float] = DEFAULT_L_BOUNDS,
+) -> PoseFopdtParams:
+    """Fit (K, tau, p0, drift) to a pose step segment with L held at ``l_fixed``.
+
+    ``t_rel`` is time relative to the step edge; ``p_meas`` is the measured pose
+    channel (body-x displacement for a vx step, yaw for a wz step); ``amp`` is
+    the signed commanded amplitude. Least-squares on the pose residual."""
+    from scipy.optimize import least_squares
+
+    t_rel = np.asarray(t_rel, dtype=float)
+    p_meas = np.asarray(p_meas, dtype=float)
+    n = int(t_rel.size)
+    if n < 4:
+        return _nan_result(n, "fewer than 4 samples in segment", l_fixed)
+    if abs(amp) < 1e-9:
+        return _nan_result(n, "amp is zero - cannot identify K", l_fixed)
+
+    span = float(p_meas[-1] - p_meas[0])
+    duration = float(t_rel[-1] - t_rel[0]) or 1.0
+    k_guess = float(np.clip(span / (amp * duration) if duration else 1.0, -K_ABS_MAX, K_ABS_MAX))
+    tau_guess = float(np.clip(0.2, *tau_bounds))
+    p0_guess = float(p_meas[0])
+
+    def residual(params: np.ndarray) -> np.ndarray:
+        k, tau, p0, drift = params
+        pred = p0 + drift * t_rel + pose_step_response(t_rel, k, tau, l_fixed, amp)
+        return np.asarray(pred - p_meas, dtype=float)
+
+    lo = [-K_ABS_MAX, tau_bounds[0], -np.inf, -np.inf]
+    hi = [K_ABS_MAX, tau_bounds[1], np.inf, np.inf]
+    try:
+        sol = least_squares(
+            residual, x0=[k_guess, tau_guess, p0_guess, 0.0], bounds=(lo, hi), max_nfev=5000
+        )
+    except Exception as e:
+        return _nan_result(n, f"least_squares failed: {type(e).__name__}: {e}", l_fixed)
+
+    k, tau, p0, drift = (float(v) for v in sol.x)
+    resid = sol.fun
+    rmse = float(np.sqrt(np.mean(resid**2)))
+    ss_res = float(np.sum(resid**2))
+    ss_tot = float(np.sum((p_meas - float(np.mean(p_meas))) ** 2))
+    r2 = 1.0 - ss_res / ss_tot if ss_tot > 0 else float("nan")
+
+    valid = (
+        bool(sol.success)
+        and tau_bounds[0] * 1.001 <= tau <= tau_bounds[1] * 0.999
+        and l_bounds[0] <= l_fixed <= l_bounds[1]
+        and abs(k) < K_ABS_MAX * 0.999
+    )
+    return PoseFopdtParams(
+        K=k,
+        tau=tau,
+        L=l_fixed,
+        p0=p0,
+        drift=drift,
+        rmse=rmse,
+        r_squared=r2,
+        n_samples=n,
+        valid=valid,
+        converged=bool(sol.success),
+        reason=None if valid else "fit outside physical plausibility bounds",
+        bounds={"tau": tau_bounds, "L": l_bounds},
+    )
+
+
+def fit_pose_fopdt_multi(
+    segments: list[tuple[np.ndarray, np.ndarray, float]],
+    l_fixed: float,
+    *,
+    tau_bounds: tuple[float, float] = DEFAULT_TAU_BOUNDS,
+    l_bounds: tuple[float, float] = DEFAULT_L_BOUNDS,
+) -> PoseFopdtParams:
+    """Joint fit of one axis across several amplitudes: shared (K, tau, drift).
+
+    A single step can't separate the steady-state slope (K*amp) from a constant
+    drift slope - they're collinear - which biases K low. Fitting several
+    amplitudes together with a SHARED drift but amplitude-scaled response breaks
+    that collinearity. Each segment keeps its own ``p0``. ``segments`` is a list
+    of ``(t_rel, p_meas, amp)``."""
+    from scipy.optimize import least_squares
+
+    segs = [
+        (np.asarray(t, dtype=float), np.asarray(p, dtype=float), float(amp))
+        for t, p, amp in segments
+        if np.asarray(t).size >= 4 and abs(amp) > 1e-9
+    ]
+    n_total = sum(t.size for t, _, _ in segs)
+    if not segs:
+        return _nan_result(n_total, "no usable segments for joint fit", l_fixed)
+
+    n_seg = len(segs)
+    spans = [float(p[-1] - p[0]) for _, p, _ in segs]
+    durations = [float(t[-1] - t[0]) or 1.0 for t, _, _ in segs]
+    k_guesses = [s / (a * d) for s, (_, _, a), d in zip(spans, segs, durations, strict=True)]
+    k_guess = float(np.clip(np.median(k_guesses), -K_ABS_MAX, K_ABS_MAX))
+    tau_guess = float(np.clip(0.2, *tau_bounds))
+    p0_guesses = [float(p[0]) for _, p, _ in segs]
+
+    def residual(x: np.ndarray) -> np.ndarray:
+        k, tau, drift = x[0], x[1], x[2]
+        p0s = x[3:]
+        parts = []
+        for (t, p, amp), p0 in zip(segs, p0s, strict=True):
+            pred = p0 + drift * t + pose_step_response(t, k, tau, l_fixed, amp)
+            parts.append(pred - p)
+        return np.concatenate(parts)
+
+    lo = [-K_ABS_MAX, tau_bounds[0], -np.inf, *([-np.inf] * n_seg)]
+    hi = [K_ABS_MAX, tau_bounds[1], np.inf, *([np.inf] * n_seg)]
+    x0 = [k_guess, tau_guess, 0.0, *p0_guesses]
+    try:
+        sol = least_squares(residual, x0=x0, bounds=(lo, hi), max_nfev=5000)
+    except Exception as e:
+        return _nan_result(n_total, f"joint least_squares failed: {type(e).__name__}: {e}", l_fixed)
+
+    k, tau, drift = float(sol.x[0]), float(sol.x[1]), float(sol.x[2])
+    resid = sol.fun
+    rmse = float(np.sqrt(np.mean(resid**2)))
+    p_all = np.concatenate([p for _, p, _ in segs])
+    ss_res = float(np.sum(resid**2))
+    ss_tot = float(np.sum((p_all - float(np.mean(p_all))) ** 2))
+    r2 = 1.0 - ss_res / ss_tot if ss_tot > 0 else float("nan")
+    valid = (
+        bool(sol.success)
+        and tau_bounds[0] * 1.001 <= tau <= tau_bounds[1] * 0.999
+        and l_bounds[0] <= l_fixed <= l_bounds[1]
+        and abs(k) < K_ABS_MAX * 0.999
+    )
+    return PoseFopdtParams(
+        K=k,
+        tau=tau,
+        L=l_fixed,
+        p0=float(sol.x[3]),
+        drift=drift,
+        rmse=rmse,
+        r_squared=r2,
+        n_samples=n_total,
+        valid=valid,
+        converged=bool(sol.success),
+        reason=None if valid else "fit outside physical plausibility bounds",
+        bounds={"tau": tau_bounds, "L": l_bounds},
+    )
+
+
+def _parabolic_vertex(x: np.ndarray, y: np.ndarray, i: int) -> float:
+    """Sub-grid minimum of ``y`` near index ``i`` by 3-point parabola fit."""
+    if i == 0 or i == x.size - 1:
+        return float(x[i])
+    y0, y1, y2 = y[i - 1], y[i], y[i + 1]
+    denom = y0 - 2.0 * y1 + y2
+    if denom <= 0.0:
+        return float(x[i])
+    offset = 0.5 * (y0 - y2) / denom
+    return float(x[i] + offset * (x[i + 1] - x[i]))
+
+
+def estimate_deadtime(
+    t_rel: np.ndarray,
+    p_meas: np.ndarray,
+    amp: float,
+    *,
+    l_candidates: np.ndarray | None = None,
+    l_bounds: tuple[float, float] = DEFAULT_L_BOUNDS,
+    tau_bounds: tuple[float, float] = DEFAULT_TAU_BOUNDS,
+    grid_dt: float = (1.0 / 18.0) / 4.0,
+) -> tuple[float, np.ndarray, np.ndarray]:
+    """Estimate deadtime L by profiling, decoupled from tau.
+
+    For each candidate L, fit (K, tau, p0, drift) on the pose and record RMSE;
+    the L with the lowest RMSE (refined by a parabolic vertex) is returned. This
+    is the profile-likelihood approach: L is chosen on an outer 1-D search rather
+    than co-fit in the same gradient step as tau, which is degenerate.
+
+    Returns ``(best_L, l_candidates, rmse_per_candidate)``."""
+    if l_candidates is None:
+        n_steps = max(3, round((l_bounds[1] - l_bounds[0]) / grid_dt) + 1)
+        l_candidates = np.linspace(l_bounds[0], l_bounds[1], n_steps)
+    rmses = np.full(l_candidates.size, np.inf)
+    for i, candidate in enumerate(l_candidates):
+        fit = fit_pose_fopdt(
+            t_rel, p_meas, amp, float(candidate), tau_bounds=tau_bounds, l_bounds=l_bounds
+        )
+        if fit.converged and np.isfinite(fit.rmse):
+            rmses[i] = fit.rmse
+    best_i = int(np.argmin(rmses))
+    best_l = _parabolic_vertex(l_candidates, rmses, best_i)
+    best_l = float(np.clip(best_l, l_bounds[0], l_bounds[1]))
+    return best_l, l_candidates, rmses
+
+
+__all__ = [
+    "PoseFopdtParams",
+    "estimate_deadtime",
+    "fit_pose_fopdt",
+    "fit_pose_fopdt_multi",
+    "pose_step_response",
+]

--- a/dimos/control/autotune/fit/synth.py
+++ b/dimos/control/autotune/fit/synth.py
@@ -1,0 +1,90 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Synthetic ground-truth generator for pinning the FOPDT fitters.
+
+Given a known ``(K, tau, L)`` plant and a measurement model (sample rate +
+noise), produce the exact velocity and pose traces the plant would emit for a
+step. The fitters must recover the known parameters from these traces - this is
+how we validate the fitters offline, with no robot or sim. Distilled from the
+characterization ground-truth harness, dropping its DB I/O and Go2 grids.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class MeasurementModel:
+    """How a continuous true signal becomes a measured stream.
+
+    ``rate_hz`` is the odom sample rate; ``noise_std`` is per-sample Gaussian
+    sigma on the measured channel; ``drift`` is a constant velocity slip added to
+    pose (the odom-slip nuisance the pose fitter absorbs)."""
+
+    rate_hz: float
+    noise_std: float = 0.0
+    drift: float = 0.0
+
+
+def true_velocity(t: np.ndarray, K: float, tau: float, L: float, amp: float) -> np.ndarray:
+    """Continuous FOPDT velocity step response, ``t`` relative to the step edge."""
+    t = np.asarray(t, dtype=float)
+    v = np.zeros_like(t)
+    mask = t >= L
+    v[mask] = K * amp * (1.0 - np.exp(-(t[mask] - L) / tau))
+    return v
+
+
+def true_pose(t: np.ndarray, K: float, tau: float, L: float, amp: float) -> np.ndarray:
+    """Closed-form integral of :func:`true_velocity` (pose from rest, p0=0)."""
+    t = np.asarray(t, dtype=float)
+    p = np.zeros_like(t)
+    mask = t >= L
+    s = t[mask] - L
+    p[mask] = K * amp * (s - tau * (1.0 - np.exp(-s / tau)))
+    return p
+
+
+def synth_step(
+    K: float,
+    tau: float,
+    L: float,
+    amp: float,
+    duration_s: float,
+    model: MeasurementModel,
+    *,
+    seed: int = 0,
+    p0: float = 0.0,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Synthesize one measured step at the model's sample rate.
+
+    Returns ``(t_rel, velocity_meas, pose_meas)`` sampled at ``rate_hz``, with
+    Gaussian noise and constant drift applied. ``t_rel`` is relative to the step
+    edge (step at t=0). Noise is seeded for reproducibility; vary ``seed`` per
+    call to get independent realizations."""
+    n = max(4, round(duration_s * model.rate_hz))
+    t = np.arange(n) / model.rate_hz
+    v = true_velocity(t, K, tau, L, amp)
+    p = p0 + model.drift * t + true_pose(t, K, tau, L, amp)
+    if model.noise_std > 0:
+        rng = np.random.default_rng(seed)
+        v = v + rng.normal(0.0, model.noise_std, size=n)
+        # Pose noise is smaller-magnitude than velocity noise in practice; scale
+        # it so the pose SNR is comparable rather than identical sigma.
+        p = p + rng.normal(0.0, model.noise_std / model.rate_hz, size=n)
+    return t, v, p

--- a/dimos/control/autotune/fit/velocity_fopdt.py
+++ b/dimos/control/autotune/fit/velocity_fopdt.py
@@ -1,0 +1,234 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Velocity-domain FOPDT fitter.
+
+Fits the FOPDT step response directly to a (reconstructed) body-velocity trace.
+Ported from the characterization modeling harness; the bounds are exposed as
+parameters rather than baked-in Go2 constants so the fitter is robot-agnostic.
+
+  K   - steady-state gain (output per unit command)
+  tau - first-order time constant (s)
+  L   - lumped dead-time (s)
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+import numpy as np
+
+# Generic plausibility bounds. Override per robot via fit_fopdt(..., bounds=...).
+K_ABS_MAX = 5.0
+TAU_MIN = 1e-3
+TAU_MAX = 5.0
+L_MIN = 0.0
+L_MAX = 1.0
+
+
+@dataclass
+class FopdtParams:
+    """Result of a single velocity-domain FOPDT fit. ``converged=False`` means
+    the optimizer failed or the input was degenerate; numeric fields are then
+    NaN and ``reason`` explains why. ``plausible`` is the gate: a converged fit
+    that lands on a bound is flagged rather than silently trusted."""
+
+    K: float
+    tau: float
+    L: float
+    K_ci: tuple[float, float]
+    tau_ci: tuple[float, float]
+    L_ci: tuple[float, float]
+    rmse: float
+    r_squared: float
+    n_samples: int
+    fit_window_s: tuple[float, float]
+    degenerate: bool
+    converged: bool
+    plausible: bool = True
+    reason: str | None = None
+    initial_guess: dict[str, float] = field(default_factory=dict)
+
+    def asdict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def fopdt_step_response(t: np.ndarray, K: float, tau: float, L: float, u_step: float) -> np.ndarray:
+    """Vectorized FOPDT step response. ``t`` is time relative to the step edge."""
+    t = np.asarray(t, dtype=float)
+    out = np.zeros_like(t)
+    if tau <= 0.0:
+        return out
+    mask = t >= L
+    out[mask] = K * u_step * (1.0 - np.exp(-(t[mask] - L) / tau))
+    return out
+
+
+def _nan_params(n: int, window: tuple[float, float], reason: str) -> FopdtParams:
+    nan = float("nan")
+    return FopdtParams(
+        K=nan,
+        tau=nan,
+        L=nan,
+        K_ci=(nan, nan),
+        tau_ci=(nan, nan),
+        L_ci=(nan, nan),
+        rmse=nan,
+        r_squared=nan,
+        n_samples=n,
+        fit_window_s=window,
+        degenerate=True,
+        converged=False,
+        plausible=False,
+        reason=reason,
+    )
+
+
+def _initial_guess(
+    t: np.ndarray,
+    y: np.ndarray,
+    u_step: float,
+    noise_std: float | None,
+    bounds: tuple[tuple[float, float, float], tuple[float, float, float]],
+) -> tuple[float, float, float]:
+    (_, tau_min, l_min), (k_abs, tau_max, l_max) = bounds
+    if t.size < 4:
+        return (1.0, 0.2, 0.05)
+    n = t.size
+    tail_n = max(1, int(n * 0.2))
+    y_tail = float(np.mean(y[-tail_n:]))
+    K_init = y_tail / u_step if abs(u_step) > 1e-9 else 1.0
+    K_init = float(np.clip(K_init, -k_abs * 0.99, k_abs * 0.99))
+    if abs(K_init) < 1e-3:
+        K_init = 0.5 if u_step >= 0 else -0.5
+
+    band = 3.0 * (noise_std if noise_std and noise_std > 0 else 1e-3)
+    above = np.flatnonzero(np.abs(y) > band)
+    L_init = float(t[above[0]]) if above.size else 0.05
+    L_init = float(np.clip(L_init, l_min, l_max * 0.99))
+
+    target = 0.63 * K_init * u_step
+    if abs(target) > 1e-6:
+        crossed = (
+            np.flatnonzero(y >= target) if K_init * u_step > 0 else np.flatnonzero(y <= target)
+        )
+        tau_init = float(t[crossed[0]] - L_init) if crossed.size else 0.3
+    else:
+        tau_init = 0.3
+    tau_init = float(np.clip(tau_init, tau_min * 10, tau_max * 0.99))
+    return (K_init, tau_init, L_init)
+
+
+def fit_fopdt(
+    t: np.ndarray,
+    y: np.ndarray,
+    u_step: float,
+    *,
+    noise_std: float | None = None,
+    fit_window_s: tuple[float, float] | None = None,
+    bounds: tuple[tuple[float, float, float], tuple[float, float, float]] | None = None,
+) -> FopdtParams:
+    """Fit FOPDT to a step-response trace.
+
+    ``t`` is time relative to the step edge (step at t=0). ``y`` is the measured
+    response with the pre-step baseline subtracted. ``u_step`` is the signed
+    commanded amplitude. ``bounds`` is ``((lo_K, lo_tau, lo_L), (hi_K, hi_tau,
+    hi_L))``; defaults to the generic plausibility box.
+    """
+    from scipy.optimize import curve_fit
+
+    t = np.asarray(t, dtype=float)
+    y = np.asarray(y, dtype=float)
+    window = (
+        fit_window_s
+        if fit_window_s is not None
+        else ((float(t[0]), float(t[-1])) if t.size else (0.0, 0.0))
+    )
+    if bounds is None:
+        bounds = ((-K_ABS_MAX, TAU_MIN, L_MIN), (K_ABS_MAX, TAU_MAX, L_MAX))
+    lo, hi = bounds
+
+    if t.size < 4:
+        return _nan_params(int(t.size), window, "fewer than 4 samples in fit window")
+    if abs(u_step) < 1e-9:
+        return _nan_params(int(t.size), window, "u_step is zero - cannot identify K")
+
+    K0, tau0, L0 = _initial_guess(t, y, u_step, noise_std, bounds)
+    sigma = np.full_like(y, float(noise_std)) if noise_std and noise_std > 0 else None
+
+    def _model(t_, K, tau, L):
+        return fopdt_step_response(t_, K, tau, L, u_step)
+
+    try:
+        popt, pcov = curve_fit(
+            _model,
+            t,
+            y,
+            p0=(K0, tau0, L0),
+            bounds=(lo, hi),
+            sigma=sigma,
+            absolute_sigma=False,
+            maxfev=5000,
+        )
+    except Exception as e:
+        out = _nan_params(int(t.size), window, f"curve_fit failed: {type(e).__name__}: {e}")
+        out.initial_guess = {"K": K0, "tau": tau0, "L": L0}
+        return out
+
+    K, tau, L = float(popt[0]), float(popt[1]), float(popt[2])
+    y_hat = _model(t, K, tau, L)
+    resid = y - y_hat
+    rmse = float(np.sqrt(np.mean(resid**2))) if resid.size else float("nan")
+    ss_res = float(np.sum(resid**2))
+    ss_tot = float(np.sum((y - float(np.mean(y))) ** 2))
+    r2 = 1.0 - ss_res / ss_tot if ss_tot > 0 else float("nan")
+
+    diag = np.diag(pcov)
+    degenerate = bool(np.any(~np.isfinite(diag)) or np.any(diag <= 0))
+    if degenerate:
+        K_ci = tau_ci = L_ci = (float("nan"), float("nan"))
+    else:
+        s = np.sqrt(diag)
+        K_ci = (K - 1.96 * float(s[0]), K + 1.96 * float(s[0]))
+        tau_ci = (tau - 1.96 * float(s[1]), tau + 1.96 * float(s[1]))
+        L_ci = (L - 1.96 * float(s[2]), L + 1.96 * float(s[2]))
+
+    # Plausibility gate: flag fits that hit a bound (likely unidentified).
+    on_bound = (
+        abs(K) >= hi[0] * 0.999
+        or tau <= lo[1] * 1.001
+        or tau >= hi[1] * 0.999
+        or L >= hi[2] * 0.999
+    )
+    return FopdtParams(
+        K=K,
+        tau=tau,
+        L=L,
+        K_ci=K_ci,
+        tau_ci=tau_ci,
+        L_ci=L_ci,
+        rmse=rmse,
+        r_squared=r2,
+        n_samples=int(t.size),
+        fit_window_s=window,
+        degenerate=degenerate,
+        converged=True,
+        plausible=not on_bound,
+        reason=None if not on_bound else "fit landed on a plausibility bound",
+        initial_guess={"K": K0, "tau": tau0, "L": L0},
+    )
+
+
+__all__ = ["FopdtParams", "fit_fopdt", "fopdt_step_response"]

--- a/dimos/control/autotune/live.py
+++ b/dimos/control/autotune/live.py
@@ -1,0 +1,132 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Live adapters binding the drive sequencer to the coordinator + recorder.
+
+These implement the ``CommandSink`` / ``EpisodeSink`` / ``Clock`` protocols from
+:mod:`drive` against the real system. The publish functions are INJECTED (wired
+to ``Out`` ports by the entry/blueprint), so the adapters themselves stay thin
+and unit-testable with fakes. The live end-to-end (real coordinator + recorder)
+cannot be validated without hardware/sim - that is a bench step - but the
+mapping logic here is pinned by tests.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import time
+
+from dimos.control.autotune.profile import RobotProfile
+from dimos.learning.collection.episode_monitor import EpisodeStatus
+from dimos.msgs.geometry_msgs.Twist import Twist
+from dimos.msgs.geometry_msgs.Vector3 import Vector3
+
+# Channel name -> (twist component, axis). The conventional twist-base mapping.
+TWIST_CHANNEL_MAP: dict[str, tuple[str, str]] = {
+    "vx": ("linear", "x"),
+    "vy": ("linear", "y"),
+    "wz": ("angular", "z"),
+}
+
+
+class TwistCommandSink:
+    """Turns a per-channel command dict into a Twist on the coordinator's
+    ``twist_command`` stream. Channels not in the command are zero; ``stop``
+    publishes an all-zero twist."""
+
+    def __init__(
+        self,
+        publish: Callable[[Twist], None],
+        channel_map: dict[str, tuple[str, str]] | None = None,
+    ) -> None:
+        self._publish = publish
+        self._map = channel_map or TWIST_CHANNEL_MAP
+
+    def _twist(self, channel_values: dict[str, float]) -> Twist:
+        lin = {"x": 0.0, "y": 0.0, "z": 0.0}
+        ang = {"x": 0.0, "y": 0.0, "z": 0.0}
+        for ch, value in channel_values.items():
+            if ch not in self._map:
+                raise KeyError(f"channel {ch!r} has no twist mapping")
+            component, axis = self._map[ch]
+            (lin if component == "linear" else ang)[axis] = value
+        return Twist(Vector3(lin["x"], lin["y"], lin["z"]), Vector3(ang["x"], ang["y"], ang["z"]))
+
+    def send(self, channel_values: dict[str, float]) -> None:
+        self._publish(self._twist(channel_values))
+
+    def stop(self) -> None:
+        self._publish(self._twist({}))
+
+
+class EpisodeStatusSink:
+    """Emits ``EpisodeStatus`` start/save events on the SAME timeline the
+    learning recorder reads - programmatically, not via teleop. We reuse the
+    EpisodeStatus message and counter semantics; we do not fork EpisodeMonitor."""
+
+    def __init__(
+        self, publish: Callable[[EpisodeStatus], None], now: Callable[[], float] | None = None
+    ) -> None:
+        self._publish = publish
+        self._now = now or time.time
+        self._saved = 0
+        self._discarded = 0
+
+    def start_episode(self, label: str) -> None:
+        self._publish(
+            EpisodeStatus(
+                ts=self._now(),
+                state="recording",
+                episodes_saved=self._saved,
+                episodes_discarded=self._discarded,
+                last_event="start",
+                task_label=label,
+            )
+        )
+
+    def save_episode(self) -> None:
+        self._saved += 1
+        self._publish(
+            EpisodeStatus(
+                ts=self._now(),
+                state="idle",
+                episodes_saved=self._saved,
+                episodes_discarded=self._discarded,
+                last_event="save",
+            )
+        )
+
+
+class WallClock:
+    """Real monotonic clock + sleep for live runs."""
+
+    def now(self) -> float:
+        return time.monotonic()
+
+    def sleep(self, seconds: float) -> None:
+        if seconds > 0:
+            time.sleep(seconds)
+
+
+def make_sinks(
+    profile: RobotProfile,
+    publish_twist: Callable[[Twist], None],
+    publish_status: Callable[[EpisodeStatus], None],
+) -> tuple[TwistCommandSink, EpisodeStatusSink, WallClock]:
+    """Convenience: build the three live adapters for a twist-base profile."""
+    if profile.command_interface != "twist":
+        raise ValueError(
+            f"live twist sinks require a twist command interface, got {profile.command_interface!r}"
+        )
+    return TwistCommandSink(publish_twist), EpisodeStatusSink(publish_status), WallClock()

--- a/dimos/control/autotune/probe.py
+++ b/dimos/control/autotune/probe.py
@@ -1,0 +1,138 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Passive timing/noise probe.
+
+Measures how fast data *arrives* and how clean it is, with the robot
+stationary and no command motion. This is distinct from plant bandwidth:
+
+  * topic frequency  - how fast odom/sensor messages arrive (Hz). Measured
+    here from inter-arrival times.
+  * plant bandwidth  - frequency where the plant response rolls off, DERIVED
+    from the fitted FOPDT (see bandwidth.py). Not measured here.
+
+The probe's job is to surface the numbers that make the user's fitter choice
+obvious - especially the samples-per-tau ratio - WITHOUT deciding for them.
+At low odom rate relative to tau, velocity differentiation inflates tau and
+the pose output-error fitter is appropriate; but the user owns that call. The
+probe only advises (RobotProfile.fitter is never modified here).
+
+The arrival-time math is a pure function (:func:`compute_timing`) so it is
+unit-testable independent of any transport; the live collector is a thin
+wrapper that records arrival times and stationary sample values.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+import numpy as np
+
+from dimos.control.autotune.profile import StreamTiming
+
+
+@dataclass(frozen=True)
+class TimingAdvice:
+    """Advisory readout for one channel/stream. Informs the user's fitter
+    choice; it does not change it."""
+
+    stream: StreamTiming
+    nyquist_hz: float
+    samples_per_tau: float | None  # None when expected_tau unknown
+    recommendation: str  # human-readable, advisory only
+
+
+def compute_timing(
+    name: str,
+    arrival_times_s: Sequence[float],
+    values: Sequence[float] | None = None,
+) -> StreamTiming:
+    """Rate, jitter, and noise floor from passively observed arrivals.
+
+    ``arrival_times_s`` are monotonic receive timestamps (seconds). ``values``
+    are concurrent scalar samples of a stationary signal (robot at rest) for
+    the noise floor; pass ``None`` to skip (noise floor reported as 0.0).
+
+    Rate is the inverse mean inter-arrival time; jitter is the std of the
+    inter-arrival times. Both require at least two arrivals.
+    """
+    t = np.asarray(arrival_times_s, dtype=float)
+    if t.size < 2:
+        raise ValueError(f"stream {name!r}: need >=2 arrivals, got {t.size}")
+    dt = np.diff(t)
+    if np.any(dt <= 0):
+        raise ValueError(f"stream {name!r}: arrival times must be increasing")
+    rate_hz = float(1.0 / dt.mean())
+    jitter_s = float(dt.std())
+    noise_floor = float(np.asarray(values, dtype=float).std()) if values is not None else 0.0
+    return StreamTiming(name=name, rate_hz=rate_hz, jitter_s=jitter_s, noise_floor=noise_floor)
+
+
+def advise(stream: StreamTiming, expected_tau_s: float | None) -> TimingAdvice:
+    """Wrap a timing measurement with Nyquist + samples-per-tau guidance.
+
+    samples_per_tau = rate * tau is how many feedback samples land within one
+    time constant. Low values (a handful) mean velocity differentiation will
+    smear the step; the pose output-error fitter avoids differentiating. This
+    is surfaced as a recommendation string only.
+    """
+    nyquist_hz = stream.rate_hz / 2.0
+    if expected_tau_s is None:
+        return TimingAdvice(
+            stream=stream,
+            nyquist_hz=nyquist_hz,
+            samples_per_tau=None,
+            recommendation=(
+                "no expected_tau declared; cannot advise fitter from sampling. "
+                "User chooses velocity vs pose fitter."
+            ),
+        )
+    spt = stream.rate_hz * expected_tau_s
+    if spt < 8.0:
+        rec = (
+            f"~{spt:.1f} samples per tau (low): differentiating odom will inflate "
+            f"tau. Pose output-error fitter is typically appropriate here - your call."
+        )
+    else:
+        rec = (
+            f"~{spt:.1f} samples per tau (ample): velocity-domain fitting is well "
+            f"sampled. Either fitter is defensible - your call."
+        )
+    return TimingAdvice(
+        stream=stream, nyquist_hz=nyquist_hz, samples_per_tau=spt, recommendation=rec
+    )
+
+
+class StreamObserver:
+    """Records arrival timestamps (and optional scalar samples) for one stream.
+
+    Transport-agnostic: feed it a monotonic clock reading per message via
+    :meth:`on_message`. The live probe subscribes the profile's streams and
+    routes callbacks here; tests drive :meth:`on_message` directly.
+    """
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self._arrivals: list[float] = []
+        self._values: list[float] = []
+
+    def on_message(self, monotonic_s: float, value: float | None = None) -> None:
+        self._arrivals.append(monotonic_s)
+        if value is not None:
+            self._values.append(value)
+
+    def timing(self) -> StreamTiming:
+        values = self._values if self._values else None
+        return compute_timing(self.name, self._arrivals, values)

--- a/dimos/control/autotune/profile.py
+++ b/dimos/control/autotune/profile.py
@@ -1,0 +1,188 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""RobotProfile - the declared characterization input.
+
+The profile is what the *user* asserts about a robot before autotune runs:
+the command interface, odometry domain, controllable channels and their
+saturation envelope, which FOPDT fitter to use, and which controller form to
+tune. Autotune never auto-detects or overrides these declarations - the
+passive probe may *advise* (e.g. "odom is slow relative to your expected
+tau"), but the user owns the fitter choice (the robot cannot judge for
+itself without knowledge the user has).
+
+The profile also carries a measured-properties slot that characterization
+fills in. Declared fields are inputs; :class:`MeasuredProperties` is the
+output the report and tuned artifact draw from.
+
+Symbols follow the fitter convention throughout autotune:
+  K   - steady-state gain (measured output per unit command)
+  tau - first-order time constant (s)
+  L   - lumped dead-time (s); includes transport + sensor pipeline + true
+        plant deadtime and is not decomposed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+OdomType = Literal["pose", "velocity"]
+"""Odometry domain the robot reports feedback in.
+
+``velocity`` - body-frame twist feedback; the velocity-domain fitter
+reconstructs body velocity from odom and fits it.
+``pose`` - world-frame pose feedback (e.g. slow legged-base odom); the
+pose-domain output-error fitter forward-models pose and never differentiates
+the measurement.
+"""
+
+FitterKind = Literal["velocity", "pose"]
+"""Which FOPDT fitter the user selected. Mirrors :data:`OdomType` but is a
+separate, explicit choice: a base may report both, and the user decides which
+domain to identify in."""
+
+
+@dataclass(frozen=True)
+class Channel:
+    """One controllable axis and its saturation envelope.
+
+    ``vmax`` is the operational saturation limit (m/s for linear axes, rad/s
+    for angular). ``amax`` is an optional declared rate/acceleration limit;
+    when ``None`` the rate limit is left to be derived from the step rise.
+    """
+
+    name: str
+    vmax: float
+    amax: float | None = None
+
+
+@dataclass(frozen=True)
+class BatteryConfig:
+    """Excitation battery shape - profile-driven, not a fixed m/s grid.
+
+    Amplitudes are fractions of each channel's ``vmax`` so the same battery
+    scales to any robot. A hardcoded absolute grid is meaningless for a base
+    whose ``vmax`` is much smaller or larger; fractions of the declared
+    envelope are robot-agnostic.
+    """
+
+    amplitude_fractions: tuple[float, ...] = (0.25, 0.5, 0.75)
+    repeats: int = 3
+
+    def __post_init__(self) -> None:
+        if not self.amplitude_fractions:
+            raise ValueError("amplitude_fractions must be non-empty")
+        for frac in self.amplitude_fractions:
+            if not 0.0 < frac <= 1.0:
+                raise ValueError(f"amplitude fraction {frac} out of (0, 1]; fractions are of vmax")
+        if self.repeats < 1:
+            raise ValueError("repeats must be >= 1")
+
+
+@dataclass
+class ChannelFopdt:
+    """Per-channel FOPDT fit result. Filled by the fitter, read by the report,
+    bandwidth derivation, and tuner."""
+
+    K: float
+    tau: float
+    L: float
+    # Direction-asymmetric gains, populated only when forward/reverse K differ
+    # beyond the pooling threshold (otherwise both fall back to ``K``).
+    K_forward: float | None = None
+    K_reverse: float | None = None
+    # Lowest command magnitude that produces sustained motion (deadzone).
+    deadzone: float | None = None
+    r2: float | None = None
+    plausible: bool = True
+
+
+@dataclass
+class StreamTiming:
+    """Passive-probe output for one stream: arrival rate and quality. No motion
+    is required to measure these."""
+
+    name: str
+    rate_hz: float
+    jitter_s: float  # std of inter-arrival dt
+    noise_floor: float  # stationary signal std at rest
+
+
+@dataclass
+class MeasuredProperties:
+    """Everything characterization measures. This is the output slot on the
+    profile; the report and tuned artifact are projections of it.
+
+    Intentionally NOT measured (marginal benefit, see design.md): isolated
+    measurement latency (already lumped into ``L``), hysteresis, and automatic
+    controller-structure selection.
+    """
+
+    fopdt: dict[str, ChannelFopdt] = field(default_factory=dict)
+    bandwidth_hz: dict[str, float] = field(default_factory=dict)
+    cross_axis_coupling: dict[str, float] = field(default_factory=dict)
+    streams: dict[str, StreamTiming] = field(default_factory=dict)
+    # samples-per-tau advisory per channel (informs, never forces, fitter pick).
+    samples_per_tau: dict[str, float] = field(default_factory=dict)
+
+
+@dataclass
+class RobotProfile:
+    """User-declared description of a robot for autotune.
+
+    The drive layer is stream-name agnostic: ``command_stream`` and
+    ``feedback_stream`` name the coordinator topics so the same module works
+    across robots without hardcoded topic names.
+    """
+
+    name: str
+    command_interface: str  # e.g. "twist", "joint", "pose_setpoint"
+    odom_type: OdomType
+    channels: list[Channel]
+    fitter: FitterKind
+    controller_form: str  # e.g. "velocity_pi"
+    command_stream: str
+    feedback_stream: str
+    # Optional prior used only for the probe's samples-per-tau advisory.
+    expected_tau_s: float | None = None
+    battery: BatteryConfig = field(default_factory=BatteryConfig)
+    measured: MeasuredProperties = field(default_factory=MeasuredProperties)
+
+    def __post_init__(self) -> None:
+        if not self.channels:
+            raise ValueError("profile must declare at least one channel")
+        names = [c.name for c in self.channels]
+        if len(names) != len(set(names)):
+            raise ValueError(f"duplicate channel names: {names}")
+        # The fitter is user-owned; we only sanity-check it is a known kind.
+        if self.fitter not in ("velocity", "pose"):
+            raise ValueError(f"unknown fitter {self.fitter!r}")
+
+    def channel(self, name: str) -> Channel:
+        for ch in self.channels:
+            if ch.name == name:
+                return ch
+        raise KeyError(f"no channel named {name!r}")
+
+    @property
+    def channel_names(self) -> list[str]:
+        return [c.name for c in self.channels]
+
+    def battery_amplitudes(self, channel: str) -> list[float]:
+        """Signed-magnitude excitation amplitudes for a channel: each fraction
+        of ``vmax``. Direction (forward/reverse) is applied by the excitation
+        generator, not here."""
+        vmax = self.channel(channel).vmax
+        return [frac * vmax for frac in self.battery.amplitude_fractions]

--- a/dimos/control/autotune/properties.py
+++ b/dimos/control/autotune/properties.py
@@ -1,0 +1,136 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Plant properties beyond the per-axis FOPDT, read from the same step data.
+
+These are the asymmetry/nonlinear-shape and deadzone characteristics the user
+asked for. Autotune *reports* them; it does NOT auto-select a controller from
+them (that choice stays with the user). Intentionally not measured (marginal
+benefit, see design.md): isolated measurement latency, hysteresis.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class DirectionAsymmetry:
+    """Forward vs reverse steady-state gain on one axis. ``asymmetric`` is True
+    when the two differ by more than ``rel_threshold``; when False the axis is
+    pooled to a single K."""
+
+    K_forward: float
+    K_reverse: float
+    rel_difference: float
+    asymmetric: bool
+
+
+def direction_asymmetry(
+    K_forward: float, K_reverse: float, *, rel_threshold: float = 0.15
+) -> DirectionAsymmetry:
+    """Compare per-direction gains. ``rel_difference`` is normalized by the mean
+    magnitude so it is sign- and scale-robust."""
+    denom = 0.5 * (abs(K_forward) + abs(K_reverse))
+    rel = abs(abs(K_forward) - abs(K_reverse)) / denom if denom > 1e-9 else 0.0
+    return DirectionAsymmetry(
+        K_forward=K_forward,
+        K_reverse=K_reverse,
+        rel_difference=float(rel),
+        asymmetric=bool(rel > rel_threshold),
+    )
+
+
+@dataclass(frozen=True)
+class GainSchedule:
+    """Steady-state gain as a function of commanded amplitude. ``nonlinear`` is
+    True when K varies across amplitude by more than ``rel_threshold`` - the
+    signal the user uses to decide whether a linear PI suffices or a
+    gain-scheduled/nonlinear controller is warranted (their call, not ours)."""
+
+    amplitudes: tuple[float, ...]
+    gains: tuple[float, ...]
+    rel_span: float
+    nonlinear: bool
+
+
+def gain_schedule(
+    amplitudes: list[float], gains: list[float], *, rel_threshold: float = 0.15
+) -> GainSchedule:
+    """Assess gain-vs-amplitude nonlinearity. ``rel_span`` is the peak-to-peak K
+    spread normalized by the mean |K|."""
+    if len(amplitudes) != len(gains) or not gains:
+        raise ValueError("amplitudes and gains must be equal-length and non-empty")
+    g = np.asarray(gains, dtype=float)
+    mean_mag = float(np.mean(np.abs(g)))
+    rel_span = float((g.max() - g.min()) / mean_mag) if mean_mag > 1e-9 else 0.0
+    return GainSchedule(
+        amplitudes=tuple(amplitudes),
+        gains=tuple(gains),
+        rel_span=rel_span,
+        nonlinear=bool(rel_span > rel_threshold),
+    )
+
+
+def cross_axis_coupling(on_axis_response: np.ndarray, off_axis_response: np.ndarray) -> float:
+    """Coupling ratio when one axis is excited: RMS off-axis response over RMS
+    on-axis response. 0 = decoupled; larger = more bleed into the other axis."""
+    on = float(np.sqrt(np.mean(np.asarray(on_axis_response, dtype=float) ** 2)))
+    off = float(np.sqrt(np.mean(np.asarray(off_axis_response, dtype=float) ** 2)))
+    if on < 1e-9:
+        return 0.0
+    return off / on
+
+
+@dataclass(frozen=True)
+class Deadzone:
+    """Smallest command magnitude that produces sustained motion."""
+
+    threshold: float
+    found: bool
+
+
+def estimate_deadzone(
+    commands: np.ndarray,
+    body_velocity: np.ndarray,
+    *,
+    motion_threshold: float = 0.02,
+    fractional_threshold: float = 0.05,
+    sustained_samples: int = 5,
+) -> Deadzone:
+    """Find the deadzone from a slow ramp.
+
+    A sample "moves" when ``|v| > motion_threshold`` AND ``|v| > fractional *
+    |cmd|`` (the AND-test rejects both sensor noise and tiny commands that
+    coincidentally exceed the floor). The deadzone is the smallest |command| at
+    which motion is sustained for ``sustained_samples`` consecutive samples.
+    ``commands`` should be monotonically increasing in magnitude (a ramp)."""
+    cmd = np.abs(np.asarray(commands, dtype=float))
+    vel = np.abs(np.asarray(body_velocity, dtype=float))
+    if cmd.size != vel.size or cmd.size == 0:
+        raise ValueError("commands and body_velocity must be equal-length, non-empty")
+
+    moving = (vel > motion_threshold) & (vel > fractional_threshold * cmd)
+    run = 0
+    for i in range(cmd.size):
+        if moving[i]:
+            run += 1
+            if run >= sustained_samples:
+                # Deadzone is the command where the sustained run began.
+                return Deadzone(threshold=float(cmd[i - sustained_samples + 1]), found=True)
+        else:
+            run = 0
+    return Deadzone(threshold=float("nan"), found=False)

--- a/dimos/control/autotune/report.py
+++ b/dimos/control/autotune/report.py
@@ -1,0 +1,227 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Emit the two autotune outputs.
+
+1. The **tuned controller artifact** - a JSON document in the EXACT shape the
+   control task config layer consumes (the ``TuningConfig`` contract, read by a
+   task's ``from_artifact``). Autotune is the canonical producer; a deployed task
+   references the artifact by path. We do not invent a new format.
+
+2. The **characterization report** - a human/machine summary of the measured
+   plant properties (FOPDT, bandwidth, asymmetry, coupling, deadzone, stream
+   timing). This is durable robot metadata, kept distinct from the tuned config.
+
+Contract notes baked in here (from the consuming side):
+  * The contract is keyed to fixed channel slots ``vx/vy/wz``. The new
+    channel-LIST profile is projected onto those slots; channels outside
+    {vx,vy,wz} have no home in the contract and raise.
+  * ``feedforward.K_*`` are PRE-INVERTED (1/K), not raw plant gain.
+  * ``valid_for_tuning`` is true only for hardware-sourced data.
+  * ``schema_version`` must be 1.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from dimos.control.autotune.profile import RobotProfile
+from dimos.control.autotune.tune import ChannelTuning
+
+# The contract's fixed channel slots. The consuming task indexes these names.
+CONTRACT_SLOTS = ("vx", "vy", "wz")
+SCHEMA_VERSION = 1
+# Headroom + ride-quality constants from the reference derivation (named, not
+# hidden, so a different robot can override).
+WZ_HEADROOM_MARGIN = 0.15
+A_LAT_MAX = 1.0
+DECEL_ACCEL_RATIO = 2.0
+DEFAULT_MIN_SPEED = 0.05
+DEFAULT_LOOKAHEAD_PTS = 8
+
+
+def _safe_inv_gain(K: float) -> float:
+    """Feedforward gain inversion 1/K, guarding near-zero K (returns 1.0)."""
+    return 1.0 / K if abs(K) > 1e-6 else 1.0
+
+
+def validate_contract_channels(profile: RobotProfile) -> None:
+    """The tuned-config contract only has slots vx/vy/wz. Raise if the profile
+    declares channels the contract cannot carry."""
+    extra = [c for c in profile.channel_names if c not in CONTRACT_SLOTS]
+    if extra:
+        raise ValueError(
+            f"channels {extra} have no slot in the vx/vy/wz tuned-config contract; "
+            f"the consuming task cannot read arbitrary channel names"
+        )
+
+
+def _plant_slots(
+    profile: RobotProfile, tunings: dict[str, ChannelTuning]
+) -> tuple[dict[str, dict[str, float]], list[str]]:
+    """Build the vx/vy/wz plant block, filling absent slots with an identity-ish
+    placeholder and returning the list of placeholder slots for a caveat."""
+    plant: dict[str, dict[str, float]] = {}
+    placeholders: list[str] = []
+    for slot in CONTRACT_SLOTS:
+        if slot in tunings:
+            plant[slot] = dict(tunings[slot].plant)
+        elif slot in profile.measured.fopdt:
+            f = profile.measured.fopdt[slot]
+            plant[slot] = {"K": f.K, "tau": f.tau, "L": f.L}
+        else:
+            plant[slot] = {"K": 1.0, "tau": 0.0, "L": 0.0}
+            placeholders.append(slot)
+    return plant, placeholders
+
+
+def _velocity_profile(profile: RobotProfile, plant: dict[str, dict[str, float]]) -> dict[str, Any]:
+    """Derive the velocity-profile block from envelope + fitted dynamics."""
+    vx_ceiling = profile.channel("vx").vmax if "vx" in profile.channel_names else 1.0
+    wz_ceiling = profile.channel("wz").vmax if "wz" in profile.channel_names else 1.5
+    tau_vx = plant["vx"]["tau"] or 0.1
+    max_linear_accel = vx_ceiling / tau_vx
+    return {
+        "max_linear_speed": vx_ceiling,
+        "max_angular_speed": wz_ceiling * (1.0 - WZ_HEADROOM_MARGIN),
+        "max_centripetal_accel": A_LAT_MAX,
+        "max_linear_accel": max_linear_accel,
+        "max_linear_decel": DECEL_ACCEL_RATIO * max_linear_accel,
+        "min_speed": DEFAULT_MIN_SPEED,
+        "lookahead_pts": DEFAULT_LOOKAHEAD_PTS,
+    }
+
+
+def build_tuned_artifact(
+    profile: RobotProfile,
+    tunings: dict[str, ChannelTuning],
+    *,
+    robot_id: str,
+    sim_or_hw: str,
+    surface: str = "",
+    mode: str = "characterization",
+    date: str = "",
+    git_sha: str = "",
+    session_dir: str = "",
+    methodology_version: int = 2,
+    extra_caveats: list[str] | None = None,
+) -> dict[str, Any]:
+    """Build the tuned-config artifact dict in the exact consuming contract.
+
+    ``tunings`` maps channel name -> ChannelTuning (the winning gains + plant).
+    ``sim_or_hw`` gates ``valid_for_tuning``: only hardware data is tune-valid."""
+    validate_contract_channels(profile)
+    plant, placeholders = _plant_slots(profile, tunings)
+
+    feedforward: dict[str, Any] = {}
+    for slot in CONTRACT_SLOTS:
+        feedforward[f"K_{slot}"] = _safe_inv_gain(plant[slot]["K"])
+        vmax = (
+            profile.channel(slot).vmax
+            if slot in profile.channel_names
+            else (1.5 if slot == "wz" else 1.0)
+        )
+        feedforward[f"output_min_{slot}"] = -vmax
+        feedforward[f"output_max_{slot}"] = vmax
+
+    is_hw = sim_or_hw == "hw"
+    caveats: list[str] = list(extra_caveats or [])
+    if not is_hw:
+        caveats.insert(0, "PIPELINE CHECK ONLY - DO NOT TUNE (data is not hardware-sourced)")
+    if placeholders:
+        caveats.append(
+            f"channels {placeholders} were not characterized; emitted as identity placeholders"
+        )
+    failed = [ch for ch, t in tunings.items() if t.verdict == "fail"]
+    if failed:
+        caveats.append(f"channels {failed} FAILED the robustness verdict; gains are unsafe")
+
+    return {
+        "provenance": {
+            "robot_id": robot_id,
+            "surface": surface,
+            "mode": mode,
+            "date": date,
+            "git_sha": git_sha,
+            "sim_or_hw": sim_or_hw,
+            "characterization_session_dir": session_dir,
+            "methodology_version": methodology_version,
+        },
+        "plant": plant,
+        "feedforward": feedforward,
+        "velocity_profile": _velocity_profile(profile, plant),
+        "recommended_controller": {
+            "name": "baseline",
+            "params": {"k_angular": 0.5},
+            "evidence": "lambda-tuned PI per axis from FOPDT fit",
+        },
+        "caveats": caveats,
+        "operating_point_map": None,
+        "velocity_envelope": None,
+        "dynamics_by_amplitude": None,
+        "floor_probe_results": None,
+        "valid_for_tuning": is_hw,
+        "schema_version": SCHEMA_VERSION,
+    }
+
+
+def write_tuned_artifact(path: str | Path, artifact: dict[str, Any]) -> Path:
+    """Write the tuned-config artifact with stable key order for round-trip."""
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(artifact, indent=2, sort_keys=False))
+    return p
+
+
+def build_characterization_report(
+    profile: RobotProfile, tunings: dict[str, ChannelTuning] | None = None
+) -> dict[str, Any]:
+    """Summarize measured plant properties as durable robot metadata. Distinct
+    from the tuned artifact: this is the characterization record, not gains."""
+    m = profile.measured
+    channels: dict[str, Any] = {}
+    for name in profile.channel_names:
+        f = m.fopdt.get(name)
+        ch: dict[str, Any] = {
+            "fopdt": {"K": f.K, "tau": f.tau, "L": f.L} if f else None,
+            "bandwidth_hz": m.bandwidth_hz.get(name),
+            "deadzone": f.deadzone if f else None,
+            "direction_asymmetric": (
+                f.K_forward is not None and f.K_reverse is not None if f else None
+            ),
+            "cross_axis_coupling": m.cross_axis_coupling.get(name),
+            "samples_per_tau": m.samples_per_tau.get(name),
+        }
+        if tunings and name in tunings:
+            ch["verdict"] = tunings[name].verdict
+        channels[name] = ch
+    return {
+        "robot": profile.name,
+        "odom_type": profile.odom_type,
+        "fitter": profile.fitter,
+        "channels": channels,
+        "streams": {
+            n: {"rate_hz": s.rate_hz, "jitter_s": s.jitter_s, "noise_floor": s.noise_floor}
+            for n, s in m.streams.items()
+        },
+    }
+
+
+def write_characterization_report(path: str | Path, report: dict[str, Any]) -> Path:
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(report, indent=2, sort_keys=False))
+    return p

--- a/dimos/control/autotune/runner.py
+++ b/dimos/control/autotune/runner.py
@@ -1,0 +1,147 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Autotune orchestration: episodes -> FOPDT fit -> bandwidth -> tune -> emit.
+
+The offline pipeline (:func:`autotune_offline`) is the heart of autotune and is
+fully testable: given recorded step segments per channel, it fits the FOPDT with
+the user-selected fitter, derives bandwidth, lambda-tunes each channel, and
+populates the profile's measured slot plus the tuned artifact + characterization
+report. It needs no robot - a collection recorded once can be re-fit any number
+of times.
+
+The live wrapper (drive the battery, record, read episodes back) lives in the
+entry point; it feeds this function the segments it reads from the store.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from dimos.control.autotune.bandwidth import bandwidth_hz
+from dimos.control.autotune.fit.pose_fopdt import estimate_deadtime, fit_pose_fopdt_multi
+from dimos.control.autotune.fit.velocity_fopdt import fit_fopdt
+from dimos.control.autotune.profile import ChannelFopdt, RobotProfile
+from dimos.control.autotune.properties import direction_asymmetry
+from dimos.control.autotune.report import (
+    build_characterization_report,
+    build_tuned_artifact,
+)
+from dimos.control.autotune.tune import ChannelTuning, tune_channel_full
+
+# One recorded excitation segment: time relative to the step edge, the measured
+# channel (velocity for the velocity fitter, pose for the pose fitter), and the
+# signed commanded amplitude.
+Segment = tuple[np.ndarray, np.ndarray, float]
+
+
+def _pool_median(values: list[float]) -> float:
+    finite = [v for v in values if np.isfinite(v)]
+    return float(np.median(finite)) if finite else float("nan")
+
+
+def fit_channel(profile: RobotProfile, channel: str, segments: list[Segment]) -> ChannelFopdt:
+    """Fit one channel's FOPDT from its recorded segments, using the profile's
+    declared fitter. Pools K/tau/L across amplitudes and records per-direction K
+    so direction asymmetry is visible downstream."""
+    if not segments:
+        raise ValueError(f"channel {channel!r}: no segments to fit")
+
+    K_fwd = K_rev = None
+    if profile.fitter == "velocity":
+        # Keep each fit paired with its signed amplitude so the main pool and the
+        # per-direction split apply the SAME plausibility gate (mismatched gates
+        # let boundary-landing fits bias the directional medians and mask real
+        # asymmetry).
+        fits = [(fit_fopdt(t, y, amp), amp) for t, y, amp in segments]
+        usable = [(f, amp) for f, amp in fits if f.converged and f.plausible]
+        if not usable:
+            usable = [(f, amp) for f, amp in fits if f.converged]
+        if not usable:
+            return ChannelFopdt(K=float("nan"), tau=float("nan"), L=float("nan"), plausible=False)
+        K = _pool_median([f.K for f, _ in usable])
+        tau = _pool_median([f.tau for f, _ in usable])
+        L = _pool_median([f.L for f, _ in usable])
+        r2 = _pool_median([f.r_squared for f, _ in usable])
+        plausible = all(f.plausible for f, _ in usable)
+        # Per-direction K from the same usable set.
+        fwd = [f.K for f, amp in usable if amp > 0]
+        rev = [f.K for f, amp in usable if amp < 0]
+        if fwd and rev:
+            kf, kr = _pool_median(fwd), _pool_median(rev)
+            if direction_asymmetry(kf, kr).asymmetric:
+                K_fwd, K_rev = kf, kr
+    else:  # pose output-error
+        # Decouple L by profiling on the largest-amplitude segment, then joint-fit.
+        biggest = max(segments, key=lambda s: abs(s[2]))
+        L, _, _ = estimate_deadtime(biggest[0], biggest[1], biggest[2])
+        joint = fit_pose_fopdt_multi(segments, L)
+        K, tau, r2, plausible = joint.K, joint.tau, joint.r_squared, joint.valid
+
+    return ChannelFopdt(
+        K=K, tau=tau, L=L, K_forward=K_fwd, K_reverse=K_rev, r2=r2, plausible=plausible
+    )
+
+
+@dataclass
+class AutotuneOutputs:
+    """Everything an autotune run produces: the populated profile, the tuned
+    artifact dict, the characterization report dict, and the per-channel
+    tuning records."""
+
+    profile: RobotProfile
+    artifact: dict[str, Any]
+    report: dict[str, Any]
+    tunings: dict[str, ChannelTuning]
+
+
+def autotune_offline(
+    profile: RobotProfile,
+    segments_by_channel: dict[str, list[Segment]],
+    *,
+    robot_id: str,
+    sim_or_hw: str,
+    fit_quality_gate: float = 0.8,
+    **artifact_kwargs: Any,
+) -> AutotuneOutputs:
+    """Fit, derive bandwidth, tune, and emit - the full offline pipeline.
+
+    Populates ``profile.measured`` in place and returns the artifact + report.
+    Channels whose fit is implausible are tuned-skipped (no gains emitted) but
+    still reported. ``sim_or_hw`` gates the artifact's ``valid_for_tuning``."""
+    tunings: dict[str, ChannelTuning] = {}
+    for channel in profile.channel_names:
+        segments = segments_by_channel.get(channel, [])
+        fopdt = fit_channel(profile, channel, segments)
+        profile.measured.fopdt[channel] = fopdt
+
+        bw = bandwidth_hz(fopdt.K, fopdt.tau, fopdt.L, r2=fopdt.r2, quality_gate=fit_quality_gate)
+        if bw is not None:
+            profile.measured.bandwidth_hz[channel] = bw
+
+        # Tune only channels with a trustworthy fit.
+        if fopdt.plausible and np.isfinite([fopdt.K, fopdt.tau, fopdt.L]).all() and fopdt.tau > 0:
+            vmax = profile.channel(channel).vmax
+            tunings[channel] = tune_channel_full(
+                channel, fopdt.K, fopdt.tau, fopdt.L, saturation_limits=(-vmax, vmax)
+            )
+
+    artifact = build_tuned_artifact(
+        profile, tunings, robot_id=robot_id, sim_or_hw=sim_or_hw, **artifact_kwargs
+    )
+    report = build_characterization_report(profile, tunings)
+    return AutotuneOutputs(profile=profile, artifact=artifact, report=report, tunings=tunings)

--- a/dimos/control/autotune/test_autotune.py
+++ b/dimos/control/autotune/test_autotune.py
@@ -1,0 +1,144 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration test for the autotune module.
+
+Drives one full autotune run against a known synthetic plant - declare a
+profile, probe the streams, build and drive the excitation battery, fit, tune,
+and emit the artifact - asserting at each stage. Every external API the module
+binds to (Twist/Vector3, EpisodeStatus) is exercised as part of the flow, so
+drift in those surfaces fails here rather than on the robot.
+
+In-process and synthetic: no coordinator is started and no LCM traffic is
+exchanged. The process-level run against a booted blueprint belongs in
+``dimos/e2e_tests/`` and needs the live drive wiring first.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from dimos.control.autotune.drive import run_battery
+from dimos.control.autotune.excitation import step_battery
+from dimos.control.autotune.fit.synth import MeasurementModel, synth_step
+from dimos.control.autotune.live import make_sinks
+from dimos.control.autotune.probe import advise, compute_timing
+from dimos.control.autotune.profile import BatteryConfig, Channel, RobotProfile
+from dimos.control.autotune.runner import autotune_offline
+
+# The plant the synthetic robot actually has; autotune must recover it.
+K_TRUE, TAU_TRUE, L_TRUE = 0.9, 0.35, 0.10
+ODOM_HZ = 50.0
+
+
+class _FakeClock:
+    def __init__(self) -> None:
+        self.t = 0.0
+
+    def now(self) -> float:
+        return self.t
+
+    def sleep(self, seconds: float) -> None:
+        self.t += max(0.0, seconds)
+
+
+def _recorded_segments(vmax: float) -> list:
+    """Step segments a real run would have recorded, from the known plant."""
+    segments = []
+    for fraction in (0.25, 0.5, 0.75):
+        for direction in (1, -1):
+            amp = direction * fraction * vmax
+            t, velocity, _ = synth_step(
+                K_TRUE,
+                TAU_TRUE,
+                L_TRUE,
+                amp=amp,
+                duration_s=4.0,
+                model=MeasurementModel(rate_hz=ODOM_HZ, noise_std=0.0),
+            )
+            segments.append((t, velocity, amp))
+    return segments
+
+
+def test_autotune_recovers_known_plant_and_emits_gains() -> None:
+    # 1. Declare the robot.
+    profile = RobotProfile(
+        name="synth-base",
+        command_interface="twist",
+        odom_type="velocity",
+        channels=[Channel("vx", vmax=1.0), Channel("wz", vmax=1.5)],
+        fitter="velocity",
+        controller_form="velocity_pi",
+        command_stream="/cmd_vel",
+        feedback_stream="/odom",
+        expected_tau_s=TAU_TRUE,
+        battery=BatteryConfig(amplitude_fractions=(0.5,), repeats=1),
+    )
+
+    # 2. Passive probe: stream timing, and the advisory that informs (never
+    #    forces) the fitter choice.
+    timing = compute_timing("odom", np.arange(0, 2.0, 1.0 / ODOM_HZ))
+    advice = advise(timing, profile.expected_tau_s)
+    assert timing.rate_hz == pytest.approx(ODOM_HZ, rel=1e-6)
+    assert advice.samples_per_tau == pytest.approx(ODOM_HZ * TAU_TRUE, rel=1e-3)
+    assert profile.fitter == "velocity"  # advice did not mutate the choice
+
+    # 3. Drive the battery through the live sinks (Twist + EpisodeStatus APIs),
+    #    capturing what a coordinator and recorder would have seen.
+    twists: list = []
+    statuses: list = []
+    command_sink, episode_sink, _ = make_sinks(profile, twists.append, statuses.append)
+    runs = step_battery(profile)  # 2 channels * 1 amplitude * 2 directions
+    played = run_battery(runs, command_sink, episode_sink, _FakeClock(), tick_hz=10.0, settle_s=0.1)
+
+    assert played == len(runs) == 4
+    # one episode per run, and the base is commanded to zero at each run's end
+    assert sum(s.last_event == "start" for s in statuses) == 4
+    assert sum(s.last_event == "save" for s in statuses) == 4
+    assert statuses[-1].episodes_saved == 4
+    assert twists[-1].linear.x == 0.0 and twists[-1].angular.z == 0.0
+    # commands landed on the right twist axes
+    assert any(t.linear.x != 0.0 for t in twists)
+    assert any(t.angular.z != 0.0 for t in twists)
+
+    # 4. Fit, derive bandwidth, tune, and emit - from the recorded episodes.
+    segments = {
+        name: _recorded_segments(profile.channel(name).vmax) for name in profile.channel_names
+    }
+    outputs = autotune_offline(profile, segments, robot_id="synth", sim_or_hw="sim")
+
+    # recovered the plant it was driven with
+    vx = outputs.profile.measured.fopdt["vx"]
+    assert vx.K == pytest.approx(K_TRUE, rel=0.05)
+    assert vx.tau == pytest.approx(TAU_TRUE, rel=0.15)
+    assert vx.L == pytest.approx(L_TRUE, abs=0.03)
+    assert outputs.profile.measured.bandwidth_hz["vx"] == pytest.approx(
+        1.0 / (2.0 * np.pi * vx.tau), rel=1e-6
+    )
+    assert set(outputs.tunings) == {"vx", "wz"}
+    assert outputs.tunings["vx"].gains.Kp > 0
+
+    # 5. The artifact a control task loads, in the shape it expects.
+    artifact = outputs.artifact
+    assert artifact["schema_version"] == 1
+    assert set(artifact["plant"]) == {"vx", "vy", "wz"}
+    assert artifact["feedforward"]["K_vx"] == pytest.approx(1.0 / vx.K, rel=1e-6)
+    assert artifact["valid_for_tuning"] is False  # synthetic data is never tune-valid
+    assert "DO NOT TUNE" in artifact["caveats"][0]
+
+    # 6. The characterization report is separate metadata, not gains.
+    assert outputs.report["robot"] == "synth-base"
+    assert outputs.report["channels"]["vx"]["verdict"] in ("pass", "marginal", "fail")
+    assert "feedforward" not in outputs.report

--- a/dimos/control/autotune/tune.py
+++ b/dimos/control/autotune/tune.py
@@ -1,0 +1,602 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Lambda-tune PI gains from a fitted FOPDT, scored in closed-loop simulation.
+
+Per channel: sweep a lambda (closed-loop time-constant) multiplier, compute PI
+gains analytically for each, score every candidate against a reference battery
+through a closed-loop FOPDT simulation, pick the lowest-cost candidate, then run
+a robustness sweep (K +/-15%, tau/L +/-20%) and emit a pass/marginal/fail
+verdict.
+
+Ported from the characterization tuning harness and made robot-agnostic: all
+Go2-specific constants (saturation limits, control rate, cost weights, verdict
+thresholds) are parameters or named module constants, not baked-in values. The
+dual-regime ("fall_params") FOPDT path is dropped - tuning never used it.
+
+Lambda (IMC) PI tuning for a FOPDT plant:
+
+    lambda_s = max(tau, L) * multiplier
+    Kp = tau / (K * (lambda_s + L))
+    Ki = Kp / tau
+    Kt = 1 / tau                      # back-calculation anti-windup gain
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import asdict, dataclass, field
+import math
+from typing import Any, Literal
+
+import numpy as np
+
+# Candidate-scoring cost weights (empirical; named so a robot with different
+# priorities can rebalance). cost = w_iae*iae + w_over*overshoot
+#                                 + w_sat*saturation_fraction + w_settle*settle.
+W_IAE = 1.0
+W_OVERSHOOT = 2.0
+W_SATURATION = 0.5
+W_SETTLE = 0.2
+# Penalty substituted when settle time is non-finite (never settled in horizon).
+SETTLE_PENALTY_S = 5.0
+
+# Verdict thresholds (design margins; surfaced as constants, not hidden).
+VERDICT_OVERSHOOT_MAX = 0.05
+VERDICT_SATURATION_MAX = 0.50
+# Stability bound: |y| must stay below max(STABILITY_GAIN*sat_max, STABILITY_FLOOR).
+STABILITY_GAIN = 10.0
+STABILITY_FLOOR = 1.0
+
+DEFAULT_CONTROL_DT_S = 0.02  # 50 Hz; override from the robot's actual control tick
+DEFAULT_SETTLE_BAND = 0.02
+
+ReferenceFn = Callable[[float], float]
+Verdict = Literal["pass", "marginal", "fail"]
+
+
+# ── plant propagator (single-regime ZOH FOPDT) ─────────────────────────────
+
+
+def _zoh_at(t_query: np.ndarray, t_grid: np.ndarray, values: np.ndarray, left: float) -> np.ndarray:
+    """Zero-order-hold sample of ``values`` (on ``t_grid``) at ``t_query``. Times
+    before ``t_grid[0]`` return ``left`` (the pre-trace value)."""
+    idx = np.searchsorted(t_grid, t_query, side="right") - 1
+    out = np.where(idx < 0, left, values[np.clip(idx, 0, values.size - 1)])
+    return np.asarray(out, dtype=float)
+
+
+def simulate_fopdt(
+    t: np.ndarray,
+    cmd: np.ndarray,
+    K: float,
+    tau: float,
+    L: float,
+    *,
+    initial: float = 0.0,
+    pre_cmd: float = 0.0,
+) -> np.ndarray:
+    """Forward-simulate a FOPDT plant for a commanded waveform.
+
+        cmd_delayed(t) = cmd(t - L)            (zero-order hold, pre-trace = pre_cmd)
+        target[k-1]    = K * cmd_delayed[k-1]
+        alpha          = exp(-dt / tau)
+        y[k]           = alpha*y[k-1] + (1-alpha)*target[k-1]
+
+    Using ``target[k-1]`` (held over the previous interval) is the exact ZOH
+    discretization of a first-order ODE. ``tau <= 0`` snaps to target."""
+    t = np.asarray(t, dtype=float)
+    cmd = np.asarray(cmd, dtype=float)
+    if t.shape != cmd.shape:
+        raise ValueError(f"t and cmd must have the same shape; got {t.shape} vs {cmd.shape}")
+    if t.size == 0:
+        return np.zeros(0, dtype=float)
+    if t.size == 1:
+        return np.full(1, initial, dtype=float)
+
+    cmd_delayed = _zoh_at(t - L, t, cmd, left=pre_cmd)
+    y = np.empty_like(t)
+    y[0] = initial
+    for k in range(1, t.size):
+        dt = t[k] - t[k - 1]
+        if dt <= 0:
+            y[k] = y[k - 1]
+            continue
+        target = K * cmd_delayed[k - 1]
+        if tau <= 0:
+            y[k] = target
+        else:
+            alpha = float(np.exp(-dt / tau))
+            y[k] = alpha * y[k - 1] + (1.0 - alpha) * target
+    return y
+
+
+# ── PI controller with back-calculation anti-windup ────────────────────────
+
+
+@dataclass
+class PIController:
+    """Velocity PI with back-calculation anti-windup. When ``u_sat`` differs from
+    ``u_raw`` the integrator is bled by ``(u_sat - u_raw) * Kt * dt``; with
+    ``Kt ~ 1/tau`` saturation excursions unwind on the plant timescale."""
+
+    Kp: float
+    Ki: float
+    Kt: float = 0.0
+    u_min: float = -math.inf
+    u_max: float = math.inf
+    integrator: float = 0.0
+
+    def reset(self) -> None:
+        self.integrator = 0.0
+
+    def step(self, ref: float, meas: float, dt: float) -> tuple[float, float]:
+        """Advance one control tick. Returns (u_raw, u_sat). The integrator is
+        updated AFTER computing u_raw, using the pre-update integrator."""
+        e = ref - meas
+        u_raw = self.Kp * e + self.Ki * self.integrator
+        u_sat = float(np.clip(u_raw, self.u_min, self.u_max))
+        self.integrator += (e + self.Kt * (u_sat - u_raw)) * dt
+        return float(u_raw), u_sat
+
+
+@dataclass
+class Gains:
+    Kp: float
+    Ki: float
+    Kt: float
+    multiplier: float
+    lambda_s: float
+
+    def asdict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def lambda_tune(K: float, tau: float, L: float, multiplier: float) -> Gains:
+    """Analytic IMC/lambda PI gains for a FOPDT plant. ``multiplier`` scales the
+    closed-loop time constant relative to the dominant plant timescale."""
+    if abs(K) < 1e-9:
+        raise ValueError("cannot tune a channel with ~zero gain K")
+    if tau <= 0:
+        raise ValueError("cannot tune a channel with non-positive tau")
+    lambda_s = max(tau, L) * multiplier
+    Kp = tau / (K * (lambda_s + L))
+    Ki = Kp / tau
+    Kt = 1.0 / tau
+    return Gains(Kp=Kp, Ki=Ki, Kt=Kt, multiplier=multiplier, lambda_s=lambda_s)
+
+
+# ── reference-signal builders (pure (t) -> value) ──────────────────────────
+
+
+def step(amplitude: float, t_start: float = 0.5) -> ReferenceFn:
+    def r(t: float) -> float:
+        return amplitude if t >= t_start else 0.0
+
+    return r
+
+
+def staircase(levels: Sequence[float], dwell_s: float, t_start: float = 0.5) -> ReferenceFn:
+    levels = list(levels)
+
+    def r(t: float) -> float:
+        if t < t_start:
+            return 0.0
+        i = int((t - t_start) // dwell_s)
+        if 0 <= i < len(levels):
+            return float(levels[i])
+        return 0.0
+
+    return r
+
+
+def ramp(
+    slope: float, duration: float, t_start: float = 0.5, *, final_hold: bool = True
+) -> ReferenceFn:
+    final_value = slope * duration
+
+    def r(t: float) -> float:
+        if t < t_start:
+            return 0.0
+        elapsed = t - t_start
+        if elapsed >= duration:
+            return float(final_value) if final_hold else 0.0
+        return float(slope * elapsed)
+
+    return r
+
+
+@dataclass(frozen=True)
+class Scenario:
+    label: str
+    reference: ReferenceFn
+    duration_s: float
+
+
+def default_scenarios(saturation_limits: tuple[float, float]) -> list[Scenario]:
+    """Reference battery scaled to a channel's command envelope. ``u_max`` is the
+    upper saturation limit; amplitudes are fractions of it so the battery is
+    channel-agnostic."""
+    u_max = saturation_limits[1]
+    return [
+        Scenario("step_50pct", step(0.5 * u_max), 4.0),
+        Scenario("step_90pct", step(0.9 * u_max), 4.0),
+        Scenario("step_neg_70pct", step(-0.7 * u_max), 4.0),
+        Scenario("staircase", staircase([l * u_max for l in (0.3, 0.6, 0.9, 0.3, 0.0)], 1.5), 8.5),
+        Scenario("ramp", ramp(0.5 * u_max, 1.5), 4.0),
+    ]
+
+
+# ── closed-loop simulation + metrics ───────────────────────────────────────
+
+
+def _compute_step_metrics(
+    t: np.ndarray,
+    r: np.ndarray,
+    u: np.ndarray,
+    u_raw: np.ndarray,
+    y: np.ndarray,
+    *,
+    settle_band: float,
+) -> dict[str, float]:
+    e = r - y
+    dt = float(np.mean(np.diff(t))) if t.size > 1 else 0.0
+    iae = float(np.sum(np.abs(e)) * dt)
+    itae = float(np.sum(t * np.abs(e)) * dt)
+    rmse = float(np.sqrt(np.mean(e**2))) if e.size else float("nan")
+    max_abs_u = float(np.max(np.abs(u))) if u.size else 0.0
+    saturation_fraction = float(np.mean(np.abs(u_raw - u) > 1e-9)) if u.size else 0.0
+
+    r_final = float(r[-1]) if r.size else 0.0
+    if r_final > 0:
+        overshoot = max(0.0, float(np.max(y)) - r_final) / abs(r_final)
+    elif r_final < 0:
+        overshoot = max(0.0, abs(float(np.min(y))) - abs(r_final)) / abs(r_final)
+    else:
+        overshoot = float("nan")
+
+    if abs(r_final) < 1e-9:
+        settle_time = float("nan")
+    else:
+        outside = np.abs(y - r_final) > settle_band * abs(r_final)
+        if not outside.any():
+            settle_time = 0.0
+        elif outside[-1]:
+            settle_time = float("inf")
+        else:
+            settle_time = float(t[np.flatnonzero(outside)[-1]])
+
+    return {
+        "iae": iae,
+        "itae": itae,
+        "rmse": rmse,
+        "max_abs_u": max_abs_u,
+        "saturation_fraction": saturation_fraction,
+        "overshoot": overshoot,
+        "settle_time_s": settle_time,
+    }
+
+
+@dataclass
+class SimResult:
+    t: np.ndarray
+    r: np.ndarray
+    y: np.ndarray
+    u: np.ndarray
+    u_raw: np.ndarray
+    metrics: dict[str, float]
+
+
+def simulate_closed_loop(
+    K: float,
+    tau: float,
+    L: float,
+    controller: PIController,
+    reference_fn: ReferenceFn,
+    *,
+    duration_s: float,
+    control_dt_s: float = DEFAULT_CONTROL_DT_S,
+    initial_y: float = 0.0,
+    settle_band: float = DEFAULT_SETTLE_BAND,
+) -> SimResult:
+    """Close the PI loop around the FOPDT plant. The controller acts on the
+    PREVIOUS measurement ``y[k-1]``; the plant is re-simulated over the full
+    command history each tick (exact, O(n^2) - preserved from the source).
+    Resets the controller integrator before running."""
+    n = int(duration_s / control_dt_s) + 1
+    t = np.arange(n) * control_dt_s
+    r = np.array([reference_fn(float(ti)) for ti in t])
+    y = np.empty(n)
+    u = np.zeros(n)
+    u_raw = np.zeros(n)
+    y[0] = initial_y
+    controller.reset()
+    for k in range(1, n):
+        ur, us = controller.step(float(r[k - 1]), float(y[k - 1]), control_dt_s)
+        u_raw[k] = ur
+        u[k] = us
+        y_traj = simulate_fopdt(t[: k + 1], u[: k + 1], K, tau, L, initial=initial_y)
+        y[k] = y_traj[k]
+    metrics = _compute_step_metrics(t, r, u, u_raw, y, settle_band=settle_band)
+    return SimResult(t=t, r=r, y=y, u=u, u_raw=u_raw, metrics=metrics)
+
+
+def _scenario_cost(m: dict[str, float]) -> float:
+    over = m["overshoot"] if math.isfinite(m["overshoot"]) else 0.0
+    settle = m["settle_time_s"] if math.isfinite(m["settle_time_s"]) else SETTLE_PENALTY_S
+    return (
+        W_IAE * m["iae"]
+        + W_OVERSHOOT * over
+        + W_SATURATION * m["saturation_fraction"]
+        + W_SETTLE * settle
+    )
+
+
+@dataclass
+class TuningCandidate:
+    gains: Gains
+    per_reference: list[dict[str, Any]]
+    cost: float
+    cost_breakdown: dict[str, float]
+
+
+@dataclass
+class TuningResult:
+    plant: dict[str, float]
+    saturation_limits: tuple[float, float]
+    multipliers: list[float]
+    candidates: list[TuningCandidate]
+    best_index: int
+
+    @property
+    def best(self) -> TuningCandidate:
+        return self.candidates[self.best_index]
+
+
+def _mean_finite(values: list[float]) -> float:
+    finite = [v for v in values if math.isfinite(v)]
+    return float(np.mean(finite)) if finite else float("nan")
+
+
+def tune_channel(
+    K: float,
+    tau: float,
+    L: float,
+    *,
+    saturation_limits: tuple[float, float],
+    multiplier_range: tuple[float, float] = (1.0, 3.0),
+    n_multipliers: int = 5,
+    control_dt_s: float = DEFAULT_CONTROL_DT_S,
+    scenarios: list[Scenario] | None = None,
+) -> TuningResult:
+    """Sweep the lambda multiplier, score each candidate over the scenario
+    battery, return all candidates with the best (lowest-cost) index."""
+    u_min, u_max = saturation_limits
+    scen = scenarios if scenarios is not None else default_scenarios(saturation_limits)
+    multipliers = list(np.linspace(multiplier_range[0], multiplier_range[1], n_multipliers))
+
+    candidates: list[TuningCandidate] = []
+    for mult in multipliers:
+        gains = lambda_tune(K, tau, L, mult)
+        per_ref: list[dict[str, Any]] = []
+        total = 0.0
+        breakdown_acc: dict[str, list[float]] = {
+            "iae": [],
+            "overshoot": [],
+            "saturation_fraction": [],
+            "settle_time_s": [],
+        }
+        for s in scen:
+            ctrl = PIController(Kp=gains.Kp, Ki=gains.Ki, Kt=gains.Kt, u_min=u_min, u_max=u_max)
+            sim = simulate_closed_loop(
+                K, tau, L, ctrl, s.reference, duration_s=s.duration_s, control_dt_s=control_dt_s
+            )
+            cost = _scenario_cost(sim.metrics)
+            total += cost
+            per_ref.append({"label": s.label, "cost": cost, **sim.metrics})
+            for key in breakdown_acc:
+                breakdown_acc[key].append(sim.metrics[key])
+        breakdown = {k: _mean_finite(v) for k, v in breakdown_acc.items()}
+        candidates.append(
+            TuningCandidate(
+                gains=gains, per_reference=per_ref, cost=total, cost_breakdown=breakdown
+            )
+        )
+
+    costs = [c.cost for c in candidates]
+    best_index = int(np.argmin(costs))
+    return TuningResult(
+        plant={"K": K, "tau": tau, "L": L},
+        saturation_limits=saturation_limits,
+        multipliers=multipliers,
+        candidates=candidates,
+        best_index=best_index,
+    )
+
+
+# ── robustness sweeps + verdict ────────────────────────────────────────────
+
+
+@dataclass
+class SweepResult:
+    which: str
+    factors: list[float]
+    iaes: list[float]
+    stable: list[bool]
+
+    @property
+    def all_stable(self) -> bool:
+        return all(self.stable)
+
+    @property
+    def worst_iae(self) -> float:
+        finite = [v for v in self.iaes if math.isfinite(v)]
+        return max(finite) if finite else float("inf")
+
+
+def _is_stable(y: np.ndarray, sat_max: float) -> bool:
+    if not np.all(np.isfinite(y)):
+        return False
+    return bool(np.max(np.abs(y)) < max(STABILITY_GAIN * sat_max, STABILITY_FLOOR))
+
+
+def _robustness_reference(saturation_limits: tuple[float, float]) -> tuple[ReferenceFn, float]:
+    u_max = saturation_limits[1]
+    return step(0.7 * u_max), 4.0
+
+
+def _sweep(
+    gains: Gains,
+    K: float,
+    tau: float,
+    L: float,
+    saturation_limits: tuple[float, float],
+    which: str,
+    factors: np.ndarray,
+    *,
+    control_dt_s: float,
+) -> SweepResult:
+    u_min, u_max = saturation_limits
+    sat_max = max(abs(u_min), abs(u_max))
+    ref, duration = _robustness_reference(saturation_limits)
+    iaes: list[float] = []
+    stable: list[bool] = []
+    for f in factors:
+        Kp_, tau_, L_ = K, tau, L
+        if which == "K":
+            Kp_ = K * f
+        elif which == "tau":
+            tau_ = tau * f
+        elif which == "L":
+            L_ = L * f
+        ctrl = PIController(Kp=gains.Kp, Ki=gains.Ki, Kt=gains.Kt, u_min=u_min, u_max=u_max)
+        sim = simulate_closed_loop(
+            Kp_, tau_, L_, ctrl, ref, duration_s=duration, control_dt_s=control_dt_s
+        )
+        iaes.append(sim.metrics["iae"])
+        stable.append(_is_stable(sim.y, sat_max))
+    return SweepResult(which=which, factors=list(factors), iaes=iaes, stable=stable)
+
+
+@dataclass
+class RobustnessReport:
+    gain_sweep: SweepResult
+    tau_sweep: SweepResult
+    l_sweep: SweepResult
+
+    @property
+    def all_stable(self) -> bool:
+        return self.gain_sweep.all_stable and self.tau_sweep.all_stable and self.l_sweep.all_stable
+
+
+def robustness_sweep(
+    gains: Gains,
+    K: float,
+    tau: float,
+    L: float,
+    saturation_limits: tuple[float, float],
+    *,
+    control_dt_s: float = DEFAULT_CONTROL_DT_S,
+) -> RobustnessReport:
+    """Three sweeps against a 70%-amplitude step: K +/-15% (run-to-run variance)
+    and tau/L +/-20% (model uncertainty)."""
+    gain_factors = np.linspace(0.85, 1.15, 7)
+    param_factors = np.linspace(0.80, 1.20, 7)
+    return RobustnessReport(
+        gain_sweep=_sweep(
+            gains, K, tau, L, saturation_limits, "K", gain_factors, control_dt_s=control_dt_s
+        ),
+        tau_sweep=_sweep(
+            gains, K, tau, L, saturation_limits, "tau", param_factors, control_dt_s=control_dt_s
+        ),
+        l_sweep=_sweep(
+            gains, K, tau, L, saturation_limits, "L", param_factors, control_dt_s=control_dt_s
+        ),
+    )
+
+
+def channel_verdict(best: TuningCandidate, robustness: RobustnessReport) -> Verdict:
+    """pass/marginal/fail from robustness stability + the winner's overshoot and
+    saturation behavior."""
+    if not robustness.all_stable:
+        return "fail"
+    overshoot = best.cost_breakdown.get("overshoot", 0.0)
+    if not math.isfinite(overshoot):
+        overshoot = 0.0
+    saturation = best.cost_breakdown.get("saturation_fraction", 0.0)
+    if overshoot <= VERDICT_OVERSHOOT_MAX and saturation <= VERDICT_SATURATION_MAX:
+        return "pass"
+    return "marginal"
+
+
+@dataclass
+class ChannelTuning:
+    """Full tuning record for one channel: winning gains, robustness, verdict."""
+
+    channel: str
+    plant: dict[str, float]
+    gains: Gains
+    verdict: Verdict
+    cost_breakdown: dict[str, float]
+    robustness: RobustnessReport = field(repr=False)
+
+
+def tune_channel_full(
+    channel: str,
+    K: float,
+    tau: float,
+    L: float,
+    *,
+    saturation_limits: tuple[float, float],
+    control_dt_s: float = DEFAULT_CONTROL_DT_S,
+    **tune_kwargs: Any,
+) -> ChannelTuning:
+    """End-to-end for one channel: sweep -> pick winner -> robustness -> verdict."""
+    result = tune_channel(
+        K, tau, L, saturation_limits=saturation_limits, control_dt_s=control_dt_s, **tune_kwargs
+    )
+    best = result.best
+    robustness = robustness_sweep(
+        best.gains, K, tau, L, saturation_limits, control_dt_s=control_dt_s
+    )
+    verdict = channel_verdict(best, robustness)
+    return ChannelTuning(
+        channel=channel,
+        plant=result.plant,
+        gains=best.gains,
+        verdict=verdict,
+        cost_breakdown=best.cost_breakdown,
+        robustness=robustness,
+    )
+
+
+__all__ = [
+    "ChannelTuning",
+    "Gains",
+    "PIController",
+    "Scenario",
+    "TuningCandidate",
+    "TuningResult",
+    "channel_verdict",
+    "default_scenarios",
+    "lambda_tune",
+    "ramp",
+    "robustness_sweep",
+    "simulate_closed_loop",
+    "simulate_fopdt",
+    "staircase",
+    "step",
+    "tune_channel",
+    "tune_channel_full",
+]

--- a/docs/capabilities/control-autotune.md
+++ b/docs/capabilities/control-autotune.md
@@ -1,0 +1,119 @@
+# Control Autotune
+
+Autotune takes a robot you describe and gives back its plant model and tuned
+velocity-controller gains. You declare what the robot is; it runs a short
+battery of motion tests, fits a model per axis, and writes out the gains in the
+format a control task already reads.
+
+The model it fits is a first-order-plus-deadtime (FOPDT) model: a steady-state
+gain `K`, a time constant `tau`, and a lumped deadtime `L` per axis. That is
+enough to derive bandwidth and to tune a PI controller analytically.
+
+This module supersedes the older `dimos/utils/characterization` and
+`dimos/utils/benchmarking` trees for plant identification and tuning.
+
+## What you declare: the RobotProfile
+
+Autotune does not guess what your robot is. You declare it:
+
+- `command_interface` — how the robot is commanded (`twist` today).
+- `odom_type` — whether feedback is body `velocity` or world-frame `pose`.
+- `channels` — the controllable axes and each one's saturation limit (`vmax`).
+- `fitter` — `velocity` or `pose` (see below). You choose; the module advises.
+- `controller_form` — what to tune (`velocity_pi`).
+- `command_stream` / `feedback_stream` — the coordinator topics to use.
+
+The excitation battery is driven off the profile, not hardcoded. Test
+amplitudes are fractions of each channel's `vmax` (default 25/50/75%), so the
+same battery scales to a slow robot or a fast one without edits.
+
+## Velocity fitter vs pose fitter
+
+You pick which domain to identify in. The two fitters exist because odometry
+rate matters:
+
+- The velocity fitter reconstructs body velocity from odometry and fits the
+  step response. It needs odometry that is fast relative to `tau`.
+- The pose fitter fits the model against raw pose without differentiating. On a
+  legged base whose odometry is slow, differentiating smears the step and
+  inflates `tau`; the pose fitter avoids that.
+
+The passive probe reports how many feedback samples land inside one time
+constant. A handful means the velocity fitter will struggle. That is advice —
+it does not switch the fitter for you. You know your robot; the module does not.
+
+## How a run goes
+
+1. Declare the `RobotProfile`.
+2. Passive probe: with the robot still, measure each stream's rate, timing
+   jitter, and noise floor. No motion. Read the samples-per-`tau` advice.
+3. Drive the battery through the coordinator while the learning recorder
+   captures each run as an episode. One excitation run is one episode; the
+   amplitude-and-repeat battery is a multi-episode collection.
+4. Fit the FOPDT per axis from the recorded episodes (offline — you can re-fit a
+   collection without re-driving the robot).
+5. Derive bandwidth from the fit, and emit Bode and pole-zero plots.
+6. Lambda-tune the PI gains, run a robustness sweep, and score a verdict per
+   axis.
+7. Write the tuned artifact and the characterization report.
+
+## Bandwidth, Bode, and pole-zero
+
+Bandwidth is derived from the fit, not measured with a frequency sweep. For an
+FOPDT the -3 dB point is `1 / (2*pi*tau)`. Bandwidth is withheld when the fit
+quality is too low to trust.
+
+The Bode plot is closed-form from `K`, `tau`, `L`. The pole-zero plot shows the
+one physical pole at `-1/tau`. The deadtime has no rational pole-zero form, so
+the plot approximates it with a first-order Padé term, which adds a pole and a
+right-half-plane zero. Those two are labeled as approximation artifacts so they
+are not read as real plant roots.
+
+## What you get out
+
+Two separate files:
+
+- The tuned artifact (`tuned_config.json`) — the gains and limits in the exact
+  shape a control task's `from_artifact` reads. A deployed task points at this
+  file by path. Autotune is the producer; the task is the consumer.
+- The characterization report (`characterization_report.json`) — the measured
+  properties (FOPDT per axis, bandwidth, deadzone, direction asymmetry,
+  cross-axis coupling, stream timing, per-axis verdict). This is durable robot
+  metadata, kept apart from the gains.
+
+The artifact's channels are the fixed slots `vx`, `vy`, `wz`. A profile that
+declares other channel names cannot be written to this contract and is
+rejected — the consuming task indexes those exact names.
+
+Gains from data that is not hardware-sourced are marked `valid_for_tuning:
+false` with a do-not-tune note. Sim data is for checking the pipeline, not for
+deploying gains.
+
+## Running it
+
+The live run is a blueprint that boots the coordinator with the robot's adapter,
+the same way the `unitree-go2-characterization` blueprint does, drives the
+battery, and records episodes. It must run on the robot or in simulation.
+
+The fit, tune, and emit steps are offline and need no robot. Call them directly
+on a recorded collection:
+
+```python
+from dimos.control.autotune.runner import autotune_offline
+outputs = autotune_offline(profile, segments_by_channel, robot_id="my-base", sim_or_hw="hw")
+```
+
+`outputs` carries the populated profile, the tuned artifact, the characterization
+report, and the per-axis tuning records. You can re-run this on a collection
+captured once without re-driving the robot.
+
+## What it does not measure
+
+By design, to avoid effort for little return:
+
+- Isolated measurement latency. It is already lumped into the deadtime `L` that
+  the controller compensates; separating the sensor share needs an external
+  clock for negligible payoff.
+- Hysteresis.
+- The choice of controller structure. Autotune reports the gain-versus-amplitude
+  curve and flags nonlinearity, but whether a linear PI suffices is your call.


### PR DESCRIPTION
## Problem

Tuning a mobile base's velocity controller is manual and expert-only.  There's no single path from a robot to its gains.

Issue: #2755 
Closes DIM-1116
---

## Solution

Adds `dimos/control/autotune/`. You declare a RobotProfile (command interface, odometry domain, channels, limits, fitter); it probes stream timing, drives a step/ramp battery through the ControlCoordinator recording one episode per run, fits a first-order-plus-deadtime model per axis, derives bandwidth plus Bode and pole-zero plots, then lambda-tunes PI gains with a robustness sweep.

Emits a tuned artifact in the shape the control task already loads, plus a separate characterization report. Fitters and tuner were ported from the characterization branches and made robot-agnostic. Live drive wiring is not included.

---

## Breaking Changes

None. Additive module.

---

## How to Test

1. `pytest dimos/control/autotune` (~2s).
2. Confirm it recovers the synthetic plant's K/tau/L and emits a schema-v1 artifact.
3. Confirm `valid_for_tuning` is false for non-hardware data.


## Checklist

- [ x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
