### PR TITLE
fix(imitation): skip pose lookup during collection

### DIFF
--- a/dimos/imitation/collection/blueprint.py
+++ b/dimos/imitation/collection/blueprint.py
@@ -60,7 +60,11 @@ learning_collect_quest_xarm7 = autoconnect(
     teleop_quest_xarm7,
     *_camera_if_real(),
     EpisodeMonitorModule.blueprint(),  # default button_map: toggle=B, discard=Y
-    CollectionRecorder.blueprint(db_path=_session_db("xarm7")),
+    CollectionRecorder.blueprint(
+        db_path=_session_db("xarm7"),
+        poseless_streams=["color_image", "coordinator_joint_state", "status"],
+        record_tf=False,
+    ),
 ).remappings(_JOINTS_FROM_ARM)
 
 
@@ -68,5 +72,9 @@ learning_collect_quest_piper = autoconnect(
     teleop_quest_piper,
     *_camera_if_real(),
     EpisodeMonitorModule.blueprint(),  # default button_map: toggle=B, discard=Y
-    CollectionRecorder.blueprint(db_path=_session_db("piper")),
+    CollectionRecorder.blueprint(
+        db_path=_session_db("piper"),
+        poseless_streams=["color_image", "coordinator_joint_state", "status"],
+        record_tf=False,
+    ),
 ).remappings(_JOINTS_FROM_ARM)

--- a/dimos/imitation/collection/test_blueprint.py
+++ b/dimos/imitation/collection/test_blueprint.py
@@ -1,0 +1,37 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from dimos.core.coordination.blueprints import Blueprint
+from dimos.imitation.collection.blueprint import (
+    learning_collect_quest_piper,
+    learning_collect_quest_xarm7,
+)
+from dimos.imitation.collection.recorder import CollectionRecorder
+
+
+@pytest.mark.parametrize(
+    "blueprint",
+    [learning_collect_quest_xarm7, learning_collect_quest_piper],
+)
+def test_collection_streams_are_poseless(blueprint: Blueprint) -> None:
+    recorder = next(atom for atom in blueprint.blueprints if atom.module is CollectionRecorder)
+
+    assert recorder.kwargs["poseless_streams"] == [
+        "color_image",
+        "coordinator_joint_state",
+        "status",
+    ]
+    assert recorder.kwargs["record_tf"] is False

--- a/dimos/memory2/module.py
+++ b/dimos/memory2/module.py
@@ -429,6 +429,8 @@ class Recorder(MemoryModule):
         """Pose to anchor *msg* with. Dispatches to the stream's (async)
         ``@pose_setter_for`` if one is defined, else falls back to a
         ``world <- frame_id`` tf lookup."""
+        if name in self.config.poseless_streams:
+            return None
         setter = self._pose_setters.get(name)
         if setter is not None:
             return cast("Pose | None", await setter(msg))

--- a/dimos/memory2/test_module.py
+++ b/dimos/memory2/test_module.py
@@ -19,10 +19,11 @@ from __future__ import annotations
 from collections.abc import Iterator
 
 import pytest
+import pytest_mock
 
 from dimos.core.module import ModuleConfig
 from dimos.core.stream import In, Out
-from dimos.memory2.module import StreamModule
+from dimos.memory2.module import Recorder, RecorderConfig, StreamModule
 from dimos.memory2.stream import Stream
 from dimos.memory2.transform import Transformer
 from dimos.memory2.type.observation import Observation
@@ -93,3 +94,14 @@ def test_blueprint_ports(module_cls: type[StreamModule]) -> None:
     stream_names = {s.name for s in atom.streams}
     assert "numbers" in stream_names
     assert "doubled" in stream_names
+
+
+async def test_poseless_stream_skips_tf_lookup(mocker: pytest_mock.MockerFixture) -> None:
+    recorder = mocker.MagicMock(spec=Recorder)
+    recorder.config = RecorderConfig(poseless_streams=["commands"])
+    recorder._pose_setters = {}
+
+    pose = await Recorder._resolve_pose(recorder, "commands", object(), 1.0)
+
+    assert pose is None
+    recorder.tf.get.assert_not_called()


### PR DESCRIPTION
## Contribution path

- Small, safe change that does not need a tracking issue

## Problem

Imitation collection streams do not use stored spatial poses, but the memory2 recorder still attempted frame and TF lookups for every message. This produced repeated missing-pose warnings and unnecessary TF recording work.

## Solution

- Skip pose resolution entirely for recorder streams configured as poseless.
- Mark imitation image, joint-state, and episode-status streams as poseless.
- Disable unused TF recording in both imitation collection blueprints.
- Add regression coverage for the recorder behavior and blueprint configuration.

## How to Test

`uv run pytest dimos/memory2/test_module.py dimos/imitation dimos/codebase_checks/test_blueprint_kwargs.py`

Simulation smoke test: `dimos --simulation run learning-collect-quest-xarm7`

## AI assistance

OpenCode with GPT-5.6 Sol reviewed the collection and dataprep pipeline, implemented this focused change, resolved the main-branch integration conflict, and ran the checks. Human review is pending.

## Checklist

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).