### PR TITLE
feat(cockpit): add UI and local relay integration

### DIFF
--- a/.github/actions/build-cockpit/action.yml
+++ b/.github/actions/build-cockpit/action.yml
@@ -1,0 +1,34 @@
+name: build-cockpit
+description: >-
+  Canonical Cockpit build for release artifacts: install the Deno version
+  pinned in dimos/utils/deno.py, validate the frozen lockfile, and build
+  web/cockpit/dist (shipped in the sdist and copied into wheels by setup.py).
+
+runs:
+  using: composite
+  steps:
+    - name: Extract Deno version
+      id: deno-version
+      shell: bash
+      # sed, not grep -P: macOS (BSD) grep has no -P, and a failed command
+      # substitution would silently yield an empty version.
+      run: |
+        version=$(sed -n 's/^DENO_VERSION = "\(.*\)"$/\1/p' dimos/utils/deno.py)
+        if [[ -z "$version" ]]; then
+          echo "::error::could not read DENO_VERSION from dimos/utils/deno.py"
+          exit 1
+        fi
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+    - name: Install Deno
+      uses: denoland/setup-deno@v2
+      with:
+        deno-version: ${{ steps.deno-version.outputs.version }}
+        cache: true
+    - name: Deno install (validates deno.lock)
+      shell: bash
+      working-directory: web
+      run: deno install --frozen
+    - name: Build cockpit dist
+      shell: bash
+      working-directory: web/cockpit
+      run: deno task build

--- a/.github/scripts/check_sdist.py
+++ b/.github/scripts/check_sdist.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Assert a release sdist ships the pre-built Cockpit and no generated junk.
+
+Usage: check_sdist.py dist/dimos-*.tar.gz
+"""
+
+import sys
+import tarfile
+
+# Real content is ~8 MB uncompressed; the web/node_modules regression alone
+# added ~74 MB. Generous headroom below that failure regime.
+MAX_UNCOMPRESSED_MB = 40
+
+# Paths below the dimos-<version>/ root that every release sdist must carry.
+REQUIRED = (
+    "web/cockpit/dist/index.html",
+    "web/deno.lock",
+    "web/relay/main.ts",
+)
+
+
+def main(sdist: str) -> None:
+    with tarfile.open(sdist) as tar:
+        members = tar.getmembers()
+    names = {m.name.split("/", 1)[1] for m in members if "/" in m.name}
+
+    problems = [f"missing {path}" for path in REQUIRED if path not in names]
+    generated = sorted(n for n in names if "node_modules" in n.split("/"))
+    if generated:
+        problems.append(f"{len(generated)} node_modules entries, e.g. {generated[0]}")
+    total_mb = sum(m.size for m in members) / 1e6
+    if total_mb > MAX_UNCOMPRESSED_MB:
+        problems.append(f"{total_mb:.1f} MB uncompressed exceeds {MAX_UNCOMPRESSED_MB} MB")
+
+    if problems:
+        sys.exit(f"{sdist} failed checks:\n" + "\n".join(f"- {p}" for p in problems))
+    print(f"{sdist} ok: {len(members)} entries, {total_mb:.1f} MB uncompressed")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        sys.exit(f"usage: {sys.argv[0]} <sdist.tar.gz>")
+    main(sys.argv[1])

--- a/.github/scripts/wheel_smoke.py
+++ b/.github/scripts/wheel_smoke.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Release-wheel smoke test, run by cibuildwheel against the installed wheel.
+
+Imports the native extension, asserts the packaged relay + Cockpit files, then
+starts the packaged relay and fetches /api/info and the Cockpit at /. Deno is
+not preinstalled in the manylinux test containers: ensure_deno() downloads the
+pinned DENO_VERSION there, exactly as it does on a customer machine.
+"""
+
+import json
+from pathlib import Path
+import urllib.request
+
+from dimos.navigation.replanning_a_star.min_cost_astar_ext import min_cost_astar_cpp  # noqa: F401
+from dimos.web.relay_bridge import locate
+from dimos.web.relay_bridge.relay_process import RelayProcess
+
+REQUIRED = (
+    "deno.json",
+    "deno.lock",
+    "relay/main.ts",
+    "shared/protocol.ts",
+    "cockpit/dist/index.html",
+)
+
+# First start in a fresh container downloads Deno plus the relay's jsr deps.
+RELAY_READY_TIMEOUT_S = 120.0
+
+
+def main() -> None:
+    dist = Path(locate.__file__).resolve().parent / "_relay_dist"
+    for rel in REQUIRED:
+        if not (dist / rel).is_file():
+            raise SystemExit(f"missing from installed wheel: {dist / rel}")
+    leaked = [p for p in dist.rglob("*") if p.name.endswith("_test.ts") or p.name == "testdata"]
+    if leaked:
+        raise SystemExit(f"test files leaked into the wheel: {leaked}")
+    web_dir = locate.find_web_dir()
+    if web_dir != dist:
+        raise SystemExit(f"find_web_dir() resolved {web_dir}, not the packaged {dist}")
+
+    with RelayProcess(timeout=RELAY_READY_TIMEOUT_S) as info:
+        if not info.cockpit:
+            raise SystemExit("relay started without the packaged Cockpit dist")
+        base = f"http://127.0.0.1:{info.http_port}"
+        with urllib.request.urlopen(f"{base}/api/info", timeout=30) as resp:
+            api_info = json.load(resp)
+        missing = [key for key in ("wtUrl", "certHash", "v") if key not in api_info]
+        if missing:
+            raise SystemExit(f"/api/info missing {missing}: {api_info}")
+        with urllib.request.urlopen(f"{base}/", timeout=30) as resp:
+            index = resp.read()
+        if index != (dist / "cockpit" / "dist" / "index.html").read_bytes():
+            raise SystemExit("/ did not serve the packaged Cockpit index.html")
+    print("wheel smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,7 +243,7 @@ jobs:
       #   run: npm run validate
 
   web:
-    timeout-minutes: 15
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     permissions:
       contents: read  # For checkout
@@ -270,13 +270,51 @@ jobs:
         working-directory: web
         run: deno lint
 
-      - name: Deno check
+      - name: Deno install (validates deno.lock)
+        working-directory: web
+        run: deno install --frozen
+
+      - name: Deno check (relay + shared)
         working-directory: web
         run: deno task check
 
-      - name: Deno test
+      - name: Deno test (relay + shared)
         working-directory: web
         run: deno task test
+
+      - name: Cockpit type-check
+        working-directory: web/cockpit
+        run: deno task check
+
+      - name: Cockpit vitest
+        working-directory: web/cockpit
+        run: deno task test
+
+      - name: Cockpit build
+        working-directory: web/cockpit
+        run: deno task build
+
+      # ---- Browser e2e: dimos run --local-relay + Playwright on the dist ----
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.3.2
+        with:
+          enable-cache: true
+      - name: Setup Python
+        uses: actions/setup-python@v6.3.0
+        with:
+          python-version: '3.12'
+      - name: Install native dependencies (pyaudio build, JPEG encoding)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y portaudio19-dev libturbojpeg
+      - name: Fetch the go2_short replay dataset
+        run: git lfs pull --include="data/.lfs/go2_short.db.tar.gz" --exclude=""
+      - name: Install dependencies
+        run: uv sync --group tests --group browser-tests --frozen
+      - name: Install Playwright browsers  # the e2e runs in both engines
+        run: uv run playwright install --with-deps chromium firefox
+      - name: Cockpit browser e2e
+        run: uv run pytest -m web_browser dimos/e2e_tests/test_cockpit_browser.py --no-cov
 
   tests:
     timeout-minutes: 20
@@ -339,13 +377,13 @@ jobs:
       - name: Install dependencies
         run: uv sync --group tests --frozen
       - name: Run tests
-        run: uv run pytest --numprocesses=logical --cov=dimos/ --junitxml=junit.xml -m 'not (self_hosted or mujoco or self_hosted_large)'
+        run: uv run pytest --numprocesses=logical --cov=dimos/ --junitxml=junit.xml -m 'not (self_hosted or mujoco or self_hosted_large or web_browser)'
       - name: Re-run the failing tests with maximum verbosity
         if: failure()
         env:
           COLOR: yes
         run: >-  # `exit 1` makes sure that the job remains red with flaky runs
-          uv run pytest --no-cov -vvvvv --lf  -m 'not (self_hosted or mujoco or self_hosted_large)' && exit 1
+          uv run pytest --no-cov -vvvvv --lf  -m 'not (self_hosted or mujoco or self_hosted_large or web_browser)' && exit 1
         shell: bash
       - name: Turn coverage into xml
         run: uv run python -m coverage xml

--- a/.github/workflows/release-build-check.yml
+++ b/.github/workflows/release-build-check.yml
@@ -1,6 +1,6 @@
 # release.yml is dispatch-only, so changes to it (including dependabot bumps of
 # pypa/cibuildwheel) merge without ever being executed. This smoke-builds one wheel
-# at PR time so release-build breakage surfaces before release day.
+# and the sdist at PR time so release-build breakage surfaces before release day.
 name: release-build-check
 
 on:
@@ -8,9 +8,17 @@ on:
     paths:
       - .github/workflows/release.yml
       - .github/workflows/release-build-check.yml
+      - .github/actions/build-cockpit/action.yml
+      - .github/scripts/check_sdist.py
+      - .github/scripts/wheel_smoke.py
       - pyproject.toml
       - setup.py
       - MANIFEST.in
+      - web/cockpit/**
+      - web/shared/**
+      - web/deno.json
+      - web/deno.lock
+      - dimos/utils/deno.py
 
 permissions: {}
 
@@ -22,11 +30,31 @@ jobs:
     env:
       # Keep in sync with the build-wheels env in release.yml
       CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_34
-      CIBW_TEST_COMMAND: "python -c 'from dimos.navigation.replanning_a_star.min_cost_astar_ext import min_cost_astar_cpp'"
+      CIBW_TEST_COMMAND: "python {project}/.github/scripts/wheel_smoke.py"
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+      - name: Build cockpit dist
+        uses: ./.github/actions/build-cockpit
       - name: Build one wheel
         uses: pypa/cibuildwheel@v4.1.0
         with:
           only: cp312-manylinux_x86_64
+
+  build-sdist:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Build cockpit dist
+        uses: ./.github/actions/build-cockpit
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.3.2
+        with:
+          enable-cache: true
+      - name: Build sdist
+        run: uv build --sdist
+      - name: Check sdist contents
+        run: python3 .github/scripts/check_sdist.py dist/*.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,8 +82,12 @@ jobs:
         uses: astral-sh/setup-uv@v8.3.2
         with:
           enable-cache: true
+      - name: Build cockpit dist  # shipped pre-built in the sdist and wheels
+        uses: ./.github/actions/build-cockpit
       - name: Build sdist
         run: uv build --sdist
+      - name: Check sdist contents
+        run: python3 .github/scripts/check_sdist.py dist/*.tar.gz
       - name: Attestation
         uses: actions/attest-build-provenance@v4
         with:
@@ -115,11 +119,14 @@ jobs:
       CIBW_SKIP: "*-musllinux_*"
       CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_34  # open3d>=0.19 requires glibc 2.31+
       CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_34  # open3d>=0.19 requires glibc 2.31+
-      CIBW_TEST_COMMAND: "python -c 'from dimos.navigation.replanning_a_star.min_cost_astar_ext import min_cost_astar_cpp'"
+      # Asserts the packaged relay + Cockpit and serves them from the installed wheel.
+      CIBW_TEST_COMMAND: "python {project}/.github/scripts/wheel_smoke.py"
       MACOSX_DEPLOYMENT_TARGET: "11.0"
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+      - name: Build cockpit dist  # setup.py copies it into the wheel's _relay_dist
+        uses: ./.github/actions/build-cockpit
       - name: Build wheels
         uses: pypa/cibuildwheel@v4.1.0
       - name: Attestation

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ target/
 dist/
 build/
 *.so
+/web/cockpit/.build.lock
+/web/cockpit/.dist-*
 
 # Nix / direnv (symlink one of the tracked .envrc.* files to .envrc)
 .direnv/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -29,8 +29,8 @@ recursive-include dimos/web/dimos_interface/api *.py *.html
 # The graft keeps them in the sdist so sdist->wheel builds (uv build, pip)
 # can reproduce that copy.
 graft web
+prune web/node_modules
 prune web/cockpit/node_modules
-prune web/cockpit/dist
 
 # Exclude development files
 exclude .gitignore

--- a/dimos/conftest.py
+++ b/dimos/conftest.py
@@ -110,6 +110,10 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "self_hosted_large: tests that need a high-memory self-hosted runner"
     )
+    config.addinivalue_line(
+        "markers",
+        "web_browser: cockpit browser e2e (playwright chromium); runs in the CI web job",
+    )
     config.addinivalue_line("markers", "skipif_in_ci: skip when CI env var is set")
     config.addinivalue_line("markers", "skipif_no_openai: skip when OPENAI_API_KEY is not set")
     config.addinivalue_line("markers", "skipif_no_alibaba: skip when ALIBABA_API_KEY is not set")

--- a/dimos/e2e_tests/dimos_cli_call.py
+++ b/dimos/e2e_tests/dimos_cli_call.py
@@ -22,10 +22,14 @@ class DimosCliCall:
     process: subprocess.Popen[bytes] | None
     demo_args: list[str] | None = None
     mcp_port: int | None = None
-    simulator: str = "mujoco"
+    # None: no --simulation flag (e.g. replay runs via --robot-ip fake).
+    simulator: str | None = "mujoco"
 
     def __init__(self) -> None:
         self.process = None
+        # Root-level CLI flags (before the subcommand), e.g. ["--robot-ip", "fake"].
+        self.global_args: list[str] = []
+        self.extra_env: dict[str, str] = {}
 
     def start(self) -> None:
         if self.demo_args is None:
@@ -45,18 +49,19 @@ class DimosCliCall:
         # overrides whose module is absent from the blueprint, but rejects
         # unknown `-o` keys outright. Blueprints without an mcpclient (e.g.
         # `coordinator-mock`) would otherwise fail config validation.
-        global_overrides: list[str] = []
+        global_overrides: list[str] = list(self.global_args)
         env = os.environ.copy()
+        env.update(self.extra_env)
         if self.mcp_port is not None:
             global_overrides += ["--mcp-port", str(self.mcp_port)]
             env["MCPCLIENT__MCP_SERVER_URL"] = f"http://localhost:{self.mcp_port}/mcp"
+        if self.simulator is not None:
+            global_overrides += ["--simulation", self.simulator]
 
         self.process = subprocess.Popen(
             [
                 "dimos",
                 *global_overrides,
-                "--simulation",
-                self.simulator,
                 *args,
             ],
             start_new_session=True,
@@ -64,20 +69,29 @@ class DimosCliCall:
         )
 
     def stop(self) -> None:
-        if self.process is None:
+        # Detach before signalling so stop() is idempotent: once the first
+        # call reaps the process its pgid can be recycled, and a second
+        # killpg could hit an unrelated process group.
+        process, self.process = self.process, None
+        if process is None:
             return
 
         try:
             # Send SIGTERM to the entire process group so child processes
             # (e.g. the mujoco viewer subprocess) are also terminated.
-            os.killpg(self.process.pid, signal.SIGTERM)
+            try:
+                os.killpg(process.pid, signal.SIGTERM)
+            except ProcessLookupError:
+                # The group is already gone: the process exited on its own
+                # and an earlier poll()/wait() reaped it.
+                return
 
             # Record the time when we sent the kill signal
             shutdown_start = time.time()
 
             # Wait for the process to terminate with a 30-second timeout
             try:
-                self.process.wait(timeout=30)
+                process.wait(timeout=30)
                 shutdown_duration = time.time() - shutdown_start
 
                 # Verify it shut down in time
@@ -87,18 +101,18 @@ class DimosCliCall:
                 )
             except subprocess.TimeoutExpired:
                 # If we reach here, the process didn't terminate in 30 seconds
-                os.killpg(self.process.pid, signal.SIGKILL)
-                self.process.wait()  # Clean up
+                os.killpg(process.pid, signal.SIGKILL)
+                process.wait()  # Clean up
                 raise AssertionError(
                     "Process did not shut down within 30 seconds after receiving SIGTERM"
                 )
 
         except Exception:
             # Clean up if something goes wrong
-            if self.process.poll() is None:  # Process still running
+            if process.poll() is None:  # Process still running
                 try:
-                    os.killpg(self.process.pid, signal.SIGKILL)
+                    os.killpg(process.pid, signal.SIGKILL)
                 except ProcessLookupError:
                     pass
-                self.process.wait()
+                process.wait()
             raise

--- a/dimos/e2e_tests/test_cockpit_browser.py
+++ b/dimos/e2e_tests/test_cockpit_browser.py
@@ -1,0 +1,146 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Cockpit browser e2e (the T3 acceptance demo, in CI).
+
+Starts `dimos --robot-ip fake run unitree-go2-basic --local-relay` (the go2
+blueprint on the go2_short replay dataset: real recorded odom + camera, no
+MuJoCo and no hardware) and drives the served Cockpit with a real headless
+browser: live odom must tick, the session must stay connected (Firefox's
+tight QUIC stream credit found the relay's stream-per-frame overflow the
+first time), and killing + restarting the dimos process must take the page
+through reconnecting and back to live data without a reload.
+
+Runs in both Chromium and Firefox: their WebTransport implementations differ
+enough that one browser staying green says little about the other.
+
+Marked web_browser: excluded from the default suite (needs the
+`browser-tests` dependency group, Playwright browsers and the LFS dataset);
+the CI `web` job runs it against a freshly-built cockpit dist. Locally:
+`uv run --group browser-tests pytest -m web_browser dimos/e2e_tests/test_cockpit_browser.py`.
+"""
+
+from collections.abc import Callable, Iterator
+import time
+
+import pytest
+import requests
+
+from dimos.e2e_tests.dimos_cli_call import DimosCliCall
+
+# Playwright lives in the `browser-tests` dependency group, which only the CI
+# web job installs; collection elsewhere must skip, not fail.
+pytest.importorskip("playwright")
+
+from playwright.sync_api import Page, expect, sync_playwright
+
+pytestmark = pytest.mark.web_browser
+
+COCKPIT_URL = "http://127.0.0.1:7780/"
+
+# The first start may download Deno and, outside CI, build the cockpit dist.
+START_TIMEOUT_S = 300
+
+# Long enough to catch periodic disconnects (the Firefox stream-credit
+# overflow kicked the viewer every ~8 s).
+STABILITY_WINDOW_S = 12
+
+
+@pytest.fixture
+def start_go2_replay() -> Iterator[Callable[[], DimosCliCall]]:
+    calls: list[DimosCliCall] = []
+
+    def start() -> DimosCliCall:
+        call = DimosCliCall()
+        call.simulator = None
+        # --viewer none: no rerun viewer spawn (headless CI); the replay
+        # connection means no MuJoCo and no hardware.
+        call.global_args = ["--robot-ip", "fake", "--viewer", "none"]
+        call.extra_env = {"RELAYBRIDGEMODULE__OPEN_BROWSER": "false"}
+        call.demo_args = ["run", "unitree-go2-basic", "--local-relay"]
+        call.start()
+        calls.append(call)
+        return call
+
+    yield start
+    for call in calls:
+        call.stop()
+
+
+@pytest.fixture(params=["chromium", "firefox"])
+def page(request: pytest.FixtureRequest) -> Iterator[Page]:
+    with sync_playwright() as p:
+        browser = getattr(p, request.param).launch()
+        try:
+            yield browser.new_page()
+        finally:
+            browser.close()
+
+
+def _wait_for_relay(call: DimosCliCall, timeout_s: float) -> None:
+    deadline = time.monotonic() + timeout_s
+    while True:
+        try:
+            requests.get(f"{COCKPIT_URL}api/info", timeout=2).raise_for_status()
+            return
+        except requests.RequestException:
+            assert call.process is not None and call.process.poll() is None, (
+                f"dimos exited with {call.process and call.process.returncode} before the relay came up"
+            )
+            if time.monotonic() > deadline:
+                raise TimeoutError(f"relay not reachable after {timeout_s} s") from None
+            time.sleep(0.5)
+
+
+def _assert_odom_ticks(page: Page) -> None:
+    seq = page.get_by_test_id("ch-odom-seq")
+    expect(seq).not_to_have_text("-", timeout=60_000)
+    first = seq.inner_text()
+    expect(seq).not_to_have_text(first, timeout=30_000)
+    expect(page.get_by_test_id("ch-odom-value")).to_contain_text("yaw")
+
+
+def test_cockpit_live_data_and_reconnect(
+    start_go2_replay: Callable[[], DimosCliCall], page: Page
+) -> None:
+    call = start_go2_replay()
+    _wait_for_relay(call, START_TIMEOUT_S)
+
+    page.goto(COCKPIT_URL)
+    status = page.get_by_test_id("status")
+    expect(status).to_have_attribute("data-phase", "connected", timeout=120_000)
+    expect(page.get_by_test_id("robot")).not_to_have_text("no robot", timeout=30_000)
+    _assert_odom_ticks(page)
+
+    # Stability: record every phase change and require none for the window.
+    page.evaluate("""() => {
+      window.__phases = [];
+      const el = document.querySelector('[data-testid="status"]');
+      new MutationObserver(() => window.__phases.push(el.dataset.phase))
+        .observe(el, { attributes: true, attributeFilter: ["data-phase"] });
+    }""")
+    page.wait_for_timeout(STABILITY_WINDOW_S * 1000)
+    flaps = page.evaluate("() => window.__phases")
+    assert flaps == [], f"session flapped during the stability window: {flaps}"
+    _assert_odom_ticks(page)
+
+    # Kill dimos (relay dies with it): the page must notice on its own.
+    call.stop()
+    expect(status).to_have_attribute("data-phase", "reconnecting", timeout=60_000)
+
+    # Restart: the page reattaches by itself and data resumes, no reload.
+    restarted = start_go2_replay()
+    _wait_for_relay(restarted, START_TIMEOUT_S)
+    expect(status).to_have_attribute("data-phase", "connected", timeout=120_000)
+    _assert_odom_ticks(page)

--- a/dimos/web/relay_bridge/locate.py
+++ b/dimos/web/relay_bridge/locate.py
@@ -17,7 +17,11 @@
 import os
 from pathlib import Path
 
+# Overrides where the web tree is looked up. An override is served as-is:
+# auto-building it would run its build tooling with full permissions, so the
+# cockpit build additionally requires the opt-in below (see build_allowed()).
 WEB_DIR_ENV_VAR = "DIMOS_WEB_DIR"
+WEB_DIR_BUILD_ENV_VAR = "DIMOS_WEB_DIR_BUILD"
 
 # Written into the wheel by the build_py hook in setup.py; absent in checkouts.
 _PACKAGED_DIR_NAME = "_relay_dist"
@@ -29,7 +33,7 @@ def find_web_dir() -> Path:
 
     env = os.environ.get(WEB_DIR_ENV_VAR)
     if env:
-        env_dir = Path(env)
+        env_dir = Path(env).resolve()
         if _is_web_dir(env_dir):
             return env_dir
         tried.append(f"{WEB_DIR_ENV_VAR}={env_dir}")
@@ -51,19 +55,53 @@ def find_web_dir() -> Path:
     )
 
 
-def relay_run_cmd(deno: str, web_dir: Path, *args: str) -> list[str]:
+def build_allowed(web_dir: Path) -> bool:
+    """True when the cockpit auto-build may run in web_dir.
+
+    A tree selected via DIMOS_WEB_DIR gets its build tooling executed with
+    `deno run -A`, so it is served as-is unless DIMOS_WEB_DIR_BUILD=1
+    acknowledges that; the repo checkout is trusted and always builds.
+    """
+    env = os.environ.get(WEB_DIR_ENV_VAR)
+    if not env or Path(env).resolve() != web_dir.resolve():
+        return True
+    return os.environ.get(WEB_DIR_BUILD_ENV_VAR) == "1"
+
+
+def find_cockpit_dist(web_dir: Path) -> Path | None:
+    """Built Cockpit app (web/cockpit/dist), canonicalized, or None when not built."""
+    dist = web_dir / "cockpit" / "dist"
+    return dist.resolve() if (dist / "index.html").is_file() else None
+
+
+def relay_run_cmd(
+    deno: str, web_dir: Path, *args: str, cockpit_dir: Path | None = None
+) -> list[str]:
     """Build the argv that runs the relay with the pinned config and least permissions."""
-    return [
+    # Canonical paths: the relay realpath-checks served files against its
+    # roots, so a symlinked --allow-read scope (macOS /tmp -> /private/tmp)
+    # would deny every read.
+    web_dir = web_dir.resolve()
+    if cockpit_dir is not None:
+        cockpit_dir = cockpit_dir.resolve()
+    # --node-modules-dir=none: the workspace root deno.json says "auto" (for
+    # the cockpit build tooling), which would make this run materialize
+    # node_modules next to the config -- inside site-packages under a wheel.
+    allow_read = str(web_dir) if cockpit_dir is None else f"{web_dir},{cockpit_dir}"
+    cmd = [
         deno,
         "run",
         "--frozen",
-        f"--allow-read={web_dir}",
+        "--node-modules-dir=none",
+        f"--allow-read={allow_read}",
         "--allow-net",
         "--config",
         str(web_dir / "deno.json"),
         str(web_dir / "relay" / "main.ts"),
-        *args,
     ]
+    if cockpit_dir is not None:
+        cmd += ["--cockpit-dir", str(cockpit_dir)]
+    return [*cmd, *args]
 
 
 def _is_web_dir(path: Path) -> bool:

--- a/dimos/web/relay_bridge/relay_bridge_module.py
+++ b/dimos/web/relay_bridge/relay_bridge_module.py
@@ -48,14 +48,15 @@ from dimos.core.stream import In
 from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
 from dimos.msgs.sensor_msgs.Image import Image
 from dimos.utils.logging_config import setup_logger
+from dimos.web.relay_bridge.locate import find_web_dir
+from dimos.web.relay_bridge.manifest import parse_manifest
 from dimos.web.relay_bridge.protocol import (
-    ChannelSpec,
     Delivery,
     RobotInfo,
     RobotManifest,
     Subs,
 )
-from dimos.web.relay_bridge.relay_process import RelayProcess
+from dimos.web.relay_bridge.relay_process import RelayProcess, ensure_cockpit_dist
 from dimos.web.relay_bridge.wt_client import (
     RelayClient,
     RelayRejectedError,
@@ -74,6 +75,25 @@ _RECONNECT_PAUSE_S = 2.0
 # notices at idle timeout (tens of seconds). The child watchdog polls the
 # process instead and force-closes the session to trigger a prompt respawn.
 _CHILD_POLL_S = 1.0
+
+# Bounded wait for the build worker thread after cancelling it (the child
+# dies within the SIGTERM-to-SIGKILL grace; this adds a margin on top).
+_BUILD_CANCEL_WAIT_S = 8.0
+
+
+def _probe_local_port(port: int) -> None:
+    if port == 0:
+        return
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+            # SO_REUSEADDR matches how the relay itself binds: a live
+            # listener still fails the probe, but the FIN_WAIT/TIME_WAIT
+            # remnants of a just-killed relay (a browser tab was
+            # attached) must not block an immediate restart.
+            probe.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            probe.bind(("127.0.0.1", port))
+    except OSError as e:
+        raise RuntimeError(f"cannot start local relay: port {port} is unavailable") from e
 
 
 async def _blocking_call(func: Callable[..., _T], *args: Any) -> _T:
@@ -118,6 +138,9 @@ class RelayBridgeConfig(ModuleConfig):
     """HTTP port of the spawned local relay; 0 picks an ephemeral port (tests)."""
     open_browser: bool = True
     """Open the local relay's page once it is up (local mode only)."""
+    cockpit_build: bool = True
+    """Build the Cockpit dist before spawning the local relay when it is
+    missing or stale (checkouts only; wheels ship it pre-built)."""
     robot_id: str = ""
     """Relay identity; empty falls back to g.robot_id, then the hostname."""
     robot_name: str = ""
@@ -176,14 +199,22 @@ CHANNELS: tuple[ChannelDef, ...] = (
 
 
 def build_manifest(config: RelayBridgeConfig, channels: tuple[ChannelDef, ...]) -> RobotManifest:
-    return RobotManifest(
-        channels=[
-            ChannelSpec(
-                ch=cd.ch, encoding=cd.encoding, delivery=cd.delivery, maxHz=cd.max_hz(config)
-            )
-            for cd in channels
-        ]
+    # Routed through the domain parser so an invalid channel table (duplicate
+    # ids, bad rates) fails module start instead of poisoning the relay.
+    manifest = parse_manifest(
+        {
+            "channels": [
+                {
+                    "ch": cd.ch,
+                    "encoding": cd.encoding,
+                    "delivery": cd.delivery,
+                    "maxHz": cd.max_hz(config),
+                }
+                for cd in channels
+            ]
+        }
     )
+    return RobotManifest(channels=manifest.channels)
 
 
 def resolve_robot_info(config: RelayBridgeConfig) -> RobotInfo:
@@ -208,6 +239,7 @@ class RelayBridgeModule(Module):
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self._relay: RelayProcess | None = None
+        self._build_cancel: threading.Event | None = None
         self._session: _Session | None = None
         self._url: str | None = None
         self._robot_info: RobotInfo | None = None
@@ -236,6 +268,14 @@ class RelayBridgeModule(Module):
             self._manifest = build_manifest(self.config, self._channel_defs)
             self._url = self.config.relay_url or self.config.g.relay_url
             if self._url is None:
+                # Probe before the (expensive) build: a start that will lose
+                # the port must not rewrite the dist a running relay serves.
+                _probe_local_port(self.config.local_port)
+                if self.config.cockpit_build:
+                    try:
+                        await self._build_cockpit()
+                    except Exception:
+                        logger.exception("cockpit build failed; continuing with the relay only")
                 self._url = await _blocking_call(self._spawn_relay, self.config.open_browser)
             # The first connect fails fast: a relay that cannot be reached at
             # startup should fail the module start visibly, not retry forever.
@@ -257,21 +297,46 @@ class RelayBridgeModule(Module):
                         # its port (it has no PDEATHSIG), so surface cleanup failure.
                         logger.exception("relay bridge: stopping the local relay failed")
 
+    async def _build_cockpit(self) -> None:
+        """Build the Cockpit dist (checkouts only) before spawning the relay.
+
+        The blocking build runs in a thread but stays cancellable: on
+        cancellation (or module close, via _close_module) the build child is
+        killed and the worker reaped within a bounded grace, so teardown
+        never waits out the 600 s build timeout.
+        """
+        cancel = threading.Event()
+        self._build_cancel = cancel
+        work = asyncio.create_task(
+            asyncio.to_thread(ensure_cockpit_dist, find_web_dir(), cancel=cancel)
+        )
+        try:
+            await asyncio.shield(work)
+        except (asyncio.CancelledError, GeneratorExit):
+            # Generator finalization (aclose) delivers GeneratorExit instead
+            # of CancelledError; both mean the same thing here.
+            cancel.set()
+            await asyncio.wait({work}, timeout=_BUILD_CANCEL_WAIT_S)
+            raise
+        finally:
+            self._build_cancel = None
+
+    def _close_module(self) -> None:
+        # Runs on every stop path, including a stop() racing a still-starting
+        # main(): an in-flight cockpit build must die now, not at its timeout.
+        cancel = self._build_cancel
+        if cancel is not None:
+            cancel.set()
+        super()._close_module()
+
     def _spawn_relay(self, open_browser: bool) -> str:
         """Start a fresh local relay child (blocking; run via to_thread)."""
-        if self.config.local_port != 0:
-            try:
-                with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
-                    probe.bind(("127.0.0.1", self.config.local_port))
-            except OSError as e:
-                raise RuntimeError(
-                    f"cannot start local relay: port {self.config.local_port} is unavailable"
-                ) from e
+        _probe_local_port(self.config.local_port)
         self._relay = RelayProcess(port=self.config.local_port)
         info = self._relay.start()
-        logger.info(f"local relay ready: {info.debug_url}")
+        logger.info(f"local relay ready: {info.open_url}")
         if open_browser:
-            webbrowser.open_new_tab(info.debug_url)
+            webbrowser.open_new_tab(info.open_url)
         return info.wt_url
 
     async def _connect_and_hello(self) -> _Session:

--- a/dimos/web/relay_bridge/relay_process.py
+++ b/dimos/web/relay_bridge/relay_process.py
@@ -14,24 +14,236 @@
 
 from __future__ import annotations
 
+import atexit
 import collections
+from collections.abc import Iterator
+import contextlib
 from dataclasses import dataclass
+import fcntl
+import hashlib
 import json
 import os
 from pathlib import Path
 import queue
+import shutil
+import signal
 import subprocess
+import tempfile
 import threading
 import time
 from typing import IO
 
 from dimos.utils.deno import ensure_deno
 from dimos.utils.logging_config import setup_logger
-from dimos.web.relay_bridge.locate import find_web_dir, relay_run_cmd
+from dimos.web.relay_bridge.locate import (
+    WEB_DIR_BUILD_ENV_VAR,
+    WEB_DIR_ENV_VAR,
+    build_allowed,
+    find_cockpit_dist,
+    find_web_dir,
+    relay_run_cmd,
+)
 
 logger = setup_logger()
 
 _STDERR_TAIL_LINES = 60
+
+_COCKPIT_BUILD_TIMEOUT_S = 600.0
+# SIGTERM-to-SIGKILL grace when a build child is cancelled or times out.
+_BUILD_KILL_GRACE_S = 5.0
+_BUILD_POLL_S = 0.2
+
+# Input-hash stamp a successful build writes into its dist; a mismatch with
+# the current inputs means the dist is stale.
+_STAMP_NAME = ".buildstamp"
+
+# Interpreter exit must kill in-flight builds: plain atexit callbacks run
+# before the executor threads driving them are joined, so exit stays bounded
+# by the kill grace instead of the build timeout.
+_live_build_cancels: set[threading.Event] = set()
+
+
+def _cancel_builds_at_exit() -> None:
+    for cancel in list(_live_build_cancels):
+        cancel.set()
+
+
+atexit.register(_cancel_builds_at_exit)
+
+
+def ensure_cockpit_dist(
+    web_dir: Path,
+    timeout: float = _COCKPIT_BUILD_TIMEOUT_S,
+    cancel: threading.Event | None = None,
+) -> Path | None:
+    """Path to the built Cockpit app, building it first when possible.
+
+    Wheel installs ship a pre-built dist and no sources: return it (or None on
+    a cockpit-less wheel). Checkouts rebuild when the dist's input stamp (a
+    hash over the cockpit/shared sources, workspace config, and lockfile) no
+    longer matches; the build runs under a cross-process lock, into a
+    temporary directory published atomically, so concurrent starts serialize
+    and a failed build leaves the served dist untouched (the relay still runs,
+    and serves the debug page when there is no dist at all). Setting `cancel`
+    kills the build child within a bounded grace.
+    """
+    dist = find_cockpit_dist(web_dir)
+    cockpit = web_dir / "cockpit"
+    if not (cockpit / "src").is_dir():
+        return dist
+    if not build_allowed(web_dir):
+        logger.warning(
+            f"{WEB_DIR_ENV_VAR} is set; serving its cockpit as-is "
+            f"(set {WEB_DIR_BUILD_ENV_VAR}=1 to allow building that tree)"
+        )
+        return dist
+    if cancel is None:
+        cancel = threading.Event()
+    deadline = time.monotonic() + timeout
+    _live_build_cancels.add(cancel)
+    try:
+        with _build_lock(cockpit, deadline, cancel) as locked:
+            if not locked:
+                logger.warning("another cockpit build is running; serving the existing dist")
+                return find_cockpit_dist(web_dir)
+            stamp = _input_stamp(web_dir)
+            dist = find_cockpit_dist(web_dir)  # a previous lock holder may have rebuilt
+            if dist is not None and _read_stamp(dist) == stamp:
+                return dist
+            state = "missing" if dist is None else "stale"
+            logger.warning(f"cockpit dist is {state}; building it (takes a minute)")
+            for leftover in cockpit.glob(".dist-*"):  # crashed builds; ours is the lock
+                shutil.rmtree(leftover, ignore_errors=True)
+            out_dir = Path(tempfile.mkdtemp(prefix=".dist-new-", dir=cockpit))
+            out_dir.chmod(0o755)  # mkdtemp gives 0o700; this becomes the dist
+            try:
+                # Fixed argv (what cockpit/deno.json's build task runs), not
+                # the tree's task definition; --outDir keeps a failed build
+                # away from the served dist.
+                cmd = [
+                    ensure_deno(),
+                    "run",
+                    "--frozen",
+                    "-A",
+                    "npm:vite",
+                    "build",
+                    "--outDir",
+                    str(out_dir),
+                ]
+                if _run_build(cmd, cockpit, deadline, cancel):
+                    (out_dir / _STAMP_NAME).write_text(stamp)
+                    _swap_dist(cockpit, out_dir)
+                    logger.info("cockpit dist built")
+            except Exception:
+                logger.exception("cockpit build did not run")
+            finally:
+                shutil.rmtree(out_dir, ignore_errors=True)
+            return find_cockpit_dist(web_dir)
+    finally:
+        _live_build_cancels.discard(cancel)
+
+
+@contextlib.contextmanager
+def _build_lock(cockpit: Path, deadline: float, cancel: threading.Event) -> Iterator[bool]:
+    """Cross-process flock; yields False when it stays busy until the deadline."""
+    with (cockpit / ".build.lock").open("w") as lock_file:
+        while True:
+            try:
+                fcntl.flock(lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except OSError:
+                if cancel.is_set() or time.monotonic() >= deadline:
+                    yield False
+                    return
+                time.sleep(_BUILD_POLL_S)
+                continue
+            yield True  # closing the file releases the lock
+            return
+
+
+def _input_stamp(web_dir: Path) -> str:
+    """Hash of the build inputs: file set plus content, so deletions rebuild
+    while test-only edits, generated output, and hidden files do not."""
+    digest = hashlib.sha256()
+    for path in _build_inputs(web_dir):
+        digest.update(str(path.relative_to(web_dir)).encode())
+        digest.update(b"\0")
+        digest.update(hashlib.sha256(path.read_bytes()).digest())
+    return digest.hexdigest()
+
+
+def _build_inputs(web_dir: Path) -> list[Path]:
+    files = [path for path in (web_dir / "deno.json", web_dir / "deno.lock") if path.is_file()]
+    for tree in (web_dir / "cockpit", web_dir / "shared"):
+        if not tree.is_dir():
+            continue
+        for path in sorted(tree.rglob("*")):
+            parts = path.relative_to(tree).parts
+            if any(part.startswith(".") for part in parts):
+                continue
+            if {"dist", "node_modules"} & set(parts[:-1]):
+                continue
+            if parts[-1].endswith(("_test.ts", ".test.ts", ".test.tsx")):
+                continue
+            if path.is_file():
+                files.append(path)
+    return files
+
+
+def _read_stamp(dist: Path) -> str | None:
+    try:
+        return (dist / _STAMP_NAME).read_text()
+    except OSError:
+        return None
+
+
+def _run_build(cmd: list[str], cwd: Path, deadline: float, cancel: threading.Event) -> bool:
+    """Run the build child in its own process group so cancellation and the
+    deadline kill the whole tree (deno -> vite -> esbuild workers)."""
+    with tempfile.TemporaryFile() as output:
+        proc = subprocess.Popen(
+            cmd, cwd=cwd, stdout=output, stderr=subprocess.STDOUT, start_new_session=True
+        )
+        while (code := proc.poll()) is None:
+            if cancel.is_set():
+                _kill_group(proc)
+                logger.warning("cockpit build cancelled")
+                return False
+            if time.monotonic() >= deadline:
+                _kill_group(proc)
+                logger.error("cockpit build timed out")
+                return False
+            time.sleep(_BUILD_POLL_S)
+        if code != 0:
+            output.seek(0)
+            tail = "\n".join(output.read().decode(errors="replace").strip().splitlines()[-20:])
+            logger.error(f"cockpit build failed (exit {code}); output tail:\n{tail}")
+            return False
+        return True
+
+
+def _kill_group(proc: subprocess.Popen[bytes]) -> None:
+    try:
+        os.killpg(proc.pid, signal.SIGTERM)
+    except OSError:
+        pass  # already gone
+    try:
+        proc.wait(timeout=_BUILD_KILL_GRACE_S)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except OSError:
+            pass
+        proc.wait()
+
+
+def _swap_dist(cockpit: Path, new_dist: Path) -> None:
+    """Publish atomically: renames, so readers never see a half-written dist."""
+    dist = cockpit / "dist"
+    old = cockpit / ".dist-old"
+    if dist.exists():
+        os.rename(dist, old)
+    os.rename(new_dist, dist)
+    shutil.rmtree(old, ignore_errors=True)
 
 
 @dataclass
@@ -40,10 +252,17 @@ class RelayReadyInfo:
     wt_url: str
     cert_hash: str
     v: int
+    # True when the relay serves a built Cockpit at /; set by RelayProcess.
+    cockpit: bool = False
 
     @property
     def debug_url(self) -> str:
         return f"http://127.0.0.1:{self.http_port}/debug.html"
+
+    @property
+    def open_url(self) -> str:
+        """What a browser should open: the Cockpit, or the debug page without one."""
+        return f"http://127.0.0.1:{self.http_port}/" if self.cockpit else self.debug_url
 
 
 class RelayProcess:
@@ -55,11 +274,13 @@ class RelayProcess:
         port: int = 0,
         host: str = "127.0.0.1",
         web_dir: Path | None = None,
+        cockpit_dir: Path | None = None,
         timeout: float = 20.0,
     ) -> None:
         self._port = port
         self._host = host
         self._web_dir = web_dir
+        self._cockpit_dir = cockpit_dir
         self._timeout = timeout
         self._process: subprocess.Popen[str] | None = None
         self._threads: list[threading.Thread] = []
@@ -70,7 +291,13 @@ class RelayProcess:
     def start(self) -> RelayReadyInfo:
         deno = ensure_deno()
         web_dir = self._web_dir or find_web_dir()
-        cmd = relay_run_cmd(deno, web_dir, "--port", str(self._port), "--host", self._host)
+        # No build here: start() must stay cheap (tests spawn many relays).
+        # The build-if-needed step is ensure_cockpit_dist(), called by the
+        # RelayBridgeModule before spawning.
+        cockpit_dir = self._cockpit_dir or find_cockpit_dist(web_dir)
+        cmd = relay_run_cmd(
+            deno, web_dir, "--port", str(self._port), "--host", self._host, cockpit_dir=cockpit_dir
+        )
         logger.info(f"starting relay: {' '.join(cmd)}")
         env = os.environ | {"NO_COLOR": "1"}
         self._process = subprocess.Popen(
@@ -107,6 +334,7 @@ class RelayProcess:
                     f"relay exited with {code} before producing a ready line; "
                     f"stderr tail:\n{stderr}"
                 ) from None
+        self.info.cockpit = cockpit_dir is not None
         logger.info(f"relay ready: {self.info}")
         return self.info
 

--- a/dimos/web/relay_bridge/test_relay_bridge_e2e.py
+++ b/dimos/web/relay_bridge/test_relay_bridge_e2e.py
@@ -92,7 +92,10 @@ class _Publisher:
 
 
 def _start_bridge() -> tuple[RelayBridgeModule, pLCMTransport, pLCMTransport]:
-    module = RelayBridgeModule(local_port=0, open_browser=False, robot_id=ROBOT_ID)
+    # cockpit_build=False: tests must never trigger the npm-downloading build.
+    module = RelayBridgeModule(
+        local_port=0, open_browser=False, cockpit_build=False, robot_id=ROBOT_ID
+    )
     odom_tr = pLCMTransport("/rb_e2e/odom")
     image_tr = pLCMTransport("/rb_e2e/color_image")
     odom_tr.start()

--- a/dimos/web/relay_bridge/test_relay_bridge_module.py
+++ b/dimos/web/relay_bridge/test_relay_bridge_module.py
@@ -25,6 +25,7 @@ import asyncio
 from collections.abc import AsyncIterator, Callable
 from dataclasses import replace
 import json
+from pathlib import Path
 import socket
 import threading
 import time
@@ -631,6 +632,65 @@ def test_supervisor_survives_reconcile_error(bridge, monkeypatch) -> None:
     assert wait_until(lambda: len(odom_transport(module).subscribers) == 1)
 
 
+def test_port_conflict_fails_before_build(monkeypatch) -> None:
+    # The port probe precedes the build: a start that cannot get the port
+    # must not touch the dist another running relay is serving.
+    builds: list[int] = []
+    monkeypatch.setattr(
+        relay_bridge_module, "ensure_cockpit_dist", lambda *args, **kwargs: builds.append(1)
+    )
+    spawns: list[int] = []
+    monkeypatch.setattr(
+        RelayBridgeModule, "_spawn_relay", lambda self, open_browser: spawns.append(1)
+    )
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as blocker:
+        blocker.bind(("127.0.0.1", 0))
+        blocker.listen(1)
+        port = blocker.getsockname()[1]
+        module = RelayBridgeModule(local_port=port, open_browser=False, robot_id="unit-bot")
+        module.odom.transport = FakeTransport()
+        with pytest.raises(RuntimeError, match="unavailable"):
+            module.start()
+        stop_module(module)
+    assert builds == [] and spawns == []
+
+
+def test_build_cancellation_is_bounded(monkeypatch) -> None:
+    # Cancelling a start mid-build must reach the build (which kills its
+    # child) promptly instead of waiting out the 600 s build timeout.
+    started = threading.Event()
+    finished = threading.Event()
+
+    def fake_ensure(web_dir: Path, cancel: threading.Event | None = None) -> None:
+        assert cancel is not None
+        started.set()
+        cancel.wait(timeout=30.0)
+        finished.set()
+
+    monkeypatch.setattr(relay_bridge_module, "ensure_cockpit_dist", fake_ensure)
+    monkeypatch.setattr(relay_bridge_module, "find_web_dir", lambda: Path("/nonexistent"))
+    module = RelayBridgeModule(relay_url="https://127.0.0.1:1", open_browser=False)
+    try:
+        assert module._loop is not None
+        future = asyncio.run_coroutine_threadsafe(module._build_cockpit(), module._loop)
+        assert started.wait(timeout=5.0)
+        future.cancel()
+        assert finished.wait(timeout=5.0)  # the cancel event reached the build
+        assert wait_until(lambda: module._build_cancel is None)
+    finally:
+        stop_module(module)
+
+
+def test_close_cancels_in_flight_build() -> None:
+    # stop() racing a still-starting main() (start blocked in the build) must
+    # cancel the build via _close_module rather than wait for its timeout.
+    module = RelayBridgeModule(relay_url="https://127.0.0.1:1", open_browser=False)
+    cancel = threading.Event()
+    module._build_cancel = cancel
+    stop_module(module)
+    assert cancel.is_set()
+
+
 def test_failed_start_stops_spawned_relay(monkeypatch) -> None:
     # First-connect failure after a successful spawn happens before main yields;
     # its unified finally must still reap the fresh child.
@@ -638,7 +698,11 @@ def test_failed_start_stops_spawned_relay(monkeypatch) -> None:
         raise OSError("connect refused")
 
     monkeypatch.setattr(relay_bridge_module, "connect_with_backoff", fail_connect)
-    module = RelayBridgeModule(local_port=0, open_browser=False, robot_id="unit-bot")
+    # cockpit_build=False: the build now runs in main() before _spawn_relay,
+    # so the fake spawn below no longer shields this test from it.
+    module = RelayBridgeModule(
+        local_port=0, open_browser=False, cockpit_build=False, robot_id="unit-bot"
+    )
     relay = FakeRelay(running=True)
 
     def fake_spawn(open_browser: bool) -> str:

--- a/dimos/web/relay_bridge/test_relay_process.py
+++ b/dimos/web/relay_bridge/test_relay_process.py
@@ -1,0 +1,354 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""RelayProcess cockpit serving and the ensure_cockpit_dist build policy."""
+
+import json
+import os
+from pathlib import Path
+import shutil
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+
+import pytest
+
+from dimos.web.relay_bridge import relay_process
+from dimos.web.relay_bridge.locate import (
+    WEB_DIR_BUILD_ENV_VAR,
+    WEB_DIR_ENV_VAR,
+    find_cockpit_dist,
+    relay_run_cmd,
+)
+from dimos.web.relay_bridge.protocol import PROTOCOL_VERSION
+from dimos.web.relay_bridge.relay_process import RelayProcess, ensure_cockpit_dist
+
+
+def _fetch(url: str) -> tuple[int, bytes]:
+    try:
+        with urllib.request.urlopen(url) as response:
+            return response.status, response.read()
+    except urllib.error.HTTPError as e:
+        return e.code, e.read()
+
+
+def _make_fake_dist(root: Path) -> Path:
+    dist = root / "dist"
+    (dist / "assets").mkdir(parents=True)
+    (dist / "index.html").write_text("<html><body>fake cockpit index</body></html>")
+    (dist / "assets" / "app.js").write_text("console.log('fake');")
+    return dist
+
+
+def test_relay_run_cmd_cockpit_flags() -> None:
+    cmd = relay_run_cmd("deno", Path("/web"), "--port", "0")
+    assert "--node-modules-dir=none" in cmd
+    assert "--allow-read=/web" in cmd
+    assert "--cockpit-dir" not in cmd
+
+    cmd = relay_run_cmd("deno", Path("/web"), "--port", "0", cockpit_dir=Path("/elsewhere/dist"))
+    assert "--allow-read=/web,/elsewhere/dist" in cmd
+    assert cmd[cmd.index("--cockpit-dir") + 1] == "/elsewhere/dist"
+
+
+def test_relay_run_cmd_resolves_symlinked_dirs(tmp_path: Path) -> None:
+    # The relay realpath-checks served files, so --allow-read must be granted
+    # on canonical paths or every read would be denied.
+    real = tmp_path / "real_web"
+    real.mkdir()
+    link = tmp_path / "link_web"
+    link.symlink_to(real)
+    cmd = relay_run_cmd("deno", link)
+    assert f"--allow-read={real.resolve()}" in cmd
+
+
+def test_relay_serves_cockpit_dist(tmp_path: Path) -> None:
+    dist = _make_fake_dist(tmp_path)
+    with RelayProcess(port=0, cockpit_dir=dist) as info:
+        assert info.cockpit is True
+        assert info.open_url == f"http://127.0.0.1:{info.http_port}/"
+
+        status, index = _fetch(info.open_url)
+        assert status == 200 and b"fake cockpit index" in index
+        status, asset = _fetch(f"{info.open_url}assets/app.js")
+        assert status == 200 and b"console.log" in asset
+        # The debug page still resolves from relay/static/ behind the cockpit.
+        status, debug = _fetch(info.debug_url)
+        assert status == 200 and b"DimOS relay debug" in debug
+
+        status, body = _fetch(f"{info.open_url}api/info")
+        assert status == 200
+        api_info = json.loads(body)
+        assert api_info["v"] == PROTOCOL_VERSION
+        assert api_info["wtUrl"].startswith("https://127.0.0.1:")
+        assert api_info["certHash"] == info.cert_hash
+
+
+def test_relay_without_cockpit_serves_debug(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The checkout may have a built dist; force the "not built" path.
+    monkeypatch.setattr(relay_process, "find_cockpit_dist", lambda _: None)
+    with RelayProcess(port=0) as info:
+        assert info.cockpit is False
+        assert info.open_url == info.debug_url
+        status, index = _fetch(f"http://127.0.0.1:{info.http_port}/")
+        assert status == 200 and b"DimOS relay debug" in index
+
+
+class _FakeBuild:
+    """Stands in for _run_build; writes a dist into the --outDir on success."""
+
+    def __init__(self, ok: bool = True) -> None:
+        self.ok = ok
+        self.calls: list[Path] = []
+
+    def __call__(self, cmd: list[str], cwd: Path, deadline: float, cancel: threading.Event) -> bool:
+        assert cmd[-2] == "--outDir"
+        self.calls.append(Path(cwd))
+        if self.ok:
+            out_dir = Path(cmd[-1])
+            (out_dir / "assets").mkdir()
+            (out_dir / "index.html").write_text("<html><body>fake cockpit index</body></html>")
+            (out_dir / "assets" / "app.js").write_text("console.log('fake');")
+        return self.ok
+
+
+@pytest.fixture
+def fake_web(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A fake checkout web/ tree with cockpit sources and no build tools."""
+    (tmp_path / "deno.json").write_text("{}")
+    (tmp_path / "deno.lock").write_text("lock-v1")
+    (tmp_path / "cockpit" / "src").mkdir(parents=True)
+    (tmp_path / "cockpit" / "src" / "main.tsx").write_text("code")
+    (tmp_path / "cockpit" / "package.json").write_text("{}")
+    (tmp_path / "shared").mkdir()
+    (tmp_path / "shared" / "protocol.ts").write_text("code")
+    monkeypatch.setattr(relay_process, "ensure_deno", lambda: "deno")
+    monkeypatch.delenv(WEB_DIR_ENV_VAR, raising=False)
+    monkeypatch.delenv(WEB_DIR_BUILD_ENV_VAR, raising=False)
+    return tmp_path
+
+
+def test_ensure_cockpit_dist_builds_when_missing(
+    fake_web: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    build = _FakeBuild()
+    monkeypatch.setattr(relay_process, "_run_build", build)
+    dist = ensure_cockpit_dist(fake_web)
+    assert build.calls == [fake_web / "cockpit"]
+    assert dist == (fake_web / "cockpit" / "dist").resolve()
+    assert (dist / relay_process._STAMP_NAME).is_file()
+    # The temp build dir was published (renamed), not left behind.
+    assert list((fake_web / "cockpit").glob(".dist-*")) == []
+
+
+def test_ensure_cockpit_dist_skips_fresh_dist(
+    fake_web: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    build = _FakeBuild()
+    monkeypatch.setattr(relay_process, "_run_build", build)
+    ensure_cockpit_dist(fake_web)
+    assert ensure_cockpit_dist(fake_web) == (fake_web / "cockpit" / "dist").resolve()
+    assert len(build.calls) == 1
+
+
+def test_ensure_cockpit_dist_rebuilds_on_source_change(
+    fake_web: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    build = _FakeBuild()
+    monkeypatch.setattr(relay_process, "_run_build", build)
+    ensure_cockpit_dist(fake_web)
+    source = fake_web / "cockpit" / "src" / "main.tsx"
+    stat = source.stat()
+    source.write_text("edited")
+    os.utime(source, (stat.st_atime, stat.st_mtime))  # content, not mtime, decides
+    ensure_cockpit_dist(fake_web)
+    assert len(build.calls) == 2
+
+
+def test_ensure_cockpit_dist_rebuilds_on_source_deletion(
+    fake_web: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    extra = fake_web / "cockpit" / "src" / "Extra.tsx"
+    extra.write_text("code")
+    build = _FakeBuild()
+    monkeypatch.setattr(relay_process, "_run_build", build)
+    ensure_cockpit_dist(fake_web)
+    extra.unlink()
+    ensure_cockpit_dist(fake_web)
+    assert len(build.calls) == 2
+
+
+def test_ensure_cockpit_dist_rebuilds_on_lockfile_change(
+    fake_web: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    build = _FakeBuild()
+    monkeypatch.setattr(relay_process, "_run_build", build)
+    ensure_cockpit_dist(fake_web)
+    (fake_web / "deno.lock").write_text("lock-v2")
+    ensure_cockpit_dist(fake_web)
+    assert len(build.calls) == 2
+
+
+def test_ensure_cockpit_dist_ignores_test_and_hidden_files(
+    fake_web: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    build = _FakeBuild()
+    monkeypatch.setattr(relay_process, "_run_build", build)
+    ensure_cockpit_dist(fake_web)
+    (fake_web / "cockpit" / "src" / "App.test.tsx").write_text("test code")
+    (fake_web / "shared" / "protocol_test.ts").write_text("test code")
+    (fake_web / "cockpit" / ".env.local").write_text("hidden")
+    ensure_cockpit_dist(fake_web)
+    assert len(build.calls) == 1
+
+
+def test_ensure_cockpit_dist_failed_build_keeps_served_dist(
+    fake_web: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(relay_process, "_run_build", _FakeBuild())
+    dist = ensure_cockpit_dist(fake_web)
+    assert dist is not None
+    index_before = (dist / "index.html").read_bytes()
+
+    (fake_web / "cockpit" / "src" / "main.tsx").write_text("edited")
+    monkeypatch.setattr(relay_process, "_run_build", _FakeBuild(ok=False))
+    assert ensure_cockpit_dist(fake_web) == dist  # stale but present beats nothing
+    assert (dist / "index.html").read_bytes() == index_before  # never clobbered
+
+    shutil.rmtree(dist)
+    assert ensure_cockpit_dist(fake_web) is None
+
+
+def test_ensure_cockpit_dist_wheel_shape_never_builds(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A wheel ships cockpit/dist but no cockpit/src: return the dist as-is.
+    dist = _make_fake_dist(tmp_path / "cockpit")
+    build = _FakeBuild()
+    monkeypatch.setattr(relay_process, "_run_build", build)
+    assert ensure_cockpit_dist(tmp_path) == dist.resolve()
+    assert build.calls == []
+    # No lock or stamp writes either: site-packages may be read-only.
+    assert not (tmp_path / "cockpit" / ".build.lock").exists()
+    # And a wheel without a cockpit at all yields None.
+    assert ensure_cockpit_dist(tmp_path / "nowhere") is None
+
+
+def test_ensure_cockpit_dist_env_tree_requires_opt_in(
+    fake_web: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A tree picked via DIMOS_WEB_DIR is served as-is: its build tooling runs
+    # with -A, so building needs the explicit acknowledgment.
+    build = _FakeBuild()
+    monkeypatch.setattr(relay_process, "_run_build", build)
+    monkeypatch.setenv(WEB_DIR_ENV_VAR, str(fake_web))
+    assert ensure_cockpit_dist(fake_web) is None
+    assert build.calls == []
+    monkeypatch.setenv(WEB_DIR_BUILD_ENV_VAR, "1")
+    assert ensure_cockpit_dist(fake_web) == (fake_web / "cockpit" / "dist").resolve()
+    assert len(build.calls) == 1
+
+
+def test_ensure_cockpit_dist_serializes_concurrent_builds(
+    fake_web: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    build = _FakeBuild()
+    gate = threading.Lock()
+    active = 0
+    peak = 0
+
+    def slow_build(cmd: list[str], cwd: Path, deadline: float, cancel: threading.Event) -> bool:
+        nonlocal active, peak
+        with gate:
+            active += 1
+            peak = max(peak, active)
+        time.sleep(0.3)
+        try:
+            return build(cmd, cwd, deadline, cancel)
+        finally:
+            with gate:
+                active -= 1
+
+    monkeypatch.setattr(relay_process, "_run_build", slow_build)
+    results: list[Path | None] = []
+    threads = [
+        threading.Thread(target=lambda: results.append(ensure_cockpit_dist(fake_web)))
+        for _ in range(2)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=30)
+    assert peak == 1  # the flock serialized the builders
+    assert build.calls == [fake_web / "cockpit"]  # the loser re-checked and found it fresh
+    assert results == [(fake_web / "cockpit" / "dist").resolve()] * 2
+
+
+def test_run_build_cancel_kills_child_group(tmp_path: Path) -> None:
+    marker = tmp_path / "started"
+    cmd = [
+        sys.executable,
+        "-c",
+        "import pathlib,sys,time; pathlib.Path(sys.argv[1]).write_text('x'); time.sleep(60)",
+        str(marker),
+    ]
+    cancel = threading.Event()
+    result: list[bool] = []
+    worker = threading.Thread(
+        target=lambda: result.append(
+            relay_process._run_build(cmd, tmp_path, time.monotonic() + 60, cancel)
+        )
+    )
+    worker.start()
+    try:
+        deadline = time.monotonic() + 10
+        while not marker.exists() and time.monotonic() < deadline:
+            time.sleep(0.02)
+        assert marker.exists()  # the child really started
+        cancelled_at = time.monotonic()
+        cancel.set()
+        worker.join(timeout=10)
+        assert not worker.is_alive()
+        # Bounded by the kill grace, nowhere near the child's 60 s sleep.
+        assert time.monotonic() - cancelled_at < relay_process._BUILD_KILL_GRACE_S + 3
+        assert result == [False]
+    finally:
+        cancel.set()
+        worker.join(timeout=10)
+
+
+def test_run_build_deadline_kills_child(tmp_path: Path) -> None:
+    cmd = [sys.executable, "-c", "import time; time.sleep(60)"]
+    started = time.monotonic()
+    ok = relay_process._run_build(cmd, tmp_path, started + 0.3, threading.Event())
+    assert ok is False
+    assert time.monotonic() - started < relay_process._BUILD_KILL_GRACE_S + 3
+
+
+def test_find_cockpit_dist_requires_index(tmp_path: Path) -> None:
+    assert find_cockpit_dist(tmp_path) is None
+    (tmp_path / "cockpit" / "dist").mkdir(parents=True)
+    assert find_cockpit_dist(tmp_path) is None
+    (tmp_path / "cockpit" / "dist" / "index.html").write_text("x")
+    assert find_cockpit_dist(tmp_path) == (tmp_path / "cockpit" / "dist").resolve()
+
+
+def test_find_cockpit_dist_resolves_symlinks(tmp_path: Path) -> None:
+    real = tmp_path / "real_web"
+    _make_fake_dist(real / "cockpit")
+    link = tmp_path / "link_web"
+    link.symlink_to(real)
+    assert find_cockpit_dist(link) == (real / "cockpit" / "dist").resolve()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -435,6 +435,12 @@ tests = [
     {include-group = "project-deps"},
 ]
 
+# Drives the cockpit browser e2e (-m web_browser). Kept out of `tests`: only
+# the CI `web` job needs the platform-specific Playwright package.
+browser-tests = [
+    "playwright>=1.55",
+]
+
 # Lint / format / type-check tooling for the dedicated `lint` CI job.
 lint = [
     # Lint / format / type-check
@@ -644,7 +650,7 @@ env = [
   "GOOGLE_MAPS_API_KEY=AIzafake_google_key",
   "PYTHONWARNINGS=ignore:cupyx.jit.rawkernel is experimental:FutureWarning",
 ]
-addopts = "--dist=loadfile --durations=10 --timeout=600 --timeout-method=thread -v -ra --showlocals --cov-report=xml -p no:launch_testing -p no:launch_ros --import-mode=importlib --color=yes -m 'not (self_hosted or mujoco or self_hosted_large)'"
+addopts = "--dist=loadfile --durations=10 --timeout=600 --timeout-method=thread -v -ra --showlocals --cov-report=xml -p no:launch_testing -p no:launch_ros --import-mode=importlib --color=yes -m 'not (self_hosted or mujoco or self_hosted_large or web_browser)'"
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,18 @@ TEST_MODULE_PATTERNS = ("test_*.py", "conftest.py")
 # dimos can run it without a checkout. Copied into build_lib below; editable
 # installs skip the copy and locate.find_web_dir() resolves the checkout.
 # MANIFEST.in grafts web/ so sdist->wheel builds can reproduce this.
-RELAY_DIST_SOURCES = ("deno.json", "deno.lock", "relay", "shared")
+# cockpit/deno.json + package.json must ship even without the dist: the
+# workspace root lists ./cockpit as a member and Deno refuses to run the
+# relay when a member's config file is missing.
+RELAY_DIST_SOURCES = (
+    "deno.json",
+    "deno.lock",
+    "relay",
+    "shared",
+    "cockpit/deno.json",
+    "cockpit/package.json",
+    "cockpit/dist",
+)
 RELAY_DIST_TARGET = os.path.join("dimos", "web", "relay_bridge", "_relay_dist")
 
 
@@ -85,14 +96,34 @@ class build_py(_build_py):
         src = Path(__file__).parent / "web"
         if not (src / "relay" / "main.ts").is_file():
             raise RuntimeError(f"relay sources missing at {src}; refusing to build the wheel")
+        if not (src / "cockpit" / "dist" / "index.html").is_file():
+            # Release wheels must carry the Cockpit (the release workflow
+            # builds it first). A plain `pip install .` from a checkout
+            # without a built dist still works: the relay serves the debug
+            # page instead.
+            if os.environ.get("CIBUILDWHEEL") == "1":
+                raise RuntimeError(
+                    f"cockpit dist missing at {src / 'cockpit' / 'dist'}; run "
+                    "`deno task build` in web/cockpit before building release wheels"
+                )
+            self.warn("cockpit dist missing; this wheel will serve the debug page only")
         dst = Path(self.build_lib) / RELAY_DIST_TARGET
         for name in RELAY_DIST_SOURCES:
-            for path in sorted((src / name).rglob("*")) if (src / name).is_dir() else [src / name]:
-                if path.is_dir() or path.name.endswith("_test.ts"):
+            entry = src / name
+            if not entry.exists():  # only cockpit/dist may be absent (warned above)
+                continue
+            for path in sorted(entry.rglob("*")) if entry.is_dir() else [entry]:
+                # Filter on the path below src: matching path.parts would also
+                # hit checkout ancestors (e.g. a build under /work/testdata/).
+                rel = path.relative_to(src)
+                if path.is_dir() or path.name.endswith("_test.ts") or "testdata" in rel.parts:
                     continue
-                target = dst / path.relative_to(src)
+                target = dst / rel
                 self.mkpath(str(target.parent))
                 self.copy_file(str(path), str(target))
+        # An over-eager exclusion filter would otherwise ship a broken wheel silently.
+        if not (dst / "relay" / "main.ts").is_file():
+            raise RuntimeError(f"relay copy did not produce {dst / 'relay' / 'main.ts'}")
 
 
 extra_compile_args = [

--- a/uv.lock
+++ b/uv.lock
@@ -1882,6 +1882,9 @@ webrtc = [
 autofix = [
     { name = "ruff" },
 ]
+browser-tests = [
+    { name = "playwright" },
+]
 lint = [
     { name = "aiortc" },
     { name = "chromadb" },
@@ -2169,6 +2172,7 @@ provides-extras = ["misc", "visualization", "learning", "agents", "web", "percep
 
 [package.metadata.requires-dev]
 autofix = [{ name = "ruff", specifier = "==0.14.3" }]
+browser-tests = [{ name = "playwright", specifier = ">=1.55" }]
 lint = [
     { name = "aiortc", specifier = ">=1.14.0" },
     { name = "chromadb", specifier = ">=1.0.0" },
@@ -3117,6 +3121,43 @@ dependencies = [
     { name = "requests" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fe/26/bca4d737a9acea25e94c19940a780bbf0be64a691f7caf3a68467d3a5838/googlemaps-4.10.0.tar.gz", hash = "sha256:3055fcbb1aa262a9159b589b5e6af762b10e80634ae11c59495bd44867e47d88", size = 33056, upload-time = "2023-01-26T16:45:02.501Z" }
+
+[[package]]
+name = "greenlet"
+version = "3.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/f1/fbbfef6af0bad0548f09bc28948ea3c275b4edb19e17fc5ca9900a6a634d/greenlet-3.5.3.tar.gz", hash = "sha256:a61efc018fd3eb317eeca31aba90ee9e7f26f22884a79b6c6ec715bf71bb62f1", size = 200270, upload-time = "2026-06-26T19:28:24.832Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/a1/1f7f0c555f5858fd2906fe9f7b0a3554fddb85cb70df7a6aaec41dc292c2/greenlet-3.5.3-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:c180d22d325fb613956b443c3c6f4406eb70e6defc70d3974da2a7b59e06f48c", size = 285838, upload-time = "2026-06-26T18:21:05.167Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/29/be9f43ed61677a5759b38c8a9389248133c8c731bbfc0574ecdff66c99fc/greenlet-3.5.3-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:483d08c11181c83a6ce1a7a61df0f624a208ec40817a3bb2302714592eee4f04", size = 602342, upload-time = "2026-06-26T19:07:06.908Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/42/ba41c97ec36aa4b3ec25e5aa691d79561254805fad7f2f826dd6770587e2/greenlet-3.5.3-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1dae6e0091eae084317e411f047f0b7cb241c6db570f7c45fd6b900a274914ce", size = 615541, upload-time = "2026-06-26T19:10:04.909Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/8c/231ca675b0df779816950ca66b40b1fa14dbff4a0ed9814a9a29ec399140/greenlet-3.5.3-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0f6ff50ff8dbd51fae9b37f4101648b04ea0df19b3f50ab2beb5061e7716a5c8", size = 622473, upload-time = "2026-06-26T19:24:12.786Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/c7/28747042e1df8a9cd120a1ebe15529fc4be3b486e13e8d551ff307a82412/greenlet-3.5.3-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9bcd2d72ccd70a1ec68ba6ef93e7fbb4420ef9997dabc7010d893bd4015e0bec", size = 615675, upload-time = "2026-06-26T18:32:14.444Z" },
+    { url = "https://files.pythonhosted.org/packages/81/fe/dd97c483a3ff82849196ccd07851600edd3ac9de74669ca8a6022ada9ea1/greenlet-3.5.3-cp310-cp310-manylinux_2_39_riscv64.whl", hash = "sha256:37bf9c538f5ae6e63d643f88dec37c0c83bdf0e2ebc62961dedcf458822f7b71", size = 418421, upload-time = "2026-06-26T19:25:34.503Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/a8/b85525a6c8fba9f009a5f7c8df1545de8fb0f0bf3e0179194ef4e500317f/greenlet-3.5.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:73f152c895e09907e0dbe24f6c2db37beb085cd63db91c3825a0fcd0064124a8", size = 1575057, upload-time = "2026-06-26T19:09:00.264Z" },
+    { url = "https://files.pythonhosted.org/packages/03/79/fb76edb218fe6735ab0edeba176c7ab80df9618f7c02ce4208979f3ae7db/greenlet-3.5.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8bdb43e1a1d1873721acab2be99c5befd4d2044ddfd52e4d610801019880a702", size = 1641692, upload-time = "2026-06-26T18:31:41.454Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/79/86fe3ee50ed55d9b3907eecd3208b5c3fe8a79515519aae98b4753c3fa1d/greenlet-3.5.3-cp310-cp310-win_amd64.whl", hash = "sha256:0909f9355a9f24845d3299f3112e266a06afb68302041989fd26bd68894933db", size = 238742, upload-time = "2026-06-26T18:20:40.758Z" },
+    { url = "https://files.pythonhosted.org/packages/51/58/5404031044f55afad7aad1aff8be3f22b1bed03e237cfeabbc7e5c8cfde0/greenlet-3.5.3-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:aca9b4ce85b152b5524ef7d88170efdff80dc0032aa8b75f9aaf7f3479ea95b4", size = 287424, upload-time = "2026-06-26T18:20:31.469Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/bf/1c65e9b94a54d547068fa5b5a8a06f221f3316b48908e08668d29c77cb50/greenlet-3.5.3-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f71be4920368fe1fabeeaa53d1e3548337e2b223d9565f8ad5e392a75ba23fc", size = 606523, upload-time = "2026-06-26T19:07:08.859Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c7/b66baacc95775ad511287acb0137b95574a9ce5491902372b7564799d790/greenlet-3.5.3-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4d77e67f65f98449e3fb83f795b5d0a8437aead2f874ca89c96576caf4be3af6", size = 618315, upload-time = "2026-06-26T19:10:06.055Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/a0/68afd1ebad40db87dac0a28ffa120726b98bf9c7c40c481b0f63c105d298/greenlet-3.5.3-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e18619ba655ac05d78d80fc83cac4ba892bd6927b99e3b8237aee861aaacc8bb", size = 626155, upload-time = "2026-06-26T19:24:14.44Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2b/28ed29463522fdbe4c15b1f63922041626a7478316b34ab4adda3f0a4aba/greenlet-3.5.3-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8540f1e6205bd13ca0ce685581037219ca54a1b41a0a15d228c6c9b8ad5903d7", size = 617381, upload-time = "2026-06-26T18:32:16.077Z" },
+    { url = "https://files.pythonhosted.org/packages/07/7f/e327d912239ec4b3b49999e3967389bcf1ee8722b9ee9194d2752ecd558a/greenlet-3.5.3-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:d27c0c653a60d9535f690226474a5cc1036a8b0d7b57504d1c4f89c44a07a80c", size = 421083, upload-time = "2026-06-26T19:25:35.804Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/7b/ad04e9d1337fc04965dc9fc616b6a72cb65a24b800a014c011ec812f5489/greenlet-3.5.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7ef56fe650f50575bf843acde967b9c567687f3c22340941a899b7bc56e956a8", size = 1577771, upload-time = "2026-06-26T19:09:01.537Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/33/6c87ab7ba663f70ca21f3022aad1ffe56d3f3e0521e836c2415e13abcc3c/greenlet-3.5.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5121af01cf911e70056c00d4b46d5e9b5d1415550038573d744138bacb59e6b8", size = 1644048, upload-time = "2026-06-26T18:31:42.996Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/35/f0d8ee998b422cf8693b270f098e55d8d4ec8006b061b333f54f177d28d9/greenlet-3.5.3-cp311-cp311-win_amd64.whl", hash = "sha256:0f41e4a05a3c0cb31b17023eff28dd111e1d16bf7d7d00406cd7df23f31398a7", size = 239137, upload-time = "2026-06-26T18:23:21.664Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/96/b9820295576ef18c9edc404f10e260ae7215ceaf3781a54b720ed2627862/greenlet-3.5.3-cp311-cp311-win_arm64.whl", hash = "sha256:ec6f1af59f6b5f3fc9678e2ea062d8377d22ac644f7844cb7a292910cf12ff44", size = 237630, upload-time = "2026-06-26T18:24:00.281Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/6e/4c37d51a2b7f82d2ff11bb6b5f7d766d9a011726624af255e843727627a3/greenlet-3.5.3-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:719757059f5a53fd0dde23f78cffeafcdd97b21c850ddb7ca684a3c1a1f122e2", size = 288685, upload-time = "2026-06-26T18:22:08.977Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/73/815dd90131c1b71ebdf53dbc7c276cafec2a1173b97559f97aba72724a87/greenlet-3.5.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:efa9f765dd09f9d0cdac651ffdf631ee59ec5dc6ee7a73e0c012ba9c52fbdf5b", size = 604761, upload-time = "2026-06-26T19:07:10.114Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/57/079cfe76bcef36b153b25607ee91c6fcb58f17f8b23c86bbbeabe0c88d72/greenlet-3.5.3-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7faba15ac005376e02a0384504e0243be3370ce010296a44a820feb342b505ab", size = 617044, upload-time = "2026-06-26T19:10:07.25Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/fb/d97dc261209c80744b7c8132693a30d70ec6e7315e632cb0a10b3fec94dd/greenlet-3.5.3-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5795cd1101371140551c645f2d408b8d3c01a5a29cf8a9bce6e759c983682d23", size = 622351, upload-time = "2026-06-26T19:24:16.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/87/b4d095775a3fb1bcafbb483fc206b27ebb785724c83051447737085dc54e/greenlet-3.5.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:87142215824be6ac05e2e8e2786eec307ccbc27c36723c3881959df654af6861", size = 614244, upload-time = "2026-06-26T18:32:17.594Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ac/e5fee13cbbd0e8de312d9a146584b8a51891c68847330ef9dc8b5109d23f/greenlet-3.5.3-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:af4923b3096e26a36d7e9cf24ab88083a20f97d191e3b97f253731ce9b41b28c", size = 425395, upload-time = "2026-06-26T19:25:37.144Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/70/7559b609683650fa2b95b8ab84b4ab0b26556a635d19675e12aa832d826d/greenlet-3.5.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:215275b1b49320987352e6c1b054acca0064f965a2c66992bed9a6f7d913f149", size = 1574210, upload-time = "2026-06-26T19:09:03.077Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/73/be55392074c60fc37655ca40fa6022457bfbf6718e9e342a7b0b41f96dd2/greenlet-3.5.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6b1b0eed82364b0e32c4ea0f221452d33e6bb17ae094d9f72aed9851812747ea", size = 1638627, upload-time = "2026-06-26T18:31:44.748Z" },
+    { url = "https://files.pythonhosted.org/packages/14/40/c57489acf8e37d74e2913d4eff63aa0dba17acccc4bdeef874dde2dbbec9/greenlet-3.5.3-cp312-cp312-win_amd64.whl", hash = "sha256:cde8adafa2365676f74a979744629589999093bc86e2484214f58e61df08902c", size = 239882, upload-time = "2026-06-26T18:23:27.518Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/6fea0e3d6600f785069481ee637e09378dd4118acdfd38ad88ae2db31c98/greenlet-3.5.3-cp312-cp312-win_arm64.whl", hash = "sha256:c4e7b79d83805475f0102008843f6eb45fd3bb0b2e88c774adab5fbaab27117d", size = 238211, upload-time = "2026-06-26T18:22:37.671Z" },
+]
 
 [[package]]
 name = "grpcio"
@@ -6196,6 +6237,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/67/48/7ef4a08d57c431e7bea8a54c7853726de6cfcc50584442377acb6be615a6/playground-0.1.0.tar.gz", hash = "sha256:30d31d59528005e13f938cbcd5ce40c831553313aa7f861bfa3c9640115f46cf", size = 9894110, upload-time = "2026-01-08T22:18:36.578Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bf/c9/59e9cd044c234b7eb0f9f5480ddec55ffcef79327f78b2004aa7ec80fd76/playground-0.1.0-py3-none-any.whl", hash = "sha256:06e8fd567bab346adfdd31bd13042d0dd121af9cdce28a4155b30d79cf99a91e", size = 10044265, upload-time = "2026-01-08T22:18:34.116Z" },
+]
+
+[[package]]
+name = "playwright"
+version = "1.61.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/ee/31e4e0db36588b817a10b299a0285082545fde7d36543c2abe498bb3d61a/playwright-1.61.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:ff138c3a604f69911e9d42fd036e55c2a171e5616edf04c1e7f60a2a285540b0", size = 43421877, upload-time = "2026-06-29T10:32:48.428Z" },
+    { url = "https://files.pythonhosted.org/packages/42/35/71395dd3ecc798965be4a3ef8c443217d4abca168e7cb34536304f9489e6/playwright-1.61.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:009588c2a7e499bc5a8b425b61fa65490968bbda9cd69e0cf2cff10f8304659a", size = 42205016, upload-time = "2026-06-29T10:32:52.104Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/44/323164cf5cd1647bdefce76ffce27651aadb959d089b48f53ea40918276e/playwright-1.61.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:9f7de4536088d12037c13a52b7ea34b59270b78926bb56935070597ffac6b1af", size = 43421884, upload-time = "2026-06-29T10:32:55.773Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/f8/a35bf179e4ba2522c1893635094a64e407572547bd61528820fc0abc87fe/playwright-1.61.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:54f3b39f6eab832e33458c1dd7da0b5682aedab3b09ae731b5c59fa12fd2024e", size = 47421381, upload-time = "2026-06-29T10:32:59.903Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/eb/e3f922348ec17c315f98c463f72faa1181a1c3de0bfe31a8d2edf6561723/playwright-1.61.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:93454322ade8c11d5d6c211bfd91bdfb9ffb4810e3e026371bcbc4bec1b7ee4c", size = 47120545, upload-time = "2026-06-29T10:33:03.574Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/a6/5be4e52b40a9c0c8a073e7c5b0785c05cf5a9ea8f8a7b5b260e32d970342/playwright-1.61.0-py3-none-win32.whl", hash = "sha256:372d55a6f1248fa1dd47599686980cb8fb5bbe6fcda59eab793eb657c11d8a9b", size = 37844841, upload-time = "2026-06-29T10:33:07.361Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fd/2b78036e5fbe9d5f5645bbe08a1eac7160c51243c0093963edbcf67c35d9/playwright-1.61.0-py3-none-win_amd64.whl", hash = "sha256:35c6cc4589a5d00964a59d7b3e59641e0aac0c02f15479a7af77d20f6bc79597", size = 37844846, upload-time = "2026-06-29T10:33:10.637Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0d/1b0f3c4ee4eb0514bc805b5c2f9a223e5b6de4f11a926f5235d51d0fc81b/playwright-1.61.0-py3-none-win_arm64.whl", hash = "sha256:e9fcbffcf557a8620fdedd92491eb59a32d18e23d6f3b4f6214b952be324fe51", size = 33955127, upload-time = "2026-06-29T10:33:14.008Z" },
 ]
 
 [[package]]

--- a/web/README.md
+++ b/web/README.md
@@ -1,16 +1,47 @@
 # DimOS web
 
 Deno workspace for the robot web stack. `shared/` holds the wire protocol and its golden vectors;
-`relay/` is the WebTransport relay. The Python mirror + client (`dimos/web/relay_bridge/`) and the
-Cockpit browser app arrive in follow-up PRs.
+`relay/` is the WebTransport relay; `cockpit/` is the browser app (Vite + React + TS). The Python
+mirror + WebTransport client live in `dimos/web/relay_bridge/`.
 
-Everything runs on Deno 2.6.10, pinned in `dimos/utils/deno.py` (CI reads the pin from there).
+Everything runs on Deno 2.6.10, pinned in `dimos/utils/deno.py` (CI reads the pin from there). No
+node/npm anywhere: vite, vitest, and tsc run as npm packages under Deno (`nodeModulesDir: auto`),
+and `dimos --local-relay` auto-downloads Deno via `ensure_deno()`.
 
 ```bash
 deno task dev            # relay on http://127.0.0.1:7780 (debug page at /debug.html)
-deno task test           # unit + loopback e2e tests
-deno task check          # type-check; deno fmt + deno lint for style
+deno task test           # relay + shared tests (unit + loopback e2e)
+deno task check          # type-check relay + shared; deno fmt + deno lint for style (all of web/)
 ```
+
+## Cockpit
+
+```bash
+cd cockpit
+deno task dev            # vite dev server on http://localhost:5173 with HMR
+deno task test           # vitest
+deno task check          # tsc --noEmit
+deno task build          # dist/ (what the relay serves at /)
+```
+
+Dev workflow: run the relay (`deno task dev` in `web/`, or just `dimos run <bp> --local-relay`) and
+the vite server side by side. `localhost:5173` is a secure context; vite proxies `/api` to the relay
+on `:7780` and the WebTransport connection goes straight to the advertised `wtUrl`.
+
+Without vite, `--local-relay` serves the built `cockpit/dist` at `/`, building it first when it is
+missing or older than the sources (`ensure_cockpit_dist` in `relay_process.py`). Release wheels ship
+a pre-built dist inside `_relay_dist` (built by the release workflow; see `setup.py`), so a
+pip-installed dimos never builds or downloads npm packages.
+
+After changing cockpit dependencies run `deno install` in `web/` and commit the `deno.lock` update;
+CI validates it with `deno install --frozen`. If vitest ever misbehaves under a new Deno, the
+fallback ladder is `--no-file-parallelism`, then `--pool=threads`, then pinning a different vitest
+minor.
+
+The cockpit browser e2e (`dimos/e2e_tests/test_cockpit_browser.py`, marker `web_browser`) drives the
+whole stack against the go2 replay dataset in both Playwright Chromium and Firefox (their
+WebTransport stacks differ; see bug 11). The CI `web` job runs it; locally it needs
+`uv run playwright install chromium firefox` once.
 
 ## Protocol shape, and why it is odd
 
@@ -54,6 +85,15 @@ Several choices are workarounds for upstream bugs, verified 2026-07-10..15 on De
     still present on Deno main 2026-07). The QUIC-level accept only fails with the connection; the
     relay parses the WebTransport preamble itself (`readWebTransportPreamble`) and a bad/reset
     stream drops alone.
+11. **Reliable channels ride ONE persistent uni stream per (viewer, channel), not a stream per
+    frame** (verified 2026-07-24, Firefox 142/Playwright). Firefox grants a WebTransport session
+    ~100 incoming uni streams and only replenishes the credit as streams complete - but the relay's
+    FIN goes out lazily (bug 2), so with stream-per-frame the relay's
+    `createUnidirectionalStream({waitUntilAvailable})` hangs after ~100 frames, the reliable FIFO
+    overflows, and the relay kicks the viewer every ~8 s. Chromium's much larger window masks this.
+    Latest channels keep per-frame streams (their reset semantics need them) and are the known
+    remaining credit pressure for T5 video under Firefox.
 
-One-stream-per-message delivers out of order by design; consumers keep the newest frame by `seq` and
-loss metrics are span-based (`maxSeq - minSeq + 1 - received`).
+Latest streams deliver out of order by design; consumers keep the newest frame by `seq` (a reliable
+channel's persistent stream is ordered) and loss metrics are span-based
+(`maxSeq - minSeq + 1 - received`).

--- a/web/cockpit/index.html
+++ b/web/cockpit/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>DimOS Cockpit</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/web/cockpit/src/App.module.css
+++ b/web/cockpit/src/App.module.css
@@ -1,0 +1,17 @@
+.app {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.main {
+  flex: 1;
+  overflow: auto;
+  padding: 1rem;
+}
+
+.notice {
+  color: #8b949e;
+  margin: 2rem auto;
+  text-align: center;
+}

--- a/web/cockpit/src/App.test.tsx
+++ b/web/cockpit/src/App.test.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { App } from "./App.tsx";
+import type { SessionHandle } from "./session/session.ts";
+import { ChannelStore, StatusStore } from "./session/store.ts";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const ODOM = { ch: "odom", encoding: "pose.json.v1", delivery: "reliable", maxHz: 20 } as const;
+
+describe("App session states", () => {
+  let container: HTMLElement;
+  let root: Root;
+  let status: StatusStore;
+  let channels: ChannelStore;
+  let session: SessionHandle;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    status = new StatusStore();
+    channels = new ChannelStore();
+    session = { status, channels, stop: () => {} };
+    act(() => root.render(<App session={session} />));
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("waits for a robot, shows its channels, and clears them when it leaves", () => {
+    expect(container.textContent).toContain("Waiting for a robot");
+
+    act(() => {
+      status.update({ robot: { id: "a", name: "A", model: "go2" }, robotCount: 1 });
+      status.update({ channels: [ODOM] });
+      channels.ingest(
+        "odom",
+        { ch: "odom", seq: 7, ts: 0.7, delivery: "reliable" },
+        { x: 1 },
+        true,
+        '{"x":1}',
+      );
+      channels.publishUi();
+    });
+    expect(container.querySelector('[data-testid="ch-odom-seq"]')!.textContent).toBe("7");
+    expect(container.querySelector('[data-testid="ch-odom-value"]')!.textContent).toContain(
+      '{"x":1}',
+    );
+
+    // Robot gone: the session clears channels and bumps the epoch; the list
+    // must unmount instead of keeping stale rows.
+    act(() => {
+      channels.reset();
+      status.update({ robot: null, robotCount: 0, channels: [], epoch: 1 });
+    });
+    expect(container.querySelector('[data-testid="ch-odom-seq"]')).toBeNull();
+    expect(container.textContent).toContain("Waiting for a robot");
+  });
+
+  it("keeps the last good frame on decode failures and flags them visibly", () => {
+    act(() => {
+      status.update({ robot: { id: "a", name: "A", model: "go2" }, robotCount: 1 });
+      status.update({ channels: [ODOM] });
+      channels.ingest(
+        "odom",
+        { ch: "odom", seq: 7, ts: 0.7, delivery: "reliable" },
+        { x: 1 },
+        true,
+        '{"x":1}',
+      );
+      channels.publishUi();
+    });
+    expect(container.querySelector('[data-testid="ch-odom-decode-error"]')).toBeNull();
+
+    // Corrupt frames arrive: the row keeps describing the good frame (seq and
+    // value stay together) and a decode-error indicator appears.
+    act(() => {
+      channels.ingest(
+        "odom",
+        { ch: "odom", seq: 8, ts: 0.8, delivery: "reliable" },
+        undefined,
+        false,
+      );
+      channels.publishUi();
+    });
+    expect(container.querySelector('[data-testid="ch-odom-seq"]')!.textContent).toBe("7");
+    expect(container.querySelector('[data-testid="ch-odom-value"]')!.textContent).toContain(
+      '{"x":1}',
+    );
+    expect(
+      container.querySelector('[data-testid="ch-odom-decode-error"]')!.textContent,
+    ).toContain("decode failing");
+
+    // Recovery: the next good frame clears the indicator and advances the row.
+    act(() => {
+      channels.ingest(
+        "odom",
+        { ch: "odom", seq: 9, ts: 0.9, delivery: "reliable" },
+        { x: 2 },
+        true,
+        '{"x":2}',
+      );
+      channels.publishUi();
+    });
+    expect(container.querySelector('[data-testid="ch-odom-decode-error"]')).toBeNull();
+    expect(container.querySelector('[data-testid="ch-odom-seq"]')!.textContent).toBe("9");
+  });
+
+  it("shows the multi-robot notice instead of channels", () => {
+    act(() => status.update({ robotCount: 2, channels: [] }));
+    expect(container.textContent).toContain("2 robots connected");
+  });
+
+  it("shows the terminal failure reason", () => {
+    act(() => status.update({ transport: { phase: "failed", reason: "protocol mismatch" } }));
+    expect(container.textContent).toContain("Connection failed: protocol mismatch");
+  });
+});

--- a/web/cockpit/src/App.tsx
+++ b/web/cockpit/src/App.tsx
@@ -1,0 +1,34 @@
+import { useStatus } from "./session/hooks.ts";
+import type { SessionHandle } from "./session/session.ts";
+import { ChannelList } from "./ui/ChannelList.tsx";
+import { StatusBar } from "./ui/StatusBar.tsx";
+import styles from "./App.module.css";
+
+export function App({ session }: { session: SessionHandle }) {
+  const status = useStatus(session.status);
+
+  let content;
+  if (status.transport.phase === "failed") {
+    content = <p className={styles.notice}>Connection failed: {status.transport.reason}</p>;
+  } else if (status.robotCount > 1) {
+    content = (
+      <p className={styles.notice}>
+        {status.robotCount} robots connected; the robot picker arrives in a later release.
+      </p>
+    );
+  } else if (status.channels.length === 0) {
+    content = <p className={styles.notice}>Waiting for a robot to register...</p>;
+  } else {
+    content = <ChannelList channels={status.channels} store={session.channels} />;
+  }
+
+  return (
+    <div className={styles.app}>
+      <StatusBar status={status} />
+      {/* A changed manifest remounts everything below the status bar. */}
+      <main className={styles.main} key={status.epoch}>
+        {content}
+      </main>
+    </div>
+  );
+}

--- a/web/cockpit/src/index.css
+++ b/web/cockpit/src/index.css
@@ -1,0 +1,17 @@
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  height: 100%;
+  margin: 0;
+}
+
+body {
+  background: #14171a;
+  color: #d7dde3;
+  font-family: system-ui, sans-serif;
+  font-size: 14px;
+}

--- a/web/cockpit/src/main.tsx
+++ b/web/cockpit/src/main.tsx
@@ -1,0 +1,25 @@
+import { createRoot } from "react-dom/client";
+import { App } from "./App.tsx";
+import { startSession } from "./session/session.ts";
+import "./index.css";
+
+const root = createRoot(document.getElementById("root")!);
+
+// Same capability checks as the debug page: WebTransport needs a secure
+// context, and Safari has no WebTransport as of mid-2026.
+if (!globalThis.isSecureContext) {
+  root.render(
+    <p style={{ padding: "1rem" }}>
+      Not a secure context: WebTransport needs https:// or http://localhost.
+    </p>,
+  );
+} else if (!("WebTransport" in globalThis)) {
+  root.render(
+    <p style={{ padding: "1rem" }}>
+      This browser has no WebTransport support. Use Chromium or Firefox.
+    </p>,
+  );
+} else {
+  const session = startSession();
+  root.render(<App session={session} />);
+}

--- a/web/cockpit/src/ui/ChannelList.module.css
+++ b/web/cockpit/src/ui/ChannelList.module.css
@@ -1,0 +1,45 @@
+.table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.table th {
+  border-bottom: 1px solid #30363d;
+  color: #8b949e;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 0.3rem 0.75rem;
+  text-align: left;
+}
+
+.table td {
+  border-bottom: 1px solid #21262d;
+  padding: 0.3rem 0.75rem;
+  vertical-align: top;
+}
+
+.ch {
+  font-weight: 600;
+}
+
+.num {
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.muted {
+  color: #8b949e;
+}
+
+.value {
+  font-family: ui-monospace, monospace;
+  font-size: 12px;
+  overflow-wrap: anywhere;
+}
+
+.error {
+  color: #f85149;
+  font-size: 12px;
+  margin-right: 0.5rem;
+}

--- a/web/cockpit/src/ui/ChannelList.tsx
+++ b/web/cockpit/src/ui/ChannelList.tsx
@@ -1,0 +1,65 @@
+import type { ChannelSpec } from "@dimos/shared";
+import { useChannel } from "../session/hooks.ts";
+import { getDecoder } from "../session/decoders/index.ts";
+import type { ChannelStore } from "../session/store.ts";
+import styles from "./ChannelList.module.css";
+
+function ChannelRow({ spec, store }: { spec: ChannelSpec; store: ChannelStore }) {
+  const { slot, stats } = useChannel(store, spec.ch);
+  const supported = getDecoder(spec.encoding) !== undefined;
+
+  let value;
+  if (!supported) {
+    // Not an error: this build has no decoder for the encoding (binary
+    // decoders arrive with their panels), so the channel is not subscribed.
+    value = <span className={styles.muted}>not subscribed (no decoder for {spec.encoding})</span>;
+  } else if (slot === null) {
+    value = <span className={styles.muted}>waiting for data...</span>;
+  } else if (slot.preview !== undefined) {
+    value = <code>{slot.preview}</code>;
+  } else {
+    value = <span className={styles.muted}>(no preview)</span>;
+  }
+
+  const age = stats.ageMs === null ? "-" : `${(stats.ageMs / 1000).toFixed(1)} s`;
+
+  return (
+    <tr>
+      <td className={styles.ch}>{spec.ch}</td>
+      <td className={styles.muted}>{spec.encoding}</td>
+      <td className={styles.num}>{stats.hz.toFixed(1)}</td>
+      <td className={styles.num}>{age}</td>
+      <td className={styles.num} data-testid={`ch-${spec.ch}-seq`}>
+        {slot?.seq ?? "-"}
+      </td>
+      <td className={styles.value} data-testid={`ch-${spec.ch}-value`}>
+        {stats.decodeFailing && (
+          <span className={styles.error} data-testid={`ch-${spec.ch}-decode-error`}>
+            decode failing ({stats.decodeErrors} bad frames)
+          </span>
+        )}
+        {value}
+      </td>
+    </tr>
+  );
+}
+
+export function ChannelList({ channels, store }: { channels: ChannelSpec[]; store: ChannelStore }) {
+  return (
+    <table className={styles.table}>
+      <thead>
+        <tr>
+          <th>channel</th>
+          <th>encoding</th>
+          <th>Hz</th>
+          <th>age</th>
+          <th>seq</th>
+          <th>value</th>
+        </tr>
+      </thead>
+      <tbody>
+        {channels.map((spec) => <ChannelRow key={spec.ch} spec={spec} store={store} />)}
+      </tbody>
+    </table>
+  );
+}

--- a/web/cockpit/src/ui/StatusBar.module.css
+++ b/web/cockpit/src/ui/StatusBar.module.css
@@ -1,0 +1,54 @@
+.bar {
+  align-items: center;
+  background: #1c2128;
+  border-bottom: 1px solid #30363d;
+  display: flex;
+  gap: 0.75rem;
+  padding: 0.5rem 1rem;
+}
+
+.title {
+  font-weight: 600;
+}
+
+.pill {
+  border-radius: 999px;
+  font-size: 12px;
+  padding: 0.1rem 0.6rem;
+}
+
+.pill[data-phase="connecting"] {
+  background: #3d3017;
+  color: #d4a72c;
+}
+
+.pill[data-phase="connected"] {
+  background: #12301c;
+  color: #3fb950;
+}
+
+.pill[data-phase="reconnecting"] {
+  background: #3d2317;
+  color: #db6d28;
+}
+
+.pill[data-phase="failed"] {
+  background: #3c1618;
+  color: #f85149;
+}
+
+.detail {
+  color: #8b949e;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+
+.robot {
+  color: #8b949e;
+  margin-left: auto;
+}
+
+.error {
+  color: #f85149;
+  font-size: 12px;
+}

--- a/web/cockpit/src/ui/StatusBar.test.tsx
+++ b/web/cockpit/src/ui/StatusBar.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import type { SessionStatus } from "../session/store.ts";
+import { StatusBar } from "./StatusBar.tsx";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function makeStatus(over: Partial<SessionStatus> = {}): SessionStatus {
+  return {
+    transport: { phase: "connected" },
+    robot: null,
+    robotCount: 0,
+    channels: [],
+    epoch: 0,
+    lastError: null,
+    ...over,
+  };
+}
+
+describe("StatusBar", () => {
+  let container: HTMLElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function render(status: SessionStatus) {
+    act(() => root.render(<StatusBar status={status} />));
+  }
+
+  function testId(id: string): Element {
+    return container.querySelector(`[data-testid="${id}"]`)!;
+  }
+
+  it("shows the transport phase and the picked robot", () => {
+    render(makeStatus({ robot: { id: "a", name: "Go2", model: "go2" } }));
+    expect(testId("status").getAttribute("data-phase")).toBe("connected");
+    expect(testId("status").textContent).toBe("connected");
+    expect(testId("robot").textContent).toBe("Go2 (go2)");
+  });
+
+  it("shows 'no robot' when none is picked", () => {
+    render(makeStatus());
+    expect(testId("robot").textContent).toBe("no robot");
+  });
+
+  it("shows the retry countdown and close reason while reconnecting", () => {
+    render(
+      makeStatus({
+        transport: {
+          phase: "reconnecting",
+          attempt: 3,
+          retryAtMs: Date.now() + 2000,
+          reason: "kicked",
+        },
+      }),
+    );
+    expect(testId("status").getAttribute("data-phase")).toBe("reconnecting");
+    expect(container.textContent).toContain("attempt 3");
+    expect(container.textContent).toContain("kicked");
+  });
+
+  it("shows lastError while set and drops it once cleared", () => {
+    render(makeStatus({ lastError: "unknown_robot: no robot a" }));
+    expect(container.textContent).toContain("unknown_robot: no robot a");
+    render(makeStatus({ lastError: null }));
+    expect(container.textContent).not.toContain("unknown_robot");
+  });
+});

--- a/web/cockpit/src/ui/StatusBar.tsx
+++ b/web/cockpit/src/ui/StatusBar.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from "react";
+import type { SessionStatus } from "../session/store.ts";
+import styles from "./StatusBar.module.css";
+
+/** Wall clock ticking at `periodMs` while `active`; frozen otherwise. */
+function useNowWhile(active: boolean, periodMs: number): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (!active) return;
+    setNow(Date.now());
+    const id = setInterval(() => setNow(Date.now()), periodMs);
+    return () => clearInterval(id);
+  }, [active, periodMs]);
+  return now;
+}
+
+const PHASE_LABEL: Record<string, string> = {
+  connecting: "connecting",
+  connected: "connected",
+  reconnecting: "reconnecting",
+  failed: "failed",
+};
+
+export function StatusBar({ status }: { status: SessionStatus }) {
+  const transport = status.transport;
+  const now = useNowWhile(transport.phase === "reconnecting", 250);
+
+  let detail = "";
+  if (transport.phase === "reconnecting") {
+    const secs = Math.max(0, transport.retryAtMs - now) / 1000;
+    detail = `retry in ${secs.toFixed(1)} s (attempt ${transport.attempt})`;
+    if (transport.reason !== undefined) detail += ` - ${transport.reason}`;
+  } else if (transport.phase === "connecting" && transport.attempt > 1) {
+    detail = `attempt ${transport.attempt}`;
+  }
+
+  return (
+    <header className={styles.bar}>
+      <span className={styles.title}>DimOS Cockpit</span>
+      <span className={styles.pill} data-testid="status" data-phase={transport.phase}>
+        {PHASE_LABEL[transport.phase]}
+      </span>
+      {detail !== "" && <span className={styles.detail}>{detail}</span>}
+      <span className={styles.robot} data-testid="robot">
+        {status.robot !== null ? `${status.robot.name} (${status.robot.model})` : "no robot"}
+      </span>
+      {status.lastError !== null && <span className={styles.error}>{status.lastError}</span>}
+    </header>
+  );
+}


### PR DESCRIPTION
* This PR adds the Cockpit UI. It's a minimal React shell over the session client: a status bar (connection phase,
  reconnect countdown, robot name). Very little now. More comming in later PRs.

- `--local-relay` now opens the Cockpit instead of the debug page.** In a checkout it builds
  `web/cockpit/dist` first if it is missing or stale.

- Added an e2e browser test using Playwright. It tests the whole stack (go2 replay dataset -> dimos ->
  relay -> browser) in both Chromium and Firefox: live odom must tick, the session must not flap for
  12 s, and killing and restarting dimos must get the page back to live data without a reload. They run in the `web` CI job.