### PR TITLE
Add @Dreamsorcerer as global codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-* @leshy @paul-nechifor @spomichter @mustafab0
+* @leshy @paul-nechifor @spomichter @mustafab0 @Dreamsorcerer
 /.github/ @Dreamsorcerer @leshy @paul-nechifor @spomichter
 /dimos/mapping/ @leshy @paul-nechifor @spomichter


### PR DESCRIPTION
Adds @Dreamsorcerer to the `*` rule in CODEOWNERS so his approval satisfies the code-owner review requirement repo-wide, not just for `/.github/`.