### PR TITLE
data: add calibrated xarm6 stationery recording

### DIFF
--- a/data/.lfs/xarm6_worldbelief_realsense_d435i_stationery_calibrated.tar.gz
+++ b/data/.lfs/xarm6_worldbelief_realsense_d435i_stationery_calibrated.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:05acc218484d7f2b8e4f1688962df90ef37a95f6dc02d5d0c15d308cfa47ed95
+size 1354895310


### PR DESCRIPTION
## Summary

Adds one calibrated XArm6 WorldBelief recording captured with an **Intel RealSense D435i**:

- `xarm6_worldbelief_realsense_d435i_stationery_calibrated`

This recording repeats the stationery six-state protocol from #3255 while addressing the reported drift risk with a validated hand-eye calibration and a world-to-camera TF path:

1. **S1 baseline** — scan the baseline scene.
2. **S2 removed** — remove the red marker and scan again.
3. **S3 returned** — return the same marker in a different pose/location and scan.
4. **S4 identical copy** — add a second visually identical Post-it pad and scan.
5. **S5 new item** — add a black-tape class absent from the baseline and scan.
6. **S6 rearranged** — move the Post-it, black pen, and book and scan.

## Proposed LFS file

```text
xarm6_worldbelief_realsense_d435i_stationery_calibrated/
├── events.jsonl
├── inventory.yaml
└── xarm6_worldbelief_20260729_203624_161992.db
```

## Recording hardware and streams

The camera was configured for 848×480 RGB-D at 15 fps with depth aligned to color.

| Stream | Count | Effective rate | Stored details |
|---|---:|---:|---|
| `color_image` | 9,065 | 15.0 Hz | JPEG, RGB, `camera_color_optical_frame` |
| `depth_image` | 9,063 | 15.0 Hz | LZ4+LCM, `DEPTH16`, aligned to color |
| `camera_info` | 604 | 1.0 Hz | Color intrinsics, 848×480 |
| `depth_camera_info` | 604 | 1.0 Hz | Aligned-depth intrinsics, 848×480 |
| `tf` | 60,244 | 99.6 Hz | Calibrated `world -> link6 -> camera` localization path plus `world -> link_base` |
| `coordinator_joint_state` | 59,344 | 98.5 Hz | Six XArm6 joints with position, velocity, and effort |
| `recording_metadata` | 604 | 1.0 Hz | Camera identity, profile, frames, and calibration provenance |

## Calibrated camera and recorded world-to-camera TF path

Runtime transform recorded in the TF stream:

```text
link6 -> camera_link
translation_m:  [0.0609457603, -0.0266769099, 0.0089297297]
rotation_xyzw:  [0.6949098576, 0.0108366484, 0.7189774628, -0.0073664659]
```

The calibrated optical-frame result from which the runtime transform is derived is:

```text
link6 -> camera_color_optical_frame
translation_m:  [0.0609308729, -0.0271184124, 0.0238119831]
rotation_xyzw:  [-0.0075273664, -0.0135016190, 0.7154838858, 0.6984581979]
```

Recorded TF edges:

```text
world -> link_base
world -> link6
link6 -> camera_link
camera_link -> camera_color_frame
camera_color_frame -> camera_color_optical_frame
camera_link -> camera_depth_frame
camera_depth_frame -> camera_depth_optical_frame
```


## Dataset technical summary

- Memory2 start: `1785382584.9011714` — `2026-07-30T03:36:24.901171Z`
- Memory2 end: `1785383189.7672107` — `2026-07-30T03:46:29.767211Z`
- Duration: `604.866039` seconds
- Total messages: `139,528`


Stationery baseline inventory: `red_marker`, yellow `post_it`, `black_pen`, and `book`. S2 removes the red marker; S3 returns that same marker in a different pose/location; S4 adds a second identical Post-it pad; S5 adds the new `black_tape` class; S6 rearranges the Post-it, black pen, and book.

| Scan window | Start offset | End offset | Duration | Physical scene during the scan |
|---|---:|---:|---:|---|
| S1 baseline | 53.278700 s | 128.799457 s | 75.520757 s | Four baseline stationery objects are present. |
| S2 removed | 134.959443 s | 210.138375 s | 75.178932 s | The red marker is absent. |
| S3 returned | 217.714593 s | 293.586833 s | 75.872240 s | The same red marker has returned at a different pose/location. |
| S4 identical | 341.707183 s | 417.850393 s | 76.143210 s | A second identical Post-it pad is present. |
| S5 new item | 427.157481 s | 502.699079 s | 75.541598 s | A roll of black tape, a class absent from baseline, is present. |
| S6 rearranged | 520.223212 s | 596.374568 s | 76.151356 s | The Post-it, black pen, and book have been moved. |

The database records continuously before, between, and after the scan windows. The gaps are scene-setup intervals.

