### PR TITLE
fix(go2): override ReplayConnection.stop() to avoid AttributeError on hot-reload

### DIFF
--- a/dimos/robot/unitree/go2/connection.py
+++ b/dimos/robot/unitree/go2/connection.py
@@ -259,6 +259,15 @@ class ReplayConnection(UnitreeWebRTCConnection, CompositeResource):
         """Fake publish request for testing."""
         return {"status": "ok", "message": "Fake publish"}
 
+    def stop(self) -> None:
+        # A replay connection has no live WebRTC loop or peer to tear down, so
+        # the inherited UnitreeWebRTCConnection.stop() (which touches self.loop
+        # and self.conn) does not apply here. Clear the deadman timer slot and
+        # let the framework handle the rest of the module teardown.
+        # Fixes 'ReplayConnection' object has no attribute 'stop_timer' raised
+        # during GO2Connection hot-reload / restart (#1967).
+        self.stop_timer = None
+
 
 _Config = TypeVar("_Config", bound=ConnectionConfig, default=ConnectionConfig)
 


### PR DESCRIPTION
Fixes #1967.

**Root cause.** `ReplayConnection` intentionally skips `UnitreeWebRTCConnection.__init__()` (that constructor opens a live WebRTC peer via `LegionConnection` + `connect()`), so it never initializes `self.stop_timer`, `self.loop`, or `self.conn`. The inherited `stop()` therefore raises `AttributeError: 'ReplayConnection' object has no attribute 'stop_timer'` as soon as `GO2Connection.stop()` is invoked — which is exactly what `restart()` does during hot-reload, breaking the reload.

**Fix.** Override `stop()` on `ReplayConnection` to clear the deadman timer slot and otherwise do nothing: a replay connection has no live loop/peer to disconnect, and the module's teardown is handled by the framework. This removes the AttributeError that aborted `restart()`.

Note: this fixes the concrete `AttributeError` thrown by `stop()` during hot-reload. If `restart()` still hangs for reasons unrelated to teardown (e.g. the daemon re-registering the module), that is a separate path and worth a follow-up issue.