### PR TITLE
recording based false-negative eval for the MLS planner

### DIFF
--- a/dimos/navigation/nav_3d/mls_planner/recording_eval.py
+++ b/dimos/navigation/nav_3d/mls_planner/recording_eval.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python
+"""False-negative eval for the MLS planner on a recorded multi-floor dataset.
+
+Idea (issue #2996, scoped with Andrew to "safe path produced iff one exists"):
+  * The robot physically traversed the whole recording in one continuous run, so
+    ANY two points on its odometry trajectory are connected by a real, feasible
+    path -- that is free ground truth, no manual labelling.
+  * We replay the recording through the production pipeline (RayTraceMap ->
+    MLSPlanner.update_region) to build the accumulated multi-floor map, then ask
+    plan(A, B) for many trajectory-derived pairs A, B.
+  * plan() -> None on a pair that is feasible-by-construction is a FALSE NEGATIVE
+    (Andrew: "as soon as there is any disconnect between start and goal it doesn't
+    plan"). We break those down by floor stratum and, via a union-find over the
+    planner's own node graph, prove whether start/goal fell in different connected
+    components (the exact "disconnect" failure).
+  * For pairs that DO plan, a light robot-box-vs-voxel slide flags any path that
+    clips occupied voxels (the "keep paths safe" guardrail). Collision detection
+    proper is a separate downstream module, so this is a guardrail, not a gate.
+
+Deliverable is a scorecard: false-negative rate (overall + a floor x floor
+matrix) and unsafe-path count. Objective (Andrew): drive FNs down while keeping
+unsafe at 0.
+
+Run:  ~/dimos/.venv/bin/python recording_eval.py [db] [--max-frames N] [--pairs-per-cell K]
+"""
+from __future__ import annotations
+
+import argparse
+import time
+from dataclasses import dataclass, field
+
+import numpy as np
+
+from dimos.mapping.ray_tracing.transformer import RayTraceMap
+from dimos.memory2.store.sqlite import SqliteStore
+from dimos.memory2.transform import FnTransformer
+from dimos.msgs.nav_msgs.Odometry import Odometry
+from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
+from dimos.navigation.nav_3d.mls_planner.mls_planner import MLSPlanner
+
+# ---- planner / pipeline params (match plan_rrd + the wiki command) ----
+VS = 0.08          # voxel size (m)
+ROBOT_H = 0.4      # robot height (m) -- from the wiki's canonical command
+STEP_THRESH = 0.16
+# Safety guardrail footprint: flag paths that come CLOSER to a voxel than the
+# planner's own hard wall_clearance (0.1 m) -- i.e. a genuine clearance violation,
+# not a path legitimately hugging a wall at the 0.1 m limit.
+ROBOT_RADIUS = 0.08
+
+# Floor strata (m), derived from the athens z-histogram: basement/landing/ground/upper.
+STRATA = [
+    ("basement", -7.0, -4.0),
+    ("landing", -4.0, -1.5),
+    ("ground", -1.5, 1.0),
+    ("upper", 1.0, 4.0),
+]
+
+
+def stratum_of(z: float) -> str | None:
+    for name, lo, hi in STRATA:
+        if lo <= z < hi:
+            return name
+    return None
+
+
+def attach_pose(pair):
+    lidar_obs, odom_obs = pair.data
+    o = odom_obs.data
+    return lidar_obs.with_pose((
+        float(o.position.x), float(o.position.y), float(o.position.z),
+        float(o.orientation.x), float(o.orientation.y),
+        float(o.orientation.z), float(o.orientation.w),
+    ))
+
+
+@dataclass
+class BuildResult:
+    planner: MLSPlanner
+    feet: np.ndarray          # (F,3) robot foot positions along the trajectory
+    voxel_curve: list         # (frame, voxel_count) samples, to confirm growth
+
+
+def build_map(db: str, max_frames: int | None, progress: bool = True) -> BuildResult:
+    """Replay the recording, accumulating the map; collect robot foot positions."""
+    store = SqliteStore(path=db, must_exist=True)
+    feet = []
+    curve = []
+    with store:
+        assert "pointlio_lidar" in store.list_streams(), store.list_streams()
+        lidar = store.stream("pointlio_lidar", PointCloud2).order_by("ts")
+        odom = store.stream("pointlio_odometry", Odometry).order_by("ts")
+        pose_tagged = lidar.align(odom, tolerance=0.05).transform(FnTransformer(attach_pose))
+        ray_pipeline = pose_tagged.transform(RayTraceMap(
+            voxel_size=VS, max_range=30.0, ray_subsample=1, shadow_depth=0.1,
+            grace_depth=0.2, emit_every=1, min_health=-1, max_health=5, support_min=4))
+        planner = MLSPlanner(
+            voxel_size=VS, robot_height=ROBOT_H, max_overhead_m=2.0,
+            surface_closing_radius=0.3, node_spacing_m=1.0, wall_clearance_m=0.1,
+            wall_buffer_m=0.75, wall_buffer_weight=100.0, step_threshold_m=STEP_THRESH,
+            step_penalty_weight=4.0)
+        n = 0
+        t0 = time.time()
+        for ray_obs in ray_pipeline:
+            if ray_obs.pose_tuple is None:
+                continue
+            ox, oy, radius, z_min, z_max = ray_obs.tags["region_bounds"]
+            px, py, pz, *_ = ray_obs.pose_tuple
+            planner.update_region(ray_obs.data.points_f32(), (ox, oy), radius, z_min, z_max, float(pz))
+            feet.append((float(px), float(py), float(pz) - ROBOT_H))
+            n += 1
+            if n % 100 == 0:
+                curve.append((n, planner.voxel_count()))
+                if progress:
+                    print(f"  frame {n:4d}  voxels={planner.voxel_count():7d}  "
+                          f"z={pz:6.2f}  {time.time()-t0:5.1f}s", flush=True)
+            if max_frames and n >= max_frames:
+                break
+    return BuildResult(planner=planner, feet=np.array(feet, dtype=np.float64), voxel_curve=curve)
+
+
+# ---------------- connectivity diagnostic (union-find over node graph) -------------
+def _key(p, vs=VS):
+    return (int(np.floor(p[0] / vs)), int(np.floor(p[1] / vs)), int(round(p[2] / vs)) - 1)
+
+
+def node_components(planner: MLSPlanner):
+    """Union-find over node_edges() segment endpoints == the components plan() routes over.
+
+    Returns (comp_of_node: list[int], nodes: (K,3)). A node absent from any segment
+    is its own singleton component (the isolated-node case).
+    """
+    nodes = planner.nodes()
+    segs = planner.node_edges()  # (E,7): [x0,y0,z0,x1,y1,z1,cost]
+    parent: dict = {}
+
+    def find(k):
+        parent.setdefault(k, k)
+        root = k
+        while parent[root] != root:
+            root = parent[root]
+        while parent[k] != root:
+            parent[k], k = root, parent[k]
+        return root
+
+    def union(a, b):
+        parent[find(a)] = find(b)
+
+    for r in segs:
+        union(_key(r[0:3]), _key(r[3:6]))
+    node_keys = [_key(n) for n in nodes]
+    roots = {}
+    comp_of = []
+    for k in node_keys:
+        root = find(k) if k in parent else k
+        comp_of.append(roots.setdefault(root, len(roots)))
+    return comp_of, nodes
+
+
+def same_component(nodes, comp_of, a, b) -> bool | None:
+    """Nearest node (3D) to a and to b; are they in the same node component?
+
+    None if there are no nodes. Must use 3D distance: on a multi-floor map the
+    floors overlap in xy (the stairwell), so an xy-only nearest node could land on
+    the wrong floor. Treat as a strong hint; the plan() result is the truth.
+    """
+    if len(nodes) == 0:
+        return None
+    da = np.linalg.norm(nodes - np.asarray(a), axis=1)
+    db = np.linalg.norm(nodes - np.asarray(b), axis=1)
+    return comp_of[int(np.argmin(da))] == comp_of[int(np.argmin(db))]
+
+
+# ---------------- safety guardrail (robot-box vs occupied voxels) -------------
+def path_is_safe(occ: set, path: np.ndarray, radius=ROBOT_RADIUS, height=ROBOT_H, vs=VS) -> bool:
+    """Slide a robot-shaped box along the path; unsafe if it intersects a voxel.
+
+    Skips the floor the robot stands on (band starts 2 voxels above the foot) and
+    checks the body column [foot+2vs, foot+height] within the footprint radius.
+    Light guardrail, not a certified collision check.
+    """
+    rc = int(np.ceil(radius / vs))
+    z_lo = 2  # cells above foot to clear the standing surface
+    z_hi = max(z_lo + 1, int(np.floor(height / vs)))
+    step = vs  # sample step < voxel edge so the box can't tunnel a thin wall
+    for i in range(len(path) - 1):
+        p0, p1 = path[i], path[i + 1]
+        seg = np.linalg.norm(p1 - p0)
+        for t in np.linspace(0.0, 1.0, max(2, int(seg / step) + 1)):
+            c = p0 + t * (p1 - p0)
+            cx, cy, cz = int(np.floor(c[0] / vs)), int(np.floor(c[1] / vs)), int(np.floor(c[2] / vs))
+            for dz in range(z_lo, z_hi + 1):
+                for dx in range(-rc, rc + 1):
+                    for dy in range(-rc, rc + 1):
+                        if dx * dx + dy * dy > rc * rc:
+                            continue
+                        if (cx + dx, cy + dy, cz + dz) in occ:
+                            return False
+    return True
+
+
+# ---------------- pair sampling: floor x floor matrix ------------------------
+@dataclass
+class Scorecard:
+    total: int = 0
+    false_neg: int = 0
+    unsafe: int = 0
+    # (stratA, stratB) -> [n_pairs, n_false_neg, n_disconnected, n_unsafe]
+    cells: dict = field(default_factory=dict)
+    # graph fragmentation context
+    n_nodes: int = 0
+    n_components: int = 0
+    largest_frac: float = 0.0
+
+
+def pick_representatives(feet: np.ndarray, per_stratum: int) -> dict:
+    """Deterministically pick per_stratum foot positions within each floor stratum."""
+    reps = {}
+    for name, lo, hi in STRATA:
+        # feet z has robot_height subtracted; compare the pose z (foot z + ROBOT_H) to bands.
+        idx = np.where((feet[:, 2] + ROBOT_H >= lo) & (feet[:, 2] + ROBOT_H < hi))[0]
+        if len(idx) == 0:
+            continue
+        take = np.linspace(0, len(idx) - 1, min(per_stratum, len(idx))).astype(int)
+        reps[name] = feet[idx[take]]
+    return reps
+
+
+def evaluate(build: BuildResult, per_cell: int = 3) -> Scorecard:
+    planner = build.planner
+    occ = set(map(tuple, np.floor(planner.voxel_map() / VS).astype(int)))
+    comp_of, nodes = node_components(planner)
+    reps = pick_representatives(build.feet, per_cell)
+    sc = Scorecard()
+    # fragmentation context: how many disjoint components did the map shatter into?
+    if len(comp_of):
+        from collections import Counter
+        sizes = Counter(comp_of)
+        sc.n_nodes = len(comp_of)
+        sc.n_components = len(sizes)
+        sc.largest_frac = max(sizes.values()) / len(comp_of)
+    strat_names = [s[0] for s in STRATA if s[0] in reps]
+    for sa in strat_names:
+        for sb in strat_names:
+            key = (sa, sb)
+            cell = [0, 0, 0, 0]
+            for a in reps[sa]:
+                for b in reps[sb]:
+                    if np.allclose(a, b):
+                        continue
+                    cell[0] += 1
+                    sc.total += 1
+                    path = planner.plan(tuple(map(float, a)), tuple(map(float, b)))
+                    if path is None:
+                        cell[1] += 1
+                        sc.false_neg += 1
+                        conn = same_component(nodes, comp_of, a, b)
+                        if conn is False:
+                            cell[2] += 1
+                    else:
+                        if not path_is_safe(occ, np.asarray(path, dtype=np.float64)):
+                            cell[3] += 1
+                            sc.unsafe += 1
+            sc.cells[key] = cell
+    return sc
+
+
+def print_scorecard(sc: Scorecard):
+    print("\n================ MLS planner false-negative scorecard ================")
+    print(f"pairs tested (all feasible by construction): {sc.total}")
+    fnr = 100.0 * sc.false_neg / sc.total if sc.total else 0.0
+    print(f"FALSE NEGATIVES (feasible but plan()->None): {sc.false_neg}  ({fnr:.1f}%)")
+    print(f"UNSAFE paths (returned path clips a voxel):  {sc.unsafe}")
+    print(f"graph: {sc.n_nodes} nodes shattered into {sc.n_components} components; "
+          f"largest holds {100*sc.largest_frac:.1f}% of nodes")
+    print("\nfloor x floor  [pairs | false-neg | of-which-disconnected | unsafe]")
+    names = sorted({k[0] for k in sc.cells} | {k[1] for k in sc.cells},
+                   key=lambda n: [s[1] for s in STRATA if s[0] == n][0])
+    hdr = "start\\goal  " + "".join(f"{n:>14}" for n in names)
+    print(hdr)
+    for sa in names:
+        row = f"{sa:>10}  "
+        for sb in names:
+            c = sc.cells.get((sa, sb))
+            row += f"{('%d|%d|%d|%d' % tuple(c)) if c else '-':>14}"
+        print(row)
+    print("======================================================================")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("db", nargs="?", default="data/mid360_athens_stairs.db")
+    ap.add_argument("--max-frames", type=int, default=None)
+    ap.add_argument("--pairs-per-cell", type=int, default=3)
+    args = ap.parse_args()
+
+    t0 = time.time()
+    print(f"building map from {args.db} ...", flush=True)
+    build = build_map(args.db, args.max_frames)
+    print(f"map built: {build.planner!r}", flush=True)
+    print(f"voxel growth: {build.voxel_curve[:3]} ... {build.voxel_curve[-3:]}", flush=True)
+    grew = all(build.voxel_curve[i][1] <= build.voxel_curve[i + 1][1]
+               for i in range(len(build.voxel_curve) - 1))
+    print(f"voxel_count monotonic non-decreasing (no floor evicted): {grew}", flush=True)
+    sc = evaluate(build, per_cell=args.pairs_per_cell)
+    print_scorecard(sc)
+    print(f"\ntotal wall time: {time.time()-t0:.1f}s", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/dimos/navigation/nav_3d/mls_planner/recording_eval.py
+++ b/dimos/navigation/nav_3d/mls_planner/recording_eval.py
@@ -1,33 +1,55 @@
-#!/usr/bin/env python
-"""False-negative eval for the MLS planner on a recorded multi-floor dataset.
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Idea (issue #2996, scoped with Andrew to "safe path produced iff one exists"):
-  * The robot physically traversed the whole recording in one continuous run, so
-    ANY two points on its odometry trajectory are connected by a real, feasible
-    path -- that is free ground truth, no manual labelling.
-  * We replay the recording through the production pipeline (RayTraceMap ->
-    MLSPlanner.update_region) to build the accumulated multi-floor map, then ask
-    plan(A, B) for many trajectory-derived pairs A, B.
-  * plan() -> None on a pair that is feasible-by-construction is a FALSE NEGATIVE
-    (Andrew: "as soon as there is any disconnect between start and goal it doesn't
-    plan"). We break those down by floor stratum and, via a union-find over the
-    planner's own node graph, prove whether start/goal fell in different connected
-    components (the exact "disconnect" failure).
-  * For pairs that DO plan, a light robot-box-vs-voxel slide flags any path that
-    clips occupied voxels (the "keep paths safe" guardrail). Collision detection
-    proper is a separate downstream module, so this is a guardrail, not a gate.
+"""Recording-based false-negative eval for the MLS planner (issue #2996).
 
-Deliverable is a scorecard: false-negative rate (overall + a floor x floor
-matrix) and unsafe-path count. Objective (Andrew): drive FNs down while keeping
-unsafe at 0.
+Ground truth for free
+---------------------
+The robot traversed the whole recording in one continuous run, so ANY two points
+on its odometry trajectory are connected by a real, feasible path -- no manual
+labelling. We replay the recording through the ONLINE pipeline
+(RayTraceMap -> MLSPlanner.update_region), then ask the planner to connect
+trajectory-sampled start/goal pairs. plan() -> None on a walkable pair is a
+FALSE NEGATIVE (Andrew: "as soon as there is any disconnect between start and
+goal it doesn't plan").
 
-Run:  ~/dimos/.venv/bin/python recording_eval.py [db] [--max-frames N] [--pairs-per-cell K]
+Why this shape
+--------------
+Planning is only as good as the map, so the point of this eval is to measure
+whether changes to the ray-tracing voxel mapper's algorithm/config improve
+planning accuracy. The mapper parameters are therefore a first-class input
+(`MapperConfig`), and `sweep()` runs the eval across several mapper configs and
+tabulates the false-negative rate for each -- an A/B harness for mapper work.
+
+It is deliberately dataset-agnostic: floor levels are detected from the
+trajectory itself (`detect_floors`), so it runs on any recording without tuning.
+
+Outputs a scorecard: overall false-negative rate, a floor x floor matrix, a
+false-negative-vs-separation breakdown, graph fragmentation stats, and a light
+robot-box-vs-voxel safety count (reported, not gated -- true collision checking
+is a separate downstream module).
+
+CLI:
+    python -m dimos.navigation.nav_3d.mls_planner.recording_eval <dataset.db>
+    python -m dimos.navigation.nav_3d.mls_planner.recording_eval <dataset.db> --sweep
 """
 from __future__ import annotations
 
 import argparse
 import time
-from dataclasses import dataclass, field
+from collections import Counter
+from dataclasses import asdict, dataclass, field, replace
 
 import numpy as np
 
@@ -38,32 +60,49 @@ from dimos.msgs.nav_msgs.Odometry import Odometry
 from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
 from dimos.navigation.nav_3d.mls_planner.mls_planner import MLSPlanner
 
-# ---- planner / pipeline params (match plan_rrd + the wiki command) ----
-VS = 0.08          # voxel size (m)
-ROBOT_H = 0.4      # robot height (m) -- from the wiki's canonical command
-STEP_THRESH = 0.16
-# Safety guardrail footprint: flag paths that come CLOSER to a voxel than the
-# planner's own hard wall_clearance (0.1 m) -- i.e. a genuine clearance violation,
-# not a path legitimately hugging a wall at the 0.1 m limit.
-ROBOT_RADIUS = 0.08
 
-# Floor strata (m), derived from the athens z-histogram: basement/landing/ground/upper.
-STRATA = [
-    ("basement", -7.0, -4.0),
-    ("landing", -4.0, -1.5),
-    ("ground", -1.5, 1.0),
-    ("upper", 1.0, 4.0),
-]
+@dataclass(frozen=True)
+class MapperConfig:
+    """Ray-tracing voxel mapper parameters -- the highest-leverage module, since
+    planning is only as good as the map. `sweep()` varies these."""
 
-
-def stratum_of(z: float) -> str | None:
-    for name, lo, hi in STRATA:
-        if lo <= z < hi:
-            return name
-    return None
+    voxel_size: float = 0.08
+    max_range: float = 30.0
+    ray_subsample: int = 1
+    shadow_depth: float = 0.1
+    grace_depth: float = 0.2
+    emit_every: int = 1
+    min_health: int = -1
+    max_health: int = 5
+    support_min: int = 4
 
 
-def attach_pose(pair):
+@dataclass(frozen=True)
+class PlannerConfig:
+    """MLS planner parameters. `voxel_size` is kept in sync with the mapper's."""
+
+    voxel_size: float = 0.08
+    robot_height: float = 0.4
+    max_overhead_m: float = 2.0
+    surface_closing_radius: float = 0.3
+    node_spacing_m: float = 1.0
+    wall_clearance_m: float = 0.1
+    wall_buffer_m: float = 0.75
+    wall_buffer_weight: float = 100.0
+    step_threshold_m: float = 0.16
+    step_penalty_weight: float = 4.0
+
+
+# Convenience constants (also used by the demo/visualization scripts).
+VS = MapperConfig().voxel_size
+ROBOT_H = PlannerConfig().robot_height
+STEP_THRESH = PlannerConfig().step_threshold_m
+
+
+# --------------------------------------------------------------------------- #
+# replay -> map
+# --------------------------------------------------------------------------- #
+def _attach_pose_from_odom(pair):
     lidar_obs, odom_obs = pair.data
     o = odom_obs.data
     return lidar_obs.with_pose((
@@ -76,28 +115,42 @@ def attach_pose(pair):
 @dataclass
 class BuildResult:
     planner: MLSPlanner
-    feet: np.ndarray          # (F,3) robot foot positions along the trajectory
-    voxel_curve: list         # (frame, voxel_count) samples, to confirm growth
+    feet: np.ndarray          # (F, 3) robot foot positions (pose xyz, z minus robot_height)
+    voxel_curve: list         # [(frame, voxel_count)] samples
+    mapper: MapperConfig
+    planner_cfg: PlannerConfig
 
 
-def build_map(db: str, max_frames: int | None, progress: bool = True) -> BuildResult:
-    """Replay the recording, accumulating the map; collect robot foot positions."""
-    store = SqliteStore(path=db, must_exist=True)
-    feet = []
-    curve = []
+def build_map(
+    db_path,
+    mapper: MapperConfig = MapperConfig(),
+    planner_cfg: PlannerConfig = PlannerConfig(),
+    *,
+    lidar_stream: str = "pointlio_lidar",
+    odom_stream: str = "pointlio_odometry",
+    align_tol: float = 0.05,
+    max_frames: int | None = None,
+    progress: bool = False,
+) -> BuildResult:
+    """Replay a recording through RayTraceMap -> MLSPlanner.update_region (the
+    online/production path) and return the accumulated planner + foot trajectory."""
+    if abs(mapper.voxel_size - planner_cfg.voxel_size) > 1e-9:
+        planner_cfg = replace(planner_cfg, voxel_size=mapper.voxel_size)
+
+    store = SqliteStore(path=str(db_path), must_exist=True)
+    feet: list = []
+    curve: list = []
     with store:
-        assert "pointlio_lidar" in store.list_streams(), store.list_streams()
-        lidar = store.stream("pointlio_lidar", PointCloud2).order_by("ts")
-        odom = store.stream("pointlio_odometry", Odometry).order_by("ts")
-        pose_tagged = lidar.align(odom, tolerance=0.05).transform(FnTransformer(attach_pose))
-        ray_pipeline = pose_tagged.transform(RayTraceMap(
-            voxel_size=VS, max_range=30.0, ray_subsample=1, shadow_depth=0.1,
-            grace_depth=0.2, emit_every=1, min_health=-1, max_health=5, support_min=4))
-        planner = MLSPlanner(
-            voxel_size=VS, robot_height=ROBOT_H, max_overhead_m=2.0,
-            surface_closing_radius=0.3, node_spacing_m=1.0, wall_clearance_m=0.1,
-            wall_buffer_m=0.75, wall_buffer_weight=100.0, step_threshold_m=STEP_THRESH,
-            step_penalty_weight=4.0)
+        streams = store.list_streams()
+        if lidar_stream not in streams or odom_stream not in streams:
+            raise ValueError(f"streams {lidar_stream!r}/{odom_stream!r} not found in {streams}")
+        lidar = store.stream(lidar_stream, PointCloud2).order_by("ts")
+        odom = store.stream(odom_stream, Odometry).order_by("ts")
+        pose_tagged = lidar.align(odom, tolerance=align_tol).transform(
+            FnTransformer(_attach_pose_from_odom))
+        ray_pipeline = pose_tagged.transform(RayTraceMap(**asdict(mapper)))
+        planner = MLSPlanner(**asdict(planner_cfg))
+
         n = 0
         t0 = time.time()
         for ray_obs in ray_pipeline:
@@ -106,31 +159,76 @@ def build_map(db: str, max_frames: int | None, progress: bool = True) -> BuildRe
             ox, oy, radius, z_min, z_max = ray_obs.tags["region_bounds"]
             px, py, pz, *_ = ray_obs.pose_tuple
             planner.update_region(ray_obs.data.points_f32(), (ox, oy), radius, z_min, z_max, float(pz))
-            feet.append((float(px), float(py), float(pz) - ROBOT_H))
+            feet.append((float(px), float(py), float(pz) - planner_cfg.robot_height))
             n += 1
             if n % 100 == 0:
                 curve.append((n, planner.voxel_count()))
                 if progress:
                     print(f"  frame {n:4d}  voxels={planner.voxel_count():7d}  "
-                          f"z={pz:6.2f}  {time.time()-t0:5.1f}s", flush=True)
+                          f"z={pz:6.2f}  {time.time() - t0:5.1f}s", flush=True)
             if max_frames and n >= max_frames:
                 break
-    return BuildResult(planner=planner, feet=np.array(feet, dtype=np.float64), voxel_curve=curve)
+    return BuildResult(planner, np.array(feet, dtype=float), curve, mapper, planner_cfg)
 
 
-# ---------------- connectivity diagnostic (union-find over node graph) -------------
+# --------------------------------------------------------------------------- #
+# floor detection (dataset-agnostic)
+# --------------------------------------------------------------------------- #
+def detect_floors(feet: np.ndarray, robot_height: float, *,
+                  bin_m: float = 0.2, dwell_frac: float = 0.04, merge_gap_m: float = 1.0) -> list:
+    """Floor levels = the dwell modes of the trajectory's height histogram.
+
+    The robot lingers on floors (tall histogram bins) and passes through stairs
+    quickly (sparse bins), so the well-populated modes are the floors. Returns a
+    sorted list of z levels (pose height)."""
+    z = feet[:, 2] + robot_height
+    lo, hi = float(z.min()), float(z.max())
+    if hi - lo < merge_gap_m:
+        return [0.5 * (lo + hi)]
+    nbins = int(np.clip(round((hi - lo) / bin_m), 8, 80))
+    hist, edges = np.histogram(z, bins=nbins)
+    centers = 0.5 * (edges[:-1] + edges[1:])
+    thresh = dwell_frac * len(z)
+    peaks = [centers[i] for i in range(nbins)
+             if hist[i] >= thresh
+             and (i == 0 or hist[i] >= hist[i - 1])
+             and (i == nbins - 1 or hist[i] >= hist[i + 1])]
+    merged: list = []
+    for p in sorted(peaks):
+        if merged and p - merged[-1] < merge_gap_m:
+            merged[-1] = 0.5 * (merged[-1] + p)
+        else:
+            merged.append(p)
+    return merged or [0.5 * (lo + hi)]
+
+
+def floor_labels(feet: np.ndarray, levels: list, robot_height: float, band_m: float = 0.75) -> np.ndarray:
+    """Label each foot position by nearest floor level, or -1 if it is between
+    floors (on the stairs). `band_m` shrinks to half the closest floor gap."""
+    if len(levels) > 1:
+        band_m = min(band_m, 0.49 * float(np.min(np.diff(sorted(levels)))))
+    z = feet[:, 2] + robot_height
+    lab = np.full(len(feet), -1, dtype=int)
+    lv = np.asarray(levels)
+    for i, zi in enumerate(z):
+        k = int(np.argmin(np.abs(zi - lv)))
+        if abs(zi - lv[k]) <= band_m:
+            lab[i] = k
+    return lab
+
+
+# --------------------------------------------------------------------------- #
+# connectivity diagnostic (union-find over the planner's own node graph)
+# --------------------------------------------------------------------------- #
 def _key(p, vs=VS):
     return (int(np.floor(p[0] / vs)), int(np.floor(p[1] / vs)), int(round(p[2] / vs)) - 1)
 
 
-def node_components(planner: MLSPlanner):
-    """Union-find over node_edges() segment endpoints == the components plan() routes over.
-
-    Returns (comp_of_node: list[int], nodes: (K,3)). A node absent from any segment
-    is its own singleton component (the isolated-node case).
-    """
+def node_components(planner: MLSPlanner, vs: float = VS):
+    """Union-find over node_edges() segment endpoints == the components plan()
+    routes over. Returns (comp_of_node: list[int], nodes: (K,3))."""
     nodes = planner.nodes()
-    segs = planner.node_edges()  # (E,7): [x0,y0,z0,x1,y1,z1,cost]
+    segs = planner.node_edges()  # (E, 7): [x0,y0,z0,x1,y1,z1,cost]
     parent: dict = {}
 
     def find(k):
@@ -142,168 +240,219 @@ def node_components(planner: MLSPlanner):
             parent[k], k = root, parent[k]
         return root
 
-    def union(a, b):
-        parent[find(a)] = find(b)
-
     for r in segs:
-        union(_key(r[0:3]), _key(r[3:6]))
-    node_keys = [_key(n) for n in nodes]
-    roots = {}
+        parent[find(_key(r[0:3], vs))] = find(_key(r[3:6], vs))
+
+    roots: dict = {}
     comp_of = []
-    for k in node_keys:
+    for n in nodes:
+        k = _key(n, vs)
         root = find(k) if k in parent else k
         comp_of.append(roots.setdefault(root, len(roots)))
     return comp_of, nodes
 
 
-def same_component(nodes, comp_of, a, b) -> bool | None:
-    """Nearest node (3D) to a and to b; are they in the same node component?
-
-    None if there are no nodes. Must use 3D distance: on a multi-floor map the
-    floors overlap in xy (the stairwell), so an xy-only nearest node could land on
-    the wrong floor. Treat as a strong hint; the plan() result is the truth.
-    """
+def same_component(nodes, comp_of, a, b):
+    """Nearest node (3D) to a and to b: same component? None if no nodes. 3D
+    distance is required -- floors overlap in xy at the stairwell."""
     if len(nodes) == 0:
         return None
-    da = np.linalg.norm(nodes - np.asarray(a), axis=1)
-    db = np.linalg.norm(nodes - np.asarray(b), axis=1)
-    return comp_of[int(np.argmin(da))] == comp_of[int(np.argmin(db))]
+    ia = int(np.argmin(np.linalg.norm(nodes - np.asarray(a), axis=1)))
+    ib = int(np.argmin(np.linalg.norm(nodes - np.asarray(b), axis=1)))
+    return comp_of[ia] == comp_of[ib]
 
 
-# ---------------- safety guardrail (robot-box vs occupied voxels) -------------
-def path_is_safe(occ: set, path: np.ndarray, radius=ROBOT_RADIUS, height=ROBOT_H, vs=VS) -> bool:
+# --------------------------------------------------------------------------- #
+# safety guardrail (robot-box vs occupied voxels) -- light, reported not gated
+# --------------------------------------------------------------------------- #
+def path_is_safe(occ: set, path: np.ndarray, *, radius: float, height: float, vs: float) -> bool:
     """Slide a robot-shaped box along the path; unsafe if it intersects a voxel.
-
-    Skips the floor the robot stands on (band starts 2 voxels above the foot) and
-    checks the body column [foot+2vs, foot+height] within the footprint radius.
-    Light guardrail, not a certified collision check.
-    """
+    Skips the standing surface (band starts 2 voxels above the foot). Approximate:
+    over-flags where the path legitimately hugs a stair edge."""
     rc = int(np.ceil(radius / vs))
-    z_lo = 2  # cells above foot to clear the standing surface
-    z_hi = max(z_lo + 1, int(np.floor(height / vs)))
-    step = vs  # sample step < voxel edge so the box can't tunnel a thin wall
+    z_lo, z_hi = 2, max(3, int(np.floor(height / vs)))
     for i in range(len(path) - 1):
         p0, p1 = path[i], path[i + 1]
-        seg = np.linalg.norm(p1 - p0)
-        for t in np.linspace(0.0, 1.0, max(2, int(seg / step) + 1)):
+        seg = float(np.linalg.norm(p1 - p0))
+        for t in np.linspace(0.0, 1.0, max(2, int(seg / vs) + 1)):
             c = p0 + t * (p1 - p0)
             cx, cy, cz = int(np.floor(c[0] / vs)), int(np.floor(c[1] / vs)), int(np.floor(c[2] / vs))
             for dz in range(z_lo, z_hi + 1):
                 for dx in range(-rc, rc + 1):
                     for dy in range(-rc, rc + 1):
-                        if dx * dx + dy * dy > rc * rc:
-                            continue
-                        if (cx + dx, cy + dy, cz + dz) in occ:
+                        if dx * dx + dy * dy <= rc * rc and (cx + dx, cy + dy, cz + dz) in occ:
                             return False
     return True
 
 
-# ---------------- pair sampling: floor x floor matrix ------------------------
+# --------------------------------------------------------------------------- #
+# evaluation
+# --------------------------------------------------------------------------- #
 @dataclass
 class Scorecard:
     total: int = 0
     false_neg: int = 0
     unsafe: int = 0
-    # (stratA, stratB) -> [n_pairs, n_false_neg, n_disconnected, n_unsafe]
-    cells: dict = field(default_factory=dict)
-    # graph fragmentation context
+    floor_levels: list = field(default_factory=list)
+    cells: dict = field(default_factory=dict)          # (i, j) -> [pairs, fn, disconnected, unsafe]
+    by_distance: dict = field(default_factory=dict)    # upper_bound_m -> [pairs, fn]
     n_nodes: int = 0
     n_components: int = 0
     largest_frac: float = 0.0
+    mapper: MapperConfig | None = None
+    planner_cfg: PlannerConfig | None = None
+
+    @property
+    def fn_rate(self) -> float:
+        return self.false_neg / self.total if self.total else 0.0
 
 
-def pick_representatives(feet: np.ndarray, per_stratum: int) -> dict:
-    """Deterministically pick per_stratum foot positions within each floor stratum."""
-    reps = {}
-    for name, lo, hi in STRATA:
-        # feet z has robot_height subtracted; compare the pose z (foot z + ROBOT_H) to bands.
-        idx = np.where((feet[:, 2] + ROBOT_H >= lo) & (feet[:, 2] + ROBOT_H < hi))[0]
-        if len(idx) == 0:
-            continue
-        take = np.linspace(0, len(idx) - 1, min(per_stratum, len(idx))).astype(int)
-        reps[name] = feet[idx[take]]
-    return reps
+def _pick(feet, labels, floor_k, per_floor):
+    idx = np.where(labels == floor_k)[0]
+    if len(idx) == 0:
+        return np.empty((0, 3))
+    take = np.linspace(0, len(idx) - 1, min(per_floor, len(idx))).astype(int)
+    return feet[idx[take]]
 
 
-def evaluate(build: BuildResult, per_cell: int = 3) -> Scorecard:
+def evaluate(build: BuildResult, *, per_floor: int = 3, dist_buckets=(2.0, 5.0, 10.0, 1e9)) -> Scorecard:
+    """Plan every start/goal pair sampled from the trajectory; tally false negatives."""
     planner = build.planner
-    occ = set(map(tuple, np.floor(planner.voxel_map() / VS).astype(int)))
-    comp_of, nodes = node_components(planner)
-    reps = pick_representatives(build.feet, per_cell)
-    sc = Scorecard()
-    # fragmentation context: how many disjoint components did the map shatter into?
-    if len(comp_of):
-        from collections import Counter
+    cfg = build.planner_cfg
+    vs = cfg.voxel_size
+    occ = set(map(tuple, np.floor(planner.voxel_map() / vs).astype(int)))
+    comp_of, nodes = node_components(planner, vs)
+    levels = detect_floors(build.feet, cfg.robot_height)
+    labels = floor_labels(build.feet, levels, cfg.robot_height)
+
+    sc = Scorecard(floor_levels=[round(float(l), 1) for l in levels],
+                   mapper=build.mapper, planner_cfg=cfg)
+    if comp_of:
         sizes = Counter(comp_of)
-        sc.n_nodes = len(comp_of)
-        sc.n_components = len(sizes)
+        sc.n_nodes, sc.n_components = len(comp_of), len(sizes)
         sc.largest_frac = max(sizes.values()) / len(comp_of)
-    strat_names = [s[0] for s in STRATA if s[0] in reps]
-    for sa in strat_names:
-        for sb in strat_names:
-            key = (sa, sb)
+
+    reps = {k: _pick(build.feet, labels, k, per_floor) for k in range(len(levels))}
+    radius = min(cfg.wall_clearance_m, vs)
+    for i in range(len(levels)):
+        for j in range(len(levels)):
             cell = [0, 0, 0, 0]
-            for a in reps[sa]:
-                for b in reps[sb]:
+            for a in reps[i]:
+                for b in reps[j]:
                     if np.allclose(a, b):
                         continue
                     cell[0] += 1
                     sc.total += 1
+                    d = float(np.linalg.norm(a - b))
+                    bucket = next(bk for bk in dist_buckets if d <= bk)
+                    db_row = sc.by_distance.setdefault(bucket, [0, 0])
+                    db_row[0] += 1
                     path = planner.plan(tuple(map(float, a)), tuple(map(float, b)))
                     if path is None:
                         cell[1] += 1
                         sc.false_neg += 1
-                        conn = same_component(nodes, comp_of, a, b)
-                        if conn is False:
+                        db_row[1] += 1
+                        if same_component(nodes, comp_of, a, b) is False:
                             cell[2] += 1
-                    else:
-                        if not path_is_safe(occ, np.asarray(path, dtype=np.float64)):
-                            cell[3] += 1
-                            sc.unsafe += 1
-            sc.cells[key] = cell
+                    elif not path_is_safe(occ, np.asarray(path, dtype=float),
+                                          radius=radius, height=cfg.robot_height, vs=vs):
+                        cell[3] += 1
+                        sc.unsafe += 1
+            sc.cells[(i, j)] = cell
     return sc
 
 
+def run_eval(db_path, mapper: MapperConfig = MapperConfig(),
+             planner_cfg: PlannerConfig = PlannerConfig(), *,
+             per_floor: int = 3, max_frames: int | None = None, progress: bool = False) -> Scorecard:
+    build = build_map(db_path, mapper, planner_cfg, max_frames=max_frames, progress=progress)
+    return evaluate(build, per_floor=per_floor)
+
+
+def sweep(db_path, mapper_configs: list, planner_cfg: PlannerConfig = PlannerConfig(),
+          *, per_floor: int = 3, max_frames: int | None = None, progress: bool = True) -> list:
+    """Run the eval for each (label, MapperConfig); return [(label, Scorecard)].
+
+    This is the A/B harness for mapper work: change the mapper config, see if the
+    planning false-negative rate moves. Pass `max_frames` to iterate on a capped
+    replay before committing to full runs."""
+    rows = []
+    for label, mc in mapper_configs:
+        sc = run_eval(db_path, mc, planner_cfg, per_floor=per_floor, max_frames=max_frames)
+        rows.append((label, sc))
+        if progress:
+            print(f"[sweep] {label:22s} FN={100 * sc.fn_rate:5.1f}%  "
+                  f"nodes={sc.n_nodes:5d}  components={sc.n_components:5d}", flush=True)
+    return rows
+
+
+# --------------------------------------------------------------------------- #
+# reporting
+# --------------------------------------------------------------------------- #
 def print_scorecard(sc: Scorecard):
     print("\n================ MLS planner false-negative scorecard ================")
+    print(f"floors detected (z, m): {sc.floor_levels}")
     print(f"pairs tested (all feasible by construction): {sc.total}")
-    fnr = 100.0 * sc.false_neg / sc.total if sc.total else 0.0
-    print(f"FALSE NEGATIVES (feasible but plan()->None): {sc.false_neg}  ({fnr:.1f}%)")
-    print(f"UNSAFE paths (returned path clips a voxel):  {sc.unsafe}")
-    print(f"graph: {sc.n_nodes} nodes shattered into {sc.n_components} components; "
-          f"largest holds {100*sc.largest_frac:.1f}% of nodes")
+    print(f"FALSE NEGATIVES (feasible but plan()->None): {sc.false_neg}  ({100 * sc.fn_rate:.1f}%)")
+    print(f"UNSAFE produced paths (approx guardrail):    {sc.unsafe}")
+    print(f"graph: {sc.n_nodes} nodes in {sc.n_components} components; "
+          f"largest holds {100 * sc.largest_frac:.1f}%")
+    print("\nfalse-negatives by start/goal separation:")
+    for bk in sorted(sc.by_distance):
+        pairs, fn = sc.by_distance[bk]
+        label = f"<={bk:g}m" if bk < 1e9 else ">10m"
+        print(f"  {label:>6}: {fn}/{pairs}  ({100 * fn / max(1, pairs):.0f}%)")
     print("\nfloor x floor  [pairs | false-neg | of-which-disconnected | unsafe]")
-    names = sorted({k[0] for k in sc.cells} | {k[1] for k in sc.cells},
-                   key=lambda n: [s[1] for s in STRATA if s[0] == n][0])
-    hdr = "start\\goal  " + "".join(f"{n:>14}" for n in names)
-    print(hdr)
-    for sa in names:
-        row = f"{sa:>10}  "
-        for sb in names:
-            c = sc.cells.get((sa, sb))
-            row += f"{('%d|%d|%d|%d' % tuple(c)) if c else '-':>14}"
+    lv = sc.floor_levels
+    header = "start\\goal " + "".join(f"{f'z={v:g}':>15}" for v in lv)
+    print(header)
+    for i, vi in enumerate(lv):
+        row = f"{f'z={vi:g}':>10} "
+        for j in range(len(lv)):
+            c = sc.cells.get((i, j))
+            row += f"{('%d|%d|%d|%d' % tuple(c)) if c else '-':>15}"
         print(row)
     print("======================================================================")
 
 
+def print_sweep(rows: list):
+    print("\n==================== mapper-config sweep ====================")
+    print(f"{'config':24s}{'FN rate':>10}{'cross-floor FN':>16}{'nodes':>8}{'comps':>8}")
+    for label, sc in rows:
+        off = [c for (i, j), c in sc.cells.items() if i != j and c[0] > 0]
+        off_pairs = sum(c[0] for c in off) or 1
+        off_fn = sum(c[1] for c in off)
+        print(f"{label:24s}{100 * sc.fn_rate:9.1f}%{100 * off_fn / off_pairs:15.1f}%"
+              f"{sc.n_nodes:8d}{sc.n_components:8d}")
+    print("lower FN rate = the mapper config yields a better-connected map for planning")
+    print("============================================================")
+
+
 def main():
-    ap = argparse.ArgumentParser()
-    ap.add_argument("db", nargs="?", default="data/mid360_athens_stairs.db")
-    ap.add_argument("--max-frames", type=int, default=None)
-    ap.add_argument("--pairs-per-cell", type=int, default=3)
+    ap = argparse.ArgumentParser(description="Recording-based MLS-planner false-negative eval")
+    ap.add_argument("db", help="recording .db (path)")
+    ap.add_argument("--sweep", action="store_true", help="A/B several mapper configs")
+    ap.add_argument("--per-floor", type=int, default=3, help="representative points sampled per floor")
+    ap.add_argument("--max-frames", type=int, default=None, help="cap replayed frames (debugging)")
     args = ap.parse_args()
 
-    t0 = time.time()
-    print(f"building map from {args.db} ...", flush=True)
-    build = build_map(args.db, args.max_frames)
-    print(f"map built: {build.planner!r}", flush=True)
-    print(f"voxel growth: {build.voxel_curve[:3]} ... {build.voxel_curve[-3:]}", flush=True)
-    grew = all(build.voxel_curve[i][1] <= build.voxel_curve[i + 1][1]
-               for i in range(len(build.voxel_curve) - 1))
-    print(f"voxel_count monotonic non-decreasing (no floor evicted): {grew}", flush=True)
-    sc = evaluate(build, per_cell=args.pairs_per_cell)
-    print_scorecard(sc)
-    print(f"\ntotal wall time: {time.time()-t0:.1f}s", flush=True)
+    planner_cfg = PlannerConfig()
+    if args.sweep:
+        configs = [
+            ("baseline", MapperConfig()),
+            ("support_min=2", MapperConfig(support_min=2)),
+            ("support_min=0", MapperConfig(support_min=0)),
+            ("voxel=0.10", MapperConfig(voxel_size=0.10)),
+            ("shadow_depth=0.2", MapperConfig(shadow_depth=0.2)),
+        ]
+        print_sweep(sweep(args.db, configs, planner_cfg,
+                          per_floor=args.per_floor, max_frames=args.max_frames))
+    else:
+        t0 = time.time()
+        build = build_map(args.db, MapperConfig(), planner_cfg,
+                          max_frames=args.max_frames, progress=True)
+        print(f"map built: {build.planner!r}  ({time.time() - t0:.0f}s)")
+        print_scorecard(evaluate(build, per_floor=args.per_floor))
 
 
 if __name__ == "__main__":

--- a/dimos/navigation/nav_3d/mls_planner/recording_eval.py
+++ b/dimos/navigation/nav_3d/mls_planner/recording_eval.py
@@ -168,7 +168,12 @@ def build_map(
                           f"z={pz:6.2f}  {time.time() - t0:5.1f}s", flush=True)
             if max_frames and n >= max_frames:
                 break
-    return BuildResult(planner, np.array(feet, dtype=float), curve, mapper, planner_cfg)
+    feet_arr = np.array(feet, dtype=float)
+    if feet_arr.size == 0:
+        raise ValueError(
+            f"no aligned lidar/odometry observations (align_tol={align_tol}) in "
+            f"{db_path}; check the stream names and that lidar/odom timestamps overlap")
+    return BuildResult(planner, feet_arr, curve, mapper, planner_cfg)
 
 
 # --------------------------------------------------------------------------- #
@@ -181,6 +186,8 @@ def detect_floors(feet: np.ndarray, robot_height: float, *,
     The robot lingers on floors (tall histogram bins) and passes through stairs
     quickly (sparse bins), so the well-populated modes are the floors. Returns a
     sorted list of z levels (pose height)."""
+    if feet.ndim != 2 or len(feet) == 0:
+        raise ValueError("detect_floors: need a non-empty (N, 3) trajectory")
     z = feet[:, 2] + robot_height
     lo, hi = float(z.min()), float(z.max())
     if hi - lo < merge_gap_m:

--- a/dimos/navigation/nav_3d/mls_planner/test_recording_eval.py
+++ b/dimos/navigation/nav_3d/mls_planner/test_recording_eval.py
@@ -16,18 +16,16 @@
 
 The robot traversed the whole recording in one continuous run, so every pair of
 points on its odometry trajectory is connected by a real feasible path -- free
-ground truth, no manual labelling. We replay the recording through the production
-pipeline (RayTraceMap -> MLSPlanner.update_region) to build the accumulated
-multi-floor map, then ask plan(A, B) for a floor x floor matrix of trajectory
-pairs. plan()->None on a feasible pair is a FALSE NEGATIVE (Andrew: "as soon as
-there is any disconnect between start and goal it doesn't plan").
+ground truth, no manual labelling. We replay the recording through the online
+pipeline (RayTraceMap -> MLSPlanner.update_region) to build the accumulated map,
+then ask plan(A, B) for a floor x floor matrix of trajectory pairs. plan()->None
+on a feasible pair is a FALSE NEGATIVE.
 
 This is a REGRESSION BASELINE, not a pass/fail gate: the current planner produces
 many false negatives on this hard dataset (sparse 45-degree-lidar stair points +
-noise shatter the traversability graph). The objective (issue #2996) is to drive
-the false-negative count DOWN while keeping produced paths safe; this test fails
-if it regresses UP past the recorded baseline. Lower BASELINE_FALSE_NEG as the
-planner improves.
+noise shatter the traversability graph). The objective is to drive that count
+DOWN -- typically by improving the ray-tracing mapper; this test fails if it
+regresses UP past the recorded baseline. Lower BASELINE_FALSE_NEG as it improves.
 
 Marked self_hosted: needs the native extensions + the LFS dataset and does a full
 replay (~5 min), so it is deselected from the default CI run.
@@ -41,6 +39,7 @@ pytest.importorskip("dimos_mls_planner")
 pytest.importorskip("dimos_voxel_ray_tracing")
 
 from dimos.navigation.nav_3d.mls_planner.recording_eval import (  # noqa: E402
+    MapperConfig,
     build_map,
     evaluate,
     print_scorecard,
@@ -50,13 +49,14 @@ from dimos.utils.data import get_data  # noqa: E402
 pytestmark = [pytest.mark.self_hosted]
 
 DATASET = "mid360_athens_stairs.db"
-PER_CELL = 4  # -> 240 feasible pairs across the 4 floor strata
+PER_FLOOR = 4
 
-# Baseline measured 2026-07-22 on the incremental (production) map: 210/240 false
-# negatives. Deterministic (Dijkstra planner + deterministic sampling). This test
-# guards against regression; lower it as false negatives are fixed.
-BASELINE_FALSE_NEG = 210
-EXPECTED_TOTAL = 240
+# Baseline measured on the incremental (production) map with the default
+# MapperConfig: 112/132 false negatives across 3 auto-detected floors.
+# Deterministic (Dijkstra planner + deterministic sampling). This test guards
+# against regression; lower it as the mapper/planner improves.
+BASELINE_FALSE_NEG = 112
+MIN_FLOORS = 2
 
 
 @pytest.fixture(scope="module")
@@ -73,34 +73,48 @@ def scorecard():
             pytest.skip(f"dataset unavailable ({DATASET}): {exc}")
         if not path or not path.exists():
             pytest.skip(f"dataset not found: {DATASET}")
-    build = build_map(str(path), max_frames=None, progress=False)
-    sc = evaluate(build, per_cell=PER_CELL)
+    build = build_map(str(path), MapperConfig(), progress=False)
+    sc = evaluate(build, per_floor=PER_FLOOR)
     print_scorecard(sc)  # visible with -s; this is the metric issue #2996 tracks
     return sc
 
 
+def test_eval_produces_multifloor_scorecard(scorecard):
+    """Smoke + generalization: floors are auto-detected and pairs are tested."""
+    assert len(scorecard.floor_levels) >= MIN_FLOORS, scorecard.floor_levels
+    assert scorecard.total > 0
+
+
 def test_false_negatives_do_not_regress(scorecard):
     """The headline metric: feasible pairs the planner fails to route."""
-    assert scorecard.total == EXPECTED_TOTAL, scorecard.total
     assert scorecard.false_neg <= BASELINE_FALSE_NEG, (
         f"false negatives {scorecard.false_neg}/{scorecard.total} regressed past "
-        f"baseline {BASELINE_FALSE_NEG} -- the planner got WORSE at routing "
-        f"feasible pairs on the athens dataset"
+        f"baseline {BASELINE_FALSE_NEG} -- routing of feasible pairs got WORSE"
     )
 
 
 def test_every_false_negative_is_a_real_disconnect(scorecard):
     """Structural invariant: the union-find disconnect diagnostic can only explain
-    false negatives it actually found, never more. Confirms the eval is measuring
-    genuine 'separate connected surface components' failures, not artifacts."""
-    for (sa, sb), (n_pairs, n_fn, n_disc, _n_unsafe) in scorecard.cells.items():
-        assert n_disc <= n_fn, f"cell {sa}->{sb}: {n_disc} disconnects > {n_fn} false negatives"
+    false negatives it actually found, never more -- so the eval measures genuine
+    'separate connected surface components' failures, not artifacts."""
+    for (i, j), (n_pairs, n_fn, n_disc, _unsafe) in scorecard.cells.items():
+        assert n_disc <= n_fn, f"cell {i}->{j}: {n_disc} disconnects > {n_fn} false negatives"
 
 
-def test_produced_paths_reported_for_safety(scorecard, capsys):
+def test_same_floor_no_harder_than_cross_floor(scorecard):
+    """Dataset-agnostic sanity: same-floor routes should be no harder to plan than
+    cross-floor ones. If this inverts, the eval or map is broken."""
+    diag = [c for (i, j), c in scorecard.cells.items() if i == j and c[0] > 0]
+    off = [c for (i, j), c in scorecard.cells.items() if i != j and c[0] > 0]
+    if not diag or not off:
+        pytest.skip("need both same-floor and cross-floor pairs")
+    diag_rate = sum(c[1] for c in diag) / sum(c[0] for c in diag)
+    off_rate = sum(c[1] for c in off) / sum(c[0] for c in off)
+    assert diag_rate <= off_rate + 1e-9, f"same-floor FN {diag_rate:.2f} > cross-floor {off_rate:.2f}"
+
+
+def test_produced_paths_reported_for_safety(scorecard):
     """The safety guardrail (box-slide vs voxels) is reported, not gated: it is a
-    coarse 2.5D check that over-flags on multi-level surfaces (stair steps), so it
-    is informational until calibrated to the planner's clearance model. Collision
-    checking proper is a separate downstream module (per issue #2996 scope)."""
-    # No assertion on scorecard.unsafe -- surfaced in the printed scorecard instead.
-    assert scorecard.total > 0
+    coarse 2.5D check that over-flags on stair steps, so it is informational until
+    calibrated. Collision checking proper is a separate downstream module."""
+    assert scorecard.unsafe >= 0  # executed; value surfaced in the printed scorecard

--- a/dimos/navigation/nav_3d/mls_planner/test_recording_eval.py
+++ b/dimos/navigation/nav_3d/mls_planner/test_recording_eval.py
@@ -38,9 +38,12 @@ import pytest
 pytest.importorskip("dimos_mls_planner")
 pytest.importorskip("dimos_voxel_ray_tracing")
 
+import numpy as np  # noqa: E402
+
 from dimos.navigation.nav_3d.mls_planner.recording_eval import (  # noqa: E402
     MapperConfig,
     build_map,
+    detect_floors,
     evaluate,
     print_scorecard,
 )
@@ -53,9 +56,13 @@ PER_FLOOR = 4
 
 # Baseline measured on the incremental (production) map with the default
 # MapperConfig: 112/132 false negatives across 3 auto-detected floors.
-# Deterministic (Dijkstra planner + deterministic sampling). This test guards
-# against regression; lower it as the mapper/planner improves.
+# Deterministic (Dijkstra planner + deterministic sampling). EXPECTED_TOTAL pins
+# the denominator so the absolute baseline stays comparable -- fewer detected
+# floors would shrink the pair count and let a worse failure RATE slip under the
+# absolute count. This test guards against regression; lower it as the eval
+# improves (and re-measure EXPECTED_TOTAL if the sampling changes).
 BASELINE_FALSE_NEG = 112
+EXPECTED_TOTAL = 132
 MIN_FLOORS = 2
 
 
@@ -87,18 +94,31 @@ def test_eval_produces_multifloor_scorecard(scorecard):
 
 def test_false_negatives_do_not_regress(scorecard):
     """The headline metric: feasible pairs the planner fails to route."""
+    # Pin the denominator: the absolute baseline is only meaningful over the same
+    # number of pairs it was measured on. Fewer detected floors -> fewer pairs ->
+    # a worse RATE could otherwise slip under the absolute count.
+    assert scorecard.total == EXPECTED_TOTAL, (
+        f"denominator changed ({scorecard.total} != {EXPECTED_TOTAL}); "
+        f"floors={scorecard.floor_levels} -- re-measure the baseline before trusting it"
+    )
     assert scorecard.false_neg <= BASELINE_FALSE_NEG, (
         f"false negatives {scorecard.false_neg}/{scorecard.total} regressed past "
         f"baseline {BASELINE_FALSE_NEG} -- routing of feasible pairs got WORSE"
     )
 
 
-def test_every_false_negative_is_a_real_disconnect(scorecard):
-    """Structural invariant: the union-find disconnect diagnostic can only explain
-    false negatives it actually found, never more -- so the eval measures genuine
-    'separate connected surface components' failures, not artifacts."""
-    for (i, j), (n_pairs, n_fn, n_disc, _unsafe) in scorecard.cells.items():
-        assert n_disc <= n_fn, f"cell {i}->{j}: {n_disc} disconnects > {n_fn} false negatives"
+def test_false_negatives_are_explained_by_disconnects(scorecard):
+    """The diagnostic must actually EXPLAIN the failures: (nearly) every false
+    negative is a confirmed graph disconnect (start/goal in different connected
+    components). That is the finding -- and unlike `n_disc <= n_fn` (true by
+    construction), this can fail if the union-find stops matching the planner."""
+    total_fn = sum(c[1] for c in scorecard.cells.values())
+    total_disc = sum(c[2] for c in scorecard.cells.values())
+    assert total_fn > 0, "expected some false negatives to explain on this dataset"
+    assert total_disc / total_fn >= 0.9, (
+        f"only {total_disc}/{total_fn} false negatives are confirmed disconnects; "
+        f"the union-find diagnostic no longer matches the planner's routing"
+    )
 
 
 def test_same_floor_no_harder_than_cross_floor(scorecard):
@@ -113,8 +133,17 @@ def test_same_floor_no_harder_than_cross_floor(scorecard):
     assert diag_rate <= off_rate + 1e-9, f"same-floor FN {diag_rate:.2f} > cross-floor {off_rate:.2f}"
 
 
-def test_produced_paths_reported_for_safety(scorecard):
-    """The safety guardrail (box-slide vs voxels) is reported, not gated: it is a
-    coarse 2.5D check that over-flags on stair steps, so it is informational until
-    calibrated. Collision checking proper is a separate downstream module."""
-    assert scorecard.unsafe >= 0  # executed; value surfaced in the printed scorecard
+def test_safety_guardrail_is_exercised(scorecard):
+    """The safety guardrail (box-slide vs voxels) runs on every produced path.
+    Assert it was actually exercised (some pairs did plan) and stayed within bounds
+    -- unlike `unsafe >= 0`, which is true for a counter that never ran. Reported,
+    not gated: a coarse 2.5D check that over-flags on stair steps."""
+    produced = scorecard.total - scorecard.false_neg
+    assert produced > 0, "no paths were produced, so the safety guardrail never ran"
+    assert 0 <= scorecard.unsafe <= produced
+
+
+def test_detect_floors_rejects_empty_trajectory():
+    """Empty/failed replays must raise a clear error, not an opaque IndexError."""
+    with pytest.raises(ValueError):
+        detect_floors(np.empty((0, 3)), robot_height=0.4)

--- a/dimos/navigation/nav_3d/mls_planner/test_recording_eval.py
+++ b/dimos/navigation/nav_3d/mls_planner/test_recording_eval.py
@@ -1,0 +1,106 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Recorded-dataset false-negative regression test for the MLS planner (issue #2996).
+
+The robot traversed the whole recording in one continuous run, so every pair of
+points on its odometry trajectory is connected by a real feasible path -- free
+ground truth, no manual labelling. We replay the recording through the production
+pipeline (RayTraceMap -> MLSPlanner.update_region) to build the accumulated
+multi-floor map, then ask plan(A, B) for a floor x floor matrix of trajectory
+pairs. plan()->None on a feasible pair is a FALSE NEGATIVE (Andrew: "as soon as
+there is any disconnect between start and goal it doesn't plan").
+
+This is a REGRESSION BASELINE, not a pass/fail gate: the current planner produces
+many false negatives on this hard dataset (sparse 45-degree-lidar stair points +
+noise shatter the traversability graph). The objective (issue #2996) is to drive
+the false-negative count DOWN while keeping produced paths safe; this test fails
+if it regresses UP past the recorded baseline. Lower BASELINE_FALSE_NEG as the
+planner improves.
+
+Marked self_hosted: needs the native extensions + the LFS dataset and does a full
+replay (~5 min), so it is deselected from the default CI run.
+"""
+import os
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("dimos_mls_planner")
+pytest.importorskip("dimos_voxel_ray_tracing")
+
+from dimos.navigation.nav_3d.mls_planner.recording_eval import (  # noqa: E402
+    build_map,
+    evaluate,
+    print_scorecard,
+)
+from dimos.utils.data import get_data  # noqa: E402
+
+pytestmark = [pytest.mark.self_hosted]
+
+DATASET = "mid360_athens_stairs.db"
+PER_CELL = 4  # -> 240 feasible pairs across the 4 floor strata
+
+# Baseline measured 2026-07-22 on the incremental (production) map: 210/240 false
+# negatives. Deterministic (Dijkstra planner + deterministic sampling). This test
+# guards against regression; lower it as false negatives are fixed.
+BASELINE_FALSE_NEG = 210
+EXPECTED_TOTAL = 240
+
+
+@pytest.fixture(scope="module")
+def scorecard():
+    # DIMOS_RECORDING_DB lets a dev point at a local .db (e.g. a host without
+    # git-lfs); otherwise fetch the LFS dataset the canonical way.
+    override = os.environ.get("DIMOS_RECORDING_DB")
+    if override and Path(override).exists():
+        path = Path(override)
+    else:
+        try:
+            path = get_data(DATASET)
+        except Exception as exc:  # e.g. git-lfs missing on this host
+            pytest.skip(f"dataset unavailable ({DATASET}): {exc}")
+        if not path or not path.exists():
+            pytest.skip(f"dataset not found: {DATASET}")
+    build = build_map(str(path), max_frames=None, progress=False)
+    sc = evaluate(build, per_cell=PER_CELL)
+    print_scorecard(sc)  # visible with -s; this is the metric issue #2996 tracks
+    return sc
+
+
+def test_false_negatives_do_not_regress(scorecard):
+    """The headline metric: feasible pairs the planner fails to route."""
+    assert scorecard.total == EXPECTED_TOTAL, scorecard.total
+    assert scorecard.false_neg <= BASELINE_FALSE_NEG, (
+        f"false negatives {scorecard.false_neg}/{scorecard.total} regressed past "
+        f"baseline {BASELINE_FALSE_NEG} -- the planner got WORSE at routing "
+        f"feasible pairs on the athens dataset"
+    )
+
+
+def test_every_false_negative_is_a_real_disconnect(scorecard):
+    """Structural invariant: the union-find disconnect diagnostic can only explain
+    false negatives it actually found, never more. Confirms the eval is measuring
+    genuine 'separate connected surface components' failures, not artifacts."""
+    for (sa, sb), (n_pairs, n_fn, n_disc, _n_unsafe) in scorecard.cells.items():
+        assert n_disc <= n_fn, f"cell {sa}->{sb}: {n_disc} disconnects > {n_fn} false negatives"
+
+
+def test_produced_paths_reported_for_safety(scorecard, capsys):
+    """The safety guardrail (box-slide vs voxels) is reported, not gated: it is a
+    coarse 2.5D check that over-flags on multi-level surfaces (stair steps), so it
+    is informational until calibrated to the planner's clearance model. Collision
+    checking proper is a separate downstream module (per issue #2996 scope)."""
+    # No assertion on scorecard.unsafe -- surfaced in the printed scorecard instead.
+    assert scorecard.total > 0


### PR DESCRIPTION
## Contribution path

- Linked issue: #2996


## Problem

The MLS planner can return "no path" when a path actually exists. There was no automated way to (a) score the planner on a real recording or (b) tell whether a change to the mapper improves planning.

## Solution
A recording-based false-negative eval. The robot traverses the whole recording in one continuous run so any points on its odometry trajectory are provably reachable. The eval replays a recording through the online pipeline, then asks `plan(A, B)` for trajectory-sampled start/goal pairs and `plan() -> None` on a walkable pair is a false negative.

Baseline on `mid360_athens_stairs`: 112/132 false negatives across 3 auto-detected floors. false negatives rise with separation.

Ships as `recording_eval.py` + a `self_hosted` regression test (`test_recording_eval.py`).

## How to Test

uv run python -m dimos.navigation.nav_3d.mls_planner.recording_eval data/mid360_athens_stairs.db
uv run python -m dimos.navigation.nav_3d.mls_planner.recording_eval data/mid360_athens_stairs.db --sweep
uv run pytest dimos/navigation/nav_3d/mls_planner/test_recording_eval.py -m self_hosted


## AI assistance

Claude Code (Opus 4.8) was used for the following: 
1. Understanding the codebase.
2. Syntax and eval test
3. Running the analysis in a WSL build environment.

## Checklist

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
