### PR TITLE
feat(hosted-teleop): auto-select operator view via robot_type broker config

### DIFF
--- a/dimos/core/coordination/module_coordinator.py
+++ b/dimos/core/coordination/module_coordinator.py
@@ -713,8 +713,7 @@ def _materialize_transports(
         config = None
         config_cls = spec.config_cls
         if config_cls is not None:
-            # Config-field kwargs pinned on the spec (e.g. robot_type in a
-            # blueprint) are defaults; CLI/env transports.<name>.* overrides win.
+            # Config-field kwargs pinned on the spec
             spec_fields = {k: v for k, v in spec.kwargs.items() if k in config_cls.model_fields}
             sub = overrides.get(transport_config_name(config_cls), {})
             config = config_cls(**{**spec_fields, **sub})

--- a/dimos/core/coordination/module_coordinator.py
+++ b/dimos/core/coordination/module_coordinator.py
@@ -713,8 +713,11 @@ def _materialize_transports(
         config = None
         config_cls = spec.config_cls
         if config_cls is not None:
+            # Config-field kwargs pinned on the spec (e.g. robot_type in a
+            # blueprint) are defaults; CLI/env transports.<name>.* overrides win.
+            spec_fields = {k: v for k, v in spec.kwargs.items() if k in config_cls.model_fields}
             sub = overrides.get(transport_config_name(config_cls), {})
-            config = config_cls(**sub)
+            config = config_cls(**{**spec_fields, **sub})
         materialized[key] = _coerce_transport_to_backend(spec.build(config=config))
     return materialized
 

--- a/dimos/core/coordination/test_module_coordinator.py
+++ b/dimos/core/coordination/test_module_coordinator.py
@@ -41,6 +41,7 @@ from dimos.core.core import rpc
 from dimos.core.global_config import GlobalConfig
 from dimos.core.module import Module
 from dimos.core.stream import In, Out
+from dimos.core.transport import CloudflareTransport
 from dimos.msgs.sensor_msgs.Image import Image
 import dimos.robot.get_all_blueprints as resolver
 from dimos.spec.utils import Spec
@@ -875,32 +876,13 @@ def test_rpc_client_pickle_preserves_remote_name(dynamic_coordinator) -> None:
         restored.stop_rpc_client()
 
 
-def _materialize_one(spec, overrides=None):
-    """Run a single TransportSpec through _materialize_transports and return the
-    built transport."""
-    bp = Blueprint(blueprints=(), transport_map=MappingProxyType({("s", bytes): spec}))
-    return _materialize_transports(bp, overrides or {})[("s", bytes)]
-
-
 def test_spec_config_kwarg_reaches_provider_config() -> None:
     """A config-field kwarg pinned on a WebRTC spec (e.g. robot_type in a hosted
     blueprint) must survive materialization. Regression: the coordinator builds a
     provider config from CLI/env overrides and passes it as config=, which the
     transport's `config or config_cls(**kwargs)` guard would otherwise let win
     unconditionally — silently dropping the spec kwarg."""
-    from dimos.core.transport import CloudflareTransport
-
-    t = _materialize_one(CloudflareTransport.spec("state_reliable", robot_type="go2"))
+    spec = CloudflareTransport.spec("state_reliable", robot_type="go2")
+    bp = Blueprint(blueprints=(), transport_map=MappingProxyType({("s", bytes): spec}))
+    t = _materialize_transports(bp, {})[("s", bytes)]
     assert t._config.robot_type == "go2"
-
-
-def test_cli_override_beats_spec_config_kwarg() -> None:
-    """transports.<name>.* CLI/env overrides take precedence over a spec-pinned
-    config kwarg (the pin is a default)."""
-    from dimos.core.transport import CloudflareTransport
-
-    t = _materialize_one(
-        CloudflareTransport.spec("state_reliable", robot_type="go2"),
-        {"broker": {"robot_type": "arm"}},
-    )
-    assert t._config.robot_type == "arm"

--- a/dimos/core/coordination/test_module_coordinator.py
+++ b/dimos/core/coordination/test_module_coordinator.py
@@ -23,6 +23,7 @@ from dimos.core._test_future_annotations_helper import (
     FutureModuleOut,
 )
 from dimos.core.coordination.blueprints import (
+    Blueprint,
     DisabledModuleProxy,
     autoconnect,
 )
@@ -31,6 +32,7 @@ from dimos.core.coordination.module_coordinator import (
     ModuleCoordinator,
     _all_name_types,
     _check_requirements,
+    _materialize_transports,
     _verify_no_conflicts_with_existing,
     _verify_no_name_conflicts,
 )
@@ -871,3 +873,34 @@ def test_rpc_client_pickle_preserves_remote_name(dynamic_coordinator) -> None:
         assert restored.whoami() == "robot0/namedmodule"
     finally:
         restored.stop_rpc_client()
+
+
+def _materialize_one(spec, overrides=None):
+    """Run a single TransportSpec through _materialize_transports and return the
+    built transport."""
+    bp = Blueprint(blueprints=(), transport_map=MappingProxyType({("s", bytes): spec}))
+    return _materialize_transports(bp, overrides or {})[("s", bytes)]
+
+
+def test_spec_config_kwarg_reaches_provider_config() -> None:
+    """A config-field kwarg pinned on a WebRTC spec (e.g. robot_type in a hosted
+    blueprint) must survive materialization. Regression: the coordinator builds a
+    provider config from CLI/env overrides and passes it as config=, which the
+    transport's `config or config_cls(**kwargs)` guard would otherwise let win
+    unconditionally — silently dropping the spec kwarg."""
+    from dimos.core.transport import CloudflareTransport
+
+    t = _materialize_one(CloudflareTransport.spec("state_reliable", robot_type="go2"))
+    assert t._config.robot_type == "go2"
+
+
+def test_cli_override_beats_spec_config_kwarg() -> None:
+    """transports.<name>.* CLI/env overrides take precedence over a spec-pinned
+    config kwarg (the pin is a default)."""
+    from dimos.core.transport import CloudflareTransport
+
+    t = _materialize_one(
+        CloudflareTransport.spec("state_reliable", robot_type="go2"),
+        {"broker": {"robot_type": "arm"}},
+    )
+    assert t._config.robot_type == "arm"

--- a/dimos/protocol/pubsub/impl/webrtc/providers/broker.py
+++ b/dimos/protocol/pubsub/impl/webrtc/providers/broker.py
@@ -68,10 +68,6 @@ class BrokerConfig(ProviderConfig):
     api_key: str | None = None
     robot_id: str | None = None
     robot_name: str = "robot"
-    # Robot kind sent in the session-create POST so the operator UI auto-selects
-    # its view. Pinned on a broker transport spec in the hosted blueprint
-    # (robot_type=...); unset for standalone callers (the POST omits it and the
-    # operator picks).
     robot_type: str | None = None
     stun_url: str = "stun:stun.cloudflare.com:3478"
     heartbeat_hz: float = 1.0
@@ -244,7 +240,6 @@ class BrokerProvider(AsyncProviderBase):
                     **({"robot_id": self._robot_id} if self._robot_id else {}),
                     "robot_name": self._robot_name,
                     # Pinned on a broker spec in the blueprint; omitted when unset
-                    # (standalone callers) so the operator picks the view.
                     **({"robot_type": self._config.robot_type} if self._config.robot_type else {}),
                     "sdp_offer": self._pc.localDescription.sdp,
                 },

--- a/dimos/protocol/pubsub/impl/webrtc/providers/broker.py
+++ b/dimos/protocol/pubsub/impl/webrtc/providers/broker.py
@@ -68,6 +68,11 @@ class BrokerConfig(ProviderConfig):
     api_key: str | None = None
     robot_id: str | None = None
     robot_name: str = "robot"
+    # Robot kind sent in the session-create POST so the operator UI auto-selects
+    # its view. Pinned on a broker transport spec in the hosted blueprint
+    # (robot_type=...); unset for standalone callers (the POST omits it and the
+    # operator picks).
+    robot_type: str | None = None
     stun_url: str = "stun:stun.cloudflare.com:3478"
     heartbeat_hz: float = 1.0
     ordered: bool = False
@@ -77,6 +82,21 @@ class BrokerConfig(ProviderConfig):
 
     def _create(self) -> BrokerProvider:
         return BrokerProvider(self)
+
+    # robot_type is session metadata, not part of the connection — exclude it
+    # from equality/hash so pinning it on one transport spec (while the blueprint's
+    # other broker specs leave it unset) still resolves to ONE shared provider
+    # instead of forking a second PeerConnection.
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, BrokerConfig):
+            return NotImplemented
+        return self._identity() == other._identity()
+
+    def __hash__(self) -> int:
+        return hash(self._identity())
+
+    def _identity(self) -> tuple[tuple[str, Any], ...]:
+        return tuple((k, v) for k, v in self.__dict__.items() if k != "robot_type")
 
 
 class BrokerProvider(AsyncProviderBase):
@@ -223,6 +243,9 @@ class BrokerProvider(AsyncProviderBase):
                     # robot_id is optional — broker derives it from the API key.
                     **({"robot_id": self._robot_id} if self._robot_id else {}),
                     "robot_name": self._robot_name,
+                    # Pinned on a broker spec in the blueprint; omitted when unset
+                    # (standalone callers) so the operator picks the view.
+                    **({"robot_type": self._config.robot_type} if self._config.robot_type else {}),
                     "sdp_offer": self._pc.localDescription.sdp,
                 },
             )

--- a/dimos/protocol/pubsub/impl/webrtc/providers/broker.py
+++ b/dimos/protocol/pubsub/impl/webrtc/providers/broker.py
@@ -92,7 +92,9 @@ class BrokerConfig(ProviderConfig):
         return hash(self._identity())
 
     def _identity(self) -> tuple[tuple[str, Any], ...]:
-        return tuple((k, v) for k, v in self.__dict__.items() if k != "robot_type")
+        # model_dump (declared fields only) not __dict__, so no pydantic internals
+        # can leak into the singleton key.
+        return tuple((k, v) for k, v in self.model_dump().items() if k != "robot_type")
 
 
 class BrokerProvider(AsyncProviderBase):

--- a/dimos/teleop/hosted/blueprints/cloudflare.py
+++ b/dimos/teleop/hosted/blueprints/cloudflare.py
@@ -58,6 +58,7 @@ from dimos.teleop.hosted.camera_mux import CameraMuxModule
 from dimos.teleop.hosted.go2_command import Go2CommandModule
 from dimos.teleop.hosted.hosted_stats import HostedStatsModule
 from dimos.teleop.hosted.map_compress import MapCompressModule
+from dimos.teleop.hosted.robot_type import RobotType
 
 # Single camera: only the Go2's front camera feeds the video track.
 teleop_hosted_go2_transport = (
@@ -85,7 +86,11 @@ teleop_hosted_go2_transport = (
         {
             # inbound operator planes
             ("cmd_vel_in", Twist): CloudflareTransport.spec("cmd_unreliable", TwistStamped),
-            ("state_json", bytes): CloudflareTransport.spec("state_reliable"),  # → stats + command
+            # robot_type auto-selects the operator view (BrokerConfig excludes it
+            # from identity, so pinning it here doesn't fork the shared provider).
+            ("state_json", bytes): CloudflareTransport.spec(
+                "state_reliable", robot_type=RobotType.GO2
+            ),  # → stats + command
             ("camera_select", bytes): CloudflareTransport.spec("state_reliable"),  # → mux
             ("cmd_raw", bytes): CloudflareTransport.spec("cmd_unreliable"),  # stats tap
             # outbound operator planes
@@ -130,7 +135,11 @@ teleop_hosted_go2_multicam = (
         {
             # inbound operator planes
             ("cmd_vel_in", Twist): CloudflareTransport.spec("cmd_unreliable", TwistStamped),
-            ("state_json", bytes): CloudflareTransport.spec("state_reliable"),  # → stats + command
+            # robot_type auto-selects the operator view (BrokerConfig excludes it
+            # from identity, so pinning it here doesn't fork the shared provider).
+            ("state_json", bytes): CloudflareTransport.spec(
+                "state_reliable", robot_type=RobotType.GO2
+            ),  # → stats + command
             ("camera_select", bytes): CloudflareTransport.spec("state_reliable"),  # → mux
             ("cmd_raw", bytes): CloudflareTransport.spec("cmd_unreliable"),  # stats tap
             ("cam2", Image): LCMTransport.spec("cam2", Image),  # realsense over LCM
@@ -189,7 +198,11 @@ teleop_hosted_xarm6 = (
     .transports(
         {
             ("cmd_raw", bytes): CloudflareTransport.spec("cmd_unreliable"),
-            ("state_json", bytes): CloudflareTransport.spec("state_reliable"),
+            # robot_type auto-selects the operator view (BrokerConfig excludes it
+            # from identity, so pinning it here doesn't fork the shared provider).
+            ("state_json", bytes): CloudflareTransport.spec(
+                "state_reliable", robot_type=RobotType.ARM
+            ),
             ("camera_select", bytes): CloudflareTransport.spec("state_reliable"),
             ("mux_image", Image): CloudflareVideoTransport.spec(),
             ("telemetry_out", bytes): CloudflareTransport.spec("state_reliable_back"),
@@ -219,7 +232,11 @@ teleop_hosted_xarm7 = (
     .transports(
         {
             ("cmd_raw", bytes): CloudflareTransport.spec("cmd_unreliable"),
-            ("state_json", bytes): CloudflareTransport.spec("state_reliable"),
+            # robot_type auto-selects the operator view (BrokerConfig excludes it
+            # from identity, so pinning it here doesn't fork the shared provider).
+            ("state_json", bytes): CloudflareTransport.spec(
+                "state_reliable", robot_type=RobotType.ARM
+            ),
             ("camera_select", bytes): CloudflareTransport.spec("state_reliable"),
             ("mux_image", Image): CloudflareVideoTransport.spec(),
             ("telemetry_out", bytes): CloudflareTransport.spec("state_reliable_back"),

--- a/dimos/teleop/hosted/blueprints/cloudflare.py
+++ b/dimos/teleop/hosted/blueprints/cloudflare.py
@@ -86,8 +86,6 @@ teleop_hosted_go2_transport = (
         {
             # inbound operator planes
             ("cmd_vel_in", Twist): CloudflareTransport.spec("cmd_unreliable", TwistStamped),
-            # robot_type auto-selects the operator view (BrokerConfig excludes it
-            # from identity, so pinning it here doesn't fork the shared provider).
             ("state_json", bytes): CloudflareTransport.spec(
                 "state_reliable", robot_type=RobotType.GO2
             ),  # → stats + command
@@ -135,8 +133,6 @@ teleop_hosted_go2_multicam = (
         {
             # inbound operator planes
             ("cmd_vel_in", Twist): CloudflareTransport.spec("cmd_unreliable", TwistStamped),
-            # robot_type auto-selects the operator view (BrokerConfig excludes it
-            # from identity, so pinning it here doesn't fork the shared provider).
             ("state_json", bytes): CloudflareTransport.spec(
                 "state_reliable", robot_type=RobotType.GO2
             ),  # → stats + command
@@ -198,8 +194,6 @@ teleop_hosted_xarm6 = (
     .transports(
         {
             ("cmd_raw", bytes): CloudflareTransport.spec("cmd_unreliable"),
-            # robot_type auto-selects the operator view (BrokerConfig excludes it
-            # from identity, so pinning it here doesn't fork the shared provider).
             ("state_json", bytes): CloudflareTransport.spec(
                 "state_reliable", robot_type=RobotType.ARM
             ),
@@ -232,8 +226,6 @@ teleop_hosted_xarm7 = (
     .transports(
         {
             ("cmd_raw", bytes): CloudflareTransport.spec("cmd_unreliable"),
-            # robot_type auto-selects the operator view (BrokerConfig excludes it
-            # from identity, so pinning it here doesn't fork the shared provider).
             ("state_json", bytes): CloudflareTransport.spec(
                 "state_reliable", robot_type=RobotType.ARM
             ),

--- a/dimos/teleop/hosted/robot_type.py
+++ b/dimos/teleop/hosted/robot_type.py
@@ -1,0 +1,32 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Robot kinds for hosted teleop - the operator views the UI can render.
+
+Pinned on a broker transport spec in the hosted blueprint (robot_type=...); the
+value is the wire string sent to the broker in the session-create POST.
+"""
+
+from enum import Enum
+
+
+class RobotType(str, Enum):
+    """Operator view kind; value is the wire string sent to the broker.
+
+    ``str`` mixin (not ``StrEnum``, which is 3.11+) so the member serializes as
+    its wire value and the package still imports on the 3.10 floor.
+    """
+
+    GO2 = "go2"
+    ARM = "arm"

--- a/dimos/teleop/hosted/test_go2_command.py
+++ b/dimos/teleop/hosted/test_go2_command.py
@@ -33,7 +33,6 @@ import pytest
 
 from dimos.core.module import Module
 from dimos.msgs.geometry_msgs.TwistStamped import TwistStamped
-from dimos.protocol.pubsub.impl.webrtc.providers.broker import BrokerConfig
 from dimos.teleop.hosted.go2_command import ALLOWED_SPORT_CMDS, Go2CommandModule
 from dimos.utils.testing.waiting import wait_until
 
@@ -345,22 +344,3 @@ def test_nav_goal_rejected_when_estopped(
 
     module.goal_request.publish.assert_not_called()
     assert acks == [(13, False)]
-
-
-# ─── robot-type (operator UI view select) ────────────────────────────
-
-
-def test_robot_type_excluded_from_broker_config_identity() -> None:
-    """robot_type is session metadata, not part of the connection: two broker
-    configs differing only in it are equal and hash the same, so pinning it on
-    one transport spec (while other broker specs leave it unset) does not fork the
-    shared provider/PeerConnection. Guards the identity-exclusion in BrokerConfig."""
-    base = dict(api_key="k")
-    assert BrokerConfig(**base, robot_type="go2") == BrokerConfig(**base)
-    assert hash(BrokerConfig(**base, robot_type="go2")) == hash(
-        BrokerConfig(**base, robot_type="arm")
-    )
-    # a real field still separates configs (identity isn't blanket-ignored)
-    assert BrokerConfig(**base, robot_type="go2") != BrokerConfig(api_key="other", robot_type="go2")
-    # unset by default (the session POST omits it)
-    assert BrokerConfig(**base).robot_type is None

--- a/dimos/teleop/hosted/test_go2_command.py
+++ b/dimos/teleop/hosted/test_go2_command.py
@@ -33,6 +33,7 @@ import pytest
 
 from dimos.core.module import Module
 from dimos.msgs.geometry_msgs.TwistStamped import TwistStamped
+from dimos.protocol.pubsub.impl.webrtc.providers.broker import BrokerConfig
 from dimos.teleop.hosted.go2_command import ALLOWED_SPORT_CMDS, Go2CommandModule
 from dimos.utils.testing.waiting import wait_until
 
@@ -344,3 +345,22 @@ def test_nav_goal_rejected_when_estopped(
 
     module.goal_request.publish.assert_not_called()
     assert acks == [(13, False)]
+
+
+# ─── robot-type (operator UI view select) ────────────────────────────
+
+
+def test_robot_type_excluded_from_broker_config_identity() -> None:
+    """robot_type is session metadata, not part of the connection: two broker
+    configs differing only in it are equal and hash the same, so pinning it on
+    one transport spec (while other broker specs leave it unset) does not fork the
+    shared provider/PeerConnection. Guards the identity-exclusion in BrokerConfig."""
+    base = dict(api_key="k")
+    assert BrokerConfig(**base, robot_type="go2") == BrokerConfig(**base)
+    assert hash(BrokerConfig(**base, robot_type="go2")) == hash(
+        BrokerConfig(**base, robot_type="arm")
+    )
+    # a real field still separates configs (identity isn't blanket-ignored)
+    assert BrokerConfig(**base, robot_type="go2") != BrokerConfig(api_key="other", robot_type="go2")
+    # unset by default (the session POST omits it)
+    assert BrokerConfig(**base).robot_type is None


### PR DESCRIPTION
## Contribution path

<!-- See CONTRIBUTING.md. Small, safe changes can skip the issue. -->

- [ ] Small, safe change that does not need a tracking issue
- [x] Linked issue or discussion: DIM-XXX / #XXX / URL

Closes DIM-1264

## Problem

- hosted-teleop operator manually picks the right view every session. 
The robot already knows its kind - the broker session should carry it so the UI opens the correct view automatically.

## Solution

- Add a `robot_type` field to `BrokerConfig`, sent in the session-create POST.
- It's pinned per-blueprint on the broker transport spec so the kind is declared where the blueprint is defined
-  Unset (standalone callers) omits it from the POST and the operator picks.

## How to Test
```
dimos run teleop-hosted-go2-transport   # dashboard opens the Go2 view, no manual pick
```
## AI assistance

Claude Code with Opus 4.8 —  (design exploration, implementation). Reviewed and understood all changes
 design decisions were mine

## Checklist

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
