### PR TITLE
Control Coordinator refactor Docs update and final cleanup

### DIFF
--- a/dimos/control/README.md
+++ b/dimos/control/README.md
@@ -86,11 +86,13 @@ dimos/control/
 ├── coordinator.py       # Module + RPC interface
 ├── tick_loop.py         # 100Hz control loop
 ├── task.py              # ControlTask protocol + types
+├── routing.py           # Routing rules + card types
 ├── hardware_interface.py # ConnectedHardware wrapper
 ├── components.py        # HardwareComponent config + type aliases
-├── blueprints.py        # Pre-configured setups
+├── blueprints/          # Pre-configured setups
 └── tasks/
-    └── trajectory_task.py  # Joint trajectory controller
+    ├── registry.py         # Task-card discovery + lazy factories
+    └── trajectory_task/    # Joint trajectory controller
 ```
 
 ## Configuration
@@ -195,17 +197,83 @@ class PIDController:
         pass  # Handle preemption
 ```
 
-## Joint State Output
+## Task Cards
 
-The coordinator publishes one aggregated `JointState` message containing all joints:
+Each task type ships a manifest at `dimos/control/tasks/<task>/_registry.py`.
+`tasks/registry.py` discovers these without importing the tasks, so heavy deps
+(Pinocchio, ONNX Runtime) load only when a task is actually created.
 
 ```python
-JointState(
-    name=["left_arm_joint1", ..., "right_arm_joint1", ...],  # All joints
-    position=[...],
-    velocity=[...],
-    effort=[...],
+TASK_FACTORIES = {"servo": "dimos.control.tasks.servo_task.servo_task:create_task"}
+TASK_CONSUMES = {"servo": {"joint_command": ("on_joint_command", "claim_overlap")}}
+TASK_EXPOSES = {"trajectory": ["execute", "cancel", "get_state"]}
+```
+
+`TASK_CONSUMES` maps a coordinator input to `(handler, routing rule)`. The
+handler gets the raw message; the coordinator only routes.
+
+`TASK_EXPOSES` lists what `task_invoke` may call. The method's own signature is
+the argument schema, so `task_invoke` binds kwargs against it and a typo raises
+back to the caller. `describe_task()` reports those signatures live.
+
+### Routing rules
+
+| Rule | Delivers when | Used by |
+|------|---------------|---------|
+| `claim_overlap` | the message names a joint the task currently claims | `joint_command` |
+| `broadcast` | always, to every task on the port | `teleop_buttons`, `gripper_command` |
+| `direct` | always, but the port is meant for one task (a second logs a warning) | `path`, `speed` |
+| `by_task_name` | `msg.frame_id == task.name` | `coordinator_cartesian_command`, `coordinator_ee_twist_command` |
+
+`by_task_name` uses `frame_id` as an address rather than a coordinate frame. It
+is legacy, slated for replacement by a targeted message; don't add new bindings.
+
+## Deployment I/O
+
+`ControlCoordinator` declares the shared streams (`joint_command`,
+`twist_command`, `teleop_buttons`, `gripper_command`, cartesian and EEF twist).
+A deployment needing more subclasses it and annotates the extra ports:
+
+```python
+class _Go2Coordinator(PathFollowingCoordinator):
+    go2_joints: Out[JointState]
+
+blueprint = _Go2Coordinator.blueprint(
+    instance_name="ControlCoordinator",  # RPC clients look the coordinator up by class name
+    publish_robot_joint_states=True,
 )
 ```
 
-Subscribe via: `/coordinator_joint_state`
+Card-bound ports are checked against the live instance at startup, not the
+registry, since a subclass can declare ports the registry never sees. A missing
+port fails `add_task()` with the annotation to add, before any route registers.
+
+`TaskConfig.stream_bind` remaps a card input per instance, so two tasks of the
+same type can read different ports (task-level remapping, ROS sense):
+
+```python
+TaskConfig(name="left", type="path_follower", stream_bind={"path": "left_path"})
+```
+
+## Joint State Views
+
+The coordinator publishes two views of the same per-tick read. Both are
+permanent; neither is a downgrade from the other.
+
+| View | Stream | Carries | Enabled by |
+|------|--------|---------|------------|
+| Aggregate | `coordinator_joint_state` | every joint, `frame_id="coordinator"` | `publish_joint_state` (on by default) |
+| Per-robot | `{hardware_id}_joints` | one robot, `frame_id=hardware_id` | `publish_robot_joint_states` plus a matching `Out[JointState]` annotation |
+
+Both carry canonical `{hardware_id}/{joint}` names sampled once per tick, so
+they line up with the commands sent on that tick. That is the *control* view.
+Connection modules (`GO2Connection`, `G1WholeBodyConnection`) publish the
+*device* view instead: raw state at the device's own rate, units and ordering.
+
+Choose by what the consumer is, not by how many robots the deployment has.
+
+Consumers that capture or model whatever is present read the aggregate:
+`CollectionRecorder`, `WorldBeliefRecorder`, `ManipulationModule`.
+
+Consumers about one named robot read that robot's stream: `scripts/g1_replay.py`
+reads `/g1/joints`, and the go2 controller blueprints pin `go2_joints`.

--- a/dimos/experimental/world_belief/xarm6_blueprint.py
+++ b/dimos/experimental/world_belief/xarm6_blueprint.py
@@ -21,9 +21,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from dimos.agents.mcp.mcp_server import McpServer
 from dimos.constants import STATE_DIR
-from dimos.control.coordinator import ControlCoordinator
 from dimos.core.coordination.blueprints import autoconnect
-from dimos.core.stream import Out
 from dimos.experimental.world_belief.worldbelief_module import (
     WorldBeliefModule,
 )
@@ -35,7 +33,6 @@ from dimos.manipulation.manipulation_module import ManipulationModule
 from dimos.msgs.geometry_msgs.Quaternion import Quaternion
 from dimos.msgs.geometry_msgs.Transform import Transform
 from dimos.msgs.geometry_msgs.Vector3 import Vector3
-from dimos.msgs.sensor_msgs.JointState import JointState
 from dimos.robot.manipulators.common.blueprints import coordinator, trajectory_task
 from dimos.robot.manipulators.xarm.config import make_xarm6_model_config, xarm6_hardware
 from dimos.visualization.rerun.bridge import RerunBridgeModule
@@ -81,11 +78,6 @@ def _rerun_blueprint() -> rrb.Blueprint:
 
 _hw = xarm6_hardware("arm")
 _hw.auto_enable = True
-
-
-class _XArm6WorldBeliefCoordinator(ControlCoordinator):
-    arm_joints: Out[JointState]
-
 
 xarm6_worldbelief = autoconnect(
     # Provides wrist-camera FK/TF.
@@ -139,17 +131,7 @@ xarm6_worldbelief = autoconnect(
     ),
     McpServer.blueprint(),
     coordinator(
-        cls=_XArm6WorldBeliefCoordinator,
-        instance_name="ControlCoordinator",
-        publish_robot_joint_states=True,
         hardware=[_hw],
         tasks=[trajectory_task(_hw)],
     ),
-)
-
-# Wiring-only remap: a Recorder names its db streams after its ports, so the
-# recording still holds "coordinator_joint_state" (and the recorder's
-# @pose_setter_for keeps matching).
-xarm6_worldbelief = xarm6_worldbelief.remappings(
-    [(WorldBeliefRecorder, "coordinator_joint_state", "arm_joints")]
 ).global_config(n_workers=8)

--- a/dimos/imitation/collection/blueprint.py
+++ b/dimos/imitation/collection/blueprint.py
@@ -49,19 +49,17 @@ def _camera_if_real() -> tuple[Blueprint, ...]:
     return (RealSenseCamera.blueprint(enable_pointcloud=False),)
 
 
-# buttons / color_image / status are left to autoconnect — each name is unique
-# across the composed blueprint, so it resolves to a stable /<name> topic shared
-# by producer and recorder. The joint stream is remapped onto the coordinator's
-# per-robot `arm_joints` output; the recorder still writes it to the db under its
-# port name (`coordinator_joint_state`), which is what DataPrep reads.
-_JOINTS_FROM_ARM = [(CollectionRecorder, "coordinator_joint_state", "arm_joints")]
-
+# buttons / color_image / coordinator_joint_state / status are left to
+# autoconnect — each name is unique across the composed blueprint, so it
+# resolves to a stable /<name> topic shared by producer and recorder. The
+# recorder captures whatever joints are present, so the coordinator's aggregate
+# stream is its intended input (see dimos/control/README.md).
 learning_collect_quest_xarm7 = autoconnect(
     teleop_quest_xarm7,
     *_camera_if_real(),
     EpisodeMonitorModule.blueprint(),  # default button_map: toggle=B, discard=Y
     CollectionRecorder.blueprint(db_path=_session_db("xarm7")),
-).remappings(_JOINTS_FROM_ARM)
+)
 
 
 learning_collect_quest_piper = autoconnect(
@@ -69,4 +67,4 @@ learning_collect_quest_piper = autoconnect(
     *_camera_if_real(),
     EpisodeMonitorModule.blueprint(),  # default button_map: toggle=B, discard=Y
     CollectionRecorder.blueprint(db_path=_session_db("piper")),
-).remappings(_JOINTS_FROM_ARM)
+)

--- a/dimos/imitation/collection/recorder.py
+++ b/dimos/imitation/collection/recorder.py
@@ -16,13 +16,11 @@
 
 A `Recorder` (memory2) subscribes each declared `In` port and appends every
 message to a SQLite store, flushing durably on stop(). Only *connected*
-streams are recorded, so the same recorder works for any arm once the
-collection blueprint remaps the joint port onto that coordinator's per-robot
-joint output.
+streams are recorded, so the same recorder works for any arm whose
+coordinator publishes `coordinator_joint_state`.
 
-The recorded stream names are the port names, and match what DataPrep reads:
-`color_image` and `coordinator_joint_state` (observation), `status` (episode
-segmentation).
+The recorded stream names match what DataPrep reads: `color_image`
+and `coordinator_joint_state` (observation), `status` (episode segmentation).
 """
 
 from __future__ import annotations

--- a/dimos/imitation/collection/test_blueprint.py
+++ b/dimos/imitation/collection/test_blueprint.py
@@ -1,0 +1,46 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import pytest
+
+from dimos.core.coordination.blueprints import Blueprint
+from dimos.imitation.collection.blueprint import (
+    learning_collect_quest_piper,
+    learning_collect_quest_xarm7,
+)
+from dimos.msgs.sensor_msgs.JointState import JointState
+
+AGGREGATE = "coordinator_joint_state"
+
+
+def _joint_streams(blueprint: Blueprint) -> dict[tuple[str, str], str]:
+    """(instance, port) -> effective stream name, as ModuleCoordinator pairs streams."""
+    return {
+        (atom.name, stream.name): blueprint.remapping_map.get((atom.name, stream.name), stream.name)
+        for atom in blueprint.active_blueprints
+        for stream in atom.streams
+        if stream.type is JointState
+    }
+
+
+@pytest.mark.parametrize("blueprint", [learning_collect_quest_xarm7, learning_collect_quest_piper])
+def test_recorder_reads_aggregate_joint_state(blueprint: Blueprint) -> None:
+    streams = _joint_streams(blueprint)
+
+    # Plain name pairing on both ends, no remap in between.
+    assert streams[("collectionrecorder", AGGREGATE)] == AGGREGATE
+    assert streams[("controlcoordinator", AGGREGATE)] == AGGREGATE
+    assert not [port for _instance, port in streams if port.endswith("_joints")]

--- a/dimos/robot/manipulators/piper/blueprints/teleop.py
+++ b/dimos/robot/manipulators/piper/blueprints/teleop.py
@@ -20,9 +20,7 @@ from dimos.control.components import make_gripper_joints
 from dimos.control.coordinator import ControlCoordinator, TaskConfig
 from dimos.core.coordination.blueprints import autoconnect
 from dimos.core.global_config import global_config
-from dimos.core.stream import Out
 from dimos.manipulation.manipulation_module import ManipulationModule
-from dimos.msgs.sensor_msgs.JointState import JointState
 from dimos.robot.manipulators.common.blueprints import (
     cartesian_ik_task,
     eef_twist_task,
@@ -86,14 +84,8 @@ coordinator_cartesian_ik_mock = ControlCoordinator.blueprint(
 _piper_teleop_hw = piper_hardware("arm", gripper_open_position=0.07, gripper_closed_position=0.0)
 
 
-class _PiperTeleopCoordinator(ControlCoordinator):
-    arm_joints: Out[JointState]
-
-
 coordinator_teleop_piper = autoconnect(
-    _PiperTeleopCoordinator.blueprint(
-        instance_name="ControlCoordinator",
-        publish_robot_joint_states=True,
+    ControlCoordinator.blueprint(
         hardware=[_piper_teleop_hw],
         tasks=[
             teleop_ik_task(

--- a/dimos/robot/manipulators/xarm/blueprints/teleop.py
+++ b/dimos/robot/manipulators/xarm/blueprints/teleop.py
@@ -21,9 +21,7 @@ from typing import cast
 from dimos.control.coordinator import ControlCoordinator, TaskConfig
 from dimos.core.coordination.blueprints import autoconnect
 from dimos.core.global_config import global_config
-from dimos.core.stream import Out
 from dimos.manipulation.manipulation_module import ManipulationModule
-from dimos.msgs.sensor_msgs.JointState import JointState
 from dimos.robot.manipulators.common.blueprints import (
     GripperTaskOverrides,
     eef_twist_task,
@@ -166,14 +164,8 @@ _xarm6_teleop_model = make_xarm6_model_config(add_gripper=True)
 # gripper toggle only takes effect when VR is disengaged.
 
 
-class _XArm7TeleopCoordinator(ControlCoordinator):
-    arm_joints: Out[JointState]
-
-
 coordinator_teleop_xarm7 = autoconnect(
-    _XArm7TeleopCoordinator.blueprint(
-        instance_name="ControlCoordinator",
-        publish_robot_joint_states=True,
+    ControlCoordinator.blueprint(
         hardware=[_xarm7_teleop_hw],
         tasks=[
             teleop_ik_task(


### PR DESCRIPTION
## Problem

The control coordinator publishes joint state two ways: one message holding every robot's joints, or one message per robot. A recent change (#3277) moved both recorders onto the per-robot streams. This is not ideal so I am reverting now, and adding more Docs.

---

## Solution

Both recorders go back on the all-robots stream. 

`dimos/control/README.md` gains an architecture section: both views are permanent, and you pick by what the consumer is. 

---

## Breaking Changes

None. Both streams still exist. The consumers that are genuinely robot-specific (g1 replay, the go2 controllers) are untouched.

---

## How to Test

1. `uv run pytest dimos/control dimos/manipulation dimos/imitation -m 'not (tool or self_hosted or mujoco or self_hosted_large)'`
2. `uv run pytest dimos/robot/test_all_blueprints_generation.py` — confirms the generated blueprint list is unchanged.
3. Record a short episode on the quest rig, then check the session DB's `coordinator_joint_state` rows hold the full joint set.
4. Smoke `dimos run xarm6-worldbelief` on the xArm6 stack.

Steps 3 and 4 need hardware; CI cannot cover them.
