### PR TITLE
fix(core): resolve remap targets through subclasses

### DIFF
--- a/dimos/core/coordination/blueprints.py
+++ b/dimos/core/coordination/blueprints.py
@@ -273,13 +273,26 @@ class Blueprint:
     def _instance_key(self, module: type[ModuleBase] | str) -> str:
         if isinstance(module, str):
             return module
+        # Exact match wins; subclasses are only a fallback. Deployments subclass a
+        # module (e.g. ControlCoordinator) to declare extra ports, and a remapping
+        # named after the base class still means that instance — but sibling modules
+        # also inherit from each other (ObjectDBModule is a Detection3DModule), and
+        # there the class you named is the one you meant.
         names = [b.name for b in self.blueprints if b.module is module]
+        if not names:
+            names = [b.name for b in self.blueprints if issubclass(b.module, module)]
         if len(names) > 1:
             raise ValueError(
                 f"{module.__name__} has multiple instances in this blueprint "
                 f"({', '.join(sorted(names))}). Pass the instance name instead of the class."
             )
-        return names[0] if names else module.name
+        if not names:
+            raise ValueError(
+                f"Cannot remap {module.__name__}: it has no instance in this blueprint, so "
+                f"the remapping would silently do nothing. Instances present: "
+                f"{', '.join(sorted(b.name for b in self.blueprints)) or '(none)'}."
+            )
+        return names[0]
 
     def namespace(self, prefix: str, *, expose: Iterable[str] = ()) -> "Blueprint":
         """Isolate this blueprint under a name prefix so several copies can coexist.

--- a/dimos/core/coordination/test_module_coordinator.py
+++ b/dimos/core/coordination/test_module_coordinator.py
@@ -424,6 +424,52 @@ def test_disabled_module_ref_gets_noop_proxy() -> None:
         coordinator.stop()
 
 
+def test_remapping_a_subclassed_module_by_its_base_class() -> None:
+    """Deployments subclass a module to declare extra ports; a remapping written
+    against the base class must still reach that instance."""
+
+    class _SubSource(SourceModule):
+        extra: Out[Data1]
+
+    blueprint_set = autoconnect(
+        _SubSource.blueprint(instance_name="SourceModule"),
+        TargetModule.blueprint(),
+    ).remappings([(SourceModule, "color_image", "remapped_data")])
+
+    all_names = _all_name_types(blueprint_set)
+    assert ("remapped_data", Data1) in all_names
+    assert ("color_image", Data1) not in all_names
+
+
+def test_remapping_prefers_the_exact_class_over_a_deployed_subclass() -> None:
+    """Sibling modules inherit from each other (ObjectDBModule is a Detection3DModule),
+    and both get deployed — naming one must not become ambiguous."""
+
+    class _SubSource(SourceModule):
+        extra: Out[Data1]
+
+    blueprint_set = autoconnect(
+        SourceModule.blueprint(),
+        _SubSource.blueprint(),
+        TargetModule.blueprint(),
+    ).remappings([(SourceModule, "color_image", "remapped_data")])
+
+    assert blueprint_set.remapping_map[SourceModule.name, "color_image"] == "remapped_data"
+    assert (_SubSource.name, "color_image") not in blueprint_set.remapping_map
+
+
+def test_remapping_a_module_that_is_not_in_the_blueprint_raises() -> None:
+    """Silently doing nothing here costs a robot its command path."""
+    with pytest.raises(ValueError) as excinfo:
+        autoconnect(TargetModule.blueprint()).remappings(
+            [(SourceModule, "color_image", "remapped_data")]
+        )
+
+    message = str(excinfo.value)
+    assert "SourceModule" in message
+    assert TargetModule.name in message
+
+
 def test_module_ref_remap_ambiguous() -> None:
     coordinator = ModuleCoordinator.build(
         autoconnect(


### PR DESCRIPTION
## Problem

A blueprint can rename a module's port so two modules connect. 

That rename is looked up by class. If a blueprint subclasses the module — which the new
per-robot joint streams need — the lookup misses and the rename never happens. Nothing
errors and nothing warns. You get a G1 that boots fine and ignores every nav and WASD
command.

Issue: #

---

## Solution

If the exact class isn't in the blueprint, look for a subclass of it instead.

Exact match is still tried first. Some modules that get deployed together inherit from
each other (`ObjectDBModule` extends `Detection3DModule`), and there you meant the class
you actually named.

Renaming a module that isn't in the blueprint used to do nothing, quietly. It now raises.


---

## Breaking Changes

None. All 139 importable blueprints resolve identically. `.remappings()` on an absent
module now raises; nothing in-repo does that.

---

## How to Test

1. `pytest dimos/core/coordination/test_module_coordinator.py -k remap`
2. `pytest dimos/core dimos/robot -m 'not (tool or self_hosted or mujoco or self_hosted_large)'`
3. Drop the exact-match preference and `unitree-g1-detection` fails; revert to `is` and the subclass test fails.
