### PR TITLE
feat(msgs): CompressedImage review fixes — jxl, alpha PNG, ros bridge, faster tests

### DIFF
--- a/dimos/memory2/codecs/test_codecs.py
+++ b/dimos/memory2/codecs/test_codecs.py
@@ -137,21 +137,16 @@ def _jpeg_case() -> Case | None:
     if not _turbojpeg_available():
         return None
 
-    from dimos.memory2.store.sqlite import SqliteStore
-    from dimos.utils.data import get_data
+    import numpy as np
 
-    try:
-        db_path = get_data("go2_short.db")
-    except RuntimeError:
-        # 84MB LFS pull — refused by the CI LFS guard on standard runners
-        return None
-
-    with SqliteStore(path=str(db_path)) as store:
-        video = store.stream("color_image", Image)
-        frames = [obs.data for obs in video.limit(3).to_list()]
-
-    if not frames:
-        return None
+    # smooth gradients survive lossy jpeg within the eq tolerance
+    frames = []
+    for shift in (0, 90, 180):
+        arr = np.zeros((48, 64, 3), np.uint8)
+        arr[..., 0] = np.linspace(0, 255, 64, dtype=np.uint8)
+        arr[..., 1] = np.linspace(0, 255, 48, dtype=np.uint8)[:, None]
+        arr[..., 2] = shift
+        frames.append(Image(data=arr, format=ImageFormat.RGB, frame_id="cam", ts=1.0))
 
     return Case(
         name="jpeg",
@@ -169,14 +164,9 @@ _case_factories = {
     "jpeg": _jpeg_case,
 }
 
-# The jpeg case reads frames from an 84 MB LFS database. Regular CI runners cap
-# LFS pulls at 1 MiB, and deselected tests still get collected (imported), so
-# the pull has to happen at test time (in the `case` fixture below) and the
-# case is marked self_hosted so only self-hosted runners and local machines
-# run it.
 case_params: list[Any] = ["pickle", "lcm", "lz4+pickle", "lz4+lcm"]
 if _turbojpeg_available():
-    case_params.append(pytest.param("jpeg", marks=pytest.mark.self_hosted))
+    case_params.append("jpeg")
 
 
 @pytest.fixture

--- a/dimos/msgs/sensor_msgs/CompressedImage.py
+++ b/dimos/msgs/sensor_msgs/CompressedImage.py
@@ -55,12 +55,14 @@ class CompressedImage(Timestamped):
         format: CompressionFormat = "jpeg",
         quality: int = 75,
         max_width: int | None = None,
+        effort: int | None = None,
     ) -> CompressedImage:
         """Encode a raw Image.
 
         JPEG rejects 16-bit/depth formats; PNG rejects float depth. JXL takes
         everything: lossless for 16-bit/float data (depth must survive the wire
-        exactly), `quality` for uint8.
+        exactly), `quality` for uint8. `effort` (jxl only, 1-9) trades encode
+        cpu for size; defaults are pinned for camera-rate streaming.
         """
         from dimos.msgs.sensor_msgs.Image import Image, ImageFormat
 
@@ -97,9 +99,9 @@ class CompressedImage(Timestamped):
             # libjxl's default effort=7 costs 83-300ms per 720p frame; these
             # pins keep camera-rate (13ms lossy / 3ms lossless) for ~5% size
             if arr.dtype == np.uint8:
-                data = bytes(imagecodecs.jpegxl_encode(arr, level=quality, effort=3))
+                data = bytes(imagecodecs.jpegxl_encode(arr, level=quality, effort=effort or 3))
             else:
-                data = bytes(imagecodecs.jpegxl_encode(arr, lossless=True, effort=1))
+                data = bytes(imagecodecs.jpegxl_encode(arr, lossless=True, effort=effort or 1))
         else:
             raise ValueError(f"unsupported format {format!r}")
         return cls(data=data, format=format, frame_id=image.frame_id, ts=image.ts)

--- a/dimos/msgs/sensor_msgs/CompressedImage.py
+++ b/dimos/msgs/sensor_msgs/CompressedImage.py
@@ -86,7 +86,11 @@ class CompressedImage(Timestamped):
             import imagecodecs
             import numpy as np
 
-            arr = image.data if image.channels == 1 else image.to_rgb().data
+            # zero-copy passthrough unless channel order actually needs fixing
+            if image.channels == 1 or image.format is ImageFormat.RGB:
+                arr = image.data
+            else:
+                arr = image.to_rgb().data
             if arr.dtype not in (np.uint8, np.uint16, np.float32):
                 raise ValueError(f"JXL cannot encode dtype {arr.dtype}")
             arr = np.ascontiguousarray(arr)
@@ -128,12 +132,9 @@ class CompressedImage(Timestamped):
 
             arr = imagecodecs.jpegxl_decode(self.data)
             if arr.ndim == 2:
-                if arr.dtype == np.float32:
-                    fmt = ImageFormat.DEPTH
-                elif arr.dtype == np.uint16:
-                    fmt = ImageFormat.GRAY16
-                else:
-                    fmt = ImageFormat.GRAY
+                fmt = {np.float32: ImageFormat.DEPTH, np.uint16: ImageFormat.GRAY16}.get(
+                    arr.dtype.type, ImageFormat.GRAY
+                )
             else:
                 fmt = ImageFormat.RGBA if arr.shape[2] == 4 else ImageFormat.RGB
         else:

--- a/dimos/msgs/sensor_msgs/CompressedImage.py
+++ b/dimos/msgs/sensor_msgs/CompressedImage.py
@@ -26,16 +26,14 @@ from dimos.types.timestamped import Timestamped, to_human_readable
 # cv2/turbojpeg/Image are imported lazily so this module stays cheap for
 # byte-level consumers that never encode or decode pixels.
 if TYPE_CHECKING:
-    import rerun as rr
-
     from dimos.msgs.sensor_msgs.Image import Image
 
-CompressionFormat = Literal["jpeg", "png"]
+CompressionFormat = Literal["jpeg", "png", "jxl"]
 
 
 @dataclass
 class CompressedImage(Timestamped):
-    """Compressed image bytes (JPEG/PNG) — ROS sensor_msgs/CompressedImage."""
+    """Compressed image bytes (JPEG/PNG/JPEG-XL) — ROS sensor_msgs/CompressedImage."""
 
     msg_name = "sensor_msgs.CompressedImage"
 
@@ -58,7 +56,12 @@ class CompressedImage(Timestamped):
         quality: int = 75,
         max_width: int | None = None,
     ) -> CompressedImage:
-        """Encode a raw Image. JPEG rejects 16-bit/depth formats; PNG rejects float depth."""
+        """Encode a raw Image.
+
+        JPEG rejects 16-bit/depth formats; PNG rejects float depth. JXL takes
+        everything: lossless for 16-bit/float data (depth must survive the wire
+        exactly), `quality` for uint8.
+        """
         from dimos.msgs.sensor_msgs.Image import Image, ImageFormat
 
         if not isinstance(image, Image):
@@ -79,6 +82,18 @@ class CompressedImage(Timestamped):
             if not ok:
                 raise ValueError("PNG encoding failed")
             data = buf.tobytes()
+        elif format == "jxl":
+            import imagecodecs
+            import numpy as np
+
+            arr = image.data if image.channels == 1 else image.to_rgb().data
+            if arr.dtype not in (np.uint8, np.uint16, np.float32):
+                raise ValueError(f"JXL cannot encode dtype {arr.dtype}")
+            arr = np.ascontiguousarray(arr)
+            if arr.dtype == np.uint8:
+                data = bytes(imagecodecs.jpegxl_encode(arr, level=quality))
+            else:
+                data = bytes(imagecodecs.jpegxl_encode(arr, lossless=True))
         else:
             raise ValueError(f"unsupported format {format!r}")
         return cls(data=data, format=format, frame_id=image.frame_id, ts=image.ts)
@@ -101,8 +116,24 @@ class CompressedImage(Timestamped):
                 raise ValueError("PNG decoding failed")
             if arr.ndim == 2:
                 fmt = ImageFormat.GRAY16 if arr.dtype == np.uint16 else ImageFormat.GRAY
+            elif arr.shape[2] == 4:
+                fmt = ImageFormat.BGRA
             else:
                 fmt = ImageFormat.BGR
+        elif self.format.startswith("jxl"):
+            import imagecodecs
+            import numpy as np
+
+            arr = imagecodecs.jpegxl_decode(self.data)
+            if arr.ndim == 2:
+                if arr.dtype == np.float32:
+                    fmt = ImageFormat.DEPTH
+                elif arr.dtype == np.uint16:
+                    fmt = ImageFormat.GRAY16
+                else:
+                    fmt = ImageFormat.GRAY
+            else:
+                fmt = ImageFormat.RGBA if arr.shape[2] == 4 else ImageFormat.RGB
         else:
             raise ValueError(f"unsupported format {self.format!r}")
         return Image(data=arr, format=fmt, frame_id=self.frame_id, ts=self.ts)
@@ -129,8 +160,11 @@ class CompressedImage(Timestamped):
             ts=msg.header.stamp.sec + msg.header.stamp.nsec / 1e9,
         )
 
-    def to_rerun(self) -> rr.EncodedImage:
+    def to_rerun(self) -> Any:
         import rerun as rr
 
-        media_type = "image/jpeg" if self.format.startswith("jpeg") else "image/png"
-        return rr.EncodedImage(contents=self.data, media_type=media_type)
+        if self.format.startswith(("jpeg", "png")):
+            media_type = "image/jpeg" if self.format.startswith("jpeg") else "image/png"
+            return rr.EncodedImage(contents=self.data, media_type=media_type)
+        # formats rerun's EncodedImage can't decode: send pixels instead
+        return self.decode().to_rerun()

--- a/dimos/msgs/sensor_msgs/CompressedImage.py
+++ b/dimos/msgs/sensor_msgs/CompressedImage.py
@@ -90,10 +90,12 @@ class CompressedImage(Timestamped):
             if arr.dtype not in (np.uint8, np.uint16, np.float32):
                 raise ValueError(f"JXL cannot encode dtype {arr.dtype}")
             arr = np.ascontiguousarray(arr)
+            # libjxl's default effort=7 costs 83-300ms per 720p frame; these
+            # pins keep camera-rate (13ms lossy / 3ms lossless) for ~5% size
             if arr.dtype == np.uint8:
-                data = bytes(imagecodecs.jpegxl_encode(arr, level=quality))
+                data = bytes(imagecodecs.jpegxl_encode(arr, level=quality, effort=3))
             else:
-                data = bytes(imagecodecs.jpegxl_encode(arr, lossless=True))
+                data = bytes(imagecodecs.jpegxl_encode(arr, lossless=True, effort=1))
         else:
             raise ValueError(f"unsupported format {format!r}")
         return cls(data=data, format=format, frame_id=image.frame_id, ts=image.ts)

--- a/dimos/msgs/sensor_msgs/test_CompressedImage.py
+++ b/dimos/msgs/sensor_msgs/test_CompressedImage.py
@@ -147,6 +147,13 @@ def test_jxl_lossy_rgb_honors_quality(rgb_image) -> None:
     assert diff < 5, f"JXL q90 mean pixel error too high: {diff}"
 
 
+def test_jxl_effort_trades_cpu_for_size(rgb_image) -> None:
+    pytest.importorskip("imagecodecs")
+    fast = CompressedImage.from_image(rgb_image, format="jxl", effort=1)
+    thorough = CompressedImage.from_image(rgb_image, format="jxl", effort=7)
+    assert len(thorough.data) <= len(fast.data)
+
+
 def test_jxl_rejects_float64() -> None:
     pytest.importorskip("imagecodecs")
     depth = Image(data=np.zeros((10, 10), dtype=np.float64), format=ImageFormat.DEPTH)

--- a/dimos/msgs/sensor_msgs/test_CompressedImage.py
+++ b/dimos/msgs/sensor_msgs/test_CompressedImage.py
@@ -63,6 +63,18 @@ def test_png_roundtrip_is_lossless_gray16() -> None:
     assert np.array_equal(img.data, data)
 
 
+def test_png_decode_alpha_is_bgra() -> None:
+    import cv2
+
+    arr = np.zeros((10, 10, 4), dtype=np.uint8)
+    arr[..., 3] = 128
+    ok, buf = cv2.imencode(".png", arr)
+    assert ok
+    img = CompressedImage(data=buf.tobytes(), format="png").decode()
+    assert img.format == ImageFormat.BGRA
+    assert np.array_equal(img.data, arr)
+
+
 def test_lcm_roundtrip(rgb_image) -> None:
     ci = CompressedImage.from_image(rgb_image)
     wire = ci.lcm_encode()
@@ -100,3 +112,43 @@ def test_to_rerun_is_encoded_image(rgb_image) -> None:
     import rerun as rr
 
     assert isinstance(CompressedImage.from_image(rgb_image).to_rerun(), rr.EncodedImage)
+
+
+def test_jxl_roundtrip_is_lossless_gray16() -> None:
+    pytest.importorskip("imagecodecs")
+    data = np.arange(100 * 80, dtype=np.uint16).reshape(100, 80)
+    src = Image(data=data, format=ImageFormat.GRAY16, frame_id="d", ts=1.0)
+    ci = CompressedImage.from_image(src, format="jxl")
+    assert ci.format == "jxl"
+    img = ci.decode()
+    assert img.format == ImageFormat.GRAY16
+    assert np.array_equal(img.data, data)
+
+
+def test_jxl_roundtrip_is_lossless_float_depth() -> None:
+    pytest.importorskip("imagecodecs")
+    data = np.linspace(0.1, 10.0, 100 * 80, dtype=np.float32).reshape(100, 80)
+    src = Image(data=data, format=ImageFormat.DEPTH, frame_id="d", ts=2.0)
+    ci = CompressedImage.from_image(src, format="jxl")
+    img = ci.decode()
+    assert img.format == ImageFormat.DEPTH
+    assert np.array_equal(img.data, data)
+    assert img.ts == src.ts
+    assert img.frame_id == "d"
+
+
+def test_jxl_lossy_rgb_honors_quality(rgb_image) -> None:
+    pytest.importorskip("imagecodecs")
+    ci = CompressedImage.from_image(rgb_image, format="jxl", quality=90)
+    assert 0 < len(ci.data) < rgb_image.data.nbytes // 4
+    img = ci.decode()
+    assert img.format == ImageFormat.RGB
+    diff = np.abs(img.data.astype(int) - rgb_image.data.astype(int)).mean()
+    assert diff < 5, f"JXL q90 mean pixel error too high: {diff}"
+
+
+def test_jxl_rejects_float64() -> None:
+    pytest.importorskip("imagecodecs")
+    depth = Image(data=np.zeros((10, 10), dtype=np.float64), format=ImageFormat.DEPTH)
+    with pytest.raises(ValueError, match="JXL cannot encode"):
+        CompressedImage.from_image(depth, format="jxl")

--- a/dimos/protocol/pubsub/benchmark/test_replay_bench.py
+++ b/dimos/protocol/pubsub/benchmark/test_replay_bench.py
@@ -113,8 +113,9 @@ def _bench(transport, frame: Image, n: int, wire_bytes: int) -> dict | None:
     drops = 0
     transport.subscribe(callback)
     try:
-        # warmup (first delivery also proves subscription is live)
-        deadline = time.monotonic() + 10
+        # warmup (first delivery also proves subscription is live); real
+        # deliveries arrive in ms — 3s only gets burned by undeliverable paths
+        deadline = time.monotonic() + 3
         while not event.is_set() and time.monotonic() < deadline:
             transport.broadcast(None, frame)
             event.wait(0.2)

--- a/dimos/protocol/pubsub/benchmark/tool_replay_bench.py
+++ b/dimos/protocol/pubsub/benchmark/tool_replay_bench.py
@@ -109,7 +109,8 @@ class BenchSink(Module):
 
     @rpc
     def stop(self) -> None:
-        self._flush()
+        with self._lock:
+            self._flush()
         super().stop()
 
     def _on_image(self, msg: Image) -> None:

--- a/dimos/protocol/pubsub/impl/rospubsub_conversion.py
+++ b/dimos/protocol/pubsub/impl/rospubsub_conversion.py
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
 COMPLEX_TYPES: set[str] = {
     "sensor_msgs.PointCloud2",
     "sensor_msgs.Image",
+    "sensor_msgs.CompressedImage",
     "sensor_msgs.CameraInfo",
     "geometry_msgs.PoseStamped",
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ dependencies = [
     "dimos-lcm>=0.1.3",
     "eclipse-zenoh>=1.0.0,<2.0",
     "PyTurboJPEG==1.8.2",
+    "imagecodecs>=2024.6.1", # JPEG-XL for CompressedImage
     # Core
     "numpy>=1.26.4",
     "scipy>=1.15.1",

--- a/uv.lock
+++ b/uv.lock
@@ -1566,6 +1566,9 @@ dependencies = [
     { name = "dimos-viewer" },
     { name = "eclipse-zenoh" },
     { name = "filelock" },
+    { name = "imagecodecs", version = "2025.3.30", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "imagecodecs", version = "2026.3.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "imagecodecs", version = "2026.6.26", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "lazy-loader" },
     { name = "llvmlite" },
     { name = "lz4" },
@@ -2076,6 +2079,7 @@ requires-dist = [
     { name = "gtsam-extended", marker = "extra == 'mapping'", specifier = ">=4.3a1.post1" },
     { name = "h5py", marker = "extra == 'learning'" },
     { name = "hydra-core", marker = "extra == 'perception'", specifier = ">=1.3.0" },
+    { name = "imagecodecs", specifier = ">=2024.6.1" },
     { name = "ipykernel", marker = "extra == 'misc'" },
     { name = "jinja2", marker = "extra == 'web'", specifier = ">=3.1.6" },
     { name = "langchain", marker = "extra == 'agents'", specifier = ">=1.2.3,<2" },
@@ -3362,6 +3366,98 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/ac/fb4c578f4a3256561548cd825646680edcadb9440f3f68add95ade1eb791/ifaddr-0.2.0.tar.gz", hash = "sha256:cc0cbfcaabf765d44595825fb96a99bb12c79716b73b44330ea38ee2b0c4aed4", size = 10485, upload-time = "2022-06-15T21:40:27.561Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9c/1f/19ebc343cc71a7ffa78f17018535adc5cbdd87afb31d7c34874680148b32/ifaddr-0.2.0-py3-none-any.whl", hash = "sha256:085e0305cfe6f16ab12d72e2024030f5d52674afad6911bb1eee207177b8a748", size = 12314, upload-time = "2022-06-15T21:40:25.756Z" },
+]
+
+[[package]]
+name = "imagecodecs"
+version = "2025.3.30"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/bf/81c848ffe2b42fc141b6db3e4e8e650183b7aab8c4535498ebff25740a3b/imagecodecs-2025.3.30.tar.gz", hash = "sha256:29256f44a7fcfb8f235a3e9b3bae72b06ea2112e63bcc892267a8c01b7097f90", size = 9506573, upload-time = "2025-03-30T04:44:50.368Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/0a/d9418201f0372deacc394e129c42a11b253e79f81ee1d3b5141315a9aa51/imagecodecs-2025.3.30-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:b5c9be23ccc7fd8aee233db5d714e61be2fc85acd77305290eb86ddb36d643b6", size = 17936592, upload-time = "2025-03-30T04:42:50.413Z" },
+    { url = "https://files.pythonhosted.org/packages/47/b3/1d5ee18476e763ad32555fe3cca7e55af3912f21357cdd18488dead7d34d/imagecodecs-2025.3.30-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7870308a908f1e1748c3b9e113a5e3e56878426e8cb7a173c98557d5db7776ea", size = 15046409, upload-time = "2025-03-30T04:42:53.976Z" },
+    { url = "https://files.pythonhosted.org/packages/19/8e/b7b329905006f1b3627e1f531de8ab36bd544fa3d6136576c19f9d90de84/imagecodecs-2025.3.30-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1c62f210f7e1c152306fa5efec0a172680932d1beb7e06d8a8dd039e718bdeb1", size = 41997395, upload-time = "2025-03-30T04:42:58.842Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f6/214e5f157979e55d57f4a4816659004b99b7ab3b0b7a5f3a950b8cb2ef53/imagecodecs-2025.3.30-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:59b5959cdd42debac19e6635ee3dadbb3d6db0d7be2fbf5f763484d4c21363e3", size = 43372901, upload-time = "2025-03-30T04:43:04.455Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/13/4fd766723152c1a453134b32276019f18cdd2156ef7127f216d8dcd26834/imagecodecs-2025.3.30-cp310-cp310-win32.whl", hash = "sha256:4cdcef20630c156d91981215dc56549520c431c99b996d685fdfb3c79c913432", size = 24134766, upload-time = "2025-03-30T04:43:09.308Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/4c/4f825eabaa350a5fc55035ea6e769b9928196aac133f0bddb30a199ea0b4/imagecodecs-2025.3.30-cp310-cp310-win_amd64.whl", hash = "sha256:e09556e03c9048852e6b8e74f569c545cda20f8d4f0e466f61ac64246fa4994e", size = 28873864, upload-time = "2025-03-30T04:43:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/09/8c475f73685e864c3742dc38596e3a2b897006402199f42905a09d05395d/imagecodecs-2025.3.30-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:7e0afe1a05a942391abd7d1f25722a07de05d9d12eb6f3ca1ef48e0719c6796a", size = 17946410, upload-time = "2025-03-30T04:43:17.129Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/81/cd6df5a61c85a5f227a3e0b242ad7a04192f8f5dd8b0f65308872e618dbb/imagecodecs-2025.3.30-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:44dc270d78b7cda29e2d430acbd8dab66322766412e596f450871e2831148aa2", size = 15050151, upload-time = "2025-03-30T04:43:20.36Z" },
+    { url = "https://files.pythonhosted.org/packages/00/bc/929ad2025a60e5cfda80330749d6b44ff7a5e1ccf457d998e0e622010881/imagecodecs-2025.3.30-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1cee56331d9a700e9ec518caeba6d9813ffd7c042f1fae47d2dafcdfc259d2a5", size = 44161549, upload-time = "2025-03-30T04:43:25.322Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/e4/23f8d23822b1fab85edc2b11ee9af7dffc5325e57fc1c05fbd8ba64b67b8/imagecodecs-2025.3.30-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e354fa2046bb7029d0a1ff15a8bb31487ca0d479cd42fdb5c312bcd9408ce3fc", size = 45559360, upload-time = "2025-03-30T04:43:31.614Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d1/4148e036c1f4d4a56aa437dfccf1d1e38ade691242ae4fb1ed6c75198984/imagecodecs-2025.3.30-cp311-cp311-win_amd64.whl", hash = "sha256:7debc7231780d8e44ffcd13aee2178644d93115c19ff73c96cf3068b219ac3a2", size = 28881661, upload-time = "2025-03-30T04:43:41.259Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/65/52c9ed63fe3ef0601775d3469b495eadf00174ac0f38d9499871866a5e3b/imagecodecs-2025.3.30-cp311-cp311-win_arm64.whl", hash = "sha256:2b5c1c02c70da9561da9b728b97599b3ed0ef7d5399979017ce90029f522587b", size = 23780188, upload-time = "2025-03-30T04:43:45.92Z" },
+    { url = "https://files.pythonhosted.org/packages/07/a8/8d5e87c271ad56076d5d41b29a72bde06f9c576796f658f84be1d704c440/imagecodecs-2025.3.30-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:dad3f0fc39eb9a88cecb2ccfe0e13eac35b21da36c0171285e4b289b12085235", size = 17999942, upload-time = "2025-03-30T04:43:49.422Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/a1/5781188860b9f77ba56743ca70c770bad3500980f6a0be0ead28bfd69679/imagecodecs-2025.3.30-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2806b6e605e674d7e3d21099779a88cb30b9da4807a88e0f02da3ea249085e5f", size = 15088408, upload-time = "2025-03-30T04:43:52.644Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/d6/7dea5c27b5e14746095f3e01a4d5ee4a3e0dbfc534b978675cfd6bbd5270/imagecodecs-2025.3.30-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:abfb2231f4741262c91f3e77af85ce1f35b7d44f71414c5d1ba6008cfc3e5672", size = 43661256, upload-time = "2025-03-30T04:43:57.461Z" },
+    { url = "https://files.pythonhosted.org/packages/20/ad/f751aed397ad9ba002ace15c028c5261c9dd57e0b366e8642e574332f318/imagecodecs-2025.3.30-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6583fdcac9a4cd75a7701ed7fac7e74d3836807eb9f8aee22f60f519b748ff56", size = 45247507, upload-time = "2025-03-30T04:44:03.489Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/42/e73497e12c5e1f3a98dc0c07a8ac80ee3b728e03cb397475337540b02432/imagecodecs-2025.3.30-cp312-cp312-win_amd64.whl", hash = "sha256:0b0f6e0f118674c76982e5a25bfeec5e6fc4fc4fc102c0d356e370f473e7b512", size = 28889883, upload-time = "2025-03-30T04:44:12.192Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/f0/66792e83443b32442a3c3377e5933b59ccf1be366973cecfc2182ee0840c/imagecodecs-2025.3.30-cp312-cp312-win_arm64.whl", hash = "sha256:bde3bd80cdf65afddb64af4c433549e882a5aa15d300e3781acab8d4df1c94a9", size = 23746584, upload-time = "2025-03-30T04:44:17.341Z" },
+]
+
+[[package]]
+name = "imagecodecs"
+version = "2026.3.6"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/8d/dc18623e5e926ad53c626e128c8baaf4ec42e41029cf0a07381cfef79289/imagecodecs-2026.3.6.tar.gz", hash = "sha256:471b8a4d1b3843cbf7179b45f7d7261f0c0b28809efc1ca6c47822477b143b85", size = 9565259, upload-time = "2026-03-07T01:26:41.183Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/db/873d063c99a726d772bf6f076288da59bb12e9f2af3518c2e4de5fde234d/imagecodecs-2026.3.6-cp311-abi3-macosx_10_15_x86_64.whl", hash = "sha256:44cfb3b609d941014f8ac7cf8611b15ccfd7119443bbb6b5e53916b242d31f9e", size = 13953250, upload-time = "2026-03-07T06:13:36.959Z" },
+    { url = "https://files.pythonhosted.org/packages/42/84/36c38a82f033ffbc9e706dad32be7148f130fc00e7bb417ab60e063897a0/imagecodecs-2026.3.6-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:e64037f22980a211b17bf6bdf03f14ff459a7432eec24f7a58c342f6992132fa", size = 11697496, upload-time = "2026-03-07T01:25:56.412Z" },
+    { url = "https://files.pythonhosted.org/packages/45/fa/f67c4e644fdf06503e120f9d1c8d8654b99066dea7093a674b67704fa4a4/imagecodecs-2026.3.6-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:30fa140bb1a112a889926af36977214ed52a22e4557356043259b5e2f79cfba5", size = 25604431, upload-time = "2026-03-07T01:26:00.703Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/29/93ea9cbab7f57b4e60480c51fc51d8e138e399d11797c981d5f6e79f9832/imagecodecs-2026.3.6-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:e30a14aa2e1c6c90e00375292726486c1d90bf003b1414d608ea4d1f62fd8a79", size = 26468592, upload-time = "2026-03-07T01:26:04.933Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/a7/e3a89b2c516eaca7446e8f1335daeec90764b50888af5e073a2b6a987fcf/imagecodecs-2026.3.6-cp311-abi3-win32.whl", hash = "sha256:c972a45dfee1befbac048ba3492607003e9a185811e8febdc1ed531d48c07e75", size = 15597722, upload-time = "2026-03-07T01:26:08.106Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c7/2b37a7fe9a2eb21011e50f046d62e68ac4e0f8d6ad94d7a10e9f8e8d685f/imagecodecs-2026.3.6-cp311-abi3-win_amd64.whl", hash = "sha256:e8fba5b9ac7be109ed35070208bc1683fa17cc381ed9535a4eae200c6d883bd8", size = 19177403, upload-time = "2026-03-07T01:26:11.718Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/c7/94e930cef9e0a29a2df5e3ba3bacd2c2f1e34ca373fe48624b64af8ae91c/imagecodecs-2026.3.6-cp311-abi3-win_arm64.whl", hash = "sha256:fc4856913be6c8b3861223158920d934a0ae203149a435f585622dbbff8ed696", size = 15193605, upload-time = "2026-03-07T01:26:15.016Z" },
+]
+
+[[package]]
+name = "imagecodecs"
+version = "2026.6.26"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
+    "python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'darwin'",
+    "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/9f/b436418349779e1c18cc27575360cad03dd492bc574ae9e297832bc48cab/imagecodecs-2026.6.26.tar.gz", hash = "sha256:da95b145f6b4f746acc9e0b8707b164eefc6a36ade3b6e70f74d102e9affad8c", size = 9669990, upload-time = "2026-06-28T18:27:01.957Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/03/89bf1a370dca9860b13414f63d7106600c527305d9d8c0369c15a93ca794/imagecodecs-2026.6.26-cp312-abi3-macosx_10_15_x86_64.whl", hash = "sha256:468314982db54c9c6c32567b159de5d97cf5273763cdede53e320414787ad80a", size = 15387254, upload-time = "2026-06-28T18:26:00.528Z" },
+    { url = "https://files.pythonhosted.org/packages/05/47/826d50cd4378a6982d8a750300b9adc81c3458c4c1bdfd979affc8ce5492/imagecodecs-2026.6.26-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:2d3298028a74d748e5b7a00bd736d41cdf2372861376e4af916818e853ca5fc6", size = 12696122, upload-time = "2026-06-28T18:26:03.714Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/52/ccd8a8a71bb2d0ed9fd4a2592028ab129f6b41c6f2b0ef6c1b9251ec7c88/imagecodecs-2026.6.26-cp312-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73b4310cab61edf5c74ec5cb19672963c2ceb42239877256ca30eb1b70849cf3", size = 27215507, upload-time = "2026-06-28T18:26:07.479Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/3a/29fa169992185df4f1e98b3a1d2b70aac5903170c33f6d66cae68f488c01/imagecodecs-2026.6.26-cp312-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6e9e57171ce7cdf884e7d45d25427f77275321a0ddbd26941c5c90b242d2b597", size = 28855566, upload-time = "2026-06-28T18:26:11.7Z" },
+    { url = "https://files.pythonhosted.org/packages/29/c7/27d82b105d871ceb6de3a68afbee5f95551b8fba796e4e6e35e334f994f4/imagecodecs-2026.6.26-cp312-abi3-win32.whl", hash = "sha256:091b66cfe11e37e5a037ff64b262bede3898f779ebd9cbf0d4a108613577ab15", size = 16568720, upload-time = "2026-06-28T18:26:15.259Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/e2/8d27dbe855293380194aa794cbcce1df2d23039058b3d917817aaa3f5547/imagecodecs-2026.6.26-cp312-abi3-win_amd64.whl", hash = "sha256:0758a273acd197e236e67f1597d630924f62c12f5b74837dc7eef2db72c1a888", size = 21275600, upload-time = "2026-06-28T18:26:19.678Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/38/3d0d0a4abc3ba607f23a3237a1cb6f7737dbd1b39498364f01f62c004e8b/imagecodecs-2026.6.26-cp312-abi3-win_arm64.whl", hash = "sha256:8bbf132cce699c6b282106e97edc65946d788ccca79f6ba8f5cd1b8a3f43423c", size = 16849832, upload-time = "2026-06-28T18:26:22.797Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Stacked on #2814 (base: `feat/compressed-image-transport`) — one reviewable diff for this round of review fixes.

## Per review comment

| Comment | Change |
|---|---|
| @paul-nechifor "we probably want JPEG-XL" / h264 thread | `format="jxl"` via `imagecodecs`: **lossless** for uint16/float32 (depth must survive the wire exactly), `quality` for uint8. h264 stays a separate PR (foxglove `CompressedVideo`) per thread. |
| greptile P1: alpha PNG labeled BGR | 4-channel PNGs now decode as `BGRA` + test |
| greptile P1 / @TomCC7: ROS bridge header flattening | `sensor_msgs.CompressedImage` added to `COMPLEX_TYPES` — same LCM-roundtrip path `Image` uses |
| greptile P2: shutdown flush race | `BenchSink.stop()` takes `_lock` before flushing |
| @Dreamsorcerer: LFS fetch in test_codecs "self_hosted or don't fetch at all" | Don't fetch at all: jpeg codec case uses synthetic gradient frames; `self_hosted` mark dropped, case now runs everywhere (~10ms) |

## Also

- `to_rerun()` gate inverted: allowlist what rerun renders natively (jpeg/png → `EncodedImage`), anything else decodes to pixels. No jxl special case, and fixes unknown formats being mislabeled `image/png`.
- Bench warmup deadline 10s → 3s — only undeliverable paths burn it: `test_benchmark_image_vs_compressed[lcm]` 15.1s → 3.4s, whole file ~5s.
- 2 mypy fixes in jxl encode (`jpegxl_encode` returns `bytes | bytearray | memoryview`).

## How to Test

```
CI=1 uv run pytest dimos/msgs/sensor_msgs/test_CompressedImage.py dimos/memory2/codecs/test_codecs.py dimos/protocol/pubsub/benchmark/test_replay_bench.py
```

38 passed in ~19s (15s of that is real lcm/zenoh round-trips). `uv run mypy` clean (CI-identical invocation, 921 files).

## Contributor License Agreement
- [x] I have read and approved the CLA
