### PR TITLE
Migrate blob consumers of `coordinaotor_joint_state` topic to per robot joint topic

### DIFF
--- a/dimos/imitation/collection/blueprint.py
+++ b/dimos/imitation/collection/blueprint.py
@@ -49,15 +49,19 @@ def _camera_if_real() -> tuple[Blueprint, ...]:
     return (RealSenseCamera.blueprint(enable_pointcloud=False),)
 
 
-# buttons / color_image / joint_state / status are left to autoconnect — each
-# name is unique across the composed blueprint, so it resolves to a stable
-# /<name> topic shared by producer and recorder.
+# buttons / color_image / status are left to autoconnect — each name is unique
+# across the composed blueprint, so it resolves to a stable /<name> topic shared
+# by producer and recorder. The joint stream is remapped onto the coordinator's
+# per-robot `arm_joints` output; the recorder still writes it to the db under its
+# port name (`coordinator_joint_state`), which is what DataPrep reads.
+_JOINTS_FROM_ARM = [(CollectionRecorder, "coordinator_joint_state", "arm_joints")]
+
 learning_collect_quest_xarm7 = autoconnect(
     teleop_quest_xarm7,
     *_camera_if_real(),
     EpisodeMonitorModule.blueprint(),  # default button_map: toggle=B, discard=Y
     CollectionRecorder.blueprint(db_path=_session_db("xarm7")),
-)
+).remappings(_JOINTS_FROM_ARM)
 
 
 learning_collect_quest_piper = autoconnect(
@@ -65,4 +69,4 @@ learning_collect_quest_piper = autoconnect(
     *_camera_if_real(),
     EpisodeMonitorModule.blueprint(),  # default button_map: toggle=B, discard=Y
     CollectionRecorder.blueprint(db_path=_session_db("piper")),
-)
+).remappings(_JOINTS_FROM_ARM)

--- a/dimos/imitation/collection/recorder.py
+++ b/dimos/imitation/collection/recorder.py
@@ -16,11 +16,13 @@
 
 A `Recorder` (memory2) subscribes each declared `In` port and appends every
 message to a SQLite store, flushing durably on stop(). Only *connected*
-streams are recorded, so the same recorder works for any arm whose
-coordinator publishes `coordinator_joint_state`.
+streams are recorded, so the same recorder works for any arm once the
+collection blueprint remaps the joint port onto that coordinator's per-robot
+joint output.
 
-The recorded stream names match what DataPrep reads: `color_image`
-and `coordinator_joint_state` (observation), `status` (episode segmentation).
+The recorded stream names are the port names, and match what DataPrep reads:
+`color_image` and `coordinator_joint_state` (observation), `status` (episode
+segmentation).
 """
 
 from __future__ import annotations

--- a/dimos/robot/manipulators/common/blueprints.py
+++ b/dimos/robot/manipulators/common/blueprints.py
@@ -129,11 +129,18 @@ def coordinator(
     tick_rate: float = 100.0,
     publish_joint_state: bool = True,
     joint_state_frame_id: str = COORDINATOR_FRAME_ID,
+    cls: type[ControlCoordinator] = ControlCoordinator,
+    instance_name: str | None = None,
+    publish_robot_joint_states: bool = False,
 ) -> Blueprint:
-    return ControlCoordinator.blueprint(
+    """*cls* is the subclass declaring the `{hardware_id}_joints` outputs; pass
+    instance_name="ControlCoordinator" with it so RPC clients still find it."""
+    return cls.blueprint(
         tick_rate=tick_rate,
         publish_joint_state=publish_joint_state,
+        publish_robot_joint_states=publish_robot_joint_states,
         joint_state_frame_id=joint_state_frame_id,
+        instance_name=instance_name,
         hardware=list(hardware),
         tasks=list(tasks),
     )

--- a/dimos/robot/manipulators/piper/blueprints/teleop.py
+++ b/dimos/robot/manipulators/piper/blueprints/teleop.py
@@ -20,7 +20,9 @@ from dimos.control.components import make_gripper_joints
 from dimos.control.coordinator import ControlCoordinator, TaskConfig
 from dimos.core.coordination.blueprints import autoconnect
 from dimos.core.global_config import global_config
+from dimos.core.stream import Out
 from dimos.manipulation.manipulation_module import ManipulationModule
+from dimos.msgs.sensor_msgs.JointState import JointState
 from dimos.robot.manipulators.common.blueprints import (
     cartesian_ik_task,
     eef_twist_task,
@@ -84,8 +86,15 @@ coordinator_cartesian_ik_mock = ControlCoordinator.blueprint(
 
 _piper_teleop_hw = piper_hardware("arm", gripper_open_position=0.07, gripper_closed_position=0.0)
 
+
+class _PiperTeleopCoordinator(ControlCoordinator):
+    arm_joints: Out[JointState]
+
+
 coordinator_teleop_piper = autoconnect(
-    ControlCoordinator.blueprint(
+    _PiperTeleopCoordinator.blueprint(
+        instance_name="ControlCoordinator",
+        publish_robot_joint_states=True,
         hardware=[_piper_teleop_hw],
         tasks=[
             teleop_ik_task(

--- a/dimos/robot/manipulators/xarm/blueprints/teleop.py
+++ b/dimos/robot/manipulators/xarm/blueprints/teleop.py
@@ -19,7 +19,9 @@ from __future__ import annotations
 from dimos.control.coordinator import ControlCoordinator, TaskConfig
 from dimos.core.coordination.blueprints import autoconnect
 from dimos.core.global_config import global_config
+from dimos.core.stream import Out
 from dimos.manipulation.manipulation_module import ManipulationModule
+from dimos.msgs.sensor_msgs.JointState import JointState
 from dimos.robot.manipulators.common.blueprints import (
     eef_twist_task,
     teleop_ik_task,
@@ -148,8 +150,15 @@ _xarm6_teleop_hw = xarm6_hardware(
 # While engaged, VR also owns the gripper joint (trigger), so the browser
 # gripper toggle only takes effect when VR is disengaged.
 
+
+class _XArm7TeleopCoordinator(ControlCoordinator):
+    arm_joints: Out[JointState]
+
+
 coordinator_teleop_xarm7 = autoconnect(
-    ControlCoordinator.blueprint(
+    _XArm7TeleopCoordinator.blueprint(
+        instance_name="ControlCoordinator",
+        publish_robot_joint_states=True,
         hardware=[_xarm7_teleop_hw],
         tasks=[
             teleop_ik_task(

--- a/dimos/robot/manipulators/xarm/blueprints/worldbelief.py
+++ b/dimos/robot/manipulators/xarm/blueprints/worldbelief.py
@@ -23,12 +23,15 @@ import rerun.blueprint as rrb
 
 from dimos.agents.mcp.mcp_server import McpServer
 from dimos.constants import STATE_DIR
+from dimos.control.coordinator import ControlCoordinator
 from dimos.core.coordination.blueprints import autoconnect
+from dimos.core.stream import Out
 from dimos.hardware.sensors.camera.realsense.camera import RealSenseCamera
 from dimos.manipulation.manipulation_module import ManipulationModule
 from dimos.msgs.geometry_msgs.Quaternion import Quaternion
 from dimos.msgs.geometry_msgs.Transform import Transform
 from dimos.msgs.geometry_msgs.Vector3 import Vector3
+from dimos.msgs.sensor_msgs.JointState import JointState
 from dimos.perception.worldbelief_module import WorldBeliefModule
 from dimos.perception.worldbelief_recorder import WorldBeliefRecorder
 from dimos.robot.manipulators.common.blueprints import coordinator, trajectory_task
@@ -71,6 +74,11 @@ def _rerun_blueprint() -> rrb.Blueprint:
 
 _hw = xarm6_hardware("arm")
 _hw.auto_enable = True
+
+
+class _XArm6WorldBeliefCoordinator(ControlCoordinator):
+    arm_joints: Out[JointState]
+
 
 xarm6_worldbelief = autoconnect(
     # Provides wrist-camera FK/TF.
@@ -124,7 +132,17 @@ xarm6_worldbelief = autoconnect(
     ),
     McpServer.blueprint(),
     coordinator(
+        cls=_XArm6WorldBeliefCoordinator,
+        instance_name="ControlCoordinator",
+        publish_robot_joint_states=True,
         hardware=[_hw],
         tasks=[trajectory_task(_hw)],
     ),
+)
+
+# Wiring-only remap: a Recorder names its db streams after its ports, so the
+# recording still holds "coordinator_joint_state" (and the recorder's
+# @pose_setter_for keeps matching).
+xarm6_worldbelief = xarm6_worldbelief.remappings(
+    [(WorldBeliefRecorder, "coordinator_joint_state", "arm_joints")]
 ).global_config(n_workers=8)

--- a/dimos/robot/unitree/g1/blueprints/basic/unitree_g1_coordinator.py
+++ b/dimos/robot/unitree/g1/blueprints/basic/unitree_g1_coordinator.py
@@ -25,6 +25,7 @@ import os
 from dimos.control.components import HardwareComponent, HardwareType, make_humanoid_joints
 from dimos.control.coordinator import ControlCoordinator, TaskConfig
 from dimos.core.coordination.blueprints import autoconnect
+from dimos.core.stream import Out
 from dimos.core.transport import LCMTransport
 from dimos.msgs.sensor_msgs.Imu import Imu
 from dimos.msgs.sensor_msgs.JointState import JointState
@@ -33,6 +34,11 @@ from dimos.robot.unitree.g1.wholebody_connection import G1WholeBodyConnection
 
 _g1_joints = make_humanoid_joints("g1")
 
+
+class _G1Coordinator(ControlCoordinator):
+    g1_joints: Out[JointState]
+
+
 # ROBOT_INTERFACE pins cyclonedds to a NIC; required on multi-NIC hosts.
 unitree_g1_coordinator = (
     autoconnect(
@@ -40,7 +46,9 @@ unitree_g1_coordinator = (
             release_sport_mode=True,
             network_interface=os.getenv("ROBOT_INTERFACE", ""),
         ),
-        ControlCoordinator.blueprint(
+        _G1Coordinator.blueprint(
+            instance_name="ControlCoordinator",
+            publish_robot_joint_states=True,
             tick_rate=500,
             hardware=[
                 HardwareComponent(
@@ -70,6 +78,7 @@ unitree_g1_coordinator = (
                 "/g1/motor_command", MotorCommandArray
             ),
             ("joint_command", JointState): LCMTransport("/g1/joint_command", JointState),
+            ("g1_joints", JointState): LCMTransport("/g1/joints", JointState),
         }
     )
 )

--- a/dimos/robot/unitree/g1/blueprints/basic/unitree_g1_groot_wbc.py
+++ b/dimos/robot/unitree/g1/blueprints/basic/unitree_g1_groot_wbc.py
@@ -61,6 +61,7 @@ from dimos.control.tasks.g1_groot_wbc_task.g1_groot_wbc_task import (
 )
 from dimos.core.coordination.blueprints import autoconnect
 from dimos.core.global_config import global_config
+from dimos.core.stream import Out
 from dimos.core.transport import LCMTransport
 from dimos.hardware.whole_body.spec import WholeBodyConfig
 from dimos.mapping.costmapper import CostMapper
@@ -129,6 +130,16 @@ _G1_NAV_OVERHEAD_SAFETY_MARGIN = 0.2
 _G1_NAV_MAX_STEP_HEIGHT = 0.10
 _G1_NAV_ROTATION_DIAMETER = 0.8
 _G1_NAV_SAFE_RADIUS_MARGIN = 0.6
+
+
+class _G1GrootCoordinator(ControlCoordinator):
+    g1_joints: Out[JointState]
+
+
+# Per-robot joint stream. Namespaced like the rest of the g1 wire topics, which
+# also fixes its Rerun entity path (`world/` + topic).
+_G1_JOINTS_TOPIC = "/g1/joints"
+_G1_JOINTS_ENTITY = f"world{_G1_JOINTS_TOPIC}"
 
 
 def _mujoco_lidar_kwargs(camera_name: str, camera_names: tuple[str, ...]) -> dict[str, Any]:
@@ -294,7 +305,7 @@ if global_config.simulation == "mujoco":
     )
     _remappings = [
         (VoxelGridMapper, "lidar", "pointcloud"),
-        (ControlCoordinator, "twist_command", "cmd_vel"),
+        (_G1GrootCoordinator, "twist_command", "cmd_vel"),
     ]
 else:
     from dimos.hardware.sensors.lidar.pointlio.module import PointLio
@@ -352,7 +363,7 @@ else:
         ),
         MovementManager.blueprint(),
     )
-    _remappings = [(ControlCoordinator, "twist_command", "cmd_vel")]
+    _remappings = [(_G1GrootCoordinator, "twist_command", "cmd_vel")]
 
 
 def _g1_groot_rerun_blueprint() -> Any:
@@ -443,13 +454,13 @@ _rerun_config: dict[str, Any] = {
         "world/camera_info": None,
         "world/depth_image": None,
         "world/depth_camera_info": None,
-        "world/coordinator_joint_state": g1_urdf_joint_state(root_path=_G1_ROOT),
+        _G1_JOINTS_ENTITY: g1_urdf_joint_state(root_path=_G1_ROOT),
         "world/global_costmap": g1_costmap,
         "world/navigation_costmap": g1_costmap,
         "world/path": _g1_nav_path,
     },
     "max_hz": {
-        "world/coordinator_joint_state": 20.0,
+        _G1_JOINTS_ENTITY: 20.0,
         # Raw state streams arrive at ~440 Hz; useful only as debug plots.
         "world/g1/imu": 10.0,
         "world/g1/motor_states": 10.0,
@@ -477,7 +488,9 @@ def _viewer() -> Any:
     return vis_module(viewer_backend=global_config.viewer, rerun_config=_rerun_config)
 
 
-_coordinator = ControlCoordinator.blueprint(
+_coordinator = _G1GrootCoordinator.blueprint(
+    instance_name="ControlCoordinator",
+    publish_robot_joint_states=True,
     tick_rate=_tick_rate,
     hardware=[
         HardwareComponent(
@@ -510,6 +523,7 @@ _coordinator = ControlCoordinator.blueprint(
 ).transports(
     {
         ("joint_command", JointState): LCMTransport("/g1/joint_command", JointState),
+        ("g1_joints", JointState): LCMTransport(_G1_JOINTS_TOPIC, JointState),
         ("cmd_vel", Twist): LCMTransport(_cmd_vel_topic, Twist),
         # Real-hw only: the transport_lcm adapter speaks to
         # G1WholeBodyConnection over these topics. autoconnect already

--- a/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_holonomic_controller.py
+++ b/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_holonomic_controller.py
@@ -53,6 +53,7 @@ from dimos.control.components import HardwareComponent, HardwareType, make_twist
 from dimos.control.coordinator import TaskConfig
 from dimos.control.path_following_coordinator import PathFollowingCoordinator
 from dimos.core.coordination.blueprints import autoconnect
+from dimos.core.stream import Out
 from dimos.core.transport import LCMTransport
 from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
 from dimos.msgs.geometry_msgs.Twist import Twist
@@ -66,6 +67,10 @@ from dimos.robot.unitree.keyboard_teleop import KeyboardTeleop
 _go2_joints = make_twist_base_joints("go2")
 
 
+class _Go2HolonomicCoordinator(PathFollowingCoordinator):
+    go2_joints: Out[JointState]
+
+
 unitree_go2_holonomic_controller = (
     autoconnect(
         # velocity_api=True routes cmd_vel through the SPORT_MOD ``Move`` API
@@ -75,8 +80,10 @@ unitree_go2_holonomic_controller = (
         # under the default the commanded and achieved speeds disagree — the
         # robot runs hot and glides past the goal.
         GO2Connection.blueprint(velocity_api=True),
-        PathFollowingCoordinator.blueprint(
+        _Go2HolonomicCoordinator.blueprint(
+            instance_name="ControlCoordinator",
             publish_joint_state=True,
+            publish_robot_joint_states=True,
             hardware=[
                 HardwareComponent(
                     hardware_id="go2",
@@ -137,11 +144,8 @@ unitree_go2_holonomic_controller = (
             ("speed", Float32): LCMTransport("/speed", Float32),
             # Operator gate (teleop -> benchmark) to pace runs.
             ("operator_command", Int8): LCMTransport("/benchmark/gate", Int8),
-            # Aggregated joint state for observability (positions = [x,y,yaw]).
-            ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-            ("coordinator_joint_state", JointState): LCMTransport(
-                "/coordinator/joint_state", JointState
-            ),
+            # This robot's joint state for observability (positions = [x,y,yaw]).
+            ("go2_joints", JointState): LCMTransport("/coordinator/joint_state", JointState),
         }
     )
     .global_config(obstacle_avoidance=False)

--- a/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_rpp_controller.py
+++ b/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_rpp_controller.py
@@ -56,6 +56,7 @@ from dimos.control.components import HardwareComponent, HardwareType, make_twist
 from dimos.control.coordinator import TaskConfig
 from dimos.control.path_following_coordinator import PathFollowingCoordinator
 from dimos.core.coordination.blueprints import autoconnect
+from dimos.core.stream import Out
 from dimos.core.transport import LCMTransport
 from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
 from dimos.msgs.geometry_msgs.Twist import Twist
@@ -69,11 +70,17 @@ from dimos.robot.unitree.keyboard_teleop import KeyboardTeleop
 _go2_joints = make_twist_base_joints("go2")
 
 
+class _Go2RppCoordinator(PathFollowingCoordinator):
+    go2_joints: Out[JointState]
+
+
 unitree_go2_rpp_controller = (
     autoconnect(
         GO2Connection.blueprint(),
-        PathFollowingCoordinator.blueprint(
+        _Go2RppCoordinator.blueprint(
+            instance_name="ControlCoordinator",
             publish_joint_state=True,
+            publish_robot_joint_states=True,
             hardware=[
                 HardwareComponent(
                     hardware_id="go2",
@@ -138,11 +145,8 @@ unitree_go2_rpp_controller = (
             ("speed", Float32): LCMTransport("/speed", Float32),
             # Operator gate (teleop -> benchmark) to pace runs.
             ("operator_command", Int8): LCMTransport("/benchmark/gate", Int8),
-            # Aggregated joint state for observability (positions = [x,y,yaw]).
-            ("joint_state", JointState): LCMTransport("/coordinator/joint_state", JointState),
-            ("coordinator_joint_state", JointState): LCMTransport(
-                "/coordinator/joint_state", JointState
-            ),
+            # This robot's joint state for observability (positions = [x,y,yaw]).
+            ("go2_joints", JointState): LCMTransport("/coordinator/joint_state", JointState),
         }
     )
     .global_config(obstacle_avoidance=False)

--- a/scripts/g1_replay.py
+++ b/scripts/g1_replay.py
@@ -37,6 +37,8 @@ from dimos.utils.logging_config import setup_logger
 _DEFAULT_TRAJECTORY_NAME = "g1_wholebody_replay.json"
 
 NUM_DOF = 29
+# The g1 coordinator blueprints publish this robot's joints here.
+_JOINT_STATE_TOPIC = "/g1/joints"
 CANONICAL_JOINTS = make_humanoid_joints("g1")
 assert len(CANONICAL_JOINTS) == NUM_DOF
 
@@ -99,9 +101,9 @@ def main() -> None:
         f"will publish to /g1/joint_command using canonical joint names ({CANONICAL_JOINTS[0]} ...)"
     )
 
-    # Subscribe to coordinator's joint_state output to capture the current pose.
-    # Coordinator joint state names are {hardware_id}/{joint} so they align with
-    # CANONICAL_JOINTS, lookup is straightforward.
+    # Subscribe to the coordinator's per-robot joint output to capture the
+    # current pose. Coordinator joint state names are {hardware_id}/{joint} so
+    # they align with CANONICAL_JOINTS, lookup is straightforward.
     state_lock = threading.Lock()
     current_q: dict[str, float] = {}
     state_event = threading.Event()
@@ -113,13 +115,13 @@ def main() -> None:
                 current_q[n] = q
         state_event.set()
 
-    state_sub: LCMTransport[JointState] = LCMTransport("/coordinator_joint_state", JointState)
+    state_sub: LCMTransport[JointState] = LCMTransport(_JOINT_STATE_TOPIC, JointState)
     # subscribe() returns an unsub callable; signature claims None (see transport.py).
     state_unsub = state_sub.subscribe(on_state)  # type: ignore[func-returns-value]
     cmd_pub: LCMTransport[JointState] = LCMTransport("/g1/joint_command", JointState)
 
     try:
-        logger.info("waiting up to 10s for /coordinator_joint_state ...")
+        logger.info(f"waiting up to 10s for {_JOINT_STATE_TOPIC} ...")
         if not state_event.wait(timeout=10.0):
             logger.error("no joint_state received — is `dimos run unitree-g1-coordinator` running?")
             return


### PR DESCRIPTION
## Problem

The control coordinator publishes one message with every robot's joints stitched
together. Anything that wants one robot's joints has to take the whole thing.

That merged message is being retired. Five places still read it, and all five only care
about a single robot.

Issue: #

---

## Solution

Each coordinator now also publishes one stream per robot, and those five readers
subscribe to the one they need.

Two halves per deployment: add the output on the coordinator, point the reader at it.
One commit per reader.

Recorder modules are untouched, so recordings keep their old stream names and DataPrep
configs still work.

The merged message still publishes. Retiring it is a later PR, as is the manipulation
module.

---

## Breaking Changes

None. The go2 controllers keep the same LCM topic, so Foxglove and lcm-spy are unaffected.

---

## How to Test

1. `pytest dimos/control dimos/imitation dimos/perception dimos/robot -m 'not (tool or self_hosted or mujoco or self_hosted_large)'`
2. `dimos --simulation mujoco run unitree-g1-groot-wbc` — G1 still animates in Rerun, nav still drives it.
3. None of the five deployments run in CI. Owner runs on hardware:
   - `learning-collect-quest-piper` — record an episode, DataPrep still builds it
   - `xarm6-worldbelief` — recording still has `coordinator_joint_state`
   - `unitree-g1-coordinator` + `g1_replay.py --dry-run` — picks up current pose
   - `unitree-go2-holonomic-controller` and `-rpp-controller` — tracking unchanged
