### PR TITLE
fix(unitree): stale movement watchdog can no longer stop a newer command

### DIFF
--- a/dimos/robot/unitree/connection.py
+++ b/dimos/robot/unitree/connection.py
@@ -108,7 +108,9 @@ class UnitreeWebRTCConnection(Resource):
     ) -> None:
         self.ip = ip
         self.mode = mode
-        self.stop_timer: threading.Timer | None = None
+        # Auto-stop watchdog deadline. Armed/cancelled/fired only on self.loop's
+        # thread so a stale expiry can never interleave with a newer command.
+        self._watchdog_handle: asyncio.TimerHandle | None = None
         self.cmd_vel_timeout = 0.2
         self._velocity_api = velocity_api
         self._move_ids = SequentialIds()
@@ -157,12 +159,8 @@ class UnitreeWebRTCConnection(Resource):
         pass
 
     def stop(self) -> None:
-        # Cancel timer
-        if self.stop_timer:
-            self.stop_timer.cancel()
-            self.stop_timer = None
-
         async def async_disconnect() -> None:
+            self._cancel_watchdog()
             try:
                 self._publish_movement(0, 0, 0)
                 await self.conn.disconnect()
@@ -199,6 +197,26 @@ class UnitreeWebRTCConnection(Resource):
             data={"lx": -y, "ly": x, "rx": -yaw, "ry": 0},
         )
 
+    # The watchdog handle is only touched from self.loop's thread. The loop
+    # serializes movement publishes, re-arms, cancels and expiry, so a cancel
+    # is decisive: a cancelled deadline can never fire after a newer command.
+
+    def _arm_watchdog(self) -> None:
+        """(Re)start the auto-stop deadline. Loop thread only."""
+        self._cancel_watchdog()
+        self._watchdog_handle = self.loop.call_later(self.cmd_vel_timeout, self._watchdog_expired)
+
+    def _cancel_watchdog(self) -> None:
+        """Cancel the pending auto-stop deadline, if any. Loop thread only."""
+        if self._watchdog_handle is not None:
+            self._watchdog_handle.cancel()
+            self._watchdog_handle = None
+
+    def _watchdog_expired(self) -> None:
+        """Deadline hit with no newer command: halt the base. Loop thread only."""
+        self._watchdog_handle = None
+        self._publish_movement(0, 0, 0)
+
     def move(self, twist: Twist, duration: float = 0.0) -> bool:
         """Send a body-frame movement command using the configured wire API.
 
@@ -213,6 +231,7 @@ class UnitreeWebRTCConnection(Resource):
 
         async def async_move() -> None:
             self._publish_movement(x, y, yaw)
+            self._arm_watchdog()
 
         async def async_move_duration() -> None:
             """Send movement commands continuously for the specified duration."""
@@ -222,15 +241,6 @@ class UnitreeWebRTCConnection(Resource):
             while time.time() - start_time < duration:
                 await async_move()
                 await asyncio.sleep(sleep_time)
-
-        # Cancel existing timer and start a new one
-        if self.stop_timer:
-            self.stop_timer.cancel()
-
-        # Auto-stop after 0.5 seconds if no new commands
-        self.stop_timer = threading.Timer(self.cmd_vel_timeout, self.stop_movement)
-        self.stop_timer.daemon = True
-        self.stop_timer.start()
 
         try:
             if duration > 0:
@@ -498,12 +508,10 @@ class UnitreeWebRTCConnection(Resource):
         return self.video_stream()
 
     def stop_movement(self) -> None:
-        """Halt the base: publish a zero twist and cancel the auto-stop timer."""
-        if self.stop_timer:
-            self.stop_timer.cancel()
-            self.stop_timer = None
+        """Halt the base: cancel the auto-stop deadline and publish a zero twist."""
 
         async def async_stop() -> None:
+            self._cancel_watchdog()
             self._publish_movement(0, 0, 0)
 
         if not self.loop.is_running():
@@ -515,14 +523,10 @@ class UnitreeWebRTCConnection(Resource):
 
     def disconnect(self) -> None:
         """Disconnect from the robot and clean up resources."""
-        # Cancel timer
-        if self.stop_timer:
-            self.stop_timer.cancel()
-            self.stop_timer = None
-
         if hasattr(self, "conn"):
 
             async def async_disconnect() -> None:
+                self._cancel_watchdog()
                 try:
                     await self.conn.disconnect()
                 except:

--- a/dimos/robot/unitree/test_connection.py
+++ b/dimos/robot/unitree/test_connection.py
@@ -15,10 +15,14 @@
 """Unit tests for UnitreeWebRTCConnection.
 
 Pure-Python test suite with no hardware or network. Covers connect() error propagation,
-aes_128_key forwarding, and the UNITREE_AES_128_KEY env var via GlobalConfig.
+aes_128_key forwarding, the UNITREE_AES_128_KEY env var via GlobalConfig, and the
+movement auto-stop watchdog ordering guarantees.
 """
 
+import asyncio
 import json
+import threading
+import time
 from typing import Any
 from unittest.mock import ANY, AsyncMock, MagicMock, call
 
@@ -31,6 +35,7 @@ from dimos.msgs.geometry_msgs.Twist import Twist
 from dimos.msgs.geometry_msgs.Vector3 import Vector3
 from dimos.robot.unitree import connection as conn_mod
 from dimos.robot.unitree.connection import UnitreeWebRTCConnection
+from dimos.utils.testing.waiting import wait_until
 
 
 def _stub_driver(connect_exc: Exception | None = None) -> MagicMock:
@@ -165,3 +170,113 @@ def test_global_config_reads_unitree_aes_128_key_env(monkeypatch: pytest.MonkeyP
     """The key enters via GlobalConfig, read from the UNITREE_AES_128_KEY env var."""
     monkeypatch.setenv("UNITREE_AES_128_KEY", "ee" * 16)
     assert GlobalConfig().unitree_aes_128_key == "ee" * 16
+
+
+def _forward_twist(x: float) -> Twist:
+    return Twist(linear=Vector3(x, 0.0, 0.0), angular=Vector3(0.0, 0.0, 0.0))
+
+
+def _joystick_wire(x: float) -> dict[str, float]:
+    """WIRELESS_CONTROLLER payload for a pure-forward twist of magnitude x."""
+    return {"lx": 0, "ly": x, "rx": 0, "ry": 0}
+
+
+_ZERO_TWIST_WIRE = _joystick_wire(0)
+
+
+def _published_data(driver: MagicMock) -> list[dict[str, float]]:
+    """Every movement payload sent over the data channel, in publish order."""
+    return [
+        c.kwargs["data"] for c in driver.datachannel.pub_sub.publish_without_callback.call_args_list
+    ]
+
+
+def _watchdog_armed(conn: UnitreeWebRTCConnection) -> bool:
+    """Read the watchdog handle on the connection loop, where it is owned."""
+
+    async def read() -> bool:
+        return conn._watchdog_handle is not None
+
+    return asyncio.run_coroutine_threadsafe(read(), conn.loop).result(timeout=2.0)
+
+
+def test_watchdog_zeroes_movement_after_timeout(built_connection: Any) -> None:
+    """With no follow-up command, the watchdog halts the base after cmd_vel_timeout."""
+    conn, driver = built_connection
+    conn.cmd_vel_timeout = 0.05
+
+    assert conn.move(_forward_twist(1.0))
+
+    wait_until(lambda: len(_published_data(driver)) >= 2, timeout=2.0, interval=0.01)
+    assert _published_data(driver) == [_joystick_wire(1.0), _ZERO_TWIST_WIRE]
+
+
+def test_stale_watchdog_expiry_does_not_stop_newer_command(
+    built_connection: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression test for #3046: a watchdog expiry that has already started when a
+    replacement command arrives must not zero out that command, and the replacement's
+    own watchdog must still be armed afterwards."""
+    conn, driver = built_connection
+    conn.cmd_vel_timeout = 0.01
+
+    expiry_started = threading.Event()
+    release_expiry = threading.Event()
+    real_expired = conn._watchdog_expired
+
+    def gated_expired() -> None:
+        expiry_started.set()
+        release_expiry.wait(timeout=2.0)
+        real_expired()
+
+    monkeypatch.setattr(conn, "_watchdog_expired", gated_expired)
+
+    assert conn.move(_forward_twist(1.0))
+    assert expiry_started.wait(timeout=2.0), "first watchdog never expired"
+
+    # The first expiry is past cancellation and holds the loop. Issue the
+    # replacement command while it is in flight; a long timeout keeps the
+    # replacement's own watchdog from firing during the assertions below.
+    conn.cmd_vel_timeout = 0.5
+    mover = threading.Thread(target=lambda: conn.move(_forward_twist(2.0)))
+    mover.start()
+    time.sleep(0.05)  # let the replacement enqueue behind the gated expiry
+    release_expiry.set()
+    mover.join(timeout=2.0)
+    assert not mover.is_alive()
+
+    # The stale zero landed before the replacement command, never after it.
+    data = _published_data(driver)
+    assert data[-1] == _joystick_wire(2.0)
+    assert data[-2] == _ZERO_TWIST_WIRE
+
+    # The replacement re-armed the watchdog, which then halts the base as usual.
+    wait_until(lambda: len(_published_data(driver)) == len(data) + 1, timeout=2.0, interval=0.01)
+    assert _published_data(driver)[-1] == _ZERO_TWIST_WIRE
+
+
+def test_stop_movement_disarms_watchdog(built_connection: Any) -> None:
+    """An explicit stop publishes one zero twist and cancels the pending deadline."""
+    conn, driver = built_connection
+    conn.cmd_vel_timeout = 5.0  # long enough that only stop_movement can publish zero
+
+    assert conn.move(_forward_twist(1.0))
+    conn.stop_movement()
+
+    assert _published_data(driver) == [_joystick_wire(1.0), _ZERO_TWIST_WIRE]
+    assert not _watchdog_armed(conn)
+
+
+def test_duration_move_is_not_zeroed_mid_stream(built_connection: Any) -> None:
+    """A duration move outliving cmd_vel_timeout keeps re-arming the watchdog:
+    the only zero twist is the final stop, never one injected mid-stream."""
+    conn, driver = built_connection
+    conn.cmd_vel_timeout = 0.1
+
+    assert conn.move(_forward_twist(1.0), duration=0.3)
+
+    data = _published_data(driver)
+    assert len(data) >= 3  # repeated move publishes plus the final stop
+    assert all(d == _joystick_wire(1.0) for d in data[:-1])
+    assert data[-1] == _ZERO_TWIST_WIRE
+    assert not _watchdog_armed(conn)


### PR DESCRIPTION
## Contribution path

- Linked issue or discussion: #3046

## Problem

The auto-stop watchdog runs on a `threading.Timer` thread. `Timer.cancel()` has no effect once the callback has started, so an expired watchdog from a previous `move()` can publish its zero twist after a newer command and halt it. The stale `stop_movement()` also cancels `self.stop_timer`, which by then points at the newer command's timer, so the newer command loses its own watchdog too. The same root cause means a duration move longer than `cmd_vel_timeout` gets a zero twist injected in the middle of its command stream.

## Solution

Move the watchdog onto the connection event loop, as suggested in the issue. `move()` now publishes and re-arms the deadline inside the same coroutine. Expiry and cancellation run on the loop as well. Since the loop serializes publish, re-arm, cancel and expiry, a cancelled deadline can never fire after a replacement command. No locks or generation counter needed. Duration moves re-arm on every publish, so the watchdog no longer interrupts them mid-stream.

## Tests

Four new tests in `test_connection.py`, reusing the existing stubbed driver fixture (no hardware, real event loop). Assertions are made on the recorded wire messages, not internal state.

1. `test_stale_watchdog_expiry_does_not_stop_newer_command`: the regression test requested in the issue. The first expiry callback is gated with a `threading.Event`, so the test holds it in flight while a replacement `move()` is issued from another thread. After releasing the gate, the newer command must be the last message on the wire (the stale zero may only land before it), and the replacement's own watchdog must still fire afterwards.
2. `test_watchdog_zeroes_movement_after_timeout`: baseline. With no follow-up command, the watchdog publishes a zero twist after `cmd_vel_timeout`.
3. `test_stop_movement_disarms_watchdog`: an explicit stop publishes exactly one zero twist and leaves no armed deadline. The deadline check runs on the loop thread, where the handle is owned.
4. `test_duration_move_is_not_zeroed_mid_stream`: a 0.3s duration move with a 0.1s timeout publishes only movement commands until the final stop. This test fails on current main because the old watchdog fires mid-stream.

## How to Test

`uv run pytest dimos/robot/unitree/test_connection.py`

## AI assistance

Claude Code (Fable 5) assisted parts of the implementation and tests. Reviewed and understood line by line.

## Checklist

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).