### PR TITLE
fix(control): arm streamed path before task is active

### DIFF
--- a/dimos/control/tasks/holonomic_pose_follower_task/holonomic_pose_follower_task.py
+++ b/dimos/control/tasks/holonomic_pose_follower_task/holonomic_pose_follower_task.py
@@ -150,7 +150,7 @@ class HolonomicPoseFollowerTask(BaseControlTask):
         )
 
     def is_active(self) -> bool:
-        return self._state in ("tracking", "settling", "stopping")
+        return self._state in ("tracking", "settling", "stopping") or self._pending_path is not None
 
     def compute(self, state: CoordinatorState) -> JointCommandOutput | None:
         if self._pending_path is not None:


### PR DESCRIPTION
## Summary

`HolonomicPoseFollowerTask` never starts driving a path that arrives via the `path` stream card (`on_path`). The robot receives the path and logs it, but doesn't move.

## Root cause

`compute()` is the only thing that arms a pending path: `on_path()` just latches it (`self._pending_path = msg`), and `compute()` arms it on the next tick that has a pose, by calling `start_path()`.

But the tick loop only calls `compute()` on tasks where `is_active()` is already `True`:

```python
# tick_loop.py, _compute_all_tasks
for task in self._tasks.values():
    if not task.is_active():
        continue
    ...
    output = task.compute(state)
```

And `is_active()` only checked states that `start_path()` itself sets:

```python
def is_active(self) -> bool:
    return self._state in ("tracking", "settling", "stopping")
```

The task starts in `"idle"`, so `is_active()` is `False` until `compute()` runs, but `compute()` never runs until `is_active()` is `True`. It's a permanent deadlock with no error, since nothing throws; the task just never starts.

## Fix

`is_active()` also returns `True` while a path is pending arm, so the tick loop lets `compute()` run once to arm it. After that, the normal state-based check takes over.

## Test plan

- Ran 50 runs on the Go2 (10 paths x 5 speeds) with this fix applied — path arms and the robot tracks correctly.