### PR TITLE
fix(ci): match SelfHosted-macOS flag case in codecov carryforward

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -13,7 +13,7 @@ flag_management:
   individual_flags:
     - name: SelfHosted-Linux
       carryforward: true
-    - name: SelfHosted-macos
+    - name: SelfHosted-macOS
       carryforward: true
     - name: SelfHosted-Large
       carryforward: true


### PR DESCRIPTION
## Contribution path

- Small, safe change that does not need a tracking issue

## Problem

External fork PRs get a spurious `codecov/project` failure whenever the base commit on main has self-hosted macOS coverage. `.codecov.yml` lists the carryforward flag as `SelfHosted-macos`, but ci.yml uploads `SelfHosted-${{ matrix.os }}`, i.e. `SelfHosted-macOS`. Codecov flag names are case-sensitive, so the macOS report never carries forward on fork PRs, while `SelfHosted-Linux` and `SelfHosted-Large` — exact-case names in the same block — carry forward fine. Dates back to the flag split in #1901.

Observed on #3210 (docs-only, so the project total couldn't legitimately move): the head report carries forward Linux ×4 and Large ×2 but no macOS; base 68bb0bd has two `SelfHosted-macOS` uploads at 74.90%, head lands at 74.62% — the missing 291 of 106,086 tracked lines are exactly the reported −0.28%. Same shape on #3060 (−0.30%, merged over the red X) and #3179 (−1.56%). #3201 and #3181 passed only because their base commits happened to be missing the macOS upload too, so for external contributors the check is effectively a coin flip on the base commit's runner health.

## Solution

One-character case fix so the config matches the flag CI actually uploads.

## How to Test

Codecov reads the YAML from the head commit, so this PR's own report should list `SelfHosted-macOS` as carried forward (visible under the uploads on the Codecov page for the head commit), and fork PRs opened after this merges should stop seeing the spurious ~0.3% project drop.

## AI assistance

Claude Code with Fable 5: ran the codecov API comparison and drafted this description. I verified the flag names in `.codecov.yml`/`ci.yml` and the upload/coverage numbers myself.

## Checklist

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
