### PR TITLE
fix(ci): detect first-time contributors by commit history

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -25,6 +25,12 @@ on:
   pull_request_target:
     types: [synchronize, converted_to_draft, ready_for_review, opened, reopened, labeled, unlabeled]
   merge_group:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to evaluate and backfill
+        required: true
+        type: number
 
 permissions: {}
 
@@ -127,35 +133,64 @@ jobs:
 
   first-time-contributor:
     if: >-
-      github.event_name == 'pull_request_target' &&
-      github.event.action == 'opened'
+      (github.event_name == 'pull_request_target' &&
+       github.event.action == 'opened') ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write  # To add the label
+      contents: read
+      pull-requests: write
     steps:
-      - uses: actions/github-script@v9
+      - name: Check contribution history and label
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
         with:
           script: |
             const label = 'first-time-contributor';
-            const firstTimeAssociations = new Set([
-              'FIRST_TIMER',
-              'FIRST_TIME_CONTRIBUTOR',
-            ]);
             const { owner, repo } = context.repo;
-            const prNumber = context.payload.pull_request.number;
-            // The opened event's author_association can be stale. Refetch the PR
-            // instead of trusting that snapshot.
-            const { data: pr } = await github.rest.pulls.get({
-              owner, repo, pull_number: prNumber,
-            });
-            core.info(`pr=#${prNumber} authorAssociation=${pr.author_association}`);
+            const prNumber = Number(process.env.PR_NUMBER);
 
-            if (!firstTimeAssociations.has(pr.author_association)) {
+            if (!Number.isSafeInteger(prNumber) || prNumber <= 0) {
+              core.setFailed(`Invalid pull request number: ${process.env.PR_NUMBER}`);
+              return;
+            }
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: prNumber,
+            });
+            const author = pr.user?.login;
+
+            if (!author) {
+              core.setFailed(`Pull request #${prNumber} has no author login`);
+              return;
+            }
+
+            const { data: commits } = await github.rest.repos.listCommits({
+              owner,
+              repo,
+              author,
+              sha: context.payload.repository.default_branch,
+              per_page: 1,
+            });
+            const isFirstTimeContributor = commits.length === 0;
+
+            core.info(
+              `pr=#${prNumber} author=${author} priorCommits=${commits.length} ` +
+              `firstTimeContributor=${isFirstTimeContributor}`,
+            );
+
+            if (!isFirstTimeContributor) {
               return;
             }
 
             await github.rest.issues.addLabels({
-              owner, repo, issue_number: prNumber, labels: [label],
+              owner,
+              repo,
+              issue_number: prNumber,
+              labels: [label],
             });
 
   backport-check:


### PR DESCRIPTION
## Contribution path

- Small, safe change that does not need a tracking issue

## Problem

The first-time-contributor job relies on `author_association`, which does not reliably indicate whether a pull request author has previously contributed commits to the repository.

## Solution

- Check the PR author’s commit history on the default branch before applying the label.
- Add the required read permission and pin `actions/github-script` to the verified v9 commit.
- Add a manual `workflow_dispatch` input to evaluate and backfill a PR by number.

## How to Test

`pre-commit run check-yaml --files .github/workflows/pr-labels.yml`

## AI assistance

Codex with GPT-5 implemented the workflow adaptation and ran YAML validation.

## Checklist

- [ ] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).