### PR TITLE
fix(core): harden basic deployment timing test

### DIFF
--- a/dimos/core/test_core.py
+++ b/dimos/core/test_core.py
@@ -116,12 +116,19 @@ def test_basic_deployment(dimos) -> None:
     robot.start()
     nav.start()
 
-    deadline = time.monotonic() + 15.0
+    first_deadline = time.monotonic() + 20.0
+    while time.monotonic() < first_deadline:
+        if robot.mov_msg_count > 0 and nav.odom_msg_count > 0 and nav.lidar_msg_count > 0:
+            break
+        time.sleep(0.1)
+
+    deadline = time.monotonic() + 20.0
     while time.monotonic() < deadline:
         if robot.mov_msg_count >= 8 and nav.odom_msg_count >= 8 and nav.lidar_msg_count >= 8:
             break
         time.sleep(0.1)
 
-    assert robot.mov_msg_count >= 8
-    assert nav.odom_msg_count >= 8
-    assert nav.lidar_msg_count >= 8
+    counts = f"lidar={nav.lidar_msg_count}, odom={nav.odom_msg_count}, mov={robot.mov_msg_count}"
+    assert robot.mov_msg_count >= 8, counts
+    assert nav.odom_msg_count >= 8, counts
+    assert nav.lidar_msg_count >= 8, counts


### PR DESCRIPTION
## Problem
`test_basic_deployment` intermittently reaches its fixed 15-second deadline before the lidar subscription receives messages on self-hosted runners.

## Solution
Wait for all three transport paths to receive an initial message before applying a separate 20-second steady-state count deadline. Include all stream counts in assertion failures.

## How to Test
`uv run pytest dimos/core/test_core.py -k test_basic_deployment -m self_hosted -v`

## AI Assistance
Implemented with OpenCode assistance; changes and test output were reviewed.

## CLA
- [x] I confirm this contribution is submitted under the project CLA.