### PR TITLE
feat(sim): add xarm6-worldbelief-sim blueprint

### DIFF
--- a/dimos/robot/all_blueprints.py
+++ b/dimos/robot/all_blueprints.py
@@ -154,6 +154,7 @@ all_blueprints = {
     "xarm-perception-sim": "dimos.robot.manipulators.xarm.blueprints.simulation:xarm_perception_sim",
     "xarm-perception-sim-agent": "dimos.robot.manipulators.xarm.blueprints.agentic:xarm_perception_sim_agent",
     "xarm6-worldbelief": "dimos.robot.manipulators.xarm.blueprints.worldbelief:xarm6_worldbelief",
+    "xarm6-worldbelief-sim": "dimos.robot.manipulators.xarm.blueprints.worldbelief_sim:xarm6_worldbelief_sim",
     "xarm7-planner-coordinator": "dimos.robot.manipulators.xarm.blueprints.basic:xarm7_planner_coordinator",
     "xarm7-planner-coordinator-agent": "dimos.robot.manipulators.xarm.blueprints.agentic:xarm7_planner_coordinator_agent",
 }

--- a/dimos/robot/manipulators/xarm/blueprints/worldbelief.py
+++ b/dimos/robot/manipulators/xarm/blueprints/worldbelief.py
@@ -23,7 +23,7 @@ import rerun.blueprint as rrb
 
 from dimos.agents.mcp.mcp_server import McpServer
 from dimos.constants import STATE_DIR
-from dimos.core.coordination.blueprints import autoconnect
+from dimos.core.coordination.blueprints import Blueprint, autoconnect
 from dimos.hardware.sensors.camera.realsense.camera import RealSenseCamera
 from dimos.manipulation.manipulation_module import ManipulationModule
 from dimos.msgs.geometry_msgs.Quaternion import Quaternion
@@ -69,6 +69,49 @@ def _rerun_blueprint() -> rrb.Blueprint:
     )
 
 
+def worldbelief_stack(state_subdir: str) -> Blueprint:
+    """Camera-source-agnostic half of an xArm WorldBelief blueprint.
+
+    The rerun bridge, recorder, and belief module are identical for the
+    RealSense and MuJoCo wrist cameras -- both publish the same color/depth/
+    camera-info topics -- so only the state directory varies. ``state_subdir``
+    keeps hardware and sim recordings from overwriting each other.
+    """
+    db_path = STATE_DIR / "worldbelief" / state_subdir / "recordings" / "xarm6_worldbelief.db"
+    return autoconnect(
+        RerunBridgeModule.blueprint(
+            blueprint=_rerun_blueprint,
+            topic_to_entity=_topic_to_entity,
+            visual_override={
+                "world/color_camera": partial(
+                    _camera_info_to_rerun, image_topic="world/color_camera/color_image"
+                ),
+                "world/depth_camera": partial(
+                    _camera_info_to_rerun, image_topic="world/depth_camera/depth_image"
+                ),
+            },
+            max_hz={
+                "world/color_camera/color_image": 10.0,
+                "world/depth_camera/depth_image": 5.0,
+                "world/detections_3d": 10.0,
+                "world/pointcloud": 5.0,
+            },
+        ),
+        WorldBeliefRecorder.blueprint(db_path=db_path),
+        WorldBeliefModule.blueprint(
+            db_path=db_path,
+            history_path=STATE_DIR / "worldbelief" / state_subdir / "worldbelief_history.db",
+            scan_prompts=[],
+            depth_tolerance_s=0.1,
+            stationary_hz=4.0,
+            yoloe_model_name="yoloe-11l-seg.pt",
+            dino_model_name="facebook/dinov2-base",
+            clip_model_name="openai/clip-vit-base-patch32",
+        ),
+        McpServer.blueprint(),
+    )
+
+
 _hw = xarm6_hardware("arm")
 _hw.auto_enable = True
 
@@ -91,38 +134,7 @@ xarm6_worldbelief = autoconnect(
         base_frame_id="link6",
         base_transform=XARM6_WORLDBELIEF_CAMERA_TRANSFORM,
     ),
-    RerunBridgeModule.blueprint(
-        blueprint=_rerun_blueprint,
-        topic_to_entity=_topic_to_entity,
-        visual_override={
-            "world/color_camera": partial(
-                _camera_info_to_rerun, image_topic="world/color_camera/color_image"
-            ),
-            "world/depth_camera": partial(
-                _camera_info_to_rerun, image_topic="world/depth_camera/depth_image"
-            ),
-        },
-        max_hz={
-            "world/color_camera/color_image": 10.0,
-            "world/depth_camera/depth_image": 5.0,
-            "world/detections_3d": 10.0,
-            "world/pointcloud": 5.0,
-        },
-    ),
-    WorldBeliefRecorder.blueprint(
-        db_path=STATE_DIR / "worldbelief" / "xarm6" / "recordings" / "xarm6_worldbelief.db",
-    ),
-    WorldBeliefModule.blueprint(
-        db_path=STATE_DIR / "worldbelief" / "xarm6" / "recordings" / "xarm6_worldbelief.db",
-        history_path=STATE_DIR / "worldbelief" / "xarm6" / "worldbelief_history.db",
-        scan_prompts=[],
-        depth_tolerance_s=0.1,
-        stationary_hz=4.0,
-        yoloe_model_name="yoloe-11l-seg.pt",
-        dino_model_name="facebook/dinov2-base",
-        clip_model_name="openai/clip-vit-base-patch32",
-    ),
-    McpServer.blueprint(),
+    worldbelief_stack("xarm6"),
     coordinator(
         hardware=[_hw],
         tasks=[trajectory_task(_hw)],

--- a/dimos/robot/manipulators/xarm/blueprints/worldbelief_sim.py
+++ b/dimos/robot/manipulators/xarm/blueprints/worldbelief_sim.py
@@ -1,0 +1,70 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""xArm6 WorldBelief perception stack against the MuJoCo sim.
+
+Mirrors :mod:`worldbelief` (xarm6_worldbelief) with the RealSense wrist camera
+replaced by :class:`MujocoSimModule`, which renders the MJCF ``wrist_camera``
+and publishes the same color/depth/camera-info topics plus the
+``link6 -> wrist_camera_*_optical_frame`` TF from simulation ground truth. The
+perception half of the stack is shared verbatim via ``worldbelief_stack``.
+
+KNOWN LIMITATION -- detected object poses read low in Z. The ``world -> link6``
+TF edge comes from ManipulationModule FK, which places ``link_base`` at the
+world origin, but ``data/xarm6/scene.xml`` spawns it on a 0.12m pedestal. The
+sim renders from the true (pedestal) camera pose while perception unprojects
+using the FK pose, so scanned objects land ~9.5cm below ground truth and IK
+targets derived from them are unreachable. Scan/detect/recall work; pick does
+not. Fixing the base-frame disagreement is tracked separately.
+"""
+
+from __future__ import annotations
+
+from dimos.core.coordination.blueprints import autoconnect
+from dimos.manipulation.manipulation_module import ManipulationModule
+from dimos.robot.manipulators.common.blueprints import coordinator, trajectory_task
+from dimos.robot.manipulators.xarm.blueprints.worldbelief import worldbelief_stack
+from dimos.robot.manipulators.xarm.config import (
+    XARM6_SIM_HOME,
+    XARM6_SIM_PATH,
+    make_xarm6_model_config,
+    make_xarm6_sim_hardware,
+    make_xarm6_sim_module_kwargs,
+)
+from dimos.simulation.engines.mujoco_sim_module import MujocoSimModule
+
+_hw = make_xarm6_sim_hardware(XARM6_SIM_PATH)
+
+xarm6_worldbelief_sim = autoconnect(
+    # Provides world->link6 FK/TF (the sim camera's TF parent) and the gripper
+    # skill path (set_gripper -> coordinator set_gripper_position RPC).
+    ManipulationModule.blueprint(
+        robots=[
+            make_xarm6_model_config(
+                name="arm",
+                add_gripper=True,
+                # link6 parents the camera; with the gripper attached the tip
+                # link is link_tcp, so link6 is no longer published implicitly.
+                tf_extra_links=["link6", "link_base"],
+                home_joints=XARM6_SIM_HOME,
+            ),
+        ],
+    ),
+    MujocoSimModule.blueprint(**make_xarm6_sim_module_kwargs(XARM6_SIM_PATH)),
+    worldbelief_stack("xarm6_sim"),
+    coordinator(
+        hardware=[_hw],
+        tasks=[trajectory_task(_hw)],
+    ),
+).global_config(n_workers=8)

--- a/dimos/robot/manipulators/xarm/config.py
+++ b/dimos/robot/manipulators/xarm/config.py
@@ -68,6 +68,34 @@ XARM_GRIPPER_PARAMS = {
 }
 XARM7_SIM_HOME = [0.0, -0.247, 0.0, 0.909, 0.0, 1.15644, 0.0]
 
+# Puts ``wrist_camera`` at world (0.45, 0, 0.52) looking straight down at the
+# table, mirroring the framing XARM7_SIM_HOME gives. Solved against
+# ``data/xarm6/scene.xml`` as shipped, i.e. with ``link_base`` spawned on the
+# 0.12m pedestal -- the same convention XARM7_SIM_HOME follows.
+XARM6_SIM_HOME = [0.0, -0.26274, -0.91777, 0.0, 1.18051, 0.0]
+
+
+def make_xarm6_sim_hardware(address: str | Path) -> HardwareComponent:
+    return make_xarm_hardware(
+        "arm",
+        6,
+        adapter_type="sim_mujoco",
+        address=address,
+        gripper=True,
+        home_joints=XARM6_SIM_HOME,
+    )
+
+
+def make_xarm6_sim_module_kwargs(address: str | Path) -> dict[str, Any]:
+    return {
+        "address": address,
+        "headless": False,
+        "dof": 6,
+        "camera_name": "wrist_camera",
+        "base_frame_id": "link6",
+        "reset_joint_positions": XARM6_SIM_HOME,
+    }
+
 
 def make_xarm7_sim_robot_config() -> RobotModelConfig:
     return make_xarm7_model_config(

--- a/dimos/robot/manipulators/xarm/test_worldbelief_sim_blueprint.py
+++ b/dimos/robot/manipulators/xarm/test_worldbelief_sim_blueprint.py
@@ -1,0 +1,101 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any
+
+import pytest
+
+from dimos.control.coordinator import ControlCoordinator, TaskConfig
+from dimos.core.coordination.blueprints import Blueprint
+from dimos.manipulation.manipulation_module import ManipulationModule
+from dimos.robot.manipulators.common.topics import trajectory_task_name
+from dimos.robot.manipulators.xarm.config import (
+    XARM6_SIM_HOME,
+    make_xarm6_sim_hardware,
+    make_xarm6_sim_module_kwargs,
+)
+from dimos.simulation.engines.mujoco_sim_module import MujocoSimModule, MujocoSimModuleConfig
+
+
+def _module_kwargs(blueprint: Blueprint, module_type: type) -> dict[str, Any]:
+    return next(atom.kwargs for atom in blueprint.blueprints if atom.module is module_type)
+
+
+def _coordinator_tasks(blueprint: Blueprint) -> list[TaskConfig]:
+    return _module_kwargs(blueprint, ControlCoordinator)["tasks"]
+
+
+def test_xarm6_sim_factories_agree_on_dof_camera_frame_and_home() -> None:
+    """The sim module and the coordinator adapter must start from one home pose.
+
+    ``MujocoSimModule`` resets the MJCF to ``reset_joint_positions`` while the
+    coordinator's mujoco adapter commands ``initial_positions``; if they drift
+    apart the arm lurches on the first tick.
+    """
+    hardware = make_xarm6_sim_hardware("test-xarm6-scene.xml")
+    sim_config = MujocoSimModuleConfig(**make_xarm6_sim_module_kwargs("test-xarm6-scene.xml"))
+
+    assert len(XARM6_SIM_HOME) == 6
+    assert sim_config.dof == 6
+    assert len(hardware.joints) == 6
+    assert sim_config.camera_name == "wrist_camera"
+    assert sim_config.base_frame_id == "link6"
+    assert hardware.adapter_type == "sim_mujoco"
+    assert hardware.gripper_joints == ["arm/gripper"]
+    assert sim_config.reset_joint_positions == XARM6_SIM_HOME
+    assert hardware.adapter_kwargs["initial_positions"] == XARM6_SIM_HOME
+
+
+@pytest.mark.self_hosted
+def test_xarm6_worldbelief_sim_wires_sim_camera_into_the_worldbelief_stack() -> None:
+    """Sim blueprint swaps the RealSense for MuJoCo and keeps its own state dir."""
+    # Imported lazily: these pull in the heavy perception stack (torch, yoloe)
+    # and the pyrealsense2 SDK, neither of which the factory test above needs.
+    from dimos.perception.worldbelief_module import WorldBeliefModule
+    from dimos.perception.worldbelief_recorder import WorldBeliefRecorder
+    from dimos.robot.manipulators.xarm.blueprints.worldbelief import xarm6_worldbelief
+    from dimos.robot.manipulators.xarm.blueprints.worldbelief_sim import xarm6_worldbelief_sim
+
+    modules = {atom.module for atom in xarm6_worldbelief_sim.blueprints}
+    assert MujocoSimModule in modules
+    assert "RealSenseCamera" not in {module.__name__ for module in modules}
+
+    robot = _module_kwargs(xarm6_worldbelief_sim, ManipulationModule)["robots"][0]
+    # MujocoSimModule parents the camera TF to link6; with the gripper attached
+    # the tip link is link_tcp, so link6 only gets published if listed here.
+    assert "link6" in robot.tf_extra_links
+    assert robot.gripper_hardware_id == "arm"
+    assert robot.home_joints == XARM6_SIM_HOME
+    sim_config = MujocoSimModuleConfig(**_module_kwargs(xarm6_worldbelief_sim, MujocoSimModule))
+    assert sim_config.base_frame_id in robot.tf_extra_links
+
+    tasks = _coordinator_tasks(xarm6_worldbelief_sim)
+    assert [(task.name, task.type) for task in tasks] == [
+        (trajectory_task_name(robot.name), "trajectory")
+    ]
+
+    # Shared worldbelief_stack: same perception knobs, distinct recordings.
+    sim_belief = _module_kwargs(xarm6_worldbelief_sim, WorldBeliefModule)
+    hw_belief = _module_kwargs(xarm6_worldbelief, WorldBeliefModule)
+    paths = ("db_path", "history_path")
+    assert {k: v for k, v in sim_belief.items() if k not in paths} == {
+        k: v for k, v in hw_belief.items() if k not in paths
+    }
+    for key in paths:
+        assert "xarm6_sim" in str(sim_belief[key])
+        assert sim_belief[key] != hw_belief[key]
+    assert (
+        _module_kwargs(xarm6_worldbelief_sim, WorldBeliefRecorder)["db_path"]
+        == sim_belief["db_path"]
+    )

--- a/dimos/robot/test_all_blueprints.py
+++ b/dimos/robot/test_all_blueprints.py
@@ -67,6 +67,7 @@ SELF_HOSTED_BLUEPRINTS = frozenset(
         "xarm-perception-agent",
         "xarm-perception-sim",
         "xarm-perception-sim-agent",
+        "xarm6-worldbelief-sim",
         "xarm7-planner-coordinator",
         "xarm7-planner-coordinator-agent",
     }


### PR DESCRIPTION
## Motivation

The WorldBelief perception stack can only be exercised with an xArm6 on the desk. This makes the sim a first-class dev surface: `dimos run xarm6-worldbelief-sim` brings up the same perception/planning/MCP stack against MuJoCo, so scan, recall, TF, gripper, and the agent path can be developed and regression-tested without hardware.

## What it wires

`xarm6-worldbelief-sim` mirrors `xarm6-worldbelief` with the RealSense wrist camera replaced by `MujocoSimModule` (`wrist_camera`, `base_frame_id=link6`, `dof=6`, `XARM6_SIM_PATH`). It renders the MJCF camera and publishes the same color/depth/camera-info topics plus `link6 -> wrist_camera_*_optical_frame` from sim ground truth; `world -> link6` comes from ManipulationModule FK.

- The rerun bridge, recorder, belief module, and MCP server were byte-identical between the two blueprints, so they move into a `worldbelief_stack(state_subdir)` factory. `xarm6_worldbelief` is otherwise untouched — verified by diffing every atom's module + kwargs before/after (only function object addresses differ).
- `XARM6_SIM_HOME` puts `wrist_camera` at world (0.45, 0, 0.52) looking straight down. Solved against `data/xarm6/scene.xml` **as shipped**, i.e. with `link_base` on the 0.12 m pedestal — the same convention `XARM7_SIM_HOME` already follows (verified: main's xarm7 home lands the camera at 0.44991, 0, 0.51979).
- `make_xarm6_sim_hardware` / `make_xarm6_sim_module_kwargs` mirror the existing xarm7 factories.

No changes outside blueprint, config, registration, and tests.

## Coordination with #3275 (worldbelief → experimental)

#3275 (approved) relegates worldbelief to `dimos/experimental/world_belief/`, including moving `xarm/blueprints/worldbelief.py` → `experimental/world_belief/xarm6_blueprint.py`.

By design this PR stays green against `main` and does **not** pre-empt those paths. `worldbelief_sim.py` intentionally stays in the xarm package. Once #3275 lands, this blueprint needs exactly one import line changed:

```diff
-from dimos.robot.manipulators.xarm.blueprints.worldbelief import worldbelief_stack
+from dimos.experimental.world_belief.xarm6_blueprint import worldbelief_stack
```

plus the same substitution for the two lazy imports in `test_worldbelief_sim_blueprint.py`. Note #3275 renames `worldbelief.py` at 96% similarity, so its move and this PR's edits to that file will need a merge resolution whichever order they land in.

## Rebase notes (onto #3183)

Rebased onto current main. Two API changes absorbed:

- `dimos/robot/manipulators/test_blueprints.py` was **deleted** by #3183, so the blueprint-composition tests moved to a scoped `dimos/robot/manipulators/xarm/test_worldbelief_sim_blueprint.py` rather than resurrecting the deleted file.
- `RobotModelConfig.coordinator_task_name` was removed by #3183; the test now derives the expected task name from `trajectory_task_name(robot.name)`.
- `xarm6-planner-only` was dropped from `SELF_HOSTED_BLUEPRINTS` on main; that removal is preserved.

## Validation

Re-run after the rebase, so these reflect #3183's new plan-execution manager.

| | result |
|---|---|
| Launch | 7/7 modules deploy, 0 errors; camera transports wired; arm reaches home |
| Trajectory | `move_to_joints` → "Reached target joint configuration"; 51-point trajectory completes; arm converges toward target (0.530 → 0.546 → 0.558 → 0.6) |
| Scan | "Scan complete: 1 object(s) present" (49 s, 12 frames folded) |
| MCP | server lists 14 skills; `go_home` / `move_to_joints` / `get_robot_state` / `scan` all invoke |
| Agent | `McpClient` deploys and discovers all 14 tools over MCP |
| Tests | 280 pass (blueprint suites + generation + kwargs checks); lint/format clean |

Detected `red ball` vs MJCF ground truth (apple at 0.40, 0.08, 0.17):

| axis | detected | truth | error |
|---|---|---|---|
| X | 0.4094 | 0.40 | +0.94 cm |
| Y | 0.0697 | 0.08 | −1.03 cm |
| Z | 0.0746 | 0.17 | **−9.54 cm** |

## Known issues (the PR ladder)

Documented, not fixed — each is its own rung.

1. **Base-frame disagreement → scan Z reads ~9.5 cm low; pick will fail IK.** `data/xarm6/scene.xml` spawns `link_base` at `pos="0 0 .12"` (plus a pedestal geom), but `make_xarm_model_config` places `base_pose` at the world origin. The sim renders from the true camera pose while perception unprojects using the FK pose. Measured −9.54 cm above, matching prediction. Scan/detect/recall work; pick does not. **Next rung.**
2. **Gripper direction inverted.** `hand.xml`'s driver joint grows as the jaws close; DiMOS positions grow as they open. Needs `gripper_position_inverted` support in `MujocoSimModule`, which main does not have.
3. **Pink IK aborts retries on QP exception.** Needed before pick converges.
4. **`scan` / `recall` exceed the 120 s default RPC timeout.** Server-side the skill succeeds (`SKILL scan result=OK duration_ms=156804.7`) but the MCP layer reports an error at 120 s. Aggravated by (5).
5. **Detector runs on CPU on this box** — `Failed to initialize NVML: Driver/library version mismatch (NVML 595.84)`, so `torch.cuda.is_available()` is False. Environment, not code, but it is what pushes scan past the RPC limit.
6. **`dimos mcp call` hardcodes a 30 s HTTP read timeout**, below the scan's runtime even on the happy path.
7. **Trajectories converge asymptotically.** `move_to_joints`/`go_home` report success while the arm is still travelling; sampling immediately after the call shows it near its start. Repeated `go_home` calls converge (joint 0: 0.417 → 0.021 → 0.013 → 0.008).
8. **Scan prompt sensitivity.** With `["red ball", "orange ball", "cup"]` only the red ball is detected; the orange and cup are missed.

## Not verified

The agent's natural-language exchange could not complete: the available OpenAI key is rejected with 401 `invalid_api_key` (confirmed with a direct `curl` to `api.openai.com`, so it is the credential, not the plumbing). Everything up to the LLM call works — the agent deploys, connects, and discovers all 14 MCP tools.
