### PR TITLE
fix(ci): refetch PR before labeling new contributors

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -142,8 +142,12 @@ jobs:
               'FIRST_TIME_CONTRIBUTOR',
             ]);
             const { owner, repo } = context.repo;
-            const pr = context.payload.pull_request;
-            const prNumber = pr.number;
+            const prNumber = context.payload.pull_request.number;
+            // The opened event's author_association can be stale. Refetch the PR
+            // instead of trusting that snapshot.
+            const { data: pr } = await github.rest.pulls.get({
+              owner, repo, pull_number: prNumber,
+            });
             core.info(`pr=#${prNumber} authorAssociation=${pr.author_association}`);
 
             if (!firstTimeAssociations.has(pr.author_association)) {


### PR DESCRIPTION
## Contribution path

Small, safe change that does not need a tracking issue.

## Problem

The `first-time-contributor` job trusted `author_association` from the `pull_request_target.opened` payload. For PR #3226, that snapshot reported `NONE`, while a fresh pull request API response reported `FIRST_TIME_CONTRIBUTOR`. The job returned early and skipped the label.

## Solution

Refetch the pull request with `pulls.get` before evaluating `author_association`. The job still runs only for `opened`, retains the label as a snapshot, executes no PR code, and keeps its existing narrow permissions.

## How to Test

`uv run python -c 'import pathlib, yaml; assert "first-time-contributor" in yaml.safe_load(pathlib.Path(".github/workflows/pr-labels.yml").read_text())["jobs"]'`

Also compiled the embedded `github-script` as an async function and exercised `FIRST_TIMER`, `FIRST_TIME_CONTRIBUTOR`, and `NONE` with a mocked stale opened-event payload. `git diff --check` passes. PR #3226 was backfilled with the label.

## AI assistance

Codex with GPT-5 diagnosed the CI failure, implemented the workflow change, and ran the validation harness. The author reviewed the requested fix and PR creation.

## Checklist

- [ ] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
