### PR TITLE
👺 disable the self-hosted macOS tests 👺

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -567,10 +567,11 @@ jobs:
                 - /var/cache/dimos-root-cache:/root/.cache
             markers: "self_hosted or skipif_no_ros"
             experimental: false
-          - os: macOS
-            container: null  # run on host — `container:` is Linux-only
-            markers: "self_hosted"
-            experimental: true
+          # macOS runner disabled for now — we don't want Mac tests.
+          # - os: macOS
+          #   container: null  # run on host — `container:` is Linux-only
+          #   markers: "self_hosted"
+          #   experimental: true
     runs-on:
       - self-hosted
       - ${{ matrix.os }}


### PR DESCRIPTION
in case mac clogs CI and you yearn to merge