### PR TITLE
ci: label first-time contributor PRs

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -142,12 +142,8 @@ jobs:
               'FIRST_TIME_CONTRIBUTOR',
             ]);
             const { owner, repo } = context.repo;
-            const prNumber = context.payload.pull_request.number;
-
-            // Refetch so a delayed or replayed event uses the current PR data.
-            const { data: pr } = await github.rest.pulls.get({
-              owner, repo, pull_number: prNumber,
-            });
+            const pr = context.payload.pull_request;
+            const prNumber = pr.number;
             core.info(`pr=#${prNumber} authorAssociation=${pr.author_association}`);
 
             if (!firstTimeAssociations.has(pr.author_association)) {

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -10,6 +10,10 @@ name: pr-labels
 # flight), every PR to main must declare backport intent via that label or
 # `backport:skip`.
 #
+# `first-time-contributor`: labels PRs whose author had not previously
+# committed to this repository when the PR was opened. The label is retained
+# as a snapshot even if the author's association changes later.
+#
 # Runs on the default branch via these events, so the GITHUB_TOKEN is
 # write-scoped even for PRs from forks — and the workflow file itself can't
 # be tampered with by a fork PR.
@@ -120,6 +124,39 @@ jobs:
               }
               await setLabel(prNumber, ciOk && !pr.draft);
             }
+
+  first-time-contributor:
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      (github.event.action == 'opened' || github.event.action == 'reopened')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write  # To add the label
+    steps:
+      - uses: actions/github-script@v9
+        with:
+          script: |
+            const label = 'first-time-contributor';
+            const firstTimeAssociations = new Set([
+              'FIRST_TIMER',
+              'FIRST_TIME_CONTRIBUTOR',
+            ]);
+            const { owner, repo } = context.repo;
+            const prNumber = context.payload.pull_request.number;
+
+            // Refetch so a delayed or replayed event uses the current PR data.
+            const { data: pr } = await github.rest.pulls.get({
+              owner, repo, pull_number: prNumber,
+            });
+            core.info(`pr=#${prNumber} authorAssociation=${pr.author_association}`);
+
+            if (!firstTimeAssociations.has(pr.author_association)) {
+              return;
+            }
+
+            await github.rest.issues.addLabels({
+              owner, repo, issue_number: prNumber, labels: [label],
+            });
 
   backport-check:
     name: "Admins: Backport label added"

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -128,7 +128,7 @@ jobs:
   first-time-contributor:
     if: >-
       github.event_name == 'pull_request_target' &&
-      (github.event.action == 'opened' || github.event.action == 'reopened')
+      github.event.action == 'opened'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write  # To add the label


### PR DESCRIPTION
## Summary

- add a fork-safe `pull_request_target` job that labels first-time contributor PRs
- recognize both `FIRST_TIMER` and `FIRST_TIME_CONTRIBUTOR` author associations
- retain the label as a snapshot of contributor status when the PR is opened

## Security

- run the trusted workflow from the default branch
- do not check out or execute pull request code
- grant only `pull-requests: write` to the labeling job

## Validation

- parsed the workflow YAML and confirmed the new job exists
- compiled the embedded `github-script` body as an async function
- ran `git diff --check`
- reconciled the live repository: all currently open first-time contributor PRs have the new label

## Rollout

The `first-time-contributor` repository label has been created and existing matching open PRs were backfilled.