### PR TITLE
fix: lidar warmup

### DIFF
--- a/dimos/msgs/sensor_msgs/PointCloud2.py
+++ b/dimos/msgs/sensor_msgs/PointCloud2.py
@@ -559,6 +559,15 @@ class PointCloud2(Timestamped):
         return msg.lcm_encode()  # type: ignore[no-any-return]
 
     @classmethod
+    def lcm_warmup(cls) -> None:
+        """Preload the heavy imports lcm_decode needs.
+
+        Called at subscribe time (see LCMEncoderMixin.subscribe) so the first
+        decode doesn't stall the LCM handler thread on the open3d import.
+        """
+        import open3d.core  # type: ignore[import-untyped] # noqa: F401
+
+    @classmethod
     def lcm_decode(cls, data: bytes) -> PointCloud2:
         import open3d as o3d  # type: ignore[import-untyped]
         import open3d.core as o3c  # type: ignore[import-untyped]

--- a/dimos/protocol/pubsub/encoders.py
+++ b/dimos/protocol/pubsub/encoders.py
@@ -104,6 +104,17 @@ class LCMTopicProto(Protocol):
 class LCMEncoderMixin(PubSubEncoderMixin[LCMTopicProto, DimosMsg, bytes]):
     """Encoder mixin for DimosMsg using LCM binary encoding."""
 
+    def subscribe(
+        self, topic: LCMTopicProto, callback: Callable[[DimosMsg, LCMTopicProto], None]
+    ) -> Callable[[], None]:
+        # Import the type's heavy decode dependencies now, on the subscriber's
+        # thread. Left to the first decode, the import would run on the LCM
+        # handler thread and block it for seconds, dropping messages meanwhile.
+        warmup = getattr(topic.lcm_type, "lcm_warmup", None)
+        if warmup is not None:
+            warmup()
+        return super().subscribe(topic, callback)
+
     def encode(self, msg: DimosMsg | bytes, _: LCMTopicProto) -> bytes:
         if isinstance(msg, bytes):
             return msg

--- a/dimos/protocol/pubsub/impl/test_lcmpubsub.py
+++ b/dimos/protocol/pubsub/impl/test_lcmpubsub.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from collections.abc import Iterator
+import threading
 from typing import Any
 
 import pytest
@@ -93,6 +94,20 @@ def test_LCMPubSubBase_pubsub(lcm_pub_sub_base: LCMPubSubBase) -> None:
 
     assert isinstance(received_topic, Topic)
     assert received_topic == topic
+
+
+def test_subscribe_calls_lcm_warmup(lcm: LCM) -> None:
+    warmup_threads = []
+
+    class WarmupMessage(MockLCMMessage):
+        @classmethod
+        def lcm_warmup(cls) -> None:
+            warmup_threads.append(threading.current_thread())
+
+    lcm.subscribe(Topic(topic="/warmup", lcm_type=WarmupMessage), lambda msg, topic: None)
+
+    # Warmed synchronously on the subscriber's thread, not the LCM handler thread.
+    assert warmup_threads == [threading.current_thread()]
 
 
 def test_lcm_autodecoder_pubsub(lcm: LCM) -> None:


### PR DESCRIPTION
## Problem

In a previous PR, `import open3d` was moved to be a function level import. This improved startup speed, but caused a subtle issue. The first lidar decode blocks the LCM handler thread for the duration of the open3d import, and every lidar message is dropped during this short period.

## Solution

Added an optional `lcm_warmup` class method where we can do heavy work at subscribe time. I've defined it for PointCloud2 as `import open3d`.
