### PR TITLE
feat(web): add protocol v2 manifests and reliable streams

### DIFF
--- a/dimos/web/relay_bridge/_wt_session.py
+++ b/dimos/web/relay_bridge/_wt_session.py
@@ -42,12 +42,13 @@ from aioquic.quic.events import ConnectionTerminated, QuicEvent
 from dimos.utils.logging_config import setup_logger
 from dimos.web.relay_bridge.protocol import (
     DataFrame,
-    DataFrameReader,
+    DataFrameStreamError,
+    DataFrameStreamReader,
     Error,
     FrameHeader,
+    Manifest,
     Msg,
     Pong,
-    ProtocolError,
     Welcome,
     decode_datagram,
     encode_data_frame,
@@ -56,8 +57,20 @@ from dimos.web.relay_bridge.protocol import (
 
 logger = setup_logger()
 
-# Received data frames waiting for the consumer; drop-oldest beyond this.
+# Received data frames waiting for the consumer; drop-oldest beyond either
+# bound. The byte bound is what matters against a hostile/compromised relay:
+# 256 frames of near-MAX_DATA_FRAME_BYTES would otherwise retain ~16 GiB.
 _FRAME_QUEUE_MAX = 256
+_FRAME_QUEUE_MAX_BYTES = 128 * 1024 * 1024
+
+# Realistic payload caps for channels whose encoding is known from the
+# watched robot's manifest (frames themselves carry no encoding);
+# MAX_DATA_FRAME_BYTES stays the outer bound for everything else. Generous:
+# a 4K quality-90 JPEG is ~4 MiB, a pose JSON object ~100 B.
+_MAX_PAYLOAD_BYTES = {
+    "jpeg.v1": 8 * 1024 * 1024,
+    "pose.json.v1": 64 * 1024,
+}
 
 # Relay-pushed control messages (subs snapshots, robots, manifest) waiting for
 # the consumer; drop-oldest beyond this. Snapshots are idempotent and resent,
@@ -67,6 +80,41 @@ _CONTROL_QUEUE_MAX = 64
 # The relay's abort of its send half surfaces as a stream reset; also used
 # when this side resets a stale latest-wins stream.
 STALE_STREAM_ERROR_CODE = 0x01
+
+
+class _FrameQueue:
+    """Drop-oldest frame buffer bounded by frame count and total payload bytes.
+
+    Single event loop only (put from the protocol callback, get from the
+    consumer task), so the plain byte counter is safe.
+    """
+
+    def __init__(self, max_frames: int, max_bytes: int) -> None:
+        self._queue: asyncio.Queue[DataFrame] = asyncio.Queue()
+        self._max_frames = max_frames
+        self._max_bytes = max_bytes
+        self.bytes = 0
+        self.dropped = 0
+
+    def qsize(self) -> int:
+        return self._queue.qsize()
+
+    def put_nowait(self, frame: DataFrame) -> None:
+        """Enqueue, evicting oldest frames until both bounds hold (a single
+        frame over the byte bound still enqueues once it is alone)."""
+        size = len(frame.payload)
+        while self._queue.qsize() > 0 and (
+            self._queue.qsize() >= self._max_frames or self.bytes + size > self._max_bytes
+        ):
+            self.bytes -= len(self._queue.get_nowait().payload)
+            self.dropped += 1
+        self._queue.put_nowait(frame)
+        self.bytes += size
+
+    async def get(self) -> DataFrame:
+        frame = await self._queue.get()
+        self.bytes -= len(frame.payload)
+        return frame
 
 
 def make_quic_configuration(insecure: bool) -> QuicConfiguration:
@@ -95,13 +143,16 @@ class SessionProtocol(QuicConnectionProtocol):
         # delivery poll consult it so they stop the moment the relay dies.
         self.closed = asyncio.Event()
         self.relay_error: Error | None = None
-        self.frames: asyncio.Queue[DataFrame] = asyncio.Queue(maxsize=_FRAME_QUEUE_MAX)
-        self.frames_dropped = 0
+        self.frames = _FrameQueue(_FRAME_QUEUE_MAX, _FRAME_QUEUE_MAX_BYTES)
+        self.frames_oversized = 0
         self.control_msgs: asyncio.Queue[Msg] = asyncio.Queue(maxsize=_CONTROL_QUEUE_MAX)
         self.control_dropped = 0
         self.session_id: int | None = None
         self._pong_waiters: dict[int | float, asyncio.Future[Pong]] = {}
-        self._frame_readers: dict[int, DataFrameReader | None] = {}
+        self._frame_readers: dict[int, DataFrameStreamReader | None] = {}
+        # ch -> encoding, learned from manifest messages; arms the
+        # per-encoding payload caps in _MAX_PAYLOAD_BYTES.
+        self._encodings: dict[str, str] = {}
 
     def open_session(self, authority: str, path: str) -> None:
         self.session_id = self._quic.get_next_available_stream_id()
@@ -138,6 +189,10 @@ class SessionProtocol(QuicConnectionProtocol):
         elif isinstance(event, WebTransportStreamDataReceived):
             self._stream_data_received(event.stream_id, event.data, event.stream_ended)
 
+    @property
+    def frames_dropped(self) -> int:
+        return self.frames.dropped
+
     def _control_msg_received(self, msg: Msg) -> None:
         if isinstance(msg, Welcome):
             self.welcomed.set()
@@ -150,6 +205,8 @@ class SessionProtocol(QuicConnectionProtocol):
             if waiter is not None and not waiter.done():
                 waiter.set_result(msg)
         else:
+            if isinstance(msg, Manifest):
+                self._encodings.update({c.ch: c.encoding for c in msg.channels})
             # Session messages (subs snapshots, robots, manifest, ...) go to
             # the consumer queue; see RelayClient.control_messages().
             if self.control_msgs.full():
@@ -158,28 +215,36 @@ class SessionProtocol(QuicConnectionProtocol):
             self.control_msgs.put_nowait(msg)
 
     def _stream_data_received(self, stream_id: int, data: bytes, ended: bool) -> None:
-        # None marks a stream whose frame is already complete (the late FIN
-        # arrives up to ~1 s afterwards; any trailing bytes are ignored).
-        reader = self._frame_readers.get(stream_id, DataFrameReader())
+        # A latest stream carries one frame; a reliable channel's persistent
+        # stream carries them back to back, so frames dispatch on byte count
+        # (the peer's FIN can be seconds late). None poisons a stream that
+        # produced a bad frame: framing is unrecoverable mid-stream.
+        reader = self._frame_readers.get(stream_id, DataFrameStreamReader())
         if reader is not None:
             self._frame_readers[stream_id] = reader
             try:
-                frame = reader.push(data)
-            except ProtocolError as e:
+                frames = reader.push(data)
+            except DataFrameStreamError as e:
+                # Frames decoded before the corruption still count; the
+                # stream itself is unrecoverable.
                 logger.warning(f"bad data frame on stream {stream_id}: {e}")
-                frame = None
+                frames = e.frames
                 self._frame_readers[stream_id] = None
             except Exception:
                 # Network ingress: no decoder bug may escape into aioquic's
                 # datagram callback and tear down the whole session.
                 logger.exception(f"unexpected error decoding data frame on stream {stream_id}")
-                frame = None
+                frames = []
                 self._frame_readers[stream_id] = None
-            if frame is not None:
-                self._frame_readers[stream_id] = None
-                if self.frames.full():
-                    self.frames.get_nowait()
-                    self.frames_dropped += 1
+            for frame in frames:
+                limit = _MAX_PAYLOAD_BYTES.get(self._encodings.get(frame.header.ch, ""))
+                if limit is not None and len(frame.payload) > limit:
+                    self.frames_oversized += 1
+                    logger.warning(
+                        f"dropping {frame.header.ch} frame: {len(frame.payload)} B over "
+                        f"the {limit} B cap for its encoding"
+                    )
+                    continue
                 self.frames.put_nowait(frame)
         if ended:
             self._frame_readers.pop(stream_id, None)

--- a/dimos/web/relay_bridge/manifest.py
+++ b/dimos/web/relay_bridge/manifest.py
@@ -1,0 +1,136 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Manifest domain model: the Python mirror of web/shared/manifest.ts.
+
+Pinned by the golden vectors in web/shared/fixtures/manifests.json (tested
+from both pytest and deno test). The transport (protocol.py) checks only
+field shapes; this module owns the domain rules: bounded unique ids, positive
+rates, and panel/layout references that resolve. Panels and layout are
+minimal until T7 (the layout is a flat panel-id order, not a tree).
+"""
+
+import json
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, ValidationError
+
+Delivery = Literal["latest", "reliable"]
+
+# Bound for channel/panel ids, encodings, and panel kinds.
+MAX_MANIFEST_ID_LEN = 64
+
+
+class ManifestError(ValueError):
+    """`code` is the machine-readable reason, pinned by the golden vectors."""
+
+    def __init__(self, code: str, message: str) -> None:
+        self.code = code
+        super().__init__(f"{code}: {message}")
+
+
+class _ManifestModel(BaseModel):
+    # strict + allow_inf_nan=False, mirroring _WireModel in protocol.py
+    # (which imports ChannelSpec from here, so this base cannot be shared).
+    model_config = ConfigDict(strict=True, allow_inf_nan=False)
+
+
+class ChannelSpec(_ManifestModel):
+    """One robot->viewer stream (see ChannelSpec in manifest.ts).
+
+    Field names are the wire names, hence the camelCase.
+    """
+
+    ch: str
+    encoding: str
+    delivery: Delivery
+    maxHz: int | float
+
+
+class PanelSpec(_ManifestModel):
+    """Minimal until T7: kind is the panel-component registry key; channels
+    lists the channel ids the panel consumes."""
+
+    id: str
+    kind: str
+    channels: list[str]
+
+
+class Manifest(_ManifestModel):
+    channels: list[ChannelSpec]
+    panels: list[PanelSpec] = Field(default_factory=list)
+    # Panel ids in display order (a layout tree replaces this in T7).
+    layout: list[str] = Field(default_factory=list)
+
+
+_MANIFEST_TA: TypeAdapter[Manifest] = TypeAdapter(Manifest)
+
+
+def _bounded_id(s: str) -> bool:
+    return 1 <= len(s) <= MAX_MANIFEST_ID_LEN
+
+
+def parse_manifest(data: Any) -> Manifest:
+    """Validated manifest from parsed JSON (or any untrusted value); raises
+    ManifestError. Absent panels/layout normalize to empty; unknown keys are
+    dropped (forward compatibility with newer bridges). Mirrors
+    parseManifest() in manifest.ts: shape first, then domain rules in
+    document order, so both sides report the same code (pinned by fixtures).
+    """
+    try:
+        # Through JSON, not validate_python: strict python-mode validation
+        # wants model instances for nested fields, but callers hold
+        # parsed-JSON dicts.
+        manifest = _MANIFEST_TA.validate_json(json.dumps(data))
+    except ValidationError as e:
+        raise ManifestError("invalid_shape", str(e)) from e
+
+    ch_ids: set[str] = set()
+    for spec in manifest.channels:
+        if not _bounded_id(spec.ch):
+            raise ManifestError(
+                "invalid_channel_id", f"channel id must be 1..{MAX_MANIFEST_ID_LEN} chars"
+            )
+        if spec.ch in ch_ids:
+            raise ManifestError("duplicate_channel_id", f"duplicate channel {spec.ch}")
+        ch_ids.add(spec.ch)
+        if not _bounded_id(spec.encoding):
+            raise ManifestError(
+                "invalid_encoding", f"encoding must be 1..{MAX_MANIFEST_ID_LEN} chars"
+            )
+        # Shape validation already rejects non-finite floats, so > 0 suffices
+        # (an isfinite() here would raise OverflowError on huge ints).
+        if spec.maxHz <= 0:
+            raise ManifestError("invalid_max_hz", f"maxHz for {spec.ch} must be a positive number")
+
+    panel_ids: set[str] = set()
+    for panel in manifest.panels:
+        if not (_bounded_id(panel.id) and _bounded_id(panel.kind)):
+            raise ManifestError(
+                "invalid_panel", f"panel id/kind must be 1..{MAX_MANIFEST_ID_LEN} chars"
+            )
+        if panel.id in panel_ids:
+            raise ManifestError("duplicate_panel_id", f"duplicate panel {panel.id}")
+        panel_ids.add(panel.id)
+        for ch in panel.channels:
+            if ch not in ch_ids:
+                raise ManifestError(
+                    "unknown_panel_channel", f"panel {panel.id} wants undeclared channel {ch}"
+                )
+
+    for panel_id in manifest.layout:
+        if panel_id not in panel_ids:
+            raise ManifestError("unknown_layout_panel", f"layout names unknown panel {panel_id}")
+
+    return manifest

--- a/dimos/web/relay_bridge/manifest.py
+++ b/dimos/web/relay_bridge/manifest.py
@@ -22,6 +22,7 @@ minimal until T7 (the layout is a flat panel-id order, not a tree).
 """
 
 import json
+import sys
 from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, ValidationError
@@ -109,9 +110,11 @@ def parse_manifest(data: Any) -> Manifest:
             raise ManifestError(
                 "invalid_encoding", f"encoding must be 1..{MAX_MANIFEST_ID_LEN} chars"
             )
-        # Shape validation already rejects non-finite floats, so > 0 suffices
-        # (an isfinite() here would raise OverflowError on huge ints).
-        if spec.maxHz <= 0:
+        # Bounded to float64: a JSON integer beyond that range is exact in
+        # Python but Infinity through JS JSON.parse, and manifest.ts rejects
+        # it here with this code. Non-finite floats are already shape-rejected
+        # (and isfinite() would raise OverflowError on huge ints).
+        if not 0 < spec.maxHz <= sys.float_info.max:
             raise ManifestError("invalid_max_hz", f"maxHz for {spec.ch} must be a positive number")
 
     panel_ids: set[str] = set()

--- a/dimos/web/relay_bridge/protocol.py
+++ b/dimos/web/relay_bridge/protocol.py
@@ -21,9 +21,11 @@ rest of the [web] extra.
 Framing (see web/README.md for the upstream-bug rationale):
 - Control stream frame: u32-LE length | UTF-8 JSON.
 - Datagram: raw UTF-8 JSON, no length prefix.
-- Data frame (one message per stream): u32-LE headerLen | u32-LE payloadLen |
-  header JSON | payload. Receivers count bytes and must never treat stream
-  EOF as a message boundary (Deno 2.6.x delays FIN by up to ~1 s).
+- Data frame: u32-LE headerLen | u32-LE payloadLen | header JSON | payload.
+  Latest channels send one frame per stream; a reliable channel packs its
+  frames back to back on one persistent stream. Receivers count bytes and
+  must never treat stream EOF as a message boundary (Deno 2.6.x delays FIN
+  by up to ~1 s, and a persistent stream has no EOF between frames).
 
 Validation policy (mirrored in protocol.ts): decoders validate shape strictly,
 and receivers drop invalid or unknown messages -- a peer's bytes must never
@@ -48,9 +50,17 @@ from pydantic import (
 
 from dimos.utils.logging_config import setup_logger
 
+# Channel/manifest domain types live in manifest.py; re-exported here (the
+# redundant aliases mark them as such for mypy) so protocol consumers keep a
+# single import surface, mirroring protocol.ts.
+from dimos.web.relay_bridge.manifest import ChannelSpec as ChannelSpec, Delivery as Delivery
+
 logger = setup_logger()
 
-PROTOCOL_VERSION = 1
+# v2: a reliable channel packs all its frames onto one persistent stream (v1
+# carried one frame per stream), which a v1 receiver would misread as a
+# single frame. Bump on any change an old peer would silently misparse.
+PROTOCOL_VERSION = 2
 
 # Reject absurd header lengths before allocating (mirrors protocol.ts).
 MAX_HEADER_LEN = 65536
@@ -60,7 +70,6 @@ MAX_HEADER_LEN = 65536
 MAX_DATA_FRAME_BYTES = 64 * 1024 * 1024
 
 Role = Literal["robot", "viewer"]
-Delivery = Literal["latest", "reliable"]
 
 
 class ProtocolError(ValueError):
@@ -84,18 +93,6 @@ class RobotInfo(_WireModel):
     id: str
     name: str
     model: str
-
-
-class ChannelSpec(_WireModel):
-    """One robot->viewer stream (see ChannelSpec in protocol.ts).
-
-    Field names are the wire names, hence the camelCase.
-    """
-
-    ch: str
-    encoding: str
-    delivery: Delivery
-    maxHz: int | float
 
 
 class RobotManifest(_WireModel):
@@ -317,7 +314,7 @@ def encode_data_frame(header: FrameHeader, payload: bytes) -> bytes:
     return struct.pack("<II", len(hdr), len(payload)) + hdr + payload
 
 
-def peek_data_frame_lengths(buf: bytes | bytearray) -> tuple[int, int, int] | None:
+def peek_data_frame_lengths(buf: bytes | bytearray | memoryview) -> tuple[int, int, int] | None:
     """(headerLen, payloadLen, total) or None if fewer than 8 bytes are available."""
     if len(buf) < 8:
         return None
@@ -330,7 +327,7 @@ def peek_data_frame_lengths(buf: bytes | bytearray) -> tuple[int, int, int] | No
     return header_len, payload_len, total
 
 
-def decode_data_frame(frame: bytes | bytearray) -> DataFrame:
+def decode_data_frame(frame: bytes | bytearray | memoryview) -> DataFrame:
     lens = peek_data_frame_lengths(frame)
     if lens is None or len(frame) < lens[2]:
         raise ProtocolError(f"truncated data frame: {len(frame)} bytes")
@@ -344,25 +341,57 @@ def decode_data_frame(frame: bytes | bytearray) -> DataFrame:
     return DataFrame(header=header, payload=bytes(view[8 + header_len : total]))
 
 
-class DataFrameReader:
-    """Incremental reader for a single-message stream.
+class DataFrameStreamError(ProtocolError):
+    """Framing/header corruption on a data-frame stream.
 
-    Returns the frame as soon as headerLen + payloadLen bytes have arrived;
-    never waits for EOF. Bytes past the frame are ignored.
+    `frames` carries the frames decoded before the corrupt one so the caller
+    can still deliver them before dropping the stream (framing is
+    unrecoverable mid-stream).
+    """
+
+    def __init__(self, message: str, frames: list[DataFrame]) -> None:
+        super().__init__(message)
+        self.frames = frames
+
+
+class DataFrameStreamReader:
+    """Incremental reader for a stream carrying sequential data frames.
+
+    Mirrors DataFrameStreamReader in protocol.ts: a reliable channel's
+    persistent stream packs frames back-to-back (a latest stream is the
+    one-frame case). Frames are returned as soon as their bytes have arrived;
+    EOF is never a boundary.
+
+    The buffer keeps a read cursor and is compacted once per push, so a
+    completed frame's bytes are copied out exactly once (in decode). On
+    corruption push() raises DataFrameStreamError (with the frames decoded
+    before it) and the reader rejects all further input.
     """
 
     def __init__(self) -> None:
         self._buf = bytearray()
-        self._done = False
+        self._failed: str | None = None
 
-    def push(self, chunk: bytes) -> DataFrame | None:
-        if self._done:
-            return None
+    def push(self, chunk: bytes) -> list[DataFrame]:
+        if self._failed is not None:
+            raise DataFrameStreamError(self._failed, [])
         self._buf += chunk
-        lens = peek_data_frame_lengths(self._buf)
-        if lens is None or len(self._buf) < lens[2]:
-            return None
-        self._done = True
-        frame = decode_data_frame(self._buf)
-        self._buf = bytearray()
-        return frame
+        frames: list[DataFrame] = []
+        pos = 0
+        with memoryview(self._buf) as view:
+            try:
+                while True:
+                    lens = peek_data_frame_lengths(view[pos:])
+                    if lens is None or len(view) - pos < lens[2]:
+                        break
+                    frames.append(decode_data_frame(view[pos : pos + lens[2]]))
+                    pos += lens[2]
+            except ProtocolError as e:
+                # Keep only the message: a stored exception would keep
+                # traceback frames (and their memoryview locals) alive and
+                # block the buffer resize below with a BufferError.
+                self._failed = str(e)
+        del self._buf[:pos]
+        if self._failed is not None:
+            raise DataFrameStreamError(self._failed, frames)
+        return frames

--- a/dimos/web/relay_bridge/test_manifest.py
+++ b/dimos/web/relay_bridge/test_manifest.py
@@ -1,0 +1,45 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Golden-fixture tests keeping manifest.py behavior identical to manifest.ts."""
+
+import json
+
+import pytest
+
+from dimos.web.relay_bridge.locate import find_web_dir
+from dimos.web.relay_bridge.manifest import ManifestError, parse_manifest
+
+with open(find_web_dir() / "shared" / "fixtures" / "manifests.json") as f:
+    VECTORS = json.load(f)["vectors"]
+
+VALID = [v for v in VECTORS if "manifest" in v]
+INVALID = [v for v in VECTORS if "error" in v]
+
+
+@pytest.mark.parametrize("vector", VALID, ids=[v["name"] for v in VALID])
+def test_valid_manifest_normalizes_per_golden(vector):
+    assert parse_manifest(vector["data"]).model_dump() == vector["manifest"]
+
+
+@pytest.mark.parametrize("vector", INVALID, ids=[v["name"] for v in INVALID])
+def test_invalid_manifest_rejected_with_pinned_code(vector):
+    with pytest.raises(ManifestError) as exc_info:
+        parse_manifest(vector["data"])
+    assert exc_info.value.code == vector["error"]
+
+
+def test_every_vector_is_classified():
+    assert VALID and INVALID
+    assert len(VALID) + len(INVALID) == len(VECTORS)

--- a/dimos/web/relay_bridge/test_manifest.py
+++ b/dimos/web/relay_bridge/test_manifest.py
@@ -43,3 +43,18 @@ def test_invalid_manifest_rejected_with_pinned_code(vector):
 def test_every_vector_is_classified():
     assert VALID and INVALID
     assert len(VALID) + len(INVALID) == len(VECTORS)
+
+
+def test_huge_int_max_hz_rejected_like_ts():
+    # Not a golden vector: gen.ts cannot emit a number beyond float64
+    # (JSON.stringify(Infinity) is null). Python parses such a JSON integer
+    # exactly while JS JSON.parse yields Infinity; both sides must reject it
+    # with the same code (manifest_test.ts pins the JS half).
+    data = {
+        "channels": [
+            {"ch": "odom", "encoding": "pose.json.v1", "delivery": "reliable", "maxHz": 10**400}
+        ]
+    }
+    with pytest.raises(ManifestError) as exc_info:
+        parse_manifest(data)
+    assert exc_info.value.code == "invalid_max_hz"

--- a/dimos/web/relay_bridge/test_protocol.py
+++ b/dimos/web/relay_bridge/test_protocol.py
@@ -27,7 +27,8 @@ from dimos.web.relay_bridge.protocol import (
     PROTOCOL_VERSION,
     ChannelSpec,
     ControlFrameReader,
-    DataFrameReader,
+    DataFrameStreamError,
+    DataFrameStreamReader,
     FrameHeader,
     Hello,
     Ping,
@@ -64,7 +65,9 @@ def _header(d):
 
 
 def test_protocol_version():
-    assert PROTOCOL_VERSION == 1
+    # v2: reliable frames pack onto one persistent stream per channel (v1
+    # carried one frame per stream); a v1 peer must fail the handshake.
+    assert PROTOCOL_VERSION == 2
 
 
 @pytest.mark.parametrize("vector", CONTROL, ids=[v["name"] for v in CONTROL])
@@ -127,27 +130,70 @@ def test_data_frame_decode_roundtrips_golden(vector):
     assert frame.payload == base64.b64decode(vector["payload_b64"])
 
 
-def test_data_frame_reader_completes_at_byte_count_split_anywhere():
+def test_data_frame_stream_reader_completes_at_byte_count_split_anywhere():
     vector = next(v for v in DATA if v["name"] == "image_latest_meta")
     frame_bytes = base64.b64decode(vector["frame_b64"])
     for split in range(len(frame_bytes) + 1):
-        reader = DataFrameReader()
+        reader = DataFrameStreamReader()
         first = reader.push(frame_bytes[:split])
         second = reader.push(frame_bytes[split:])
         if split < len(frame_bytes):
-            assert first is None, f"complete before full frame at split {split}"
-        out = first or second
-        assert out is not None, f"incomplete after full frame at split {split}"
-        assert out.header == _header(vector["header"])
-        assert out.payload == base64.b64decode(vector["payload_b64"])
+            assert first == [], f"complete before full frame at split {split}"
+        out = first + second
+        assert len(out) == 1, f"frames after full push at split {split}"
+        assert out[0].header == _header(vector["header"])
+        assert out[0].payload == base64.b64decode(vector["payload_b64"])
 
 
-def test_data_frame_reader_ignores_bytes_past_frame():
+def test_data_frame_stream_reader_parses_back_to_back_frames():
+    all_bytes = b"".join(base64.b64decode(v["frame_b64"]) for v in DATA)
+    out = DataFrameStreamReader().push(all_bytes)
+    assert [f.header for f in out] == [_header(v["header"]) for v in DATA]
+    assert [f.payload for f in out] == [base64.b64decode(v["payload_b64"]) for v in DATA]
+
+    trickle = DataFrameStreamReader()
+    out = []
+    for i in range(len(all_bytes)):
+        out.extend(trickle.push(all_bytes[i : i + 1]))
+    assert len(out) == len(DATA)
+
+
+def test_data_frame_stream_reader_raises_on_garbage_between_frames():
     vector = next(v for v in DATA if v["name"] == "odom_reliable")
-    frame_bytes = base64.b64decode(vector["frame_b64"])
-    out = DataFrameReader().push(frame_bytes + b"\x00" * 32)
-    assert out is not None
-    assert out.header == _header(vector["header"])
+    reader = DataFrameStreamReader()
+    assert len(reader.push(base64.b64decode(vector["frame_b64"]))) == 1
+    # Framing is unrecoverable mid-stream; the caller drops the stream.
+    with pytest.raises(ProtocolError):
+        reader.push(b"\x00" * 32)
+
+
+def test_data_frame_stream_reader_assembles_large_fragmented_frame():
+    payload = bytes(range(256)) * (32 * 1024)  # 8 MiB
+    header = FrameHeader(ch="cam", seq=1, ts=0.5, delivery="latest")
+    frame_bytes = encode_data_frame(header, payload)
+    reader = DataFrameStreamReader()
+    out = []
+    chunk = 64 * 1024
+    for i in range(0, len(frame_bytes), chunk):
+        out.extend(reader.push(frame_bytes[i : i + chunk]))
+    assert len(out) == 1
+    assert out[0].header == header
+    assert out[0].payload == payload
+
+
+def test_data_frame_stream_reader_surfaces_error_with_decoded_batch():
+    vector = next(v for v in DATA if v["name"] == "odom_reliable")
+    good = base64.b64decode(vector["frame_b64"])
+    bad = _raw_data_frame(b"{not json")
+    reader = DataFrameStreamReader()
+    with pytest.raises(DataFrameStreamError) as exc_info:
+        reader.push(good + bad)
+    # The valid frame preceding the corrupt one is delivered, not dropped.
+    assert [f.header for f in exc_info.value.frames] == [_header(vector["header"])]
+    # Poisoned: further input keeps raising with an empty batch.
+    with pytest.raises(DataFrameStreamError) as exc_again:
+        reader.push(good)
+    assert exc_again.value.frames == []
 
 
 def test_peek_and_decode_guard_truncation_and_absurd_headers():

--- a/dimos/web/relay_bridge/test_relay_e2e.py
+++ b/dimos/web/relay_bridge/test_relay_e2e.py
@@ -30,9 +30,12 @@ import pytest
 
 from dimos.web.relay_bridge.e2e_support import attach_viewer, collect_until, wait_subs
 from dimos.web.relay_bridge.protocol import (
+    ChannelSpec,
     DataFrame,
     FrameHeader,
+    Hello,
     RobotInfo,
+    RobotManifest,
     Unsub,
 )
 from dimos.web.relay_bridge.relay_process import RelayProcess, RelayReadyInfo
@@ -113,6 +116,32 @@ async def test_robot_hello_without_identity_is_rejected(relay: RelayReadyInfo) -
     async with await RelayClient.connect(relay.wt_url, "robot") as robot:
         with pytest.raises(Exception, match="missing_robot_id"):
             await robot.hello()
+
+
+async def test_previous_protocol_version_is_rejected(relay: RelayReadyInfo) -> None:
+    # A v1 (T2-era) bridge would misread the v2 persistent reliable stream as
+    # a single frame; the relay must fail its handshake loudly. Hello rides
+    # lossy datagrams, so resend until the error lands.
+    async with await RelayClient.connect(relay.wt_url, "robot") as old:
+        deadline = time.monotonic() + 5.0
+        while old._session.relay_error is None and time.monotonic() < deadline:
+            old.send_control(Hello(v=1, role="robot", robot=ROBOT))
+            await asyncio.sleep(0.05)
+        error = old._session.relay_error
+        assert error is not None and error.code == "version_mismatch"
+
+
+async def test_invalid_manifest_hello_is_rejected(relay: RelayReadyInfo) -> None:
+    duplicated = RobotManifest(
+        channels=[
+            ChannelSpec(ch="odom", encoding="pose.json.v1", delivery="reliable", maxHz=20.0),
+            ChannelSpec(ch="odom", encoding="jpeg.v1", delivery="latest", maxHz=15.0),
+        ]
+    )
+    async with await RelayClient.connect(relay.wt_url, "robot") as robot:
+        with pytest.raises(RelayRejectedError) as exc_info:
+            await robot.hello(robot=ROBOT, manifest=duplicated)
+        assert exc_info.value.code == "invalid_manifest"
 
 
 async def test_reliable_channel_is_complete_and_intact(

--- a/dimos/web/relay_bridge/test_wt_session.py
+++ b/dimos/web/relay_bridge/test_wt_session.py
@@ -1,0 +1,113 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Ingress-bound tests for the viewer session's frame queue (no network:
+frames are fed straight into the protocol callbacks)."""
+
+from aioquic.quic.connection import QuicConnection
+
+from dimos.web.relay_bridge._wt_session import (
+    _FRAME_QUEUE_MAX,
+    _FRAME_QUEUE_MAX_BYTES,
+    SessionProtocol,
+    _FrameQueue,
+    make_quic_configuration,
+)
+from dimos.web.relay_bridge.protocol import (
+    ChannelSpec,
+    DataFrame,
+    FrameHeader,
+    Manifest,
+    encode_data_frame,
+)
+
+
+def _session() -> SessionProtocol:
+    return SessionProtocol(QuicConnection(configuration=make_quic_configuration(insecure=True)))
+
+
+def _frame_bytes(ch: str, seq: int, size: int) -> bytes:
+    header = FrameHeader(ch=ch, seq=seq, ts=0.5, delivery="latest")
+    return encode_data_frame(header, b"\xab" * size)
+
+
+async def test_frame_queue_bounded_by_total_bytes():
+    session = _session()
+    size = 48 * 1024 * 1024  # three frames exceed the byte budget
+    assert 2 * size <= _FRAME_QUEUE_MAX_BYTES < 3 * size
+    for seq in range(3):
+        session._stream_data_received(4 * seq, _frame_bytes("cam", seq, size), True)
+    assert session.frames.qsize() == 2
+    assert session.frames_dropped == 1
+    assert session.frames.bytes <= _FRAME_QUEUE_MAX_BYTES
+    # Oldest first: seq 0 was evicted, and get() releases its bytes.
+    first = await session.frames.get()
+    assert first.header.seq == 1
+    assert session.frames.bytes == size
+
+
+async def test_frame_queue_still_bounded_by_count():
+    session = _session()
+    for seq in range(_FRAME_QUEUE_MAX + 10):
+        session._stream_data_received(4, _frame_bytes("cam", seq, 8), False)
+    assert session.frames.qsize() == _FRAME_QUEUE_MAX
+    assert session.frames_dropped == 10
+
+
+async def test_single_frame_over_budget_still_enqueues_alone():
+    # Eviction stops at an empty queue: a frame bigger than the whole byte
+    # budget still makes progress instead of being unqueueable.
+    queue = _FrameQueue(max_frames=4, max_bytes=1000)
+
+    def frame(seq: int, size: int) -> DataFrame:
+        return DataFrame(
+            header=FrameHeader(ch="cam", seq=seq, ts=0.5, delivery="latest"),
+            payload=b"\xab" * size,
+        )
+
+    queue.put_nowait(frame(0, 400))
+    queue.put_nowait(frame(1, 400))
+    queue.put_nowait(frame(2, 1200))
+    assert queue.qsize() == 1
+    assert queue.dropped == 2
+    assert (await queue.get()).header.seq == 2
+    assert queue.bytes == 0
+
+
+async def test_per_encoding_payload_caps():
+    session = _session()
+    session._control_msg_received(
+        Manifest(
+            robotId="r1",
+            channels=[
+                ChannelSpec(ch="odom", encoding="pose.json.v1", delivery="reliable", maxHz=20.5),
+                ChannelSpec(ch="cam", encoding="jpeg.v1", delivery="latest", maxHz=15.5),
+            ],
+        )
+    )
+    # The manifest still reaches the control consumer queue.
+    assert session.control_msgs.qsize() == 1
+
+    # Over the pose cap: dropped before it is queued.
+    session._stream_data_received(4, _frame_bytes("odom", 1, 128 * 1024), False)
+    assert session.frames.qsize() == 0
+    assert session.frames_oversized == 1
+    # Under the caps: queued.
+    session._stream_data_received(4, _frame_bytes("odom", 2, 100), False)
+    session._stream_data_received(8, _frame_bytes("cam", 1, 1024 * 1024), False)
+    assert session.frames.qsize() == 2
+    # Channels with no known encoding only get the outer frame-size bound.
+    session._stream_data_received(12, _frame_bytes("mystery", 1, 9 * 1024 * 1024), True)
+    assert session.frames.qsize() == 3
+    assert session.frames_oversized == 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -534,9 +534,10 @@ ignore = [
 "dimos/models/Detic/*" = ["ALL"]
 # Naming needs to match the actual libraries.
 "stubs/*.pyi" = ["N801", "N802", "N803", "N815", "N816", "N818"]
-# Wire-protocol mirror: model field names are the wire names (camelCase,
-# pinned to protocol.ts by the golden fixtures).
+# Wire-protocol/manifest mirrors: model field names are the wire names
+# (camelCase, pinned to the TS side by the golden fixtures).
 "dimos/web/relay_bridge/protocol.py" = ["N815"]
+"dimos/web/relay_bridge/manifest.py" = ["N815"]
 # Polyfill module: re-exports ROS message types (with a dimos_lcm fallback).
 "dimos/types/ros_polyfill.py" = ["F401"]
 

--- a/web/relay/forward.ts
+++ b/web/relay/forward.ts
@@ -19,10 +19,18 @@ const RELIABLE_MAX_BYTES = 16 * 1024 * 1024;
 // frame rather than routing a mangled channel name).
 const headerDecoder = new TextDecoder("utf-8", { fatal: true });
 
-/** Transport surface a policy writes to: one uni stream per sendFrame call. */
+/** Transport surface a policy writes to. */
 export interface ViewerSink {
+  /** One uni stream per call (latest channels; reset semantics need it). */
   sendFrame(bytes: Uint8Array): Promise<void>;
+  /** One persistent uni stream (reliable channels pack frames onto it). */
+  openStream(): Promise<FrameWriter>;
   kick(reason: string): void;
+}
+
+export interface FrameWriter {
+  write(bytes: Uint8Array): Promise<void>;
+  abort(reason?: unknown): Promise<void>;
 }
 
 export interface ChannelPolicy {
@@ -31,6 +39,9 @@ export interface ChannelPolicy {
   dropped: number;
   queued(): number;
   offer(bytes: Uint8Array): void;
+  /** Discard queued frames and release any persistent stream; later offers
+   * and in-flight drain completions become no-ops. Idempotent. */
+  dispose(): void;
 }
 
 /**
@@ -44,6 +55,7 @@ export class LatestChannel implements ChannelPolicy {
   dropped = 0;
   #pending: Uint8Array | null = null;
   #writing = false;
+  #disposed = false;
 
   constructor(readonly sink: ViewerSink) {}
 
@@ -52,13 +64,19 @@ export class LatestChannel implements ChannelPolicy {
   }
 
   offer(bytes: Uint8Array): void {
+    if (this.#disposed) return;
     if (this.#pending) this.dropped++;
     this.#pending = bytes;
     this.#drain();
   }
 
+  dispose(): void {
+    this.#disposed = true;
+    this.#pending = null;
+  }
+
   #drain(): void {
-    if (this.#writing) return;
+    if (this.#writing || this.#disposed) return;
     this.#writing = true;
     (async () => {
       while (this.#pending) {
@@ -68,9 +86,18 @@ export class LatestChannel implements ChannelPolicy {
         this.sent++;
       }
     })()
-      .catch(() => this.sink.kick("write failed"))
+      .catch(() => {
+        if (this.#disposed) return; // failure caused by disposal, not the viewer
+        this.sink.kick("write failed");
+        this.dispose();
+      })
       .finally(() => {
+        // Clearing #writing and rechecking must be one synchronous step: a
+        // frame offered between the loop observing an empty queue and this
+        // callback saw #writing still true and started no drain, so only
+        // this recheck can pick it up.
         this.#writing = false;
+        if (this.#pending) this.#drain();
       });
   }
 }
@@ -78,6 +105,12 @@ export class LatestChannel implements ChannelPolicy {
 /**
  * Reliable: bounded per-viewer FIFO, no drops, delivery order preserved. On
  * overflow the viewer is kicked (better a visible reconnect than silent loss).
+ *
+ * All frames ride ONE persistent uni stream (opened on first use): QUIC
+ * streams deliver in order, and stream-per-frame exhausts Firefox's ~100
+ * uni-stream credit, which is only replenished when streams complete - and
+ * Deno's lazy FIN (README bug 2) keeps delivered streams incomplete for
+ * seconds (README bug 11).
  */
 export class ReliableChannel implements ChannelPolicy {
   readonly delivery: Delivery = "reliable";
@@ -86,6 +119,8 @@ export class ReliableChannel implements ChannelPolicy {
   #fifo: Uint8Array[] = [];
   #bytes = 0;
   #writing = false;
+  #writer: FrameWriter | null = null;
+  #disposed = false;
 
   constructor(readonly sink: ViewerSink) {}
 
@@ -94,6 +129,7 @@ export class ReliableChannel implements ChannelPolicy {
   }
 
   offer(bytes: Uint8Array): void {
+    if (this.#disposed) return;
     this.#fifo.push(bytes);
     this.#bytes += bytes.byteLength;
     if (this.#fifo.length > RELIABLE_MAX_QUEUE || this.#bytes > RELIABLE_MAX_BYTES) {
@@ -103,19 +139,46 @@ export class ReliableChannel implements ChannelPolicy {
     this.#drain();
   }
 
+  dispose(): void {
+    this.#disposed = true;
+    this.#fifo.length = 0;
+    this.#bytes = 0;
+    // Abort, not close: close would still deliver the queued stale frames and
+    // (with Deno's lazy FIN, README bug 2) hold the stream's credit for
+    // seconds; both receivers treat a reset as end-of-stream, dropping a
+    // partial frame.
+    this.#writer?.abort().catch(() => {});
+    this.#writer = null;
+  }
+
   #drain(): void {
-    if (this.#writing) return;
+    if (this.#writing || this.#disposed) return;
     this.#writing = true;
     (async () => {
+      const writer = this.#writer ??= await this.sink.openStream();
+      if (this.#disposed) {
+        // dispose() ran while the stream was opening and saw no writer to
+        // abort; release the stream here.
+        writer.abort().catch(() => {});
+        this.#writer = null;
+        return;
+      }
       for (let bytes = this.#fifo.shift(); bytes; bytes = this.#fifo.shift()) {
         this.#bytes -= bytes.byteLength;
-        await this.sink.sendFrame(bytes);
+        await writer.write(bytes);
         this.sent++;
       }
     })()
-      .catch(() => this.sink.kick("write failed"))
+      .catch(() => {
+        if (this.#disposed) return; // failure caused by disposal, not the viewer
+        this.sink.kick("write failed");
+        this.dispose();
+      })
       .finally(() => {
+        // Same lost-wakeup guard as LatestChannel: recheck in the step that
+        // clears #writing.
         this.#writing = false;
+        if (this.#fifo.length > 0) this.#drain();
       });
   }
 }

--- a/web/relay/forward_test.ts
+++ b/web/relay/forward_test.ts
@@ -1,6 +1,7 @@
 import { assertEquals, assertRejects } from "@std/assert";
 import { encodeDataFrame, type FrameHeader } from "@dimos/shared";
 import {
+  type FrameWriter,
   LatestChannel,
   parseRobotFrameHeader,
   readDataFrameBytes,
@@ -12,21 +13,50 @@ import {
 class FakeSink implements ViewerSink {
   sent: Uint8Array[] = [];
   kicked: string | null = null;
+  streamsOpened = 0;
+  streamsAborted = 0;
   auto: boolean;
-  #waiters: (() => void)[] = [];
+  manualOpen = false;
+  #waiters: { resolve: () => void; reject: (e: Error) => void }[] = [];
+  #openWaiters: (() => void)[] = [];
 
   constructor(auto = true) {
     this.auto = auto;
   }
 
   sendFrame(bytes: Uint8Array): Promise<void> {
+    return this.#write(bytes);
+  }
+
+  openStream(): Promise<FrameWriter> {
+    this.streamsOpened++;
+    const writer: FrameWriter = {
+      write: (bytes: Uint8Array) => this.#write(bytes),
+      abort: () => {
+        this.streamsAborted++;
+        return Promise.resolve();
+      },
+    };
+    if (!this.manualOpen) return Promise.resolve(writer);
+    return new Promise((resolve) => this.#openWaiters.push(() => resolve(writer)));
+  }
+
+  #write(bytes: Uint8Array): Promise<void> {
     this.sent.push(bytes);
     if (this.auto) return Promise.resolve();
-    return new Promise<void>((resolve) => this.#waiters.push(resolve));
+    return new Promise<void>((resolve, reject) => this.#waiters.push({ resolve, reject }));
   }
 
   release(n = 1): void {
-    while (n-- > 0) this.#waiters.shift()?.();
+    while (n-- > 0) this.#waiters.shift()?.resolve();
+  }
+
+  rejectWrite(): void {
+    this.#waiters.shift()?.reject(new Error("stream aborted"));
+  }
+
+  releaseOpen(): void {
+    this.#openWaiters.shift()?.();
   }
 
   kick(reason: string): void {
@@ -94,6 +124,7 @@ Deno.test("reliable: FIFO order, zero drops", async () => {
   const sink = new FakeSink(false);
   const ch = new ReliableChannel(sink);
   for (let i = 0; i < 10; i++) ch.offer(frame(i));
+  await tick(); // the persistent stream opens before the first write
   for (let i = 0; i < 10; i++) {
     sink.release();
     await tick();
@@ -102,6 +133,21 @@ Deno.test("reliable: FIFO order, zero drops", async () => {
   assertEquals(ch.sent, 10);
   assertEquals(ch.dropped, 0);
   assertEquals(sink.kicked, null);
+  // All frames rode one persistent stream (per-frame streams starve Firefox's
+  // uni-stream credit; see ReliableChannel docs).
+  assertEquals(sink.streamsOpened, 1);
+});
+
+Deno.test("reliable: drain pauses reuse the same persistent stream", async () => {
+  const sink = new FakeSink();
+  const ch = new ReliableChannel(sink);
+  ch.offer(frame(1));
+  await tick();
+  assertEquals(sink.sent, [frame(1)]); // FIFO idle: the writing loop ended
+  ch.offer(frame(2));
+  await tick();
+  assertEquals(sink.sent, [frame(1), frame(2)]);
+  assertEquals(sink.streamsOpened, 1);
 });
 
 Deno.test("reliable: queue overflow kicks the viewer", async () => {
@@ -111,6 +157,99 @@ Deno.test("reliable: queue overflow kicks the viewer", async () => {
   for (let i = 0; i < 66 && sink.kicked === null; i++) ch.offer(frame(i));
   await tick();
   assertEquals(sink.kicked, "reliable channel overflow");
+});
+
+Deno.test("latest: dispose during an in-flight write discards the pending frame", async () => {
+  const sink = new FakeSink(false);
+  const ch = new LatestChannel(sink);
+  ch.offer(frame(1)); // write in flight
+  ch.offer(frame(2)); // parked in the pending slot
+  ch.dispose();
+  assertEquals(ch.queued(), 0);
+  sink.release(); // the in-flight write completes after disposal
+  await tick();
+  ch.offer(frame(3)); // ignored after dispose
+  await tick();
+  assertEquals(sink.sent, [frame(1)]);
+  assertEquals(sink.kicked, null);
+});
+
+Deno.test("latest: an in-flight write failing after dispose does not kick", async () => {
+  const sink = new FakeSink(false);
+  const ch = new LatestChannel(sink);
+  ch.offer(frame(1));
+  ch.dispose();
+  sink.rejectWrite(); // the stream died with the disposal
+  await tick();
+  assertEquals(sink.kicked, null);
+});
+
+Deno.test("reliable: dispose aborts the persistent stream and discards the queue", async () => {
+  const sink = new FakeSink(false);
+  const ch = new ReliableChannel(sink);
+  ch.offer(frame(1));
+  await tick(); // stream opened; first write in flight
+  ch.offer(frame(2));
+  ch.offer(frame(3));
+  ch.dispose();
+  assertEquals(ch.queued(), 0);
+  assertEquals(sink.streamsAborted, 1);
+  sink.rejectWrite(); // the aborted stream fails the in-flight write
+  await tick();
+  ch.offer(frame(4)); // ignored after dispose
+  await tick();
+  assertEquals(sink.sent, [frame(1)]);
+  assertEquals(sink.streamsOpened, 1);
+  assertEquals(sink.kicked, null);
+});
+
+Deno.test("reliable: dispose while the persistent stream opens still releases it", async () => {
+  const sink = new FakeSink(false);
+  sink.manualOpen = true;
+  const ch = new ReliableChannel(sink);
+  ch.offer(frame(1)); // drain is awaiting openStream
+  ch.dispose();
+  sink.releaseOpen();
+  await tick();
+  assertEquals(sink.streamsAborted, 1);
+  assertEquals(sink.sent, []);
+  assertEquals(sink.kicked, null);
+});
+
+// Lost-wakeup regression: the vulnerable window is between the drain loop
+// observing an empty queue and #writing clearing in its .finally, a fixed
+// number of microtasks later. Sweeping the depth at which the next offer
+// lands hits the window whatever the engine's await scheduling (depths 1-2
+// on Deno 2.6, where the stranded frame stayed queued forever).
+Deno.test("latest: a frame offered in the drain-completion window still sends", async () => {
+  for (let depth = 0; depth < 5; depth++) {
+    const sink = new FakeSink(false);
+    const ch = new LatestChannel(sink);
+    ch.offer(frame(1));
+    sink.release();
+    for (let i = 0; i < depth; i++) await Promise.resolve();
+    ch.offer(frame(2));
+    await tick();
+    sink.release();
+    await tick();
+    assertEquals([ch.sent, ch.queued()], [2, 0], `depth ${depth}`);
+  }
+});
+
+Deno.test("reliable: a frame offered in the drain-completion window still sends", async () => {
+  for (let depth = 0; depth < 5; depth++) {
+    const sink = new FakeSink(false);
+    const ch = new ReliableChannel(sink);
+    ch.offer(frame(1));
+    await tick(); // persistent stream opened; first write in flight
+    sink.release();
+    for (let i = 0; i < depth; i++) await Promise.resolve();
+    ch.offer(frame(2));
+    await tick();
+    sink.release();
+    await tick();
+    assertEquals([ch.sent, ch.queued()], [2, 0], `depth ${depth}`);
+  }
 });
 
 Deno.test("parseRobotFrameHeader accepts valid frames and rejects junk", () => {

--- a/web/relay/main.ts
+++ b/web/relay/main.ts
@@ -6,7 +6,7 @@ import { PROTOCOL_VERSION } from "@dimos/shared";
 import { startRelay } from "./server.ts";
 
 const args = parseArgs(Deno.args, {
-  string: ["host", "static-dir"],
+  string: ["host", "static-dir", "cockpit-dir"],
   default: { port: 7780, host: "127.0.0.1" },
 });
 
@@ -25,6 +25,7 @@ const relay = await startRelay({
   port: Number(args.port),
   host,
   staticDir: args["static-dir"],
+  cockpitDir: args["cockpit-dir"],
 });
 
 console.log(JSON.stringify({
@@ -35,6 +36,9 @@ console.log(JSON.stringify({
   v: PROTOCOL_VERSION,
 }));
 const pageHost = host === "0.0.0.0" ? "127.0.0.1" : host;
+if (args["cockpit-dir"] !== undefined) {
+  console.log(`[relay] cockpit: http://${pageHost}:${relay.httpPort}/`);
+}
 console.log(`[relay] debug page: http://${pageHost}:${relay.httpPort}/debug.html`);
 
 for (const signal of ["SIGINT", "SIGTERM"] as const) {

--- a/web/relay/registry.ts
+++ b/web/relay/registry.ts
@@ -55,6 +55,14 @@ export interface ViewerPeer {
   sendMsg(msg: Msg): void;
 }
 
+/** Dispose and drop every delivery policy of `viewer` (queued frames from the
+ * old watch must not reach the viewer, and persistent writers must release
+ * their streams). */
+function disposePolicies(viewer: ViewerPeer): void {
+  for (const policy of viewer.policies.values()) policy.dispose();
+  viewer.policies.clear();
+}
+
 interface ChannelInStats {
   delivery: Delivery;
   framesIn: number;
@@ -84,6 +92,7 @@ export class Registry {
 
   viewerClosed(viewer: ViewerPeer): void {
     if (!this.#viewers.delete(viewer)) return;
+    disposePolicies(viewer);
     if (viewer.watched !== null) this.#syncSubs(viewer.watched);
   }
 
@@ -175,7 +184,7 @@ export class Registry {
         const previous = viewer.watched;
         if (previous !== null && previous !== msg.robotId) {
           viewer.subs.clear();
-          viewer.policies.clear();
+          disposePolicies(viewer);
         }
         viewer.watched = msg.robotId;
         if (previous !== null && previous !== msg.robotId) this.#syncSubs(previous);
@@ -211,6 +220,8 @@ export class Registry {
           viewer.subs.add(msg.ch);
         } else {
           viewer.subs.delete(msg.ch);
+          viewer.policies.get(msg.ch)?.dispose();
+          viewer.policies.delete(msg.ch);
         }
         this.#syncSubs(viewer.watched);
         break;
@@ -250,6 +261,7 @@ export class Registry {
       if (viewer.watched !== id || !viewer.subs.has(ch)) continue;
       let policy = viewer.policies.get(ch);
       if (policy === undefined || policy.delivery !== delivery) {
+        policy?.dispose();
         policy = delivery === "reliable"
           ? new ReliableChannel(viewer.sink)
           : new LatestChannel(viewer.sink);

--- a/web/relay/registry_test.ts
+++ b/web/relay/registry_test.ts
@@ -11,16 +11,42 @@ import {
   type RobotInfo,
   type SubsMsg,
 } from "@dimos/shared";
-import { type ChannelPolicy, LatestChannel, ReliableChannel, type ViewerSink } from "./forward.ts";
+import {
+  type ChannelPolicy,
+  type FrameWriter,
+  LatestChannel,
+  ReliableChannel,
+  type ViewerSink,
+} from "./forward.ts";
 import { Registry, type RobotPeer, type ViewerPeer } from "./registry.ts";
 
 class FakeSink implements ViewerSink {
   sent: Uint8Array[] = [];
   kicked: string | null = null;
+  streamsOpened = 0;
+  streamsAborted = 0;
+  auto = true;
+  #waiters: (() => void)[] = [];
 
   sendFrame(bytes: Uint8Array): Promise<void> {
     this.sent.push(bytes);
-    return Promise.resolve();
+    if (this.auto) return Promise.resolve();
+    return new Promise<void>((resolve) => this.#waiters.push(resolve));
+  }
+
+  openStream(): Promise<FrameWriter> {
+    this.streamsOpened++;
+    return Promise.resolve({
+      write: (bytes: Uint8Array) => this.sendFrame(bytes),
+      abort: () => {
+        this.streamsAborted++;
+        return Promise.resolve();
+      },
+    });
+  }
+
+  release(n = 1): void {
+    while (n-- > 0) this.#waiters.shift()?.();
   }
 
   kick(reason: string): void {
@@ -87,6 +113,10 @@ function attach(reg: Registry, robotId: string, chs: string[]): FakeViewer {
 function frame(ch: string, seq: number, delivery: "latest" | "reliable" = "latest"): Uint8Array {
   const header: FrameHeader = { ch, seq, ts: seq + 0.5, delivery };
   return encodeDataFrame(header, new Uint8Array([seq]));
+}
+
+function tick(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
 }
 
 const SPECS: ChannelSpec[] = [
@@ -204,6 +234,14 @@ Deno.test("viewer hello rejects wrong version and role", () => {
   assertEquals((badVersion.replies[0] as { code: string }).code, "version_mismatch");
   assertEquals(badVersion.greeted, false);
 
+  // A v1 (T2-era) viewer would decode one frame per reliable stream and then
+  // silently freeze on the v2 persistent stream; it must be rejected too.
+  const v1Viewer = new FakeViewer();
+  reg.addViewer(v1Viewer);
+  assertEquals(send(reg, v1Viewer, { t: "hello", v: 1, role: "viewer" }), false);
+  assertEquals((v1Viewer.replies[0] as { code: string }).code, "version_mismatch");
+  assertEquals(v1Viewer.greeted, false);
+
   const badRole = new FakeViewer();
   reg.addViewer(badRole);
   assertEquals(
@@ -227,7 +265,7 @@ Deno.test("viewer commands before hello are rejected without changing state", ()
   assertEquals(viewer.subs, new Set());
 });
 
-Deno.test("frames route only to watching+subscribed viewers", () => {
+Deno.test("frames route only to watching+subscribed viewers", async () => {
   const reg = new Registry();
   const r1 = new FakeRobot("r1", SPECS);
   const r2 = new FakeRobot("r2", SPECS);
@@ -239,10 +277,100 @@ Deno.test("frames route only to watching+subscribed viewers", () => {
   const noSub = attach(reg, "r1", []);
 
   reg.onRobotFrame(r1, frame("odom", 1));
+  // The reliable policy opens its persistent stream before the first write.
+  await tick();
   assertEquals(subscribed.sink.sent.length, 1);
   assertEquals(otherChannel.sink.sent.length, 0);
   assertEquals(otherRobot.sink.sent.length, 0);
   assertEquals(noSub.sink.sent.length, 0);
+});
+
+Deno.test("watch switch disposes the old robot's policies", async () => {
+  const reg = new Registry();
+  const r1 = new FakeRobot("r1", SPECS);
+  const r2 = new FakeRobot("r2", SPECS);
+  reg.registerRobot(r1);
+  reg.registerRobot(r2);
+  const viewer = attach(reg, "r1", ["odom"]);
+  viewer.sink.auto = false;
+  reg.onRobotFrame(r1, frame("odom", 1));
+  reg.onRobotFrame(r1, frame("odom", 2));
+  await tick(); // stream opened; frame 1 in flight, frame 2 queued
+  send(reg, viewer, { t: "watch", robotId: "r2" });
+  assertEquals(viewer.policies.size, 0);
+  assertEquals(viewer.sink.streamsAborted, 1);
+  viewer.sink.release(); // the in-flight write completes after the switch
+  await tick();
+  assertEquals(viewer.sink.sent.length, 1); // the queued r1 frame never went out
+  assertEquals(viewer.sink.kicked, null);
+});
+
+Deno.test("rapid watch switches release every abandoned persistent stream", async () => {
+  const reg = new Registry();
+  const robots: Record<string, FakeRobot> = {
+    r1: new FakeRobot("r1", SPECS),
+    r2: new FakeRobot("r2", SPECS),
+  };
+  reg.registerRobot(robots.r1);
+  reg.registerRobot(robots.r2);
+  const viewer = attach(reg, "r1", ["odom"]);
+  reg.onRobotFrame(robots.r1, frame("odom", 0));
+  let watching = "r1";
+  for (let i = 1; i <= 6; i++) {
+    watching = watching === "r1" ? "r2" : "r1";
+    send(reg, viewer, { t: "watch", robotId: watching });
+    send(reg, viewer, { t: "sub", ch: "odom" });
+    reg.onRobotFrame(robots[watching], frame("odom", i));
+  }
+  await tick();
+  assertEquals(viewer.sink.streamsOpened, 7);
+  assertEquals(viewer.sink.streamsAborted, 6); // only the live stream remains
+  assertEquals(viewer.sink.kicked, null);
+});
+
+Deno.test("unsub disposes the channel's policy and releases its stream", async () => {
+  const reg = new Registry();
+  const robot = new FakeRobot("r1", SPECS);
+  reg.registerRobot(robot);
+  const viewer = attach(reg, "r1", ["odom"]);
+  reg.onRobotFrame(robot, frame("odom", 1));
+  await tick();
+  send(reg, viewer, { t: "unsub", ch: "odom" });
+  assertEquals(viewer.policies.size, 0);
+  assertEquals(viewer.sink.streamsAborted, 1);
+  // Re-subscribing starts a fresh policy on a fresh stream.
+  send(reg, viewer, { t: "sub", ch: "odom" });
+  reg.onRobotFrame(robot, frame("odom", 2));
+  await tick();
+  assertEquals(viewer.sink.streamsOpened, 2);
+  assertEquals(viewer.sink.sent.length, 2);
+});
+
+Deno.test("a delivery change disposes the superseded policy", async () => {
+  const reg = new Registry();
+  const robot = new FakeRobot("r1", []); // no manifest: the frame header rules
+  reg.registerRobot(robot);
+  const viewer = attach(reg, "r1", ["tele"]);
+  reg.onRobotFrame(robot, frame("tele", 1, "reliable"));
+  await tick();
+  assert(viewer.policies.get("tele") instanceof ReliableChannel);
+  reg.onRobotFrame(robot, frame("tele", 2, "latest"));
+  assert(viewer.policies.get("tele") instanceof LatestChannel);
+  assertEquals(viewer.sink.streamsAborted, 1); // the reliable writer released
+  await tick();
+  assertEquals(viewer.sink.sent.length, 2);
+});
+
+Deno.test("viewer teardown disposes its policies", async () => {
+  const reg = new Registry();
+  const robot = new FakeRobot("r1", SPECS);
+  reg.registerRobot(robot);
+  const viewer = attach(reg, "r1", ["odom"]);
+  reg.onRobotFrame(robot, frame("odom", 1));
+  await tick();
+  reg.viewerClosed(viewer);
+  assertEquals(viewer.policies.size, 0);
+  assertEquals(viewer.sink.streamsAborted, 1);
 });
 
 Deno.test("manifest delivery wins over the frame header's", () => {

--- a/web/relay/server.ts
+++ b/web/relay/server.ts
@@ -4,7 +4,7 @@
 // Session/transport handling lives in session.ts, registration + routing in
 // registry.ts; this file owns the listeners and process-level wiring.
 import { PROTOCOL_VERSION } from "@dimos/shared";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { makeEphemeralCert } from "./cert.ts";
 import { Registry } from "./registry.ts";
 import { RobotSession, ViewerSession } from "./session.ts";
@@ -20,6 +20,12 @@ export interface RelayOptions {
   host?: string;
   /** Directory served over HTTP. Defaults to ./static next to this module. */
   staticDir?: string;
+  /**
+   * Built Cockpit app (web/cockpit/dist). When set, / serves its index.html
+   * and files resolve here first, with staticDir as the fallback (so
+   * /debug.html keeps working). Without it, / serves the debug page.
+   */
+  cockpitDir?: string;
 }
 
 export interface RelayHandle {
@@ -39,6 +45,52 @@ const MIME: Record<string, string> = {
   ".svg": "image/svg+xml",
   ".png": "image/png",
 };
+
+function resolveDirUrl(dir: string): URL {
+  // Canonical (realPath) so serveFrom compares symlink-free paths (macOS /tmp
+  // is itself a symlink); href must end with "/" so new URL(name, root)
+  // resolves under it.
+  const real = Deno.realPathSync(dir);
+  return pathToFileURL(real.endsWith("/") ? real : real + "/");
+}
+
+/**
+ * Serve `name` from under `root` (canonical, via resolveDirUrl): a 400 for
+ * path traversal or symlink escape, null when the file does not exist
+ * (callers fall through to the next root or a 404).
+ */
+async function serveFrom(root: URL, name: string): Promise<Response | null> {
+  // Resolve the request to a real path and confirm it stays under the root. A
+  // leading "/" or "\" makes `new URL(name, root)` jump to the filesystem
+  // root; fileURLToPath additionally throws on encoded slashes.
+  let filePath: string;
+  try {
+    filePath = fileURLToPath(new URL(name, root));
+  } catch {
+    return new Response("bad path", { status: 400 });
+  }
+  const rootPath = fileURLToPath(root);
+  if (!filePath.startsWith(rootPath)) return new Response("bad path", { status: 400 });
+  // The lexical check cannot see symlinks: canonicalize (realPath follows
+  // them) and require the target to still be under the root, so a link
+  // inside a served tree cannot expose files outside it.
+  let realPath: string;
+  try {
+    realPath = await Deno.realPath(filePath);
+  } catch {
+    return null; // absent (or a dangling link)
+  }
+  if (!realPath.startsWith(rootPath)) return new Response("bad path", { status: 400 });
+  try {
+    const data = await Deno.readFile(realPath);
+    const ext = name.slice(name.lastIndexOf("."));
+    return new Response(data, {
+      headers: { "content-type": MIME[ext] ?? "application/octet-stream" },
+    });
+  } catch {
+    return null;
+  }
+}
 
 export function installUnhandledRejectionGuard(): void {
   // deno#28406: WT sessions leak unhandled rejections on disconnect/idle
@@ -105,15 +157,11 @@ export async function startRelay(options: RelayOptions = {}): Promise<RelayHandl
     // listener stopped (shutdown)
   });
 
-  const staticRoot = options.staticDir
-    ? new URL(
-      options.staticDir.endsWith("/") ? options.staticDir : options.staticDir + "/",
-      `file://${Deno.cwd()}/`,
-    )
-    : new URL("./static/", import.meta.url);
-  // Resolved filesystem prefix every served path must stay under (href ends
-  // with "/", so the path does too).
-  const staticRootPath = fileURLToPath(staticRoot);
+  const staticRoot = resolveDirUrl(
+    options.staticDir ?? fileURLToPath(new URL("./static/", import.meta.url)),
+  );
+  const cockpitRoot = options.cockpitDir ? resolveDirUrl(options.cockpitDir) : null;
+  const roots = cockpitRoot !== null ? [cockpitRoot, staticRoot] : [staticRoot];
 
   async function handleHttp(req: Request): Promise<Response> {
     const url = new URL(req.url);
@@ -127,26 +175,14 @@ export async function startRelay(options: RelayOptions = {}): Promise<RelayHandl
     if (url.pathname === "/api/stats") {
       return Response.json(registry.stats());
     }
-    const name = url.pathname === "/" ? "debug.html" : url.pathname.slice(1);
-    // Resolve the request to a real path and confirm it stays under the static
-    // root. A leading "/" or "\" makes `new URL(name, root)` jump to the
-    // filesystem root; fileURLToPath additionally throws on encoded slashes.
-    let filePath: string;
-    try {
-      filePath = fileURLToPath(new URL(name, staticRoot));
-    } catch {
-      return new Response("bad path", { status: 400 });
+    const name = url.pathname === "/"
+      ? (cockpitRoot !== null ? "index.html" : "debug.html")
+      : url.pathname.slice(1);
+    for (const root of roots) {
+      const resp = await serveFrom(root, name);
+      if (resp !== null) return resp;
     }
-    if (!filePath.startsWith(staticRootPath)) return new Response("bad path", { status: 400 });
-    try {
-      const data = await Deno.readFile(filePath);
-      const ext = name.slice(name.lastIndexOf("."));
-      return new Response(data, {
-        headers: { "content-type": MIME[ext] ?? "application/octet-stream" },
-      });
-    } catch {
-      return new Response("not found", { status: 404 });
-    }
+    return new Response("not found", { status: 404 });
   }
 
   const httpServer = Deno.serve(

--- a/web/relay/server.ts
+++ b/web/relay/server.ts
@@ -46,11 +46,21 @@ const MIME: Record<string, string> = {
   ".png": "image/png",
 };
 
-function resolveDirUrl(dir: string): URL {
+function resolveDirUrl(dir: string, label: string): URL {
   // Canonical (realPath) so serveFrom compares symlink-free paths (macOS /tmp
   // is itself a symlink); href must end with "/" so new URL(name, root)
-  // resolves under it.
-  const real = Deno.realPathSync(dir);
+  // resolves under it. Fail with a clear labeled error on a bad path: the
+  // raw NotFound is cryptic, and a plain file would "start" fine and then
+  // 404 every request.
+  let real: string;
+  try {
+    real = Deno.realPathSync(dir);
+  } catch {
+    throw new Error(`${label} does not exist: ${dir}`);
+  }
+  if (!Deno.statSync(real).isDirectory) {
+    throw new Error(`${label} is not a directory: ${dir}`);
+  }
   return pathToFileURL(real.endsWith("/") ? real : real + "/");
 }
 
@@ -106,6 +116,16 @@ export function installUnhandledRejectionGuard(): void {
 export async function startRelay(options: RelayOptions = {}): Promise<RelayHandle> {
   installUnhandledRejectionGuard();
   const host = options.host ?? "127.0.0.1";
+
+  // Resolve the served roots before binding anything so a bad path fails
+  // fast, without a QUIC endpoint or timer left behind.
+  const staticRoot = resolveDirUrl(
+    options.staticDir ?? fileURLToPath(new URL("./static/", import.meta.url)),
+    "staticDir",
+  );
+  const cockpitRoot = options.cockpitDir ? resolveDirUrl(options.cockpitDir, "cockpitDir") : null;
+  const roots = cockpitRoot !== null ? [cockpitRoot, staticRoot] : [staticRoot];
+
   const cert = await makeEphemeralCert();
 
   // QUIC always binds an ephemeral port; clients discover it via the ready
@@ -156,12 +176,6 @@ export async function startRelay(options: RelayOptions = {}): Promise<RelayHandl
   })().catch(() => {
     // listener stopped (shutdown)
   });
-
-  const staticRoot = resolveDirUrl(
-    options.staticDir ?? fileURLToPath(new URL("./static/", import.meta.url)),
-  );
-  const cockpitRoot = options.cockpitDir ? resolveDirUrl(options.cockpitDir) : null;
-  const roots = cockpitRoot !== null ? [cockpitRoot, staticRoot] : [staticRoot];
 
   async function handleHttp(req: Request): Promise<Response> {
     const url = new URL(req.url);

--- a/web/relay/server_test.ts
+++ b/web/relay/server_test.ts
@@ -3,9 +3,11 @@
 // streams (verified; the 2.6.10 incoming-uni bug is server-side receive
 // only), so this covers the full forwarding path without a browser.
 import { assert, assertEquals } from "@std/assert";
+import { fileURLToPath } from "node:url";
 import {
   type ChannelSpec,
   ControlFrameReader,
+  DataFrameStreamReader,
   decodeDatagram,
   encodeControlFrame,
   encodeDataFrame,
@@ -15,7 +17,6 @@ import {
   PROTOCOL_VERSION,
   type RobotInfo,
 } from "@dimos/shared";
-import { readDataFrameBytes } from "./forward.ts";
 import { startRelay } from "./server.ts";
 
 const ROBOT: RobotInfo = { id: "deno-bot", name: "Deno Bot", model: "test" };
@@ -87,26 +88,32 @@ function datagramQueue(readable: ReadableStream<Uint8Array>): () => Promise<Msg>
   };
 }
 
-/** Collect forwarded data frames arriving on relay-initiated uni streams. */
+/**
+ * Collect forwarded data frames arriving on relay-initiated uni streams
+ * (one frame per latest stream; back-to-back frames on a reliable channel's
+ * persistent stream).
+ */
 function frameQueue(
   wt: WebTransport,
 ): () => Promise<{ header: FrameHeader; payload: Uint8Array }> {
   const queue: { header: FrameHeader; payload: Uint8Array }[] = [];
   const waiters: ((f: { header: FrameHeader; payload: Uint8Array }) => void)[] = [];
+  const deliver = (frame: { header: FrameHeader; payload: Uint8Array }) => {
+    const waiter = waiters.shift();
+    if (waiter) waiter(frame);
+    else queue.push(frame);
+  };
   (async () => {
     for await (const stream of wt.incomingUnidirectionalStreams) {
-      readDataFrameBytes(stream)
-        .then((bytes) => {
-          const headerLen = new DataView(bytes.buffer, bytes.byteOffset).getUint32(0, true);
-          const header = JSON.parse(
-            new TextDecoder().decode(bytes.subarray(8, 8 + headerLen)),
-          ) as FrameHeader;
-          const payload = bytes.subarray(8 + headerLen);
-          const waiter = waiters.shift();
-          if (waiter) waiter({ header, payload });
-          else queue.push({ header, payload });
-        })
-        .catch(() => {});
+      (async () => {
+        const frames = new DataFrameStreamReader();
+        const reader = (stream as ReadableStream<Uint8Array>).getReader();
+        while (true) {
+          const { value, done } = await reader.read();
+          if (value && value.byteLength) frames.push(value).forEach(deliver);
+          if (done) break;
+        }
+      })().catch(() => {});
     }
   })().catch(() => {});
   return () => {
@@ -359,6 +366,43 @@ Deno.test({
     await within(bare.closed.catch(() => {}), "bare robot session close");
   });
 
+  await t.step("robot hello with an invalid manifest -> invalid_manifest + close", async () => {
+    const dup = new WebTransport(`${relay.wtUrl}/robot`, certOpts(relay.certHash));
+    await within(dup.ready, "dup-manifest robot connect");
+    const dupDatagrams = datagramQueue(dup.datagrams.readable);
+    const dupWriter = dup.datagrams.writable.getWriter();
+    await dupWriter.write(encodeDatagram({
+      t: "hello",
+      v: PROTOCOL_VERSION,
+      role: "robot",
+      robot: { id: "dup-bot", name: "Dup Bot", model: "test" },
+      manifest: { channels: [CHANNELS[0], CHANNELS[0]] },
+    }));
+    const err = await within(dupDatagrams(), "invalid_manifest error");
+    assertEquals(err.t, "error");
+    assertEquals((err as { code: string }).code, "invalid_manifest");
+    await within(dup.closed.catch(() => {}), "dup-manifest robot close");
+  });
+
+  await t.step("robot hello with the previous protocol version -> error + close", async () => {
+    // A v1 bridge would misread the v2 persistent reliable stream as one
+    // frame; the handshake must fail loudly instead.
+    const old = new WebTransport(`${relay.wtUrl}/robot`, certOpts(relay.certHash));
+    await within(old.ready, "old-version robot connect");
+    const oldDatagrams = datagramQueue(old.datagrams.readable);
+    const oldWriter = old.datagrams.writable.getWriter();
+    await oldWriter.write(encodeDatagram({
+      t: "hello",
+      v: 1,
+      role: "robot",
+      robot: { id: "old-bot", name: "Old Bot", model: "test" },
+    }));
+    const err = await within(oldDatagrams(), "old-version error");
+    assertEquals(err.t, "error");
+    assertEquals((err as { code: string }).code, "version_mismatch");
+    await within(old.closed.catch(() => {}), "old-version robot close");
+  });
+
   await t.step("hello with a wrong version -> error + close", async () => {
     const bad = new WebTransport(`${relay.wtUrl}/viewer`, certOpts(relay.certHash));
     await within(bad.ready, "bad-version viewer connect");
@@ -425,4 +469,39 @@ Deno.test({
   viewer.close();
   robot.close();
   await relay.shutdown();
+});
+
+Deno.test({
+  name: "relay serves the cockpit dist when configured",
+  sanitizeOps: false,
+  sanitizeResources: false,
+}, async () => {
+  const cockpitDir = fileURLToPath(new URL("./testdata/fake_cockpit", import.meta.url));
+  const relay = await startRelay({ port: 0, cockpitDir });
+  const httpBase = `http://127.0.0.1:${relay.httpPort}`;
+  try {
+    const index = await (await fetch(`${httpBase}/`)).text();
+    assert(index.includes("fake cockpit index"));
+    const asset = await fetch(`${httpBase}/assets/app.js`);
+    assertEquals(asset.status, 200);
+    assertEquals(asset.headers.get("content-type"), "application/javascript");
+    await asset.body?.cancel();
+    // The debug page still resolves from relay/static/ behind the cockpit.
+    const page = await (await fetch(`${httpBase}/debug.html`)).text();
+    assert(page.includes("DimOS relay debug"));
+    // The traversal guard covers the cockpit root too.
+    const res = await fetch(`${httpBase}//etc/passwd`);
+    await res.body?.cancel();
+    assertEquals(res.status, 400);
+    // A symlink whose target lies outside the root must not be followed
+    // (readFile follows symlinks; the containment check compares realpaths).
+    const escape = await fetch(`${httpBase}/escape.txt`);
+    await escape.body?.cancel();
+    assertEquals(escape.status, 400);
+    // A symlink staying inside the root still serves.
+    const alias = await (await fetch(`${httpBase}/alias.txt`)).text();
+    assert(alias.includes("fake cockpit index"));
+  } finally {
+    await relay.shutdown();
+  }
 });

--- a/web/relay/server_test.ts
+++ b/web/relay/server_test.ts
@@ -2,7 +2,7 @@
 // both robot and viewer. Deno's client CAN receive relay-initiated uni
 // streams (verified; the 2.6.10 incoming-uni bug is server-side receive
 // only), so this covers the full forwarding path without a browser.
-import { assert, assertEquals } from "@std/assert";
+import { assert, assertEquals, assertRejects } from "@std/assert";
 import { fileURLToPath } from "node:url";
 import {
   type ChannelSpec,
@@ -504,4 +504,20 @@ Deno.test({
   } finally {
     await relay.shutdown();
   }
+});
+
+Deno.test("startRelay rejects a bad served dir with a labeled error", async () => {
+  // Before binding anything, so nothing leaks: a typo'd path names the
+  // offending option, and a file (realpath-able, would 404 everything) is
+  // rejected too.
+  await assertRejects(
+    () => startRelay({ staticDir: "/no/such/dir" }),
+    Error,
+    "staticDir does not exist: /no/such/dir",
+  );
+  await assertRejects(
+    () => startRelay({ cockpitDir: fileURLToPath(import.meta.url) }),
+    Error,
+    "cockpitDir is not a directory",
+  );
 });

--- a/web/relay/session.ts
+++ b/web/relay/session.ts
@@ -19,13 +19,24 @@ import {
   PROTOCOL_VERSION,
   type RobotInfo,
 } from "@dimos/shared";
+import { parseManifest } from "@dimos/shared/manifest";
 import {
   type ChannelPolicy,
+  type FrameWriter,
   readDataFrameBytes,
   readWebTransportPreamble,
   type ViewerSink,
 } from "./forward.ts";
 import type { Registry, RobotPeer, ViewerPeer } from "./registry.ts";
+
+// Relay->viewer send priorities, all in one place. WebTransport sendOrder
+// (backed by quinn stream priority here): queued bytes of a higher-order
+// stream are sent before those of a lower-order one, so control must outrank
+// reliable telemetry and reliable must outrank latest video, whose per-frame
+// streams count down from -1 to complete oldest-first (README bug 7).
+// Datagrams (the Python viewer's control leg) have no sendOrder API.
+export const CONTROL_SEND_ORDER = 2;
+export const RELIABLE_SEND_ORDER = 1;
 
 function closeAfterFlush(wt: WebTransport, reason: string): void {
   // Session close discards queued stream/datagram data, so give a just-sent
@@ -111,6 +122,16 @@ export class RobotSession implements RobotPeer {
           "missing robot id",
         );
       }
+      // Manifest-less hellos are legal (transport tests); a declared manifest
+      // must pass the domain rules or duplicate/bogus channels would be
+      // interpreted inconsistently downstream.
+      if (msg.manifest !== undefined) {
+        try {
+          parseManifest(msg.manifest);
+        } catch (e) {
+          return this.#reject("invalid_manifest", (e as Error).message, "invalid manifest");
+        }
+      }
       // First hello wins; resends (the bridge repeats hello until welcome)
       // must not mutate identity mid-session.
       if (this.info === null) {
@@ -164,16 +185,24 @@ export class ViewerSession implements ViewerPeer {
     this.#wt = wt;
     this.id = id;
     this.#registry = registry;
-    let sendOrder = 1;
+    let latestOrder = 1;
     this.sink = {
       async sendFrame(bytes: Uint8Array): Promise<void> {
         const stream = await wt.createUnidirectionalStream({
           waitUntilAvailable: true,
-          sendOrder: -(sendOrder++),
+          sendOrder: -(latestOrder++),
         });
         const writer = stream.getWriter();
         await writer.write(bytes);
         await writer.close();
+      },
+      async openStream(): Promise<FrameWriter> {
+        // Persistent stream for a reliable channel.
+        const stream = await wt.createUnidirectionalStream({
+          waitUntilAvailable: true,
+          sendOrder: RELIABLE_SEND_ORDER,
+        });
+        return stream.getWriter();
       },
       kick(reason: string): void {
         console.log(`[relay] kicking viewer: ${reason}`);
@@ -216,6 +245,9 @@ export class ViewerSession implements ViewerPeer {
     (async () => {
       for await (const bidi of this.#wt.incomingBidirectionalStreams) {
         (async () => {
+          // Viewer-opened, so its send half starts at the default order 0,
+          // which a saturated reliable stream would starve.
+          bidi.writable.sendOrder = CONTROL_SEND_ORDER;
           const writer = bidi.writable.getWriter();
           const reply = (m: Msg) => {
             writer.write(encodeControlFrame(m)).catch(() => {});

--- a/web/relay/session_test.ts
+++ b/web/relay/session_test.ts
@@ -1,0 +1,75 @@
+// ViewerSession unit tests over a fake WebTransport: the send-priority
+// scheme (control > reliable telemetry > latest video) must hold for every
+// stream the relay creates or replies on. Wire-level scheduling itself is
+// quinn's job; here we pin the orders the relay assigns.
+import { assert, assertEquals } from "@std/assert";
+import { ControlFrameReader, encodeControlFrame, type Msg, PROTOCOL_VERSION } from "@dimos/shared";
+import { Registry } from "./registry.ts";
+import { CONTROL_SEND_ORDER, RELIABLE_SEND_ORDER, ViewerSession } from "./session.ts";
+
+function tick(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+Deno.test("send-order bands: control above reliable above every latest stream", () => {
+  assert(CONTROL_SEND_ORDER > RELIABLE_SEND_ORDER);
+  assert(RELIABLE_SEND_ORDER > 0); // latest streams are all negative
+});
+
+Deno.test("the sink assigns the documented sendOrder to each stream kind", async () => {
+  const orders: (number | undefined)[] = [];
+  const wt = {
+    createUnidirectionalStream(opts?: WebTransportSendStreamOptions) {
+      orders.push(opts?.sendOrder);
+      return Promise.resolve(new WritableStream<Uint8Array>());
+    },
+  } as unknown as WebTransport;
+  const session = new ViewerSession(wt, 1, new Registry());
+  await session.sink.sendFrame(new Uint8Array([1]));
+  await session.sink.sendFrame(new Uint8Array([2]));
+  await session.sink.openStream();
+  // Latest streams count down (oldest first, all below reliable).
+  assertEquals(orders, [-1, -2, RELIABLE_SEND_ORDER]);
+});
+
+Deno.test("the viewer control stream is raised to CONTROL_SEND_ORDER", async () => {
+  const written: Uint8Array[] = [];
+  const controlWritable = new WritableStream<Uint8Array>({
+    write(chunk) {
+      written.push(chunk);
+    },
+  });
+  const wt = {
+    closed: new Promise<void>(() => {}),
+    datagrams: {
+      readable: new ReadableStream<Uint8Array>(),
+      writable: new WritableStream<Uint8Array>(),
+    },
+    incomingBidirectionalStreams: new ReadableStream({
+      start(controller) {
+        controller.enqueue({
+          readable: new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(
+                encodeControlFrame({ t: "hello", v: PROTOCOL_VERSION, role: "viewer" }),
+              );
+            },
+          }),
+          writable: controlWritable,
+        });
+      },
+    }),
+  } as unknown as WebTransport;
+  const session = new ViewerSession(wt, 1, new Registry());
+  session.start();
+  for (let i = 0; i < 100 && written.length < 2; i++) await tick();
+  const frames = new ControlFrameReader();
+  const replies = written.flatMap((chunk) => frames.push(chunk));
+  assertEquals(replies[0], { t: "welcome", v: PROTOCOL_VERSION } as Msg);
+  // The viewer opened this stream, so its send half started at the default
+  // order 0; the session must have raised it above reliable telemetry.
+  assertEquals(
+    (controlWritable as unknown as { sendOrder?: number }).sendOrder,
+    CONTROL_SEND_ORDER,
+  );
+});

--- a/web/relay/static/debug.html
+++ b/web/relay/static/debug.html
@@ -134,50 +134,72 @@
         };
       }
 
-      // Read one data frame by byte count; never wait for EOF (the relay's FIN can
-      // arrive up to ~1 s late on Deno 2.6.x).
-      async function readDataFrame(stream) {
+      // Read data frames by byte count; never wait for EOF (the relay's FIN
+      // can arrive up to ~1 s late on Deno 2.6.x). A latest stream carries
+      // one frame, a reliable channel's persistent stream carries them back
+      // to back; no cancel, which would reset a persistent stream. Chunks are
+      // queued behind a read cursor so each frame is copied out exactly once
+      // (keep in sync with DataFrameStreamReader in web/shared/protocol.ts).
+      async function readDataFrames(stream, onFrame) {
         const reader = stream.getReader();
         const chunks = [];
-        let size = 0;
-        let total = null;
-        let head = new Uint8Array(0);
+        let head = 0; // index of the chunk holding the read cursor
+        let cursor = 0; // byte offset into chunks[head]
+        let size = 0; // unread bytes across all queued chunks
+        // First `n` unread bytes; consuming advances the cursor.
+        const gather = (n, consume) => {
+          const first = chunks[head];
+          if (!consume && first.byteLength - cursor >= n) {
+            return first.subarray(cursor, cursor + n);
+          }
+          const out = new Uint8Array(n);
+          let off = 0;
+          let i = head;
+          let at = cursor;
+          while (off < n) {
+            const chunk = chunks[i];
+            const step = Math.min(chunk.byteLength - at, n - off);
+            out.set(chunk.subarray(at, at + step), off);
+            off += step;
+            at += step;
+            if (at === chunk.byteLength) {
+              i++;
+              at = 0;
+            }
+          }
+          if (consume) {
+            head = i;
+            cursor = at;
+            size -= n;
+          }
+          return out;
+        };
         try {
-          while (total === null || size < total) {
+          while (true) {
             const { value, done } = await reader.read();
             if (value && value.byteLength) {
               chunks.push(value);
               size += value.byteLength;
-              if (total === null) {
-                const merged = new Uint8Array(Math.min(size, 8));
-                let off = 0;
-                for (const c of chunks) {
-                  for (let i = 0; i < c.byteLength && off < 8; i++) merged[off++] = c[i];
-                }
-                head = merged;
-                if (size >= 8) {
-                  const dv = new DataView(head.buffer);
-                  total = 8 + dv.getUint32(0, true) + dv.getUint32(4, true);
-                }
+              while (size >= 8) {
+                const prefix = gather(8, false);
+                const dv = new DataView(prefix.buffer, prefix.byteOffset);
+                const hlen = dv.getUint32(0, true);
+                const total = 8 + hlen + dv.getUint32(4, true);
+                if (size < total) break;
+                const frame = gather(total, true);
+                onFrame(
+                  JSON.parse(dec.decode(frame.subarray(8, 8 + hlen))),
+                  frame.subarray(8 + hlen),
+                );
               }
+              chunks.splice(0, head);
+              head = 0;
             }
             if (done) break;
           }
         } finally {
-          reader.releaseLock(); // no cancel: the late FIN closes the stream
+          reader.releaseLock();
         }
-        if (total === null || size < total) throw new Error("stream ended mid-frame");
-        const buf = new Uint8Array(size);
-        let off = 0;
-        for (const c of chunks) {
-          buf.set(c, off);
-          off += c.byteLength;
-        }
-        const hlen = new DataView(buf.buffer).getUint32(0, true);
-        return {
-          header: JSON.parse(dec.decode(buf.subarray(8, 8 + hlen))),
-          payload: buf.subarray(8 + hlen, total),
-        };
       }
 
       // ---- per-channel stats ----
@@ -389,10 +411,10 @@
             }
           })().catch(() => {});
 
-          // data plane: one uni stream per frame; ends with the session
+          // data plane: latest = one uni stream per frame, reliable = one
+          // persistent stream per channel; both end with the session
           for await (const stream of wt.incomingUnidirectionalStreams) {
-            readDataFrame(stream).then(({ header, payload }) => onFrame(header, payload))
-              .catch(() => {});
+            readDataFrames(stream, onFrame).catch(() => {});
           }
         } finally {
           for (const t of timers) clearInterval(t);

--- a/web/relay/testdata/fake_cockpit/alias.txt
+++ b/web/relay/testdata/fake_cockpit/alias.txt
@@ -1,0 +1,1 @@
+index.html

--- a/web/relay/testdata/fake_cockpit/assets/app.js
+++ b/web/relay/testdata/fake_cockpit/assets/app.js
@@ -1,0 +1,1 @@
+console.log("fake cockpit asset");

--- a/web/relay/testdata/fake_cockpit/escape.txt
+++ b/web/relay/testdata/fake_cockpit/escape.txt
@@ -1,0 +1,1 @@
+../secret.txt

--- a/web/relay/testdata/fake_cockpit/index.html
+++ b/web/relay/testdata/fake_cockpit/index.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<html>
+  <body>fake cockpit index</body>
+</html>

--- a/web/relay/testdata/secret.txt
+++ b/web/relay/testdata/secret.txt
@@ -1,0 +1,1 @@
+top secret: must never be served

--- a/web/shared/deno.json
+++ b/web/shared/deno.json
@@ -2,6 +2,7 @@
   "name": "@dimos/shared",
   "version": "0.0.0",
   "exports": {
-    ".": "./protocol.ts"
+    ".": "./protocol.ts",
+    "./manifest": "./manifest.ts"
   }
 }

--- a/web/shared/fixtures/control_frames.json
+++ b/web/shared/fixtures/control_frames.json
@@ -4,7 +4,7 @@
       "name": "hello_robot",
       "message": {
         "t": "hello",
-        "v": 1,
+        "v": 2,
         "role": "robot",
         "robot": {
           "id": "go2-lab",
@@ -28,24 +28,24 @@
           ]
         }
       },
-      "b64": "GwEAAHsidCI6ImhlbGxvIiwidiI6MSwicm9sZSI6InJvYm90Iiwicm9ib3QiOnsiaWQiOiJnbzItbGFiIiwibmFtZSI6IkdvMiBMYWJvcmF0b3IgzrIiLCJtb2RlbCI6InVuaXRyZWUtZ28yIn0sIm1hbmlmZXN0Ijp7ImNoYW5uZWxzIjpbeyJjaCI6ImNvbG9yX2ltYWdlIiwiZW5jb2RpbmciOiJqcGVnLnYxIiwiZGVsaXZlcnkiOiJsYXRlc3QiLCJtYXhIeiI6MTUuNX0seyJjaCI6Im9kb20iLCJlbmNvZGluZyI6InBvc2UuanNvbi52MSIsImRlbGl2ZXJ5IjoicmVsaWFibGUiLCJtYXhIeiI6MjAuNX1dfX0="
+      "b64": "GwEAAHsidCI6ImhlbGxvIiwidiI6Miwicm9sZSI6InJvYm90Iiwicm9ib3QiOnsiaWQiOiJnbzItbGFiIiwibmFtZSI6IkdvMiBMYWJvcmF0b3IgzrIiLCJtb2RlbCI6InVuaXRyZWUtZ28yIn0sIm1hbmlmZXN0Ijp7ImNoYW5uZWxzIjpbeyJjaCI6ImNvbG9yX2ltYWdlIiwiZW5jb2RpbmciOiJqcGVnLnYxIiwiZGVsaXZlcnkiOiJsYXRlc3QiLCJtYXhIeiI6MTUuNX0seyJjaCI6Im9kb20iLCJlbmNvZGluZyI6InBvc2UuanNvbi52MSIsImRlbGl2ZXJ5IjoicmVsaWFibGUiLCJtYXhIeiI6MjAuNX1dfX0="
     },
     {
       "name": "hello_viewer",
       "message": {
         "t": "hello",
-        "v": 1,
+        "v": 2,
         "role": "viewer"
       },
-      "b64": "IwAAAHsidCI6ImhlbGxvIiwidiI6MSwicm9sZSI6InZpZXdlciJ9"
+      "b64": "IwAAAHsidCI6ImhlbGxvIiwidiI6Miwicm9sZSI6InZpZXdlciJ9"
     },
     {
       "name": "welcome",
       "message": {
         "t": "welcome",
-        "v": 1
+        "v": 2
       },
-      "b64": "FQAAAHsidCI6IndlbGNvbWUiLCJ2IjoxfQ=="
+      "b64": "FQAAAHsidCI6IndlbGNvbWUiLCJ2IjoyfQ=="
     },
     {
       "name": "ping",
@@ -70,9 +70,9 @@
       "message": {
         "t": "error",
         "code": "version_mismatch",
-        "message": "protocol v1 required, versiune neacceptată"
+        "message": "protocol v2 required, versiune neacceptată"
       },
-      "b64": "XwAAAHsidCI6ImVycm9yIiwiY29kZSI6InZlcnNpb25fbWlzbWF0Y2giLCJtZXNzYWdlIjoicHJvdG9jb2wgdjEgcmVxdWlyZWQsIHZlcnNpdW5lIG5lYWNjZXB0YXTEgyJ9"
+      "b64": "XwAAAHsidCI6ImVycm9yIiwiY29kZSI6InZlcnNpb25fbWlzbWF0Y2giLCJtZXNzYWdlIjoicHJvdG9jb2wgdjIgcmVxdWlyZWQsIHZlcnNpdW5lIG5lYWNjZXB0YXTEgyJ9"
     },
     {
       "name": "robots_two",

--- a/web/shared/fixtures/datagrams.json
+++ b/web/shared/fixtures/datagrams.json
@@ -4,7 +4,7 @@
       "name": "hello_robot",
       "message": {
         "t": "hello",
-        "v": 1,
+        "v": 2,
         "role": "robot",
         "robot": {
           "id": "go2-lab",
@@ -28,24 +28,24 @@
           ]
         }
       },
-      "b64": "eyJ0IjoiaGVsbG8iLCJ2IjoxLCJyb2xlIjoicm9ib3QiLCJyb2JvdCI6eyJpZCI6ImdvMi1sYWIiLCJuYW1lIjoiR28yIExhYm9yYXRvciDOsiIsIm1vZGVsIjoidW5pdHJlZS1nbzIifSwibWFuaWZlc3QiOnsiY2hhbm5lbHMiOlt7ImNoIjoiY29sb3JfaW1hZ2UiLCJlbmNvZGluZyI6ImpwZWcudjEiLCJkZWxpdmVyeSI6ImxhdGVzdCIsIm1heEh6IjoxNS41fSx7ImNoIjoib2RvbSIsImVuY29kaW5nIjoicG9zZS5qc29uLnYxIiwiZGVsaXZlcnkiOiJyZWxpYWJsZSIsIm1heEh6IjoyMC41fV19fQ=="
+      "b64": "eyJ0IjoiaGVsbG8iLCJ2IjoyLCJyb2xlIjoicm9ib3QiLCJyb2JvdCI6eyJpZCI6ImdvMi1sYWIiLCJuYW1lIjoiR28yIExhYm9yYXRvciDOsiIsIm1vZGVsIjoidW5pdHJlZS1nbzIifSwibWFuaWZlc3QiOnsiY2hhbm5lbHMiOlt7ImNoIjoiY29sb3JfaW1hZ2UiLCJlbmNvZGluZyI6ImpwZWcudjEiLCJkZWxpdmVyeSI6ImxhdGVzdCIsIm1heEh6IjoxNS41fSx7ImNoIjoib2RvbSIsImVuY29kaW5nIjoicG9zZS5qc29uLnYxIiwiZGVsaXZlcnkiOiJyZWxpYWJsZSIsIm1heEh6IjoyMC41fV19fQ=="
     },
     {
       "name": "hello_viewer",
       "message": {
         "t": "hello",
-        "v": 1,
+        "v": 2,
         "role": "viewer"
       },
-      "b64": "eyJ0IjoiaGVsbG8iLCJ2IjoxLCJyb2xlIjoidmlld2VyIn0="
+      "b64": "eyJ0IjoiaGVsbG8iLCJ2IjoyLCJyb2xlIjoidmlld2VyIn0="
     },
     {
       "name": "welcome",
       "message": {
         "t": "welcome",
-        "v": 1
+        "v": 2
       },
-      "b64": "eyJ0Ijoid2VsY29tZSIsInYiOjF9"
+      "b64": "eyJ0Ijoid2VsY29tZSIsInYiOjJ9"
     },
     {
       "name": "ping",
@@ -70,9 +70,9 @@
       "message": {
         "t": "error",
         "code": "version_mismatch",
-        "message": "protocol v1 required, versiune neacceptată"
+        "message": "protocol v2 required, versiune neacceptată"
       },
-      "b64": "eyJ0IjoiZXJyb3IiLCJjb2RlIjoidmVyc2lvbl9taXNtYXRjaCIsIm1lc3NhZ2UiOiJwcm90b2NvbCB2MSByZXF1aXJlZCwgdmVyc2l1bmUgbmVhY2NlcHRhdMSDIn0="
+      "b64": "eyJ0IjoiZXJyb3IiLCJjb2RlIjoidmVyc2lvbl9taXNtYXRjaCIsIm1lc3NhZ2UiOiJwcm90b2NvbCB2MiByZXF1aXJlZCwgdmVyc2l1bmUgbmVhY2NlcHRhdMSDIn0="
     },
     {
       "name": "robots_two",

--- a/web/shared/fixtures/gen.ts
+++ b/web/shared/fixtures/gen.ts
@@ -15,7 +15,9 @@ import {
   encodeDatagram,
   type FrameHeader,
   type Msg,
+  PROTOCOL_VERSION,
 } from "../protocol.ts";
+import { ManifestError, parseManifest } from "../manifest.ts";
 
 function b64(bytes: Uint8Array): string {
   let s = "";
@@ -26,7 +28,7 @@ function b64(bytes: Uint8Array): string {
 const controlMsgs: Record<string, Msg> = {
   hello_robot: {
     t: "hello",
-    v: 1,
+    v: PROTOCOL_VERSION,
     role: "robot",
     robot: { id: "go2-lab", name: "Go2 Laborator β", model: "unitree-go2" },
     manifest: {
@@ -36,14 +38,14 @@ const controlMsgs: Record<string, Msg> = {
       ],
     },
   },
-  hello_viewer: { t: "hello", v: 1, role: "viewer" },
-  welcome: { t: "welcome", v: 1 },
+  hello_viewer: { t: "hello", v: PROTOCOL_VERSION, role: "viewer" },
+  welcome: { t: "welcome", v: PROTOCOL_VERSION },
   ping: { t: "ping", n: 7, ts: 1752576000.5 },
   pong: { t: "pong", n: 7, ts: 1752576000.5 },
   error_version: {
     t: "error",
     code: "version_mismatch",
-    message: "protocol v1 required, versiune neacceptată",
+    message: `protocol v${PROTOCOL_VERSION} required, versiune neacceptată`,
   },
   robots_two: {
     t: "robots",
@@ -91,6 +93,68 @@ const dataFrames: Record<string, { header: FrameHeader; payload: Uint8Array }> =
   },
 };
 
+// Manifest vectors: valid cases pin normalization, invalid cases pin the
+// rejection code. Inputs are declared here (invalid ones cannot come from an
+// encoder); outputs come from parseManifest, and test_manifest.py pins the
+// Python mirror against them.
+const chOdom = { ch: "odom", encoding: "pose.json.v1", delivery: "reliable", maxHz: 20.5 };
+const chImage = { ch: "color_image", encoding: "jpeg.v1", delivery: "latest", maxHz: 15.5 };
+const longId = "x".repeat(65);
+const manifestCases: Record<string, unknown> = {
+  channels_only: { channels: [chImage, chOdom] },
+  empty: { channels: [] },
+  full: {
+    channels: [chImage, chOdom],
+    panels: [
+      { id: "camera", kind: "video", channels: ["color_image"] },
+      { id: "pose", kind: "readout", channels: ["odom"] },
+      { id: "drive", kind: "teleop", channels: [] },
+    ],
+    layout: ["camera", "pose", "drive"],
+  },
+  extra_keys_ignored: {
+    channels: [{ ...chOdom, later: 1.5 }],
+    panels: [{ id: "pose", kind: "readout", channels: ["odom"], future: true }],
+    unknown_top_level: { x: 1 },
+  },
+  not_an_object: [1, 2],
+  missing_channels: {},
+  channel_bad_shape: { channels: [{ ch: "odom" }] },
+  bad_delivery: { channels: [{ ...chOdom, delivery: "sometimes" }] },
+  max_hz_string: { channels: [{ ...chOdom, maxHz: "20" }] },
+  max_hz_bool: { channels: [{ ...chOdom, maxHz: true }] },
+  empty_channel_id: { channels: [{ ...chOdom, ch: "" }] },
+  long_channel_id: { channels: [{ ...chOdom, ch: longId }] },
+  duplicate_channel_id: { channels: [chOdom, { ...chOdom, encoding: "jpeg.v1" }] },
+  empty_encoding: { channels: [{ ...chOdom, encoding: "" }] },
+  long_encoding: { channels: [{ ...chOdom, encoding: longId }] },
+  zero_max_hz: { channels: [{ ...chOdom, maxHz: 0 }] },
+  negative_max_hz: { channels: [{ ...chOdom, maxHz: -2.5 }] },
+  panels_not_list: { channels: [chOdom], panels: {} },
+  null_panels: { channels: [chOdom], panels: null },
+  panel_bad_shape: { channels: [chOdom], panels: [{ id: "a" }] },
+  panel_channels_not_strings: {
+    channels: [chOdom],
+    panels: [{ id: "a", kind: "readout", channels: [1.5] }],
+  },
+  empty_panel_id: { channels: [chOdom], panels: [{ id: "", kind: "readout", channels: [] }] },
+  empty_panel_kind: { channels: [chOdom], panels: [{ id: "a", kind: "", channels: [] }] },
+  duplicate_panel_id: {
+    channels: [chOdom],
+    panels: [
+      { id: "a", kind: "readout", channels: [] },
+      { id: "a", kind: "video", channels: [] },
+    ],
+  },
+  panel_unknown_channel: {
+    channels: [chOdom],
+    panels: [{ id: "a", kind: "video", channels: ["lidar"] }],
+  },
+  layout_not_list: { channels: [chOdom], layout: "row" },
+  layout_not_strings: { channels: [chOdom], layout: [1.5] },
+  layout_unknown_panel: { channels: [chOdom], layout: ["ghost"] },
+};
+
 const control = {
   vectors: Object.entries(controlMsgs).map(([name, message]) => ({
     name,
@@ -116,12 +180,24 @@ const data = {
   })),
 };
 
+const manifests = {
+  vectors: Object.entries(manifestCases).map(([name, data]) => {
+    try {
+      return { name, data, manifest: parseManifest(data) };
+    } catch (e) {
+      if (e instanceof ManifestError) return { name, data, error: e.code };
+      throw e;
+    }
+  }),
+};
+
 const dir = new URL(".", import.meta.url);
 for (
   const [file, obj] of [
     ["control_frames.json", control],
     ["datagrams.json", datagrams],
     ["data_frames.json", data],
+    ["manifests.json", manifests],
   ] as const
 ) {
   await Deno.writeTextFile(new URL(file, dir), JSON.stringify(obj, null, 2) + "\n");

--- a/web/shared/fixtures/manifests.json
+++ b/web/shared/fixtures/manifests.json
@@ -1,0 +1,568 @@
+{
+  "vectors": [
+    {
+      "name": "channels_only",
+      "data": {
+        "channels": [
+          {
+            "ch": "color_image",
+            "encoding": "jpeg.v1",
+            "delivery": "latest",
+            "maxHz": 15.5
+          },
+          {
+            "ch": "odom",
+            "encoding": "pose.json.v1",
+            "delivery": "reliable",
+            "maxHz": 20.5
+          }
+        ]
+      },
+      "manifest": {
+        "channels": [
+          {
+            "ch": "color_image",
+            "encoding": "jpeg.v1",
+            "delivery": "latest",
+            "maxHz": 15.5
+          },
+          {
+            "ch": "odom",
+            "encoding": "pose.json.v1",
+            "delivery": "reliable",
+            "maxHz": 20.5
+          }
+        ],
+        "panels": [],
+        "layout": []
+      }
+    },
+    {
+      "name": "empty",
+      "data": {
+        "channels": []
+      },
+      "manifest": {
+        "channels": [],
+        "panels": [],
+        "layout": []
+      }
+    },
+    {
+      "name": "full",
+      "data": {
+        "channels": [
+          {
+            "ch": "color_image",
+            "encoding": "jpeg.v1",
+            "delivery": "latest",
+            "maxHz": 15.5
+          },
+          {
+            "ch": "odom",
+            "encoding": "pose.json.v1",
+            "delivery": "reliable",
+            "maxHz": 20.5
+          }
+        ],
+        "panels": [
+          {
+            "id": "camera",
+            "kind": "video",
+            "channels": [
+              "color_image"
+            ]
+          },
+          {
+            "id": "pose",
+            "kind": "readout",
+            "channels": [
+              "odom"
+            ]
+          },
+          {
+            "id": "drive",
+            "kind": "teleop",
+            "channels": []
+          }
+        ],
+        "layout": [
+          "camera",
+          "pose",
+          "drive"
+        ]
+      },
+      "manifest": {
+        "channels": [
+          {
+            "ch": "color_image",
+            "encoding": "jpeg.v1",
+            "delivery": "latest",
+            "maxHz": 15.5
+          },
+          {
+            "ch": "odom",
+            "encoding": "pose.json.v1",
+            "delivery": "reliable",
+            "maxHz": 20.5
+          }
+        ],
+        "panels": [
+          {
+            "id": "camera",
+            "kind": "video",
+            "channels": [
+              "color_image"
+            ]
+          },
+          {
+            "id": "pose",
+            "kind": "readout",
+            "channels": [
+              "odom"
+            ]
+          },
+          {
+            "id": "drive",
+            "kind": "teleop",
+            "channels": []
+          }
+        ],
+        "layout": [
+          "camera",
+          "pose",
+          "drive"
+        ]
+      }
+    },
+    {
+      "name": "extra_keys_ignored",
+      "data": {
+        "channels": [
+          {
+            "ch": "odom",
+            "encoding": "pose.json.v1",
+            "delivery": "reliable",
+            "maxHz": 20.5,
+            "later": 1.5
+          }
+        ],
+        "panels": [
+          {
+            "id": "pose",
+            "kind": "readout",
+            "channels": [
+              "odom"
+            ],
+            "future": true
+          }
+        ],
+        "unknown_top_level": {
+          "x": 1
+        }
+      },
+      "manifest": {
+        "channels": [
+          {
+            "ch": "odom",
+            "encoding": "pose.json.v1",
+            "delivery": "reliable",
+            "maxHz": 20.5
+          }
+        ],
+        "panels": [
+          {
+            "id": "pose",
+            "kind": "readout",
+            "channels": [
+              "odom"
+            ]
+          }
+        ],
+        "layout": []
+      }
+    },
+    {
+      "name": "not_an_object",
+      "data": [
+        1,
+        2
+      ],
+      "error": "invalid_shape"
+    },
+    {
+      "name": "missing_channels",
+      "data": {},
+      "error": "invalid_shape"
+    },
+    {
+      "name": "channel_bad_shape",
+      "data": {
+        "channels": [
+          {
+            "ch": "odom"
+          }
+        ]
+      },
+      "error": "invalid_shape"
+    },
+    {
+      "name": "bad_delivery",
+      "data": {
+        "channels": [
+          {
+            "ch": "odom",
+            "encoding": "pose.json.v1",
+            "delivery": "sometimes",
+            "maxHz": 20.5
+          }
+        ]
+      },
+      "error": "invalid_shape"
+    },
+    {
+      "name": "max_hz_string",
+      "data": {
+        "channels": [
+          {
+            "ch": "odom",
+            "encoding": "pose.json.v1",
+            "delivery": "reliable",
+            "maxHz": "20"
+          }
+        ]
+      },
+      "error": "invalid_shape"
+    },
+    {
+      "name": "max_hz_bool",
+      "data": {
+        "channels": [
+          {
+            "ch": "odom",
+            "encoding": "pose.json.v1",
+            "delivery": "reliable",
+            "maxHz": true
+          }
+        ]
+      },
+      "error": "invalid_shape"
+    },
+    {
+      "name": "empty_channel_id",
+      "data": {
+        "channels": [
+          {
+            "ch": "",
+            "encoding": "pose.json.v1",
+            "delivery": "reliable",
+            "maxHz": 20.5
+          }
+        ]
+      },
+      "error": "invalid_channel_id"
+    },
+    {
+      "name": "long_channel_id",
+      "data": {
+        "channels": [
+          {
+            "ch": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+            "encoding": "pose.json.v1",
+            "delivery": "reliable",
+            "maxHz": 20.5
+          }
+        ]
+      },
+      "error": "invalid_channel_id"
+    },
+    {
+      "name": "duplicate_channel_id",
+      "data": {
+        "channels": [
+          {
+            "ch": "odom",
+            "encoding": "pose.json.v1",
+            "delivery": "reliable",
+            "maxHz": 20.5
+          },
+          {
+            "ch": "odom",
+            "encoding": "jpeg.v1",
+            "delivery": "reliable",
+            "maxHz": 20.5
+          }
+        ]
+      },
+      "error": "duplicate_channel_id"
+    },
+    {
+      "name": "empty_encoding",
+      "data": {
+        "channels": [
+          {
+            "ch": "odom",
+            "encoding": "",
+            "delivery": "reliable",
+            "maxHz": 20.5
+          }
+        ]
+      },
+      "error": "invalid_encoding"
+    },
+    {
+      "name": "long_encoding",
+      "data": {
+        "channels": [
+          {
+            "ch": "odom",
+            "encoding": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+            "delivery": "reliable",
+            "maxHz": 20.5
+          }
+        ]
+      },
+      "error": "invalid_encoding"
+    },
+    {
+      "name": "zero_max_hz",
+      "data": {
+        "channels": [
+          {
+            "ch": "odom",
+            "encoding": "pose.json.v1",
+            "delivery": "reliable",
+            "maxHz": 0
+          }
+        ]
+      },
+      "error": "invalid_max_hz"
+    },
+    {
+      "name": "negative_max_hz",
+      "data": {
+        "channels": [
+          {
+            "ch": "odom",
+            "encoding": "pose.json.v1",
+            "delivery": "reliable",
+            "maxHz": -2.5
+          }
+        ]
+      },
+      "error": "invalid_max_hz"
+    },
+    {
+      "name": "panels_not_list",
+      "data": {
+        "channels": [
+          {
+            "ch": "odom",
+            "encoding": "pose.json.v1",
+            "delivery": "reliable",
+            "maxHz": 20.5
+          }
+        ],
+        "panels": {}
+      },
+      "error": "invalid_shape"
+    },
+    {
+      "name": "null_panels",
+      "data": {
+        "channels": [
+          {
+            "ch": "odom",
+            "encoding": "pose.json.v1",
+            "delivery": "reliable",
+            "maxHz": 20.5
+          }
+        ],
+        "panels": null
+      },
+      "error": "invalid_shape"
+    },
+    {
+      "name": "panel_bad_shape",
+      "data": {
+        "channels": [
+          {
+            "ch": "odom",
+            "encoding": "pose.json.v1",
+            "delivery": "reliable",
+            "maxHz": 20.5
+          }
+        ],
+        "panels": [
+          {
+            "id": "a"
+          }
+        ]
+      },
+      "error": "invalid_shape"
+    },
+    {
+      "name": "panel_channels_not_strings",
+      "data": {
+        "channels": [
+          {
+            "ch": "odom",
+            "encoding": "pose.json.v1",
+            "delivery": "reliable",
+            "maxHz": 20.5
+          }
+        ],
+        "panels": [
+          {
+            "id": "a",
+            "kind": "readout",
+            "channels": [
+              1.5
+            ]
+          }
+        ]
+      },
+      "error": "invalid_shape"
+    },
+    {
+      "name": "empty_panel_id",
+      "data": {
+        "channels": [
+          {
+            "ch": "odom",
+            "encoding": "pose.json.v1",
+            "delivery": "reliable",
+            "maxHz": 20.5
+          }
+        ],
+        "panels": [
+          {
+            "id": "",
+            "kind": "readout",
+            "channels": []
+          }
+        ]
+      },
+      "error": "invalid_panel"
+    },
+    {
+      "name": "empty_panel_kind",
+      "data": {
+        "channels": [
+          {
+            "ch": "odom",
+            "encoding": "pose.json.v1",
+            "delivery": "reliable",
+            "maxHz": 20.5
+          }
+        ],
+        "panels": [
+          {
+            "id": "a",
+            "kind": "",
+            "channels": []
+          }
+        ]
+      },
+      "error": "invalid_panel"
+    },
+    {
+      "name": "duplicate_panel_id",
+      "data": {
+        "channels": [
+          {
+            "ch": "odom",
+            "encoding": "pose.json.v1",
+            "delivery": "reliable",
+            "maxHz": 20.5
+          }
+        ],
+        "panels": [
+          {
+            "id": "a",
+            "kind": "readout",
+            "channels": []
+          },
+          {
+            "id": "a",
+            "kind": "video",
+            "channels": []
+          }
+        ]
+      },
+      "error": "duplicate_panel_id"
+    },
+    {
+      "name": "panel_unknown_channel",
+      "data": {
+        "channels": [
+          {
+            "ch": "odom",
+            "encoding": "pose.json.v1",
+            "delivery": "reliable",
+            "maxHz": 20.5
+          }
+        ],
+        "panels": [
+          {
+            "id": "a",
+            "kind": "video",
+            "channels": [
+              "lidar"
+            ]
+          }
+        ]
+      },
+      "error": "unknown_panel_channel"
+    },
+    {
+      "name": "layout_not_list",
+      "data": {
+        "channels": [
+          {
+            "ch": "odom",
+            "encoding": "pose.json.v1",
+            "delivery": "reliable",
+            "maxHz": 20.5
+          }
+        ],
+        "layout": "row"
+      },
+      "error": "invalid_shape"
+    },
+    {
+      "name": "layout_not_strings",
+      "data": {
+        "channels": [
+          {
+            "ch": "odom",
+            "encoding": "pose.json.v1",
+            "delivery": "reliable",
+            "maxHz": 20.5
+          }
+        ],
+        "layout": [
+          1.5
+        ]
+      },
+      "error": "invalid_shape"
+    },
+    {
+      "name": "layout_unknown_panel",
+      "data": {
+        "channels": [
+          {
+            "ch": "odom",
+            "encoding": "pose.json.v1",
+            "delivery": "reliable",
+            "maxHz": 20.5
+          }
+        ],
+        "layout": [
+          "ghost"
+        ]
+      },
+      "error": "unknown_layout_panel"
+    }
+  ]
+}

--- a/web/shared/manifest.ts
+++ b/web/shared/manifest.ts
@@ -1,0 +1,165 @@
+// Manifest domain model shared by the relay and the Cockpit. Mirrored in
+// Python at dimos/web/relay_bridge/manifest.py and pinned by the golden
+// vectors in ./fixtures/manifests.json (tested from both deno test and
+// pytest).
+//
+// The transport (protocol.ts) checks only field shapes; this module owns the
+// domain rules: bounded unique ids, positive rates, and panel/layout
+// references that resolve. Panels and layout are minimal until T7 (the
+// layout is a flat panel-id order, not a tree).
+
+export type Delivery = "latest" | "reliable";
+
+// One robot->viewer stream: encoding names the payload format (e.g. jpeg.v1,
+// pose.json.v1), delivery picks the relay's forwarding policy, maxHz is the
+// bridge's advertised send cap (informational for viewers).
+export interface ChannelSpec {
+  ch: string;
+  encoding: string;
+  delivery: Delivery;
+  maxHz: number;
+}
+
+// Minimal until T7: kind is the panel-component registry key; channels lists
+// the channel ids the panel consumes. Kind-specific config arrives with the
+// panel system.
+export interface PanelSpec {
+  id: string;
+  kind: string;
+  channels: string[];
+}
+
+export interface Manifest {
+  channels: ChannelSpec[];
+  panels: PanelSpec[];
+  /** Panel ids in display order (a layout tree replaces this in T7). */
+  layout: string[];
+}
+
+/** Bound for channel/panel ids, encodings, and panel kinds. */
+export const MAX_MANIFEST_ID_LEN = 64;
+
+export class ManifestError extends Error {
+  constructor(readonly code: string, message: string) {
+    super(`${code}: ${message}`);
+    this.name = "ManifestError";
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function isChannelSpec(value: unknown): value is ChannelSpec {
+  return (
+    isRecord(value) &&
+    typeof value.ch === "string" &&
+    typeof value.encoding === "string" &&
+    (value.delivery === "latest" || value.delivery === "reliable") &&
+    typeof value.maxHz === "number"
+  );
+}
+
+function isPanelSpec(value: unknown): value is PanelSpec {
+  return (
+    isRecord(value) &&
+    typeof value.id === "string" &&
+    typeof value.kind === "string" &&
+    Array.isArray(value.channels) &&
+    value.channels.every((ch) => typeof ch === "string")
+  );
+}
+
+function boundedId(s: string): boolean {
+  return s.length >= 1 && s.length <= MAX_MANIFEST_ID_LEN;
+}
+
+/**
+ * Validated manifest from parsed JSON (or any untrusted value); throws
+ * ManifestError. Absent panels/layout normalize to empty; unknown keys are
+ * dropped (forward compatibility with newer bridges). Mirrors
+ * parse_manifest() in manifest.py: shape first, then domain rules in
+ * document order, so both sides report the same code (pinned by fixtures).
+ */
+export function parseManifest(value: unknown): Manifest {
+  if (!isRecord(value)) throw new ManifestError("invalid_shape", "manifest must be an object");
+  const rawChannels = value.channels;
+  const rawPanels = value.panels === undefined ? [] : value.panels;
+  const rawLayout = value.layout === undefined ? [] : value.layout;
+  if (
+    !Array.isArray(rawChannels) || !rawChannels.every(isChannelSpec) ||
+    !Array.isArray(rawPanels) || !rawPanels.every(isPanelSpec) ||
+    !Array.isArray(rawLayout) || !rawLayout.every((id) => typeof id === "string")
+  ) {
+    throw new ManifestError("invalid_shape", "bad channels/panels/layout shape");
+  }
+  const channels = rawChannels as ChannelSpec[];
+  const panels = rawPanels as PanelSpec[];
+  const layout = rawLayout as string[];
+
+  const chIds = new Set<string>();
+  for (const spec of channels) {
+    if (!boundedId(spec.ch)) {
+      throw new ManifestError(
+        "invalid_channel_id",
+        `channel id must be 1..${MAX_MANIFEST_ID_LEN} chars`,
+      );
+    }
+    if (chIds.has(spec.ch)) {
+      throw new ManifestError("duplicate_channel_id", `duplicate channel ${spec.ch}`);
+    }
+    chIds.add(spec.ch);
+    if (!boundedId(spec.encoding)) {
+      throw new ManifestError(
+        "invalid_encoding",
+        `encoding must be 1..${MAX_MANIFEST_ID_LEN} chars`,
+      );
+    }
+    if (!Number.isFinite(spec.maxHz) || spec.maxHz <= 0) {
+      throw new ManifestError("invalid_max_hz", `maxHz for ${spec.ch} must be a positive number`);
+    }
+  }
+
+  const panelIds = new Set<string>();
+  for (const panel of panels) {
+    if (!boundedId(panel.id) || !boundedId(panel.kind)) {
+      throw new ManifestError(
+        "invalid_panel",
+        `panel id/kind must be 1..${MAX_MANIFEST_ID_LEN} chars`,
+      );
+    }
+    if (panelIds.has(panel.id)) {
+      throw new ManifestError("duplicate_panel_id", `duplicate panel ${panel.id}`);
+    }
+    panelIds.add(panel.id);
+    for (const ch of panel.channels) {
+      if (!chIds.has(ch)) {
+        throw new ManifestError(
+          "unknown_panel_channel",
+          `panel ${panel.id} wants undeclared channel ${ch}`,
+        );
+      }
+    }
+  }
+
+  for (const id of layout) {
+    if (!panelIds.has(id)) {
+      throw new ManifestError("unknown_layout_panel", `layout names unknown panel ${id}`);
+    }
+  }
+
+  return {
+    channels: channels.map((spec) => ({
+      ch: spec.ch,
+      encoding: spec.encoding,
+      delivery: spec.delivery,
+      maxHz: spec.maxHz,
+    })),
+    panels: panels.map((panel) => ({
+      id: panel.id,
+      kind: panel.kind,
+      channels: [...panel.channels],
+    })),
+    layout: [...layout],
+  };
+}

--- a/web/shared/manifest.ts
+++ b/web/shared/manifest.ts
@@ -115,6 +115,9 @@ export function parseManifest(value: unknown): Manifest {
         `encoding must be 1..${MAX_MANIFEST_ID_LEN} chars`,
       );
     }
+    // isFinite also bounds maxHz to float64: JSON.parse turns an
+    // out-of-range literal into Infinity. manifest.py mirrors this with an
+    // explicit float64 bound (Python parses such integers exactly).
     if (!Number.isFinite(spec.maxHz) || spec.maxHz <= 0) {
       throw new ManifestError("invalid_max_hz", `maxHz for ${spec.ch} must be a positive number`);
     }

--- a/web/shared/manifest_test.ts
+++ b/web/shared/manifest_test.ts
@@ -1,0 +1,25 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { ManifestError, parseManifest } from "./manifest.ts";
+import manifestFixture from "./fixtures/manifests.json" with { type: "json" };
+
+// Each vector pins either normalization ({name, data, manifest}) or the
+// rejection code ({name, data, error}); test_manifest.py runs the same set.
+type Vector = { name: string; data: unknown; manifest?: unknown; error?: string };
+const vectors = manifestFixture.vectors as Vector[];
+
+Deno.test("valid manifests normalize per the golden vectors", () => {
+  const valid = vectors.filter((v) => v.manifest !== undefined);
+  assertEquals(valid.length > 0, true);
+  for (const v of valid) {
+    assertEquals(parseManifest(v.data), v.manifest, v.name);
+  }
+});
+
+Deno.test("invalid manifests are rejected with the pinned code", () => {
+  const invalid = vectors.filter((v) => v.error !== undefined);
+  assertEquals(invalid.length > 0, true);
+  for (const v of invalid) {
+    const err = assertThrows(() => parseManifest(v.data), ManifestError, undefined, v.name);
+    assertEquals(err.code, v.error, v.name);
+  }
+});

--- a/web/shared/manifest_test.ts
+++ b/web/shared/manifest_test.ts
@@ -23,3 +23,17 @@ Deno.test("invalid manifests are rejected with the pinned code", () => {
     assertEquals(err.code, v.error, v.name);
   }
 });
+
+Deno.test("maxHz beyond float64 is rejected", () => {
+  // Not a golden vector: gen.ts cannot emit a number beyond float64
+  // (JSON.stringify(Infinity) is null). JSON.parse turns such a literal into
+  // Infinity; test_manifest.py pins the Python half (an exact huge int) to
+  // the same code.
+  const data = {
+    channels: [
+      { ch: "odom", encoding: "pose.json.v1", delivery: "reliable", maxHz: Infinity },
+    ],
+  };
+  const err = assertThrows(() => parseManifest(data), ManifestError);
+  assertEquals(err.code, "invalid_max_hz");
+});

--- a/web/shared/protocol.ts
+++ b/web/shared/protocol.ts
@@ -5,16 +5,27 @@
 // Framing (see web/README.md for the upstream-bug rationale):
 // - Control stream frame: u32-LE length | UTF-8 JSON.
 // - Datagram: raw UTF-8 JSON, no length prefix.
-// - Data frame (one message per stream): u32-LE headerLen | u32-LE payloadLen
-//   | header JSON | payload. Receivers count bytes and must never treat
-//   stream EOF as a message boundary (Deno 2.6.x delays FIN by up to ~1 s).
+// - Data frame: u32-LE headerLen | u32-LE payloadLen | header JSON | payload.
+//   Latest channels send one frame per stream; a reliable channel packs its
+//   frames back to back on one persistent stream. Receivers count bytes and
+//   must never treat stream EOF as a message boundary (Deno 2.6.x delays FIN
+//   by up to ~1 s, and a persistent stream has no EOF between frames).
 //
 // Validation policy (mirrored in protocol.py): decoders validate shape
 // strictly, and receivers drop invalid or unknown messages -- a peer's bytes
 // must never kill a session. Framing-level corruption (absurd length
 // prefixes) throws and kills only the affected stream.
 
-export const PROTOCOL_VERSION = 1;
+import { type ChannelSpec, type Delivery, isChannelSpec } from "./manifest.ts";
+
+// Channel/manifest domain types live in manifest.ts; re-exported so protocol
+// consumers keep a single import surface.
+export type { ChannelSpec, Delivery } from "./manifest.ts";
+
+// v2: a reliable channel packs all its frames onto one persistent stream (v1
+// carried one frame per stream), which a v1 receiver would misread as a
+// single frame. Bump on any change an old peer would silently misparse.
+export const PROTOCOL_VERSION = 2;
 
 // Reject absurd header lengths before allocating.
 export const MAX_HEADER_LEN = 65536;
@@ -24,22 +35,11 @@ export const MAX_HEADER_LEN = 65536;
 export const MAX_DATA_FRAME_BYTES = 64 * 1024 * 1024;
 
 export type Role = "robot" | "viewer";
-export type Delivery = "latest" | "reliable";
 
 export interface RobotInfo {
   id: string;
   name: string;
   model: string;
-}
-
-// One robot->viewer stream: encoding names the payload format (e.g. jpeg.v1,
-// pose.json.v1), delivery picks the relay's forwarding policy, maxHz is the
-// bridge's advertised send cap (informational for viewers).
-export interface ChannelSpec {
-  ch: string;
-  encoding: string;
-  delivery: Delivery;
-  maxHz: number;
 }
 
 export interface RobotManifest {
@@ -189,16 +189,6 @@ function isRobotInfo(value: unknown): value is RobotInfo {
     typeof value.id === "string" &&
     typeof value.name === "string" &&
     typeof value.model === "string"
-  );
-}
-
-function isChannelSpec(value: unknown): value is ChannelSpec {
-  return (
-    isRecord(value) &&
-    typeof value.ch === "string" &&
-    typeof value.encoding === "string" &&
-    (value.delivery === "latest" || value.delivery === "reliable") &&
-    typeof value.maxHz === "number"
   );
 }
 
@@ -353,28 +343,93 @@ export function concatBytes(chunks: Uint8Array[], limit: number): Uint8Array {
 }
 
 /**
- * Incremental reader for a single-message stream. Returns the frame as soon
- * as headerLen + payloadLen bytes have arrived; never waits for EOF. Bytes
- * past the frame are ignored. Chunks are held by reference and copied once
- * at completion (a per-push merge is quadratic at multi-MB frame sizes).
+ * Framing/header corruption on a data-frame stream. `frames` carries the
+ * frames decoded before the corrupt one so the caller can still deliver them
+ * before dropping the stream (framing is unrecoverable mid-stream).
  */
-export class DataFrameReader {
-  #chunks: Uint8Array[] = [];
-  #size = 0;
-  #lens: { headerLen: number; payloadLen: number; total: number } | null = null;
-  #done = false;
+export class DataFrameStreamError extends Error {
+  constructor(message: string, readonly frames: DataFrame[]) {
+    super(message);
+    this.name = "DataFrameStreamError";
+  }
+}
 
-  push(chunk: Uint8Array): DataFrame | null {
-    if (this.#done) return null;
-    this.#chunks.push(chunk);
-    this.#size += chunk.byteLength;
-    if (this.#lens === null && this.#size >= 8) {
-      this.#lens = peekDataFrameLengths(concatBytes(this.#chunks, 8));
+/**
+ * Incremental reader for a stream carrying sequential data frames (a reliable
+ * channel's persistent stream; a latest stream is the one-frame case). Frames
+ * are returned as soon as their bytes have arrived; EOF is never a boundary.
+ *
+ * Chunks are queued behind a read cursor, never concatenated: a completed
+ * frame is copied out exactly once, so a 64 MiB frame arriving in 64 KiB
+ * chunks costs 64 MiB of copying, not gigabytes. On corruption push() throws
+ * DataFrameStreamError (with the frames decoded before it) and the reader
+ * rejects all further input.
+ */
+export class DataFrameStreamReader {
+  #chunks: Uint8Array[] = [];
+  #head = 0; // index of the chunk holding the read cursor
+  #cursor = 0; // byte offset into #chunks[#head]
+  #size = 0; // unread bytes across all queued chunks
+  #failed: string | null = null;
+
+  push(chunk: Uint8Array): DataFrame[] {
+    if (this.#failed !== null) throw new DataFrameStreamError(this.#failed, []);
+    if (chunk.byteLength > 0) {
+      this.#chunks.push(chunk);
+      this.#size += chunk.byteLength;
     }
-    if (this.#lens === null || this.#size < this.#lens.total) return null;
-    this.#done = true;
-    const frame = decodeDataFrame(concatBytes(this.#chunks, this.#lens.total));
-    this.#chunks = [];
-    return frame;
+    const frames: DataFrame[] = [];
+    try {
+      while (this.#size >= 8) {
+        const lens = peekDataFrameLengths(this.#peek(8))!;
+        if (this.#size < lens.total) break;
+        frames.push(decodeDataFrame(this.#take(lens.total)));
+      }
+    } catch (e) {
+      this.#failed = (e as Error).message;
+      throw new DataFrameStreamError(this.#failed, frames);
+    } finally {
+      this.#chunks.splice(0, this.#head);
+      this.#head = 0;
+    }
+    return frames;
+  }
+
+  /** First `n` unread bytes without consuming them (requires #size >= n). */
+  #peek(n: number): Uint8Array {
+    const first = this.#chunks[this.#head];
+    if (first.byteLength - this.#cursor >= n) {
+      return first.subarray(this.#cursor, this.#cursor + n);
+    }
+    const out = new Uint8Array(n);
+    let off = 0;
+    let cursor = this.#cursor;
+    for (let i = this.#head; off < n; i++) {
+      const chunk = this.#chunks[i];
+      const step = Math.min(chunk.byteLength - cursor, n - off);
+      out.set(chunk.subarray(cursor, cursor + step), off);
+      off += step;
+      cursor = 0;
+    }
+    return out;
+  }
+
+  /** Consume `n` unread bytes into one fresh buffer (requires #size >= n). */
+  #take(n: number): Uint8Array {
+    const out = new Uint8Array(n);
+    let off = 0;
+    while (off < n) {
+      const chunk = this.#chunks[this.#head];
+      const step = Math.min(chunk.byteLength - this.#cursor, n - off);
+      out.set(chunk.subarray(this.#cursor, this.#cursor + step), off);
+      off += step;
+      this.#cursor += step;
+      if (this.#cursor === chunk.byteLength) {
+        this.#head++;
+        this.#cursor = 0;
+      }
+    }
+    this.#size -= n;
+    return out;
   }
 }

--- a/web/shared/protocol_test.ts
+++ b/web/shared/protocol_test.ts
@@ -1,7 +1,9 @@
-import { assertEquals, assertThrows } from "@std/assert";
+import { assert, assertEquals, assertThrows } from "@std/assert";
 import {
   ControlFrameReader,
-  DataFrameReader,
+  type DataFrame,
+  DataFrameStreamError,
+  DataFrameStreamReader,
   decodeDataFrame,
   decodeDatagram,
   encodeControlFrame,
@@ -87,31 +89,108 @@ Deno.test("data frame decode round-trips the golden vectors", () => {
   }
 });
 
-Deno.test("data frame reader completes at exact byte count, split anywhere", () => {
+Deno.test("data frame stream reader completes at exact byte count, split anywhere", () => {
   const v = dataFixture.vectors.find((v) => v.name === "image_latest_meta")!;
   const frame = fromB64(v.frame_b64);
   for (let split = 0; split <= frame.length; split++) {
-    const reader = new DataFrameReader();
+    const reader = new DataFrameStreamReader();
     const first = reader.push(frame.subarray(0, split));
     const second = reader.push(frame.subarray(split));
     if (split < frame.length) {
-      assertEquals(first, null, `complete before full frame at split ${split}`);
+      assertEquals(first, [], `complete before full frame at split ${split}`);
     }
-    const out = first ?? second;
-    assertEquals(out !== null, true, `incomplete after full frame at split ${split}`);
-    assertEquals(out!.header, v.header as FrameHeader);
-    assertEquals(out!.payload, fromB64(v.payload_b64));
+    const out = [...first, ...second];
+    assertEquals(out.length, 1, `frames after full push at split ${split}`);
+    assertEquals(out[0].header, v.header as FrameHeader);
+    assertEquals(out[0].payload, fromB64(v.payload_b64));
   }
 });
 
-Deno.test("data frame reader ignores bytes past the frame (no EOF dependence)", () => {
+Deno.test("data frame stream reader parses back-to-back frames (persistent stream)", () => {
+  const parts = dataFixture.vectors.map((v) => fromB64(v.frame_b64));
+  const all = new Uint8Array(parts.reduce((n, f) => n + f.length, 0));
+  let off = 0;
+  for (const part of parts) {
+    all.set(part, off);
+    off += part.length;
+  }
+  const whole = new DataFrameStreamReader().push(all);
+  assertEquals(whole.length, dataFixture.vectors.length);
+  whole.forEach((frame, i) => {
+    assertEquals(frame.header, dataFixture.vectors[i].header as FrameHeader);
+    assertEquals(frame.payload, fromB64(dataFixture.vectors[i].payload_b64));
+  });
+
+  const trickle = new DataFrameStreamReader();
+  const out = [];
+  for (const byte of all) out.push(...trickle.push(Uint8Array.of(byte)));
+  assertEquals(out.length, dataFixture.vectors.length);
+});
+
+Deno.test("data frame stream reader throws on garbage between frames", () => {
   const v = dataFixture.vectors.find((v) => v.name === "odom_reliable")!;
+  const reader = new DataFrameStreamReader();
+  assertEquals(reader.push(fromB64(v.frame_b64)).length, 1);
+  // Framing is unrecoverable mid-stream; the caller drops the stream.
+  assertThrows(() => reader.push(new Uint8Array(32)));
+});
+
+Deno.test("data frame stream reader assembles a large fragmented frame with one copy", () => {
+  const payload = new Uint8Array(8 * 1024 * 1024);
+  for (let i = 0; i < payload.length; i++) payload[i] = i & 0xff;
+  const header: FrameHeader = { ch: "cam", seq: 1, ts: 0.5, delivery: "latest" };
+  const frame = encodeDataFrame(header, payload);
+  const reader = new DataFrameStreamReader();
+  const out: DataFrame[] = [];
+  for (let off = 0; off < frame.length; off += 64 * 1024) {
+    out.push(...reader.push(frame.subarray(off, Math.min(off + 64 * 1024, frame.length))));
+  }
+  assertEquals(out.length, 1);
+  assertEquals(out[0].header, header);
+  assertEquals(out[0].payload.byteLength, payload.byteLength);
+  let mismatch = -1;
+  for (let i = 0; i < payload.length; i++) {
+    if (out[0].payload[i] !== payload[i]) {
+      mismatch = i;
+      break;
+    }
+  }
+  assertEquals(mismatch, -1);
+});
+
+Deno.test("data frame stream reader surfaces corruption with the decoded batch", () => {
+  const v = dataFixture.vectors.find((v) => v.name === "odom_reliable")!;
+  const good = fromB64(v.frame_b64);
+  const badBody = new TextEncoder().encode("{not json");
+  const bad = new Uint8Array(8 + badBody.length);
+  new DataView(bad.buffer).setUint32(0, badBody.length, true);
+  bad.set(badBody, 8);
+  const reader = new DataFrameStreamReader();
+  const err = assertThrows(
+    () => reader.push(new Uint8Array([...good, ...bad])),
+    DataFrameStreamError,
+  );
+  // The valid frame preceding the corrupt one is delivered, not dropped.
+  assertEquals(err.frames.length, 1);
+  assertEquals(err.frames[0].header, v.header as FrameHeader);
+  assertEquals(err.frames[0].payload, fromB64(v.payload_b64));
+  // Poisoned: further input keeps throwing with an empty batch.
+  const again = assertThrows(() => reader.push(good), DataFrameStreamError);
+  assertEquals(again.frames, []);
+});
+
+Deno.test("data frame stream reader handles a prefix split across chunk boundaries", () => {
+  const v = dataFixture.vectors.find((v) => v.name === "image_latest_meta")!;
   const frame = fromB64(v.frame_b64);
-  const padded = new Uint8Array(frame.length + 32);
-  padded.set(frame, 0);
-  const out = new DataFrameReader().push(padded);
-  assertEquals(out !== null, true);
-  assertEquals(out!.header, v.header as FrameHeader);
+  const reader = new DataFrameStreamReader();
+  // 3-byte chunks force the 8-byte length prefix to straddle chunks.
+  const out: DataFrame[] = [];
+  for (let off = 0; off < frame.length; off += 3) {
+    out.push(...reader.push(frame.subarray(off, Math.min(off + 3, frame.length))));
+  }
+  assertEquals(out.length, 1);
+  assertEquals(out[0].payload, fromB64(v.payload_b64));
+  assert(reader.push(new Uint8Array(0)).length === 0);
 });
 
 Deno.test("peek and decode guard against truncation and absurd headers", () => {


### PR DESCRIPTION
- Protocol v2: reliable channels use one persistent stream (Firefox allows about 100 concurrent streams and since Deno sends a late FIN, it breaks)
- Added a new manifest module: `web/shared/manifest.ts` with a Python mirror in `dimos/web/relay_bridge/manifest.py`
- Updated the channel lifecycle. Policies now have `dispose()`, so unsubscribe, re-watch and viewer close drop queued frames and abort the persistent stream instead of leaking it.
- Hardened the Bridge ingress. The receive queue is bounded by bytes as well as frame count, and payloads are capped per encoding using the watched robot's manifest.
