### PR TITLE
fix memory issues DIM-1326

### DIFF
--- a/dimos/msgs/sensor_msgs/Image.py
+++ b/dimos/msgs/sensor_msgs/Image.py
@@ -50,29 +50,6 @@ class ImageFormat(Enum):
     DEPTH16 = "DEPTH16"
 
 
-def _format_to_rerun(data: np.ndarray, fmt: ImageFormat) -> Any:
-    """Convert image data to Rerun archetype based on format."""
-    match fmt:
-        case ImageFormat.RGB:
-            return rr.Image(data, color_model="RGB")
-        case ImageFormat.RGBA:
-            return rr.Image(data, color_model="RGBA")
-        case ImageFormat.BGR:
-            return rr.Image(data, color_model="BGR")
-        case ImageFormat.BGRA:
-            return rr.Image(data, color_model="BGRA")
-        case ImageFormat.GRAY:
-            return rr.Image(data, color_model="L")
-        case ImageFormat.GRAY16:
-            return rr.Image(data, color_model="L")
-        case ImageFormat.DEPTH:
-            return rr.DepthImage(data)
-        case ImageFormat.DEPTH16:
-            return rr.DepthImage(data)
-        case _:
-            raise ValueError(f"Unsupported format for Rerun: {fmt}")
-
-
 class AgentImageMessage(TypedDict):
     """Type definition for agent-compatible image representation."""
 
@@ -331,8 +308,14 @@ class Image(Timestamped):
         raise ValueError(f"Unsupported format: {self.format}")
 
     def to_rerun(self) -> Any:
-        """Convert to rerun Image format."""
-        return _format_to_rerun(self.data, self.format)
+        """Convert to a Rerun archetype: JPEG-encoded for color images, raw for depth."""
+        match self.format:
+            case ImageFormat.DEPTH | ImageFormat.DEPTH16:
+                return rr.DepthImage(self.data)
+            case ImageFormat.GRAY16:
+                return rr.Image(self.data, color_model="L")
+            case _:
+                return rr.EncodedImage(contents=self.to_jpeg_bytes(), media_type="image/jpeg")
 
     def resize(self, width: int, height: int, interpolation: int = cv2.INTER_LINEAR) -> Image:
         return Image(

--- a/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_basic.py
+++ b/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_basic.py
@@ -95,6 +95,7 @@ rerun_config: dict[str, Any] = {
         "world/global_map": 0,  # publishes at ~7.8 Hz
         "world/color_image": 0,  # publishes at ~14 Hz
         "world/global_costmap": 0,  # publishes at ~7.6 Hz
+        "world/lidar": 1,  # publishes at ~7.7 Hz; hidden by default in the blueprint
     },
     # slapping a go2 shaped box on top of tf/base_link
     "static": {


### PR DESCRIPTION
Cut memory consumption for such and alike `uv run dimos --replay-db=go2_bigoffice --replay run unitree-go2` as down as x 17 times

BEFORE - 2.8Gb (_top left spot rerun_) for 1 minute of replay
<img width="1586" height="1112" alt="main_mem_cons_2 8GB" src="https://github.com/user-attachments/assets/5459f84b-8036-406b-8372-e1c0309bbccc" />


AFTER - 162Mb for 1 minute of replay
<img width="1572" height="1035" alt="main_fix_mem_cons_162MB" src="https://github.com/user-attachments/assets/972a2813-abca-4523-b33d-ed8942944d18" />

