### PR TITLE
fix(perception): use pos_x/pos_y/pos_z metadata keys in spatial location queries

### DIFF
--- a/dimos/perception/spatial_vector_db.py
+++ b/dimos/perception/spatial_vector_db.py
@@ -177,8 +177,8 @@ class SpatialVectorDB:
         filtered_results = {"ids": [], "metadatas": [], "distances": []}  # type: ignore[var-annotated]
 
         for i, metadata in enumerate(results["metadatas"]):  # type: ignore[arg-type]
-            item_x = metadata.get("x")
-            item_y = metadata.get("y")
+            item_x = metadata.get("pos_x")
+            item_y = metadata.get("pos_y")
 
             if item_x is not None and item_y is not None:
                 distance = np.sqrt((x - item_x) ** 2 + (y - item_y) ** 2)
@@ -280,10 +280,10 @@ class SpatialVectorDB:
             if isinstance(metadata, list) and metadata and isinstance(metadata[0], dict):
                 metadata = metadata[0]  # Handle nested metadata
 
-            if isinstance(metadata, dict) and "x" in metadata and "y" in metadata:
-                x = metadata.get("x", 0)
-                y = metadata.get("y", 0)
-                z = metadata.get("z", 0) if "z" in metadata else 0
+            if isinstance(metadata, dict) and "pos_x" in metadata and "pos_y" in metadata:
+                x = metadata.get("pos_x", 0)
+                y = metadata.get("pos_y", 0)
+                z = metadata.get("pos_z", 0) if "pos_z" in metadata else 0
                 locations.append((x, y, z))
 
         return locations

--- a/dimos/perception/test_spatial_vector_db.py
+++ b/dimos/perception/test_spatial_vector_db.py
@@ -1,0 +1,69 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+
+from dimos.perception.spatial_vector_db import SpatialVectorDB
+
+NEAR_FRAME_ID = "frame_near"
+FAR_FRAME_ID = "frame_far"
+NEAR_POS = (1.5, -2.0, 0.3)
+FAR_POS = (30.0, 40.0, 0.0)
+
+
+def _frame_metadata(frame_id: str, pos: tuple[float, float, float]) -> dict[str, float | str]:
+    """Metadata with the keys SpatialMemory._process_frame stores for each frame."""
+    return {
+        "pos_x": pos[0],
+        "pos_y": pos[1],
+        "pos_z": pos[2],
+        "rot_x": 0.0,
+        "rot_y": 0.0,
+        "rot_z": 0.0,
+        "timestamp": 1700000000.0,
+        "frame_id": frame_id,
+    }
+
+
+@pytest.fixture(scope="module")
+def db() -> SpatialVectorDB:
+    db = SpatialVectorDB(collection_name="test_spatial_vector_db")
+    image = np.zeros((8, 8, 3), dtype=np.uint8)
+    db.add_image_vector(
+        NEAR_FRAME_ID,
+        image,
+        np.array([1.0, 0.0]),
+        _frame_metadata(NEAR_FRAME_ID, NEAR_POS),
+    )
+    db.add_image_vector(
+        FAR_FRAME_ID,
+        image,
+        np.array([0.0, 1.0]),
+        _frame_metadata(FAR_FRAME_ID, FAR_POS),
+    )
+    return db
+
+
+def test_query_by_location_returns_frames_within_radius(db: SpatialVectorDB) -> None:
+    results = db.query_by_location(1.0, -2.0, radius=2.0)
+
+    assert [r["id"] for r in results] == [NEAR_FRAME_ID]
+    assert results[0]["metadata"]["pos_x"] == NEAR_POS[0]
+    assert results[0]["metadata"]["pos_y"] == NEAR_POS[1]
+    assert results[0]["distance"] == pytest.approx(0.5)
+
+
+def test_get_all_locations_returns_stored_coordinates(db: SpatialVectorDB) -> None:
+    assert sorted(db.get_all_locations()) == sorted([NEAR_POS, FAR_POS])

--- a/dimos/perception/test_spatial_vector_db.py
+++ b/dimos/perception/test_spatial_vector_db.py
@@ -19,6 +19,7 @@ from dimos.perception.spatial_vector_db import SpatialVectorDB
 
 NEAR_FRAME_ID = "frame_near"
 FAR_FRAME_ID = "frame_far"
+NO_POS_FRAME_ID = "frame_no_pos"
 NEAR_POS = (1.5, -2.0, 0.3)
 FAR_POS = (30.0, 40.0, 0.0)
 
@@ -53,6 +54,13 @@ def db() -> SpatialVectorDB:
         np.array([0.0, 1.0]),
         _frame_metadata(FAR_FRAME_ID, FAR_POS),
     )
+    # Entry without position metadata — location queries must skip it, not crash.
+    db.add_image_vector(
+        NO_POS_FRAME_ID,
+        image,
+        np.array([1.0, 1.0]),
+        {"frame_id": NO_POS_FRAME_ID, "timestamp": 1700000000.0},
+    )
     return db
 
 
@@ -63,6 +71,12 @@ def test_query_by_location_returns_frames_within_radius(db: SpatialVectorDB) -> 
     assert results[0]["metadata"]["pos_x"] == NEAR_POS[0]
     assert results[0]["metadata"]["pos_y"] == NEAR_POS[1]
     assert results[0]["distance"] == pytest.approx(0.5)
+
+
+def test_query_by_location_skips_frames_without_position(db: SpatialVectorDB) -> None:
+    results = db.query_by_location(1.0, -2.0, radius=1e9)
+
+    assert [r["id"] for r in results] == [NEAR_FRAME_ID, FAR_FRAME_ID]
 
 
 def test_get_all_locations_returns_stored_coordinates(db: SpatialVectorDB) -> None:


### PR DESCRIPTION
## Contribution path

- [x] Small, safe change that does not need a tracking issue

## Problem

`SpatialVectorDB.query_by_location()` and `get_all_locations()` filter stored frames by metadata keys `"x"`/`"y"`/`"z"`, but frames are stored with keys `pos_x`/`pos_y`/`pos_z` (see the metadata dict built in `SpatialMemory._process_frame`). The keys never match, so both methods always return empty results against real spatial-memory data.

## Solution

Read `pos_x`/`pos_y`/`pos_z` in both methods.

Added `dimos/perception/test_spatial_vector_db.py`: stores frames in an in-memory `SpatialVectorDB` using the exact metadata shape `_process_frame` writes, and asserts location queries find them. The test fails against the old
code and runs in the default (fast) CI suite.

## How to Test

`uv run pytest dimos/perception/test_spatial_vector_db.py`

Also verified against real recorded data:

First I populated the chromadb: `dimos --replay --replay-db go2_china_office run unitree-go2-spatial --disable perceive-loop-skill` (`--disable` because the blueprint's PerceiveLoopSkill requires an agent module it doesn't include — separate issue). Let it log `Stored frame at position (…)` for ~60s, then stop it.

Then, I ran this script:
```sh
uv run python - <<'EOF'
import chromadb
from dimos.perception.spatial_vector_db import SpatialVectorDB

client = chromadb.PersistentClient(path="assets/output/memory/spatial_memory/chromadb_data")
db = SpatialVectorDB(collection_name="spatial_memory", chroma_client=client)
frames = db.image_collection.get(include=["metadatas"])
print(len(frames["ids"]), "frames stored")          # non-zero — the data exists
print("sample metadata:", frames["metadatas"][0])   # keys are pos_x/pos_y/pos_z
print("get_all_locations:", db.get_all_locations()) # [] — the bug
print("query (infinite radius):", db.query_by_location(0, 0, radius=1e9))  # still []
EOF
```

Running it on `main` produced empty query results. Running it on this feature branch produced results.


## AI assistance

My associate (Fable 5) discovered the issue, proposed a fix, and implemented it. I then reviewed the output and manually ran the verification against the chromadb as outlined in the `How to Test` section.