### PR TITLE
resolve agent restoration (#1898)

### DIFF
--- a/dimos/agents/mcp/mcp_client.py
+++ b/dimos/agents/mcp/mcp_client.py
@@ -29,7 +29,7 @@ from langchain_openai import ChatOpenAI
 from langgraph.graph.state import CompiledStateGraph
 from reactivex.disposable import Disposable
 
-from dimos.agents.mcp import tool_stream
+from dimos.agents.mcp import session_store, tool_stream
 from dimos.agents.system_prompt import SYSTEM_PROMPT
 from dimos.agents.utils import pretty_print_langchain_message
 from dimos.constants import DEFAULT_THREAD_JOIN_TIMEOUT
@@ -62,6 +62,10 @@ class McpClientConfig(ModuleConfig):
     model: str = "gpt-5.6-luna"
     model_fixture: str | None = None
     mcp_server_url: str = "http://localhost:9990/mcp"
+    # Issue #1898: conversation persistence. CLI usually sets session_id; when
+    # restore_session is True we load that file before accepting new messages.
+    session_id: str | None = None
+    restore_session: bool = False
 
 
 class McpClient(Module):
@@ -80,6 +84,7 @@ class McpClient(Module):
     _http_client: httpx.Client
     _seq_ids: SequentialIds
     _tool_stream_cleanup: Callable[[], None] | None
+    _session_id: str
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
@@ -88,6 +93,7 @@ class McpClient(Module):
         self._message_queue = Queue()
         self._tool_registry = {}
         self._history = []
+        self._session_id = self.config.session_id or str(uuid.uuid4())
         self._thread = Thread(
             target=self._thread_loop,
             name=f"{self.__class__.__name__}-thread",
@@ -236,13 +242,58 @@ class McpClient(Module):
             model = _init_model(self.config.model)
 
         with self._lock:
+            if self.config.restore_session:
+                self._load_session_history()
             self._state_graph = create_agent(
                 model=model,
                 tools=tools,
                 system_prompt=self.config.system_prompt,
             )
+            logger.info(
+                "Agent session ready",
+                session_id=self._session_id,
+                restore=self.config.restore_session,
+                n_history=len(self._history),
+            )
             if not self._thread.is_alive():
                 self._thread.start()
+
+    def _load_session_history(self) -> None:
+        try:
+            self._history = session_store.load_session(self._session_id)
+        except FileNotFoundError:
+            logger.warning(
+                "restore_session set but no file found; starting empty",
+                session_id=self._session_id,
+            )
+            self._history = []
+            return
+        except Exception:
+            # Corrupt JSON / unexpected message payload must not block robot start.
+            logger.exception(
+                "Failed to restore agent session; starting empty",
+                session_id=self._session_id,
+            )
+            self._history = []
+            return
+        logger.info(
+            "Restored agent session from disk",
+            session_id=self._session_id,
+            n_messages=len(self._history),
+        )
+
+    def _save_session_history(self) -> None:
+        # Avoid creating empty session files when a run never received messages.
+        if not self._history:
+            return
+        try:
+            session_store.save_session(
+                self._session_id,
+                self._history,
+                model=self.config.model,
+            )
+        except Exception:
+            logger.exception("Failed to save agent session", session_id=self._session_id)
 
     @rpc
     def stop(self) -> None:
@@ -254,6 +305,8 @@ class McpClient(Module):
         self._stop_event.set()
         if self._thread.is_alive():
             self._thread.join(timeout=DEFAULT_THREAD_JOIN_TIMEOUT)
+        with self._lock:
+            self._save_session_history()
         self._http_client.close()
         super().stop()
 
@@ -346,6 +399,8 @@ class McpClient(Module):
                     self._history.append(msg)
                     pretty_print_langchain_message(msg)
                     self.agent.publish(msg)
+
+        self._save_session_history()
 
         if self._message_queue.empty():
             self.agent_idle.publish(True)

--- a/dimos/agents/mcp/session_store.py
+++ b/dimos/agents/mcp/session_store.py
@@ -1,0 +1,242 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Persist McpClient conversation history to disk (issue #1898).
+
+JSON fields:
+- ``summary``: auto title from the first human message (refreshed on every save)
+- ``user_summary``: optional CLI-set display name (empty by default)
+
+``dimos agent sessions`` shows ``user_summary`` if non-empty, else ``summary``.
+
+Follow-up: optional LLM-generated one-line summaries (ChatGPT-style).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from typing import Any
+
+from langchain_core.load import dumpd, load
+from langchain_core.messages import BaseMessage
+
+from dimos.constants import STATE_DIR
+
+SCHEMA_VERSION = 1
+_IMAGE_PLACEHOLDER = "[image omitted from session restore]"
+_SUMMARY_MAX_LEN = 72
+
+
+def sessions_dir() -> Path:
+    path = STATE_DIR / "agent_sessions"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def session_path(session_id: str) -> Path:
+    # Keep session files strictly under sessions_dir (no path traversal).
+    safe_id = Path(session_id).name
+    if safe_id != session_id or not safe_id:
+        raise ValueError(f"Invalid session_id: {session_id!r}")
+    return sessions_dir() / f"{safe_id}.json"
+
+
+def _text_from_content(content: Any) -> str:
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if isinstance(block, str):
+                parts.append(block)
+            elif isinstance(block, dict) and block.get("type") == "text":
+                parts.append(str(block.get("text", "")))
+        return " ".join(p for p in parts if p).strip()
+    return ""
+
+
+def heuristic_summary(messages: list[BaseMessage]) -> str:
+    """First human text, truncated — no LLM call."""
+    for msg in messages:
+        if msg.type != "human":
+            continue
+        text = _text_from_content(msg.content)
+        if not text:
+            continue
+        text = " ".join(text.split())
+        if len(text) > _SUMMARY_MAX_LEN:
+            return text[: _SUMMARY_MAX_LEN - 1] + "…"
+        return text
+    return "(no user messages yet)"
+
+
+def _strip_images_in_content(content: Any) -> Any:
+    if not isinstance(content, list):
+        return content
+    cleaned: list[Any] = []
+    for block in content:
+        if isinstance(block, dict) and block.get("type") in ("image_url", "image"):
+            cleaned.append({"type": "text", "text": _IMAGE_PLACEHOLDER})
+        else:
+            cleaned.append(block)
+    return cleaned
+
+
+def _messages_for_disk(messages: list[BaseMessage]) -> list[dict[str, Any]]:
+    """Serialize messages, dropping bulky image payloads."""
+    out: list[dict[str, Any]] = []
+    for msg in messages:
+        content = _strip_images_in_content(msg.content)
+        if content is msg.content:
+            dumped = dumpd(msg)
+        else:
+            dumped = dumpd(msg.model_copy(update={"content": content}))
+        if not isinstance(dumped, dict):
+            raise TypeError(f"Expected dict from dumpd, got {type(dumped)}")
+        out.append(dumped)
+    return out
+
+
+def _messages_from_disk(raw: list[Any]) -> list[BaseMessage]:
+    messages: list[BaseMessage] = []
+    for item in raw:
+        # allowed_objects="messages": session files only store chat messages.
+        loaded = load(item, allowed_objects="messages")
+        if not isinstance(loaded, BaseMessage):
+            raise TypeError(f"Expected BaseMessage, got {type(loaded)}")
+        messages.append(loaded)
+    return messages
+
+
+@dataclass(frozen=True)
+class SessionInfo:
+    session_id: str
+    summary: str  # display summary: user_summary if set, else auto summary
+    updated_at: str
+    n_messages: int
+    model: str | None
+
+
+def _read_payload(session_id: str) -> dict[str, Any]:
+    path = session_path(session_id)
+    if not path.is_file():
+        raise FileNotFoundError(f"No agent session saved at {path}")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise TypeError(f"Session file must be a JSON object: {path}")
+    return payload
+
+
+def _write_payload(session_id: str, payload: dict[str, Any]) -> Path:
+    path = session_path(session_id)
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    tmp.replace(path)
+    return path
+
+
+def display_summary(payload: dict[str, Any]) -> str:
+    """Prefer user_summary; fall back to auto summary from first human message."""
+    user = str(payload.get("user_summary") or "").strip()
+    if user:
+        return user
+    auto = str(payload.get("summary") or "").strip()
+    return auto or "(no summary)"
+
+
+def save_session(
+    session_id: str,
+    messages: list[BaseMessage],
+    *,
+    model: str | None = None,
+) -> Path:
+    path = session_path(session_id)
+    user_summary = ""
+    if path.is_file():
+        try:
+            old = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            old = {}
+        if isinstance(old, dict):
+            user_summary = str(old.get("user_summary") or "")
+
+    payload = {
+        "version": SCHEMA_VERSION,
+        "session_id": session_id,
+        "model": model,
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+        # Auto title from first human message — always refreshed on save.
+        "summary": heuristic_summary(messages),
+        # Optional user-facing name; preserved across saves unless CLI updates it.
+        "user_summary": user_summary,
+        "messages": _messages_for_disk(messages),
+    }
+    return _write_payload(session_id, payload)
+
+
+def load_session(session_id: str) -> list[BaseMessage]:
+    payload = _read_payload(session_id)
+    version = payload.get("version", SCHEMA_VERSION)
+    if version != SCHEMA_VERSION:
+        raise ValueError(
+            f"Unsupported agent session schema version {version!r} "
+            f"(expected {SCHEMA_VERSION}) at {session_path(session_id)}"
+        )
+    raw = payload.get("messages") or []
+    if not isinstance(raw, list):
+        raise TypeError("session messages must be a list")
+    return _messages_from_disk(raw)
+
+
+def update_session_summary(session_id: str, summary: str) -> Path:
+    """Set ``user_summary`` (list display name). Empty string clears it."""
+    text = " ".join(summary.split()).strip()
+    payload = _read_payload(session_id)
+    payload["user_summary"] = text
+    payload["updated_at"] = datetime.now(timezone.utc).isoformat()
+    return _write_payload(session_id, payload)
+
+
+def delete_session(session_id: str) -> None:
+    """Delete a saved session file."""
+    path = session_path(session_id)
+    if not path.is_file():
+        raise FileNotFoundError(f"No agent session saved at {path}")
+    path.unlink()
+
+
+def list_sessions() -> list[SessionInfo]:
+    infos: list[SessionInfo] = []
+    for path in sessions_dir().glob("*.json"):
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        session_id = str(payload.get("session_id") or path.stem)
+        messages = payload.get("messages") or []
+        infos.append(
+            SessionInfo(
+                session_id=session_id,
+                summary=display_summary(payload),
+                updated_at=str(payload.get("updated_at") or ""),
+                n_messages=len(messages) if isinstance(messages, list) else 0,
+                model=payload.get("model"),
+            )
+        )
+    infos.sort(key=lambda s: s.updated_at, reverse=True)
+    return infos

--- a/dimos/agents/mcp/test_session_store.py
+++ b/dimos/agents/mcp/test_session_store.py
@@ -1,0 +1,193 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from langchain_core.messages import AIMessage, HumanMessage
+import pytest
+
+from dimos.agents.mcp import session_store
+
+
+@pytest.fixture()
+def sessions_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    root = tmp_path / "agent_sessions"
+    monkeypatch.setattr(session_store, "sessions_dir", lambda: root)
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def test_save_load_roundtrip(sessions_root: Path) -> None:
+    messages = [
+        HumanMessage(content="add 3 and 5 with the tool"),
+        AIMessage(content="I'll call sum_numbers"),
+    ]
+    session_store.save_session("sess-1", messages, model="gpt-4o")
+    loaded = session_store.load_session("sess-1")
+    assert len(loaded) == 2
+    assert loaded[0].content == "add 3 and 5 with the tool"
+    assert loaded[1].content == "I'll call sum_numbers"
+
+
+def test_heuristic_summary_uses_first_human_message() -> None:
+    messages = [
+        AIMessage(content="ignore me"),
+        HumanMessage(content="  go to the kitchen please  "),
+        HumanMessage(content="second"),
+    ]
+    assert session_store.heuristic_summary(messages) == "go to the kitchen please"
+
+
+def test_heuristic_summary_truncates_long_text() -> None:
+    long = "x" * 200
+    summary = session_store.heuristic_summary([HumanMessage(content=long)])
+    assert summary.endswith("…")
+    assert len(summary) == session_store._SUMMARY_MAX_LEN
+
+
+def test_images_stripped_on_save(sessions_root: Path) -> None:
+    messages = [
+        HumanMessage(
+            content=[
+                {"type": "text", "text": "see this"},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/jpeg;base64,AAAA"},
+                },
+            ]
+        )
+    ]
+    session_store.save_session("sess-img", messages)
+    loaded = session_store.load_session("sess-img")
+    assert isinstance(loaded[0].content, list)
+    types = [b.get("type") for b in loaded[0].content if isinstance(b, dict)]
+    assert "image_url" not in types
+    assert any(
+        isinstance(b, dict) and "omitted" in str(b.get("text", "")) for b in loaded[0].content
+    )
+
+
+def test_list_sessions_includes_summary(sessions_root: Path) -> None:
+    session_store.save_session(
+        "aaa",
+        [HumanMessage(content="first chat")],
+        model="gpt-4o",
+    )
+    session_store.save_session(
+        "bbb",
+        [HumanMessage(content="second chat")],
+        model="gpt-4o",
+    )
+    listed = session_store.list_sessions()
+    assert [s.session_id for s in listed] == ["bbb", "aaa"] or {s.session_id for s in listed} == {
+        "aaa",
+        "bbb",
+    }
+    by_id = {s.session_id: s for s in listed}
+    assert by_id["aaa"].summary == "first chat"
+    assert by_id["bbb"].n_messages == 1
+
+
+def test_load_missing_session_raises(sessions_root: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        session_store.load_session("does-not-exist")
+
+
+def test_update_session_summary_uses_user_summary_field(sessions_root: Path) -> None:
+    session_store.save_session("sess-name", [HumanMessage(content="original first line")])
+    path = session_store.session_path("sess-name")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["summary"] == "original first line"
+    assert payload.get("user_summary", "") == ""
+
+    session_store.update_session_summary("sess-name", "厨房导航实验")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["summary"] == "original first line"
+    assert payload["user_summary"] == "厨房导航实验"
+    assert session_store.list_sessions()[0].summary == "厨房导航实验"
+
+    # Auto summary still refreshes; display keeps user_summary.
+    session_store.save_session(
+        "sess-name",
+        [
+            HumanMessage(content="original first line"),
+            AIMessage(content="ok"),
+            HumanMessage(content="another user line"),
+        ],
+    )
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["summary"] == "original first line"
+    assert payload["user_summary"] == "厨房导航实验"
+    assert session_store.list_sessions()[0].summary == "厨房导航实验"
+
+    # Empty user_summary clears the custom name → fall back to auto summary.
+    session_store.update_session_summary("sess-name", "")
+    assert session_store.list_sessions()[0].summary == "original first line"
+
+
+def test_delete_session_removes_file(sessions_root: Path) -> None:
+    session_store.save_session("sess-del", [HumanMessage(content="bye")])
+    session_store.delete_session("sess-del")
+    assert session_store.list_sessions() == []
+    with pytest.raises(FileNotFoundError):
+        session_store.delete_session("sess-del")
+
+
+def test_display_summary_prefers_user_summary() -> None:
+    assert (
+        session_store.display_summary(
+            {"summary": "auto", "user_summary": "custom"}
+        )
+        == "custom"
+    )
+    assert session_store.display_summary({"summary": "auto", "user_summary": ""}) == "auto"
+    assert session_store.display_summary({"summary": "", "user_summary": ""}) == "(no summary)"
+
+
+def test_update_session_summary_missing_raises(sessions_root: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        session_store.update_session_summary("missing", "x")
+
+
+def test_invalid_session_id_rejected() -> None:
+    with pytest.raises(ValueError):
+        session_store.session_path("../escape")
+    with pytest.raises(ValueError):
+        session_store.session_path("")
+
+
+def test_load_rejects_bad_schema_version(sessions_root: Path) -> None:
+    session_store.save_session("sess-ver", [HumanMessage(content="hi")])
+    path = session_store.session_path("sess-ver")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["version"] = 999
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(ValueError, match="Unsupported"):
+        session_store.load_session("sess-ver")
+
+
+def test_load_rejects_corrupt_json(sessions_root: Path) -> None:
+    path = sessions_root / "sess-bad.json"
+    path.write_text("{not-json", encoding="utf-8")
+    with pytest.raises(json.JSONDecodeError):
+        session_store.load_session("sess-bad")
+
+
+def test_list_skips_corrupt_files(sessions_root: Path) -> None:
+    session_store.save_session("good", [HumanMessage(content="ok")])
+    (sessions_root / "junk.json").write_text("{broken", encoding="utf-8")
+    listed = session_store.list_sessions()
+    assert [s.session_id for s in listed] == ["good"]

--- a/dimos/robot/cli/dimos.py
+++ b/dimos/robot/cli/dimos.py
@@ -31,6 +31,7 @@ from pydantic.fields import FieldInfo
 from pydantic_core import PydanticUndefined
 import requests
 import typer
+import uuid
 
 from dimos.agents.mcp.mcp_adapter import McpAdapter, McpError
 from dimos.constants import CONFIG_DIR, LOG_DIR
@@ -300,6 +301,47 @@ def load_config_args(config: type[BaseModel], args: Iterable[str], path: Path) -
     return kwargs  # type: ignore[no-any-return]
 
 
+def _apply_agent_session_cli(
+    kwargs: dict[str, Any],
+    blueprint_config: type[BaseModel],
+    restore_session: str | None,
+    robot_types: list[str],
+) -> None:
+    """Wire --restore-session / auto session id when the blueprint has McpClient."""
+    if "mcpclient" not in blueprint_config.model_fields:
+        if restore_session:
+            typer.echo(
+                "Warning: --restore-session ignored (blueprint has no McpClient)",
+                err=True,
+            )
+        return
+
+    mcp = kwargs.setdefault("mcpclient", {})
+    if not isinstance(mcp, dict):
+        typer.echo("Error: mcpclient config must be a mapping", err=True)
+        raise typer.Exit(1)
+
+    if restore_session:
+        from dimos.agents.mcp.session_store import session_path
+
+        try:
+            session_path(restore_session)  # validate id (no path traversal)
+        except ValueError as e:
+            typer.echo(f"Error: {e}", err=True)
+            raise typer.Exit(1)
+        mcp["session_id"] = restore_session
+        mcp["restore_session"] = True
+        typer.echo(f"  Agent session: {restore_session} (restoring)")
+        return
+
+    mcp.setdefault("session_id", str(uuid.uuid4()))
+    mcp.setdefault("restore_session", False)
+    session_id = mcp["session_id"]
+    blueprint_token = " ".join(robot_types)
+    typer.echo(f"  Agent session: {session_id}")
+    typer.echo(f"  Resume with:  dimos run {blueprint_token} --restore-session={session_id}")
+
+
 @main.command()
 def run(
     ctx: typer.Context,
@@ -309,6 +351,11 @@ def run(
     blueprint_args: list[str] = typer.Option((), "--option", "-o"),
     config_path: Path = typer.Option(
         CONFIG_DIR / "dimos", "--config", "-c", help="Path to config file"
+    ),
+    restore_session: str | None = typer.Option(
+        None,
+        "--restore-session",
+        help="Restore McpClient conversation history for this session UUID (#1898)",
     ),
     show_help: bool = typer.Option(False, "--help"),
 ) -> None:
@@ -369,6 +416,8 @@ def run(
     kwargs = load_config_args(blueprint_config, blueprint_args, config_path)
     if cli_config_overrides:
         kwargs["g"] = cli_config_overrides
+
+    _apply_agent_session_cli(kwargs, blueprint_config, restore_session, robot_types)
 
     coordinator = ModuleCoordinator.build(blueprint, kwargs)
 
@@ -642,6 +691,74 @@ def agent_send_cmd(
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)
     typer.echo(text)
+
+
+agent_app = typer.Typer(help="Agent session helpers (issue #1898)")
+main.add_typer(agent_app, name="agent")
+
+
+@agent_app.command("sessions")
+def agent_sessions() -> None:
+    """List saved agent conversation sessions on disk."""
+    from dimos.agents.mcp.session_store import list_sessions
+
+    sessions = list_sessions()
+    if not sessions:
+        typer.echo("No saved agent sessions.")
+        return
+
+    typer.echo(f"{'SESSION ID':<38} {'MSGS':>4}  {'UPDATED':<28}  SUMMARY")
+    for s in sessions:
+        typer.echo(
+            f"{s.session_id:<38} {s.n_messages:>4}  {s.updated_at:<28}  {s.summary}"
+        )
+    typer.echo("\nResume: dimos run <blueprint> --restore-session=<SESSION ID>")
+    typer.echo("Rename: dimos agent update-summary <SESSION ID> \"new title\"")
+    typer.echo("Delete: dimos agent delete <SESSION ID>")
+
+
+@agent_app.command("update-summary")
+def agent_update_summary(
+    session_id: str = typer.Argument(..., help="Session UUID"),
+    summary: str = typer.Argument(
+        ...,
+        help="Custom display name (user_summary). Empty string clears it.",
+    ),
+) -> None:
+    """Set user_summary for a session. List shows user_summary, else auto summary."""
+    from dimos.agents.mcp.session_store import update_session_summary
+
+    try:
+        update_session_summary(session_id, summary)
+    except (FileNotFoundError, ValueError) as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(1)
+    text = " ".join(summary.split()).strip()
+    if text:
+        typer.echo(f"Updated user_summary for {session_id}: {text}")
+    else:
+        typer.echo(f"Cleared user_summary for {session_id} (will show auto summary)")
+
+
+@agent_app.command("delete")
+def agent_delete_session(
+    session_id: str = typer.Argument(..., help="Session UUID to delete"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation"),
+) -> None:
+    """Delete a saved agent session file."""
+    from dimos.agents.mcp.session_store import delete_session
+
+    if not yes:
+        confirm = typer.confirm(f"Delete agent session {session_id}?")
+        if not confirm:
+            typer.echo("Cancelled.")
+            raise typer.Exit(0)
+    try:
+        delete_session(session_id)
+    except (FileNotFoundError, ValueError) as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(1)
+    typer.echo(f"Deleted session {session_id}")
 
 
 @main.command()

--- a/dimos/robot/cli/test_dimos.py
+++ b/dimos/robot/cli/test_dimos.py
@@ -17,6 +17,7 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 import pytest
+import typer
 from typer.testing import CliRunner
 
 from dimos.core.coordination.blueprints import autoconnect
@@ -24,8 +25,62 @@ import dimos.core.coordination.worker_manager_python as worker_manager_python
 from dimos.core.global_config import global_config
 from dimos.core.module import Module, ModuleConfig
 from dimos.robot import external_blueprints as external
-from dimos.robot.cli.dimos import _normalize_simulation_argv, arg_help, load_config_args, main
+from dimos.robot.cli.dimos import (
+    _apply_agent_session_cli,
+    _normalize_simulation_argv,
+    arg_help,
+    load_config_args,
+    main,
+)
 import dimos.utils.cli.spy.run_spy as run_spy
+
+
+def test_apply_agent_session_cli_assigns_new_id(capsys: pytest.CaptureFixture[str]) -> None:
+    class Cfg(BaseModel):
+        mcpclient: dict[str, object] = Field(default_factory=dict)
+
+    kwargs: dict[str, object] = {}
+    _apply_agent_session_cli(kwargs, Cfg, None, ["demo-skill"])
+    mcp = kwargs["mcpclient"]
+    assert isinstance(mcp, dict)
+    assert mcp["restore_session"] is False
+    assert isinstance(mcp["session_id"], str) and len(mcp["session_id"]) > 0
+    out = capsys.readouterr().out
+    assert "Agent session:" in out
+    assert "--restore-session=" in out
+
+
+def test_apply_agent_session_cli_restore(capsys: pytest.CaptureFixture[str]) -> None:
+    class Cfg(BaseModel):
+        mcpclient: dict[str, object] = Field(default_factory=dict)
+
+    kwargs: dict[str, object] = {}
+    _apply_agent_session_cli(kwargs, Cfg, "fixed-session-id", ["demo-skill"])
+    mcp = kwargs["mcpclient"]
+    assert isinstance(mcp, dict)
+    assert mcp["session_id"] == "fixed-session-id"
+    assert mcp["restore_session"] is True
+    assert "restoring" in capsys.readouterr().out
+
+
+def test_apply_agent_session_cli_rejects_bad_id() -> None:
+    class Cfg(BaseModel):
+        mcpclient: dict[str, object] = Field(default_factory=dict)
+
+    with pytest.raises(typer.Exit):
+        _apply_agent_session_cli({}, Cfg, "../escape", ["demo-skill"])
+
+
+def test_apply_agent_session_cli_ignored_without_mcpclient(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    class Cfg(BaseModel):
+        other: int = 1
+
+    kwargs: dict[str, object] = {}
+    _apply_agent_session_cli(kwargs, Cfg, "x", ["unitree-go2-basic"])
+    assert "mcpclient" not in kwargs
+    assert "ignored" in capsys.readouterr().err
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Contribution path

- Linked issue or discussion: https://github.com/dimensionalOS/dimos/issues/1898

## Problem

Agent conversation state lives only in memory (``McpClient._history``). After ``dimos stop`` / process exit, the agent forgets prior turns. There is no way to resume a previous chat by session id.

## Solution

- Persist ``_history`` to ``STATE_DIR/agent_sessions/<UUID>.json``
- New ``dimos run`` assigns a fresh session UUID; restore only with ``--restore-session=<UUID>``
- CLI helpers: ``dimos agent sessions`` / ``update-summary`` / ``delete``
- Auto ``summary`` from first user message; optional ``user_summary`` for a custom display name

## How to Test

Assumes a normal DimOS install (`uv sync --extra all` / see AGENTS.md) with `dimos` on PATH and `OPENAI_API_KEY` exported. Use two terminals if needed (one for `dimos run`, one for `dimos agent-send`).
Manual:

```bash
# Terminal 1 — start an agentic blueprint; note the printed session UUID
dimos run demo-skill
# Terminal 2 — send any chat message to the running agent
dimos agent-send "<your message>"
# Stop the run, then list saved sessions
dimos stop
dimos agent sessions
# expect: your UUID appears with a short summary and message count > 0
# Start again with the same UUID to restore history
dimos run demo-skill --restore-session=<UUID>
# Ask something that only makes sense if prior turns were restored
# (e.g. "What did I just ask you?")
dimos agent-send "<follow-up that depends on earlier context>"
# expect: agent continues from restored history, not a blank new session

Automated:
uv run pytest dimos/agents/mcp/test_session_store.py dimos/robot/cli/test_dimos.py::test_apply_agent_session_cli_assigns_new_id dimos/robot/cli/test_dimos.py::test_apply_agent_session_cli_restore dimos/robot/cli/test_dimos.py::test_apply_agent_session_cli_ignored_without_mcpclient dimos/robot/cli/test_dimos.py::test_apply_agent_session_cli_rejects_bad_id -q

## AI assistance

Cursor (assisted implementation). I reviewed and understand the changes.

## Checklist

- [x ] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
