### PR TITLE
feat: CLI magic opts

### DIFF
--- a/dimos/cli/dimos.py
+++ b/dimos/cli/dimos.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
 from datetime import datetime, timezone
 import inspect
 import json
@@ -23,7 +22,7 @@ from pathlib import Path
 import sys
 import time
 import types
-from typing import TYPE_CHECKING, Any, Literal, Union, cast, get_args, get_origin
+from typing import TYPE_CHECKING, Any, Literal, cast, get_args, get_origin
 
 # Native thread-pool hygiene. Every OpenMP/BLAS runtime sizes its pool to all
 # cores and spin-waits at barriers (libgomp: ~300k pause iterations per region;
@@ -46,9 +45,6 @@ os.environ.setdefault("NUMEXPR_NUM_THREADS", "2")
 os.environ.setdefault("OPENCV_FOR_THREADS_NUM", "2")
 
 from dotenv import load_dotenv
-from pydantic import BaseModel
-from pydantic.fields import FieldInfo
-from pydantic_core import PydanticUndefined
 import requests
 import typer
 
@@ -71,7 +67,7 @@ from dimos.utils.logging_config import setup_logger
 from dimos.visualization.rerun.constants import RerunOpenOption
 
 if TYPE_CHECKING:
-    from dimos.core.coordination.blueprints import Blueprint, BlueprintAtom
+    from dimos.core.coordination.blueprints import Blueprint
 
 logger = setup_logger()
 
@@ -116,7 +112,7 @@ def create_dynamic_callback():  # type: ignore[no-untyped-def]
         field_type = field_info.annotation
 
         # Container generics (e.g. `tuple[...]` fields) have no single-flag CLI
-        # representation; they're configured via env/JSON. Skip like arg_help does.
+        # representation; they're configured via environment variables or JSON.
         if isinstance(field_type, types.GenericAlias):
             continue
 
@@ -182,161 +178,6 @@ main.command()(shell)
 main.add_typer(cache_app, name="cache")
 
 
-def arg_help(
-    config: type[BaseModel],
-    blueprint: Blueprint,
-    indent: str = "    ",
-    module: str = "",
-    _atom: BlueprintAtom | None = None,
-    _defaults: BaseModel | dict[str, Any] | None = None,
-) -> str:
-    # Imported here for performance reasons.
-    from dimos.core.coordination.blueprints import config_key
-
-    output = ""
-    for k, info in config.model_fields.items():
-        if k in ("g", "instance_name"):
-            continue
-        t: object = info.annotation
-        if isinstance(t, types.GenericAlias):
-            # Can't be specified on CLI
-            continue
-
-        fallback = _field_default(info)
-        field_defaults = _get_default_value(_defaults, k, fallback)
-        t = _unwrap_base_model_annotation(t, field_defaults)
-
-        if inspect.isclass(t) and issubclass(t, BaseModel):
-            output += f"{indent}{module}{k}:\n"
-            if _atom is None:
-                # Root BlueprintConfig fields are blueprint atoms, except schema
-                # branches such as transports.* that have no backing atom.
-                bp = next((bp for bp in blueprint.blueprints if config_key(bp.name) == k), None)
-                defaults = bp.kwargs if bp is not None else field_defaults
-            else:
-                # Nested BaseModel fields belong to the current atom and must not
-                # be atom-looked-up.
-                bp = _atom
-                defaults = field_defaults
-            output += arg_help(
-                t,
-                blueprint,
-                indent=indent + "  ",
-                module=module + k + ".",
-                _atom=bp,
-                _defaults=defaults,
-            )
-        else:
-            # Use __name__ to avoid "<class 'int'>" style output on basic types.
-            display_type = t.__name__ if isinstance(t, type) else t
-            has_default = _has_default_value(_defaults, k)
-            required = "[Required] " if info.is_required() and not has_default else ""
-            d = field_defaults
-            default = f" (default: {d})" if d is not PydanticUndefined else ""
-            output += f"{indent}* {required}{module}{k}: {display_type}{default}\n"
-    return output
-
-
-def _field_default(info: FieldInfo) -> Any:
-    if info.default is not PydanticUndefined:
-        return info.default
-    if info.default_factory is not None:
-        return info.get_default(call_default_factory=True)
-    return PydanticUndefined
-
-
-def _unwrap_base_model_annotation(annotation: object, defaults: object) -> object:
-    # TODO(PY314): if isinstance(annotation, Union):
-    if get_origin(annotation) not in {Union, types.UnionType}:
-        return annotation
-
-    candidates = tuple(
-        u for u in get_args(annotation) if inspect.isclass(u) and issubclass(u, BaseModel)
-    )
-    if not candidates:
-        return annotation
-    return _select_base_model_candidate(candidates, defaults)
-
-
-def _select_base_model_candidate(
-    candidates: tuple[type[BaseModel], ...], defaults: object
-) -> type[BaseModel]:
-    backend = _backend_default(defaults)
-    if backend is not PydanticUndefined:
-        for candidate in candidates:
-            backend_info = candidate.model_fields.get("backend")
-            if backend_info is not None and _field_default(backend_info) == backend:
-                return candidate
-    return candidates[0]
-
-
-def _backend_default(defaults: object) -> object:
-    if isinstance(defaults, BaseModel):
-        return getattr(defaults, "backend", PydanticUndefined)
-    if isinstance(defaults, dict):
-        return defaults.get("backend", PydanticUndefined)
-    return PydanticUndefined
-
-
-def _has_default_value(defaults: BaseModel | dict[str, Any] | None, key: str) -> bool:
-    if isinstance(defaults, BaseModel):
-        return key in defaults.model_fields_set
-    if isinstance(defaults, dict):
-        return key in defaults
-    return False
-
-
-def _get_default_value(defaults: object, key: str, fallback: Any) -> Any:
-    if isinstance(defaults, BaseModel):
-        if key in defaults.model_fields_set:
-            return getattr(defaults, key)
-    if isinstance(defaults, dict):
-        return defaults.get(key, fallback)
-    return fallback
-
-
-def load_config_args(
-    config: type[BaseModel],
-    args: Iterable[str],
-    path: Path,
-    cli_g_overrides: dict[str, Any] | None = None,
-) -> dict[str, Any]:
-    try:
-        kwargs = json.loads(path.read_text())
-    except (OSError, json.JSONDecodeError):
-        kwargs = {}
-
-    for k, v in os.environ.items():
-        parts = k.lower().split("__")
-        if parts[0] not in config.model_fields:
-            continue
-        d = kwargs
-        for p in parts[:-1]:
-            d = d.setdefault(p, {})
-        d[parts[-1]] = v
-
-    for arg in args:
-        k, _, v = arg.partition("=")
-        # Accept namespaced instance names in both forms: robot0/sensor.ip
-        # and robot0_sensor.ip (config keys escape "/" to "_").
-        parts = [p.replace("/", "_") for p in k.split(".")]
-        d = kwargs
-        for p in parts[:-1]:
-            d = d.setdefault(p, {})
-        d[parts[-1]] = v
-
-    if cli_g_overrides:
-        # Explicit CLI flags (--transport, --local-relay, ...) win for their
-        # own keys but must not wipe the rest of the g subtree built above.
-        kwargs.setdefault("g", {}).update(cli_g_overrides)
-
-    # We don't need this config, but this atleast validates the user input first.
-    # This will help catch misspellings and similar mistakes.
-    config(**kwargs)
-
-    return kwargs  # type: ignore[no-any-return]
-
-
 def _with_relay_bridge(blueprint: Blueprint) -> Blueprint:
     """Append one relay bridge to an enabled CLI run after blueprint resolution."""
     if not (global_config.local_relay or global_config.relay_url):
@@ -352,14 +193,13 @@ def _with_relay_bridge(blueprint: Blueprint) -> Blueprint:
     return with_relay_bridge(blueprint)
 
 
-@main.command()
+@main.command(context_settings={"allow_extra_args": True, "ignore_unknown_options": True})
 @cache_usage_locked
 def run(
     ctx: typer.Context,
     robot_types: list[str] = typer.Argument(..., help="Blueprints or modules to run"),
     daemon: bool = typer.Option(False, "--daemon", "-d", help="Run in background"),
     disable: list[str] = typer.Option([], "--disable", help="Module names to disable"),
-    blueprint_args: list[str] = typer.Option((), "--option", "-o"),
     config_path: Path = typer.Option(
         CONFIG_DIR / "dimos", "--config", "-c", help="Path to config file"
     ),
@@ -374,8 +214,11 @@ def run(
     show_help: bool = typer.Option(False, "--help"),
 ) -> None:
     """Start a robot blueprint"""
-    logger.info("Starting DimOS")
-
+    from dimos.core.coordination.blueprint_config.errors import BlueprintConfigError
+    from dimos.core.coordination.blueprint_config.parser import (
+        BlueprintConfigParser,
+        split_run_arguments,
+    )
     from dimos.core.coordination.blueprints import autoconnect
     from dimos.core.coordination.module_coordinator import ModuleCoordinator
     from dimos.core.coordination.process_lifecycle import (
@@ -392,7 +235,13 @@ def run(
 
     setup_exception_handler()
 
-    cli_config_overrides: dict[str, Any] = ctx.obj
+    try:
+        blueprint_names, config_tokens = split_run_arguments(robot_types)
+    except BlueprintConfigError as error:
+        typer.echo(f"Error: {error}", err=True)
+        raise typer.Exit(2) from error
+
+    global_option_overrides: dict[str, Any] = dict(ctx.obj or {})
 
     # These flags are accepted on `run` itself, not just as global options.
     run_overrides = {
@@ -401,15 +250,67 @@ def run(
         if value is not None
     }
     if run_overrides:
-        cli_config_overrides.update(run_overrides)
-        global_config.update(**run_overrides)
+        global_option_overrides.update(run_overrides)
 
-    # Clean stale registry entries
+    try:
+        preparsed_global_config = BlueprintConfigParser.preparse_global_config(
+            config_tokens,
+            config_path=config_path,
+            environ=os.environ,
+            global_overrides=global_option_overrides,
+        )
+    except BlueprintConfigError as error:
+        typer.echo(f"Error: {error}", err=True)
+        raise typer.Exit(2) from error
+    # Some blueprint modules select their composition at import time, so all
+    # global sources must be visible before resolving the requested names.
+    global_config.update(**preparsed_global_config)
+
+    blueprint = autoconnect(*map(get_by_name_or_exit, blueprint_names))
+
+    if disable:
+        disabled_classes = tuple(
+            get_module_by_name_or_exit(name).blueprints[0].module for name in disable
+        )
+        blueprint = blueprint.disabled_modules(*disabled_classes)
+
+    blueprint = _with_relay_bridge(blueprint)
+    parser = BlueprintConfigParser(blueprint)
+
+    if show_help:
+        reserved_options = {
+            option
+            for parameter in ctx.command.params
+            for option in (
+                *getattr(parameter, "opts", ()),
+                *getattr(parameter, "secondary_opts", ()),
+            )
+            if option.startswith("--")
+        }
+        typer.echo(ctx.get_help())
+        typer.echo()
+        typer.echo(parser.format_help(reserved_options))
+        return
+
+    try:
+        parsed_config = parser.parse(
+            config_tokens,
+            config_path=config_path,
+            environ=os.environ,
+            global_overrides=global_option_overrides,
+        )
+    except BlueprintConfigError as error:
+        typer.echo(f"Error: {error}", err=True)
+        raise typer.Exit(2) from error
+
+    logger.info("Starting DimOS")
+
+    # Clean stale registry entries only after the full command has validated.
     stale = cleanup_stale()
     if stale:
         logger.info(f"Cleaned {stale} stale run entries")
 
-    blueprint_name = "-".join(robot_types)
+    blueprint_name = "-".join(blueprint_names)
     run_id = generate_run_id(blueprint_name)
     log_dir = LOG_DIR / run_id
 
@@ -421,27 +322,7 @@ def run(
     # Workers inherit DIMOS_RUN_LOG_DIR env var via forkserver.
     set_run_log_dir(log_dir)
 
-    blueprint = autoconnect(*map(get_by_name_or_exit, robot_types))
-
-    if disable:
-        disabled_classes = tuple(
-            get_module_by_name_or_exit(name).blueprints[0].module for name in disable
-        )
-        blueprint = blueprint.disabled_modules(*disabled_classes)
-
-    blueprint = _with_relay_bridge(blueprint)
-
-    if show_help:
-        print("Blueprint arguments:")
-        print("  Override with --option/-o module.field=value.")
-        print("  Nested config paths use dotted names, e.g. module.nested.field=value.")
-        print(arg_help(blueprint.config(), blueprint))
-        return
-
-    blueprint_config = blueprint.config()
-    kwargs = load_config_args(blueprint_config, blueprint_args, config_path, cli_config_overrides)
-
-    coordinator = ModuleCoordinator.build(blueprint, kwargs)
+    coordinator = ModuleCoordinator.build(blueprint, parsed_config)
 
     if daemon:
         # Health check before daemonizing — catch early crashes
@@ -469,8 +350,8 @@ def run(
             blueprint=blueprint_name,
             started_at=datetime.now(timezone.utc).isoformat(),
             log_dir=str(log_dir),
-            cli_args=list(robot_types),
-            config_overrides=cli_config_overrides,
+            cli_args=list(blueprint_names),
+            config_overrides=global_option_overrides,
             original_argv=sys.argv,
         )
         entry.save()
@@ -484,8 +365,8 @@ def run(
             blueprint=blueprint_name,
             started_at=datetime.now(timezone.utc).isoformat(),
             log_dir=str(log_dir),
-            cli_args=list(robot_types),
-            config_overrides=cli_config_overrides,
+            cli_args=list(blueprint_names),
+            config_overrides=global_option_overrides,
             original_argv=sys.argv,
         )
         entry.save()

--- a/dimos/cli/test_dimos.py
+++ b/dimos/cli/test_dimos.py
@@ -12,28 +12,50 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import Iterator
 from pathlib import Path
+import re
 import sys
-from typing import Literal
+from typing import Any
 
-from pydantic import BaseModel, Field
 import pytest
 from typer.testing import CliRunner
 
+import dimos.cli.dimos as dimos_cli
 from dimos.cli.dimos import (
     _normalize_simulation_argv,
     _with_relay_bridge,
-    arg_help,
-    load_config_args,
     main,
 )
 import dimos.cli.spy.run_spy as run_spy
-from dimos.core.coordination.blueprints import autoconnect
-import dimos.core.coordination.worker_manager_python as worker_manager_python
+import dimos.core.coordination.module_coordinator as module_coordinator
+import dimos.core.coordination.process_lifecycle as process_lifecycle
 from dimos.core.global_config import global_config
 from dimos.core.module import Module, ModuleConfig
+import dimos.core.run_registry as run_registry
 from dimos.robot import external_blueprints as external
+import dimos.robot.get_all_blueprints as get_all_blueprints
 import dimos.utils.cache as cache_utils
+import dimos.utils.logging_config as logging_config
+
+
+class RunConfigA(ModuleConfig):
+    map_file: str | None = None
+    entity_prefix: str = "world"
+    daemon: str = "module-default"
+
+
+class RunModuleA(Module):
+    config: RunConfigA
+
+
+class RunConfigB(ModuleConfig):
+    map_file: str | None = None
+    lookahead: float = 1.0
+
+
+class RunModuleB(Module):
+    config: RunConfigB
 
 
 @pytest.mark.parametrize(
@@ -74,106 +96,6 @@ def test_global_config_flag_applies_before_subcommand():
         global_config.update(transport=original)
 
 
-def test_blueprint_arg_help():
-    class ConfigA(ModuleConfig):
-        min_interval_sec: float = 0.1
-        entity_prefix: str = "world"
-        viewer_mode: Literal["native", "web", "connect", "none"] = "native"
-
-    class TestModuleA(Module):
-        config: ConfigA
-
-    class ConfigB(ModuleConfig):
-        memory_limit: str = "25%"
-        ip: str = "127.0.0.1"
-
-    class TestModuleB(Module):
-        config: ConfigB
-
-    blueprint = autoconnect(TestModuleA.blueprint(), TestModuleB.blueprint())
-    output = arg_help(blueprint.config(), blueprint)
-    # List output produces better diff in pytest error output.
-    assert output.split("\n") == [
-        "    testmodulea:",
-        "      * testmodulea.default_rpc_timeout: float (default: 120.0)",
-        "      * testmodulea.frame_id_prefix: str | None (default: None)",
-        "      * testmodulea.frame_id: str | None (default: None)",
-        "      * testmodulea.min_interval_sec: float (default: 0.1)",
-        "      * testmodulea.entity_prefix: str (default: world)",
-        "      * testmodulea.viewer_mode: typing.Literal['native', 'web', 'connect', 'none'] (default: native)",
-        "    testmoduleb:",
-        "      * testmoduleb.default_rpc_timeout: float (default: 120.0)",
-        "      * testmoduleb.frame_id_prefix: str | None (default: None)",
-        "      * testmoduleb.frame_id: str | None (default: None)",
-        "      * testmoduleb.memory_limit: str (default: 25%)",
-        "      * testmoduleb.ip: str (default: 127.0.0.1)",
-        "",
-    ]
-
-
-def test_blueprint_arg_help_extra_args():
-    """Test defaults passed to .blueprint() override."""
-
-    class ConfigA(ModuleConfig):
-        frame_id_prefix: str | None = None
-        min_interval_sec: float = 0.1
-        entity_prefix: str = "world"
-        viewer_mode: Literal["native", "web", "connect", "none"] = "native"
-
-    class TestModuleA(Module):
-        config: ConfigA
-
-    class ConfigB(ModuleConfig):
-        memory_limit: str = "25%"
-        ip: str = "127.0.0.1"
-
-    class TestModuleB(Module):
-        config: ConfigB
-
-    module_a = TestModuleA.blueprint(frame_id_prefix="foo", viewer_mode="web")
-    blueprint = autoconnect(module_a, TestModuleB.blueprint(ip="1.1.1.1"))
-    output = arg_help(blueprint.config(), blueprint)
-    # List output produces better diff in pytest error output.
-    assert output.split("\n") == [
-        "    testmodulea:",
-        "      * testmodulea.default_rpc_timeout: float (default: 120.0)",
-        "      * testmodulea.frame_id_prefix: str | None (default: foo)",
-        "      * testmodulea.frame_id: str | None (default: None)",
-        "      * testmodulea.min_interval_sec: float (default: 0.1)",
-        "      * testmodulea.entity_prefix: str (default: world)",
-        "      * testmodulea.viewer_mode: typing.Literal['native', 'web', 'connect', 'none'] (default: web)",
-        "    testmoduleb:",
-        "      * testmoduleb.default_rpc_timeout: float (default: 120.0)",
-        "      * testmoduleb.frame_id_prefix: str | None (default: None)",
-        "      * testmoduleb.frame_id: str | None (default: None)",
-        "      * testmoduleb.memory_limit: str (default: 25%)",
-        "      * testmoduleb.ip: str (default: 1.1.1.1)",
-        "",
-    ]
-
-
-def test_load_config_args_merges_cli_g_overrides(tmp_path):
-    """CLI flags (--transport, --local-relay, ...) must merge into the g
-    subtree built from config file / G__* env / -o g.* args, not replace it:
-    a replace silently reverts every other g.* key to its default."""
-
-    class Config(ModuleConfig):
-        pass
-
-    class TestModuleG(Module):
-        config: Config
-
-    blueprint = TestModuleG.blueprint()
-    kwargs = load_config_args(
-        blueprint.config(),
-        ["g.robot_id=go2-lab", "g.local_relay=false"],
-        tmp_path / "config.json",
-        cli_g_overrides={"local_relay": True},
-    )
-    assert kwargs["g"]["robot_id"] == "go2-lab"  # survives the CLI overrides
-    assert kwargs["g"]["local_relay"] is True  # the explicit flag wins its own key
-
-
 def test_run_composition_leaves_blueprint_alone_when_relay_disabled() -> None:
     class Config(ModuleConfig):
         pass
@@ -192,29 +114,6 @@ def test_run_composition_leaves_blueprint_alone_when_relay_disabled() -> None:
             local_relay=original_local_relay,
             relay_url=original_relay_url,
         )
-
-
-def test_blueprint_arg_help_required():
-    """Test required arguments."""
-
-    class Config(ModuleConfig):
-        foo: int
-        spam: str = "eggs"
-
-    class TestModule(Module):
-        config: Config
-
-    blueprint = TestModule.blueprint()
-    output = arg_help(blueprint.config(), blueprint)
-    assert output.split("\n") == [
-        "    testmodule:",
-        "      * testmodule.default_rpc_timeout: float (default: 120.0)",
-        "      * testmodule.frame_id_prefix: str | None (default: None)",
-        "      * testmodule.frame_id: str | None (default: None)",
-        "      * [Required] testmodule.foo: int",
-        "      * testmodule.spam: str (default: eggs)",
-        "",
-    ]
 
 
 def test_list_blueprints_groups_builtin_and_external(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -263,6 +162,222 @@ def test_list_blueprints_reports_external_discovery_errors(
 def isolated_cache_locks(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(cache_utils, "_CACHE_LOCK_DIR", tmp_path / "cache-users")
     monkeypatch.setattr(cache_utils, "_CACHE_GATE_PATH", tmp_path / "cache-clean.lock")
+
+
+@pytest.fixture
+def stubbed_run(
+    isolated_cache_locks: None,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[dict[str, Any]]:
+    """Drive `dimos run` through parsing without starting processes."""
+    recorded: dict[str, Any] = {}
+    original_global_config = global_config.model_dump()
+
+    class FakeCoordinator:
+        n_modules = 1
+
+        @classmethod
+        def build(cls, blueprint: Any, parsed_config: Any = None) -> "FakeCoordinator":
+            recorded["blueprint"] = blueprint
+            recorded["parsed_config"] = parsed_config
+            return cls()
+
+        def health_check(self) -> bool:
+            return True
+
+        def stop(self) -> None:
+            return None
+
+        def suppress_console(self) -> None:
+            return None
+
+        def loop(self) -> None:
+            return None
+
+    class FakeEntry:
+        def __init__(self, **fields: Any) -> None:
+            recorded["entry"] = fields
+
+        def save(self) -> None:
+            return None
+
+        def remove(self) -> None:
+            return None
+
+    blueprints = {
+        "alpha": RunModuleA.blueprint(),
+        "beta": RunModuleB.blueprint(),
+    }
+    modules = {
+        "runmodulea": RunModuleA.blueprint(),
+        "runmoduleb": RunModuleB.blueprint(),
+    }
+
+    global_config.update(local_relay=False, relay_url=None)
+    monkeypatch.setattr(module_coordinator, "ModuleCoordinator", FakeCoordinator)
+    monkeypatch.setattr(run_registry, "RunEntry", FakeEntry)
+    monkeypatch.setattr(run_registry, "cleanup_stale", lambda: 0)
+    monkeypatch.setattr(run_registry, "generate_run_id", lambda name: f"test-{name}")
+    monkeypatch.setattr(process_lifecycle, "spawn_watchdog", lambda *args, **kwargs: None)
+    monkeypatch.setattr(dimos_cli, "install_signal_handlers", lambda *args, **kwargs: None)
+    monkeypatch.setattr(dimos_cli, "LOG_DIR", tmp_path / "logs")
+    monkeypatch.setattr(logging_config, "set_run_log_dir", lambda path: None)
+    monkeypatch.setattr(get_all_blueprints, "get_by_name_or_exit", blueprints.__getitem__)
+    monkeypatch.setattr(
+        get_all_blueprints,
+        "get_module_by_name_or_exit",
+        lambda name: modules[name.lower()],
+    )
+    monkeypatch.setenv("DIMOS_RUN_ID", "")
+
+    try:
+        yield recorded
+    finally:
+        global_config.update(**original_global_config)
+
+
+def test_run_parses_spaced_and_equals_config_flags(stubbed_run: dict[str, Any]) -> None:
+    result = CliRunner().invoke(
+        main,
+        [
+            "run",
+            "alpha",
+            "beta",
+            "--entity-prefix=hall",
+            "--lookahead",
+            "2.5",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    parsed = stubbed_run["parsed_config"]
+    assert parsed.module_kwargs("runmodulea")["entity_prefix"] == "hall"
+    assert parsed.module_kwargs("runmoduleb")["lookahead"] == 2.5
+    assert stubbed_run["entry"]["blueprint"] == "alpha-beta"
+    assert stubbed_run["entry"]["cli_args"] == ["alpha", "beta"]
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["--robot-ip", "192.168.0.116", "run", "alpha"],
+        ["run", "alpha", "--robot-ip", "192.168.0.116"],
+    ],
+)
+def test_run_accepts_global_config_flags_before_and_after_blueprint(
+    argv: list[str],
+    stubbed_run: dict[str, Any],
+) -> None:
+    result = CliRunner().invoke(main, argv)
+
+    assert result.exit_code == 0, result.output
+    assert stubbed_run["parsed_config"].global_config["robot_ip"] == "192.168.0.116"
+
+
+def test_after_run_global_config_is_applied_before_blueprint_resolution(
+    stubbed_run: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed_robot_ips: list[str | None] = []
+
+    def resolve(name: str) -> Any:
+        observed_robot_ips.append(global_config.robot_ip)
+        assert name == "alpha"
+        return RunModuleA.blueprint()
+
+    monkeypatch.setattr(get_all_blueprints, "get_by_name_or_exit", resolve)
+
+    result = CliRunner().invoke(
+        main,
+        ["run", "alpha", "--robot-ip", "192.0.2.42"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert observed_robot_ips == ["192.0.2.42"]
+
+
+def test_qualified_global_relay_flag_is_applied_before_composition(
+    stubbed_run: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed_relay_values: list[tuple[bool, str | None]] = []
+
+    def compose(blueprint: Any) -> Any:
+        observed_relay_values.append((global_config.local_relay, global_config.relay_url))
+        return blueprint
+
+    monkeypatch.setattr(dimos_cli, "_with_relay_bridge", compose)
+
+    result = CliRunner().invoke(main, ["run", "alpha", "--g.local-relay=true"])
+
+    assert result.exit_code == 0, result.output
+    assert observed_relay_values == [(True, None)]
+    assert stubbed_run["parsed_config"].global_config["local_relay"] is True
+
+
+def test_run_rejects_ambiguous_short_config_flag(stubbed_run: dict[str, Any]) -> None:
+    result = CliRunner().invoke(main, ["run", "alpha", "beta", "--map-file", "office"])
+
+    assert result.exit_code == 2
+    assert "--runmodulea.map-file" in result.output
+    assert "--runmoduleb.map-file" in result.output
+    assert "parsed_config" not in stubbed_run
+    assert "entry" not in stubbed_run
+
+
+def test_run_accepts_qualified_config_flag(stubbed_run: dict[str, Any]) -> None:
+    result = CliRunner().invoke(
+        main,
+        ["run", "alpha", "beta", "--runmoduleb.map-file=office"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert stubbed_run["parsed_config"].module_kwargs("runmoduleb")["map_file"] == "office"
+    assert "map_file" not in stubbed_run["parsed_config"].module_kwargs("runmodulea")
+
+
+def test_run_options_still_work_after_dynamic_config_flags(
+    stubbed_run: dict[str, Any],
+) -> None:
+    result = CliRunner().invoke(
+        main,
+        ["run", "alpha", "beta", "--entity-prefix", "hall", "--disable", "RunModuleB"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert stubbed_run["parsed_config"].module_kwargs("runmodulea")["entity_prefix"] == "hall"
+    assert stubbed_run["blueprint"].disabled_modules_tuple == (RunModuleB,)
+
+
+def test_run_help_lists_dynamic_flags_without_starting(stubbed_run: dict[str, Any]) -> None:
+    result = CliRunner().invoke(main, ["run", "alpha", "--help"])
+
+    assert result.exit_code == 0, result.output
+    # In CI, GITHUB_ACTIONS makes typer emit ANSI styling that splits option
+    # names mid-string, so strip the escape codes before matching.
+    output_plain = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
+    assert "--map-file" in output_plain
+    assert "--runmodulea.daemon" in output_plain
+    assert output_plain.count("--daemon") == 1
+    assert "parsed_config" not in stubbed_run
+    assert "entry" not in stubbed_run
+
+
+@pytest.mark.parametrize("legacy_flag", ["-o", "--option"])
+def test_run_rejects_removed_legacy_option(
+    legacy_flag: str,
+    stubbed_run: dict[str, Any],
+) -> None:
+    result = CliRunner().invoke(
+        main,
+        ["run", "alpha", legacy_flag, "runmodulea.entity_prefix=hall"],
+    )
+
+    assert result.exit_code == 2
+    assert "removed" in result.output.lower()
+    assert "--map-file" in result.output
+    assert "parsed_config" not in stubbed_run
 
 
 def test_run_reports_external_resolution_errors(
@@ -345,92 +460,3 @@ def test_spy_rejects_root_transport(monkeypatch, spy_main_argv):
     assert result.exit_code == 2
     assert "dimos spy --transport" in result.output
     assert spy_main_argv == []  # never reaches the spy
-
-
-def test_blueprint_arg_help_nested_config_paths():
-    class NestedConfig(BaseModel):
-        enabled: bool = True
-        mode: str = "auto"
-
-    class Config(ModuleConfig):
-        nested: NestedConfig = Field(default_factory=NestedConfig)
-
-    class TestModule(Module):
-        config: Config
-
-    blueprint = TestModule.blueprint(nested={"mode": "manual"})
-    output = arg_help(blueprint.config(), blueprint)
-
-    assert "      testmodule.nested:" in output
-    assert "        * testmodule.nested.enabled: bool (default: True)" in output
-    assert "        * testmodule.nested.mode: str (default: manual)" in output
-
-
-def test_blueprint_arg_help_uses_nested_backend_defaults():
-    class DisabledConfig(BaseModel):
-        backend: Literal["disabled"] = "disabled"
-
-    class EnabledConfig(BaseModel):
-        backend: Literal["enabled"] = "enabled"
-        level: int = 1
-
-    class Config(ModuleConfig):
-        nested: DisabledConfig | EnabledConfig = Field(default_factory=DisabledConfig)
-
-    class TestModule(Module):
-        config: Config
-
-    blueprint = TestModule.blueprint(nested={"backend": "enabled", "level": 3})
-    output = arg_help(blueprint.config(), blueprint)
-
-    assert "      testmodule.nested:" in output
-    assert (
-        "        * testmodule.nested.backend: typing.Literal['enabled'] (default: enabled)"
-        in output
-    )
-    assert "        * testmodule.nested.level: int (default: 3)" in output
-
-
-def test_nested_blueprint_config_defaults_survive_cli_override(tmp_path, monkeypatch):
-    class NestedConfig(BaseModel):
-        enabled: bool = True
-        mode: str = "auto"
-
-    class Config(ModuleConfig):
-        nested: NestedConfig = Field(default_factory=NestedConfig)
-
-    class TestModule(Module):
-        config: Config
-
-    class FakeWorker:
-        dedicated = False
-        module_count = 0
-
-        def reserve_slot(self):
-            self.module_count += 1
-
-        def deploy_module(self, _module_class, _global_config, kwargs):
-            return kwargs
-
-    monkeypatch.setattr(
-        worker_manager_python, "RPCClient", lambda actor, _module_class, _instance_name: actor
-    )
-
-    blueprint = TestModule.blueprint(nested={"mode": "manual"})
-    blueprint_args = load_config_args(
-        blueprint.config(),
-        ["testmodule.nested.enabled=false"],
-        tmp_path / "config.json",
-    )
-    worker_manager = worker_manager_python.WorkerManagerPython(global_config)
-    worker_manager._started = True
-    worker_manager._workers = [FakeWorker()]
-
-    deployed_configs = worker_manager.deploy_parallel(
-        [(TestModule, global_config, blueprint.blueprints[0].kwargs.copy())],
-        blueprint_args,
-    )
-    config = Config(**deployed_configs[0])
-
-    assert config.nested.enabled is False
-    assert config.nested.mode == "manual"

--- a/dimos/core/coordination/blueprint_config/errors.py
+++ b/dimos/core/coordination/blueprint_config/errors.py
@@ -1,0 +1,32 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Blueprint configuration error type and error formatting."""
+
+from __future__ import annotations
+
+from pydantic import ValidationError
+
+
+class BlueprintConfigError(ValueError):
+    """A user-correctable blueprint configuration error."""
+
+
+def format_validation_error(root: str, error: ValidationError) -> str:
+    details = []
+    for item in error.errors(include_url=False):
+        location = ".".join(str(part) for part in item["loc"])
+        qualified = f"{root}.{location}" if location else root
+        details.append(f"{qualified}: {item['msg']}")
+    return "Invalid blueprint configuration: " + "; ".join(details)

--- a/dimos/core/coordination/blueprint_config/fields.py
+++ b/dimos/core/coordination/blueprint_config/fields.py
@@ -1,0 +1,313 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Introspection of pydantic models and their field annotations."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import inspect
+from types import UnionType
+from typing import Annotated, Any, Union, get_args, get_origin, get_type_hints
+
+from pydantic import BaseModel, TypeAdapter
+from pydantic.errors import PydanticInvalidForJsonSchema, PydanticSchemaGenerationError
+from pydantic.fields import FieldInfo
+from pydantic_core import PydanticUndefined
+
+from dimos.core.coordination.blueprint_config.errors import BlueprintConfigError
+from dimos.core.coordination.blueprint_config.values import plain, plain_mapping
+from dimos.core.coordination.blueprints import BlueprintAtom
+
+
+def module_config_cls(atom: BlueprintAtom) -> type[BaseModel]:
+    try:
+        config_cls = get_type_hints(atom.module)["config"]
+    except (KeyError, NameError, TypeError) as error:
+        raise BlueprintConfigError(
+            f"Could not resolve configuration type for {atom.module.__name__}: {error}"
+        ) from error
+    if not inspect.isclass(config_cls) or not issubclass(config_cls, BaseModel):
+        raise BlueprintConfigError(
+            f"{atom.module.__name__}.config must be a pydantic BaseModel type."
+        )
+    return config_cls
+
+
+def leaf_fields(
+    model: type[BaseModel],
+    prefix: tuple[str, ...] = (),
+    *,
+    excluded: set[str] | None = None,
+    ancestors: frozenset[type[BaseModel]] = frozenset(),
+) -> list[tuple[tuple[str, ...], Any]]:
+    leaves: dict[tuple[str, ...], Any] = {}
+    excluded = excluded or set()
+    if model in ancestors:
+        return []
+    next_ancestors = ancestors | {model}
+
+    for name, info in model.model_fields.items():
+        if not prefix and name in excluded:
+            continue
+        path = (*prefix, name)
+        nested_models = _base_model_types(info.annotation)
+        if nested_models:
+            nested_leaves: list[tuple[tuple[str, ...], Any]] = []
+            for nested in nested_models:
+                nested_leaves.extend(
+                    leaf_fields(nested, path, excluded=set(), ancestors=next_ancestors)
+                )
+            if nested_leaves:
+                for nested_path, annotation in nested_leaves:
+                    existing = leaves.get(nested_path)
+                    if existing is None:
+                        leaves[nested_path] = annotation
+                    elif existing != annotation:
+                        leaves[nested_path] = existing | annotation
+                continue
+        if _contains_runtime_type(info.annotation):
+            continue
+        if not _is_cli_settable(info.annotation):
+            continue
+        leaves[path] = info.annotation
+    return list(leaves.items())
+
+
+def _base_model_types(annotation: Any) -> tuple[type[BaseModel], ...]:
+    annotation = _unwrap_annotated(annotation)
+    candidates = (
+        get_args(annotation) if get_origin(annotation) in (Union, UnionType) else (annotation,)
+    )
+    return tuple(
+        candidate
+        for candidate in candidates
+        if inspect.isclass(candidate) and issubclass(candidate, BaseModel)
+    )
+
+
+def _unwrap_annotated(annotation: Any) -> Any:
+    while get_origin(annotation) is Annotated:
+        annotation = get_args(annotation)[0]
+    return annotation
+
+
+def _contains_runtime_type(annotation: Any) -> bool:
+    """Whether an annotation requires a Python class object, not CLI data."""
+    annotation = _unwrap_annotated(annotation)
+    if annotation is type or get_origin(annotation) is type:
+        return True
+    if get_origin(annotation) in (Union, UnionType):
+        return any(_contains_runtime_type(candidate) for candidate in get_args(annotation))
+    return False
+
+
+def all_annotation_types(annotation: Any) -> set[Any]:
+    annotation = _unwrap_annotated(annotation)
+    if get_origin(annotation) in (Union, UnionType):
+        result: set[Any] = set()
+        for candidate in get_args(annotation):
+            result.update(all_annotation_types(candidate))
+        return result
+    return {annotation}
+
+
+def scalar_annotation_types(annotation: Any) -> set[Any]:
+    return {
+        candidate for candidate in all_annotation_types(annotation) if candidate is not type(None)
+    }
+
+
+def _is_cli_settable(annotation: Any) -> bool:
+    """Whether pydantic can build some union member from CLI-provided data.
+
+    Arbitrary classes (permitted via ``arbitrary_types_allowed``) validate by
+    isinstance only, and callables cannot be produced from a string either; a
+    bare ``TypeAdapter`` refuses to generate a JSON schema for exactly those
+    types, even nested inside containers.
+    """
+    return any(_member_is_cli_settable(member) for member in scalar_annotation_types(annotation))
+
+
+def _member_is_cli_settable(member: Any) -> bool:
+    try:
+        TypeAdapter(member).json_schema()
+    except (PydanticInvalidForJsonSchema, PydanticSchemaGenerationError):
+        return False
+    return True
+
+
+def prepare_model_input(
+    model: type[BaseModel],
+    values: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Add only schema defaults needed to validate sparse nested overrides.
+
+    A discriminated union cannot validate ``{"solver": "foo"}`` even when its
+    field has a default backend model. Copy that model's discriminator into the
+    sparse input, while leaving ordinary defaults for construction in workers.
+    """
+    prepared = plain_mapping(values)
+    for name, info in model.model_fields.items():
+        raw_value = prepared.get(name)
+        if not isinstance(raw_value, Mapping):
+            continue
+        nested_models = _base_model_types(info.annotation)
+        if not nested_models:
+            continue
+
+        selected: type[BaseModel] | None = None
+        discriminator = info.discriminator if isinstance(info.discriminator, str) else None
+        nested_values = plain_mapping(raw_value)
+        if discriminator is not None:
+            discriminator_value = nested_values.get(discriminator, PydanticUndefined)
+            if discriminator_value is PydanticUndefined:
+                default = _parse_field_default(info)
+                if isinstance(default, BaseModel):
+                    discriminator_value = getattr(
+                        default,
+                        discriminator,
+                        PydanticUndefined,
+                    )
+                elif isinstance(default, Mapping):
+                    discriminator_value = default.get(discriminator, PydanticUndefined)
+                if discriminator_value is not PydanticUndefined:
+                    nested_values[discriminator] = plain(discriminator_value)
+            if discriminator_value is not PydanticUndefined:
+                selected = _select_discriminated_model(
+                    nested_models,
+                    discriminator,
+                    discriminator_value,
+                )
+        elif len(nested_models) == 1:
+            selected = nested_models[0]
+
+        if selected is not None:
+            nested_values = prepare_model_input(selected, nested_values)
+        prepared[name] = nested_values
+    return prepared
+
+
+def _parse_field_default(info: FieldInfo) -> Any:
+    if info.default is not PydanticUndefined:
+        return info.default
+    if info.default_factory is not None:
+        return info.get_default(call_default_factory=True)
+    return PydanticUndefined
+
+
+def _select_discriminated_model(
+    candidates: tuple[type[BaseModel], ...],
+    discriminator: str,
+    value: Any,
+) -> type[BaseModel] | None:
+    for candidate in candidates:
+        info = candidate.model_fields.get(discriminator)
+        if info is None:
+            continue
+        if _parse_field_default(info) == value:
+            return candidate
+    return None
+
+
+def display_annotation(annotations: tuple[Any, ...]) -> str:
+    names = []
+    for annotation in annotations:
+        annotation = _unwrap_annotated(annotation)
+        if isinstance(annotation, type):
+            name = annotation.__name__
+        else:
+            name = str(annotation).replace("typing.", "")
+        if name not in names:
+            names.append(name)
+    return " | ".join(names)
+
+
+def nested_get(values: Any, path: tuple[str, ...]) -> Any:
+    current = values
+    for part in path:
+        if isinstance(current, BaseModel):
+            if part not in current.model_fields_set:
+                return PydanticUndefined
+            current = getattr(current, part)
+        elif isinstance(current, Mapping):
+            if part not in current:
+                return PydanticUndefined
+            current = current[part]
+        else:
+            return PydanticUndefined
+    return current
+
+
+def safe_field_default(model: type[BaseModel], path: tuple[str, ...]) -> Any:
+    if not path:
+        return PydanticUndefined
+    info = model.model_fields.get(path[0])
+    if info is None:
+        return PydanticUndefined
+    if len(path) == 1:
+        return info.default
+
+    if info.default is not PydanticUndefined:
+        configured = nested_get(info.default, path[1:])
+        if configured is not PydanticUndefined:
+            return configured
+
+    for nested_model in _base_model_types(info.annotation):
+        nested_default = safe_field_default(nested_model, path[1:])
+        if nested_default is not PydanticUndefined:
+            return nested_default
+    return PydanticUndefined
+
+
+def field_is_required(model: type[BaseModel], path: tuple[str, ...]) -> bool:
+    current_models: tuple[type[BaseModel], ...] = (model,)
+    for index, part in enumerate(path):
+        infos = [
+            info
+            for candidate in current_models
+            if (info := candidate.model_fields.get(part)) is not None
+        ]
+        if not infos:
+            return False
+        if not all(info.is_required() for info in infos):
+            return False
+        if index == len(path) - 1:
+            return True
+        nested: list[type[BaseModel]] = []
+        for info in infos:
+            nested.extend(_base_model_types(info.annotation))
+        current_models = tuple(dict.fromkeys(nested))
+    return False
+
+
+def field_has_required_parent(model: type[BaseModel], path: tuple[str, ...]) -> bool:
+    current_models: tuple[type[BaseModel], ...] = (model,)
+    for index, part in enumerate(path[:-1]):
+        infos = [
+            info
+            for candidate in current_models
+            if (info := candidate.model_fields.get(part)) is not None
+        ]
+        if not infos:
+            return False
+        if all(info.is_required() for info in infos):
+            return True
+        nested: list[type[BaseModel]] = []
+        for info in infos:
+            nested.extend(_base_model_types(info.annotation))
+        current_models = tuple(dict.fromkeys(nested))
+        if not current_models and index < len(path) - 2:
+            return False
+    return False

--- a/dimos/core/coordination/blueprint_config/merging.py
+++ b/dimos/core/coordination/blueprint_config/merging.py
@@ -1,0 +1,234 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Merging raw source values into per-section configuration dicts."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import difflib
+from typing import Any
+
+from dimos.core.coordination.blueprint_config.errors import BlueprintConfigError
+from dimos.core.coordination.blueprint_config.schema import (
+    OptionTarget,
+    ParserSchema,
+    coerce_cli_value,
+    coerce_environment_value,
+    display_normalized_option,
+    normalize_option_name,
+)
+from dimos.core.coordination.blueprint_config.sources import global_environment_names
+from dimos.core.coordination.blueprint_config.values import (
+    deep_merge,
+    deep_set,
+    normalize_mapping_keys,
+)
+from dimos.core.coordination.blueprints import config_key
+
+
+def merge_root_source(
+    module_values: dict[str, dict[str, Any]],
+    global_values: dict[str, Any],
+    transport_values: dict[str, Any],
+    values: Mapping[str, Any],
+    *,
+    source: str,
+    schema: ParserSchema,
+) -> None:
+    module_roots: dict[str, str] = {}
+    for module in schema.modules:
+        module_roots[module.atom.name.lower()] = module.atom.name
+        module_roots[config_key(module.atom.name).lower()] = module.atom.name
+
+    for raw_root, raw_value in values.items():
+        if not isinstance(raw_root, str):
+            raise BlueprintConfigError(f"{source} contains a non-string root key.")
+        root = raw_root.lower().replace("-", "_")
+        if raw_value is None:
+            continue
+        if not isinstance(raw_value, Mapping):
+            raise BlueprintConfigError(
+                f"{source} section {raw_root!r} must be an object, not {type(raw_value).__name__}."
+            )
+        normalized = normalize_mapping_keys(raw_value)
+        if root == "g":
+            deep_merge(global_values, normalized)
+        elif root == "transports":
+            deep_merge(transport_values, normalized)
+        elif root in module_roots:
+            deep_merge(module_values[module_roots[root]], normalized)
+        else:
+            choices = [*module_roots, "g", "transports"]
+            suggestion = difflib.get_close_matches(root, choices, n=1)
+            hint = f" Did you mean {suggestion[0]!r}?" if suggestion else ""
+            raise BlueprintConfigError(
+                f"Unknown configuration section {raw_root!r} in {source}.{hint}"
+            )
+
+
+def merge_environment(
+    module_values: dict[str, dict[str, Any]],
+    global_values: dict[str, Any],
+    transport_values: dict[str, Any],
+    environ: Mapping[str, str],
+    schema: ParserSchema,
+) -> None:
+    roots: dict[str, str] = {"g": "g", "transports": "transports"}
+    for module in schema.modules:
+        roots[config_key(module.atom.name).lower()] = module.atom.name
+        roots[module.atom.name.lower()] = module.atom.name
+
+    global_env_names = global_environment_names()
+    targets = {target.identity: target for target in schema.targets}
+    env_source: dict[str, Any] = {}
+
+    def set_coerced(path: tuple[str, ...], raw_name: str, value: str) -> None:
+        identity = _environment_identity(path)
+        target = targets.get(identity) if identity is not None else None
+        coerced = value if target is None else coerce_environment_value(value, target, raw_name)
+        deep_set(env_source, path, coerced)
+
+    for raw_name, value in environ.items():
+        lowered = raw_name.lower()
+        global_field = global_env_names.get(lowered)
+        if global_field is not None:
+            set_coerced(("g", global_field), raw_name, value)
+            continue
+
+        parts = tuple(part.lower().replace("-", "_") for part in raw_name.split("__"))
+        if len(parts) < 2 or parts[0] not in roots:
+            continue
+        set_coerced((roots[parts[0]], *parts[1:]), raw_name, value)
+
+    if env_source:
+        merge_root_source(
+            module_values,
+            global_values,
+            transport_values,
+            env_source,
+            source="environment",
+            schema=schema,
+        )
+
+
+def merge_cli(
+    module_values: dict[str, dict[str, Any]],
+    global_values: dict[str, Any],
+    transport_values: dict[str, Any],
+    tokens: tuple[str, ...],
+    schema: ParserSchema,
+) -> None:
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if (
+            token == "-o"
+            or token.startswith("-o=")
+            or token == "--option"
+            or token.startswith("--option=")
+        ):
+            raise BlueprintConfigError(
+                "The legacy -o/--option syntax was removed. "
+                "Use a blueprint option directly, for example "
+                "`--map-file recording_go2`."
+            )
+        if not token.startswith("--"):
+            raise BlueprintConfigError(
+                f"Unexpected configuration argument {token!r}; options must start with '--'."
+            )
+
+        option, separator, attached_value = token[2:].partition("=")
+        if not option:
+            raise BlueprintConfigError("Empty configuration option '--'.")
+
+        negated_global = False
+        normalized = normalize_option_name(option)
+        target = _resolve_target(normalized, schema)
+        if target is None and normalized.startswith("no_"):
+            positive = normalized.removeprefix("no_")
+            candidate = _resolve_target(positive, schema)
+            if candidate is not None and candidate.section == "global" and candidate.is_bool:
+                target = candidate
+                negated_global = True
+        if target is None:
+            _raise_unknown_option(option, schema)
+
+        assert target is not None
+        if separator:
+            raw_value: Any = attached_value
+        elif negated_global:
+            raw_value = False
+        elif target.section == "global" and target.is_bool:
+            if index + 1 < len(tokens) and not tokens[index + 1].startswith("--"):
+                index += 1
+                raw_value = tokens[index]
+            else:
+                raw_value = True
+        else:
+            if index + 1 >= len(tokens) or tokens[index + 1].startswith("--"):
+                raise BlueprintConfigError(
+                    f"Option --{option} requires a value. "
+                    f"Use --{option}=VALUE when the value starts with '--'."
+                )
+            index += 1
+            raw_value = tokens[index]
+
+        if negated_global and separator:
+            raise BlueprintConfigError(f"Negated option --{option} does not accept a value.")
+        value = coerce_cli_value(raw_value, target, option)
+        if target.section == "module":
+            deep_set(module_values[target.root], target.path, value)
+        elif target.section == "global":
+            deep_set(global_values, target.path, value)
+        else:
+            section = transport_values.setdefault(target.root, {})
+            if not isinstance(section, dict):
+                raise BlueprintConfigError(f"Transport section {target.root!r} is not an object.")
+            deep_set(section, target.path, value)
+        index += 1
+
+
+def _environment_identity(path: tuple[str, ...]) -> tuple[str, str, tuple[str, ...]] | None:
+    """Map an environment source path to an OptionTarget identity."""
+    root, *rest = path
+    if root == "g":
+        return ("global", "g", tuple(rest))
+    if root == "transports":
+        if len(rest) < 2:
+            return None
+        return ("transport", rest[0], tuple(rest[1:]))
+    return ("module", root, tuple(rest))
+
+
+def _resolve_target(normalized: str, schema: ParserSchema) -> OptionTarget | None:
+    candidates = schema.aliases.get(normalized)
+    if not candidates:
+        return None
+    if len(candidates) == 1:
+        return candidates[0]
+    choices = ", ".join(f"--{candidate.qualified_name}" for candidate in candidates)
+    raise BlueprintConfigError(
+        f"Option --{display_normalized_option(normalized)} is ambiguous. Use one of: {choices}."
+    )
+
+
+def _raise_unknown_option(option: str, schema: ParserSchema) -> None:
+    normalized = normalize_option_name(option)
+    suggestions = difflib.get_close_matches(normalized, schema.aliases.keys(), n=3)
+    hint = ""
+    if suggestions:
+        rendered = ", ".join(f"--{display_normalized_option(name)}" for name in suggestions)
+        hint = f" Did you mean {rendered}?"
+    raise BlueprintConfigError(f"Unknown blueprint configuration option --{option}.{hint}")

--- a/dimos/core/coordination/blueprint_config/parsed.py
+++ b/dimos/core/coordination/blueprint_config/parsed.py
@@ -1,0 +1,92 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The immutable result of parsing blueprint configuration."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any, cast
+
+from dimos.core.coordination.blueprint_config.errors import BlueprintConfigError
+from dimos.core.coordination.blueprint_config.values import read_only_view, snapshot_mapping
+from dimos.core.coordination.blueprints import Blueprint, config_key
+
+
+@dataclass(frozen=True, slots=True)
+class ParsedBlueprintConfig:
+    """Validated, immutable configuration snapshot for one blueprint."""
+
+    _module_config_values: Mapping[str, Any] = field(repr=False)
+    _global_config_values: Mapping[str, Any] = field(repr=False)
+    _global_explicit_values: Mapping[str, Any] = field(repr=False)
+    _transport_config_values: Mapping[str, Any] = field(repr=False)
+    _blueprint: Blueprint = field(repr=False, compare=False)
+
+    @property
+    def module_configs(self) -> Mapping[str, Any]:
+        """Return a read-only view detached from the stored snapshot."""
+        return cast("Mapping[str, Any]", read_only_view(self._module_config_values))
+
+    @property
+    def global_config(self) -> Mapping[str, Any]:
+        """Return a read-only view detached from the stored snapshot."""
+        return cast("Mapping[str, Any]", read_only_view(self._global_config_values))
+
+    @property
+    def transport_configs(self) -> Mapping[str, Any]:
+        """Return a read-only view detached from the stored snapshot."""
+        return cast("Mapping[str, Any]", read_only_view(self._transport_config_values))
+
+    def assert_matches(self, blueprint: Blueprint) -> None:
+        """Reject use with a blueprint other than the one that was parsed."""
+        if blueprint is not self._blueprint:
+            raise BlueprintConfigError(
+                "Parsed blueprint configuration belongs to a different blueprint."
+            )
+
+    def global_config_values(self) -> dict[str, Any]:
+        """Return an independent mutable copy of the resolved GlobalConfig values."""
+        return snapshot_mapping(self._global_config_values)
+
+    def explicit_global_config_values(self) -> dict[str, Any]:
+        """Return only the validated GlobalConfig values a source explicitly set.
+
+        Schema defaults are excluded, so a live coordinator can apply these
+        without resetting unrelated fields.
+        """
+        return snapshot_mapping(self._global_explicit_values)
+
+    def module_kwargs(self, instance_name: str) -> dict[str, Any]:
+        """Return independent mutable kwargs for a module instance."""
+        try:
+            values = self._module_config_values[instance_name]
+        except KeyError:
+            escaped = config_key(instance_name)
+            matching = [
+                value
+                for name, value in self._module_config_values.items()
+                if config_key(name) == escaped
+            ]
+            if len(matching) != 1:
+                raise KeyError(f"No parsed configuration for module {instance_name!r}") from None
+            values = matching[0]
+        if not isinstance(values, Mapping):
+            raise TypeError(f"Module configuration for {instance_name!r} is not a mapping")
+        return snapshot_mapping(values)
+
+    def transport_overrides(self) -> dict[str, Any]:
+        """Return independent mutable transport configuration overrides."""
+        return snapshot_mapping(self._transport_config_values)

--- a/dimos/core/coordination/blueprint_config/parser.py
+++ b/dimos/core/coordination/blueprint_config/parser.py
@@ -1,0 +1,504 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Blueprint-aware command-line configuration parsing.
+
+This package deliberately has no dependency on Typer.  It owns the complete
+configuration merge and validation flow so that CLI, tests, and programmatic
+callers all resolve blueprint configuration in the same way.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Collection, Iterable, Mapping, Sequence
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any
+
+from pydantic import BaseModel, ValidationError
+from pydantic_core import PydanticUndefined
+
+from dimos.core.coordination.blueprint_config.errors import (
+    BlueprintConfigError,
+    format_validation_error,
+)
+from dimos.core.coordination.blueprint_config.fields import (
+    display_annotation,
+    field_has_required_parent,
+    field_is_required,
+    leaf_fields,
+    module_config_cls,
+    nested_get,
+    prepare_model_input,
+    safe_field_default,
+)
+from dimos.core.coordination.blueprint_config.merging import (
+    merge_cli,
+    merge_environment,
+    merge_root_source,
+)
+from dimos.core.coordination.blueprint_config.parsed import ParsedBlueprintConfig
+from dimos.core.coordination.blueprint_config.schema import (
+    ModuleSchema,
+    OptionTarget,
+    ParserSchema,
+    TransportSchema,
+    cli_path,
+    normalize_option_name,
+)
+from dimos.core.coordination.blueprint_config.sources import (
+    configuration_environment,
+    global_environment_names,
+    global_schema_defaults,
+    merge_global_cli,
+    merge_global_environment,
+    read_config_file,
+    reserved_global_short_names,
+    validate_global_values,
+)
+from dimos.core.coordination.blueprint_config.values import (
+    deep_merge,
+    extract_shape,
+    normalize_mapping_keys,
+    plain,
+    plain_mapping,
+    snapshot_mapping,
+)
+from dimos.core.coordination.blueprints import (
+    Blueprint,
+    TransportSpec,
+    config_key,
+    transport_config_name,
+)
+from dimos.core.global_config import GlobalConfig
+
+
+def split_run_arguments(tokens: Sequence[str]) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """Split Typer's variadic run arguments into blueprint names and config tokens.
+
+    Blueprint names must form the leading positional segment.  Once any
+    dash-prefixed token is seen, all remaining tokens belong to option parsing.
+    """
+    split_at = next((i for i, token in enumerate(tokens) if token.startswith("-")), len(tokens))
+    blueprint_names = tuple(tokens[:split_at])
+    if not blueprint_names:
+        raise BlueprintConfigError(
+            "At least one blueprint name must precede configuration options. "
+            "Usage: dimos run <blueprint> [--config-field value]."
+        )
+    return blueprint_names, tuple(tokens[split_at:])
+
+
+class BlueprintConfigParser:
+    """Resolve all configuration sources for a blueprint."""
+
+    def __init__(self, blueprint: Blueprint) -> None:
+        self.blueprint = blueprint
+        self._schema: ParserSchema | None = None
+
+    @classmethod
+    def preparse_global_config(
+        cls,
+        cli_tokens: Iterable[str] = (),
+        *,
+        config_path: Path | str | None = None,
+        environ: Mapping[str, str] | None = None,
+        global_overrides: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Resolve GlobalConfig before importing a blueprint.
+
+        Blueprint modules may choose their composition at import time from
+        ``global_config``. This pre-pass consumes only recognized global
+        sources and ignores blueprint-specific CLI tokens; the regular
+        :meth:`parse` call still performs complete validation afterward.
+        """
+        values = global_schema_defaults()
+        if config_path is not None:
+            config_values = read_config_file(Path(config_path))
+            raw_global = config_values.get("g")
+            if raw_global is not None:
+                if not isinstance(raw_global, Mapping):
+                    raise BlueprintConfigError(
+                        "config file section 'g' must be an object, not "
+                        f"{type(raw_global).__name__}."
+                    )
+                deep_merge(values, normalize_mapping_keys(raw_global))
+
+        merge_global_environment(
+            values,
+            configuration_environment(environ),
+        )
+        merge_global_cli(values, tuple(cli_tokens))
+        if global_overrides is not None:
+            deep_merge(values, normalize_mapping_keys(global_overrides))
+        return validate_global_values(values)
+
+    def parse(
+        self,
+        cli_tokens: Iterable[str] = (),
+        *,
+        config_path: Path | str | None = None,
+        environ: Mapping[str, str] | None = None,
+        global_overrides: Mapping[str, Any] | None = None,
+        overrides: Mapping[str, Any] | None = None,
+    ) -> ParsedBlueprintConfig:
+        """Merge, validate, and freeze blueprint configuration.
+
+        Precedence, from lowest to highest, is blueprint/schema defaults,
+        blueprint-pinned values, JSON config, environment, programmatic
+        ``overrides``, dynamic CLI flags, and explicit ``global_overrides``.
+        """
+        schema = self._get_schema()
+        self._validate_structure(schema)
+
+        module_values = {
+            module.atom.name: {
+                key: plain(value)
+                for key, value in module.atom.kwargs.items()
+                if key in module.config_cls.model_fields
+            }
+            for module in schema.modules
+        }
+        # Collect only values a source explicitly set; schema defaults are
+        # overlaid just before validation. Equivalent to seeding the defaults
+        # first because GlobalConfig is flat (no nested mappings for
+        # deep_merge to recurse into).
+        global_values: dict[str, Any] = {}
+        deep_merge(global_values, plain_mapping(self.blueprint.global_config_overrides))
+        transport_values: dict[str, Any] = {}
+
+        if config_path is not None:
+            config_values = read_config_file(Path(config_path))
+            merge_root_source(
+                module_values,
+                global_values,
+                transport_values,
+                config_values,
+                source="config file",
+                schema=schema,
+            )
+
+        merge_environment(
+            module_values,
+            global_values,
+            transport_values,
+            configuration_environment(environ),
+            schema,
+        )
+
+        if overrides is not None:
+            merge_root_source(
+                module_values,
+                global_values,
+                transport_values,
+                overrides,
+                source="programmatic overrides",
+                schema=schema,
+            )
+
+        merge_cli(
+            module_values,
+            global_values,
+            transport_values,
+            tuple(cli_tokens),
+            schema,
+        )
+
+        if global_overrides is not None:
+            deep_merge(global_values, plain_mapping(global_overrides))
+
+        parsed_modules = self._validate_modules(module_values, schema)
+        resolved_global = global_schema_defaults()
+        deep_merge(resolved_global, global_values)
+        parsed_global = validate_global_values(resolved_global)
+        # Pick the validated values of the explicitly-set fields, translating
+        # alias keys (e.g. DIMOS_TRANSPORT) to field names first.
+        field_names = global_environment_names()
+        explicit_shape = {
+            field_names.get(key.lower(), key): value for key, value in global_values.items()
+        }
+        explicit_global = extract_shape(parsed_global, explicit_shape)
+        parsed_transports = self._validate_transports(transport_values, schema)
+
+        return ParsedBlueprintConfig(
+            _module_config_values=snapshot_mapping(parsed_modules),
+            _global_config_values=snapshot_mapping(parsed_global),
+            _global_explicit_values=snapshot_mapping(explicit_global),
+            _transport_config_values=snapshot_mapping(parsed_transports),
+            _blueprint=self.blueprint,
+        )
+
+    def format_help(self, reserved_options: Collection[str] = ()) -> str:
+        """Render discoverable dynamic options without evaluating default factories."""
+        schema = self._get_schema()
+        lines = ["Blueprint configuration options:"]
+        global_names = reserved_global_short_names()
+        reserved = {normalize_option_name(option.removeprefix("--")) for option in reserved_options}
+
+        for target in sorted(schema.targets, key=lambda item: item.qualified_name):
+            aliases = schema.aliases[normalize_option_name(target.qualified_name)]
+            relative_available = (
+                target.section != "module"
+                or len(target.path) != 1
+                or target.path[0] not in global_names
+            )
+            relative_available = (
+                relative_available and normalize_option_name(target.relative_name) not in reserved
+            )
+            relative_aliases = schema.aliases.get(normalize_option_name(target.relative_name), ())
+            option_names = [f"--{target.qualified_name}"]
+            if (
+                relative_available
+                and len(relative_aliases) == 1
+                and relative_aliases[0].identity == target.identity
+            ):
+                option_names.insert(0, f"--{target.relative_name}")
+
+            annotation = display_annotation(target.annotations)
+            default = self._help_default(target, schema)
+            parent_required = self._target_has_required_parent(target, schema)
+            suffix = ""
+            if default is not PydanticUndefined:
+                suffix = f" (default: {default})"
+                if parent_required:
+                    suffix += " [parent required]"
+            elif self._target_is_required(target, schema):
+                suffix = " [required]"
+            elif parent_required:
+                suffix = " [parent required]"
+            if len(aliases) > 1:
+                option_names = [f"--{target.qualified_name}"]
+            lines.append(f"  {', '.join(option_names)} <{annotation}>{suffix}")
+
+        return "\n".join(lines)
+
+    def _get_schema(self) -> ParserSchema:
+        if self._schema is not None:
+            return self._schema
+
+        modules = tuple(
+            ModuleSchema(atom=atom, config_cls=module_config_cls(atom))
+            for atom in self.blueprint.active_blueprints
+        )
+        transports_by_name: dict[str, tuple[type[BaseModel], list[TransportSpec]]] = {}
+        for spec in self.blueprint.transport_map.values():
+            if not isinstance(spec, TransportSpec) or spec.config_cls is None:
+                continue
+            name = transport_config_name(spec.config_cls)
+            existing = transports_by_name.get(name)
+            if existing is None:
+                transports_by_name[name] = (spec.config_cls, [spec])
+            else:
+                existing[1].append(spec)
+        transports = tuple(
+            TransportSchema(name=name, config_cls=config_cls, specs=tuple(specs))
+            for name, (config_cls, specs) in transports_by_name.items()
+        )
+
+        target_annotations: dict[tuple[str, str, tuple[str, ...]], list[Any]] = defaultdict(list)
+        for module in modules:
+            for path, annotation in leaf_fields(module.config_cls, excluded={"g", "instance_name"}):
+                target_annotations[("module", module.atom.name, path)].append(annotation)
+        for path, annotation in leaf_fields(GlobalConfig):
+            target_annotations[("global", "g", path)].append(annotation)
+        for transport in transports:
+            for path, annotation in leaf_fields(transport.config_cls):
+                target_annotations[("transport", transport.name, path)].append(annotation)
+
+        targets = tuple(
+            OptionTarget(
+                section=section,  # type: ignore[arg-type]
+                root=root,
+                path=path,
+                annotations=tuple(annotations),
+            )
+            for (section, root, path), annotations in target_annotations.items()
+        )
+        aliases = self._build_aliases(targets)
+        self._schema = ParserSchema(
+            modules=modules,
+            transports=transports,
+            targets=targets,
+            aliases=MappingProxyType(aliases),
+        )
+        return self._schema
+
+    def _build_aliases(
+        self, targets: tuple[OptionTarget, ...]
+    ) -> dict[str, tuple[OptionTarget, ...]]:
+        canonical: dict[str, dict[tuple[str, str, tuple[str, ...]], OptionTarget]] = defaultdict(
+            dict
+        )
+        shorthand: dict[str, dict[tuple[str, str, tuple[str, ...]], OptionTarget]] = defaultdict(
+            dict
+        )
+        global_names = reserved_global_short_names()
+
+        for target in targets:
+            canonical_names = {target.qualified_name}
+            shorthand_names: set[str] = set()
+            if target.section == "global":
+                shorthand_names.add(target.relative_name)
+            elif target.section == "transport":
+                shorthand_names.add(target.relative_name)
+            else:
+                escaped = cli_path((config_key(target.root), *target.path))
+                canonical_names.add(escaped)
+                if len(target.path) != 1 or target.path[0] not in global_names:
+                    shorthand_names.add(target.relative_name)
+                canonical_names.add(cli_path(("modules", target.root, *target.path)))
+
+            for name in canonical_names:
+                canonical[normalize_option_name(name)][target.identity] = target
+            for name in shorthand_names:
+                shorthand[normalize_option_name(name)][target.identity] = target
+
+        # A fully qualified address must always be usable. A relative alias
+        # that happens to spell another target's qualified address is hidden
+        # rather than making that stable address ambiguous.
+        aliases = {name: dict(values) for name, values in canonical.items()}
+        for name, values in shorthand.items():
+            if name not in aliases:
+                aliases[name] = dict(values)
+
+        return {
+            name: tuple(sorted(values.values(), key=lambda target: target.qualified_name))
+            for name, values in aliases.items()
+        }
+
+    def _validate_structure(self, schema: ParserSchema) -> None:
+        roots: dict[str, list[str]] = defaultdict(list)
+        for module in schema.modules:
+            roots[config_key(module.atom.name)].append(module.atom.name)
+        conflicts = {key: names for key, names in roots.items() if len(names) > 1}
+        reserved = {key: names for key, names in roots.items() if key in {"g", "transports"}}
+        if conflicts or reserved:
+            details = []
+            for key, names in sorted({**conflicts, **reserved}.items()):
+                details.append(f"{key!r}: {', '.join(sorted(names))}")
+            raise BlueprintConfigError(
+                "Blueprint configuration instance-key collision: " + "; ".join(details)
+            )
+
+        transport_types: dict[str, set[type[BaseModel]]] = defaultdict(set)
+        for spec in self.blueprint.transport_map.values():
+            if isinstance(spec, TransportSpec) and spec.config_cls is not None:
+                transport_types[transport_config_name(spec.config_cls)].add(spec.config_cls)
+        collisions = {name: types for name, types in transport_types.items() if len(types) > 1}
+        if collisions:
+            transport_details = ", ".join(
+                f"{name}: {', '.join(sorted(cls.__name__ for cls in classes))}"
+                for name, classes in sorted(collisions.items())
+            )
+            raise BlueprintConfigError(
+                f"Transport configuration name collision: {transport_details}"
+            )
+
+    def _validate_modules(
+        self, module_values: Mapping[str, Mapping[str, Any]], schema: ParserSchema
+    ) -> dict[str, Any]:
+        parsed: dict[str, Any] = {}
+        for module in schema.modules:
+            values = prepare_model_input(
+                module.config_cls,
+                module_values[module.atom.name],
+            )
+            try:
+                model = module.config_cls.model_validate(values)
+            except ValidationError as error:
+                raise BlueprintConfigError(
+                    format_validation_error(module.atom.name, error)
+                ) from error
+            dumped = model.model_dump(mode="python", exclude_unset=True)
+            dumped.pop("g", None)
+            dumped.pop("instance_name", None)
+            parsed[module.atom.name] = dumped
+        return parsed
+
+    def _validate_transports(
+        self, values: Mapping[str, Any], schema: ParserSchema
+    ) -> dict[str, Any]:
+        known = {transport.name for transport in schema.transports}
+        unknown = set(values) - known
+        if unknown:
+            names = ", ".join(sorted(unknown))
+            raise BlueprintConfigError(f"Unknown transport configuration section(s): {names}.")
+
+        parsed: dict[str, Any] = {}
+        for transport in schema.transports:
+            raw_overrides = values.get(transport.name, {})
+            if not isinstance(raw_overrides, Mapping):
+                raise BlueprintConfigError(
+                    f"Transport configuration {transport.name!r} must be an object."
+                )
+            models: list[BaseModel] = []
+            for spec in transport.specs:
+                pinned = {
+                    key: plain(value)
+                    for key, value in spec.kwargs.items()
+                    if key in transport.config_cls.model_fields
+                }
+                deep_merge(pinned, plain_mapping(raw_overrides))
+                pinned = prepare_model_input(transport.config_cls, pinned)
+                try:
+                    models.append(transport.config_cls.model_validate(pinned))
+                except ValidationError as error:
+                    raise BlueprintConfigError(
+                        format_validation_error(
+                            f"transports.{transport.name}",
+                            error,
+                        )
+                    ) from error
+            if not models:
+                continue
+            full = models[0].model_dump(mode="python")
+            if raw_overrides:
+                parsed[transport.name] = extract_shape(full, raw_overrides)
+        return parsed
+
+    def _help_default(self, target: OptionTarget, schema: ParserSchema) -> Any:
+        if target.section == "global":
+            values: Any = self.blueprint.global_config_overrides
+            configured = nested_get(values, target.path)
+            if configured is not PydanticUndefined:
+                return configured
+            return safe_field_default(GlobalConfig, target.path)
+        if target.section == "transport":
+            transport = next(item for item in schema.transports if item.name == target.root)
+            for spec in transport.specs:
+                configured = nested_get(spec.kwargs, target.path)
+                if configured is not PydanticUndefined:
+                    return configured
+            return safe_field_default(transport.config_cls, target.path)
+
+        module = next(item for item in schema.modules if item.atom.name == target.root)
+        configured = nested_get(module.atom.kwargs, target.path)
+        if configured is not PydanticUndefined:
+            return configured
+        return safe_field_default(module.config_cls, target.path)
+
+    def _target_is_required(self, target: OptionTarget, schema: ParserSchema) -> bool:
+        return field_is_required(self._target_model(target, schema), target.path)
+
+    def _target_has_required_parent(self, target: OptionTarget, schema: ParserSchema) -> bool:
+        return field_has_required_parent(self._target_model(target, schema), target.path)
+
+    @staticmethod
+    def _target_model(target: OptionTarget, schema: ParserSchema) -> type[BaseModel]:
+        if target.section == "global":
+            return GlobalConfig
+        if target.section == "transport":
+            return next(item.config_cls for item in schema.transports if item.name == target.root)
+        return next(item.config_cls for item in schema.modules if item.atom.name == target.root)

--- a/dimos/core/coordination/blueprint_config/schema.py
+++ b/dimos/core/coordination/blueprint_config/schema.py
@@ -1,0 +1,149 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Option schema: the configuration targets a blueprint exposes."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+import json
+from typing import Any, Literal
+
+from pydantic import BaseModel
+
+from dimos.core.coordination.blueprint_config.errors import BlueprintConfigError
+from dimos.core.coordination.blueprint_config.fields import (
+    all_annotation_types,
+    scalar_annotation_types,
+)
+from dimos.core.coordination.blueprints import BlueprintAtom, TransportSpec
+
+
+@dataclass(frozen=True, slots=True)
+class ModuleSchema:
+    atom: BlueprintAtom
+    config_cls: type[BaseModel]
+
+
+@dataclass(frozen=True, slots=True)
+class TransportSchema:
+    name: str
+    config_cls: type[BaseModel]
+    specs: tuple[TransportSpec, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class OptionTarget:
+    section: Literal["module", "global", "transport"]
+    root: str
+    path: tuple[str, ...]
+    annotations: tuple[Any, ...]
+
+    @property
+    def identity(self) -> tuple[str, str, tuple[str, ...]]:
+        return (self.section, self.root, self.path)
+
+    @property
+    def qualified_name(self) -> str:
+        if self.section == "global":
+            parts = ("g", *self.path)
+        elif self.section == "transport":
+            parts = ("transports", self.root, *self.path)
+        else:
+            parts = (self.root, *self.path)
+        return cli_path(parts)
+
+    @property
+    def relative_name(self) -> str:
+        if self.section == "transport":
+            return cli_path((self.root, *self.path))
+        return cli_path(self.path)
+
+    @property
+    def scalar_types(self) -> set[Any]:
+        scalar_types: set[Any] = set()
+        for annotation in self.annotations:
+            scalar_types.update(scalar_annotation_types(annotation))
+        return scalar_types
+
+    @property
+    def is_bool(self) -> bool:
+        return self.scalar_types == {bool}
+
+    @property
+    def allows_none(self) -> bool:
+        return any(type(None) in all_annotation_types(a) for a in self.annotations)
+
+
+@dataclass(frozen=True, slots=True)
+class ParserSchema:
+    modules: tuple[ModuleSchema, ...]
+    transports: tuple[TransportSchema, ...]
+    targets: tuple[OptionTarget, ...]
+    aliases: Mapping[str, tuple[OptionTarget, ...]]
+
+
+def cli_path(parts: tuple[str, ...]) -> str:
+    return ".".join(part.replace("_", "-") for part in parts)
+
+
+def normalize_option_name(name: str) -> str:
+    return ".".join(part.replace("-", "_").lower() for part in name.split("."))
+
+
+def display_normalized_option(name: str) -> str:
+    return ".".join(part.replace("_", "-") for part in name.split("."))
+
+
+def coerce_cli_value(value: Any, target: OptionTarget, option: str) -> Any:
+    if target.is_bool:
+        if isinstance(value, bool):
+            return value
+        normalized = str(value).lower()
+        if normalized not in {"true", "false"}:
+            raise BlueprintConfigError(
+                f"Boolean option --{option} requires an explicit true or false value."
+            )
+        return normalized == "true"
+
+    return coerce_string_value(value, target, f"Option --{option}")
+
+
+def coerce_environment_value(value: str, target: OptionTarget, name: str) -> Any:
+    """Coerce an environment value like a CLI value.
+
+    Booleans keep pydantic's lax coercion and pure-str fields keep their raw
+    string (a value starting with '[' or '{' must not become an error), so
+    environment usage that predates the coercion keeps working.
+    """
+    scalars = target.scalar_types
+    parse_json = scalars != {bool} and scalars != {str}
+    return coerce_string_value(value, target, f"Environment variable {name}", parse_json=parse_json)
+
+
+def coerce_string_value(
+    value: Any, target: OptionTarget, label: str, *, parse_json: bool = True
+) -> Any:
+    if not isinstance(value, str):
+        return value
+    stripped = value.strip()
+    if stripped == "null" and target.allows_none:
+        return None
+    if parse_json and stripped.startswith(("[", "{")):
+        try:
+            return json.loads(stripped)
+        except json.JSONDecodeError as error:
+            raise BlueprintConfigError(f"{label} contains invalid JSON: {error.msg}.") from error
+    return value

--- a/dimos/core/coordination/blueprint_config/sources.py
+++ b/dimos/core/coordination/blueprint_config/sources.py
@@ -1,0 +1,188 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Configuration sources: config file, environment, and GlobalConfig resolution."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from dotenv import dotenv_values
+from pydantic import AliasChoices, ValidationError
+
+from dimos.core.coordination.blueprint_config.errors import (
+    BlueprintConfigError,
+    format_validation_error,
+)
+from dimos.core.coordination.blueprint_config.fields import leaf_fields, scalar_annotation_types
+from dimos.core.coordination.blueprint_config.schema import (
+    OptionTarget,
+    coerce_cli_value,
+    coerce_environment_value,
+    normalize_option_name,
+)
+from dimos.core.coordination.blueprint_config.values import deep_set, plain_mapping
+from dimos.core.global_config import GlobalConfig
+
+
+def global_schema_defaults() -> dict[str, Any]:
+    """Return GlobalConfig defaults without consulting environment sources."""
+    defaults = GlobalConfig.model_construct().model_dump(mode="python")
+    return plain_mapping(defaults)
+
+
+def configuration_environment(
+    environ: Mapping[str, str] | None,
+) -> Mapping[str, str]:
+    if environ is not None:
+        return environ
+    from_dotenv = {key: value for key, value in dotenv_values(".env").items() if value is not None}
+    return {**from_dotenv, **os.environ}
+
+
+def validate_global_values(values: Mapping[str, Any]) -> dict[str, Any]:
+    try:
+        model = GlobalConfig.model_validate(values)
+    except ValidationError as error:
+        raise BlueprintConfigError(format_validation_error("g", error)) from error
+    return model.model_dump(mode="python")
+
+
+def read_config_file(path: Path) -> Mapping[str, Any]:
+    try:
+        raw = path.read_text()
+    except FileNotFoundError:
+        return {}
+    except OSError as error:
+        raise BlueprintConfigError(f"Could not read config file {path}: {error}") from error
+    try:
+        values = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise BlueprintConfigError(
+            f"Invalid JSON in config file {path}: {error.msg} "
+            f"(line {error.lineno}, column {error.colno})"
+        ) from error
+    if not isinstance(values, Mapping):
+        raise BlueprintConfigError(f"Config file {path} must contain a JSON object.")
+    return values
+
+
+def merge_global_environment(
+    destination: dict[str, Any],
+    environ: Mapping[str, str],
+) -> None:
+    global_env_names = global_environment_names()
+    targets = _global_option_targets()
+
+    def set_coerced(path: tuple[str, ...], raw_name: str, value: str) -> None:
+        target = targets.get(normalize_option_name(".".join(path)))
+        coerced = value if target is None else coerce_environment_value(value, target, raw_name)
+        deep_set(destination, path, coerced)
+
+    for raw_name, value in environ.items():
+        global_field = global_env_names.get(raw_name.lower())
+        if global_field is not None:
+            set_coerced((global_field,), raw_name, value)
+            continue
+        parts = tuple(part.lower().replace("-", "_") for part in raw_name.split("__"))
+        if len(parts) >= 2 and parts[0] == "g":
+            set_coerced(parts[1:], raw_name, value)
+
+
+def _global_option_targets() -> dict[str, OptionTarget]:
+    targets: dict[str, OptionTarget] = {}
+    for path, annotation in leaf_fields(GlobalConfig):
+        target = OptionTarget(
+            section="global",
+            root="g",
+            path=path,
+            annotations=(annotation,),
+        )
+        targets[normalize_option_name(target.relative_name)] = target
+        targets[normalize_option_name(target.qualified_name)] = target
+    return targets
+
+
+def merge_global_cli(
+    destination: dict[str, Any],
+    tokens: tuple[str, ...],
+) -> None:
+    targets = _global_option_targets()
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if not token.startswith("--"):
+            index += 1
+            continue
+
+        option, separator, attached_value = token[2:].partition("=")
+        normalized = normalize_option_name(option)
+        target = targets.get(normalized)
+        negated = False
+        if target is None and normalized.startswith("no_"):
+            target = targets.get(normalized.removeprefix("no_"))
+            negated = target is not None and target.is_bool
+        if target is None:
+            index += 1
+            continue
+
+        if separator:
+            raw_value: Any = attached_value
+        elif negated:
+            raw_value = False
+        elif target.is_bool:
+            if index + 1 < len(tokens) and not tokens[index + 1].startswith("--"):
+                index += 1
+                raw_value = tokens[index]
+            else:
+                raw_value = True
+        else:
+            if index + 1 >= len(tokens) or tokens[index + 1].startswith("--"):
+                raise BlueprintConfigError(
+                    f"Option --{option} requires a value. "
+                    f"Use --{option}=VALUE when the value starts with '--'."
+                )
+            index += 1
+            raw_value = tokens[index]
+
+        if negated and separator:
+            raise BlueprintConfigError(f"Negated option --{option} does not accept a value.")
+        deep_set(destination, target.path, coerce_cli_value(raw_value, target, option))
+        index += 1
+
+
+def reserved_global_short_names() -> set[str]:
+    reserved = set(GlobalConfig.model_fields)
+    for name, info in GlobalConfig.model_fields.items():
+        if scalar_annotation_types(info.annotation) == {bool}:
+            reserved.add(f"no_{name}")
+    return reserved
+
+
+def global_environment_names() -> dict[str, str]:
+    names: dict[str, str] = {}
+    for field_name, info in GlobalConfig.model_fields.items():
+        names[field_name.lower()] = field_name
+        alias = info.validation_alias
+        if isinstance(alias, str):
+            names[alias.lower()] = field_name
+        elif isinstance(alias, AliasChoices):
+            for choice in alias.choices:
+                if isinstance(choice, str):
+                    names[choice.lower()] = field_name
+    return names

--- a/dimos/core/coordination/blueprint_config/test_parsed.py
+++ b/dimos/core/coordination/blueprint_config/test_parsed.py
@@ -1,0 +1,117 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+import pytest
+
+from dimos.core.coordination.blueprint_config.errors import BlueprintConfigError
+from dimos.core.coordination.blueprint_config.parser import BlueprintConfigParser
+from dimos.core.module import Module, ModuleConfig
+
+
+class NestedConfig(BaseModel):
+    enabled: bool = True
+    mode: str = "auto"
+
+
+class PrimaryConfig(ModuleConfig):
+    nested: NestedConfig = Field(default_factory=NestedConfig)
+    labels: list[str] = Field(default_factory=list)
+
+
+class PrimaryModule(Module):
+    config: PrimaryConfig
+
+
+def test_parsed_config_is_deeply_immutable_and_accessors_return_copies() -> None:
+    parsed = BlueprintConfigParser(PrimaryModule.blueprint()).parse(
+        ["--labels", '["one"]', "--nested.mode", "manual"],
+        environ={},
+    )
+
+    with pytest.raises(TypeError):
+        parsed.module_configs["primarymodule"] = {}  # type: ignore[index]
+    with pytest.raises(TypeError):
+        parsed.module_configs["primarymodule"]["nested"]["mode"] = "changed"
+    assert parsed.module_configs["primarymodule"]["labels"] == ("one",)
+
+    copy = parsed.module_kwargs("primarymodule")
+    copy["nested"]["mode"] = "changed"
+    copy["labels"].append("two")
+    assert parsed.module_kwargs("primarymodule") == {
+        "nested": {"mode": "manual"},
+        "labels": ["one"],
+    }
+
+
+def test_parsed_config_isolated_from_mutable_opaque_values() -> None:
+    class Box:
+        def __init__(self) -> None:
+            self.items: list[str] = []
+
+    class OpaqueConfig(ModuleConfig):
+        box: Box
+
+    class OpaqueModule(Module):
+        config: OpaqueConfig
+
+    source = Box()
+    parsed = BlueprintConfigParser(OpaqueModule.blueprint(box=source)).parse(environ={})
+
+    source.items.append("source")
+    parsed.module_configs["opaquemodule"]["box"].items.append("public-view")
+    accessor_copy = parsed.module_kwargs("opaquemodule")
+    accessor_copy["box"].items.append("accessor")
+
+    assert parsed.module_kwargs("opaquemodule")["box"].items == []
+
+
+def test_parsed_config_preserves_container_types_and_mapping_keys() -> None:
+    class AnyConfig(ModuleConfig):
+        value: Any
+
+    class AnyModule(Module):
+        config: AnyConfig
+
+    source = {
+        "tuple": ("one",),
+        "frozenset": frozenset({"two"}),
+        "mapping": {1: "integer key"},
+    }
+    parsed_configs = (
+        BlueprintConfigParser(AnyModule.blueprint(value=source)).parse(environ={}),
+        BlueprintConfigParser(AnyModule.blueprint()).parse(
+            environ={},
+            overrides={"anymodule": {"value": source}},
+        ),
+    )
+
+    for parsed in parsed_configs:
+        value = parsed.module_kwargs("anymodule")["value"]
+        assert value["tuple"] == ("one",)
+        assert isinstance(value["tuple"], tuple)
+        assert value["frozenset"] == frozenset({"two"})
+        assert isinstance(value["frozenset"], frozenset)
+        assert value["mapping"] == {1: "integer key"}
+
+
+def test_parsed_config_rejects_a_different_blueprint_identity() -> None:
+    blueprint = PrimaryModule.blueprint()
+    parsed = BlueprintConfigParser(blueprint).parse(environ={})
+
+    parsed.assert_matches(blueprint)
+    with pytest.raises(BlueprintConfigError, match="different blueprint"):
+        parsed.assert_matches(PrimaryModule.blueprint())

--- a/dimos/core/coordination/blueprint_config/test_parser.py
+++ b/dimos/core/coordination/blueprint_config/test_parser.py
@@ -1,0 +1,535 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Annotated, Any, Literal
+
+from pydantic import BaseModel, Field
+import pytest
+
+from dimos.core.coordination.blueprint_config.errors import BlueprintConfigError
+from dimos.core.coordination.blueprint_config.parser import (
+    BlueprintConfigParser,
+    split_run_arguments,
+)
+from dimos.core.coordination.blueprints import TransportSpec, autoconnect
+from dimos.core.module import Module, ModuleConfig
+from dimos.core.stream import Stream, Transport
+
+
+class NestedConfig(BaseModel):
+    enabled: bool = True
+    mode: str = "auto"
+
+
+class PrimaryConfig(ModuleConfig):
+    map_file: str | None = None
+    speed: float = 1.0
+    nested: NestedConfig = Field(default_factory=NestedConfig)
+    labels: list[str] = Field(default_factory=list)
+
+
+class PrimaryModule(Module):
+    config: PrimaryConfig
+
+
+class SecondaryConfig(ModuleConfig):
+    map_file: str | None = None
+
+
+class SecondaryModule(Module):
+    config: SecondaryConfig
+
+
+class ProviderConfig(BaseModel):
+    api_key: str
+    retries: int = 1
+
+
+class ConfigurableTransport(Transport[bytes]):
+    _config_cls = ProviderConfig
+
+    def broadcast(self, selfstream: Stream[bytes] | None, value: bytes) -> None:
+        pass
+
+    def subscribe(self, callback: Any, selfstream: Stream[bytes] | None = None) -> Any:
+        return lambda: None
+
+
+def test_parse_supports_value_forms_types_nested_defaults_and_last_wins() -> None:
+    blueprint = PrimaryModule.blueprint(nested={"mode": "manual"})
+
+    parsed = BlueprintConfigParser(blueprint).parse(
+        [
+            "--map-file=first",
+            "--map-file",
+            "recording_go2",
+            "--speed",
+            "-0.5",
+            "--nested.enabled=false",
+            "--labels",
+            '["one", "two"]',
+        ],
+        environ={},
+    )
+
+    assert parsed.module_kwargs("primarymodule") == {
+        "map_file": "recording_go2",
+        "speed": -0.5,
+        "nested": {"enabled": False, "mode": "manual"},
+        "labels": ["one", "two"],
+    }
+
+
+def test_ambiguous_shorthand_requires_deterministic_qualified_option() -> None:
+    blueprint = autoconnect(PrimaryModule.blueprint(), SecondaryModule.blueprint())
+    parser = BlueprintConfigParser(blueprint)
+
+    parser.parse(environ={})
+    with pytest.raises(BlueprintConfigError) as error:
+        parser.parse(["--map-file", "map"], environ={})
+
+    assert str(error.value) == (
+        "Option --map-file is ambiguous. Use one of: "
+        "--primarymodule.map-file, --secondarymodule.map-file."
+    )
+    parsed = parser.parse(["--secondarymodule.map-file=map"], environ={})
+    assert parsed.module_kwargs("secondarymodule") == {"map_file": "map"}
+
+
+def test_qualified_option_wins_over_another_fields_relative_alias() -> None:
+    class FooConfig(ModuleConfig):
+        bar: str | None = None
+
+    class Foo(Module):
+        config: FooConfig
+
+    class NestedFooConfig(BaseModel):
+        bar: str | None = None
+
+    class OtherConfig(ModuleConfig):
+        foo: NestedFooConfig = Field(default_factory=NestedFooConfig)
+
+    class Other(Module):
+        config: OtherConfig
+
+    blueprint = autoconnect(Foo.blueprint(), Other.blueprint())
+    parser = BlueprintConfigParser(blueprint)
+
+    parsed = parser.parse(["--foo.bar", "root"], environ={})
+
+    assert parsed.module_kwargs("foo") == {"bar": "root"}
+    assert parsed.module_kwargs("other") == {}
+    assert "--other.foo.bar" in parser.format_help()
+    assert "--foo.bar, --other.foo.bar" not in parser.format_help()
+
+
+def test_global_short_name_is_reserved_when_module_field_collides() -> None:
+    class CollisionConfig(ModuleConfig):
+        robot_ip: str = "module-default"
+
+    class CollisionModule(Module):
+        config: CollisionConfig
+
+    blueprint = CollisionModule.blueprint()
+    parsed = BlueprintConfigParser(blueprint).parse(
+        [
+            "--robot-ip",
+            "192.0.2.10",
+            "--collisionmodule.robot-ip",
+            "module-value",
+            "--replay=false",
+            "--no-obstacle-avoidance",
+        ],
+        environ={},
+    )
+
+    assert parsed.global_config_values()["robot_ip"] == "192.0.2.10"
+    assert parsed.global_config_values()["replay"] is False
+    assert parsed.global_config_values()["obstacle_avoidance"] is False
+    assert parsed.module_kwargs("collisionmodule") == {"robot_ip": "module-value"}
+
+
+def test_negated_global_bool_is_reserved_from_module_shorthand() -> None:
+    class CollisionConfig(ModuleConfig):
+        no_replay: str | None = None
+
+    class CollisionModule(Module):
+        config: CollisionConfig
+
+    blueprint = CollisionModule.blueprint().global_config(replay=True)
+    parser = BlueprintConfigParser(blueprint)
+
+    parsed = parser.parse(["--no-replay"], environ={})
+
+    assert parsed.global_config_values()["replay"] is False
+    assert parsed.module_kwargs("collisionmodule") == {}
+    help_text = parser.format_help()
+    assert "--collisionmodule.no-replay" in help_text
+    assert "  --no-replay," not in help_text
+
+
+def test_sources_deep_merge_in_documented_precedence(tmp_path: Path) -> None:
+    blueprint = PrimaryModule.blueprint(
+        speed=1.0,
+        nested={"enabled": True, "mode": "blueprint"},
+    ).global_config(viewer="none")
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        '{"primarymodule":{"speed":2,"nested":{"mode":"file"}},"g":{"robot_ip":"file"}}'
+    )
+
+    parsed = BlueprintConfigParser(blueprint).parse(
+        ["--speed", "5", "--nested.enabled", "false"],
+        config_path=config_path,
+        environ={
+            "PRIMARYMODULE__SPEED": "3",
+            "PRIMARYMODULE__NESTED__MODE": "environment",
+            "ROBOT_IP": "environment",
+        },
+        overrides={
+            "primarymodule": {"speed": 4, "nested": {"mode": "override"}},
+            "g": {"robot_ip": "override"},
+        },
+        global_overrides={"robot_ip": "explicit"},
+    )
+
+    assert parsed.module_kwargs("primarymodule") == {
+        "speed": 5.0,
+        "nested": {"enabled": False, "mode": "override"},
+    }
+    assert parsed.global_config_values()["robot_ip"] == "explicit"
+    assert parsed.global_config_values()["viewer"] == "none"
+
+
+def test_namespaced_instance_accepts_slash_qualified_option() -> None:
+    blueprint = PrimaryModule.blueprint().namespace("robot0")
+
+    parsed = BlueprintConfigParser(blueprint).parse(
+        ["--robot0/primarymodule.map-file", "map"],
+        environ={},
+    )
+
+    assert parsed.module_kwargs("robot0/primarymodule") == {
+        "frame_id_prefix": "robot0",
+        "map_file": "map",
+    }
+
+
+def test_disabled_module_does_not_make_shorthand_ambiguous() -> None:
+    blueprint = autoconnect(
+        PrimaryModule.blueprint(),
+        SecondaryModule.blueprint(),
+    ).disabled_modules(SecondaryModule)
+
+    parsed = BlueprintConfigParser(blueprint).parse(["--map-file", "map"], environ={})
+
+    assert set(parsed.module_configs) == {"primarymodule"}
+    assert parsed.module_kwargs("primarymodule") == {"map_file": "map"}
+
+
+def test_transport_options_support_relative_full_and_environment_forms() -> None:
+    blueprint = PrimaryModule.blueprint().transports(
+        {
+            ("payload", bytes): TransportSpec(
+                ConfigurableTransport,
+                kwargs={"api_key": "blueprint-key"},
+            )
+        }
+    )
+    parser = BlueprintConfigParser(blueprint)
+
+    from_environment = parser.parse(
+        environ={"TRANSPORTS__PROVIDER__RETRIES": "2"},
+    )
+    from_cli = parser.parse(
+        ["--transports.provider.retries=3", "--provider.api-key", "cli-key"],
+        environ={},
+    )
+
+    assert from_environment.transport_overrides() == {"provider": {"retries": 2}}
+    assert from_environment.transport_configs["provider"] == {"retries": 2}
+    assert from_cli.transport_overrides() == {"provider": {"api_key": "cli-key", "retries": 3}}
+
+
+def test_environment_values_coerce_null_and_json_like_cli() -> None:
+    parsed = BlueprintConfigParser(PrimaryModule.blueprint(map_file="pinned")).parse(
+        environ={
+            "PRIMARYMODULE__MAP_FILE": "null",
+            "PRIMARYMODULE__LABELS": '["one", "two"]',
+        },
+    )
+
+    kwargs = parsed.module_kwargs("primarymodule")
+    assert kwargs["map_file"] is None
+    assert kwargs["labels"] == ["one", "two"]
+
+
+def test_environment_str_field_keeps_bracketed_string() -> None:
+    parsed = BlueprintConfigParser(PrimaryModule.blueprint()).parse(
+        environ={"PRIMARYMODULE__NESTED__MODE": "[not json"},
+    )
+
+    assert parsed.module_kwargs("primarymodule")["nested"]["mode"] == "[not json"
+
+
+def test_environment_invalid_json_names_the_variable() -> None:
+    with pytest.raises(BlueprintConfigError, match="PRIMARYMODULE__LABELS"):
+        BlueprintConfigParser(PrimaryModule.blueprint()).parse(
+            environ={"PRIMARYMODULE__LABELS": '["one"'},
+        )
+
+
+def test_environment_json_object_merges_into_pinned_mapping() -> None:
+    class MappingConfig(ModuleConfig):
+        extras: dict[str, int] = Field(default_factory=dict)
+
+    class MappingModule(Module):
+        config: MappingConfig
+
+    parsed = BlueprintConfigParser(MappingModule.blueprint(extras={"a": 1})).parse(
+        environ={"MAPPINGMODULE__EXTRAS": '{"b": 2}'},
+    )
+
+    assert parsed.module_kwargs("mappingmodule")["extras"] == {"a": 1, "b": 2}
+
+
+def test_explicit_global_config_values_exclude_schema_defaults() -> None:
+    blueprint = PrimaryModule.blueprint().global_config(viewer="none")
+
+    parsed = BlueprintConfigParser(blueprint).parse(["--n-workers", "3"], environ={})
+
+    assert parsed.explicit_global_config_values() == {"viewer": "none", "n_workers": 3}
+    assert parsed.global_config_values()["n_workers"] == 3
+
+
+def test_required_module_field_can_be_supplied_by_blueprint_pin() -> None:
+    class RequiredConfig(ModuleConfig):
+        required_value: str
+
+    class RequiredModule(Module):
+        config: RequiredConfig
+
+    parsed = BlueprintConfigParser(RequiredModule.blueprint(required_value="pinned")).parse(
+        environ={}
+    )
+
+    assert parsed.module_kwargs("requiredmodule") == {"required_value": "pinned"}
+    with pytest.raises(BlueprintConfigError, match="requiredmodule.required_value"):
+        BlueprintConfigParser(RequiredModule.blueprint()).parse(environ={})
+
+
+def test_constructor_only_blueprint_kwargs_are_not_treated_as_module_config() -> None:
+    class ConstructorOnlyModule(Module):
+        def __init__(self, resource_name: str, **kwargs: Any) -> None:
+            self.resource_name = resource_name
+            super().__init__(**kwargs)
+
+    blueprint = ConstructorOnlyModule.blueprint(resource_name="camera")
+
+    parsed = BlueprintConfigParser(blueprint).parse(environ={})
+
+    assert parsed.module_kwargs("constructoronlymodule") == {}
+    assert blueprint.blueprints[0].kwargs["resource_name"] == "camera"
+
+
+def test_discriminated_union_exposes_one_logical_nested_path() -> None:
+    class DisabledConfig(BaseModel):
+        backend: Literal["disabled"] = "disabled"
+
+    class EnabledConfig(BaseModel):
+        backend: Literal["enabled"] = "enabled"
+        level: int = 1
+
+    BackendConfig = Annotated[
+        DisabledConfig | EnabledConfig,
+        Field(discriminator="backend"),
+    ]
+
+    class UnionConfig(ModuleConfig):
+        backend_config: BackendConfig = Field(default_factory=DisabledConfig)
+
+    class UnionModule(Module):
+        config: UnionConfig
+
+    parsed = BlueprintConfigParser(UnionModule.blueprint()).parse(
+        [
+            "--backend-config.backend",
+            "enabled",
+            "--backend-config.level",
+            "4",
+        ],
+        environ={},
+    )
+
+    assert parsed.module_kwargs("unionmodule") == {
+        "backend_config": {"backend": "enabled", "level": 4}
+    }
+
+
+def test_discriminated_union_leaf_override_preserves_default_backend() -> None:
+    class FirstConfig(BaseModel):
+        backend: Literal["first"] = "first"
+
+    class SecondConfig(BaseModel):
+        backend: Literal["second"] = "second"
+        level: int = 1
+
+    BackendConfig = Annotated[
+        FirstConfig | SecondConfig,
+        Field(discriminator="backend"),
+    ]
+
+    class UnionConfig(ModuleConfig):
+        backend_config: BackendConfig = Field(default_factory=SecondConfig)
+
+    class UnionModule(Module):
+        config: UnionConfig
+
+    parsed = BlueprintConfigParser(UnionModule.blueprint()).parse(
+        ["--backend-config.level", "4"],
+        environ={},
+    )
+
+    assert parsed.module_kwargs("unionmodule") == {
+        "backend_config": {"backend": "second", "level": 4}
+    }
+
+
+@pytest.mark.parametrize(
+    "tokens",
+    [
+        ("-o", "primarymodule.map_file=map"),
+        ("--option", "primarymodule.map_file=map"),
+        ("--option=primarymodule.map_file=map",),
+    ],
+)
+def test_legacy_option_syntax_has_migration_error(tokens: tuple[str, ...]) -> None:
+    with pytest.raises(BlueprintConfigError, match="legacy -o/--option syntax was removed"):
+        BlueprintConfigParser(PrimaryModule.blueprint()).parse(tokens, environ={})
+
+
+def test_format_help_does_not_call_default_factories_and_hides_reserved_shorthand() -> None:
+    calls = 0
+
+    def create_value() -> str:
+        nonlocal calls
+        calls += 1
+        return "created"
+
+    class HelpConfig(ModuleConfig):
+        daemon: str = "module"
+        generated: str = Field(default_factory=create_value)
+
+    class HelpModule(Module):
+        config: HelpConfig
+
+    output = BlueprintConfigParser(HelpModule.blueprint()).format_help(
+        reserved_options={"--daemon"}
+    )
+
+    assert calls == 0
+    assert "--helpmodule.daemon <str>" in output
+    assert "  --daemon," not in output
+    assert "--generated, --helpmodule.generated <str>" in output
+    assert "rpc-transport" not in output
+
+
+class Anchor:
+    def __str__(self) -> str:
+        return "Anchor:\n  multi\n  line"
+
+
+class ArbitraryConfig(ModuleConfig):
+    scaling: Anchor = Field(default_factory=Anchor)
+    hybrid: Anchor | str = "fallback"
+    transform: Callable[[Any], str] | None = None
+    handlers: dict[str, Callable[[Any], Any]] = Field(default_factory=dict)
+    speed: float = 1.0
+
+
+class ArbitraryModule(Module):
+    config: ArbitraryConfig
+
+
+def test_arbitrary_type_fields_are_hidden_and_rejected_as_unknown() -> None:
+    parser = BlueprintConfigParser(ArbitraryModule.blueprint())
+
+    help_text = parser.format_help()
+    assert "scaling" not in help_text
+    assert "transform" not in help_text
+    assert "handlers" not in help_text
+    assert "--hybrid, --arbitrarymodule.hybrid <" in help_text
+    assert "Anchor | str> (default: fallback)" in help_text
+    assert "--speed" in help_text
+
+    with pytest.raises(
+        BlueprintConfigError, match="Unknown blueprint configuration option --scaling"
+    ):
+        parser.parse(["--scaling", "x"], environ={})
+
+    parsed = parser.parse(["--hybrid", "value"], environ={})
+    assert parsed.module_kwargs("arbitrarymodule")["hybrid"] == "value"
+
+
+def test_blueprint_pinned_arbitrary_value_survives_filtering() -> None:
+    parsed = BlueprintConfigParser(ArbitraryModule.blueprint(scaling=Anchor())).parse(environ={})
+
+    assert isinstance(parsed.module_kwargs("arbitrarymodule")["scaling"], Anchor)
+
+
+def test_format_help_uses_nested_parent_default_instance() -> None:
+    class NestedRequiredConfig(BaseModel):
+        value: int
+
+    class ParentDefaultConfig(ModuleConfig):
+        nested: NestedRequiredConfig = NestedRequiredConfig(value=7)
+
+    class ParentDefaultModule(Module):
+        config: ParentDefaultConfig
+
+    output = BlueprintConfigParser(ParentDefaultModule.blueprint()).format_help()
+    value_line = next(line for line in output.splitlines() if "--nested.value" in line)
+
+    assert "(default: 7)" in value_line
+    assert "[required]" not in value_line
+
+
+def test_format_help_marks_a_required_nested_parent_with_default_children() -> None:
+    class NestedDefaultConfig(BaseModel):
+        value: int = 7
+
+    class RequiredParentConfig(ModuleConfig):
+        nested: NestedDefaultConfig
+
+    class RequiredParentModule(Module):
+        config: RequiredParentConfig
+
+    parser = BlueprintConfigParser(RequiredParentModule.blueprint())
+    output = parser.format_help()
+    value_line = next(line for line in output.splitlines() if "--nested.value" in line)
+
+    assert "(default: 7) [parent required]" in value_line
+    with pytest.raises(BlueprintConfigError, match="nested"):
+        parser.parse(environ={})
+
+
+def test_split_run_arguments_requires_leading_blueprint_names() -> None:
+    assert split_run_arguments(("first-blueprint", "second-blueprint", "--map-file", "map")) == (
+        ("first-blueprint", "second-blueprint"),
+        ("--map-file", "map"),
+    )
+    with pytest.raises(BlueprintConfigError, match="must precede"):
+        split_run_arguments(("--map-file", "map"))

--- a/dimos/core/coordination/blueprint_config/test_sources.py
+++ b/dimos/core/coordination/blueprint_config/test_sources.py
@@ -1,0 +1,82 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+import pytest
+
+from dimos.core.coordination.blueprint_config.errors import BlueprintConfigError
+from dimos.core.coordination.blueprint_config.parser import BlueprintConfigParser
+from dimos.core.global_config import global_config as process_global_config
+from dimos.core.module import Module, ModuleConfig
+
+
+class PrimaryConfig(ModuleConfig):
+    speed: float = 1.0
+
+
+class PrimaryModule(Module):
+    config: PrimaryConfig
+
+
+def test_explicit_empty_environment_does_not_leak_process_global_mutations() -> None:
+    previous_robot_ip = process_global_config.robot_ip
+    process_global_config.update(robot_ip="198.51.100.7")
+    try:
+        parsed = BlueprintConfigParser(PrimaryModule.blueprint()).parse(environ={})
+    finally:
+        process_global_config.update(robot_ip=previous_robot_ip)
+
+    assert parsed.global_config_values()["robot_ip"] is None
+
+
+def test_default_environment_reads_dotenv_at_environment_precedence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (tmp_path / ".env").write_text("ROBOT_IP=192.0.2.17\nPRIMARYMODULE__SPEED=3.5\n")
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"g":{"robot_ip":"config"},"primarymodule":{"speed":2}}')
+    monkeypatch.chdir(tmp_path)
+
+    parsed = BlueprintConfigParser(PrimaryModule.blueprint()).parse(
+        config_path=config_path,
+    )
+
+    assert parsed.global_config_values()["robot_ip"] == "192.0.2.17"
+    assert parsed.module_kwargs("primarymodule")["speed"] == 3.5
+
+
+def test_preparse_environment_null_coerces_to_none() -> None:
+    values = BlueprintConfigParser.preparse_global_config(
+        environ={"ROBOT_IP": "null", "G__RELAY_URL": "null"},
+    )
+
+    assert values["robot_ip"] is None
+    assert values["relay_url"] is None
+
+
+def test_config_file_errors_are_clear_but_missing_file_is_optional(tmp_path: Path) -> None:
+    parser = BlueprintConfigParser(PrimaryModule.blueprint())
+    parser.parse(config_path=tmp_path / "missing.json", environ={})
+
+    invalid = tmp_path / "invalid.json"
+    invalid.write_text("{")
+    with pytest.raises(BlueprintConfigError, match="Invalid JSON"):
+        parser.parse(config_path=invalid, environ={})
+
+    not_an_object = tmp_path / "array.json"
+    not_an_object.write_text("[]")
+    with pytest.raises(BlueprintConfigError, match="must contain a JSON object"):
+        parser.parse(config_path=not_an_object, environ={})

--- a/dimos/core/coordination/blueprint_config/values.py
+++ b/dimos/core/coordination/blueprint_config/values.py
@@ -1,0 +1,117 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Plain-data helpers: copying, merging, and freezing configuration values."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import copy
+from types import MappingProxyType
+from typing import Any, cast
+
+from pydantic import BaseModel
+
+from dimos.core.coordination.blueprint_config.errors import BlueprintConfigError
+
+
+def normalize_mapping_keys(values: Mapping[str, Any]) -> dict[str, Any]:
+    """Normalize schema field names without rewriting nested data mappings."""
+    normalized: dict[str, Any] = {}
+    for key, value in values.items():
+        if not isinstance(key, str):
+            raise BlueprintConfigError("Configuration object keys must be strings.")
+        normalized_key = key.replace("-", "_")
+        normalized[normalized_key] = plain(value)
+    return normalized
+
+
+def plain_mapping(values: Mapping[str, Any]) -> dict[str, Any]:
+    return {key: plain(value) for key, value in values.items()}
+
+
+def plain(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        return {key: plain(item) for key, item in value.model_dump(mode="python").items()}
+    if isinstance(value, Mapping):
+        return {_copy_opaque(key): plain(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [plain(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(plain(item) for item in value)
+    if isinstance(value, set):
+        return {plain(item) for item in value}
+    return _copy_opaque(value)
+
+
+def deep_merge(destination: dict[str, Any], incoming: Mapping[str, Any]) -> None:
+    for key, value in incoming.items():
+        if key in destination and isinstance(destination[key], dict) and isinstance(value, Mapping):
+            deep_merge(destination[key], value)
+        else:
+            destination[key] = plain(value)
+
+
+def deep_set(destination: dict[str, Any], path: tuple[str, ...], value: Any) -> None:
+    current = destination
+    for part in path[:-1]:
+        child = current.setdefault(part, {})
+        if not isinstance(child, dict):
+            child = {}
+            current[part] = child
+        current = child
+    current[path[-1]] = plain(value)
+
+
+def extract_shape(values: Mapping[str, Any], shape: Mapping[str, Any]) -> dict[str, Any]:
+    extracted: dict[str, Any] = {}
+    for key, shape_value in shape.items():
+        if key not in values:
+            continue
+        value = values[key]
+        if isinstance(shape_value, Mapping) and isinstance(value, Mapping):
+            extracted[key] = extract_shape(value, shape_value)
+        else:
+            extracted[key] = plain(value)
+    return extracted
+
+
+def read_only_view(value: Any) -> Any:
+    """Return a detached, recursively read-only view of a snapshot."""
+    if isinstance(value, Mapping):
+        return MappingProxyType(
+            {_copy_opaque(key): read_only_view(item) for key, item in value.items()}
+        )
+    if isinstance(value, (list, tuple)):
+        return tuple(read_only_view(item) for item in value)
+    if isinstance(value, (set, frozenset)):
+        return frozenset(read_only_view(item) for item in value)
+    if isinstance(value, BaseModel):
+        return read_only_view(value.model_dump(mode="python"))
+    return _copy_opaque(value)
+
+
+def snapshot_mapping(value: Mapping[str, Any]) -> dict[str, Any]:
+    """Copy a configuration mapping without changing nested Python types."""
+    snapshot = _copy_opaque(dict(value))
+    return cast("dict[str, Any]", snapshot)
+
+
+def _copy_opaque(value: Any) -> Any:
+    try:
+        return copy.deepcopy(value)
+    except Exception as error:
+        raise BlueprintConfigError(
+            f"Configuration value of type {type(value).__name__} cannot be copied safely: {error}"
+        ) from error

--- a/dimos/core/coordination/blueprints.py
+++ b/dimos/core/coordination/blueprints.py
@@ -22,12 +22,11 @@ import types as types_mod
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Literal, Union, get_args, get_origin, get_type_hints
 
-from pydantic import BaseModel, create_model
+from pydantic import BaseModel
 
 if TYPE_CHECKING:
     from dimos.protocol.service.system_configurator.base import SystemConfigurator
 
-from dimos.core.global_config import GlobalConfig
 from dimos.core.module import ModuleBase, is_module_type
 from dimos.core.stream import IO, In, Out, Transport
 from dimos.spec.utils import Spec, is_spec
@@ -217,36 +216,6 @@ class Blueprint:
 
     def disabled_modules(self, *modules: type[ModuleBase]) -> "Blueprint":
         return replace(self, disabled_modules_tuple=self.disabled_modules_tuple + modules)
-
-    def config(self) -> type:
-        configs = {}
-
-        for b in self.blueprints:
-            key = config_key(b.name)
-            if key in configs:
-                raise ValueError(
-                    f"Config key collision: two module instances map to {key!r}. "
-                    f"Rename one of the instances."
-                )
-            configs[key] = (get_type_hints(b.module)["config"] | None, None)
-
-        configs["g"] = (GlobalConfig | None, None)
-        transport_fields: dict[str, Any] = {}
-        seen: set[type] = set()
-        for spec in self.transport_map.values():
-            # Raw transport instances (plain `LCMTransport(...)` pins) have no
-            # config override surface — only deferred specs participate.
-            cls = spec.config_cls if isinstance(spec, TransportSpec) else None
-            if cls is None or cls in seen:
-                continue
-            seen.add(cls)
-            transport_fields[transport_config_name(cls)] = (cls | None, None)
-        if transport_fields:
-            transports_model = create_model(
-                "TransportsConfig", __config__={"extra": "forbid"}, **transport_fields
-            )
-            configs["transports"] = (transports_model | None, None)
-        return create_model("BlueprintConfig", __config__={"extra": "forbid"}, **configs)  # type: ignore[call-overload,no-any-return]
 
     def transports(
         self, transports: dict[tuple[str, type], TransportSpec | Transport[Any]]

--- a/dimos/core/coordination/module_coordinator.py
+++ b/dimos/core/coordination/module_coordinator.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Callable, Mapping, MutableMapping
+from collections.abc import Callable, Mapping
 import dataclasses
 import importlib
 import inspect
@@ -24,6 +24,7 @@ import sys
 import threading
 from typing import TYPE_CHECKING, Any, NamedTuple, cast
 
+from dimos.core.coordination.blueprint_config.values import deep_merge, plain
 from dimos.core.coordination.blueprints import TransportSpec, transport_config_name
 from dimos.core.coordination.coordinator_rpc import CoordinatorRPC
 from dimos.core.coordination.worker_manager import WorkerManager
@@ -46,6 +47,7 @@ from dimos.utils.logging_config import setup_logger
 from dimos.utils.safe_thread_map import safe_thread_map
 
 if TYPE_CHECKING:
+    from dimos.core.coordination.blueprint_config.parsed import ParsedBlueprintConfig
     from dimos.core.coordination.blueprints import Blueprint, BlueprintAtom
     from dimos.core.rpc_client import ModuleProxy, ModuleProxyProtocol
 
@@ -195,9 +197,7 @@ class ModuleCoordinator(Resource):
             self._instance_classes[name] = module_class
         return deployed_module  # type: ignore[return-value]
 
-    def deploy_parallel(
-        self, module_specs: list[ModuleSpec], blueprint_args: Mapping[str, Mapping[str, Any]]
-    ) -> list[ModuleProxy]:
+    def deploy_parallel(self, module_specs: list[ModuleSpec]) -> list[ModuleProxy]:
         if not self._managers:
             raise ValueError("Not started")
 
@@ -213,7 +213,7 @@ class ModuleCoordinator(Resource):
         results: list[Any] = [None] * len(module_specs)
 
         def _deploy_group(dep: str) -> None:
-            deployed = self._managers[dep].deploy_parallel(specs_by_deployment[dep], blueprint_args)
+            deployed = self._managers[dep].deploy_parallel(specs_by_deployment[dep])
             for index, module in zip(indices_by_deployment[dep], deployed, strict=True):
                 results[index] = module
 
@@ -336,14 +336,20 @@ class ModuleCoordinator(Resource):
     def build(
         cls,
         blueprint: Blueprint,
-        blueprint_args: MutableMapping[str, Any] | None = None,
+        parsed_config: ParsedBlueprintConfig | None = None,
     ) -> ModuleCoordinator:
+        """Build a blueprint from its pinned values or an exact parsed config.
+
+        With ``parsed_config`` this resets the process-global ``global_config``
+        singleton to the full parsed resolution (schema defaults plus all
+        sources); :meth:`load_blueprint` instead applies only explicitly-set
+        fields.
+        """
         logger.info("Building the blueprint")
-        global_config.update(**dict(blueprint.global_config_overrides))
-        blueprint_args = blueprint_args or {}
-        if "g" in blueprint_args:
-            global_config.update(**blueprint_args.pop("g"))
-        transport_overrides = blueprint_args.pop("transports", None) or {}
+        global_values, module_kwargs, transport_overrides = _resolve_blueprint_config(
+            blueprint, parsed_config
+        )
+        global_config.update(**global_values)
         transports = _materialize_transports(blueprint, transport_overrides)
 
         _run_configurators(blueprint)
@@ -354,7 +360,7 @@ class ModuleCoordinator(Resource):
         coordinator = cls(g=global_config)
         coordinator.start()
 
-        _deploy_all_modules(blueprint, coordinator, global_config, blueprint_args)
+        _deploy_all_modules(blueprint, coordinator, global_config, module_kwargs)
         coordinator._connect_streams(blueprint, transports)
         _connect_module_refs(blueprint, coordinator)
 
@@ -368,31 +374,30 @@ class ModuleCoordinator(Resource):
     def load_blueprint(
         self,
         blueprint: Blueprint,
-        blueprint_args: MutableMapping[str, Mapping[str, Any]] | None = None,
+        parsed_config: ParsedBlueprintConfig | None = None,
     ) -> None:
         """Load a blueprint into an already-running coordinator.
 
         Deploys, wires, builds and starts the modules described by *blueprint*.
         Workers are added automatically based on the blueprint's ``n_workers``
-        global-config override (additive).
+        global-config override (additive). ``parsed_config``, when provided,
+        must have been produced for this exact blueprint.
         """
         if not self._started:
             raise RuntimeError("ModuleCoordinator not started; call start() first")
 
         with self._modules_lock:
-            self._load_blueprint(blueprint, blueprint_args)
+            self._load_blueprint(blueprint, parsed_config)
 
     def _load_blueprint(
         self,
         blueprint: Blueprint,
-        blueprint_args: MutableMapping[str, Mapping[str, Any]] | None = None,
+        parsed_config: ParsedBlueprintConfig | None = None,
     ) -> None:
-        # Apply config overrides.
-        self._global_config.update(**dict(blueprint.global_config_overrides))
-        blueprint_args = blueprint_args or {}
-        if "g" in blueprint_args:
-            self._global_config.update(**blueprint_args.pop("g"))
-        transport_overrides = blueprint_args.pop("transports", None) or {}
+        global_values, module_kwargs, transport_overrides = _resolve_blueprint_config(
+            blueprint, parsed_config, sparse_globals=True
+        )
+        self._global_config.update(**global_values)
         transports = _materialize_transports(blueprint, transport_overrides)
 
         # Scale worker pool.
@@ -421,7 +426,7 @@ class ModuleCoordinator(Resource):
         )
         existing_classes = {self._instance_classes[name] for name in before}
 
-        _deploy_all_modules(blueprint, self, self._global_config, blueprint_args)
+        _deploy_all_modules(blueprint, self, self._global_config, module_kwargs)
         self._connect_streams(blueprint, transports)
         _connect_module_refs(
             blueprint,
@@ -440,12 +445,8 @@ class ModuleCoordinator(Resource):
 
         self._send_on_system_modules()
 
-    def load_module(
-        self,
-        module_class: type[ModuleBase],
-        blueprint_args: MutableMapping[str, Mapping[str, Any]] | None = None,
-    ) -> None:
-        self.load_blueprint(module_class.blueprint(**blueprint_args or {}))
+    def load_module(self, module_class: type[ModuleBase]) -> None:
+        self.load_blueprint(module_class.blueprint())
 
     def unload_module(self, module: type[ModuleBase] | str) -> None:
         """Stop and tear down a single deployed module.
@@ -721,12 +722,58 @@ def _materialize_transports(
         config = None
         config_cls = spec.config_cls
         if config_cls is not None:
-            # Config-field kwargs pinned on the spec
-            spec_fields = {k: v for k, v in spec.kwargs.items() if k in config_cls.model_fields}
-            sub = overrides.get(transport_config_name(config_cls), {})
-            config = config_cls(**{**spec_fields, **sub})
+            # Config-field kwargs pinned on the spec, sparse overrides on top.
+            spec_fields = {
+                k: plain(v) for k, v in spec.kwargs.items() if k in config_cls.model_fields
+            }
+            deep_merge(spec_fields, overrides.get(transport_config_name(config_cls), {}))
+            config = config_cls(**spec_fields)
         materialized[key] = _coerce_transport_to_backend(spec.build(config=config))
     return materialized
+
+
+def _resolve_blueprint_config(
+    blueprint: Blueprint,
+    parsed_config: ParsedBlueprintConfig | None,
+    *,
+    sparse_globals: bool = False,
+) -> tuple[
+    dict[str, Any],
+    dict[str, dict[str, Any]],
+    dict[str, dict[str, Any]],
+]:
+    """Return the config values one build or dynamic load should apply.
+
+    A bare coordinator build remains convenient for programmatic callers:
+    module arguments pinned by the blueprint and its GlobalConfig overrides
+    are used directly. All external configuration sources must first be
+    resolved and validated by ``BlueprintConfigParser``. ``sparse_globals``
+    restricts the parsed path to GlobalConfig fields a configuration source
+    explicitly set, so loading into a live coordinator does not reset
+    unrelated fields to schema defaults.
+    """
+    if parsed_config is None:
+        return dict(blueprint.global_config_overrides), {}, {}
+
+    from dimos.core.coordination.blueprint_config.parsed import ParsedBlueprintConfig
+
+    if not isinstance(parsed_config, ParsedBlueprintConfig):
+        raise TypeError(
+            "parsed_config must be a ParsedBlueprintConfig; "
+            "resolve overrides with BlueprintConfigParser.parse()"
+        )
+
+    parsed_config.assert_matches(blueprint)
+    global_values = (
+        parsed_config.explicit_global_config_values()
+        if sparse_globals
+        else parsed_config.global_config_values()
+    )
+    return (
+        global_values,
+        {atom.name: parsed_config.module_kwargs(atom.name) for atom in blueprint.active_blueprints},
+        cast("dict[str, dict[str, Any]]", parsed_config.transport_overrides()),
+    )
 
 
 def _verify_no_name_conflicts(blueprint: Blueprint) -> None:
@@ -830,19 +877,26 @@ def _deploy_all_modules(
     blueprint: Blueprint,
     module_coordinator: ModuleCoordinator,
     gc: GlobalConfig,
-    blueprint_args: Mapping[str, Mapping[str, Any]],
+    module_kwargs: Mapping[str, Mapping[str, Any]],
 ) -> None:
     module_specs: list[ModuleSpec] = []
+    deployed_atoms: dict[str, BlueprintAtom] = {}
     for bp in blueprint.active_blueprints:
-        kwargs = bp.kwargs.copy()
+        # Shallow copies: pinned kwargs may hold objects that cannot be
+        # deep-copied, and parsed values are already independent snapshots.
+        kwargs = dict(bp.kwargs)
+        kwargs.update(module_kwargs.get(bp.name, {}))
+        # Instance identity belongs to blueprint composition, not user config.
+        kwargs.pop("instance_name", None)
         if bp.instance_name is not None:
-            kwargs.setdefault("instance_name", bp.instance_name)
+            kwargs["instance_name"] = bp.instance_name
         module_specs.append((bp.module, gc, kwargs))
+        deployed_atoms[bp.name] = dataclasses.replace(bp, kwargs=dict(kwargs))
 
-    module_coordinator.deploy_parallel(module_specs, blueprint_args)
+    module_coordinator.deploy_parallel(module_specs)
 
     for bp in blueprint.active_blueprints:
-        module_coordinator._deployed_atoms[bp.name] = bp
+        module_coordinator._deployed_atoms[bp.name] = deployed_atoms[bp.name]
 
 
 def _ref_msg(module_name: str, ref: object, spec_name: str, detail: str) -> str:

--- a/dimos/core/coordination/python_worker.py
+++ b/dimos/core/coordination/python_worker.py
@@ -222,7 +222,7 @@ class PythonWorker:
         if self._conn is None:
             raise RuntimeError("Worker process not started")
 
-        kwargs = kwargs or {}
+        kwargs = dict(kwargs or {})
         kwargs["g"] = global_config
         module_id = _module_ids.next()
 

--- a/dimos/core/coordination/test_blueprints.py
+++ b/dimos/core/coordination/test_blueprints.py
@@ -15,9 +15,8 @@
 
 import pickle
 from types import MappingProxyType
-from typing import Protocol, get_type_hints
+from typing import Protocol
 
-from pydantic import ValidationError
 import pytest
 
 from dimos.core._test_future_annotations_helper import (
@@ -25,6 +24,8 @@ from dimos.core._test_future_annotations_helper import (
     FutureModuleIn,
     FutureModuleOut,
 )
+from dimos.core.coordination.blueprint_config.errors import BlueprintConfigError
+from dimos.core.coordination.blueprint_config.parser import BlueprintConfigParser
 from dimos.core.coordination.blueprints import (
     Blueprint,
     BlueprintAtom,
@@ -126,15 +127,14 @@ def test_autoconnect() -> None:
     )
 
 
-def test_config() -> None:
+def test_config_rejects_unknown_fields_and_sections() -> None:
     blueprint = autoconnect(ModuleA.blueprint(), ModuleB.blueprint())
-    config = blueprint.config()
-    assert config.model_fields.keys() == {"modulea", "moduleb", "g"}
-    assert config.model_fields["modulea"].annotation == get_type_hints(ModuleA)["config"] | None
-    assert config.model_fields["moduleb"].annotation == get_type_hints(ModuleB)["config"] | None
+    parser = BlueprintConfigParser(blueprint)
 
-    with pytest.raises(ValidationError, match="invalid_key"):
-        config(module_a={"invalid_key": 5})
+    with pytest.raises(BlueprintConfigError, match="invalid_key"):
+        parser.parse(environ={}, overrides={"modulea": {"invalid_key": 5}})
+    with pytest.raises(BlueprintConfigError, match="Unknown configuration section"):
+        parser.parse(environ={}, overrides={"nosuchmodule": {"x": 1}})
 
 
 def test_transports() -> None:
@@ -316,8 +316,10 @@ def test_namespace_config_keys_escaped() -> None:
         ModuleA.blueprint().namespace("robot0"),
         ModuleA.blueprint().namespace("robot1"),
     )
-    config = blueprint.config()
-    assert {"robot0_modulea", "robot1_modulea", "g"} <= set(config.model_fields.keys())
+    parser = BlueprintConfigParser(blueprint)
+    parser.parse(environ={}, overrides={"robot0_modulea": {}, "robot1_modulea": {}})
+    with pytest.raises(BlueprintConfigError, match="Unknown configuration section"):
+        parser.parse(environ={}, overrides={"robot2_modulea": {}})
 
 
 def test_explicit_instance_name_sets_blueprint_identity() -> None:
@@ -326,7 +328,6 @@ def test_explicit_instance_name_sets_blueprint_identity() -> None:
     atom = blueprint.blueprints[0]
     assert atom.name == "custom/modulea"
     assert atom.instance_name == "custom/modulea"
-    assert set(blueprint.config().model_fields) == {"custom_modulea", "g"}
 
 
 def test_namespace_prefixes_pinned_transports() -> None:

--- a/dimos/core/coordination/test_module_coordinator.py
+++ b/dimos/core/coordination/test_module_coordinator.py
@@ -12,16 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import Callable
 import pickle
+import threading
 from types import MappingProxyType
-from typing import Protocol
+from typing import Any, Protocol
 
+from pydantic import BaseModel
 import pytest
 
 from dimos.core._test_future_annotations_helper import (
     FutureModuleIn,
     FutureModuleOut,
 )
+from dimos.core.coordination.blueprint_config.parser import BlueprintConfigParser
 from dimos.core.coordination.blueprints import (
     Blueprint,
     DisabledModuleProxy,
@@ -32,6 +36,7 @@ from dimos.core.coordination.module_coordinator import (
     ModuleCoordinator,
     _all_name_types,
     _check_requirements,
+    _deploy_all_modules,
     _materialize_transports,
     _verify_no_conflicts_with_existing,
     _verify_no_name_conflicts,
@@ -40,20 +45,13 @@ from dimos.core.coordination.worker_manager_python import WorkerManagerPython
 from dimos.core.core import rpc
 from dimos.core.global_config import GlobalConfig
 from dimos.core.module import Module
-from dimos.core.stream import IO, In, Out
-from dimos.core.transport import CloudflareTransport
+from dimos.core.stream import IO, In, Out, Stream
+from dimos.core.transport import CloudflareTransport, PubSubTransport
 from dimos.msgs.geometry_msgs.Transform import Transform
 from dimos.msgs.sensor_msgs.Image import Image
 from dimos.msgs.tf2_msgs.TFMessage import TFMessage
 import dimos.robot.get_all_blueprints as resolver
 from dimos.spec.utils import Spec
-
-# Disable Rerun for tests (prevents viewer spawn and gRPC flush errors)
-_BUILD_WITHOUT_RERUN = MappingProxyType(
-    {
-        "g": {"viewer": "none"},
-    }
-)
 
 
 class Data1:
@@ -103,6 +101,45 @@ class TargetModule(Module):
 
 class ExternalNameLoadModule(Module):
     pass
+
+
+class TransportCredentials(BaseModel):
+    client_id: str
+    client_secret: str
+
+
+class NestedTransportConfig(BaseModel):
+    credentials: TransportCredentials
+
+
+class NestedConfiguredTransport(PubSubTransport[bytes]):
+    _config_cls = NestedTransportConfig
+
+    def __init__(
+        self,
+        topic: str,
+        *,
+        config: NestedTransportConfig | None = None,
+        **config_kwargs: Any,
+    ) -> None:
+        super().__init__(topic)
+        self._config = config or self._config_cls(**config_kwargs)
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+    def broadcast(self, selfstream: Stream[bytes] | None, value: bytes) -> None:
+        pass
+
+    def subscribe(
+        self,
+        callback: Callable[[bytes], Any],
+        selfstream: Stream[bytes] | None = None,
+    ) -> Callable[[], None]:
+        return lambda: None
 
 
 # ModuleRef / RPC tests
@@ -172,10 +209,19 @@ class Mod2(Module):
     def stop(self) -> None: ...
 
 
+def _build_without_rerun(blueprint: Blueprint) -> ModuleCoordinator:
+    """Build with a parsed viewer override so tests never spawn Rerun."""
+    parsed = BlueprintConfigParser(blueprint).parse(
+        environ={},
+        overrides={"g": {"viewer": "none"}},
+    )
+    return ModuleCoordinator.build(blueprint, parsed)
+
+
 def test_build_happy_path() -> None:
     blueprint_set = autoconnect(ModuleA.blueprint(), ModuleB.blueprint(), ModuleC.blueprint())
 
-    coordinator = ModuleCoordinator.build(blueprint_set, _BUILD_WITHOUT_RERUN.copy())
+    coordinator = _build_without_rerun(blueprint_set)
 
     try:
         assert isinstance(coordinator, ModuleCoordinator)
@@ -203,6 +249,84 @@ def test_build_happy_path() -> None:
 
     finally:
         coordinator.stop()
+
+
+def test_build_does_not_mutate_parsed_config(mocker) -> None:
+    blueprint = ModuleA.blueprint()
+    parsed = BlueprintConfigParser(blueprint).parse(
+        environ={},
+        overrides={"g": {"viewer": "none"}},
+    )
+    module_values = parsed.module_kwargs(ModuleA.name)
+    global_values = parsed.global_config_values()
+
+    mocker.patch.object(ModuleCoordinator, "start")
+    deploy = mocker.patch("dimos.core.coordination.module_coordinator._deploy_all_modules")
+    mocker.patch.object(ModuleCoordinator, "_connect_streams")
+    mocker.patch("dimos.core.coordination.module_coordinator._connect_module_refs")
+    mocker.patch.object(ModuleCoordinator, "build_all_modules")
+    mocker.patch.object(ModuleCoordinator, "start_all_modules")
+    mocker.patch("dimos.core.coordination.module_coordinator._log_blueprint_graph")
+
+    coordinator = ModuleCoordinator.build(blueprint, parsed)
+
+    assert parsed.module_kwargs(ModuleA.name) == module_values
+    assert parsed.global_config_values() == global_values
+    assert coordinator._global_config.viewer == "none"
+    assert deploy.call_args.args[3] == {ModuleA.name: module_values}
+
+
+def test_build_rejects_config_parsed_for_another_blueprint() -> None:
+    source = ModuleA.blueprint()
+    parsed = BlueprintConfigParser(source).parse(environ={})
+
+    with pytest.raises(ValueError):
+        ModuleCoordinator.build(ModuleC.blueprint(), parsed)
+
+
+def test_build_rejects_raw_config_mapping() -> None:
+    with pytest.raises(TypeError, match="ParsedBlueprintConfig"):
+        ModuleCoordinator.build(  # type: ignore[arg-type]
+            ModuleA.blueprint(),
+            {"g": {"viewer": "none"}},
+        )
+
+
+def test_deploy_preserves_constructor_only_blueprint_kwargs(mocker) -> None:
+    class ConstructorOnlyModule(Module):
+        def __init__(self, resource_name: str, **kwargs: Any) -> None:
+            self.resource_name = resource_name
+            super().__init__(**kwargs)
+
+    blueprint = ConstructorOnlyModule.blueprint(resource_name="camera")
+    parsed = BlueprintConfigParser(blueprint).parse(environ={})
+    coordinator = ModuleCoordinator(g=GlobalConfig(viewer="none"))
+    deploy = mocker.patch.object(coordinator, "deploy_parallel", return_value=[])
+
+    _deploy_all_modules(
+        blueprint,
+        coordinator,
+        coordinator._global_config,
+        {atom.name: parsed.module_kwargs(atom.name) for atom in blueprint.active_blueprints},
+    )
+
+    assert deploy.call_args.args[0][0][2]["resource_name"] == "camera"
+
+
+def test_deploy_does_not_deepcopy_pinned_kwargs(mocker) -> None:
+    class LockHolderModule(Module):
+        def __init__(self, lock: Any, **kwargs: Any) -> None:
+            self.lock = lock
+            super().__init__(**kwargs)
+
+    lock = threading.Lock()
+    blueprint = LockHolderModule.blueprint(lock=lock)
+    coordinator = ModuleCoordinator(g=GlobalConfig(viewer="none"))
+    deploy = mocker.patch.object(coordinator, "deploy_parallel", return_value=[])
+
+    _deploy_all_modules(blueprint, coordinator, coordinator._global_config, {})
+
+    assert deploy.call_args.args[0][0][2]["lock"] is lock
 
 
 def test_name_conflicts_are_reported() -> None:
@@ -304,7 +428,7 @@ def test_remapping() -> None:
     assert ("color_image", Data1) not in all_names
 
     # Build and verify streams work
-    coordinator = ModuleCoordinator.build(blueprint_set, _BUILD_WITHOUT_RERUN.copy())
+    coordinator = _build_without_rerun(blueprint_set)
 
     try:
         source_instance = coordinator.get_instance(SourceModule)
@@ -335,7 +459,7 @@ def test_future_annotations_autoconnect() -> None:
 
     blueprint_set = autoconnect(FutureModuleOut.blueprint(), FutureModuleIn.blueprint())
 
-    coordinator = ModuleCoordinator.build(blueprint_set, _BUILD_WITHOUT_RERUN.copy())
+    coordinator = _build_without_rerun(blueprint_set)
 
     try:
         out_instance = coordinator.get_instance(FutureModuleOut)
@@ -356,12 +480,11 @@ def test_future_annotations_autoconnect() -> None:
 
 
 def test_module_ref_direct() -> None:
-    coordinator = ModuleCoordinator.build(
+    coordinator = _build_without_rerun(
         autoconnect(
             Calculator1.blueprint(),
             Mod1.blueprint(),
-        ),
-        _BUILD_WITHOUT_RERUN.copy(),
+        )
     )
 
     try:
@@ -374,12 +497,11 @@ def test_module_ref_direct() -> None:
 
 
 def test_module_ref_spec() -> None:
-    coordinator = ModuleCoordinator.build(
+    coordinator = _build_without_rerun(
         autoconnect(
             Calculator1.blueprint(),
             Mod2.blueprint(),
-        ),
-        _BUILD_WITHOUT_RERUN.copy(),
+        )
     )
 
     try:
@@ -396,7 +518,7 @@ def test_disabled_modules_are_skipped_during_build() -> None:
         ModuleA.blueprint(), ModuleB.blueprint(), ModuleC.blueprint()
     ).disabled_modules(ModuleC)
 
-    coordinator = ModuleCoordinator.build(blueprint_set, _BUILD_WITHOUT_RERUN.copy())
+    coordinator = _build_without_rerun(blueprint_set)
 
     try:
         assert coordinator.get_instance(ModuleA) is not None
@@ -413,7 +535,7 @@ def test_disabled_module_ref_gets_noop_proxy() -> None:
         Mod2.blueprint(),
     ).disabled_modules(Calculator1)
 
-    coordinator = ModuleCoordinator.build(blueprint_set, _BUILD_WITHOUT_RERUN.copy())
+    coordinator = _build_without_rerun(blueprint_set)
 
     try:
         mod2 = coordinator.get_instance(Mod2)
@@ -427,7 +549,7 @@ def test_disabled_module_ref_gets_noop_proxy() -> None:
 
 
 def test_module_ref_remap_ambiguous() -> None:
-    coordinator = ModuleCoordinator.build(
+    coordinator = _build_without_rerun(
         autoconnect(
             Calculator1.blueprint(),
             Calculator2.blueprint(),
@@ -436,8 +558,7 @@ def test_module_ref_remap_ambiguous() -> None:
             [
                 (Mod2, "calc", Calculator1),
             ]
-        ),
-        _BUILD_WITHOUT_RERUN.copy(),
+        )
     )
 
     try:
@@ -546,7 +667,7 @@ def build_coordinator():
     coordinators = []
 
     def _build(blueprint):
-        c = ModuleCoordinator.build(blueprint, _BUILD_WITHOUT_RERUN.copy())
+        c = _build_without_rerun(blueprint)
         coordinators.append(c)
         return c
 
@@ -912,6 +1033,44 @@ def test_spec_config_kwarg_reaches_provider_config() -> None:
     assert t._config.robot_type == "go2"
 
 
+def test_materialize_transports_deep_merges_sparse_nested_overrides() -> None:
+    pinned_credentials = {
+        "client_id": "blueprint-client",
+        "client_secret": "blueprint-secret",
+    }
+    spec = NestedConfiguredTransport.spec("events", credentials=pinned_credentials)
+    bp = Blueprint(blueprints=(), transport_map=MappingProxyType({("s", bytes): spec}))
+    parsed = BlueprintConfigParser(bp).parse(
+        [
+            "--transports.nestedtransport.credentials.client-id",
+            "cli-client",
+        ],
+        environ={},
+    )
+    overrides = parsed.transport_overrides()
+
+    transport = _materialize_transports(bp, overrides)[("s", bytes)]
+
+    assert isinstance(transport, NestedConfiguredTransport)
+    assert transport._config == NestedTransportConfig(
+        credentials=TransportCredentials(
+            client_id="cli-client",
+            client_secret="blueprint-secret",
+        )
+    )
+    assert pinned_credentials == {
+        "client_id": "blueprint-client",
+        "client_secret": "blueprint-secret",
+    }
+    assert overrides == {
+        "nestedtransport": {
+            "credentials": {
+                "client_id": "cli-client",
+            }
+        }
+    }
+
+
 class IoTfPublisher(Module):
     tf: Out[TFMessage]
 
@@ -968,7 +1127,7 @@ def test_io_port_autoconnects_and_flows_both_ways(wait_until) -> None:
         IoTfPublisher.blueprint(), IoTfEcho.blueprint(), IoTfConsumer.blueprint()
     )
 
-    coordinator = ModuleCoordinator.build(blueprint_set, _BUILD_WITHOUT_RERUN.copy())
+    coordinator = _build_without_rerun(blueprint_set)
     try:
         publisher = coordinator.get_instance(IoTfPublisher)
         echo = coordinator.get_instance(IoTfEcho)

--- a/dimos/core/coordination/test_namespace.py
+++ b/dimos/core/coordination/test_namespace.py
@@ -12,21 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from types import MappingProxyType
+from typing import Any
 
 import pytest
 
-from dimos.core.coordination.blueprints import autoconnect
+from dimos.core.coordination.blueprint_config.parsed import ParsedBlueprintConfig
+from dimos.core.coordination.blueprint_config.parser import BlueprintConfigParser
+from dimos.core.coordination.blueprints import Blueprint, autoconnect
 from dimos.core.coordination.module_coordinator import ModuleCoordinator
 from dimos.core.core import rpc
+from dimos.core.global_config import GlobalConfig
 from dimos.core.module import Module, ModuleConfig
 from dimos.core.stream import In, Out
-
-_BUILD_WITHOUT_RERUN = MappingProxyType(
-    {
-        "g": {"viewer": "none"},
-    }
-)
 
 
 class Cloud:
@@ -97,12 +94,20 @@ def _fleet_blueprint():
     ).remappings([(FleetCommander, "cmd", "robot0/cmd")])
 
 
+def _parsed_config(
+    blueprint: Blueprint,
+    overrides: dict[str, Any] | None = None,
+) -> ParsedBlueprintConfig:
+    all_overrides: dict[str, Any] = {"g": {"viewer": "none"}}
+    all_overrides.update(overrides or {})
+    return BlueprintConfigParser(blueprint).parse(environ={}, overrides=all_overrides)
+
+
 @pytest.fixture
 def fleet_coordinator():
-    args = dict(_BUILD_WITHOUT_RERUN)
-    args["robot0_sensor"] = {"sensitivity": 2.0}
-
-    coordinator = ModuleCoordinator.build(_fleet_blueprint(), args)
+    blueprint = _fleet_blueprint()
+    parsed = _parsed_config(blueprint, {"robot0_sensor": {"sensitivity": 2.0}})
+    coordinator = ModuleCoordinator.build(blueprint, parsed)
     try:
         yield coordinator
     finally:
@@ -160,27 +165,65 @@ def test_fleet_blueprint(fleet_coordinator: ModuleCoordinator):
     assert sensor1.cmd.transport.topic != sensor0.cmd.transport.topic
 
 
-def test_fleet_blueprint_config_keys():
-    config = _fleet_blueprint().config()
-    assert {
-        "robot0_sensor",
-        "robot1_sensor",
-        "robot0_localmapper",
-        "robot1_localmapper",
+def test_restart_preserves_parsed_instance_config(fleet_coordinator: ModuleCoordinator):
+    fleet_coordinator.restart_module("robot0/sensor", reload_source=False)
+
+    restarted_sensor = fleet_coordinator.get_instance("robot0/sensor")
+    assert restarted_sensor.get_sensitivity() == 2.0
+
+
+def test_load_blueprint_accepts_parsed_module_config() -> None:
+    blueprint = Sensor.blueprint()
+    parsed = _parsed_config(blueprint, {"sensor": {"sensitivity": 3.0}})
+    coordinator = ModuleCoordinator(g=GlobalConfig(n_workers=0, viewer="none"))
+    coordinator.start()
+    try:
+        coordinator.load_blueprint(blueprint, parsed)
+
+        sensor = coordinator.get_instance(Sensor)
+        assert sensor.get_sensitivity() == 3.0
+    finally:
+        coordinator.stop()
+
+
+def test_load_blueprint_preserves_unrelated_global_config() -> None:
+    blueprint = Sensor.blueprint()
+    parsed = BlueprintConfigParser(blueprint).parse(environ={})
+    coordinator = ModuleCoordinator(g=GlobalConfig(viewer="none", robot_ip="10.9.8.7", n_workers=0))
+    coordinator.start()
+    try:
+        coordinator.load_blueprint(blueprint, parsed)
+
+        config = coordinator._global_config
+        assert config.viewer == "none"
+        assert config.robot_ip == "10.9.8.7"
+        assert config.n_workers == 0
+    finally:
+        coordinator.stop()
+
+
+def test_fleet_blueprint_config_keys() -> None:
+    parsed = BlueprintConfigParser(_fleet_blueprint()).parse(
+        environ={}, overrides={"robot0_sensor": {"sensitivity": 5.0}}
+    )
+    assert set(parsed.module_configs) == {
+        "robot0/sensor",
+        "robot1/sensor",
+        "robot0/localmapper",
+        "robot1/localmapper",
         "aggregator",
         "fleetcommander",
-        "g",
-    } == set(config.model_fields.keys())
+    }
+    # Escaped roots resolve back to the namespaced instances.
+    assert parsed.module_kwargs("robot0/sensor")["sensitivity"] == 5.0
 
 
 def test_load_blueprint_resolves_existing_provider_in_same_namespace():
-    coordinator = ModuleCoordinator.build(
-        autoconnect(
-            Sensor.blueprint().namespace("robot0"),
-            Sensor.blueprint().namespace("robot1"),
-        ),
-        dict(_BUILD_WITHOUT_RERUN),
+    blueprint = autoconnect(
+        Sensor.blueprint().namespace("robot0"),
+        Sensor.blueprint().namespace("robot1"),
     )
+    coordinator = ModuleCoordinator.build(blueprint, _parsed_config(blueprint))
     try:
         coordinator.load_blueprint(LocalMapper.blueprint().namespace("robot0"))
 

--- a/dimos/core/coordination/test_worker.py
+++ b/dimos/core/coordination/test_worker.py
@@ -157,16 +157,17 @@ def test_worker_manager_multiple_different_modules(create_worker_manager):
 @pytest.mark.skipif_macos_bug
 def test_worker_manager_parallel_deployment(create_worker_manager):
     worker_manager = create_worker_manager(n_workers=2)
+    simple_kwargs = {}
     modules = worker_manager.deploy_parallel(
         [
-            (SimpleModule, global_config, {}),
+            (SimpleModule, global_config, simple_kwargs),
             (AnotherModule, global_config, {}),
             (ThirdModule, global_config, {}),
         ],
-        {},
     )
 
     assert len(modules) == 3
+    assert simple_kwargs == {}
     module1, module2, module3 = modules
 
     # Start all modules

--- a/dimos/core/coordination/worker_manager.py
+++ b/dimos/core/coordination/worker_manager.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Protocol
 
 from dimos.core.global_config import GlobalConfig
@@ -40,11 +40,7 @@ class WorkerManager(Protocol):
         kwargs: dict[str, Any],
     ) -> ModuleProxyProtocol: ...
 
-    def deploy_parallel(
-        self,
-        specs: Sequence[ModuleSpec],
-        blueprint_args: Mapping[str, Mapping[str, Any]],
-    ) -> list[ModuleProxyProtocol]: ...
+    def deploy_parallel(self, specs: Sequence[ModuleSpec]) -> list[ModuleProxyProtocol]: ...
 
     def stop(self) -> None: ...
 

--- a/dimos/core/coordination/worker_manager_python.py
+++ b/dimos/core/coordination/worker_manager_python.py
@@ -14,10 +14,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any
 
-from dimos.core.coordination.blueprints import config_key
 from dimos.core.coordination.python_worker import PythonWorker
 from dimos.core.global_config import GlobalConfig
 from dimos.core.module import ModuleBase, ModuleSpec
@@ -29,17 +28,6 @@ if TYPE_CHECKING:
     from dimos.core.resource_monitor.monitor import StatsMonitor
 
 logger = setup_logger()
-
-
-def _merge_config_kwargs(base: Mapping[str, Any], overrides: Mapping[str, Any]) -> dict[str, Any]:
-    merged = dict(base)
-    for key, override_value in overrides.items():
-        base_value = merged.get(key)
-        if isinstance(base_value, Mapping) and isinstance(override_value, Mapping):
-            merged[key] = _merge_config_kwargs(base_value, override_value)
-        else:
-            merged[key] = override_value
-    return merged
 
 
 class WorkerManagerPython:
@@ -147,9 +135,7 @@ class WorkerManagerPython:
             self._workers.remove(target)
             self._n_workers = max(0, self._n_workers - 1)
 
-    def deploy_parallel(
-        self, specs: Iterable[ModuleSpec], blueprint_args: Mapping[str, Mapping[str, Any]]
-    ) -> list[ModuleProxyProtocol]:
+    def deploy_parallel(self, specs: Iterable[ModuleSpec]) -> list[ModuleProxyProtocol]:
         if self._closed:
             raise RuntimeError("WorkerManager is closed")
 
@@ -170,15 +156,9 @@ class WorkerManagerPython:
         workers_by_index: dict[int, PythonWorker] = {}
         order = sorted(range(len(specs)), key=lambda i: not specs[i][0].dedicated_worker)
         for i in order:
-            module_class, _, kwargs = specs[i]
+            module_class, _, _ = specs[i]
             worker = self._select_worker(dedicated=module_class.dedicated_worker)
             worker.reserve_slot()
-            instance_key = kwargs.get("instance_name") or module_class.name
-            args = blueprint_args.get(config_key(instance_key), {})
-            # instance_name is assigned by the blueprint; a user-supplied value
-            # would desync the module's RPC topic from the coordinator's proxy.
-            args = {k: v for k, v in args.items() if k != "instance_name"}
-            kwargs.update(_merge_config_kwargs(kwargs, args))
             workers_by_index[i] = worker
 
         assignments = [(workers_by_index[i], specs[i]) for i in range(len(specs))]

--- a/dimos/core/transport.py
+++ b/dimos/core/transport.py
@@ -462,7 +462,7 @@ class CloudflareTransport(WebRTCTransport[M]):
     """WebRTC via the hosted teleop broker + Cloudflare Realtime SFU.
 
     Config kwargs flow into :class:`BrokerConfig`; unset fields fall back to
-    the blueprint config flow (``-o transports.broker.<field>=...`` or the
+    the blueprint config flow (``--transports.broker.<field>=...`` or the
     ``TRANSPORTS__BROKER__<FIELD>=...`` env form).
 
     Blueprint usage::

--- a/dimos/e2e_tests/dimos_cli_call.py
+++ b/dimos/e2e_tests/dimos_cli_call.py
@@ -44,11 +44,11 @@ class DimosCliCall:
         # defaults to a hard-coded `http://localhost:9990/mcp`) so server
         # and client agree on the same port.
         #
-        # The McpClient URL goes through an env var rather than a `-o`
-        # blueprint override: `load_config_args` silently skips env-var
-        # overrides whose module is absent from the blueprint, but rejects
-        # unknown `-o` keys outright. Blueprints without an mcpclient (e.g.
-        # `coordinator-mock`) would otherwise fail config validation.
+        # The McpClient URL goes through an env var rather than a dynamic
+        # blueprint flag: BlueprintConfigParser skips environment overrides
+        # whose module is absent from the blueprint, but rejects unknown CLI
+        # configuration flags. Blueprints without an mcpclient (e.g.
+        # `coordinator-mock`) would otherwise fail configuration validation.
         global_overrides: list[str] = list(self.global_args)
         env = os.environ.copy()
         env.update(self.extra_env)

--- a/dimos/experimental/scene_cooking/README.md
+++ b/dimos/experimental/scene_cooking/README.md
@@ -196,11 +196,11 @@ dimos --simulation mujoco \
   --viewer rerun \
   --n-workers 12 \
   run unitree-g1-groot-wbc \
-  -o mujocosimmodule.headless=true
+  --headless=true
 ```
 
-Use `headless=true` for normal testing and inspect Rerun. Use
-`headless=false` only when the native MuJoCo window is needed for contact or
+Use `--headless=true` for normal testing and inspect Rerun. Use
+`--headless=false` only when the native MuJoCo window is needed for contact or
 render debugging; it can run much slower.
 
 ## Data Publishing

--- a/dimos/manipulation/planning/README.md
+++ b/dimos/manipulation/planning/README.md
@@ -119,9 +119,9 @@ module.execute()  # Sends to coordinator
 | `PinkIK` | Pinocchio/Pink | Local differential IK with task QP composition |
 
 `PinkIK` is selectable with `kinematics={"backend": "pink"}` or the CLI override
-`-o manipulationmodule.kinematics.backend=pink`. Pink tuning fields are nested
+`--kinematics.backend=pink`. Pink tuning fields are nested
 under the same config, for example
-`-o manipulationmodule.kinematics.max_iterations=100`. It is installed with the
+`--kinematics.max-iterations=100`. It is installed with the
 `manipulation` optional dependencies, which include the PyPI package `pin-pink`
 (import name `pink`) and a `qpsolvers` backend (`proxqp`). Pink is
 local/differential rather than global IK, so it can converge to local minima;

--- a/dimos/manipulation/test_manipulation_unit.py
+++ b/dimos/manipulation/test_manipulation_unit.py
@@ -494,7 +494,7 @@ class TestPlanningInitialization:
         )
 
     def test_nested_kinematics_config_parses_cli_override_shape(self) -> None:
-        """Pydantic parses the nested CLI config shape used by -o overrides."""
+        """Pydantic parses the nested shape used by dynamic CLI overrides."""
         config = ManipulationModuleConfig(
             kinematics={
                 "backend": "pink",

--- a/dimos/mapping/relocalization/module.py
+++ b/dimos/mapping/relocalization/module.py
@@ -45,9 +45,7 @@ MAP_SUFFIX = ".pc2.lcm"
 
 
 class Config(ModuleConfig):
-    map_file: str | None = (
-        None  # e.g. `-o relocalizationmodule.map_file=go2_hongkong_office_twopass_map`
-    )
+    map_file: str | None = None  # e.g. `--map-file=go2_hongkong_office_twopass_map`
     publish_loaded_map: bool = False
     fitness_threshold: float = 0.45
     use_carving: bool = True

--- a/dimos/navigation/dannav/holonomic_tc/docs/run_profiles.md
+++ b/dimos/navigation/dannav/holonomic_tc/docs/run_profiles.md
@@ -18,10 +18,10 @@ name at deploy time.
 | Surface                               | How you set the profile                                                     | Status                                                   | Code                                                                                                              |
 | ------------------------------------- | --------------------------------------------------------------------------- | -------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | Blueprint                             | `DanHolonomicTC.blueprint(run_profile="walk")` on the `autoconnect` chain   | Wired at deploy                                          | e.g. `unitree_go2_mls_htc.py`                                                                                     |
-| CLI                                   | `dimos run <blueprint> -o danholonomictc.run_profile=trot`                  | Wired at deploy                                          | `dimos/cli/dimos.py` (`load_config_args` -> module `config`)                                                |
+| CLI                                   | `dimos run <blueprint> --run-profile=trot`                                  | Wired at deploy                                          | `BlueprintConfigParser.parse()` -> module `config`                                                                  |
 | Module default                        | Omit `run_profile`; `DanHolonomicTCConfig` defaults to `"walk"`             | Wired                                                    | `module.py` (`DanHolonomicTCConfig.run_profile`)                                                                  |
 | Live RPC                              | `DanHolonomicTC.set_run_profile("trot")` on a running module                | Wired in module; no production caller yet                | `module.py` (`set_run_profile` RPC -> `_HolonomicPathFollower.set_run_profile`)                                   |
-| Cruise override                       | `DanHolonomicTC.blueprint(speed_m_s=1.0)` or `danholonomictc.speed_m_s=1.0` | Wired; overrides profile cruise only, not accel/yaw caps | `module.py` (`_cruise_speed_override` in `_profile_run_envelope`)                                                 |
+| Cruise override                       | `DanHolonomicTC.blueprint(speed_m_s=1.0)` or `--speed-m-s=1.0`              | Wired; overrides profile cruise only, not accel/yaw caps | `module.py` (`_cruise_speed_override` in `_profile_run_envelope`)                                                 |
 | Agent skills (`relative_move`, etc.)  | N/A                                                                         | Not wired to run profiles                                | Skills use `NavigationInterface`; MLS+HTC stack uses click goals via `MovementManager`                            |
 | MCP tools                             | N/A                                                                         | Not wired to run profiles                                | No MCP tool calls `set_run_profile`                                                                               |
 | `GO2_RUN_PROFILE` env var             | N/A                                                                         | Removed                                                  | Was `GlobalConfig.go2_run_profile`; use blueprint / CLI module config instead                                     |
@@ -106,5 +106,5 @@ DanHolonomicTC.blueprint(run_profile="walk"),
 Example CLI override:
 
 ```bash
-dimos run unitree-go2-mls-htc -o danholonomictc.run_profile=trot
+dimos run unitree-go2-mls-htc --run-profile=trot
 ```

--- a/dimos/protocol/pubsub/impl/webrtc/providers/broker.py
+++ b/dimos/protocol/pubsub/impl/webrtc/providers/broker.py
@@ -123,7 +123,7 @@ class BrokerProvider(AsyncProviderBase):
         if not config.api_key:
             raise RuntimeError(
                 "BrokerConfig.api_key required "
-                "(set -o transports.broker.api_key=dtk_live_... or "
+                "(set --transports.broker.api-key=dtk_live_... or "
                 "TRANSPORTS__BROKER__API_KEY=dtk_live_...; "
                 "create one in the teleop dashboard: New Key)"
             )

--- a/dimos/protocol/pubsub/impl/webrtc/providers/cloudflare.py
+++ b/dimos/protocol/pubsub/impl/webrtc/providers/cloudflare.py
@@ -23,7 +23,7 @@ loopback pubsub through the CF edge: exactly what the integration tests and
 the pubsub benchmark need, and nothing else.
 
 ``app_id`` / ``app_secret`` reach ``CloudflareConfig`` via the standard
-blueprint config flow (``-o transports.cloudflare.app_id=...`` or
+blueprint config flow (``--transports.cloudflare.app-id=...`` or
 ``TRANSPORTS__CLOUDFLARE__APP_ID=...``).
 """
 
@@ -105,7 +105,8 @@ class CloudflareProvider(AsyncProviderBase):
         if not config.app_id or not config.app_secret:
             raise RuntimeError(
                 "CloudflareConfig.app_id and app_secret required "
-                "(set -o transports.cloudflare.app_id=... and app_secret=..., or the "
+                "(set --transports.cloudflare.app-id=... and "
+                "--transports.cloudflare.app-secret=..., or the "
                 "TRANSPORTS__CLOUDFLARE__APP_ID / TRANSPORTS__CLOUDFLARE__APP_SECRET env form)"
             )
         self._app_secret = config.app_secret

--- a/dimos/protocol/pubsub/impl/webrtc/test_transport.py
+++ b/dimos/protocol/pubsub/impl/webrtc/test_transport.py
@@ -19,11 +19,12 @@ from __future__ import annotations
 from collections.abc import Callable
 import pickle
 import struct
-from typing import get_args
 
 from pydantic import ValidationError
 import pytest
 
+from dimos.core.coordination.blueprint_config.errors import BlueprintConfigError
+from dimos.core.coordination.blueprint_config.parser import BlueprintConfigParser
 from dimos.core.coordination.blueprints import Blueprint
 from dimos.core.coordination.module_coordinator import _materialize_transports
 from dimos.core.transport import WebRTCTransport
@@ -259,29 +260,27 @@ def test_provider_config_is_frozen_and_hashable() -> None:
 
 
 def test_blueprint_config_exposes_transport_fields() -> None:
-    """Each unique `_config_cls` becomes a `transports.<name>` sub-model on the schema."""
+    """Each unique `_config_cls` becomes a `transports.<name>` config section."""
     bp = Blueprint(blueprints=()).transports({("topic", FakeLCMMsg): MockTransport.spec("topic")})
-    cfg = bp.config()
-    parsed = cfg(transports={"mock": {"name": "override"}})
-    assert parsed.transports.mock.name == "override"
+    parser = BlueprintConfigParser(bp)
+    parsed = parser.parse(environ={}, overrides={"transports": {"mock": {"name": "override"}}})
+    assert parsed.transport_overrides() == {"mock": {"name": "override"}}
     # Sub-field name → MockConfig; extra fields and unknown namespaces rejected.
-    with pytest.raises(ValidationError, match="bogus"):
-        cfg(transports={"mock": {"bogus": 1}})
-    with pytest.raises(ValidationError, match="other"):
-        cfg(transports={"other": {}})
-    # Multiple transports sharing one `_config_cls` collapse to one slot.
+    with pytest.raises(BlueprintConfigError, match="bogus"):
+        parser.parse(environ={}, overrides={"transports": {"mock": {"bogus": 1}}})
+    with pytest.raises(BlueprintConfigError, match="other"):
+        parser.parse(environ={}, overrides={"transports": {"other": {}}})
+    # Multiple transports sharing one `_config_cls` collapse to one section.
     bp_shared = Blueprint(blueprints=()).transports(
         {
             ("a", FakeLCMMsg): MockTransport.spec("a"),
             ("b", FakeLCMMsg): MockTransport.spec("b"),
         }
     )
-    inner = next(
-        a
-        for a in get_args(bp_shared.config().model_fields["transports"].annotation)
-        if a is not type(None)
+    shared = BlueprintConfigParser(bp_shared).parse(
+        environ={}, overrides={"transports": {"mock": {"name": "both"}}}
     )
-    assert set(inner.model_fields.keys()) == {"mock"}
+    assert shared.transport_overrides() == {"mock": {"name": "both"}}
 
 
 def test_transport_overrides_apply_and_survive_pickle() -> None:
@@ -317,8 +316,9 @@ def test_transport_overrides_coerce_string_values() -> None:
 
 def test_raw_transport_pins_still_work() -> None:
     """Backwards compat: plain transport instances in .transports() (the pre-spec
-    style used across existing blueprints) must survive config() and materialize
-    unchanged — only spec-declared transports opt into the override flow."""
+    style used across existing blueprints) must survive config parsing and
+    materialize unchanged — only spec-declared transports opt into the
+    override flow."""
     from dimos.core.transport import LCMTransport
 
     raw = LCMTransport("/raw_topic", FakeLCMMsg)
@@ -328,9 +328,11 @@ def test_raw_transport_pins_still_work() -> None:
             ("speced", FakeLCMMsg): MockTransport.spec("topic"),
         }
     )
-    # Raw pins contribute no transports.* config fields; the spec still does.
-    cfg = bp.config()
-    assert cfg(transports={"mock": {"name": "x"}}).transports.mock.name == "x"
+    # Raw pins contribute no transports.* config sections; the spec still does.
+    parsed = BlueprintConfigParser(bp).parse(
+        environ={}, overrides={"transports": {"mock": {"name": "x"}}}
+    )
+    assert parsed.transport_overrides() == {"mock": {"name": "x"}}
 
     materialized = _materialize_transports(bp, {})
     assert materialized[("raw", FakeLCMMsg)] is raw

--- a/dimos/protocol/pubsub/impl/webrtc/tool_blueprint_e2e.py
+++ b/dimos/protocol/pubsub/impl/webrtc/tool_blueprint_e2e.py
@@ -26,10 +26,10 @@ from __future__ import annotations
 
 import os
 import time
-from types import MappingProxyType
 
 import pytest
 
+from dimos.core.coordination.blueprint_config.parser import BlueprintConfigParser
 from dimos.core.coordination.blueprints import autoconnect
 from dimos.core.core import rpc
 from dimos.core.module import Module
@@ -92,9 +92,11 @@ def test_blueprint_stream_over_cloudflare() -> None:
         }
     )
 
-    coordinator = ModuleCoordinator.build(
-        blueprint, MappingProxyType({"g": {"viewer": "none", "n_workers": 1}}).copy()
+    parsed = BlueprintConfigParser(blueprint).parse(
+        environ={},
+        overrides={"g": {"viewer": "none", "n_workers": 1}},
     )
+    coordinator = ModuleCoordinator.build(blueprint, parsed)
     try:
         coordinator.start_all_modules()
         source = coordinator.get_instance(TwistSource)

--- a/dimos/robot/drone/README.md
+++ b/dimos/robot/drone/README.md
@@ -15,7 +15,7 @@ dimos --replay run drone-agentic
 dimos run drone-basic
 
 # Real drone — outdoor (GPS-based odometry)
-dimos run drone-basic --set outdoor=true
+dimos run drone-basic --outdoor=true
 
 # Agentic with LLM control
 dimos run drone-agentic
@@ -35,7 +35,10 @@ Connection + camera + visualization. The foundation layer.
 | `WebsocketVisModule` | Web-based visualization |
 | `RerunBridgeModule` | 3D viewer (selected by `--viewer`) |
 
-**Indoor vs Outdoor:** By default, the drone uses velocity integration for odometry (indoor mode). For outdoor flights with GPS, set `outdoor=true` — this switches to GPS-only positioning which is more reliable in open environments but less precise for close-range maneuvers.
+**Indoor vs Outdoor:** By default, the drone uses velocity integration for
+odometry (indoor mode). For outdoor flights with GPS, pass `--outdoor=true`;
+this switches to GPS-only positioning, which is more reliable in open
+environments but less precise for close-range maneuvers.
 
 ### `drone-agentic`
 Composes on top of `drone-basic`, adding autonomous capabilities:

--- a/dimos/robot/unitree/g1/blueprints/basic/unitree_g1_groot_wbc.py
+++ b/dimos/robot/unitree/g1/blueprints/basic/unitree_g1_groot_wbc.py
@@ -41,7 +41,7 @@ Usage:
 
 Overrides (replace the old env-var dance):
     dimos run unitree-g1-groot-wbc \\
-        -o g1wholebodyconnection.network_interface=enp2s0
+        --network-interface=enp2s0
 """
 
 from __future__ import annotations

--- a/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_multi.py
+++ b/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_multi.py
@@ -19,7 +19,7 @@
 Each robot gets its own namespaced GO2Connection: topics like `/robot0/lidar`,
 TF frames like `robot0/...`, and RPC like `robot0/go2connection/move`.
 
-Configure a single robot with `-o robot0/go2connection.<field>=<value>`.
+Configure a single robot with `--robot0/go2connection.<field>=<value>`.
 
 Usage:
     ROBOT_IPS=10.0.0.102,10.0.0.209 dimos run unitree-go2-multi

--- a/dimos/simulation/scenes/README.md
+++ b/dimos/simulation/scenes/README.md
@@ -160,7 +160,7 @@ dimos \
 ```
 
 Prefer headless MuJoCo with Rerun native for normal testing. Opening the MuJoCo
-viewer with `mujocosimmodule.headless=false` is useful for contact debugging,
+viewer with `--headless=false` is useful for contact debugging,
 but it can run much slower.
 
 ## Boundaries

--- a/dimos/teleop/hosted/blueprints/cloudflare.py
+++ b/dimos/teleop/hosted/blueprints/cloudflare.py
@@ -151,7 +151,7 @@ teleop_hosted_go2_multicam = (
 
 
 # Distinct classes only because blueprints can't yet run two instances of one
-# module. Serials: -o frontcamera.serial_number=... -o wristcamera.serial_number=...
+# module. Serials: --frontcamera.serial-number=... --wristcamera.serial-number=...
 class FrontCamera(RealSenseCamera):
     pass
 

--- a/dimos/teleop/hosted/test_go2_audio_bridge.py
+++ b/dimos/teleop/hosted/test_go2_audio_bridge.py
@@ -26,6 +26,7 @@ import numpy as np
 from numpy.typing import NDArray
 import pytest
 
+from dimos.core.coordination.blueprint_config.parser import BlueprintConfigParser
 from dimos.core.module import Module
 from dimos.stream.audio.base import AudioEvent
 from dimos.teleop.hosted.blueprints.cloudflare import teleop_hosted_go2_transport
@@ -86,11 +87,11 @@ def test_stereo_audio_is_mixed_and_resampled_for_go2() -> None:
 
 
 def test_hosted_blueprint_accepts_speaker_override() -> None:
-    config = teleop_hosted_go2_transport.config()
+    parser = BlueprintConfigParser(teleop_hosted_go2_transport)
 
-    resolved = config(**{"go2audiobridgemodule": {"speaker": "enabled"}})
+    parsed = parser.parse(environ={}, overrides={"go2audiobridgemodule": {"speaker": "enabled"}})
 
-    assert resolved.go2audiobridgemodule.speaker == "enabled"
+    assert parsed.module_kwargs("go2audiobridgemodule")["speaker"] == "enabled"
 
 
 def test_auto_mode_disables_speaker_when_audio_hub_probe_fails(

--- a/docs/capabilities/manipulation/index.md
+++ b/docs/capabilities/manipulation/index.md
@@ -52,17 +52,17 @@ Pink IK is the default solver. Tune it with nested module config overrides:
 
 ```bash
 dimos run xarm7-planner-coordinator \
-  -o manipulationmodule.kinematics.backend=pink \
-  -o manipulationmodule.kinematics.max_iterations=100 \
-  -o manipulationmodule.kinematics.dt=0.02
+  --kinematics.backend=pink \
+  --kinematics.max-iterations=100 \
+  --kinematics.dt=0.02
 ```
 
-For blueprints that instantiate `PickAndPlaceModule`, use the corresponding
-module prefix:
+The same nested shorthand applies to blueprints that instantiate
+`PickAndPlaceModule`:
 
 ```bash
 dimos run xarm-perception-sim \
-  -o pickandplacemodule.kinematics.backend=pink
+  --kinematics.backend=pink
 ```
 
 Then use the IPython client:
@@ -96,8 +96,8 @@ Select the legacy Drake world and generic RRT planner explicitly when needed:
 
 ```bash
 dimos run xarm7-planner-coordinator \
-  -o manipulationmodule.world_backend=drake \
-  -o manipulationmodule.planner.backend=rrt_connect
+  --world-backend=drake \
+  --planner.backend=rrt_connect
 ```
 
 Valid combinations:
@@ -190,7 +190,7 @@ CLI example:
 
 ```bash
 uv run dimos run xarm7-planner-coordinator \
-  -o manipulationmodule.visualization.backend=viser
+  --visualization.backend=viser
 ```
 
 Blueprint example:

--- a/docs/capabilities/navigation/relocalization.md
+++ b/docs/capabilities/navigation/relocalization.md
@@ -91,7 +91,7 @@ Test alignment without the robot. `unitree-go2-relocalization` is `unitree-go2` 
 
 ```bash
 dimos --replay --replay-db recording_go2 run unitree-go2-relocalization \
-  -o relocalizationmodule.map_file=recording_go2
+  --map-file=recording_go2
 ```
 
 `map_file` resolves `{DB_NAME}.pc2.lcm` with the same search order as above (cwd, then project root, then `data/`).
@@ -122,7 +122,7 @@ Run the replay test first. On hardware, use the same blueprint and `map_file`:
 
 ```bash
 dimos --robot-ip {YOUR_ROBOT_IP} run unitree-go2-relocalization \
-  -o relocalizationmodule.map_file=recording_go2
+  --map-file=recording_go2
 ```
 
 Before sending navigation goals, walk through this checklist:
@@ -169,7 +169,9 @@ Note that [`CostMapper`](/dimos/mapping/costmapper.py) builds the costmap from t
 
 ## Configuration reference
 
-CLI overrides use blueprint module config (`-o relocalizationmodule.<field>=…`):
+CLI overrides use dynamically generated kebab-case flags such as
+`--map-file=…`. If a shorthand is ambiguous, qualify it with the module key,
+for example `--relocalizationmodule.map-file=…`.
 
 | Field | Default | Description |
 |-------|---------|-------------|
@@ -189,14 +191,16 @@ Constants are not overridable via CLI today:
 To accept all candidates for visualization only (not for production nav):
 
 ```bash
--o relocalizationmodule.fitness_threshold=0.0
+dimos run unitree-go2-relocalization \
+  --map-file=recording_go2 \
+  --fitness-threshold=0.0
 ```
 
 ## Troubleshooting
 
 | Symptom | Likely cause | Fix |
 |---------|--------------|-----|
-| `Relocalization module disabled (no map_file configured)` | Missing `-o relocalizationmodule.map_file=…` | Set `map_file` to your premap stem |
+| `Relocalization module disabled (no map_file configured)` | Missing `--map-file=…` | Set `map_file` to your premap stem |
 | File not found for `.pc2.lcm` | Export not run or wrong cwd | Run `dimos map global … --export` and check cwd or `data/` |
 | Long stretch of `relocalize skipped` | Map still accumulating points | Wait or drive slowly through mapped geometry |
 | Repeated `relocalize rejected` | Poor overlap with premap or wrong space | Start in a known area and check premap in `.rrd` |

--- a/docs/capabilities/teleoperation/hosted.md
+++ b/docs/capabilities/teleoperation/hosted.md
@@ -60,7 +60,7 @@ robot appears under **Available Robots**. Click **Connect** and you're driving.
 The API key alone is enough — the broker derives the robot identity from it.
 `TRANSPORTS__BROKER__ROBOT_ID` / `TRANSPORTS__BROKER__ROBOT_NAME` are optional
 overrides. All broker settings can also be passed on the CLI, e.g.
-`-o transports.broker.api_key=dtk_live_...`.
+`--transports.broker.api-key=dtk_live_...`.
 
 ## Get an API key
 
@@ -83,7 +83,7 @@ broker-bound modules run in one worker so they share a single broker session;
 the `GO2Connection` driver runs in a second worker (`n_workers=2`).
 
 Enable the glass-to-glass latency benchmark with
-`-o cameramuxmodule.latency_stamp=true`.
+`--latency-stamp=true`.
 
 ## Operating the robot
 
@@ -121,7 +121,7 @@ The command bar exposes the robot's allow-listed actions:
   (relax the joints).
 - **Greetings / stretch** — `Hello`, `Stretch`.
 - **Acrobatics** — `FrontJump`, `FrontPounce` — only available when the robot
-  was launched with `-o go2commandmodule.allow_acrobatics=true`.
+  was launched with `--allow-acrobatics=true`.
 - **Obstacle avoidance** — toggle the onboard avoidance layer on or off.
 - **Rage mode** — toggle the high-agility gait on or off.
 - **Head LED** — set the head light brightness.
@@ -178,8 +178,9 @@ regenerate from an old .db with `python -m dimos.teleop.utils.report path.db`.
 ## Configuration
 
 Each concern is its own module, so its commonly-tuned fields live under that
-module's config key (module class name, lowercased). Pass with `-o`, e.g.
-`-o hostedstatsmodule.telemetry_hz=5`.
+module's config key (module class name, lowercased). Pass a unique field directly,
+for example `--telemetry-hz=5`; if a field is ambiguous, qualify it with the
+module key, such as `--hostedstatsmodule.telemetry-hz=5`.
 
 `hostedstatsmodule` — `HostedStatsModule`:
 

--- a/docs/coding-agents/code-quality-rules.md
+++ b/docs/coding-agents/code-quality-rules.md
@@ -35,7 +35,7 @@ Rules dimos code is expected to follow. They address recurring issues found in c
 
 ## Configuration
 
-* Don't use environment variables for what the config/CLI system already handles. Config values override from the CLI (`-o module.param=value`).
+* Don't use environment variables for what the config/CLI system already handles. Config values override from the CLI (`--module.param-name=value`).
 * Don't bake personal/hardware config into source or blueprints: IPs (`192.168.x.x`), interface names (`enp86s0`), default IPs in constructors. Use a `GlobalConfig` field with a sensible default (often `None`) and set it via `.env` or CLI.
 * Type required fields as required, not `... | None = None`. Then you drop the runtime None-check and the `or default` / `or ""` / `or "can0"` patterns.
 * Listen on `global_config.listen_host` by default, not `0.0.0.0`.

--- a/docs/usage/blueprints.md
+++ b/docs/usage/blueprints.md
@@ -307,10 +307,10 @@ Module references (Specs or direct classes) resolve within the consumer's
 namespace first, then enclosing namespaces, then globally, so per-robot
 consumers bind to their own robot's providers.
 
-Configuration addresses instances with `/` escaped to `_`:
-`-o robot0/go2connection.ip=10.0.0.5` (or `-o robot0_go2connection.ip=...`),
-env `ROBOT0_GO2CONNECTION__IP=...`. `.remappings` accepts an instance name
-string wherever it accepts a module class.
+Dynamic CLI configuration uses the canonical namespaced instance address:
+`--robot0/go2connection.ip=10.0.0.5`. Environment configuration uses
+`ROBOT0_GO2CONNECTION__IP=...`. `.remappings` accepts an instance name string
+wherever it accepts a module class.
 
 The downside of this is that the number of modules is fixed at blueprint creation. But it can be easily overcome by using a global variable. For example you can invoke with this:
 
@@ -355,55 +355,56 @@ blueprint = ModuleA.blueprint().global_config(n_workers=8)
 
 ## Providing blueprint configuration to users
 
-`Blueprint.config()` can be used to get a `pydantic.BaseModel` that can be used to
-inspect or test configuration settings that can be passed to `Blueprint.build()`:
+`BlueprintConfigParser` discovers the configuration exposed by a blueprint,
+resolves configuration sources, and returns an immutable
+`ParsedBlueprintConfig` for the coordinator:
 
 ```python session=blueprint-ex1
-# Validate config input
-blueprint_args = {
-    "module1": {"arg1": 5}
-}
-config = base_blueprint.config()
-config(**blueprint_args)  # raises pydantic.ValidationError if args are incorrect
+from dimos.core.coordination.blueprint_config.parser import BlueprintConfigParser
+
+parser = BlueprintConfigParser(base_blueprint)
+parsed = parser.parse(["--module1.arg1=5"])
 ```
 
-`dimos.cli.dimos.arg_help()` is a helper function that will return a string
-containing all details of these arguments (this is how the output is produced when
-running `dimos run unitree-go2 --help`, for example):
+Use the same parser to render blueprint-aware CLI help (this is how
+`dimos run unitree-go2 --help` lists module configuration):
 
-```python session=blueprint-ex1
-from dimos.cli.dimos import arg_help
-
-print(arg_help(base_blueprint.config(), base_blueprint))
+```python skip
+print(parser.format_help())
 ```
 
-```results
-    module1:
-      * module1.default_rpc_timeout: float (default: 120.0)
-      * module1.frame_id_prefix: str | None (default: None)
-      * module1.frame_id: str | None (default: None)
-      * module1.arg1: int (default: 1)
-    module2:
-      * module2.default_rpc_timeout: float (default: 120.0)
-      * module2.frame_id_prefix: str | None (default: None)
-      * module2.frame_id: str | None (default: None)
+The output includes each unambiguous shorthand alongside its stable qualified
+address:
+
+```text
+Blueprint configuration options:
+  ...
+  --arg1, --module1.arg1 <int> (default: 1)
+  --module1.default-rpc-timeout <float> (default: 120.0)
+  --module2.default-rpc-timeout <float> (default: 120.0)
 ```
 
-Another function is `dimos.cli.dimos.load_config_args()` which can create the
-argument dict for users from a config file, environment variables and CLI arguments:
+`parse()` combines a config file, recognized environment variables, programmatic
+overrides, and dynamic CLI flags. Pass its result directly to the coordinator:
 
-```python session=blueprint-ex1
+```python skip
 from pathlib import Path
 
-from dimos.cli.dimos import load_config_args
+from dimos.core.coordination.module_coordinator import ModuleCoordinator
 
 config_path = Path.home() / "base-blueprint-config.json"
-cli_args = ["module1.arg1=5"]
-blueprint_args = load_config_args(base_blueprint.config(), cli_args, config_path)
-# Test user input is valid
-config(**blueprint_args)
-# Then pass blueprint_args to ModuleCoordinator.build(...) (see coordinator docs)
+cli_args = ["--module1.arg1=5"]
+parsed = BlueprintConfigParser(base_blueprint).parse(
+    cli_args,
+    config_path=config_path,
+)
+coordinator = ModuleCoordinator.build(base_blueprint, parsed)
 ```
+
+Note that `build()` resets the process-global `global_config` to the full parsed
+resolution (schema defaults plus all sources). Loading into an already-running
+coordinator with `load_blueprint(blueprint, parsed)` applies only the fields a
+configuration source explicitly set.
 
 ## Calling the methods of other modules
 

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -67,16 +67,22 @@ Start one or more robot blueprints. Built-in DimOS blueprints use bare names suc
 such as `my-robot-stack.go2`.
 
 ```bash
-dimos run <blueprint> [<blueprint> ...] [--daemon] [--disable <module> ...]
+dimos run <blueprint> [<blueprint> ...] [--daemon] [--disable <module> ...] [--<config-field> <value> ...]
 ```
 
 | Option | Description |
 |--------|-------------|
-| `--config` `-c` | Path to read JSON config file from (options can be overriden with `-o` |
+| `--config`, `-c` | Path to a JSON configuration file; dynamic flags override its values |
 | `--daemon`, `-d` | Run in background (double-fork, health check, writes run registry) |
 | `--disable` | Module class names to exclude from the blueprint |
-| `--option`, `-o` | Provide an configuration option to the blueprint (e.g. `-o voxelgridmapper.voxel_size=1` |
-| `--help` | Display the available configuration options that can be changed with `-o` or the config file |
+| `--<config-field>` | Set a blueprint configuration field using its kebab-case name, for example `--voxel-size=1`; qualify ambiguous fields as `--voxelgridmapper.voxel-size=1` |
+| `--help` | Display the run options and available blueprint configuration flags |
+
+Dynamic values accept both `--field=value` and `--field value`. A shorthand is
+available only when it identifies one active module. If two modules expose the
+same field, the CLI reports the ambiguity and lists stable qualified forms such
+as `--relocalizationmodule.map-file`. Global flags work on either side of
+`run`; older wrapper-style overrides are no longer accepted.
 
 ```bash
 # Foreground (Ctrl-C to stop)
@@ -93,6 +99,9 @@ dimos --transport=zenoh --dtop --replay --replay-db=go2_bigoffice run unitree-go
 
 # Real robot
 dimos run unitree-go2-agentic --robot-ip 192.168.123.161
+
+# Blueprint configuration (both value forms are accepted)
+dimos run unitree-go2-relocalization --map-file recording_go2
 
 # Compose modules dynamically
 dimos run unitree-go2 keyboard-teleop


### PR DESCRIPTION
The core change is this:

```python
# All the config parsing code is encapsulated in this class constructed from a blueprint
parser = BlueprintConfigParser(blueprint)

# the parser takes data from CLI and other places and constructs a ParsedBlueprintConfig (immutable)
parsed_config = parser.parse(
    config_tokens,
    config_path=config_path,
    environ=os.environ,
    global_overrides=global_option_overrides,
)

# The coordinator builds the blueprint with the help of the config in `parsed_config`.
coordinator = ModuleCoordinator.build(base_blueprint, parsed)
```

## Testing

```bash
uv run dimos run unitree-go2 --simulation --voxel-size 0.2

uv run dimos run unitree-go2 --simulation --voxelgridmapper.voxel-size 0.2
```

Or disambiguate further by providing the file name (it's in `module.py`):

```
uv run dimos run unitree-go2 --simulation --module.voxelgridmapper.voxel-size 0.2
```

You get suggestions for inexistent options:
```
$ uv run dimos run unitree-go2 --simulation --voxel-sizes 0.2
Error: Unknown blueprint configuration option --voxel-sizes. Did you mean --voxel-size?
```

Works for more precise ones too:

```
uv run dimos run unitree-go2 --simulation --voxelgridmapppppppppper.voxel-size 0.2
Error: Unknown blueprint configuration option --voxelgridmapppppppppper.voxel-size. Did you mean --voxelgridmapper.voxel-size, --modules.voxelgridmapper.voxel-size, --voxelgridmapper.device?
```

Works for namespaces too. E.g. for the namespace `robot0`, you use `--robot0/go2connection.ip=10.0.0.5`

Closes DIM-1378