### PR TITLE
perf(msgs): cache TurboJPEG per thread — ctor costs ~2ms per call

### DIFF
--- a/dimos/agents/skills/person_follow.py
+++ b/dimos/agents/skills/person_follow.py
@@ -19,7 +19,6 @@ from typing import Any
 
 import numpy as np
 from reactivex.disposable import Disposable
-from turbojpeg import TurboJPEG
 
 from dimos.agents.annotation import skill
 from dimos.agents.capabilities import CAP_MOVEMENT
@@ -33,7 +32,7 @@ from dimos.models.vl.base import VlModel
 from dimos.models.vl.create import create
 from dimos.msgs.geometry_msgs.Twist import Twist
 from dimos.msgs.sensor_msgs.CameraInfo import CameraInfo
-from dimos.msgs.sensor_msgs.Image import Image, ImageFormat
+from dimos.msgs.sensor_msgs.Image import Image, ImageFormat, _turbojpeg
 from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
 from dimos.navigation.visual.query import get_object_bbox_from_image
 from dimos.navigation.visual_servoing.detection_navigation import DetectionNavigation
@@ -328,5 +327,5 @@ class PersonFollowSkillContainer(Module):
 
 
 def _decode_base64_image(b64: str) -> Image:
-    bgr_array = TurboJPEG().decode(base64.b64decode(b64))
+    bgr_array = _turbojpeg().decode(base64.b64decode(b64))
     return Image(data=bgr_array, format=ImageFormat.BGR)

--- a/dimos/msgs/sensor_msgs/Image.py
+++ b/dimos/msgs/sensor_msgs/Image.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import base64
 from dataclasses import dataclass, field
 from enum import Enum
+import threading
 import time
 from typing import TYPE_CHECKING, Any, Literal, TypedDict
 import warnings
@@ -37,6 +38,21 @@ if TYPE_CHECKING:
     import os
 
     from reactivex.observable import Observable
+    from turbojpeg import TurboJPEG
+
+
+_tj_local = threading.local()
+
+
+def _turbojpeg() -> TurboJPEG:
+    """Per-thread cached TurboJPEG: the constructor costs ~2ms per call and
+    native handles are not safe for concurrent use across threads."""
+    tj = getattr(_tj_local, "tj", None)
+    if tj is None:
+        from turbojpeg import TurboJPEG
+
+        tj = _tj_local.tj = TurboJPEG()
+    return tj
 
 
 class ImageFormat(Enum):
@@ -521,12 +537,11 @@ class Image(Timestamped):
         Returns:
             Raw JPEG bytes.
         """
-        from turbojpeg import TJPF_RGB, TurboJPEG
+        from turbojpeg import TJPF_RGB
 
-        jpeg = TurboJPEG()
         # Canonicalize to RGB so JPEG bytes are deterministic regardless of input format.
         rgb_array = self.to_rgb().data
-        return jpeg.encode(rgb_array, quality=quality, pixel_format=TJPF_RGB)  # type: ignore[no-any-return]
+        return _turbojpeg().encode(rgb_array, quality=quality, pixel_format=TJPF_RGB)  # type: ignore[no-any-return]
 
     def lcm_jpeg_encode(self, quality: int = 75, frame_id: str | None = None) -> bytes:
         """Convert to LCM Image message with JPEG-compressed data.
@@ -578,9 +593,9 @@ class Image(Timestamped):
         Returns:
             Image instance
         """
-        from turbojpeg import TJPF_RGB, TurboJPEG
+        from turbojpeg import TJPF_RGB
 
-        jpeg = TurboJPEG()
+        jpeg = _turbojpeg()
         msg = LCMImage.lcm_decode(data)
 
         if msg.encoding != "jpeg":


### PR DESCRIPTION
Every jpeg encode/decode in Image.to_jpeg_bytes, the lcm jpeg decode path, and person_follow constructed a fresh TurboJPEG() per frame — measured ~1.9ms/call, roughly 30-50% of total jpeg codec time at 720p. Replaces them with a lazy threading.local cache (native handles are not thread-safe across threads, so a module singleton would be wrong); zero behavior change. CompressedImage.decode in #2814 can adopt the same helper once both land.