### PR TITLE
codebase_checks: make whitelist path matching OS-agnostic

### DIFF
--- a/dimos/codebase_checks/test_get_logger.py
+++ b/dimos/codebase_checks/test_get_logger.py
@@ -87,7 +87,10 @@ def find_get_logger_usages() -> list[tuple[str, int, str]]:
             full_path = os.path.join(dirpath, fname)
             if os.path.realpath(full_path) == self_path:
                 continue
-            rel_path = os.path.relpath(full_path, DIMOS_PROJECT_ROOT)
+            # Normalize to forward slashes so the WHITELIST (written with "/")
+            # matches regardless of the host OS's path separator (os.sep is "\\"
+            # on Windows, which would otherwise never equal the "/" entries).
+            rel_path = os.path.relpath(full_path, DIMOS_PROJECT_ROOT).replace(os.sep, "/")
 
             try:
                 with open(full_path, encoding="utf-8", errors="replace") as f:

--- a/dimos/codebase_checks/test_no_dunder_new.py
+++ b/dimos/codebase_checks/test_no_dunder_new.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import ast
+import os
 from pathlib import Path
 
 from dimos.constants import DIMOS_PROJECT_ROOT
@@ -42,7 +43,10 @@ def find_dunder_new_calls() -> list[tuple[Path, int, str]]:
             continue
         source = path.read_text(encoding="utf-8")
         lines = source.splitlines()
-        rel_path = str(path.relative_to(DIMOS_PROJECT_ROOT))
+        # Normalize to forward slashes so the WHITELIST (written with "/")
+        # matches regardless of the host OS's path separator (os.sep is "\\"
+        # on Windows, which would otherwise never equal the "/" entries).
+        rel_path = str(path.relative_to(DIMOS_PROJECT_ROOT)).replace(os.sep, "/")
         for node in ast.walk(ast.parse(source)):
             if not (
                 isinstance(node, ast.Call)

--- a/dimos/codebase_checks/test_no_sections.py
+++ b/dimos/codebase_checks/test_no_sections.py
@@ -102,7 +102,10 @@ def find_section_markers() -> list[tuple[str, int, str]]:
 
         for fname in filenames:
             full_path = os.path.join(dirpath, fname)
-            rel_path = os.path.join(rel_dir, fname)
+            # Normalize to forward slashes so the WHITELIST (written with "/")
+            # matches regardless of the host OS's path separator (os.sep is "\\"
+            # on Windows, which would otherwise never equal the "/" entries).
+            rel_path = os.path.join(rel_dir, fname).replace(os.sep, "/")
 
             if not _should_scan(full_path):
                 continue


### PR DESCRIPTION
The WHITELIST path comparisons in `test_get_logger`, `test_no_sections`, and `test_no_dunder_new` compare `rel_path` against "/"-hardcoded paths. But `rel_path` is built from `os.path.relpath` / `Path.relative_to`, which yield OS-native separators ("\\" on Windows). On any OS where `os.sep != "/"`, the comparison never matches, so the whitelist is dead code: it masks real violations and reports spurious ones.

`test_no_get_logger` currently fails on Windows with 8 false positives (the 8 whitelisted `logging.getLogger` usages all get flagged). The same latent bug affects `test_no_sections` (docker_module.py sentinel) and `test_no_dunder_new` (mujoco `__new__`).

Normalize `rel_path` to forward slashes before comparing. No-op on Linux/macOS, correct everywhere. Verified: the three checks now pass on Windows and are unchanged on POSIX.