### PR TITLE
Cut Mac OpenMP spin-wait CPU by setting passive wait policy. DIM-1329

### DIFF
--- a/dimos/robot/cli/dimos.py
+++ b/dimos/robot/cli/dimos.py
@@ -25,6 +25,18 @@ import time
 import types
 from typing import TYPE_CHECKING, Any, Literal, Union, cast, get_args, get_origin
 
+# macOS Open3D uses LLVM libomp, which (when OMP_WAIT_POLICY is unset) still
+# actively spins for KMP_BLOCKTIME (default 200ms) after each parallel region.
+# Several point-cloud workers each owning a core-sized pool then yield-spin
+# between frames and burn whole cores in kernel time (measured: replay dropped
+# from ~1120% to ~70% CPU on a 12-core Mac with these set). Linux Open3D links
+# libgomp, whose unset default is only a short spin then sleep, so leave it
+# alone. Set before any library loads libomp; workers inherit via the
+# forkserver. User environment overrides win.
+if sys.platform == "darwin":
+    os.environ.setdefault("KMP_BLOCKTIME", "0")
+    os.environ.setdefault("OMP_WAIT_POLICY", "PASSIVE")
+
 from dotenv import load_dotenv
 from pydantic import BaseModel
 from pydantic.fields import FieldInfo


### PR DESCRIPTION
Running any replay even simple like this, `uv run dimos --replay run unitree-go2` causes severe CPU load on Mac and high power usage.

## Before CPU: 100%, POWER: 33W
<img width="1512" height="982" alt="high-cpu-no-openMP-fix" src="https://github.com/user-attachments/assets/d7951dbb-bcb6-42e6-a0fa-6369e0d8464b" />

## After CPU: 16%, POWER: 12W
<img width="1512" height="982" alt="low-cpu-openMP-fix-in-place" src="https://github.com/user-attachments/assets/695eea26-0bac-4b32-9657-2ffd0d2a1ec5" />
