### PR TITLE
test: pin Drake backend in manipulation integration suite

### DIFF
--- a/dimos/manipulation/test_manipulation_module.py
+++ b/dimos/manipulation/test_manipulation_module.py
@@ -120,6 +120,8 @@ def module(xarm7_config):
     mod = ManipulationModule(
         robots=[xarm7_config],
         planning_timeout=10.0,
+        world_backend="drake",
+        planner_name="rrt_connect",
         visualization={"backend": "none"},
     )
     mod.coordinator_joint_state = None


### PR DESCRIPTION
## Contribution path

- Small, safe change that does not need a tracking issue

## Problem

The manipulation integration suite describes and gates itself as a Drake test, but it relied on `ManipulationModule` defaults. After #3155 changed those defaults to RoboPlan, the suite began constructing a native RoboPlan scene and reproducibly segfaulted in the experimental macOS self-hosted job.

## Solution

Pin the shared integration fixture to the Drake world backend and RRT-Connect planner. This restores the suite's documented backend and retains its macOS coverage without changing production defaults, CI markers, or RoboPlan.

## How to Test

`uv run pytest dimos/manipulation/test_manipulation_module.py -m self_hosted`

The file collects successfully in the development environment. Its 12 integration tests skip locally because `pydrake` is unavailable; the macOS self-hosted runner has Drake and exercises the suite.

Ruff check, Ruff format check, and `git diff --check` pass.

## AI assistance

Codex with GPT-5 diagnosed the regression, implemented the test fixture change, and ran the reported validation.

## Checklist

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
