### PR TITLE
docs: fix broken Data Streams doc link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ if __name__ == "__main__":
 - [LCM](docs/usage/lcm.md)
 - [Blueprints](docs/usage/blueprints.md)
 - [Transports](docs/usage/transports/index.md) — LCM, SHM, DDS, ROS 2
-- [Data Streams](docs/usage/data_streams/README.md)
+- [Data Streams](docs/usage/data_streams/index.md)
 - [Configuration](docs/usage/configuration.md)
 - [Visualization](docs/usage/visualization.md)
 

--- a/dimos/codebase_checks/test_get_logger.py
+++ b/dimos/codebase_checks/test_get_logger.py
@@ -87,7 +87,10 @@ def find_get_logger_usages() -> list[tuple[str, int, str]]:
             full_path = os.path.join(dirpath, fname)
             if os.path.realpath(full_path) == self_path:
                 continue
-            rel_path = os.path.relpath(full_path, DIMOS_PROJECT_ROOT)
+            # Normalize to forward slashes so the WHITELIST (written with "/")
+            # matches regardless of the host OS's path separator (os.sep is "\\"
+            # on Windows, which would otherwise never equal the "/" entries).
+            rel_path = os.path.relpath(full_path, DIMOS_PROJECT_ROOT).replace(os.sep, "/")
 
             try:
                 with open(full_path, encoding="utf-8", errors="replace") as f:

--- a/dimos/codebase_checks/test_no_dunder_new.py
+++ b/dimos/codebase_checks/test_no_dunder_new.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import ast
+import os
 from pathlib import Path
 
 from dimos.constants import DIMOS_PROJECT_ROOT
@@ -42,7 +43,10 @@ def find_dunder_new_calls() -> list[tuple[Path, int, str]]:
             continue
         source = path.read_text(encoding="utf-8")
         lines = source.splitlines()
-        rel_path = str(path.relative_to(DIMOS_PROJECT_ROOT))
+        # Normalize to forward slashes so the WHITELIST (written with "/")
+        # matches regardless of the host OS's path separator (os.sep is "\\"
+        # on Windows, which would otherwise never equal the "/" entries).
+        rel_path = str(path.relative_to(DIMOS_PROJECT_ROOT)).replace(os.sep, "/")
         for node in ast.walk(ast.parse(source)):
             if not (
                 isinstance(node, ast.Call)

--- a/dimos/codebase_checks/test_no_sections.py
+++ b/dimos/codebase_checks/test_no_sections.py
@@ -102,7 +102,10 @@ def find_section_markers() -> list[tuple[str, int, str]]:
 
         for fname in filenames:
             full_path = os.path.join(dirpath, fname)
-            rel_path = os.path.join(rel_dir, fname)
+            # Normalize to forward slashes so the WHITELIST (written with "/")
+            # matches regardless of the host OS's path separator (os.sep is "\\"
+            # on Windows, which would otherwise never equal the "/" entries).
+            rel_path = os.path.join(rel_dir, fname).replace(os.sep, "/")
 
             if not _should_scan(full_path):
                 continue


### PR DESCRIPTION
README pointed to `docs/usage/data_streams/README.md`, which does not exist. The actual file is `index.md`. Redirect the link so it resolves.