### PR TITLE
feat(control): per-robot JointState output streams

### DIFF
--- a/dimos/control/coordinator.py
+++ b/dimos/control/coordinator.py
@@ -92,6 +92,8 @@ class ControlCoordinatorConfig(ModuleConfig):
 
     tick_rate: float = 100.0
     publish_joint_state: bool = True
+    # Transitional: goes away once every consumer reads per-robot streams.
+    publish_robot_joint_states: bool = False
     joint_state_frame_id: str = "coordinator"
     log_ticks: bool = False
     hardware: list[HardwareComponent] = field(default_factory=lambda: [])
@@ -312,6 +314,24 @@ class ControlCoordinator(Module):
 
         return control_task_registry.create(cfg.type, cfg, hardware=self._hardware)
 
+    def _robot_joint_port(self, hardware_id: HardwareId) -> Out[JointState]:
+        name = f"{hardware_id}_joints"
+        port = getattr(self, name, None)
+        if isinstance(port, Out):
+            return port
+        if not name.isidentifier():
+            raise ValueError(
+                f"publish_robot_joint_states is on but hardware_id {hardware_id!r} cannot name "
+                f"an output port — rename it so `{name}` is a valid Python identifier"
+            )
+        raise ValueError(
+            f"publish_robot_joint_states is on but hardware {hardware_id!r} has no output "
+            f"port — add `{name}: Out[JointState]` to your coordinator subclass"
+        )
+
+    def _publish_robot_joint_state(self, hardware_id: HardwareId, msg: JointState) -> None:
+        self._robot_joint_port(hardware_id).publish(msg)
+
     @rpc
     def add_hardware(
         self,
@@ -335,6 +355,9 @@ class ControlCoordinator(Module):
                 f"hardware_type={component.hardware_type.value} but got "
                 f"{type(adapter).__name__}"
             )
+
+        if self.config.publish_robot_joint_states:
+            self._robot_joint_port(component.hardware_id)
 
         with self._hardware_lock:
             if component.hardware_id in self._hardware:
@@ -869,6 +892,17 @@ class ControlCoordinator(Module):
             logger.warning("Coordinator already running")
             return
 
+        if type(self) is not ControlCoordinator and self.config.instance_name is None:
+            logger.warning(
+                f"Coordinator subclass {type(self).__name__} has no instance_name, so it "
+                f"serves RPCs under '{type(self).__name__}' — the shipped clients look for "
+                "'ControlCoordinator'. Pass instance_name='ControlCoordinator' in the blueprint."
+            )
+
+        if self.config.publish_robot_joint_states:
+            for component in self.config.hardware:
+                self._robot_joint_port(component.hardware_id)
+
         super().start()
 
         # Setup hardware and tasks from config (if any)
@@ -879,6 +913,9 @@ class ControlCoordinator(Module):
         publish_cb = (
             self.coordinator_joint_state.publish if self.config.publish_joint_state else None
         )
+        publish_robot_cb = (
+            self._publish_robot_joint_state if self.config.publish_robot_joint_states else None
+        )
         self._tick_loop = TickLoop(
             tick_rate=self.config.tick_rate,
             hardware=self._hardware,
@@ -887,6 +924,7 @@ class ControlCoordinator(Module):
             task_lock=self._task_lock,
             joint_to_hardware=self._joint_to_hardware,
             publish_callback=publish_cb,
+            publish_robot_callback=publish_robot_cb,
             frame_id=self.config.joint_state_frame_id,
             log_ticks=self.config.log_ticks,
         )

--- a/dimos/control/test_per_robot_joint_states.py
+++ b/dimos/control/test_per_robot_joint_states.py
@@ -1,0 +1,394 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for opt-in per-robot JointState output streams."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+import threading
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from dimos.control.components import HardwareComponent, HardwareType, make_joints
+import dimos.control.coordinator as coord_mod
+from dimos.control.coordinator import ControlCoordinator, TaskConfig
+from dimos.control.hardware_interface import ConnectedHardware
+from dimos.control.tick_loop import TickLoop
+from dimos.core.stream import In, Out
+from dimos.hardware.manipulators.registry import adapter_registry
+from dimos.hardware.manipulators.spec import ManipulatorAdapter
+from dimos.msgs.sensor_msgs.JointState import JointState
+
+LEFT_JOINTS = make_joints("left_arm", 2)
+RIGHT_JOINTS = make_joints("right_arm", 3)
+LEFT_POSITIONS = [0.11, 0.12]
+RIGHT_POSITIONS = [0.21, 0.22, 0.23]
+
+
+class DualArmCoordinator(ControlCoordinator):
+    left_arm_joints: Out[JointState]
+    right_arm_joints: Out[JointState]
+
+
+class LeftOnlyCoordinator(ControlCoordinator):
+    left_arm_joints: Out[JointState]
+
+
+class TeleopStyleCoordinator(DualArmCoordinator):
+    left_arm_command: In[JointState]
+
+
+def _component(hardware_id: str, joints: list[str], positions: list[float]) -> HardwareComponent:
+    return HardwareComponent(
+        hardware_id=hardware_id,
+        hardware_type=HardwareType.MANIPULATOR,
+        joints=joints,
+        adapter_type="mock",
+        adapter_kwargs={"initial_positions": positions},
+    )
+
+
+def _left() -> HardwareComponent:
+    return _component("left_arm", LEFT_JOINTS, LEFT_POSITIONS)
+
+
+def _right() -> HardwareComponent:
+    return _component("right_arm", RIGHT_JOINTS, RIGHT_POSITIONS)
+
+
+class OutTap:
+    def __init__(self, port: Out) -> None:
+        self._messages: list[JointState] = []
+        self._lock = threading.Lock()
+        port.subscribe(self._record)
+
+    def _record(self, msg: JointState) -> None:
+        with self._lock:
+            self._messages.append(msg)
+
+    @property
+    def count(self) -> int:
+        with self._lock:
+            return len(self._messages)
+
+    def latest(self) -> JointState:
+        with self._lock:
+            assert self._messages, "port never published"
+            return self._messages[-1]
+
+
+class InTap:
+    def __init__(self, mocker: Any, port: In) -> None:
+        self._callbacks: list[Callable[[Any], None]] = []
+        mocker.patch.object(port, "subscribe", side_effect=self._subscribe)
+
+    def _subscribe(self, cb: Callable[[Any], None]) -> Callable[[], None]:
+        self._callbacks.append(cb)
+        return lambda: self._callbacks.remove(cb)
+
+    def emit(self, msg: Any) -> None:
+        assert self._callbacks, "port was never subscribed"
+        for cb in list(self._callbacks):
+            cb(msg)
+
+
+@pytest.fixture
+def make_coordinator() -> Iterator[Callable[..., ControlCoordinator]]:
+    built: list[ControlCoordinator] = []
+
+    def make(
+        coordinator_cls: type[ControlCoordinator] = ControlCoordinator, **kwargs: Any
+    ) -> ControlCoordinator:
+        coordinator = coordinator_cls(**kwargs)
+        built.append(coordinator)
+        return coordinator
+
+    try:
+        yield make
+    finally:
+        for coordinator in built:
+            coordinator.stop()
+
+
+def _mock_hardware(
+    hardware_id: str,
+    joints: list[str],
+    positions: list[float],
+    velocities: list[float],
+    efforts: list[float],
+) -> ConnectedHardware:
+    adapter = MagicMock(spec=ManipulatorAdapter)
+    adapter.read_joint_positions.return_value = positions
+    adapter.read_joint_velocities.return_value = velocities
+    adapter.read_joint_efforts.return_value = efforts
+    component = HardwareComponent(
+        hardware_id=hardware_id,
+        hardware_type=HardwareType.MANIPULATOR,
+        joints=joints,
+    )
+    return ConnectedHardware(adapter, component)
+
+
+class TestFlagOff:
+    def test_default_is_off(self, make_coordinator):
+        coordinator = make_coordinator(publish_joint_state=False)
+
+        assert coordinator.config.publish_robot_joint_states is False
+
+    def test_declared_ports_stay_silent_while_the_blob_publishes(
+        self, make_coordinator, wait_until
+    ):
+        coordinator = make_coordinator(
+            coordinator_cls=DualArmCoordinator, hardware=[_left(), _right()]
+        )
+        merged = OutTap(coordinator.coordinator_joint_state)
+        left = OutTap(coordinator.left_arm_joints)
+        right = OutTap(coordinator.right_arm_joints)
+        coordinator.start()
+
+        wait_until(lambda: merged.count > 2, timeout=5.0)
+        assert left.count == 0
+        assert right.count == 0
+
+    def test_plain_coordinator_needs_no_per_robot_ports(self, make_coordinator):
+        coordinator = make_coordinator(hardware=[_left(), _right()])
+        coordinator.start()
+
+        assert sorted(coordinator.list_hardware()) == ["left_arm", "right_arm"]
+        assert sorted(coordinator.outputs) == ["coordinator_joint_state"]
+
+
+class TestPerRobotPublishing:
+    def test_each_port_gets_only_its_own_robot(self, make_coordinator, wait_until):
+        coordinator = make_coordinator(
+            coordinator_cls=DualArmCoordinator,
+            publish_robot_joint_states=True,
+            hardware=[_left(), _right()],
+        )
+        merged = OutTap(coordinator.coordinator_joint_state)
+        left = OutTap(coordinator.left_arm_joints)
+        right = OutTap(coordinator.right_arm_joints)
+        coordinator.start()
+
+        wait_until(lambda: bool(left.count and right.count and merged.count), timeout=5.0)
+
+        left_msg = left.latest()
+        assert list(left_msg.name) == LEFT_JOINTS
+        assert left_msg.frame_id == "left_arm"
+        assert list(left_msg.position) == LEFT_POSITIONS
+
+        right_msg = right.latest()
+        assert list(right_msg.name) == RIGHT_JOINTS
+        assert right_msg.frame_id == "right_arm"
+        assert list(right_msg.position) == RIGHT_POSITIONS
+
+        assert set(merged.latest().name) == {*LEFT_JOINTS, *RIGHT_JOINTS}
+
+    def test_runtime_added_hardware_publishes_on_its_port(self, make_coordinator, wait_until):
+        coordinator = make_coordinator(
+            coordinator_cls=DualArmCoordinator,
+            publish_robot_joint_states=True,
+            hardware=[_left()],
+        )
+        right = OutTap(coordinator.right_arm_joints)
+        coordinator.start()
+        assert right.count == 0
+
+        component = _right()
+        adapter = adapter_registry.create(
+            "mock",
+            dof=len(RIGHT_JOINTS),
+            hardware_id="right_arm",
+            initial_positions=RIGHT_POSITIONS,
+        )
+        assert adapter.connect()
+        assert coordinator.add_hardware(adapter, component)
+
+        wait_until(lambda: right.count > 0, timeout=5.0)
+        assert list(right.latest().position) == RIGHT_POSITIONS
+
+
+class TestTickLoopMessages:
+    @staticmethod
+    def _tick_once(publish_robot_callback):
+        merged: list[JointState] = []
+        left = _mock_hardware("left_arm", LEFT_JOINTS, [0.1, 0.2], [1.1, 1.2], [2.1, 2.2])
+        right = _mock_hardware(
+            "right_arm", RIGHT_JOINTS, [0.3, 0.4, 0.5], [1.3, 1.4, 1.5], [2.3, 2.4, 2.5]
+        )
+        tick_loop = TickLoop(
+            tick_rate=100.0,
+            hardware={"left_arm": left, "right_arm": right},
+            hardware_lock=threading.Lock(),
+            tasks={},
+            task_lock=threading.Lock(),
+            joint_to_hardware={},
+            publish_callback=merged.append,
+            publish_robot_callback=publish_robot_callback,
+        )
+        tick_loop._tick()
+        return merged, left, right
+
+    def test_message_carries_only_that_robots_values(self):
+        published: list[tuple[str, JointState]] = []
+        merged, _, _ = self._tick_once(lambda hw_id, msg: published.append((hw_id, msg)))
+
+        by_id = dict(published)
+        assert sorted(by_id) == ["left_arm", "right_arm"]
+
+        left_msg = by_id["left_arm"]
+        assert list(left_msg.name) == LEFT_JOINTS
+        assert list(left_msg.position) == [0.1, 0.2]
+        assert list(left_msg.velocity) == [1.1, 1.2]
+        assert list(left_msg.effort) == [2.1, 2.2]
+        assert left_msg.frame_id == "left_arm"
+
+        right_msg = by_id["right_arm"]
+        assert list(right_msg.position) == [0.3, 0.4, 0.5]
+        assert list(right_msg.velocity) == [1.3, 1.4, 1.5]
+        assert list(right_msg.effort) == [2.3, 2.4, 2.5]
+        assert right_msg.frame_id == "right_arm"
+
+        assert left_msg.ts == merged[0].ts
+        assert right_msg.ts == merged[0].ts
+
+    def test_hardware_is_read_once_per_tick(self):
+        published: list[tuple[str, JointState]] = []
+        _, left, _ = self._tick_once(lambda hw_id, msg: published.append((hw_id, msg)))
+
+        assert left.adapter.read_joint_positions.call_count == 1
+        assert left.adapter.read_joint_velocities.call_count == 1
+        assert left.adapter.read_joint_efforts.call_count == 1
+
+    def test_one_failing_port_does_not_starve_the_others(self):
+        published: list[str] = []
+
+        def publish(hw_id: str, msg: JointState) -> None:
+            if hw_id == "left_arm":
+                raise RuntimeError("transport down")
+            published.append(hw_id)
+
+        self._tick_once(publish)
+
+        assert published == ["right_arm"]
+
+
+class TestMissingPortIsLoud:
+    def test_startup_names_the_hardware_and_the_line_to_add(self, make_coordinator, mocker):
+        coordinator = make_coordinator(
+            coordinator_cls=LeftOnlyCoordinator,
+            publish_robot_joint_states=True,
+            hardware=[_left(), _right()],
+        )
+        create = mocker.patch.object(adapter_registry, "create", wraps=adapter_registry.create)
+
+        with pytest.raises(ValueError) as excinfo:
+            coordinator.start()
+
+        message = str(excinfo.value)
+        assert "right_arm" in message
+        assert "right_arm_joints: Out[JointState]" in message
+        assert coordinator.list_hardware() == []
+        assert not create.called
+
+    def test_hardware_id_that_cannot_name_a_port_says_so(self, make_coordinator):
+        coordinator = make_coordinator(
+            coordinator_cls=LeftOnlyCoordinator,
+            publish_robot_joint_states=True,
+            hardware=[_component("left-arm", ["left-arm/joint1"], [0.0])],
+        )
+
+        with pytest.raises(ValueError) as excinfo:
+            coordinator.start()
+
+        message = str(excinfo.value)
+        assert "left-arm" in message
+        assert "rename" in message
+
+    def test_runtime_add_hardware_names_the_line_to_add(self, make_coordinator):
+        coordinator = make_coordinator(
+            coordinator_cls=LeftOnlyCoordinator,
+            publish_robot_joint_states=True,
+            hardware=[_left()],
+        )
+        coordinator.start()
+
+        adapter = adapter_registry.create("mock", dof=len(RIGHT_JOINTS), hardware_id="right_arm")
+        assert adapter.connect()
+
+        with pytest.raises(ValueError) as excinfo:
+            coordinator.add_hardware(adapter, _right())
+
+        message = str(excinfo.value)
+        assert "right_arm" in message
+        assert "right_arm_joints: Out[JointState]" in message
+        assert coordinator.list_hardware() == ["left_arm"]
+
+
+class TestPostPivotPattern:
+    def test_subclass_serves_its_own_input_and_outputs_together(
+        self, make_coordinator, mocker, wait_until
+    ):
+        coordinator = make_coordinator(
+            coordinator_cls=TeleopStyleCoordinator,
+            instance_name="ControlCoordinator",
+            publish_robot_joint_states=True,
+            hardware=[_left(), _right()],
+            tasks=[
+                TaskConfig(
+                    name="servo_left",
+                    type="servo",
+                    joint_names=LEFT_JOINTS,
+                    stream_bind={"joint_command": "left_arm_command"},
+                )
+            ],
+        )
+        commands = InTap(mocker, coordinator.left_arm_command)
+        left = OutTap(coordinator.left_arm_joints)
+        right = OutTap(coordinator.right_arm_joints)
+        coordinator.start()
+
+        commands.emit(JointState(name=LEFT_JOINTS, position=[0.4, 0.5]))
+
+        assert coordinator.get_task("servo_left")._target == [0.4, 0.5]
+        wait_until(lambda: bool(left.count and right.count), timeout=5.0)
+        assert list(left.latest().name) == LEFT_JOINTS
+        assert list(right.latest().name) == RIGHT_JOINTS
+
+
+class TestInstanceNameGuard:
+    def test_subclass_without_instance_name_warns(self, make_coordinator, mocker):
+        warn = mocker.patch.object(coord_mod.logger, "warning")
+        make_coordinator(coordinator_cls=DualArmCoordinator).start()
+
+        logged = " ".join(str(call) for call in warn.call_args_list)
+        assert "instance_name" in logged
+        assert "DualArmCoordinator" in logged
+
+    def test_subclass_with_instance_name_does_not_warn(self, make_coordinator, mocker):
+        warn = mocker.patch.object(coord_mod.logger, "warning")
+        make_coordinator(
+            coordinator_cls=DualArmCoordinator, instance_name="ControlCoordinator"
+        ).start()
+
+        assert not any("instance_name" in str(call) for call in warn.call_args_list)
+
+    def test_plain_coordinator_does_not_warn(self, make_coordinator, mocker):
+        warn = mocker.patch.object(coord_mod.logger, "warning")
+        make_coordinator().start()
+
+        assert not any("instance_name" in str(call) for call in warn.call_args_list)

--- a/dimos/control/tick_loop.py
+++ b/dimos/control/tick_loop.py
@@ -45,7 +45,7 @@ from dimos.utils.logging_config import setup_logger
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from dimos.control.components import HardwareId, JointName, TaskName
+    from dimos.control.components import HardwareId, JointName, JointState as JointReading, TaskName
     from dimos.control.hardware_interface import ConnectedHardware
     from dimos.hardware.manipulators.spec import ControlMode
     from dimos.hardware.whole_body.spec import IMUState
@@ -72,7 +72,7 @@ class TickLoop:
     4. NOTIFY: Send preemption notifications to affected tasks
     5. ROUTE: Convert joint-centric commands to hardware-centric
     6. WRITE: Send commands to hardware
-    7. PUBLISH: Output aggregated JointState
+    7. PUBLISH: Output aggregated JointState, plus one stream per robot
 
     Args:
         tick_rate: Control loop frequency in Hz
@@ -81,7 +81,8 @@ class TickLoop:
         tasks: Dict of task_name -> ControlTask
         task_lock: Lock protecting tasks dict
         joint_to_hardware: Dict mapping joint_name -> hardware_id
-        publish_callback: Optional callback to publish JointState
+        publish_callback: Optional callback to publish the merged JointState
+        publish_robot_callback: Optional callback, called with (hardware_id, msg)
         frame_id: Frame ID for published JointState
         log_ticks: Whether to log tick information
     """
@@ -95,6 +96,7 @@ class TickLoop:
         task_lock: threading.Lock,
         joint_to_hardware: dict[JointName, HardwareId],
         publish_callback: Callable[[JointState], None] | None = None,
+        publish_robot_callback: Callable[[HardwareId, JointState], None] | None = None,
         frame_id: str = "coordinator",
         log_ticks: bool = False,
     ) -> None:
@@ -105,6 +107,7 @@ class TickLoop:
         self._task_lock = task_lock
         self._joint_to_hardware = joint_to_hardware
         self._publish_callback = publish_callback
+        self._publish_robot_callback = publish_robot_callback
         self._frame_id = frame_id
         self._log_ticks = log_ticks
 
@@ -174,7 +177,7 @@ class TickLoop:
         self._last_tick_time = t_now
         self._tick_count += 1
 
-        joint_states = self._read_all_hardware()
+        joint_states, per_hardware = self._read_all_hardware()
         imu_states = self._read_all_imu()
         state = CoordinatorState(joints=joint_states, imu=imu_states, t_now=t_now, dt=dt)
 
@@ -191,6 +194,9 @@ class TickLoop:
         if self._publish_callback:
             self._publish_joint_state(joint_states)
 
+        if self._publish_robot_callback:
+            self._publish_robot_joint_states(per_hardware, joint_states.timestamp)
+
         # Optional logging
         if self._log_ticks:
             active = len([c for c in commands if c[2] is not None])
@@ -200,11 +206,14 @@ class TickLoop:
                 f"{active} active tasks"
             )
 
-    def _read_all_hardware(self) -> JointStateSnapshot:
+    def _read_all_hardware(
+        self,
+    ) -> tuple[JointStateSnapshot, dict[HardwareId, dict[JointName, JointReading]]]:
         """Read state from all hardware interfaces."""
         joint_positions: dict[str, float] = {}
         joint_velocities: dict[str, float] = {}
         joint_efforts: dict[str, float] = {}
+        per_hardware: dict[HardwareId, dict[JointName, JointReading]] = {}
 
         with self._hardware_lock:
             for hw in self._hardware.values():
@@ -214,15 +223,18 @@ class TickLoop:
                         joint_positions[joint_name] = joint_state.position
                         joint_velocities[joint_name] = joint_state.velocity
                         joint_efforts[joint_name] = joint_state.effort
+                    if self._publish_robot_callback:
+                        per_hardware[hw.hardware_id] = state
                 except Exception as e:
                     logger.error(f"Failed to read {hw.hardware_id}: {e}")
 
-        return JointStateSnapshot(
+        snapshot = JointStateSnapshot(
             joint_positions=joint_positions,
             joint_velocities=joint_velocities,
             joint_efforts=joint_efforts,
             timestamp=time.time(),
         )
+        return snapshot, per_hardware
 
     def _read_all_imu(self) -> dict[str, IMUState]:
         """Poll IMU from every whole-body hardware in the pool.
@@ -414,3 +426,27 @@ class TickLoop:
         )
         if self._publish_callback:
             self._publish_callback(msg)
+
+    def _publish_robot_joint_states(
+        self,
+        per_hardware: dict[HardwareId, dict[JointName, JointReading]],
+        timestamp: float,
+    ) -> None:
+        publish = self._publish_robot_callback
+        if publish is None:
+            return
+
+        for hw_id, state in per_hardware.items():
+            names = list(state.keys())
+            msg = JointState(
+                ts=timestamp,
+                frame_id=hw_id,
+                name=names,
+                position=[state[n].position for n in names],
+                velocity=[state[n].velocity for n in names],
+                effort=[state[n].effort for n in names],
+            )
+            try:
+                publish(hw_id, msg)
+            except Exception as e:
+                logger.error(f"Failed to publish joint state for {hw_id}: {e}")

--- a/dimos/robot/manipulators/common/mock.py
+++ b/dimos/robot/manipulators/common/mock.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 from dimos.control.components import HardwareComponent, HardwareType, make_joints
 from dimos.control.coordinator import ControlCoordinator, TaskConfig
+from dimos.core.stream import Out
+from dimos.msgs.sensor_msgs.JointState import JointState
 
 _mock_hw = HardwareComponent(
     hardware_id="arm",
@@ -51,7 +53,15 @@ _mock_right = HardwareComponent(
     adapter_type="mock",
 )
 
-coordinator_dual_mock = ControlCoordinator.blueprint(
+
+class _DualMockCoordinator(ControlCoordinator):
+    left_arm_joints: Out[JointState]
+    right_arm_joints: Out[JointState]
+
+
+coordinator_dual_mock = _DualMockCoordinator.blueprint(
+    instance_name="ControlCoordinator",
+    publish_robot_joint_states=True,
     hardware=[_mock_left, _mock_right],
     tasks=[
         TaskConfig(name="traj_left", type="trajectory", joint_names=_mock_left.joints, priority=10),


### PR DESCRIPTION
## Problem

A multi-robot coordinator publishes only one merged `coordinator_joint_state`, so every consumer has to untangle a concatenated joint list to find the arm it cares about.

Issue: #

---

## Solution

Coordinator subclasses can declare `{hardware_id}_joints: Out[JointState]` per robot. The tick loop reuses the read it and publishes outside the hardware lock. 

A missing port fails loudly at `start()` before any adapter connects, and at runtime `add_hardware`. 

`coordinator-dual-mock` is the migrated exemplar; it pins `instance_name="ControlCoordinator"` since a subclass otherwise serves RPCs under its own name (`start()` now warns). 

---

## Breaking Changes

None. Backwards support bool added with `publish_robot_joint_states=True`. Keeps all previous blueprints working.

Will remove this after transisitioning all blueprints to new Control Coordinator

---

## How to Test

1. `uv run pytest dimos/control -m 'not (tool or self_hosted or mujoco or self_hosted_large)'`
2. `dimos run coordinator-dual-mock`
3. Confirm `left_arm_joints` and `right_arm_joints` each carry only their own arm, alongside the unchanged `coordinator_joint_state`.
