### PR TITLE
feat: Keyboard Teleop

### DIFF
--- a/dimos/robot/unitree/go2/blueprints/smart/unitree_go2_cockpit.py
+++ b/dimos/robot/unitree/go2/blueprints/smart/unitree_go2_cockpit.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 """The smart go2 with an authored cockpit: video left (2/3), costmap+pose
-right. Edit the layout (swap Row for Col, change shares, drop a panel) and
-rerun - the browser rearranges and dropped channels leave the wire entirely.
+over keyboard teleop right. Edit the layout (swap Row for Col, change
+shares, drop a panel) and rerun - the browser rearranges and dropped
+channels leave the wire entirely.
 
 Separate file on purpose: cockpit() needs the [web] extra at import time,
 and `unitree-go2` itself must stay importable without it.
@@ -22,14 +23,14 @@ and `unitree-go2` itself must stay importable without it.
 
 from dimos.core.coordination.blueprints import autoconnect
 from dimos.robot.unitree.go2.blueprints.smart.unitree_go2 import unitree_go2
-from dimos.web.cockpit import Col, Map2D, Row, Video, cockpit
+from dimos.web.cockpit import Col, Map2D, Row, Teleop, Video, cockpit
 
 unitree_go2_cockpit = autoconnect(
     unitree_go2,
     cockpit(
         layout=Row(
             Video("color_image"),
-            Col(Map2D(costmap="global_costmap", pose="odom")),
+            Col(Map2D(costmap="global_costmap", pose="odom"), Teleop(), shares=[3, 1]),
             shares=[2, 1],
         ),
     ),

--- a/dimos/web/cockpit.py
+++ b/dimos/web/cockpit.py
@@ -139,6 +139,50 @@ class Map2D(Panel):
         return tuple(requests)
 
 
+@dataclass(frozen=True)
+class Teleop(Panel):
+    """Keyboard teleop: twist datagrams on one tx stream (WASD drive, Q/E
+    strafe, Shift boost, Space e-stop; click the panel to arm).
+
+    All params ride the tx channel in the manifest: the Cockpit machine
+    reads speeds and cadence from there, the bridge reads watchdog_ms (its
+    deadman window) and clamps incoming twists to max * boost.
+    """
+
+    kind: ClassVar[str] = "teleop"
+    stream: str = "tele_cmd_vel"
+    max_linear: float = field(default=0.8, kw_only=True)
+    max_angular: float = field(default=1.0, kw_only=True)
+    boost: float = field(default=2.0, kw_only=True)
+    publish_hz: float = field(default=15.0, kw_only=True)
+    watchdog_ms: float = field(default=300.0, kw_only=True)
+    title: str = field(default="", kw_only=True)
+
+    def __post_init__(self) -> None:
+        _check_stream("stream", self.stream)
+        _check_rate("max_linear", self.max_linear)
+        _check_rate("max_angular", self.max_angular)
+        _check_rate("boost", self.boost)
+        _check_rate("publish_hz", self.publish_hz)
+        _check_rate("watchdog_ms", self.watchdog_ms)
+
+    def _channel_requests(self) -> tuple[ChannelRequest, ...]:
+        return (
+            ChannelRequest(
+                self.stream,
+                "tx",
+                "twist.json.v1",
+                self.publish_hz,
+                {
+                    "maxLinear": self.max_linear,
+                    "maxAngular": self.max_angular,
+                    "boost": self.boost,
+                    "watchdogMs": self.watchdog_ms,
+                },
+            ),
+        )
+
+
 class _Split:
     """Base for Row/Col: children plus optional flex shares."""
 
@@ -173,8 +217,13 @@ class Col(_Split):
 
 
 def _default_preset() -> Row:
-    """The no-layout cockpit: video left (2/3), costmap+pose right (1/3)."""
-    return Row(Video("color_image"), Map2D(costmap="global_costmap", pose="odom"), shares=[2, 1])
+    """The no-layout cockpit: video left (2/3); costmap+pose over teleop
+    right (1/3)."""
+    return Row(
+        Video("color_image"),
+        Col(Map2D(costmap="global_costmap", pose="odom"), Teleop(), shares=[3, 1]),
+        shares=[2, 1],
+    )
 
 
 def build_manifest_data(
@@ -184,19 +233,21 @@ def build_manifest_data(
     registry: Mapping[str, tuple[str, str]],
     rx_streams: AbstractSet[str],
     tx_streams: AbstractSet[str],
+    tx_registry: Mapping[str, tuple[str, str]] | None = None,
     extra_channels: Sequence[ChannelRequest] = (),
 ) -> dict[str, Any]:
     """Compile a layout tree + pages into a plain manifest-v1 dict.
 
     Shared by cockpit() and the bridge's availability-driven default
-    manifest (default_manifest in relay_bridge_module.py). `registry` maps
-    stream name -> (encoding, delivery) in advertisement order (the bridge's
-    CHANNELS table); rx/tx_streams are the module's typed In/Out names.
-    Panel ids are p0..pN in tree order (layout depth-first, then pages).
-    Channels requested by several panels merge: max_hz takes the max, any
-    other disagreement raises. `extra_channels` are advertised channel-only
-    unless a panel already requested the stream.
+    manifest (default_manifest in relay_bridge_module.py). `registry` and
+    `tx_registry` map stream name -> (encoding, delivery) in advertisement
+    order (the bridge's CHANNELS/TX_CHANNELS tables); rx/tx_streams are the
+    module's typed In/Out names. Panel ids are p0..pN in tree order (layout
+    depth-first, then pages). Channels requested by several panels merge:
+    max_hz takes the max, any other disagreement raises. `extra_channels`
+    are advertised channel-only unless a panel already requested the stream.
     """
+    tx_registry = {} if tx_registry is None else tx_registry
     channels: dict[str, ChannelRequest] = {}
     panels_out: list[dict[str, Any]] = []
 
@@ -272,17 +323,30 @@ def build_manifest_data(
                     f"unknown tx stream {stream!r}; this robot bridge has no matching "
                     f"output stream (outputs: {sorted(tx_streams) or 'none'})"
                 )
-            # Guards the delivery gap below: tx channels need a delivery
-            # source once a bridge grows Out streams (teleop/chat tickets).
-            raise NotImplementedError("tx channels arrive with the teleop/chat tickets")
+            expected = tx_registry.get(stream)
+            if expected is None:
+                raise ValueError(
+                    f"tx stream {stream!r} has no channel-table entry; this bridge "
+                    f"sends: {sorted(tx_registry) or 'none'}"
+                )
+            if expected[0] != request.encoding:
+                raise ValueError(
+                    f"stream {stream!r} encodes {expected[0]}, not {request.encoding} "
+                    f"(wrong panel type for this stream?)"
+                )
 
     for request in extra_channels:
         if request.stream not in channels:
             channels[request.stream] = request
 
     # Registry order, not first-request order: the advertisement order is the
-    # bridge's channel-table order however panels were nested.
+    # bridge's channel-table order (rx table, then tx table) however panels
+    # were nested.
     ordered = [channels[stream] for stream in registry if stream in channels]
+    ordered += [channels[stream] for stream in tx_registry if stream in channels]
+    delivery = {
+        stream: pair[1] for table in (registry, tx_registry) for stream, pair in table.items()
+    }
     return {
         "version": MANIFEST_VERSION,
         "channels": [
@@ -290,7 +354,7 @@ def build_manifest_data(
                 "ch": request.stream,
                 "dir": request.dir,
                 "encoding": request.encoding,
-                "delivery": registry[request.stream][1],
+                "delivery": delivery[request.stream],
                 "maxHz": request.max_hz,
                 "params": dict(request.params),
             }
@@ -312,7 +376,11 @@ def cockpit(layout: Panel | Row | Col | None = None, pages: Sequence[Panel] = ()
     data" (no runtime stream probing).
     """
     try:
-        from dimos.web.relay_bridge.relay_bridge_module import CHANNELS, RelayBridgeModule
+        from dimos.web.relay_bridge.relay_bridge_module import (
+            CHANNELS,
+            TX_CHANNELS,
+            RelayBridgeModule,
+        )
     except ImportError as e:
         raise RuntimeError(
             "the cockpit blueprint needs the web extra: `uv sync --extra web --inexact`"
@@ -326,6 +394,7 @@ def cockpit(layout: Panel | Row | Col | None = None, pages: Sequence[Panel] = ()
         registry={cd.ch: (cd.encoding, cd.delivery) for cd in CHANNELS},
         rx_streams={s.name for s in atom.streams if s.direction == "in"},
         tx_streams={s.name for s in atom.streams if s.direction == "out"},
+        tx_registry={ch: (encoding, delivery) for ch, encoding, delivery in TX_CHANNELS},
     )
     # The domain parser is the authority; authoring bugs must fail at
     # blueprint definition time, not at robot start.

--- a/dimos/web/relay_bridge/e2e_support.py
+++ b/dimos/web/relay_bridge/e2e_support.py
@@ -24,6 +24,8 @@ from dimos.web.relay_bridge.protocol import (
     Msg,
     Sub,
     Subs,
+    TeleopStart,
+    TeleopStarted,
     Watch,
 )
 from dimos.web.relay_bridge.relay_bridge_module import RelayBridgeModule
@@ -66,6 +68,21 @@ async def attach_viewer(
             raise TimeoutError(f"no manifest for {robot_id} within {timeout} s")
     for ch in chs:
         viewer.send_control(Sub(ch=ch))
+
+
+async def arm_teleop(viewer: RelayClient, timeout: float = 10.0) -> None:
+    """Acquire the robot's teleop lease (retrying: the Python viewer's control
+    plane is datagrams, so the teleop_started ack can be lost)."""
+    deadline = time.monotonic() + timeout
+    while True:
+        viewer.send_control(TeleopStart())
+        msg = await next_control(viewer, 0.5)
+        while msg is not None and not isinstance(msg, TeleopStarted):
+            msg = await next_control(viewer, 0.5)
+        if isinstance(msg, TeleopStarted):
+            return
+        if time.monotonic() >= deadline:
+            raise TimeoutError(f"teleop lease not granted within {timeout} s")
 
 
 async def wait_subs(

--- a/dimos/web/relay_bridge/manifest.py
+++ b/dimos/web/relay_bridge/manifest.py
@@ -19,7 +19,7 @@ from both pytest and deno test). The transport (protocol.py) carries the
 manifest as one opaque dict; this module is the single owner of its
 structure and domain rules: version gate, bounded unique ids, positive
 rates, panel/layout/pages references that resolve, and kind-specific panel
-rules (video, map2d).
+rules (video, map2d, teleop).
 
 Manifest v1 is frozen. Additive changes (new panel kinds, new params) ride
 the existing shape: unknown keys and kinds pass through validation.
@@ -262,6 +262,18 @@ def parse_manifest(data: Any) -> Manifest:
                         "invalid_map2d_panel",
                         f"map2d panel {panel.id} pose channel must be a pose.json.v1 rx channel",
                     )
+        if panel.kind == "teleop":
+            if len(panel.channels) != 1:
+                raise ManifestError(
+                    "invalid_teleop_panel",
+                    f"teleop panel {panel.id} must bind exactly one channel",
+                )
+            cmd = ch_ids[panel.channels[0]]
+            if cmd.encoding != "twist.json.v1" or cmd.delivery != "latest" or cmd.dir != "tx":
+                raise ManifestError(
+                    "invalid_teleop_panel",
+                    f"teleop panel {panel.id} needs a twist.json.v1 latest tx channel",
+                )
 
     seen: set[str] = set()
     if manifest.layout is not None:

--- a/dimos/web/relay_bridge/protocol.py
+++ b/dimos/web/relay_bridge/protocol.py
@@ -40,6 +40,7 @@ from typing import Annotated, Any, Literal
 
 from pydantic import (
     BaseModel,
+    BeforeValidator,
     ConfigDict,
     Field,
     TypeAdapter,
@@ -63,12 +64,17 @@ from dimos.web.relay_bridge.manifest import (
 
 logger = setup_logger()
 
-# v3: the manifest travels as one opaque record nested in hello/manifest
-# messages (v2 carried flat channels/panels fields, which a v2 peer would
-# silently misread in both directions). v2: a reliable channel packs all its
-# frames onto one persistent stream. Bump on any change an old peer would
-# silently misparse.
-PROTOCOL_VERSION = 3
+# v4: the twist datagram gains vy (strafe) and the teleop lease messages
+# (teleop_start/teleop_started/teleop_stop) enter the control plane;
+# robot-bound twist/stop/teleop_start/teleop_stop carry the relay-stamped
+# lease generation `gen` (amended into v4 pre-release: an older v4 peer
+# without gen gets dead teleop, never unsafe motion). v3: the
+# manifest travels as one opaque record nested in hello/manifest messages
+# (v2 carried flat channels/panels fields, which a v2 peer would silently
+# misread in both directions). v2: a reliable channel packs all its frames
+# onto one persistent stream. Bump on any change an old peer would silently
+# misparse.
+PROTOCOL_VERSION = 4
 
 # Reject absurd header lengths before allocating (mirrors protocol.ts).
 MAX_HEADER_LEN = 65536
@@ -208,20 +214,59 @@ class Subs(_WireModel):
     n: int | float
 
 
-# Teleop datagrams (carried from T6 on; declared so the wire format is pinned
-# by fixtures from day one).
+# Teleop (T6). twist/stop ride datagrams viewer->relay->robot (loss-tolerant:
+# commands repeat and the bridge deadman covers silence). The lease messages
+# ride the viewer's control stream so they are ordered after watch:
+# teleop_start requests the per-robot exclusive lease (relay acks with
+# teleop_started, or replies error code "teleop_held"), teleop_stop releases
+# it. Robot-bound teleop messages are datagrams stamped with `gen`, the
+# relay-issued lease generation: teleop_start announces a granted lease,
+# teleop_stop means "the lease ended" (holder gone), twist/stop are the
+# forwarded holder commands. The bridge permanently rejects generations
+# below its floor, so a released holder's delayed datagrams cannot move the
+# robot after a stop. Viewer-authored messages never carry gen.
+
+
+def _gen_reject_wire_null(value: Any, info: ValidationInfo) -> Any:
+    if value is None and info.context is _WIRE_CTX:
+        raise ValueError("explicit null (absent optional fields are omitted)")
+    return value
+
+
+# The relay-stamped lease generation: optional (viewer-authored messages omit
+# it), never null on the wire (mirrors genAbsentOrNumber in protocol.ts).
+_WireGen = Annotated[int | float | None, BeforeValidator(_gen_reject_wire_null)]
+
+
 class Twist(_WireModel):
     t: Literal["twist"] = "twist"
     vx: int | float
+    vy: int | float
     wz: int | float
     seq: int | float
     ts: int | float
+    gen: _WireGen = None
 
 
 class Stop(_WireModel):
     t: Literal["stop"] = "stop"
     seq: int | float
     ts: int | float
+    gen: _WireGen = None
+
+
+class TeleopStart(_WireModel):
+    t: Literal["teleop_start"] = "teleop_start"
+    gen: _WireGen = None
+
+
+class TeleopStarted(_WireModel):
+    t: Literal["teleop_started"] = "teleop_started"
+
+
+class TeleopStop(_WireModel):
+    t: Literal["teleop_stop"] = "teleop_stop"
+    gen: _WireGen = None
 
 
 Msg = (
@@ -238,6 +283,9 @@ Msg = (
     | Subs
     | Twist
     | Stop
+    | TeleopStart
+    | TeleopStarted
+    | TeleopStop
 )
 
 # One pydantic-core pass takes raw peer bytes to a validated message: UTF-8

--- a/dimos/web/relay_bridge/relay_bridge_module.py
+++ b/dimos/web/relay_bridge/relay_bridge_module.py
@@ -40,6 +40,7 @@ from collections.abc import AsyncIterator, Callable, Collection
 from dataclasses import dataclass, field
 import functools
 import json
+import math
 import socket
 import threading
 import time
@@ -53,15 +54,26 @@ from reactivex.disposable import Disposable
 
 from dimos.core.coordination.blueprints import Blueprint, autoconnect
 from dimos.core.module import Module, ModuleConfig
-from dimos.core.stream import In
+from dimos.core.stream import In, Out
 from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
+from dimos.msgs.geometry_msgs.Twist import Twist
+from dimos.msgs.geometry_msgs.Vector3 import Vector3
 from dimos.msgs.nav_msgs.OccupancyGrid import OccupancyGrid, block_max_reduce
 from dimos.msgs.sensor_msgs.Image import Image
 from dimos.utils.logging_config import setup_logger
 
 # No import cycle: cockpit.py only imports this module lazily inside
 # cockpit(), and its own module body is relay-free.
-from dimos.web.cockpit import ChannelRequest, Map2D, Panel, Row, Video, build_manifest_data
+from dimos.web.cockpit import (
+    ChannelRequest,
+    Col,
+    Map2D,
+    Panel,
+    Row,
+    Teleop,
+    Video,
+    build_manifest_data,
+)
 from dimos.web.relay_bridge.locate import find_web_dir
 from dimos.web.relay_bridge.manifest import parse_manifest
 from dimos.web.relay_bridge.protocol import (
@@ -69,7 +81,11 @@ from dimos.web.relay_bridge.protocol import (
     Delivery,
     RobotInfo,
     RobotManifest,
+    Stop as WireStop,
     Subs,
+    TeleopStart as WireTeleopStart,
+    TeleopStop as WireTeleopStop,
+    Twist as WireTwist,
 )
 from dimos.web.relay_bridge.relay_process import RelayProcess, ensure_cockpit_dist
 from dimos.web.relay_bridge.wt_client import (
@@ -96,6 +112,28 @@ _CHILD_POLL_S = 1.0
 # Bounded wait for the build worker thread after cancelling it (the child
 # dies within the SIGTERM-to-SIGKILL grace; this adds a margin on top).
 _BUILD_CANCEL_WAIT_S = 8.0
+
+# Deadman poll granularity; small against the default 300 ms watchdog window
+# so the zero lands close to the deadline.
+_TELEOP_POLL_S = 0.05
+
+
+@dataclass(frozen=True)
+class _TeleopParams:
+    """Teleop tx channel params resolved at start (manifest, with defaults)."""
+
+    max_linear: float
+    max_angular: float
+    boost: float
+    watchdog_s: float
+
+
+# Manifest param keys and their defaults (matching the Teleop panel's).
+_TELEOP_PARAM_DEFAULTS = {"maxLinear": 0.8, "maxAngular": 1.0, "boost": 2.0, "watchdogMs": 300.0}
+
+
+def _clamp(value: float, bound: float) -> float:
+    return max(-bound, min(bound, value))
 
 
 def _probe_local_port(port: int) -> None:
@@ -295,19 +333,26 @@ CHANNELS: tuple[ChannelDef, ...] = (
     ),
 )
 
+# The tx (viewer->robot) counterpart of CHANNELS: stream -> (encoding,
+# delivery). Every entry needs a matching `Out` on the module and a handler
+# in _supervise; it is also the delivery source for tx channels in authored
+# manifests (dimos/web/cockpit.py).
+TX_CHANNELS: tuple[tuple[str, str, Delivery], ...] = (("tele_cmd_vel", "twist.json.v1", "latest"),)
+
 
 def default_manifest(config: RelayBridgeConfig, available: Collection[str]) -> dict[str, Any]:
-    """Availability-driven default cockpit: video + map2d panels for the
-    channels in `available`, remaining channels advertised channel-only (raw
-    rows in the cockpit's channel list). Rates and jpeg quality come from
-    the config fields, so `-o relay-bridge-module.*` overrides keep working
-    in the no-manifest (auto) mode."""
+    """Availability-driven default cockpit: video/map2d/teleop panels for the
+    channels in `available`, remaining rx channels advertised channel-only
+    (raw rows in the cockpit's channel list). Rates and jpeg quality come
+    from the config fields, so `-o relay-bridge-module.*` overrides keep
+    working in the no-manifest (auto) mode."""
     present = frozenset(available)
-    panels: list[Panel] = []
+    main: Panel | None = None
     if "color_image" in present:
-        panels.append(Video("color_image", max_hz=config.image_max_hz, quality=config.jpeg_quality))
+        main = Video("color_image", max_hz=config.image_max_hz, quality=config.jpeg_quality)
+    side_panels: list[Panel] = []
     if "global_costmap" in present:
-        panels.append(
+        side_panels.append(
             Map2D(
                 costmap="global_costmap",
                 pose="odom" if "odom" in present else None,
@@ -315,20 +360,29 @@ def default_manifest(config: RelayBridgeConfig, available: Collection[str]) -> d
                 pose_hz=config.odom_max_hz,
             )
         )
-    layout: Panel | Row | None
-    if len(panels) == 2:
-        layout = Row(*panels, shares=[2, 1])
-    elif panels:
-        layout = panels[0]
+    if "tele_cmd_vel" in present:
+        side_panels.append(Teleop())
+    side: Panel | Col | None
+    if len(side_panels) > 1:
+        side = Col(*side_panels, shares=[3, 1])
+    elif side_panels:
+        side = side_panels[0]
     else:
-        layout = None
+        side = None
+    layout: Panel | Row | Col | None
+    if main is not None and side is not None:
+        layout = Row(main, side, shares=[2, 1])
+    else:
+        layout = main if main is not None else side
     registry = {cd.ch: (cd.encoding, cd.delivery) for cd in CHANNELS}
+    tx_registry = {ch: (encoding, delivery) for ch, encoding, delivery in TX_CHANNELS}
     return build_manifest_data(
         layout,
         (),
         registry=registry,
         rx_streams=frozenset(registry),
-        tx_streams=frozenset(),
+        tx_streams=frozenset(tx_registry),
+        tx_registry=tx_registry,
         extra_channels=tuple(
             ChannelRequest(cd.ch, "rx", cd.encoding, cd.max_hz(config))
             for cd in CHANNELS
@@ -355,6 +409,9 @@ class RelayBridgeModule(Module):
     color_image: In[Image]
     odom: In[PoseStamped]
     global_costmap: In[OccupancyGrid]
+    # tx: cockpit teleop twists, autoconnected by name+type to
+    # MovementManager.tele_cmd_vel (publish is a no-op while unwired).
+    tele_cmd_vel: Out[Twist]
     # NEVER add handle_color_image/handle_odom methods here: _auto_bind_handlers
     # subscribes any handle_<input> eagerly at start(), defeating lazy encode.
 
@@ -377,6 +434,19 @@ class RelayBridgeModule(Module):
         self._last_msg: dict[str, tuple[Any, float]] = {}
         # Resolved at start from the manifest's jpeg channel params.
         self._jpeg_quality: int = self.config.jpeg_quality
+        # Teleop state, all touched on the module loop only. None params =
+        # the manifest advertises no teleop channel; every teleop message is
+        # then ignored. `driving` implements the release-edge rule: publish
+        # a zero only after a nonzero (MovementManager cancels the nav goal
+        # on EVERY teleop message, so idle zeros must never repeat).
+        self._teleop_params: _TeleopParams | None = None
+        self._teleop_driving = False
+        # Lease-generation floor (relay-stamped, monotonic in a session):
+        # anything below it is voided permanently, so a released holder's
+        # delayed datagrams cannot restart motion after a stop.
+        self._teleop_gen: int | float = -math.inf
+        self._teleop_last_seq = -math.inf
+        self._teleop_last_rx = 0.0
         self.encoded: dict[str, int] = {cd.ch: 0 for cd in CHANNELS}
 
     async def main(self) -> AsyncIterator[None]:
@@ -395,6 +465,12 @@ class RelayBridgeModule(Module):
                     for cd in CHANNELS
                     if (allowed is None or cd.ch in allowed)
                     and self.inputs[cd.ch].transport is not None
+                )
+                # tx side: an Out gets a transport whether or not anything
+                # consumes it, so availability comes from the composition
+                # (with_relay_bridge scans the blueprint's consumers).
+                available += tuple(
+                    ch for ch, _, _ in TX_CHANNELS if allowed is not None and ch in allowed
                 )
                 manifest_data = default_manifest(self.config, available)
             # The domain parser is the authority: an invalid manifest fails
@@ -416,6 +492,17 @@ class RelayBridgeModule(Module):
             self._channel_defs = tuple(by_ch[spec.ch] for spec in rx_specs)
             self._min_interval = {spec.ch: 1.0 / spec.maxHz for spec in rx_specs}
             self._jpeg_quality = self._resolve_jpeg_quality(rx_specs)
+            by_tx = {ch: (encoding, delivery) for ch, encoding, delivery in TX_CHANNELS}
+            for spec in manifest.channels:
+                if spec.dir != "tx":
+                    continue
+                if by_tx.get(spec.ch) != (spec.encoding, spec.delivery):
+                    raise RuntimeError(
+                        f"manifest tx channel {spec.ch!r} ({spec.encoding}/{spec.delivery}) has "
+                        f"no matching handler; this bridge supports: {sorted(by_tx)}"
+                    )
+                if spec.ch == "tele_cmd_vel":
+                    self._teleop_params = self._resolve_teleop_params(spec)
             # No runtime stream probing: an authored channel whose input got
             # no transport stays advertised (its panel shows "waiting for
             # data"); _reconcile just never subscribes it.
@@ -563,12 +650,16 @@ class RelayBridgeModule(Module):
         client.send_frame(ch, payload, delivery="reliable", meta=meta, ts=ts)
 
     async def _supervise(self, session: _Session) -> None:
-        """Consume subs snapshots; on session loss, reconnect (and respawn a
-        dead local relay child) until the module stops."""
+        """Consume relay control messages (subs snapshots, teleop); on session
+        loss, reconnect (and respawn a dead local relay child) until the
+        module stops."""
         watchdog: asyncio.Task[None] | None = None
+        deadman: asyncio.Task[None] | None = None
         try:
             if self._relay is not None:
                 watchdog = asyncio.create_task(self._watch_child())
+            if self._teleop_params is not None:
+                deadman = asyncio.create_task(self._teleop_watchdog())
             while True:
                 crashed = False
                 try:
@@ -576,6 +667,14 @@ class RelayBridgeModule(Module):
                         if isinstance(msg, Subs) and msg.n > session.last_n:
                             session.last_n = msg.n
                             self._reconcile(session, set(msg.chs))
+                        elif isinstance(msg, WireTwist):
+                            self._on_wire_twist(msg)
+                        elif isinstance(msg, WireStop):
+                            self._on_wire_stop(msg)
+                        elif isinstance(msg, WireTeleopStart):
+                            self._on_wire_teleop_start(msg)
+                        elif isinstance(msg, WireTeleopStop):
+                            self._on_wire_teleop_stop(msg)
                     # The iterator only ends when the session closed.
                 except Exception:
                     # An unguarded error here would silently end supervision while
@@ -594,6 +693,7 @@ class RelayBridgeModule(Module):
                 session = reconnected
                 self._session = session
         finally:
+            await _cancel_task(deadman, "teleop watchdog")
             await _cancel_task(watchdog, "watchdog")
             await self._disconnect(session)
 
@@ -612,6 +712,132 @@ class RelayBridgeModule(Module):
             ):
                 logger.warning("local relay child died; closing the session to reconnect")
                 await session.client.close()
+
+    def _resolve_teleop_params(self, spec: ChannelSpec) -> _TeleopParams:
+        values: dict[str, float] = {}
+        for key, default in _TELEOP_PARAM_DEFAULTS.items():
+            candidate = spec.params.get(key, default)
+            if (
+                isinstance(candidate, bool)
+                or not isinstance(candidate, (int, float))
+                or not math.isfinite(candidate)
+                or candidate <= 0
+            ):
+                raise RuntimeError(
+                    f"manifest channel {spec.ch!r} {key} must be a positive number, "
+                    f"got {candidate!r}"
+                )
+            values[key] = float(candidate)
+        return _TeleopParams(
+            max_linear=values["maxLinear"],
+            max_angular=values["maxAngular"],
+            boost=values["boost"],
+            watchdog_s=values["watchdogMs"] / 1000.0,
+        )
+
+    def _on_wire_twist(self, msg: WireTwist) -> None:
+        params = self._teleop_params
+        if params is None:
+            return
+        # Non-finite components cannot reach here: the wire decoders reject
+        # NaN/Infinity (allow_inf_nan=False).
+        gen = msg.gen
+        if gen is None or gen < self._teleop_gen:
+            return  # unstamped, or in flight from a lease already voided
+        if gen == self._teleop_gen and msg.seq <= self._teleop_last_seq:
+            # Within a generation the high-water mark is permanent: a paused
+            # holder resumes with rising seq, while a delayed pre-stop twist
+            # stays dead even after watchdog silence. A new lease (gen above
+            # the floor) rebaselines instead.
+            return
+        self._teleop_gen = gen
+        self._teleop_last_seq = float(msg.seq)
+        self._teleop_last_rx = time.monotonic()
+        bound_linear = params.max_linear * params.boost
+        vx = _clamp(float(msg.vx), bound_linear)
+        vy = _clamp(float(msg.vy), bound_linear)
+        wz = _clamp(float(msg.wz), params.max_angular * params.boost)
+        if vx == 0.0 and vy == 0.0 and wz == 0.0:
+            self._teleop_zero("release")
+            return
+        self._teleop_driving = True
+        self.tele_cmd_vel.publish(Twist(linear=Vector3(vx, vy, 0.0), angular=Vector3(0.0, 0.0, wz)))
+
+    def _on_wire_stop(self, msg: WireStop) -> None:
+        """E-stop: unconditional zero, even from idle - it must also cancel
+        an autonomous nav goal (MovementManager cancels on any teleop msg)."""
+        if self._teleop_params is None:
+            return
+        gen = msg.gen
+        if gen is None or gen < self._teleop_gen:
+            # A voided lease's in-flight e-stop must not blip the current
+            # holder (the relay gate already blocks post-release sends).
+            return
+        self._teleop_zero("stop message (e-stop)", force=True)
+        if gen > self._teleop_gen:
+            self._teleop_gen = gen
+            self._teleop_last_seq = float(msg.seq)
+        else:
+            # max(): a stale reordered e-stop must not lower the high-water
+            # mark and let an already-superseded twist re-apply.
+            self._teleop_last_seq = max(self._teleop_last_seq, float(msg.seq))
+        self._teleop_last_rx = time.monotonic()
+
+    def _on_wire_teleop_start(self, msg: WireTeleopStart) -> None:
+        """A relay-granted lease: adopt its generation, voiding the previous
+        one. Heals a lost teleop_stop (zeroing if it arrived mid-drive)."""
+        if self._teleop_params is None:
+            return
+        gen = msg.gen
+        if gen is None or gen <= self._teleop_gen:
+            return  # a duplicated start must not reset the high-water mid-lease
+        self._teleop_zero("new teleop lease")
+        self._teleop_gen = gen
+        self._teleop_last_seq = -math.inf
+        self._teleop_last_rx = 0.0
+
+    def _on_wire_teleop_stop(self, msg: WireTeleopStop) -> None:
+        """The lease ended (holder released, disconnected, or watched away)."""
+        if self._teleop_params is None:
+            return
+        gen = msg.gen
+        if gen is None or gen < self._teleop_gen:
+            return  # a stale lease-end must not blip or reset the current holder
+        self._teleop_zero("teleop lease ended")
+        # The relay bumps by exactly 1 per grant, so this floor equals the
+        # next lease's generation; the ended lease and everything below it
+        # are voided permanently.
+        self._teleop_gen = gen + 1
+        self._teleop_last_seq = -math.inf
+        self._teleop_last_rx = 0.0
+
+    def _teleop_zero(self, reason: str, *, force: bool = False) -> None:
+        """Publish one zero twist; edge-gated unless `force` (e-stop)."""
+        if not force and not self._teleop_driving:
+            return
+        self._teleop_driving = False
+        logger.warning(f"relay bridge teleop: zero twist ({reason})")
+        self.tele_cmd_vel.publish(Twist.zero())
+
+    def _teleop_reset(self) -> None:
+        # Session teardown only: datagrams are QUIC-session-scoped and the
+        # relay's lease generation dies with the robot registration, so
+        # nothing stale can leak into the next session.
+        self._teleop_gen = -math.inf
+        self._teleop_last_seq = -math.inf
+        self._teleop_last_rx = 0.0
+
+    async def _teleop_watchdog(self) -> None:
+        """Deadman: the cockpit repeats commands at publish_hz, so silence
+        while driving means the chain broke (viewer gone, relay killed,
+        datagrams lost) - zero within ~watchdog_s regardless of which hop
+        failed."""
+        assert self._teleop_params is not None
+        watchdog_s = self._teleop_params.watchdog_s
+        while True:
+            await asyncio.sleep(_TELEOP_POLL_S)
+            if self._teleop_driving and time.monotonic() - self._teleop_last_rx > watchdog_s:
+                self._teleop_zero("watchdog: twist silence")
 
     async def _reconnect(self) -> _Session | None:
         while True:
@@ -730,6 +956,12 @@ class RelayBridgeModule(Module):
         target.retired.set()
         if self._session is target:
             self._session = None
+        # A driving teleop stream cannot outlive its session (this also
+        # covers module stop, KeyboardTeleop.stop() parity). Idempotent:
+        # the edge gate makes the second call of a double-disconnect a no-op.
+        if self._teleop_params is not None:
+            self._teleop_zero("relay session ended")
+            self._teleop_reset()
         for ch, unsubscribe in tuple(target.unsubs.items()):
             try:
                 unsubscribe()
@@ -751,23 +983,34 @@ def with_relay_bridge(blueprint: Blueprint) -> Blueprint:
         return blueprint
 
     producer_keys: set[tuple[str, type]] = set()
+    consumer_keys: set[tuple[str, type]] = set()
     for atom in blueprint.active_blueprints:
         for stream in atom.streams:
-            if stream.direction != "out":
-                continue
             effective_name = blueprint.remapping_map.get((atom.name, stream.name), stream.name)
-            if isinstance(effective_name, str):
-                producer_keys.add((effective_name, stream.type))
+            if not isinstance(effective_name, str):
+                continue
+            keys = producer_keys if stream.direction == "out" else consumer_keys
+            keys.add((effective_name, stream.type))
 
     bridge_atom = RelayBridgeModule.blueprint().blueprints[0]
     bridge_input_types = {
         stream.name: stream.type for stream in bridge_atom.streams if stream.direction == "in"
+    }
+    # Every declared Out gets a transport whether or not a counterparty
+    # exists, so tx availability is derived from the blueprint's consumers
+    # (mirroring the producer scan above), not from bound transports.
+    bridge_output_types = {
+        stream.name: stream.type for stream in bridge_atom.streams if stream.direction == "out"
     }
     available_channels = tuple(
         channel.ch
         for channel in CHANNELS
         if (channel_type := bridge_input_types.get(channel.ch)) is not None
         and (channel.ch, channel_type) in producer_keys
+    ) + tuple(
+        ch
+        for ch, _, _ in TX_CHANNELS
+        if (tx_type := bridge_output_types.get(ch)) is not None and (ch, tx_type) in consumer_keys
     )
     return autoconnect(
         blueprint,

--- a/dimos/web/relay_bridge/test_protocol.py
+++ b/dimos/web/relay_bridge/test_protocol.py
@@ -35,6 +35,7 @@ from dimos.web.relay_bridge.protocol import (
     ProtocolError,
     RobotInfo,
     Robots,
+    TeleopStop,
     decode_data_frame,
     decode_datagram,
     encode_control_frame,
@@ -64,10 +65,10 @@ def _header(d):
 
 
 def test_protocol_version():
-    # v3: the manifest travels as one opaque record nested in hello/manifest
-    # messages (v2 carried flat channels/panels fields); a v2 peer must fail
-    # the handshake.
-    assert PROTOCOL_VERSION == 3
+    # v4: the twist datagram gains vy, the teleop lease messages enter the
+    # control plane, and robot-bound teleop messages carry the relay-stamped
+    # lease generation; a v3 peer must fail the handshake.
+    assert PROTOCOL_VERSION == 4
 
 
 @pytest.mark.parametrize("vector", CONTROL, ids=[v["name"] for v in CONTROL])
@@ -241,6 +242,9 @@ def test_msg_from_dict_validates_types():
         msg_from_dict({"t": "bogus"})  # unknown type
     with pytest.raises(ProtocolError):
         msg_from_dict({"t": "ping", "n": True, "ts": 2.5})  # bool is not a number
+    with pytest.raises(ProtocolError):
+        # v3-era twist without vy: an old peer must fail loudly, not default.
+        msg_from_dict({"t": "twist", "vx": 0.5, "wz": -0.25, "seq": 12, "ts": 2.5})
     # Mirrored-validator parity: protocol.ts must also reject prototype-chain
     # keys instead of resolving them through Object.prototype (protocol_test.ts
     # asserts the same three).
@@ -293,6 +297,11 @@ def test_msg_from_dict_validates_nested_session_shapes():
         {"t": "watch"},
         {"t": "subs", "chs": ["a", 5], "n": 1},
         {"t": "subs", "chs": ["a"]},
+        # Teleop gen mirrors hello.robot: absent ok, null/non-number rejected.
+        {"t": "twist", "vx": 0.5, "vy": 0.0, "wz": 0.0, "seq": 1, "ts": 2.5, "gen": None},
+        {"t": "twist", "vx": 0.5, "vy": 0.0, "wz": 0.0, "seq": 1, "ts": 2.5, "gen": "1"},
+        {"t": "twist", "vx": 0.5, "vy": 0.0, "wz": 0.0, "seq": 1, "ts": 2.5, "gen": True},
+        {"t": "teleop_stop", "gen": None},
     ]
     for data in bad:
         with pytest.raises(ProtocolError):
@@ -314,6 +323,8 @@ def test_encode_omits_absent_optional_fields():
     # A viewer hello must stay byte-identical to its T1 wire form: no
     # "robot":null / "manifest":null keys (JSON.stringify omits undefined).
     assert encode_datagram(Hello(v=1, role="viewer")) == b'{"t":"hello","v":1,"role":"viewer"}'
+    # Same for teleop gen: viewer-authored messages carry no "gen":null key.
+    assert encode_datagram(TeleopStop()) == b'{"t":"teleop_stop"}'
 
 
 def test_nested_roundtrip_returns_models():

--- a/dimos/web/relay_bridge/test_relay_bridge_e2e.py
+++ b/dimos/web/relay_bridge/test_relay_bridge_e2e.py
@@ -42,11 +42,27 @@ import pytest
 from dimos.core.transport import pLCMTransport
 from dimos.msgs.geometry_msgs.Pose import Pose
 from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
+from dimos.msgs.geometry_msgs.Twist import Twist
 from dimos.msgs.nav_msgs.OccupancyGrid import OccupancyGrid
 from dimos.msgs.sensor_msgs.Image import Image
-from dimos.web.relay_bridge.e2e_support import attach_viewer, collect_until, stop_module
-from dimos.web.relay_bridge.protocol import Unsub
-from dimos.web.relay_bridge.relay_bridge_module import RelayBridgeModule
+from dimos.web.relay_bridge.e2e_support import (
+    arm_teleop,
+    attach_viewer,
+    collect_until,
+    stop_module,
+)
+from dimos.web.relay_bridge.protocol import (
+    Stop as WireStop,
+    TeleopStart,
+    Twist as WireTwist,
+    Unsub,
+)
+from dimos.web.relay_bridge.relay_bridge_module import (
+    RelayBridgeConfig,
+    RelayBridgeModule,
+    default_manifest,
+)
+from dimos.web.relay_bridge.relay_process import RelayProcess
 from dimos.web.relay_bridge.wt_client import RelayClient
 
 ROBOT_ID = "bridge-e2e"
@@ -380,5 +396,203 @@ def test_relay_child_death_respawns_and_recovers(
                 viewer, lambda fs: any(f.header.ch == "odom" for f in fs), timeout=15.0
             )
             assert any(f.header.ch == "odom" for f in frames)
+
+    asyncio.run(flow())
+
+
+# Teleop e2e: viewer datagrams -> relay lease gate -> bridge publishes.
+
+
+def _start_teleop_bridge() -> tuple[RelayBridgeModule, tuple[pLCMTransport, ...]]:
+    manifest = default_manifest(
+        RelayBridgeConfig(), ("color_image", "odom", "global_costmap", "tele_cmd_vel")
+    )
+    module = RelayBridgeModule(
+        local_port=0,
+        open_browser=False,
+        cockpit_build=False,
+        robot_id=ROBOT_ID,
+        manifest=manifest,
+    )
+    transports = (
+        pLCMTransport("/rb_e2e/odom"),
+        pLCMTransport("/rb_e2e/color_image"),
+        pLCMTransport("/rb_e2e/global_costmap"),
+    )
+    for transport in transports:
+        transport.start()
+    module.odom.transport = transports[0]
+    module.color_image.transport = transports[1]
+    module.global_costmap.transport = transports[2]
+    module.start()
+    return module, transports
+
+
+@pytest.fixture
+def teleop_bridge() -> Iterator[RelayBridgeModule]:
+    """Function-scoped: teleop lease state must not leak between tests."""
+    module, transports = _start_teleop_bridge()
+    try:
+        yield module
+    finally:
+        stop_module(module)
+        for transport in transports:
+            transport.stop()
+
+
+async def _until(cond, what: str, timeout: float = 10.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if cond():
+            return
+        await asyncio.sleep(0.02)
+    raise TimeoutError(what)
+
+
+async def _drive(viewer: RelayClient, seq: int, stop: asyncio.Event, vx: float = 0.5) -> int:
+    """Send nonzero twists at ~20 Hz until stopped; returns the last seq used."""
+    while not stop.is_set():
+        seq += 1
+        try:
+            viewer.send_control(WireTwist(vx=vx, vy=0.0, wz=0.0, seq=seq, ts=time.time()))
+        except Exception:
+            break  # dead relay: sends are best-effort, the watchdog owns safety
+        await asyncio.sleep(0.05)
+    return seq
+
+
+def test_teleop_drive_and_estop(teleop_bridge: RelayBridgeModule) -> None:
+    bridge = teleop_bridge
+    twists: list[Twist] = []
+    bridge.tele_cmd_vel.subscribe(twists.append)
+
+    async def flow() -> None:
+        assert bridge._url is not None
+        async with await RelayClient.connect(bridge._url, "viewer") as viewer:
+            await viewer.hello()
+            await attach_viewer(viewer, ROBOT_ID, [])
+            await arm_teleop(viewer)
+
+            stop = asyncio.Event()
+            driver = asyncio.create_task(_drive(viewer, 0, stop))
+            await _until(lambda: any(not t.is_zero() for t in twists), "no twist published")
+
+            # E-stop: the stop datagram publishes an unconditional zero.
+            stop.set()
+            seq = await driver
+            marker = len(twists)
+            viewer.send_control(WireStop(seq=seq + 1, ts=time.time()))
+            await _until(
+                lambda: len(twists) > marker and twists[-1].is_zero(), "no zero after stop"
+            )
+
+    asyncio.run(flow())
+
+
+@pytest.fixture
+def deadman_bridge() -> Iterator[tuple[RelayProcess, RelayBridgeModule]]:
+    """A teleop bridge attached to an externally spawned relay. With no local
+    child there is no 1 s child watchdog, and a SIGKILLed relay sends no
+    CONNECTION_CLOSE so the session-teardown zero stays out of reach: the
+    teleop deadman is the only path that can stop the robot."""
+    relay = RelayProcess()
+    ready = relay.start()
+    manifest = default_manifest(RelayBridgeConfig(), ("tele_cmd_vel",))
+    module = RelayBridgeModule(
+        relay_url=ready.wt_url,
+        open_browser=False,
+        cockpit_build=False,
+        robot_id=ROBOT_ID,
+        manifest=manifest,
+    )
+    module.start()
+    try:
+        yield relay, module
+    finally:
+        stop_module(module)
+        relay.stop()
+
+
+def test_teleop_relay_kill_deadman_deadline(
+    deadman_bridge: tuple[RelayProcess, RelayBridgeModule],
+) -> None:
+    relay, bridge = deadman_bridge
+    twists: list[Twist] = []
+    bridge.tele_cmd_vel.subscribe(twists.append)
+
+    async def flow() -> None:
+        assert bridge._url is not None
+        async with await RelayClient.connect(bridge._url, "viewer") as viewer:
+            await viewer.hello()
+            await attach_viewer(viewer, ROBOT_ID, [])
+            await arm_teleop(viewer)
+
+            stop = asyncio.Event()
+            driver = asyncio.create_task(_drive(viewer, 0, stop))
+            await _until(lambda: any(not t.is_zero() for t in twists), "no twist published")
+
+            marker = len(twists)
+            assert relay._process is not None
+            killed_at = time.monotonic()
+            relay._process.kill()
+            await _until(
+                lambda: len(twists) > marker and twists[-1].is_zero(),
+                "no zero after relay kill (deadman broken?)",
+                timeout=5.0,
+            )
+            # The deadline enforces the deadman itself: watchdogMs 300
+            # (default) + _TELEOP_POLL_S 0.05 + CI scheduling margin.
+            assert time.monotonic() - killed_at < 1.0
+            stop.set()
+            await driver
+
+    asyncio.run(flow())
+
+
+def test_teleop_lease_exclusive_and_handover(teleop_bridge: RelayBridgeModule) -> None:
+    bridge = teleop_bridge
+    twists: list[Twist] = []
+    bridge.tele_cmd_vel.subscribe(twists.append)
+
+    async def flow() -> None:
+        assert bridge._url is not None
+        async with await RelayClient.connect(bridge._url, "viewer") as second:
+            await second.hello()
+            await attach_viewer(second, ROBOT_ID, [])
+            async with await RelayClient.connect(bridge._url, "viewer") as holder:
+                await holder.hello()
+                await attach_viewer(holder, ROBOT_ID, [])
+                await arm_teleop(holder)
+
+                # The second viewer is refused while the lease is held (the
+                # error reply lands in relay_error; retried because replies
+                # ride lossy datagrams).
+                async def held() -> bool:
+                    second.send_control(TeleopStart())
+                    await asyncio.sleep(0.1)
+                    error = second._session.relay_error
+                    return error is not None and error.code == "teleop_held"
+
+                deadline = time.monotonic() + 10
+                while not await held():
+                    assert time.monotonic() < deadline, "teleop_held never reported"
+
+                # The holder drives; the bystander's twists are gated out.
+                second.send_control(WireTwist(vx=9.0, vy=0.0, wz=0.0, seq=1, ts=time.time()))
+                holder.send_control(WireTwist(vx=0.5, vy=0.0, wz=0.0, seq=1, ts=time.time()))
+                await _until(lambda: any(not t.is_zero() for t in twists), "no twist published")
+                assert all(t.linear.x != 9.0 for t in twists)
+
+            # Holder disconnected mid-drive: the relay releases the lease and
+            # sends teleop_stop, so the bridge zeroes without waiting for the
+            # watchdog, and the second viewer can now arm and drive.
+            await _until(lambda: twists[-1].is_zero(), "no zero after holder disconnect")
+            await arm_teleop(second)
+            marker = len(twists)
+            second.send_control(WireTwist(vx=0.25, vy=0.0, wz=0.0, seq=1, ts=time.time()))
+            await _until(
+                lambda: len(twists) > marker and twists[-1].linear.x == 0.25,
+                "handover drive never published",
+            )
 
     asyncio.run(flow())

--- a/dimos/web/relay_bridge/test_relay_bridge_module.py
+++ b/dimos/web/relay_bridge/test_relay_bridge_module.py
@@ -40,16 +40,25 @@ import pytest
 
 from dimos.core.coordination.blueprints import autoconnect
 from dimos.core.module import Module, ModuleConfig
-from dimos.core.stream import Out
+from dimos.core.stream import In, Out
 from dimos.msgs.geometry_msgs.Pose import Pose
 from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
+from dimos.msgs.geometry_msgs.Twist import Twist
+from dimos.msgs.geometry_msgs.Vector3 import Vector3
 from dimos.msgs.nav_msgs.OccupancyGrid import OccupancyGrid
 from dimos.msgs.sensor_msgs.Image import Image
 from dimos.simulation.mujoco.constants import VIDEO_FPS
 from dimos.web.relay_bridge import relay_bridge_module
 from dimos.web.relay_bridge.e2e_support import stop_module
 from dimos.web.relay_bridge.manifest import ManifestError, parse_manifest
-from dimos.web.relay_bridge.protocol import Msg, Subs
+from dimos.web.relay_bridge.protocol import (
+    Msg,
+    Stop as WireStop,
+    Subs,
+    TeleopStart as WireTeleopStart,
+    TeleopStop as WireTeleopStop,
+    Twist as WireTwist,
+)
 from dimos.web.relay_bridge.relay_bridge_module import (
     CHANNELS,
     RelayBridgeConfig,
@@ -1037,7 +1046,7 @@ def test_default_manifest_matches_cockpit_default_preset() -> None:
 
     (atom,) = cockpit().blueprints
     assert atom.kwargs["manifest"] == default_manifest(
-        RelayBridgeConfig(), ("color_image", "odom", "global_costmap")
+        RelayBridgeConfig(), ("color_image", "odom", "global_costmap", "tele_cmd_vel")
     )
     # Normalization is idempotent: the parser accepts its own output.
     assert parse_manifest(atom.kwargs["manifest"]).model_dump() == atom.kwargs["manifest"]
@@ -1162,6 +1171,338 @@ def test_failed_start_stops_spawned_relay(monkeypatch) -> None:
     assert relay.stops == 1
 
 
+# Teleop (the tele_cmd_vel tx channel).
+
+# Short deadman window so silence tests stay fast; well above the 50 ms
+# watchdog poll.
+_TELEOP_TEST_WATCHDOG_MS = 120.0
+
+
+def teleop_manifest(**params: Any) -> dict[str, Any]:
+    merged: dict[str, Any] = {
+        "maxLinear": 0.8,
+        "maxAngular": 1.0,
+        "boost": 2.0,
+        "watchdogMs": _TELEOP_TEST_WATCHDOG_MS,
+    }
+    merged.update(params)
+    return {
+        "version": 1,
+        "channels": [
+            {
+                "ch": "tele_cmd_vel",
+                "dir": "tx",
+                "encoding": "twist.json.v1",
+                "delivery": "latest",
+                "maxHz": 15.0,
+                "params": merged,
+            }
+        ],
+        "panels": [{"id": "p0", "kind": "teleop", "channels": ["tele_cmd_vel"]}],
+        "layout": "p0",
+    }
+
+
+def wire_twist(vx: float, vy: float, wz: float, seq: float, gen: int | None = 1) -> WireTwist:
+    # gen defaults to 1: the relay stamps every robot-bound message, so a
+    # first lease's twists arrive as gen 1.
+    return WireTwist(vx=vx, vy=vy, wz=wz, seq=seq, ts=time.time(), gen=gen)
+
+
+@pytest.fixture
+def teleop_bridge(monkeypatch):
+    module, clients = _make_bridge(monkeypatch, manifest=teleop_manifest())
+    twists: list[Twist] = []
+    module.tele_cmd_vel.subscribe(twists.append)
+    try:
+        yield module, clients, twists
+    finally:
+        stop_module(module)
+
+
+def settle(module: RelayBridgeModule) -> None:
+    """Give queued teleop handling time to run before a negative assert."""
+    flush_loop(module)
+    time.sleep(0.03)
+    flush_loop(module)
+
+
+def test_teleop_twist_publishes_geometry_twist(teleop_bridge) -> None:
+    module, clients, twists = teleop_bridge
+    push(module, clients[0], wire_twist(0.4, 0.2, -0.5, seq=1))
+    assert wait_until(lambda: len(twists) == 1)
+    assert twists[0] == Twist(linear=Vector3(0.4, 0.2, 0.0), angular=Vector3(0.0, 0.0, -0.5))
+
+
+def test_teleop_clamps_to_boost_bounds(teleop_bridge) -> None:
+    module, clients, twists = teleop_bridge
+    push(module, clients[0], wire_twist(100.0, -100.0, -100.0, seq=1))
+    assert wait_until(lambda: len(twists) == 1)
+    # maxLinear 0.8 * boost 2.0; maxAngular 1.0 * boost 2.0.
+    assert twists[0] == Twist(linear=Vector3(1.6, -1.6, 0.0), angular=Vector3(0.0, 0.0, -2.0))
+
+
+def test_teleop_seq_guard_drops_stale_within_live_stream(teleop_bridge) -> None:
+    module, clients, twists = teleop_bridge
+    push(module, clients[0], wire_twist(0.1, 0.0, 0.0, seq=5))
+    push(module, clients[0], wire_twist(0.9, 0.0, 0.0, seq=4))  # reordered: dropped
+    push(module, clients[0], wire_twist(0.2, 0.0, 0.0, seq=6))
+    assert wait_until(lambda: len(twists) == 2)
+    settle(module)
+    assert [t.linear.x for t in twists] == [0.1, 0.2]
+
+
+def test_teleop_watchdog_deadline_and_high_water_survives_silence(teleop_bridge) -> None:
+    module, clients, twists = teleop_bridge
+    push(module, clients[0], wire_twist(0.5, 0.0, 0.0, seq=100))
+    assert wait_until(lambda: len(twists) == 1)
+    started = time.monotonic()
+    # Silence while driving: the deadman publishes exactly one zero, within
+    # the watchdog window plus its poll granularity (margin covers the 10 ms
+    # wait_until poll and thread scheduling).
+    assert wait_until(lambda: len(twists) == 2)
+    elapsed = time.monotonic() - started
+    assert twists[1].is_zero()
+    deadline = _TELEOP_TEST_WATCHDOG_MS / 1000 + relay_bridge_module._TELEOP_POLL_S + 0.5
+    assert elapsed < deadline, f"deadman zero took {elapsed:.3f}s (deadline {deadline:.3f}s)"
+    time.sleep(3 * _TELEOP_TEST_WATCHDOG_MS / 1000)
+    settle(module)
+    assert len(twists) == 2  # no repeated idle zeros
+    # The high-water mark survives silence: a delayed lower-seq twist from
+    # the same lease stays dead, while the paused holder resumes with a
+    # rising seq.
+    push(module, clients[0], wire_twist(0.9, 0.0, 0.0, seq=99))
+    settle(module)
+    assert len(twists) == 2
+    push(module, clients[0], wire_twist(0.3, 0.0, 0.0, seq=101))
+    assert wait_until(lambda: len(twists) == 3)
+    assert twists[2].linear.x == 0.3
+
+
+def test_teleop_zero_only_on_release_edge(teleop_bridge) -> None:
+    module, clients, twists = teleop_bridge
+    # Idle zeros never publish (MovementManager cancels a nav goal on every
+    # teleop message, so a parked cockpit must stay silent).
+    push(module, clients[0], wire_twist(0.0, 0.0, 0.0, seq=1))
+    settle(module)
+    assert twists == []
+    push(module, clients[0], wire_twist(0.5, 0.0, 0.0, seq=2))
+    push(module, clients[0], wire_twist(0.0, 0.0, 0.0, seq=3))
+    push(module, clients[0], wire_twist(0.0, 0.0, 0.0, seq=4))  # release burst repeat
+    assert wait_until(lambda: len(twists) == 2)
+    settle(module)
+    assert len(twists) == 2
+    assert twists[1].is_zero()
+
+
+def test_teleop_stop_is_unconditional(teleop_bridge) -> None:
+    module, clients, twists = teleop_bridge
+    # E-stop from idle still publishes (it must cancel an autonomous nav
+    # goal), and every repeat publishes again.
+    push(module, clients[0], WireStop(seq=1, ts=time.time(), gen=1))
+    push(module, clients[0], WireStop(seq=2, ts=time.time(), gen=1))
+    assert wait_until(lambda: len(twists) == 2)
+    assert all(t.is_zero() for t in twists)
+
+
+def test_teleop_stop_blocks_stale_reordered_twist(teleop_bridge) -> None:
+    module, clients, twists = teleop_bridge
+    push(module, clients[0], wire_twist(0.5, 0.0, 0.0, seq=9))
+    push(module, clients[0], WireStop(seq=10, ts=time.time(), gen=1))
+    assert wait_until(lambda: len(twists) == 2)
+    # A pre-e-stop twist arriving late must not restart the robot.
+    push(module, clients[0], wire_twist(0.5, 0.0, 0.0, seq=8))
+    settle(module)
+    assert len(twists) == 2
+    push(module, clients[0], wire_twist(0.2, 0.0, 0.0, seq=11))
+    assert wait_until(lambda: len(twists) == 3)
+
+
+def test_teleop_lease_end_zeroes_once_and_resets_seq(teleop_bridge) -> None:
+    module, clients, twists = teleop_bridge
+    push(module, clients[0], wire_twist(0.5, 0.0, 0.0, seq=50))
+    assert wait_until(lambda: len(twists) == 1)
+    push(module, clients[0], WireTeleopStop(gen=1))
+    assert wait_until(lambda: len(twists) == 2)
+    assert twists[1].is_zero()
+    push(module, clients[0], WireTeleopStop(gen=1))  # repeat: dead on the gen gate
+    settle(module)
+    assert len(twists) == 2
+    # The next holder's lease (relay bumps by exactly 1) starts a fresh seq
+    # space immediately.
+    push(module, clients[0], wire_twist(0.3, 0.0, 0.0, seq=1, gen=2))
+    assert wait_until(lambda: len(twists) == 3)
+
+
+def test_teleop_session_drop_zeroes(teleop_bridge) -> None:
+    module, clients, twists = teleop_bridge
+    push(module, clients[0], wire_twist(0.5, 0.0, 0.0, seq=1))
+    assert wait_until(lambda: len(twists) == 1)
+    kill_session(module, clients[0])
+    assert wait_until(lambda: len(twists) == 2 and twists[1].is_zero())
+    assert wait_until(lambda: len(clients) == 2)  # supervisor reconnected
+    settle(module)
+    assert len(twists) == 2
+
+
+def test_teleop_lease_end_blocks_stale_gen_twist_permanently(teleop_bridge) -> None:
+    module, clients, twists = teleop_bridge
+    push(module, clients[0], wire_twist(0.5, 0.0, 0.0, seq=50))
+    assert wait_until(lambda: len(twists) == 1)
+    push(module, clients[0], WireTeleopStop(gen=1))
+    assert wait_until(lambda: len(twists) == 2 and twists[1].is_zero())
+    # Past the watchdog window, delayed twists from the released lease must
+    # stay dead regardless of seq: a reordered pre-stop command must never
+    # restart the robot after a stop.
+    time.sleep(2 * _TELEOP_TEST_WATCHDOG_MS / 1000)
+    push(module, clients[0], wire_twist(0.5, 0.0, 0.0, seq=51))
+    push(module, clients[0], wire_twist(0.5, 0.0, 0.0, seq=999))
+    settle(module)
+    assert len(twists) == 2
+    # The next lease is admitted immediately.
+    push(module, clients[0], wire_twist(0.3, 0.0, 0.0, seq=1, gen=2))
+    assert wait_until(lambda: len(twists) == 3)
+    assert twists[2].linear.x == 0.3
+
+
+def test_teleop_stale_gen_estop_is_void(teleop_bridge) -> None:
+    module, clients, twists = teleop_bridge
+    push(module, clients[0], wire_twist(0.5, 0.0, 0.0, seq=10, gen=2))
+    assert wait_until(lambda: len(twists) == 1)
+    # An e-stop from a voided lease must not blip the current holder.
+    push(module, clients[0], WireStop(seq=999, ts=time.time(), gen=1))
+    settle(module)
+    assert len(twists) == 1
+    push(module, clients[0], wire_twist(0.2, 0.0, 0.0, seq=11, gen=2))
+    assert wait_until(lambda: len(twists) == 2)
+    assert twists[1].linear.x == 0.2
+
+
+def test_teleop_start_adopts_new_gen_and_zeroes_lost_stop(teleop_bridge) -> None:
+    module, clients, twists = teleop_bridge
+    push(module, clients[0], wire_twist(0.5, 0.0, 0.0, seq=50))
+    assert wait_until(lambda: len(twists) == 1)
+    # The lease changed hands but its teleop_stop datagram was lost: the
+    # next grant's announcement stops the robot and voids the old lease.
+    push(module, clients[0], WireTeleopStart(gen=2))
+    assert wait_until(lambda: len(twists) == 2 and twists[1].is_zero())
+    push(module, clients[0], wire_twist(0.5, 0.0, 0.0, seq=51))  # old lease
+    settle(module)
+    assert len(twists) == 2
+    push(module, clients[0], wire_twist(0.3, 0.0, 0.0, seq=1, gen=2))
+    assert wait_until(lambda: len(twists) == 3)
+    # A duplicated start (idempotent re-arm resend) must not reset the
+    # high-water: the holder's own reordered twist stays dead.
+    push(module, clients[0], WireTeleopStart(gen=2))
+    push(module, clients[0], wire_twist(0.9, 0.0, 0.0, seq=1, gen=2))
+    settle(module)
+    assert len(twists) == 3
+
+
+def test_teleop_estop_does_not_lower_high_water(teleop_bridge) -> None:
+    module, clients, twists = teleop_bridge
+    push(module, clients[0], wire_twist(0.5, 0.0, 0.0, seq=12))
+    assert wait_until(lambda: len(twists) == 1)
+    # A stale reordered e-stop still zeroes (safe direction) but must not
+    # lower the high-water and let the superseded twist 11 re-apply.
+    push(module, clients[0], WireStop(seq=10, ts=time.time(), gen=1))
+    assert wait_until(lambda: len(twists) == 2 and twists[1].is_zero())
+    push(module, clients[0], wire_twist(0.9, 0.0, 0.0, seq=11))
+    settle(module)
+    assert len(twists) == 2
+    push(module, clients[0], wire_twist(0.2, 0.0, 0.0, seq=13))
+    assert wait_until(lambda: len(twists) == 3)
+    assert twists[2].linear.x == 0.2
+
+
+def test_teleop_stale_lease_end_does_not_blip_new_holder(teleop_bridge) -> None:
+    module, clients, twists = teleop_bridge
+    push(module, clients[0], wire_twist(0.5, 0.0, 0.0, seq=5, gen=2))
+    assert wait_until(lambda: len(twists) == 1)
+    # The previous lease's stop arrives late: it must neither zero nor
+    # reset the current lease's state.
+    push(module, clients[0], WireTeleopStop(gen=1))
+    settle(module)
+    assert len(twists) == 1
+    push(module, clients[0], wire_twist(0.2, 0.0, 0.0, seq=6, gen=2))
+    assert wait_until(lambda: len(twists) == 2)
+    assert twists[1].linear.x == 0.2
+
+
+def test_teleop_genless_messages_ignored(teleop_bridge) -> None:
+    # Unstamped wire messages (a version-skewed relay) must never move the
+    # robot or disturb the lease state.
+    module, clients, twists = teleop_bridge
+    push(module, clients[0], wire_twist(0.5, 0.0, 0.0, seq=1, gen=None))
+    push(module, clients[0], WireStop(seq=2, ts=time.time()))
+    push(module, clients[0], WireTeleopStart())
+    push(module, clients[0], WireTeleopStop())
+    settle(module)
+    assert twists == []
+    push(module, clients[0], wire_twist(0.3, 0.0, 0.0, seq=1))
+    assert wait_until(lambda: len(twists) == 1)
+
+
+def test_teleop_ignored_without_a_teleop_channel(bridge) -> None:
+    # No tx channel in the manifest: teleop messages are protocol noise.
+    module, clients = bridge
+    twists: list[Twist] = []
+    module.tele_cmd_vel.subscribe(twists.append)
+    push(module, clients[0], wire_twist(0.5, 0.0, 0.0, seq=1))
+    push(module, clients[0], WireStop(seq=2, ts=time.time(), gen=1))
+    settle(module)
+    assert twists == []
+
+
+def test_teleop_manifest_validation_fails_start(monkeypatch) -> None:
+    async def fake_connect(url: str, role: str, **kwargs: Any) -> FakeClient:
+        raise AssertionError("must not reach the relay with an invalid manifest")
+
+    monkeypatch.setattr(relay_bridge_module, "connect_with_backoff", fake_connect)
+
+    def start_with(manifest: dict[str, Any]) -> None:
+        module = RelayBridgeModule(
+            relay_url="https://127.0.0.1:1", robot_id="unit-bot", manifest=manifest
+        )
+        try:
+            module.start()
+        finally:
+            stop_module(module)
+
+    bad_params = teleop_manifest(boost=-1.0)
+    with pytest.raises(RuntimeError, match="boost"):
+        start_with(bad_params)
+    # A tx channel this bridge cannot handle (wrong encoding vs TX_CHANNELS)
+    # fails start too - channel-only, since the teleop panel rule would
+    # reject the encoding first.
+    with pytest.raises(RuntimeError, match="no matching handler"):
+        start_with(
+            {
+                "version": 1,
+                "channels": [
+                    {
+                        "ch": "tele_cmd_vel",
+                        "dir": "tx",
+                        "encoding": "chat.json.v1",
+                        "delivery": "latest",
+                        "maxHz": 15.0,
+                    }
+                ],
+            }
+        )
+
+
+def test_default_manifest_teleop_degradations() -> None:
+    config = RelayBridgeConfig()
+    solo = default_manifest(config, ("tele_cmd_vel",))
+    assert [c["ch"] for c in solo["channels"]] == ["tele_cmd_vel"]
+    assert [p["kind"] for p in solo["panels"]] == ["teleop"]
+    assert solo["layout"] == "p0"
+    with_video = default_manifest(config, ("color_image", "tele_cmd_vel"))
+    assert [p["kind"] for p in with_video["panels"]] == ["video", "teleop"]
+    assert with_video["layout"] == {"row": ["p0", "p1"], "shares": [2, 1]}
+
+
 # Composition helpers live at module level: under PEP 563 (`from __future__
 # import annotations`) a Module class defined inside a function loses its
 # streams, because its annotations cannot be resolved from module globals.
@@ -1177,6 +1518,11 @@ class _ImageProducer(Module):
 class _CostmapProducer(Module):
     config: _EmptyConfig
     global_costmap: Out[OccupancyGrid]
+
+
+class _TwistConsumer(Module):
+    config: _EmptyConfig
+    tele_cmd_vel: In[Twist]
 
 
 class _BareModule(Module):
@@ -1198,6 +1544,18 @@ def test_composition_includes_costmap_producer() -> None:
     relay_atom = next(atom for atom in blueprint.blueprints if atom.module is RelayBridgeModule)
 
     assert relay_atom.kwargs["available_channels"] == ("color_image", "global_costmap")
+
+
+def test_composition_derives_tx_channels_from_consumers() -> None:
+    # A MovementManager-like consumer of tele_cmd_vel makes the tx channel
+    # available (Out transports exist regardless of wiring, so consumers are
+    # the availability signal).
+    blueprint = with_relay_bridge(
+        autoconnect(_ImageProducer.blueprint(), _TwistConsumer.blueprint())
+    )
+    relay_atom = next(atom for atom in blueprint.blueprints if atom.module is RelayBridgeModule)
+
+    assert relay_atom.kwargs["available_channels"] == ("color_image", "tele_cmd_vel")
 
 
 def test_composition_ignores_disabled_producers() -> None:

--- a/dimos/web/test_cockpit.py
+++ b/dimos/web/test_cockpit.py
@@ -20,7 +20,7 @@ import sys
 
 import pytest
 
-from dimos.web.cockpit import ChannelRequest, Col, Map2D, Panel, Row, Video, cockpit
+from dimos.web.cockpit import ChannelRequest, Col, Map2D, Panel, Row, Teleop, Video, cockpit
 from dimos.web.relay_bridge.manifest import parse_manifest
 from dimos.web.relay_bridge.protocol import PROTOCOL_VERSION, Hello, RobotInfo, encode_datagram
 from dimos.web.relay_bridge.relay_bridge_module import RelayBridgeModule
@@ -31,7 +31,7 @@ from dimos.web.relay_bridge.wt_client import _HELLO_DATAGRAM_MAX_BYTES
 # and need the TS side reviewed too.
 GO2_LAYOUT = Row(
     Video("color_image"),
-    Col(Map2D(costmap="global_costmap", pose="odom")),
+    Col(Map2D(costmap="global_costmap", pose="odom"), Teleop(), shares=[3, 1]),
     shares=[2, 1],
 )
 
@@ -62,6 +62,14 @@ GO2_MANIFEST = {
             "maxHz": 5.0,
             "params": {},
         },
+        {
+            "ch": "tele_cmd_vel",
+            "dir": "tx",
+            "encoding": "twist.json.v1",
+            "delivery": "latest",
+            "maxHz": 15.0,
+            "params": {"maxLinear": 0.8, "maxAngular": 1.0, "boost": 2.0, "watchdogMs": 300.0},
+        },
     ],
     "panels": [
         {"id": "p0", "kind": "video", "title": "", "channels": ["color_image"], "params": {}},
@@ -72,8 +80,9 @@ GO2_MANIFEST = {
             "channels": ["global_costmap", "odom"],
             "params": {},
         },
+        {"id": "p2", "kind": "teleop", "title": "", "channels": ["tele_cmd_vel"], "params": {}},
     ],
-    "layout": {"row": ["p0", {"col": ["p1"]}], "shares": [2, 1]},
+    "layout": {"row": ["p0", {"col": ["p1", "p2"], "shares": [3, 1]}], "shares": [2, 1]},
     "pages": [],
 }
 
@@ -92,12 +101,10 @@ def test_go2_example_manifest_golden() -> None:
 
 
 def test_default_preset() -> None:
-    # cockpit() with no layout: video left (2/3), costmap+pose right (1/3).
+    # cockpit() with no layout: video left (2/3); costmap+pose over teleop
+    # right (1/3). Same shape as the go2 example.
     manifest = manifest_of(cockpit())
-    assert manifest["channels"] == GO2_MANIFEST["channels"]
-    assert manifest["panels"] == GO2_MANIFEST["panels"]
-    assert manifest["layout"] == {"row": ["p0", "p1"], "shares": [2, 1]}
-    assert manifest["pages"] == []
+    assert manifest == GO2_MANIFEST
 
 
 def test_blueprint_pickles() -> None:
@@ -136,14 +143,19 @@ def test_wrong_encoding_for_stream_raises() -> None:
 
 
 def test_unknown_tx_stream_raises() -> None:
+    with pytest.raises(ValueError, match="unknown tx stream 'cmd_vel'"):
+        cockpit(layout=Teleop(stream="cmd_vel"))
+
+
+def test_wrong_tx_encoding_raises() -> None:
     class Sender(Panel):
         kind = "sender"
         title = ""
 
         def _channel_requests(self) -> tuple[ChannelRequest, ...]:
-            return (ChannelRequest("cmd_vel", "tx", "twist.json.v1", 15.0),)
+            return (ChannelRequest("tele_cmd_vel", "tx", "chat.json.v1", 15.0),)
 
-    with pytest.raises(ValueError, match="unknown tx stream 'cmd_vel'"):
+    with pytest.raises(ValueError, match="'tele_cmd_vel' encodes twist.json.v1, not chat.json.v1"):
         cockpit(layout=Sender())
 
 
@@ -170,6 +182,11 @@ def test_pages_get_ids_after_the_grid() -> None:
         lambda: Video("color_image", quality=True),
         lambda: Map2D(costmap=""),
         lambda: Map2D(costmap_hz=-5.0),
+        lambda: Teleop(stream=""),
+        lambda: Teleop(max_linear=0),
+        lambda: Teleop(boost=-2.0),
+        lambda: Teleop(publish_hz=True),
+        lambda: Teleop(watchdog_ms=0),
     ],
     ids=[
         "row_empty",
@@ -185,6 +202,11 @@ def test_pages_get_ids_after_the_grid() -> None:
         "video_quality_bool",
         "map2d_empty_costmap",
         "map2d_negative_rate",
+        "teleop_empty_stream",
+        "teleop_zero_linear",
+        "teleop_negative_boost",
+        "teleop_bool_rate",
+        "teleop_zero_watchdog",
     ],
 )
 def test_authoring_validation_errors(build) -> None:
@@ -201,7 +223,9 @@ def test_go2_hello_fits_the_datagram_budget() -> None:
     # The whole manifest rides one hello datagram (wt_client caps it at
     # _HELLO_DATAGRAM_MAX_BYTES and raises loudly beyond). Pin the go2
     # example under 1000 B so >= 100 B of headroom remains for longer
-    # hostnames before authors ever see that error.
+    # hostnames before authors ever see that error. The teleop channel
+    # brought this to 999 B: the next channel (chat, T8) cannot fit and
+    # must rethink the budget (trim params, or move hello off datagrams).
     hello = Hello(
         v=PROTOCOL_VERSION,
         role="robot",

--- a/web/README.md
+++ b/web/README.md
@@ -43,6 +43,30 @@ whole stack against the go2 replay dataset in both Playwright Chromium and Firef
 WebTransport stacks differ; see bug 11). The CI `web` job runs it; locally it needs
 `uv run playwright install chromium firefox` once.
 
+## Teleop safety chain
+
+Keyboard teleop (the `teleop` panel; WASD drive, Q/E strafe, Shift boost, Space e-stop, key
+semantics from `dimos/robot/unitree/keyboard_teleop.py`) sends `twist` datagrams cockpit -> relay ->
+bridge, which publishes on `tele_cmd_vel`. Driving needs the per-robot exclusive lease
+(`teleop_start` on the control stream, acked with `teleop_started`; a second viewer gets error
+`teleop_held`); the relay forwards twist/stop datagrams robot-ward only from the lease holder.
+Datagram loss is fine: commands repeat at the channel's `maxHz` and silence trips the bridge
+deadman. Each hop covers the failure of the previous one:
+
+1. The cockpit zeroes on every disarm trigger: last key release (zero + two repeats over 200 ms),
+   Esc, focus loss, window blur, hidden tab, unmount, disconnect. Armed only while the panel has
+   focus. Space is the e-stop: a `stop` burst on datagrams plus one on the control stream, which the
+   bridge publishes as an unconditional zero (it also cancels an autonomous nav goal).
+2. The relay releases the lease and sends `teleop_stop` robot-ward when the holder disconnects or
+   watches away. It stamps every robot-bound teleop message with the lease generation `gen` (bumped
+   per grant, announced with a robot-ward `teleop_start`).
+3. The bridge watchdog is authoritative: it publishes `Twist.zero()` on stop, `teleop_stop`, session
+   loss, or `watchdogMs` (default 300 ms) of twist silence - so a SIGKILLed relay stops the robot
+   without any goodbye reaching either end. Older generations are rejected permanently and the seq
+   high-water mark survives silence, so a released holder's delayed datagrams cannot restart motion
+   after a stop. Zeros are edge-gated (only after a nonzero twist): MovementManager cancels the nav
+   goal on every teleop message, so idle zeros must never repeat.
+
 ## Protocol shape, and why it is odd
 
 The framing is defined once in `shared/protocol.ts`, mirrored in Python, and pinned by golden

--- a/web/cockpit/src/App.test.tsx
+++ b/web/cockpit/src/App.test.tsx
@@ -44,7 +44,12 @@ describe("App session states", () => {
     root = createRoot(container);
     status = new StatusStore();
     channels = new ChannelStore();
-    session = { status, channels, stop: () => {} };
+    session = {
+      status,
+      channels,
+      teleop: { control: () => {}, datagram: () => {}, onMsg: () => () => {}, status },
+      stop: () => {},
+    };
     act(() => root.render(<App session={session} />));
   });
 

--- a/web/cockpit/src/App.tsx
+++ b/web/cockpit/src/App.tsx
@@ -29,8 +29,8 @@ export function App({ session }: { session: SessionHandle }) {
     content = <p className={styles.notice}>Waiting for a robot to register...</p>;
   } else {
     content = (
-      <Tabs manifest={status.manifest} store={session.channels}>
-        <LayoutTree manifest={status.manifest} store={session.channels} />
+      <Tabs manifest={status.manifest} store={session.channels} teleop={session.teleop}>
+        <LayoutTree manifest={status.manifest} store={session.channels} teleop={session.teleop} />
         <ChannelList
           channels={status.manifest.channels}
           panels={status.manifest.panels}

--- a/web/cockpit/src/layout/LayoutTree.tsx
+++ b/web/cockpit/src/layout/LayoutTree.tsx
@@ -6,34 +6,35 @@
 // render.
 
 import type { LayoutNode, Manifest, PanelSpec } from "@dimos/shared/manifest";
-import { getPanel, UnknownPanel } from "../panels/registry.tsx";
-import type { ChannelStore } from "../session/store.ts";
+import { getPanel, type PanelProps, UnknownPanel } from "../panels/registry.tsx";
 import styles from "./LayoutTree.module.css";
 
-function Node({ node, byId, store }: {
+type PanelContext = Omit<PanelProps, "spec">;
+
+function Node({ node, byId, panelProps }: {
   node: LayoutNode;
   byId: Map<string, PanelSpec>;
-  store: ChannelStore;
+  panelProps: PanelContext;
 }) {
   if (typeof node === "string") {
     const spec = byId.get(node);
     if (spec === undefined) return null; // unreachable post-validation
     const Component = getPanel(spec.kind) ?? UnknownPanel;
-    return <Component spec={spec} store={store} />;
+    return <Component spec={spec} {...panelProps} />;
   }
   const children = "row" in node ? node.row : node.col;
   return (
     <div className={"row" in node ? styles.row : styles.col}>
       {children.map((child, i) => (
         <div key={i} className={styles.cell} style={{ flexGrow: node.shares?.[i] ?? 1 }}>
-          <Node node={child} byId={byId} store={store} />
+          <Node node={child} byId={byId} panelProps={panelProps} />
         </div>
       ))}
     </div>
   );
 }
 
-export function LayoutTree({ manifest, store }: { manifest: Manifest; store: ChannelStore }) {
+export function LayoutTree({ manifest, ...panelProps }: { manifest: Manifest } & PanelContext) {
   const byId = new Map(manifest.panels.map((p) => [p.id, p]));
   const pages = new Set(manifest.pages);
   const gridIds = manifest.panels.filter((p) => !pages.has(p.id)).map((p) => p.id);
@@ -41,7 +42,7 @@ export function LayoutTree({ manifest, store }: { manifest: Manifest; store: Cha
   if (node === null) return null;
   return (
     <div className={styles.root}>
-      <Node node={node} byId={byId} store={store} />
+      <Node node={node} byId={byId} panelProps={panelProps} />
     </div>
   );
 }

--- a/web/cockpit/src/layout/Tabs.tsx
+++ b/web/cockpit/src/layout/Tabs.tsx
@@ -7,15 +7,13 @@
 
 import { type ReactNode, useState } from "react";
 import type { Manifest } from "@dimos/shared/manifest";
-import { getPanel, UnknownPanel } from "../panels/registry.tsx";
-import type { ChannelStore } from "../session/store.ts";
+import { getPanel, type PanelProps, UnknownPanel } from "../panels/registry.tsx";
 import styles from "./Tabs.module.css";
 
-export function Tabs({ manifest, store, children }: {
+export function Tabs({ manifest, children, ...panelProps }: {
   manifest: Manifest;
-  store: ChannelStore;
   children: ReactNode;
-}) {
+} & Omit<PanelProps, "spec">) {
   const [active, setActive] = useState(0);
   if (manifest.pages.length === 0) return <>{children}</>;
   const byId = new Map(manifest.panels.map((p) => [p.id, p]));
@@ -24,7 +22,7 @@ export function Tabs({ manifest, store, children }: {
     const spec = byId.get(manifest.pages[active - 1]);
     if (spec !== undefined) {
       const Component = getPanel(spec.kind) ?? UnknownPanel;
-      page = <Component spec={spec} store={store} />;
+      page = <Component spec={spec} {...panelProps} />;
     }
   }
   return (

--- a/web/cockpit/src/panels/TeleopPanel.module.css
+++ b/web/cockpit/src/panels/TeleopPanel.module.css
@@ -1,0 +1,78 @@
+.pad,
+.padArmed {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem;
+  height: 100%;
+  box-sizing: border-box;
+  outline: none;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.padArmed {
+  border-color: #2f81f7;
+  cursor: default;
+}
+
+.banner {
+  font-size: 0.8rem;
+}
+
+.hint {
+  color: #8b949e;
+}
+
+.armed {
+  color: #2f81f7;
+}
+
+.stopped {
+  color: #f85149;
+}
+
+.cluster {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.keyRow {
+  display: flex;
+  gap: 0.25rem;
+  justify-content: center;
+}
+
+.key,
+.keyDown {
+  width: 1.8rem;
+  height: 1.8rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid #30363d;
+  border-radius: 4px;
+  color: #8b949e;
+  font-size: 0.8rem;
+}
+
+.keyDown {
+  background: #2f81f7;
+  border-color: #2f81f7;
+  color: #fff;
+}
+
+.readout {
+  display: flex;
+  gap: 0.75rem;
+  font-family: monospace;
+  font-size: 0.8rem;
+  color: #8b949e;
+}
+
+.boost {
+  color: #d29922;
+}

--- a/web/cockpit/src/panels/TeleopPanel.test.tsx
+++ b/web/cockpit/src/panels/TeleopPanel.test.tsx
@@ -1,0 +1,191 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import type { Msg, PanelSpec } from "@dimos/shared";
+import type { Manifest } from "@dimos/shared/manifest";
+import { ChannelStore, StatusStore } from "../session/store.ts";
+import type { TeleopHooks } from "./teleopMachine.ts";
+import { TeleopPanel } from "./TeleopPanel.tsx";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const CH = "tele_cmd_vel";
+const SPEC: PanelSpec = { id: "p0", kind: "teleop", title: "", channels: [CH], params: {} };
+const MANIFEST: Manifest = {
+  version: 1,
+  channels: [
+    {
+      ch: CH,
+      dir: "tx",
+      encoding: "twist.json.v1",
+      delivery: "latest",
+      maxHz: 15,
+      params: { maxLinear: 0.8, maxAngular: 1.0, boost: 2.0, watchdogMs: 300 },
+    },
+  ],
+  panels: [SPEC],
+  layout: "p0",
+  pages: [],
+};
+
+class FakeHooks implements TeleopHooks {
+  controls: Msg[] = [];
+  datagrams: Msg[] = [];
+  cbs = new Set<(msg: Msg) => void>();
+  status = new StatusStore();
+
+  control = (msg: Msg) => this.controls.push(msg);
+  datagram = (msg: Msg) => this.datagrams.push(msg);
+  onMsg = (cb: (msg: Msg) => void) => {
+    this.cbs.add(cb);
+    return () => this.cbs.delete(cb);
+  };
+
+  reply(msg: Msg): void {
+    for (const cb of this.cbs) cb(msg);
+  }
+}
+
+describe("TeleopPanel", () => {
+  let container: HTMLElement;
+  let root: Root;
+  let hooks: FakeHooks;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    hooks = new FakeHooks();
+    hooks.status.update({ transport: { phase: "connected" }, manifest: MANIFEST });
+    act(() => root.render(<TeleopPanel spec={SPEC} store={new ChannelStore()} teleop={hooks} />));
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function pad(): HTMLElement {
+    const el = container.querySelector<HTMLElement>(`[data-testid="teleop-${CH}"]`);
+    if (el === null) throw new Error("teleop pad not rendered");
+    return el;
+  }
+
+  function armPanel(): void {
+    act(() => pad().focus());
+    act(() => hooks.reply({ t: "teleop_started" }));
+  }
+
+  function key(type: "keydown" | "keyup", code: string): void {
+    act(() => {
+      pad().dispatchEvent(new KeyboardEvent(type, { code, bubbles: true, cancelable: true }));
+    });
+  }
+
+  it("arms on focus only after the relay grants the lease", () => {
+    expect(pad().dataset.state).toBe("disarmed");
+    expect(container.textContent).toContain("click to arm");
+    act(() => pad().focus());
+    expect(hooks.controls).toEqual([{ t: "teleop_start" }]);
+    expect(pad().dataset.state).toBe("arming");
+    act(() => hooks.reply({ t: "teleop_started" }));
+    expect(pad().dataset.state).toBe("armed");
+  });
+
+  it("shows the held reason when the lease is refused", () => {
+    act(() => pad().focus());
+    act(() => hooks.reply({ t: "error", code: "teleop_held", message: "held" }));
+    expect(pad().dataset.state).toBe("disarmed");
+    expect(container.textContent).toContain("teleop held by another viewer");
+  });
+
+  it("re-arms by click while still focused after a lease refusal", () => {
+    act(() => pad().focus());
+    act(() => hooks.reply({ t: "error", code: "teleop_held", message: "held" }));
+    expect(pad().dataset.state).toBe("disarmed");
+    // The pad still holds focus, so no further focus event will fire; the
+    // click alone must request the lease again.
+    act(() => pad().click());
+    expect(hooks.controls).toEqual([{ t: "teleop_start" }, { t: "teleop_start" }]);
+    // While arming, further clicks are no-ops (no duplicate teleop_start).
+    act(() => pad().click());
+    expect(hooks.controls).toHaveLength(2);
+    act(() => hooks.reply({ t: "teleop_started" }));
+    expect(pad().dataset.state).toBe("armed");
+  });
+
+  it("re-arms by click on the still-focused pad after a reconnect", () => {
+    armPanel();
+    act(() => {
+      hooks.status.update({
+        transport: { phase: "reconnecting", attempt: 1, retryAtMs: 0 },
+      });
+    });
+    expect(pad().dataset.state).toBe("stopped");
+    act(() => hooks.status.update({ transport: { phase: "connected" } }));
+    expect(pad().dataset.state).toBe("disarmed");
+    expect(container.textContent).toContain("connection lost");
+    act(() => pad().click());
+    expect(hooks.controls.at(-1)).toEqual({ t: "teleop_start" });
+    act(() => hooks.reply({ t: "teleop_started" }));
+    expect(pad().dataset.state).toBe("armed");
+  });
+
+  it("drives from key events and reflects them in cluster and readout", () => {
+    armPanel();
+    key("keydown", "KeyW");
+    expect(hooks.datagrams.at(-1)).toMatchObject({ t: "twist", vx: 0.8, vy: 0, wz: 0 });
+    const wKey = container.querySelector('[data-testid="teleop-key-W"]');
+    expect(wKey?.getAttribute("data-pressed")).toBe("true");
+    expect(container.textContent).toContain("vx 0.80");
+    key("keyup", "KeyW");
+    expect(hooks.datagrams.at(-1)).toMatchObject({ t: "twist", vx: 0, vy: 0, wz: 0 });
+  });
+
+  it("Space e-stops on both paths and stays armed", () => {
+    armPanel();
+    key("keydown", "KeyW");
+    key("keydown", "Space");
+    expect(hooks.controls.at(-1)?.t).toBe("stop");
+    expect(hooks.datagrams.at(-1)?.t).toBe("stop");
+    expect(pad().dataset.state).toBe("armed");
+  });
+
+  it("Escape disarms and releases the lease", () => {
+    armPanel();
+    key("keydown", "Escape");
+    expect(pad().dataset.state).toBe("disarmed");
+    expect(hooks.controls.at(-1)).toEqual({ t: "teleop_stop" });
+  });
+
+  it("focus loss and window blur disarm", () => {
+    armPanel();
+    act(() => pad().blur());
+    expect(pad().dataset.state).toBe("disarmed");
+
+    armPanel();
+    act(() => {
+      globalThis.dispatchEvent(new Event("blur"));
+    });
+    expect(pad().dataset.state).toBe("disarmed");
+  });
+
+  it("unmount releases the lease", () => {
+    armPanel();
+    act(() => root.unmount());
+    expect(hooks.controls.at(-1)).toEqual({ t: "teleop_stop" });
+  });
+
+  it("shows STOPPED while the transport is down and refuses to arm", () => {
+    act(() => {
+      hooks.status.update({
+        transport: { phase: "reconnecting", attempt: 1, retryAtMs: 0 },
+      });
+    });
+    expect(pad().dataset.state).toBe("stopped");
+    expect(container.textContent).toContain("connection lost");
+    act(() => pad().focus());
+    expect(hooks.controls).toHaveLength(0);
+  });
+});

--- a/web/cockpit/src/panels/TeleopPanel.tsx
+++ b/web/cockpit/src/panels/TeleopPanel.tsx
@@ -1,0 +1,173 @@
+// Keyboard teleop panel. Click to focus = arm (the lease handshake runs
+// through teleopMachine); armed only while the wrapper subtree has focus, so
+// typing anywhere else can never drive the robot. All safety logic lives in
+// the machine; this component is listeners + visuals.
+
+import { useEffect, useState, useSyncExternalStore } from "react";
+import type { FocusEvent, KeyboardEvent } from "react";
+import { PanelFrame } from "../layout/PanelFrame.tsx";
+import { useStatus } from "../session/hooks.ts";
+import type { PanelProps } from "./registry.tsx";
+import styles from "./TeleopPanel.module.css";
+import {
+  HANDLED_CODES,
+  teleopConfigFromChannel,
+  TeleopMachine,
+  type TeleopSnapshot,
+} from "./teleopMachine.ts";
+
+const KEY_ROWS: { code: string; label: string }[][] = [
+  [
+    { code: "KeyQ", label: "Q" },
+    { code: "KeyW", label: "W" },
+    { code: "KeyE", label: "E" },
+  ],
+  [
+    { code: "KeyA", label: "A" },
+    { code: "KeyS", label: "S" },
+    { code: "KeyD", label: "D" },
+  ],
+];
+
+function pressedClass(snap: TeleopSnapshot, code: string): string {
+  return snap.pressed.has(code) ? styles.keyDown : styles.key;
+}
+
+export function TeleopPanel({ spec, teleop }: PanelProps) {
+  const ch = spec.channels[0] as string | undefined;
+  if (ch === undefined || teleop === undefined) {
+    // No channel is a bridge authoring mistake; no teleop hooks means a
+    // host (test) that cannot send - render visibly instead of crashing.
+    return (
+      <PanelFrame spec={spec}>
+        <span className={styles.hint}>teleop panel {spec.id}: no send path bound</span>
+      </PanelFrame>
+    );
+  }
+  return <TeleopControls spec={spec} teleop={teleop} ch={ch} />;
+}
+
+function TeleopControls({ spec, teleop, ch }: {
+  spec: PanelProps["spec"];
+  teleop: NonNullable<PanelProps["teleop"]>;
+  ch: string;
+}) {
+  const status = useStatus(teleop.status);
+  const connected = status.transport.phase === "connected";
+  // Config is read once per mount: a manifest edit changes the channel
+  // params, which changes the manifest, which remounts via the App epoch.
+  const [machine] = useState(() =>
+    new TeleopMachine(
+      teleopConfigFromChannel(status.manifest?.channels.find((c) => c.ch === ch)),
+      teleop,
+    )
+  );
+  const snap = useSyncExternalStore(machine.subscribe, machine.getSnapshot);
+
+  useEffect(() => teleop.onMsg((msg) => machine.onRelayMsg(msg)), [teleop, machine]);
+  useEffect(() => machine.connectionChanged(connected), [machine, connected]);
+  useEffect(() => {
+    // Missed keyups and background tabs must never keep driving.
+    const onBlur = () => machine.disarm("window blurred");
+    const onVisibility = () => {
+      if (document.visibilityState === "hidden") machine.disarm("tab hidden");
+    };
+    globalThis.addEventListener("blur", onBlur);
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => {
+      globalThis.removeEventListener("blur", onBlur);
+      document.removeEventListener("visibilitychange", onVisibility);
+      // Unmount (robot gone, layout change): zero and release the lease.
+      machine.disarm("panel unmounted");
+    };
+  }, [machine]);
+
+  // Arm from focus AND click: after teleop_held or a reconnect the pad can
+  // still hold focus, and clicking an already-focused element fires no focus
+  // event. arm() no-ops unless disarmed, so the pair never double-sends.
+  const arm = () => {
+    if (connected) machine.arm();
+  };
+  const onBlur = (e: FocusEvent<HTMLDivElement>) => {
+    // Focus moves within the panel (relatedTarget still inside) do not
+    // disarm; leaving the subtree does.
+    if (e.relatedTarget instanceof Node && e.currentTarget.contains(e.relatedTarget)) return;
+    machine.disarm("focus lost");
+  };
+  const onKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (!HANDLED_CODES.has(e.code)) return;
+    e.preventDefault();
+    if (e.repeat) return;
+    if (e.code === "Escape") {
+      // Blur (which disarms) so the next click re-focuses and re-arms.
+      e.currentTarget.blur();
+    } else if (e.code === "Space") {
+      machine.estop();
+    } else {
+      machine.keyDown(e.code);
+    }
+  };
+  const onKeyUp = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (!HANDLED_CODES.has(e.code)) return;
+    e.preventDefault();
+    machine.keyUp(e.code);
+  };
+
+  const state = !connected ? "stopped" : snap.phase;
+  let banner;
+  if (state === "stopped") {
+    banner = <span className={styles.stopped}>connection lost</span>;
+  } else if (state === "arming") {
+    banner = <span className={styles.hint}>requesting teleop...</span>;
+  } else if (state === "armed") {
+    banner = <span className={styles.armed}>armed - WASD drive, QE strafe, Space stop</span>;
+  } else {
+    banner = (
+      <span className={styles.hint}>
+        click to arm{snap.reason !== null ? ` (${snap.reason})` : ""}
+      </span>
+    );
+  }
+
+  return (
+    <PanelFrame spec={spec}>
+      <div
+        tabIndex={0}
+        role="application"
+        aria-label={`keyboard teleop ${ch}`}
+        className={state === "armed" ? styles.padArmed : styles.pad}
+        data-testid={`teleop-${ch}`}
+        data-state={state}
+        onFocus={arm}
+        onClick={arm}
+        onBlur={onBlur}
+        onKeyDown={onKeyDown}
+        onKeyUp={onKeyUp}
+      >
+        <div className={styles.banner}>{banner}</div>
+        <div className={styles.cluster}>
+          {KEY_ROWS.map((row) => (
+            <div key={row[0].code} className={styles.keyRow}>
+              {row.map(({ code, label }) => (
+                <span
+                  key={code}
+                  className={pressedClass(snap, code)}
+                  data-testid={`teleop-key-${label}`}
+                  data-pressed={snap.pressed.has(code) || undefined}
+                >
+                  {label}
+                </span>
+              ))}
+            </div>
+          ))}
+        </div>
+        <div className={styles.readout} data-testid={`teleop-${ch}-readout`}>
+          <span>vx {snap.vx.toFixed(2)}</span>
+          <span>vy {snap.vy.toFixed(2)}</span>
+          <span>wz {snap.wz.toFixed(2)}</span>
+          {snap.boosted && <span className={styles.boost}>boost</span>}
+        </div>
+      </div>
+    </PanelFrame>
+  );
+}

--- a/web/cockpit/src/panels/registry.tsx
+++ b/web/cockpit/src/panels/registry.tsx
@@ -14,11 +14,16 @@ import { PanelFrame } from "../layout/PanelFrame.tsx";
 import type { ChannelStore } from "../session/store.ts";
 import { MapPanel } from "./MapPanel.tsx";
 import styles from "./registry.module.css";
+import type { TeleopHooks } from "./teleopMachine.ts";
+import { TeleopPanel } from "./TeleopPanel.tsx";
 import { VideoPanel } from "./VideoPanel.tsx";
 
 export interface PanelProps {
   spec: PanelSpec;
   store: ChannelStore;
+  /** Session send surface for tx panels (teleop); optional so rx-only
+   * panels and their tests need not care. */
+  teleop?: TeleopHooks;
 }
 
 const registry = new Map<string, ComponentType<PanelProps>>();
@@ -43,3 +48,4 @@ export function UnknownPanel({ spec }: PanelProps) {
 
 registerPanel("video", VideoPanel);
 registerPanel("map2d", MapPanel);
+registerPanel("teleop", TeleopPanel);

--- a/web/cockpit/src/panels/teleopMachine.test.ts
+++ b/web/cockpit/src/panels/teleopMachine.test.ts
@@ -1,0 +1,215 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Msg } from "@dimos/shared";
+import type { ChannelSpec } from "@dimos/shared/manifest";
+import {
+  TELEOP_DEFAULTS,
+  teleopConfigFromChannel,
+  TeleopMachine,
+  type TeleopSnapshot,
+} from "./teleopMachine.ts";
+
+interface Sent {
+  via: "control" | "datagram";
+  msg: Msg;
+}
+
+function makeMachine(config = TELEOP_DEFAULTS): { machine: TeleopMachine; sent: Sent[] } {
+  const sent: Sent[] = [];
+  const machine = new TeleopMachine(config, {
+    control: (msg) => sent.push({ via: "control", msg }),
+    datagram: (msg) => sent.push({ via: "datagram", msg }),
+  });
+  return { machine, sent };
+}
+
+function armed(): { machine: TeleopMachine; sent: Sent[] } {
+  const { machine, sent } = makeMachine();
+  machine.arm();
+  machine.onRelayMsg({ t: "teleop_started" });
+  sent.length = 0;
+  return { machine, sent };
+}
+
+function twists(sent: Sent[]): { vx: number; vy: number; wz: number; seq: number }[] {
+  return sent.flatMap(({ msg }) => (msg.t === "twist" ? [msg] : []));
+}
+
+function snap(machine: TeleopMachine): TeleopSnapshot {
+  return machine.getSnapshot();
+}
+
+describe("TeleopMachine", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("arms only after the relay grants the lease", () => {
+    const { machine, sent } = makeMachine();
+    machine.arm();
+    expect(sent).toEqual([{ via: "control", msg: { t: "teleop_start" } }]);
+    expect(snap(machine).phase).toBe("arming");
+    machine.keyDown("KeyW");
+    expect(twists(sent)).toHaveLength(0); // not armed yet: nothing drives
+    machine.onRelayMsg({ t: "teleop_started" });
+    expect(snap(machine).phase).toBe("armed");
+  });
+
+  it("a refused lease disarms with the reason and sends nothing", () => {
+    const { machine, sent } = makeMachine();
+    machine.arm();
+    machine.onRelayMsg({ t: "error", code: "teleop_held", message: "held" });
+    expect(snap(machine).phase).toBe("disarmed");
+    expect(snap(machine).reason).toBe("teleop held by another viewer");
+    expect(sent).toHaveLength(1); // only the teleop_start
+  });
+
+  it("streams twists at publishHz while a motion key is held", () => {
+    const { machine, sent } = armed();
+    machine.keyDown("KeyW");
+    expect(twists(sent)).toHaveLength(1); // immediate send on the edge
+    vi.advanceTimersByTime(1000);
+    const stream = twists(sent);
+    // 1 edge send + ~15 interval ticks (exact count is timer float rounding).
+    expect(stream.length).toBeGreaterThanOrEqual(15);
+    expect(stream.length).toBeLessThanOrEqual(17);
+    for (const t of stream) {
+      expect(t).toMatchObject({ vx: TELEOP_DEFAULTS.maxLinear, vy: 0, wz: 0 });
+    }
+    const seqs = stream.map((t) => t.seq);
+    expect(seqs).toEqual([...seqs].sort((a, b) => a - b));
+    expect(new Set(seqs).size).toBe(seqs.length); // strictly increasing
+  });
+
+  it("applies the pygame key map with assignment semantics", () => {
+    const { machine, sent } = armed();
+    // S wins over W, E over Q, D over A (checked in that order).
+    for (const code of ["KeyW", "KeyS", "KeyQ", "KeyE", "KeyA", "KeyD"]) machine.keyDown(code);
+    const last = twists(sent).at(-1);
+    expect(last).toMatchObject({
+      vx: -TELEOP_DEFAULTS.maxLinear,
+      vy: -TELEOP_DEFAULTS.maxLinear,
+      wz: -TELEOP_DEFAULTS.maxAngular,
+    });
+  });
+
+  it("Shift boosts and its release drops back", () => {
+    const { machine, sent } = armed();
+    machine.keyDown("KeyW");
+    machine.keyDown("ShiftLeft");
+    expect(twists(sent).at(-1)?.vx).toBe(TELEOP_DEFAULTS.maxLinear * TELEOP_DEFAULTS.boost);
+    expect(snap(machine).boosted).toBe(true);
+    machine.keyUp("ShiftLeft");
+    expect(twists(sent).at(-1)?.vx).toBe(TELEOP_DEFAULTS.maxLinear);
+  });
+
+  it("the last release sends zero now plus two repeats, then goes silent", () => {
+    const { machine, sent } = armed();
+    machine.keyDown("KeyW");
+    machine.keyUp("KeyW");
+    const zeros = () => twists(sent).filter((t) => t.vx === 0 && t.vy === 0 && t.wz === 0);
+    expect(zeros()).toHaveLength(1);
+    vi.advanceTimersByTime(100);
+    expect(zeros()).toHaveLength(2);
+    vi.advanceTimersByTime(100);
+    expect(zeros()).toHaveLength(3);
+    const total = sent.length;
+    vi.advanceTimersByTime(2000);
+    expect(sent.length).toBe(total); // silence after the burst
+  });
+
+  it("a keydown during the release burst cancels it and resumes streaming", () => {
+    const { machine, sent } = armed();
+    machine.keyDown("KeyW");
+    machine.keyUp("KeyW");
+    vi.advanceTimersByTime(50);
+    machine.keyDown("KeyW");
+    sent.length = 0;
+    vi.advanceTimersByTime(300);
+    expect(twists(sent).every((t) => t.vx === TELEOP_DEFAULTS.maxLinear)).toBe(true);
+  });
+
+  it("Space clears keys, bursts stops on both paths, and stays armed", () => {
+    const { machine, sent } = armed();
+    machine.keyDown("KeyW");
+    machine.keyDown("ShiftLeft");
+    sent.length = 0;
+    machine.estop();
+    expect(sent.filter((s) => s.via === "control" && s.msg.t === "stop")).toHaveLength(1);
+    const stops = () => sent.filter((s) => s.via === "datagram" && s.msg.t === "stop");
+    expect(stops()).toHaveLength(1);
+    vi.advanceTimersByTime(200);
+    expect(stops()).toHaveLength(3);
+    expect(snap(machine).phase).toBe("armed");
+    expect(snap(machine).pressed.size).toBe(0);
+    const total = sent.length;
+    vi.advanceTimersByTime(1000);
+    expect(sent.length).toBe(total); // the drive interval died with the keys
+  });
+
+  it("every disarm trigger zeroes once and releases the lease", () => {
+    for (const reason of ["escape", "focus lost", "window blurred", "tab hidden", "unmounted"]) {
+      const { machine, sent } = armed();
+      machine.keyDown("KeyW");
+      sent.length = 0;
+      machine.disarm(reason);
+      expect(twists(sent)).toEqual([
+        { t: "twist", vx: 0, vy: 0, wz: 0, seq: expect.any(Number), ts: expect.any(Number) },
+      ]);
+      expect(sent.filter((s) => s.msg.t === "teleop_stop")).toHaveLength(1);
+      expect(snap(machine)).toMatchObject({ phase: "disarmed", reason });
+      const total = sent.length;
+      vi.advanceTimersByTime(2000);
+      expect(sent.length).toBe(total); // all timers stopped
+    }
+  });
+
+  it("connection loss disarms locally without wire sends", () => {
+    const { machine, sent } = armed();
+    machine.keyDown("KeyW");
+    sent.length = 0;
+    machine.connectionChanged(false);
+    expect(sent).toHaveLength(0);
+    expect(snap(machine)).toMatchObject({ phase: "disarmed", reason: "connection lost" });
+    vi.advanceTimersByTime(2000);
+    expect(sent).toHaveLength(0);
+  });
+
+  it("never sends while disarmed", () => {
+    const { machine, sent } = makeMachine();
+    machine.keyDown("KeyW");
+    machine.keyUp("KeyW");
+    machine.estop();
+    machine.disarm("noop");
+    vi.advanceTimersByTime(1000);
+    expect(sent).toHaveLength(0);
+  });
+});
+
+describe("teleopConfigFromChannel", () => {
+  const base: ChannelSpec = {
+    ch: "tele_cmd_vel",
+    dir: "tx",
+    encoding: "twist.json.v1",
+    delivery: "latest",
+    maxHz: 10,
+    params: { maxLinear: 0.5, maxAngular: 0.9, boost: 3 },
+  };
+
+  it("reads params and maxHz from the channel spec", () => {
+    expect(teleopConfigFromChannel(base)).toEqual({
+      maxLinear: 0.5,
+      maxAngular: 0.9,
+      boost: 3,
+      publishHz: 10,
+    });
+  });
+
+  it("falls back per-field on junk (params crossed the wire)", () => {
+    const junk = {
+      ...base,
+      maxHz: -1,
+      params: { maxLinear: "fast", maxAngular: NaN, boost: 0 },
+    };
+    expect(teleopConfigFromChannel(junk)).toEqual(TELEOP_DEFAULTS);
+    expect(teleopConfigFromChannel(undefined)).toEqual(TELEOP_DEFAULTS);
+  });
+});

--- a/web/cockpit/src/panels/teleopMachine.ts
+++ b/web/cockpit/src/panels/teleopMachine.ts
@@ -1,0 +1,268 @@
+// Teleop state machine: pure TS, no React, no DOM listeners. The panel feeds
+// it key/focus events; it owns the lease handshake, the publish cadence, and
+// the zeroing rules, and reports state through a tiny external-store surface.
+//
+// Key semantics copied from the pygame module
+// (dimos/robot/unitree/keyboard_teleop.py): W/S = +-linear.x, Q/E =
+// +-linear.y (strafe), A/D = +-angular.z, assignment not accumulation (S
+// wins over W, E over Q, D over A), Shift held = boost, Space = e-stop that
+// clears held keys but keeps running (here: stays armed). No slow modifier
+// (Ctrl+W/Ctrl+Q are browser-reserved and would close the tab mid-drive).
+//
+// Safety shape (hop 1 of the chain; the relay lease and the bridge deadman
+// are hops 2 and 3): twists repeat at publishHz while a motion key is held;
+// the last release sends a zero immediately plus two repeats, then goes
+// silent; every disarm sends one zero plus teleop_stop (the relay and
+// bridge cover the lossy rest); Space bursts stop datagrams and puts one
+// Stop on the ordered control stream.
+
+import type { Msg } from "@dimos/shared";
+import type { ChannelSpec } from "@dimos/shared/manifest";
+import type { StatusStore } from "../session/store.ts";
+
+/** The session's teleop surface handed to panels (registry PanelProps). */
+export interface TeleopHooks {
+  /** Send on the ordered control stream (teleop_start/teleop_stop, Stop). */
+  control(msg: Msg): void;
+  /** Fire-and-forget datagram (twist/stop at publish rate). */
+  datagram(msg: Msg): void;
+  /** Teleop-routed relay replies: teleop_started and the teleop_held error. */
+  onMsg(cb: (msg: Msg) => void): () => void;
+  status: StatusStore;
+}
+
+export interface TeleopConfig {
+  maxLinear: number;
+  maxAngular: number;
+  boost: number;
+  publishHz: number;
+}
+
+export const TELEOP_DEFAULTS: TeleopConfig = {
+  maxLinear: 0.8,
+  maxAngular: 1.0,
+  boost: 2.0,
+  publishHz: 15,
+};
+
+function finitePositive(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+/** Config from the manifest tx channel: params for speeds, maxHz for the
+ * cadence. Params crossed the wire, so junk falls back per-field. */
+export function teleopConfigFromChannel(spec: ChannelSpec | undefined): TeleopConfig {
+  const params = spec?.params ?? {};
+  return {
+    maxLinear: finitePositive(params.maxLinear, TELEOP_DEFAULTS.maxLinear),
+    maxAngular: finitePositive(params.maxAngular, TELEOP_DEFAULTS.maxAngular),
+    boost: finitePositive(params.boost, TELEOP_DEFAULTS.boost),
+    publishHz: finitePositive(spec?.maxHz, TELEOP_DEFAULTS.publishHz),
+  };
+}
+
+const MOTION_CODES = new Set(["KeyW", "KeyA", "KeyS", "KeyD", "KeyQ", "KeyE"]);
+const BOOST_CODES = new Set(["ShiftLeft", "ShiftRight"]);
+/** Codes the panel intercepts (preventDefault) while it has focus. */
+export const HANDLED_CODES = new Set([...MOTION_CODES, ...BOOST_CODES, "Space", "Escape"]);
+
+/** Release/e-stop burst schedule: send now, repeat twice over 200 ms. */
+const BURST_DELAYS_MS = [100, 200];
+
+export type TeleopPhase = "disarmed" | "arming" | "armed";
+
+export interface TeleopSnapshot {
+  phase: TeleopPhase;
+  /** Why the machine is disarmed (shown by the panel), or null. */
+  reason: string | null;
+  pressed: ReadonlySet<string>;
+  vx: number;
+  vy: number;
+  wz: number;
+  boosted: boolean;
+}
+
+export class TeleopMachine {
+  readonly config: TeleopConfig;
+  #send: Pick<TeleopHooks, "control" | "datagram">;
+  #phase: TeleopPhase = "disarmed";
+  #reason: string | null = null;
+  #pressed = new Set<string>();
+  #seq = 0;
+  #command = { vx: 0, vy: 0, wz: 0, boosted: false };
+  #interval: ReturnType<typeof setInterval> | null = null;
+  #burstTimers: ReturnType<typeof setTimeout>[] = [];
+  #listeners = new Set<() => void>();
+  #snapshot: TeleopSnapshot;
+
+  constructor(config: TeleopConfig, send: Pick<TeleopHooks, "control" | "datagram">) {
+    this.config = config;
+    this.#send = send;
+    this.#snapshot = this.#buildSnapshot();
+  }
+
+  subscribe = (cb: () => void): () => void => {
+    this.#listeners.add(cb);
+    return () => this.#listeners.delete(cb);
+  };
+
+  getSnapshot = (): TeleopSnapshot => this.#snapshot;
+
+  /** Request the lease; ARMED only once the relay acks with teleop_started. */
+  arm(): void {
+    if (this.#phase !== "disarmed") return;
+    this.#phase = "arming";
+    this.#reason = null;
+    this.#send.control({ t: "teleop_start" });
+    this.#emit();
+  }
+
+  onRelayMsg(msg: Msg): void {
+    if (msg.t === "teleop_started") {
+      if (this.#phase === "arming") {
+        this.#phase = "armed";
+        this.#emit();
+      }
+    } else if (msg.t === "error" && msg.code === "teleop_held") {
+      // Refused: another viewer holds the lease. Local-only teardown (there
+      // is nothing of ours to zero or release).
+      this.#stopTimers();
+      this.#pressed.clear();
+      this.#phase = "disarmed";
+      this.#reason = "teleop held by another viewer";
+      this.#emit();
+    }
+  }
+
+  /** Zero, release the lease, and go idle. Every disarm trigger (Esc, focus
+   * loss, blur, hidden tab, unmount) funnels here. */
+  disarm(reason: string): void {
+    if (this.#phase === "disarmed") return;
+    const wasArmed = this.#phase === "armed";
+    this.#stopTimers();
+    this.#pressed.clear();
+    this.#phase = "disarmed";
+    this.#reason = reason;
+    if (wasArmed) {
+      // One immediate zero; the repeats would race the lease release below
+      // and be gated at the relay. The relay's robot-ward teleop_stop and
+      // the bridge deadman cover a lost datagram.
+      this.#sendTwist(0, 0, 0);
+    }
+    this.#send.control({ t: "teleop_stop" });
+    this.#emit();
+  }
+
+  /** Transport phase edges; disconnect disarms without wire sends. */
+  connectionChanged(connected: boolean): void {
+    if (connected || this.#phase === "disarmed") return;
+    this.#stopTimers();
+    this.#pressed.clear();
+    this.#phase = "disarmed";
+    this.#reason = "connection lost";
+    this.#emit();
+  }
+
+  /** Space: clear all held keys and burst stops. Stays armed, like the
+   * pygame module keeps running after its e-stop. */
+  estop(): void {
+    if (this.#phase !== "armed") return;
+    this.#stopTimers();
+    this.#pressed.clear();
+    this.#send.control({ t: "stop", seq: ++this.#seq, ts: Date.now() / 1000 });
+    this.#sendStop();
+    this.#burstTimers = BURST_DELAYS_MS.map((ms) => setTimeout(() => this.#sendStop(), ms));
+    this.#emit();
+  }
+
+  keyDown(code: string): void {
+    if (!MOTION_CODES.has(code) && !BOOST_CODES.has(code)) return;
+    if (this.#phase !== "armed") return;
+    this.#pressed.add(code);
+    if (this.#anyMotionHeld()) {
+      this.#cancelBurst();
+      this.#sendCurrent();
+      this.#interval ??= setInterval(() => this.#sendCurrent(), 1000 / this.config.publishHz);
+    }
+    this.#emit();
+  }
+
+  keyUp(code: string): void {
+    if (!this.#pressed.delete(code)) return;
+    if (this.#phase === "armed" && this.#anyMotionHeld()) {
+      this.#sendCurrent();
+    } else if (this.#phase === "armed" && this.#interval !== null) {
+      // Last motion key released: zero now plus two repeats, then silence.
+      this.#stopInterval();
+      this.#sendTwist(0, 0, 0);
+      this.#burstTimers = BURST_DELAYS_MS.map((ms) =>
+        setTimeout(() => this.#sendTwist(0, 0, 0), ms)
+      );
+    }
+    this.#emit();
+  }
+
+  #anyMotionHeld(): boolean {
+    for (const code of this.#pressed) if (MOTION_CODES.has(code)) return true;
+    return false;
+  }
+
+  #sendCurrent(): void {
+    const held = this.#pressed;
+    let vx = 0;
+    let vy = 0;
+    let wz = 0;
+    if (held.has("KeyW")) vx = this.config.maxLinear;
+    if (held.has("KeyS")) vx = -this.config.maxLinear;
+    if (held.has("KeyQ")) vy = this.config.maxLinear;
+    if (held.has("KeyE")) vy = -this.config.maxLinear;
+    if (held.has("KeyA")) wz = this.config.maxAngular;
+    if (held.has("KeyD")) wz = -this.config.maxAngular;
+    const boosted = held.has("ShiftLeft") || held.has("ShiftRight");
+    const k = boosted ? this.config.boost : 1;
+    this.#sendTwist(vx * k, vy * k, wz * k, boosted);
+  }
+
+  #sendTwist(vx: number, vy: number, wz: number, boosted = false): void {
+    this.#command = { vx, vy, wz, boosted };
+    this.#send.datagram({ t: "twist", vx, vy, wz, seq: ++this.#seq, ts: Date.now() / 1000 });
+    this.#emit();
+  }
+
+  #sendStop(): void {
+    this.#command = { vx: 0, vy: 0, wz: 0, boosted: false };
+    this.#send.datagram({ t: "stop", seq: ++this.#seq, ts: Date.now() / 1000 });
+    this.#emit();
+  }
+
+  #stopInterval(): void {
+    if (this.#interval !== null) {
+      clearInterval(this.#interval);
+      this.#interval = null;
+    }
+  }
+
+  #cancelBurst(): void {
+    for (const timer of this.#burstTimers) clearTimeout(timer);
+    this.#burstTimers = [];
+  }
+
+  #stopTimers(): void {
+    this.#stopInterval();
+    this.#cancelBurst();
+  }
+
+  #buildSnapshot(): TeleopSnapshot {
+    return {
+      phase: this.#phase,
+      reason: this.#reason,
+      pressed: new Set(this.#pressed),
+      ...this.#command,
+    };
+  }
+
+  #emit(): void {
+    this.#snapshot = this.#buildSnapshot();
+    for (const cb of this.#listeners) cb();
+  }
+}

--- a/web/cockpit/src/session/session.test.ts
+++ b/web/cockpit/src/session/session.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   type ChannelSpec,
   ControlFrameReader,
+  decodeDatagram,
   encodeControlFrame,
   encodeDataFrame,
   type Msg,
@@ -180,6 +181,8 @@ const ROBOT_B: RobotInfo = { id: "b", name: "B", model: "go2" };
 
 class FakeRelayEnd {
   readonly sent: Msg[] = [];
+  /** Decoded datagrams the viewer sent (the teleop twist path). */
+  readonly sentDatagrams: Msg[] = [];
   /** Awaited per decoded viewer message: lets a test react at the exact
    * moment a message is observed while holding the session's control writer
    * (e.g. to land a data frame mid-sub-loop). */
@@ -217,6 +220,14 @@ class FakeRelayEnd {
           this.#uni = c;
         },
       }),
+      datagrams: {
+        writable: new WritableStream<Uint8Array>({
+          write: (chunk) => {
+            const msg = decodeDatagram(chunk);
+            if (msg !== null) this.sentDatagrams.push(msg);
+          },
+        }),
+      },
     };
   }
 
@@ -633,5 +644,42 @@ describe("Session over a fake WebTransport", () => {
     await until(() => relay.watches("b") === 1, "watch B");
     relay.pushManifest("b", manifest([spec({ ch: "status" })]));
     await until(() => adopted(handle)[0]?.ch === "status", "manifest B");
+  });
+
+  it("teleop control rides the control stream and twists ride datagrams", async () => {
+    const { relay, handle } = start();
+    await goLive(relay, handle);
+    handle.teleop.control({ t: "teleop_start" });
+    await until(() => relay.sent.some((m) => m.t === "teleop_start"), "teleop_start");
+    const twist: Msg = { t: "twist", vx: 0.5, vy: 0.25, wz: -0.25, seq: 1, ts: 1.5 };
+    handle.teleop.datagram(twist);
+    await until(() => relay.sentDatagrams.length === 1, "twist datagram");
+    expect(relay.sentDatagrams[0]).toEqual(twist);
+    expect(relay.sent.some((m) => m.t === "twist")).toBe(false); // not on the stream
+  });
+
+  it("routes teleop_started and teleop_held to the facade, not lastError", async () => {
+    const { relay, handle } = start();
+    await goLive(relay, handle);
+    const received: Msg[] = [];
+    const unsubscribe = handle.teleop.onMsg((msg) => received.push(msg));
+    relay.push({ t: "teleop_started" });
+    await until(() => received.length === 1, "teleop_started routed");
+    relay.push({ t: "error", code: "teleop_held", message: "held by viewer 1" });
+    await until(() => received.length === 2, "teleop_held routed");
+    expect(received.map((m) => m.t)).toEqual(["teleop_started", "error"]);
+    expect(handle.status.get().lastError).toBeNull();
+    unsubscribe();
+    relay.push({ t: "teleop_started" });
+    await settle();
+    expect(received).toHaveLength(2);
+  });
+
+  it("other error codes still land in lastError", async () => {
+    const { relay, handle } = start();
+    await goLive(relay, handle);
+    relay.push({ t: "error", code: "unknown_channel", message: "no channel x" });
+    await until(() => handle.status.get().lastError !== null, "lastError");
+    expect(handle.status.get().lastError).toContain("unknown_channel");
   });
 });

--- a/web/cockpit/src/session/session.ts
+++ b/web/cockpit/src/session/session.ts
@@ -9,6 +9,7 @@ import {
   DataFrameStreamError,
   DataFrameStreamReader,
   encodeControlFrame,
+  encodeDatagram,
   type Msg,
   type PanelSpec,
   PROTOCOL_VERSION,
@@ -16,6 +17,7 @@ import {
 } from "@dimos/shared";
 import { type Manifest, ManifestError, parseManifest } from "@dimos/shared/manifest";
 import { getPanel } from "../panels/registry.tsx";
+import type { TeleopHooks } from "../panels/teleopMachine.ts";
 import { getDecoder } from "./decoders/index.ts";
 import { ChannelStore, StatusStore } from "./store.ts";
 import { ReconnectingTransport, type TransportDeps, type WebTransportLike } from "./transport.ts";
@@ -25,6 +27,7 @@ const UI_TICK_MS = 500;
 export interface SessionHandle {
   status: StatusStore;
   channels: ChannelStore;
+  teleop: TeleopHooks;
   stop(): void;
 }
 
@@ -147,6 +150,22 @@ class Session {
   #manifest: Manifest | null = null;
   #ticker: ReturnType<typeof setInterval>;
 
+  // Per-connection teleop senders, swapped in #runSession. Fire-and-forget:
+  // a send racing a reconnect lands on the dead connection and is dropped
+  // (the machine repeats at publishHz and the bridge deadman covers loss).
+  #teleopControl: ((msg: Msg) => void) | null = null;
+  #teleopDatagram: ((msg: Msg) => void) | null = null;
+  #teleopCbs = new Set<(msg: Msg) => void>();
+  readonly teleop: TeleopHooks = {
+    control: (msg) => this.#teleopControl?.(msg),
+    datagram: (msg) => this.#teleopDatagram?.(msg),
+    onMsg: (cb) => {
+      this.#teleopCbs.add(cb);
+      return () => this.#teleopCbs.delete(cb);
+    },
+    status: this.status,
+  };
+
   constructor(transportDeps: TransportDeps = {}) {
     this.transport = new ReconnectingTransport(
       {
@@ -169,6 +188,13 @@ class Session {
     const writer = control.writable.getWriter();
     const send = async (msg: Msg) => {
       await writer.write(encodeControlFrame(msg));
+    };
+    const datagrams = wt.datagrams.writable.getWriter();
+    this.#teleopControl = (msg) => {
+      if (runId === this.#runId) void send(msg).catch(() => {});
+    };
+    this.#teleopDatagram = (msg) => {
+      if (runId === this.#runId) void datagrams.write(encodeDatagram(msg)).catch(() => {});
     };
     await send({ t: "hello", v: PROTOCOL_VERSION, role: "viewer" });
     void this.#readUniStreams(wt, runId);
@@ -239,9 +265,16 @@ class Session {
               }
               break;
             }
+            case "teleop_started":
+              for (const cb of this.#teleopCbs) cb(msg);
+              break;
             case "error": {
               if (msg.code === "version_mismatch") {
                 this.transport.fail(msg.message);
+              } else if (msg.code === "teleop_held") {
+                // A refused lease is the teleop panel's state, not a
+                // session-level error banner.
+                for (const cb of this.#teleopCbs) cb(msg);
               } else {
                 this.status.update({ lastError: `${msg.code}: ${msg.message}` });
               }
@@ -359,6 +392,7 @@ export function startSession(transportDeps: TransportDeps = {}): SessionHandle {
   return {
     status: session.status,
     channels: session.channels,
+    teleop: session.teleop,
     stop: () => session.stop(),
   };
 }

--- a/web/cockpit/src/session/transport.test.ts
+++ b/web/cockpit/src/session/transport.test.ts
@@ -36,6 +36,7 @@ function makeFakeWt({ readyFails = false, readyHangs = false } = {}): FakeWt {
     close: vi.fn(),
     createBidirectionalStream: () => Promise.reject(new Error("not used in transport tests")),
     incomingUnidirectionalStreams: new ReadableStream(),
+    datagrams: { writable: new WritableStream() },
     resolveClosed,
     rejectClosed,
   };

--- a/web/cockpit/src/session/transport.ts
+++ b/web/cockpit/src/session/transport.ts
@@ -35,6 +35,9 @@ export interface WebTransportLike {
   close(): void;
   createBidirectionalStream(): Promise<BidiStreamLike>;
   incomingUnidirectionalStreams: ReadableStream<ReadableStream<Uint8Array>>;
+  // Writable only: teleop twists ride datagrams viewer->relay; everything
+  // the relay sends a browser viewer rides the control stream.
+  datagrams: { writable: WritableStream<Uint8Array> };
 }
 
 export interface TransportEvents {

--- a/web/relay/registry.ts
+++ b/web/relay/registry.ts
@@ -80,6 +80,14 @@ interface RobotEntry {
   peer: RobotPeer;
   /** Manifest delivery per channel; frame-header delivery is the fallback. */
   delivery: Map<string, Delivery>;
+  /** Viewer holding the exclusive teleop lease, or null. Dies with the
+   * entry: a re-registered robot starts lease-free. */
+  teleop: ViewerPeer | null;
+  /** Lease generation, bumped on every fresh grant and stamped into
+   * robot-bound teleop messages so the bridge can permanently void a
+   * released lease's in-flight datagrams. Dies with the entry (safe: the
+   * bridge resets its floor with the session). */
+  teleopGen: number;
   /** Snapshot counter, monotonic for this robot session's registration. */
   n: number;
   /** Last snapshot content, for change detection and periodic resend. */
@@ -97,6 +105,8 @@ export class Registry {
   #viewers = new Set<ViewerPeer>();
   #framesDropped = 0;
   #framesFromUnregistered = 0;
+  #teleopForwarded = 0;
+  #teleopDropped = 0;
 
   addViewer(viewer: ViewerPeer): void {
     this.#viewers.add(viewer);
@@ -105,7 +115,10 @@ export class Registry {
   viewerClosed(viewer: ViewerPeer): void {
     if (!this.#viewers.delete(viewer)) return;
     disposePolicies(viewer);
-    if (viewer.watched !== null) this.#syncSubs(viewer.watched);
+    if (viewer.watched !== null) {
+      this.#releaseTeleop(viewer.watched, viewer);
+      this.#syncSubs(viewer.watched);
+    }
   }
 
   /**
@@ -126,6 +139,8 @@ export class Registry {
     this.#robots.set(info.id, {
       peer,
       delivery,
+      teleop: null,
+      teleopGen: 0,
       n: 0,
       lastChs: [],
       channelsIn: new Map(),
@@ -198,6 +213,7 @@ export class Registry {
         if (previous !== null && previous !== msg.robotId) {
           viewer.subs.clear();
           disposePolicies(viewer);
+          this.#releaseTeleop(previous, viewer);
         }
         viewer.watched = msg.robotId;
         if (previous !== null && previous !== msg.robotId) this.#syncSubs(previous);
@@ -244,8 +260,76 @@ export class Registry {
         this.#syncSubs(viewer.watched);
         break;
       }
+      case "teleop_start": {
+        if (viewer.watched === null) {
+          reply({ t: "error", code: "no_watch", message: "watch a robot before teleop_start" });
+          break;
+        }
+        const entry = this.#robots.get(viewer.watched);
+        if (entry === undefined) {
+          reply({ t: "error", code: "unknown_robot", message: `no robot ${viewer.watched}` });
+          break;
+        }
+        if (entry.teleop !== null && entry.teleop !== viewer) {
+          reply({
+            t: "error",
+            code: "teleop_held",
+            message: `robot ${viewer.watched} teleop is held by another viewer`,
+          });
+          break;
+        }
+        if (entry.teleop === null) {
+          entry.teleop = viewer;
+          entry.teleopGen++;
+          console.log(
+            `[relay] robot ${viewer.watched} teleop lease -> viewer ${viewer.id} ` +
+              `(gen ${entry.teleopGen})`,
+          );
+        }
+        // Resent on an idempotent re-arm to heal datagram loss, like the
+        // re-acked teleop_started; the bridge ignores duplicates.
+        entry.peer.sendMsg({ t: "teleop_start", gen: entry.teleopGen });
+        reply({ t: "teleop_started" });
+        break;
+      }
+      case "teleop_stop": {
+        // Idempotent release; no ack (disarm is local to the cockpit and the
+        // bridge watchdog covers a lost robot-ward teleop_stop).
+        if (viewer.watched !== null) this.#releaseTeleop(viewer.watched, viewer);
+        break;
+      }
+      case "twist":
+      case "stop": {
+        // Lease-gated, silent on drop: gating runs at twist rate on lossy
+        // datagrams, and the arm handshake (teleop_start) is where a viewer
+        // learns it lacks the lease.
+        const entry = viewer.watched === null ? undefined : this.#robots.get(viewer.watched);
+        if (entry === undefined || entry.teleop !== viewer) {
+          this.#teleopDropped++;
+          break;
+        }
+        // The spread puts the relay's stamp last: a viewer-supplied gen is
+        // overridden, the relay is the only generation authority.
+        entry.peer.sendMsg({ ...msg, gen: entry.teleopGen });
+        this.#teleopForwarded++;
+        break;
+      }
     }
     return true;
+  }
+
+  /** Release `viewer`'s teleop lease on `robotId`, if held: the bridge gets
+   * a gen-stamped teleop_stop that permanently voids this lease's datagrams
+   * (its deadman watchdog covers a lost stop) and the next teleop_start
+   * wins the lease. */
+  #releaseTeleop(robotId: string, viewer: ViewerPeer): void {
+    const entry = this.#robots.get(robotId);
+    if (entry === undefined || entry.teleop !== viewer) return;
+    entry.teleop = null;
+    // At release time teleopGen still names the released lease (it bumps
+    // only on grant).
+    entry.peer.sendMsg({ t: "teleop_stop", gen: entry.teleopGen });
+    console.log(`[relay] robot ${robotId} teleop lease released (viewer ${viewer.id})`);
   }
 
   /**
@@ -342,9 +426,12 @@ export class Registry {
       viewers: this.#viewers.size,
       framesDropped: this.#framesDropped,
       framesFromUnregistered: this.#framesFromUnregistered,
+      teleopForwarded: this.#teleopForwarded,
+      teleopDropped: this.#teleopDropped,
       perRobot: Object.fromEntries(
         [...this.#robots].map(([id, e]) => [id, {
           subs: e.lastChs,
+          teleop: e.teleop?.id ?? null,
           channels: Object.fromEntries(
             [...e.channelsIn].map(([ch, s]) => [ch, {
               delivery: s.delivery,

--- a/web/relay/registry_test.ts
+++ b/web/relay/registry_test.ts
@@ -535,7 +535,7 @@ Deno.test("stats project exact per-channel key sets with counters and rates", as
     }>;
     perViewer: { channels: Record<string, Record<string, unknown>> }[];
   };
-  assertEquals(Object.keys(stats.perRobot.r1).sort(), ["channels", "subs", "undeclared"]);
+  assertEquals(Object.keys(stats.perRobot.r1).sort(), ["channels", "subs", "teleop", "undeclared"]);
   const inKeys = Object.keys(stats.perRobot.r1.channels.color_image).sort();
   assertEquals(inKeys, ["bps", "bytesIn", "delivery", "fps", "framesIn"]);
   // Declared-only traffic leaves the aggregate bucket zeroed.
@@ -591,4 +591,196 @@ Deno.test("undeclared channel frames aggregate into one per-robot bucket", async
   stats = reg.stats() as typeof stats;
   assertEquals(stats.perRobot.r2.channels, {});
   assertEquals(stats.perRobot.r2.undeclared.framesIn, 1);
+});
+
+// --- Teleop lease ---
+
+const TWIST: Msg = { t: "twist", vx: 0.5, vy: 0.25, wz: -0.25, seq: 1, ts: 1.5 };
+
+function teleopMsgs(robot: FakeRobot): Msg[] {
+  return robot.msgs.filter((m) =>
+    m.t === "twist" || m.t === "stop" || m.t === "teleop_start" || m.t === "teleop_stop"
+  );
+}
+
+Deno.test("teleop_start grants the lease and acks; re-start by the holder is idempotent", () => {
+  const reg = new Registry();
+  const robot = new FakeRobot("r1", SPECS);
+  reg.registerRobot(robot);
+  const viewer = attach(reg, "r1", []);
+  assert(send(reg, viewer, { t: "teleop_start" }));
+  assertEquals(viewer.replies.at(-1), { t: "teleop_started" });
+  assert(send(reg, viewer, { t: "teleop_start" }));
+  assertEquals(viewer.replies.at(-1), { t: "teleop_started" });
+  // The robot-bound announcement is resent with the SAME gen (no bump): a
+  // re-arm heals a lost start datagram without voiding the holder's twists.
+  assertEquals(teleopMsgs(robot), [
+    { t: "teleop_start", gen: 1 },
+    { t: "teleop_start", gen: 1 },
+  ]);
+});
+
+Deno.test("teleop_start while held replies teleop_held without closing", () => {
+  const reg = new Registry();
+  const robot = new FakeRobot("r1", SPECS);
+  reg.registerRobot(robot);
+  const holder = attach(reg, "r1", []);
+  send(reg, holder, { t: "teleop_start" });
+  const second = attach(reg, "r1", []);
+  assert(send(reg, second, { t: "teleop_start" })); // non-fatal
+  const reply = second.replies.at(-1);
+  assert(reply !== undefined && reply.t === "error" && reply.code === "teleop_held");
+  // The holder keeps driving; the loser stays gated.
+  send(reg, holder, TWIST);
+  send(reg, second, TWIST);
+  assertEquals(teleopMsgs(robot), [{ t: "teleop_start", gen: 1 }, { ...TWIST, gen: 1 }]);
+});
+
+Deno.test("teleop_start needs a watch and a live robot", () => {
+  const reg = new Registry();
+  const robot = new FakeRobot("r1", SPECS);
+  reg.registerRobot(robot);
+  const unwatched = new FakeViewer();
+  reg.addViewer(unwatched);
+  send(reg, unwatched, { t: "hello", v: PROTOCOL_VERSION, role: "viewer" });
+  assert(send(reg, unwatched, { t: "teleop_start" }));
+  let reply = unwatched.replies.at(-1);
+  assert(reply !== undefined && reply.t === "error" && reply.code === "no_watch");
+
+  const watcher = attach(reg, "r1", []);
+  reg.robotClosed(robot);
+  assert(send(reg, watcher, { t: "teleop_start" }));
+  reply = watcher.replies.at(-1);
+  assert(reply !== undefined && reply.t === "error" && reply.code === "unknown_robot");
+});
+
+Deno.test("twist and stop forward robot-ward only from the lease holder", () => {
+  const reg = new Registry();
+  const robot = new FakeRobot("r1", SPECS);
+  reg.registerRobot(robot);
+  const bystander = attach(reg, "r1", []);
+  send(reg, bystander, TWIST); // no lease at all yet
+  const holder = attach(reg, "r1", []);
+  send(reg, holder, { t: "teleop_start" });
+  send(reg, holder, TWIST);
+  send(reg, holder, { t: "stop", seq: 2, ts: 2.5 });
+  send(reg, bystander, TWIST);
+  assertEquals(teleopMsgs(robot), [
+    { t: "teleop_start", gen: 1 },
+    { ...TWIST, gen: 1 },
+    { t: "stop", seq: 2, ts: 2.5, gen: 1 },
+  ]);
+  const stats = reg.stats() as { teleopForwarded: number; teleopDropped: number };
+  assertEquals(stats.teleopForwarded, 2);
+  assertEquals(stats.teleopDropped, 2);
+});
+
+Deno.test("teleop_stop from the holder releases and forwards teleop_stop robot-ward", () => {
+  const reg = new Registry();
+  const robot = new FakeRobot("r1", SPECS);
+  reg.registerRobot(robot);
+  const holder = attach(reg, "r1", []);
+  send(reg, holder, { t: "teleop_start" });
+  send(reg, holder, { t: "teleop_stop" });
+  assertEquals(teleopMsgs(robot), [{ t: "teleop_start", gen: 1 }, { t: "teleop_stop", gen: 1 }]);
+  // Released: the ex-holder is gated again, and another viewer can take over.
+  send(reg, holder, TWIST);
+  assertEquals(teleopMsgs(robot), [{ t: "teleop_start", gen: 1 }, { t: "teleop_stop", gen: 1 }]);
+  const next = attach(reg, "r1", []);
+  send(reg, next, { t: "teleop_start" });
+  assertEquals(next.replies.at(-1), { t: "teleop_started" });
+});
+
+Deno.test("teleop_stop from a non-holder does not disturb the lease", () => {
+  const reg = new Registry();
+  const robot = new FakeRobot("r1", SPECS);
+  reg.registerRobot(robot);
+  const holder = attach(reg, "r1", []);
+  send(reg, holder, { t: "teleop_start" });
+  const other = attach(reg, "r1", []);
+  send(reg, other, { t: "teleop_stop" });
+  assertEquals(teleopMsgs(robot), [{ t: "teleop_start", gen: 1 }]); // no stop sent
+  send(reg, holder, TWIST);
+  assertEquals(teleopMsgs(robot), [{ t: "teleop_start", gen: 1 }, { ...TWIST, gen: 1 }]);
+});
+
+Deno.test("holder disconnect releases the lease and sends teleop_stop robot-ward", () => {
+  const reg = new Registry();
+  const robot = new FakeRobot("r1", SPECS);
+  reg.registerRobot(robot);
+  const holder = attach(reg, "r1", []);
+  send(reg, holder, { t: "teleop_start" });
+  reg.viewerClosed(holder);
+  assertEquals(teleopMsgs(robot), [{ t: "teleop_start", gen: 1 }, { t: "teleop_stop", gen: 1 }]);
+  const next = attach(reg, "r1", []);
+  send(reg, next, { t: "teleop_start" });
+  assertEquals(next.replies.at(-1), { t: "teleop_started" });
+});
+
+Deno.test("holder watch-switch releases the old robot's lease", () => {
+  const reg = new Registry();
+  const r1 = new FakeRobot("r1", SPECS);
+  const r2 = new FakeRobot("r2", SPECS);
+  reg.registerRobot(r1);
+  reg.registerRobot(r2);
+  const holder = attach(reg, "r1", []);
+  send(reg, holder, { t: "teleop_start" });
+  send(reg, holder, { t: "watch", robotId: "r2" });
+  assertEquals(teleopMsgs(r1), [{ t: "teleop_start", gen: 1 }, { t: "teleop_stop", gen: 1 }]);
+  // r2's lease was never granted: twists stay gated until teleop_start.
+  send(reg, holder, TWIST);
+  assertEquals(teleopMsgs(r2), []);
+});
+
+Deno.test("robot death drops the lease; a re-registered robot starts free", () => {
+  const reg = new Registry();
+  const robot = new FakeRobot("r1", SPECS);
+  reg.registerRobot(robot);
+  const holder = attach(reg, "r1", []);
+  send(reg, holder, { t: "teleop_start" });
+  reg.robotClosed(robot);
+  const reborn = new FakeRobot("r1", SPECS);
+  reg.registerRobot(reborn);
+  // The ex-holder's twists are dropped until it re-arms.
+  send(reg, holder, TWIST);
+  assertEquals(teleopMsgs(reborn), []);
+  send(reg, holder, { t: "teleop_start" });
+  assertEquals(holder.replies.at(-1), { t: "teleop_started" });
+  send(reg, holder, TWIST);
+  // The reborn entry restarts at gen 1: safe, because the bridge's floor
+  // reset with its session.
+  assertEquals(teleopMsgs(reborn), [{ t: "teleop_start", gen: 1 }, { ...TWIST, gen: 1 }]);
+});
+
+Deno.test("lease generations increment per grant and stamp robot-bound teleop", () => {
+  const reg = new Registry();
+  const robot = new FakeRobot("r1", SPECS);
+  reg.registerRobot(robot);
+  const first = attach(reg, "r1", []);
+  send(reg, first, { t: "teleop_start" });
+  // A viewer-supplied gen must lose to the relay's stamp.
+  send(reg, first, { ...TWIST, gen: 99 });
+  send(reg, first, { t: "teleop_stop" });
+  const second = attach(reg, "r1", []);
+  send(reg, second, { t: "teleop_start" });
+  send(reg, second, TWIST);
+  assertEquals(teleopMsgs(robot), [
+    { t: "teleop_start", gen: 1 },
+    { ...TWIST, gen: 1 },
+    { t: "teleop_stop", gen: 1 },
+    { t: "teleop_start", gen: 2 },
+    { ...TWIST, gen: 2 },
+  ]);
+});
+
+Deno.test("stats expose the lease holder", () => {
+  const reg = new Registry();
+  const robot = new FakeRobot("r1", SPECS);
+  reg.registerRobot(robot);
+  const holder = attach(reg, "r1", []);
+  let stats = reg.stats() as { perRobot: Record<string, { teleop: number | null }> };
+  assertEquals(stats.perRobot.r1.teleop, null);
+  send(reg, holder, { t: "teleop_start" });
+  stats = reg.stats() as typeof stats;
+  assertEquals(stats.perRobot.r1.teleop, holder.id);
 });

--- a/web/shared/fixtures/control_frames.json
+++ b/web/shared/fixtures/control_frames.json
@@ -4,7 +4,7 @@
       "name": "hello_robot",
       "message": {
         "t": "hello",
-        "v": 3,
+        "v": 4,
         "role": "robot",
         "robot": {
           "id": "go2-lab",
@@ -52,24 +52,24 @@
           "pages": []
         }
       },
-      "b64": "5wEAAHsidCI6ImhlbGxvIiwidiI6Mywicm9sZSI6InJvYm90Iiwicm9ib3QiOnsiaWQiOiJnbzItbGFiIiwibmFtZSI6IkdvMiBMYWJvcmF0b3IgzrIiLCJtb2RlbCI6InVuaXRyZWUtZ28yIn0sIm1hbmlmZXN0Ijp7InZlcnNpb24iOjEsImNoYW5uZWxzIjpbeyJjaCI6ImNvbG9yX2ltYWdlIiwiZGlyIjoicngiLCJlbmNvZGluZyI6ImpwZWcudjEiLCJkZWxpdmVyeSI6ImxhdGVzdCIsIm1heEh6IjoxNS41LCJwYXJhbXMiOnsicXVhbGl0eSI6NzUuNX19LHsiY2giOiJvZG9tIiwiZGlyIjoicngiLCJlbmNvZGluZyI6InBvc2UuanNvbi52MSIsImRlbGl2ZXJ5IjoicmVsaWFibGUiLCJtYXhIeiI6MjAuNSwicGFyYW1zIjp7fX1dLCJwYW5lbHMiOlt7ImlkIjoicDAiLCJraW5kIjoidmlkZW8iLCJ0aXRsZSI6IkNhbWVyYSDOsiIsImNoYW5uZWxzIjpbImNvbG9yX2ltYWdlIl0sInBhcmFtcyI6e319XSwibGF5b3V0Ijp7InJvdyI6WyJwMCJdfSwicGFnZXMiOltdfX0="
+      "b64": "5wEAAHsidCI6ImhlbGxvIiwidiI6NCwicm9sZSI6InJvYm90Iiwicm9ib3QiOnsiaWQiOiJnbzItbGFiIiwibmFtZSI6IkdvMiBMYWJvcmF0b3IgzrIiLCJtb2RlbCI6InVuaXRyZWUtZ28yIn0sIm1hbmlmZXN0Ijp7InZlcnNpb24iOjEsImNoYW5uZWxzIjpbeyJjaCI6ImNvbG9yX2ltYWdlIiwiZGlyIjoicngiLCJlbmNvZGluZyI6ImpwZWcudjEiLCJkZWxpdmVyeSI6ImxhdGVzdCIsIm1heEh6IjoxNS41LCJwYXJhbXMiOnsicXVhbGl0eSI6NzUuNX19LHsiY2giOiJvZG9tIiwiZGlyIjoicngiLCJlbmNvZGluZyI6InBvc2UuanNvbi52MSIsImRlbGl2ZXJ5IjoicmVsaWFibGUiLCJtYXhIeiI6MjAuNSwicGFyYW1zIjp7fX1dLCJwYW5lbHMiOlt7ImlkIjoicDAiLCJraW5kIjoidmlkZW8iLCJ0aXRsZSI6IkNhbWVyYSDOsiIsImNoYW5uZWxzIjpbImNvbG9yX2ltYWdlIl0sInBhcmFtcyI6e319XSwibGF5b3V0Ijp7InJvdyI6WyJwMCJdfSwicGFnZXMiOltdfX0="
     },
     {
       "name": "hello_viewer",
       "message": {
         "t": "hello",
-        "v": 3,
+        "v": 4,
         "role": "viewer"
       },
-      "b64": "IwAAAHsidCI6ImhlbGxvIiwidiI6Mywicm9sZSI6InZpZXdlciJ9"
+      "b64": "IwAAAHsidCI6ImhlbGxvIiwidiI6NCwicm9sZSI6InZpZXdlciJ9"
     },
     {
       "name": "welcome",
       "message": {
         "t": "welcome",
-        "v": 3
+        "v": 4
       },
-      "b64": "FQAAAHsidCI6IndlbGNvbWUiLCJ2IjozfQ=="
+      "b64": "FQAAAHsidCI6IndlbGNvbWUiLCJ2Ijo0fQ=="
     },
     {
       "name": "ping",
@@ -94,9 +94,9 @@
       "message": {
         "t": "error",
         "code": "version_mismatch",
-        "message": "protocol v3 required, versiune neacceptată"
+        "message": "protocol v4 required, versiune neacceptată"
       },
-      "b64": "XwAAAHsidCI6ImVycm9yIiwiY29kZSI6InZlcnNpb25fbWlzbWF0Y2giLCJtZXNzYWdlIjoicHJvdG9jb2wgdjMgcmVxdWlyZWQsIHZlcnNpdW5lIG5lYWNjZXB0YXTEgyJ9"
+      "b64": "XwAAAHsidCI6ImVycm9yIiwiY29kZSI6InZlcnNpb25fbWlzbWF0Y2giLCJtZXNzYWdlIjoicHJvdG9jb2wgdjQgcmVxdWlyZWQsIHZlcnNpdW5lIG5lYWNjZXB0YXTEgyJ9"
     },
     {
       "name": "robots_two",
@@ -207,6 +207,27 @@
         "n": 4
       },
       "b64": "GwAAAHsidCI6InN1YnMiLCJjaHMiOltdLCJuIjo0fQ=="
+    },
+    {
+      "name": "teleop_start",
+      "message": {
+        "t": "teleop_start"
+      },
+      "b64": "FAAAAHsidCI6InRlbGVvcF9zdGFydCJ9"
+    },
+    {
+      "name": "teleop_started",
+      "message": {
+        "t": "teleop_started"
+      },
+      "b64": "FgAAAHsidCI6InRlbGVvcF9zdGFydGVkIn0="
+    },
+    {
+      "name": "teleop_stop",
+      "message": {
+        "t": "teleop_stop"
+      },
+      "b64": "EwAAAHsidCI6InRlbGVvcF9zdG9wIn0="
     }
   ]
 }

--- a/web/shared/fixtures/datagrams.json
+++ b/web/shared/fixtures/datagrams.json
@@ -4,7 +4,7 @@
       "name": "hello_robot",
       "message": {
         "t": "hello",
-        "v": 3,
+        "v": 4,
         "role": "robot",
         "robot": {
           "id": "go2-lab",
@@ -52,24 +52,24 @@
           "pages": []
         }
       },
-      "b64": "eyJ0IjoiaGVsbG8iLCJ2IjozLCJyb2xlIjoicm9ib3QiLCJyb2JvdCI6eyJpZCI6ImdvMi1sYWIiLCJuYW1lIjoiR28yIExhYm9yYXRvciDOsiIsIm1vZGVsIjoidW5pdHJlZS1nbzIifSwibWFuaWZlc3QiOnsidmVyc2lvbiI6MSwiY2hhbm5lbHMiOlt7ImNoIjoiY29sb3JfaW1hZ2UiLCJkaXIiOiJyeCIsImVuY29kaW5nIjoianBlZy52MSIsImRlbGl2ZXJ5IjoibGF0ZXN0IiwibWF4SHoiOjE1LjUsInBhcmFtcyI6eyJxdWFsaXR5Ijo3NS41fX0seyJjaCI6Im9kb20iLCJkaXIiOiJyeCIsImVuY29kaW5nIjoicG9zZS5qc29uLnYxIiwiZGVsaXZlcnkiOiJyZWxpYWJsZSIsIm1heEh6IjoyMC41LCJwYXJhbXMiOnt9fV0sInBhbmVscyI6W3siaWQiOiJwMCIsImtpbmQiOiJ2aWRlbyIsInRpdGxlIjoiQ2FtZXJhIM6yIiwiY2hhbm5lbHMiOlsiY29sb3JfaW1hZ2UiXSwicGFyYW1zIjp7fX1dLCJsYXlvdXQiOnsicm93IjpbInAwIl19LCJwYWdlcyI6W119fQ=="
+      "b64": "eyJ0IjoiaGVsbG8iLCJ2Ijo0LCJyb2xlIjoicm9ib3QiLCJyb2JvdCI6eyJpZCI6ImdvMi1sYWIiLCJuYW1lIjoiR28yIExhYm9yYXRvciDOsiIsIm1vZGVsIjoidW5pdHJlZS1nbzIifSwibWFuaWZlc3QiOnsidmVyc2lvbiI6MSwiY2hhbm5lbHMiOlt7ImNoIjoiY29sb3JfaW1hZ2UiLCJkaXIiOiJyeCIsImVuY29kaW5nIjoianBlZy52MSIsImRlbGl2ZXJ5IjoibGF0ZXN0IiwibWF4SHoiOjE1LjUsInBhcmFtcyI6eyJxdWFsaXR5Ijo3NS41fX0seyJjaCI6Im9kb20iLCJkaXIiOiJyeCIsImVuY29kaW5nIjoicG9zZS5qc29uLnYxIiwiZGVsaXZlcnkiOiJyZWxpYWJsZSIsIm1heEh6IjoyMC41LCJwYXJhbXMiOnt9fV0sInBhbmVscyI6W3siaWQiOiJwMCIsImtpbmQiOiJ2aWRlbyIsInRpdGxlIjoiQ2FtZXJhIM6yIiwiY2hhbm5lbHMiOlsiY29sb3JfaW1hZ2UiXSwicGFyYW1zIjp7fX1dLCJsYXlvdXQiOnsicm93IjpbInAwIl19LCJwYWdlcyI6W119fQ=="
     },
     {
       "name": "hello_viewer",
       "message": {
         "t": "hello",
-        "v": 3,
+        "v": 4,
         "role": "viewer"
       },
-      "b64": "eyJ0IjoiaGVsbG8iLCJ2IjozLCJyb2xlIjoidmlld2VyIn0="
+      "b64": "eyJ0IjoiaGVsbG8iLCJ2Ijo0LCJyb2xlIjoidmlld2VyIn0="
     },
     {
       "name": "welcome",
       "message": {
         "t": "welcome",
-        "v": 3
+        "v": 4
       },
-      "b64": "eyJ0Ijoid2VsY29tZSIsInYiOjN9"
+      "b64": "eyJ0Ijoid2VsY29tZSIsInYiOjR9"
     },
     {
       "name": "ping",
@@ -94,9 +94,9 @@
       "message": {
         "t": "error",
         "code": "version_mismatch",
-        "message": "protocol v3 required, versiune neacceptată"
+        "message": "protocol v4 required, versiune neacceptată"
       },
-      "b64": "eyJ0IjoiZXJyb3IiLCJjb2RlIjoidmVyc2lvbl9taXNtYXRjaCIsIm1lc3NhZ2UiOiJwcm90b2NvbCB2MyByZXF1aXJlZCwgdmVyc2l1bmUgbmVhY2NlcHRhdMSDIn0="
+      "b64": "eyJ0IjoiZXJyb3IiLCJjb2RlIjoidmVyc2lvbl9taXNtYXRjaCIsIm1lc3NhZ2UiOiJwcm90b2NvbCB2NCByZXF1aXJlZCwgdmVyc2l1bmUgbmVhY2NlcHRhdMSDIn0="
     },
     {
       "name": "robots_two",
@@ -209,15 +209,37 @@
       "b64": "eyJ0Ijoic3VicyIsImNocyI6W10sIm4iOjR9"
     },
     {
+      "name": "teleop_start",
+      "message": {
+        "t": "teleop_start"
+      },
+      "b64": "eyJ0IjoidGVsZW9wX3N0YXJ0In0="
+    },
+    {
+      "name": "teleop_started",
+      "message": {
+        "t": "teleop_started"
+      },
+      "b64": "eyJ0IjoidGVsZW9wX3N0YXJ0ZWQifQ=="
+    },
+    {
+      "name": "teleop_stop",
+      "message": {
+        "t": "teleop_stop"
+      },
+      "b64": "eyJ0IjoidGVsZW9wX3N0b3AifQ=="
+    },
+    {
       "name": "twist",
       "message": {
         "t": "twist",
         "vx": 0.5,
+        "vy": 0.25,
         "wz": -0.25,
         "seq": 12,
         "ts": 1752576000.5
       },
-      "b64": "eyJ0IjoidHdpc3QiLCJ2eCI6MC41LCJ3eiI6LTAuMjUsInNlcSI6MTIsInRzIjoxNzUyNTc2MDAwLjV9"
+      "b64": "eyJ0IjoidHdpc3QiLCJ2eCI6MC41LCJ2eSI6MC4yNSwid3oiOi0wLjI1LCJzZXEiOjEyLCJ0cyI6MTc1MjU3NjAwMC41fQ=="
     },
     {
       "name": "stop",
@@ -227,6 +249,45 @@
         "ts": 1752576000.5
       },
       "b64": "eyJ0Ijoic3RvcCIsInNlcSI6MTMsInRzIjoxNzUyNTc2MDAwLjV9"
+    },
+    {
+      "name": "twist_gen",
+      "message": {
+        "t": "twist",
+        "vx": 0.5,
+        "vy": 0.25,
+        "wz": -0.25,
+        "seq": 12,
+        "ts": 1752576000.5,
+        "gen": 3
+      },
+      "b64": "eyJ0IjoidHdpc3QiLCJ2eCI6MC41LCJ2eSI6MC4yNSwid3oiOi0wLjI1LCJzZXEiOjEyLCJ0cyI6MTc1MjU3NjAwMC41LCJnZW4iOjN9"
+    },
+    {
+      "name": "stop_gen",
+      "message": {
+        "t": "stop",
+        "seq": 13,
+        "ts": 1752576000.5,
+        "gen": 3
+      },
+      "b64": "eyJ0Ijoic3RvcCIsInNlcSI6MTMsInRzIjoxNzUyNTc2MDAwLjUsImdlbiI6M30="
+    },
+    {
+      "name": "teleop_start_gen",
+      "message": {
+        "t": "teleop_start",
+        "gen": 3
+      },
+      "b64": "eyJ0IjoidGVsZW9wX3N0YXJ0IiwiZ2VuIjozfQ=="
+    },
+    {
+      "name": "teleop_stop_gen",
+      "message": {
+        "t": "teleop_stop",
+        "gen": 3
+      },
+      "b64": "eyJ0IjoidGVsZW9wX3N0b3AiLCJnZW4iOjN9"
     }
   ]
 }

--- a/web/shared/fixtures/gen.ts
+++ b/web/shared/fixtures/gen.ts
@@ -99,11 +99,21 @@ const controlMsgs: Record<string, Msg> = {
   unsub: { t: "unsub", ch: "color_image" },
   subs_snapshot: { t: "subs", chs: ["color_image", "odom"], n: 3 },
   subs_empty: { t: "subs", chs: [], n: 4 },
+  // Bare lease messages are the viewer-leg shapes (control stream); the
+  // gen-stamped robot-bound forms are pinned in teleopMsgs below.
+  teleop_start: { t: "teleop_start" },
+  teleop_started: { t: "teleop_started" },
+  teleop_stop: { t: "teleop_stop" },
 };
 
 const teleopMsgs: Record<string, Msg> = {
-  twist: { t: "twist", vx: 0.5, wz: -0.25, seq: 12, ts: 1752576000.5 },
+  twist: { t: "twist", vx: 0.5, vy: 0.25, wz: -0.25, seq: 12, ts: 1752576000.5 },
   stop: { t: "stop", seq: 13, ts: 1752576000.5 },
+  // Robot-bound forms: the relay stamps the lease generation.
+  twist_gen: { t: "twist", vx: 0.5, vy: 0.25, wz: -0.25, seq: 12, ts: 1752576000.5, gen: 3 },
+  stop_gen: { t: "stop", seq: 13, ts: 1752576000.5, gen: 3 },
+  teleop_start_gen: { t: "teleop_start", gen: 3 },
+  teleop_stop_gen: { t: "teleop_stop", gen: 3 },
 };
 
 const dataFrames: Record<string, { header: FrameHeader; payload: Uint8Array }> = {
@@ -148,6 +158,14 @@ const chCostmap = {
   delivery: "latest",
   maxHz: 5.5,
 };
+const chTwist = {
+  ch: "tele_cmd_vel",
+  dir: "tx",
+  encoding: "twist.json.v1",
+  delivery: "latest",
+  maxHz: 15.5,
+  params: { maxLinear: 0.85, maxAngular: 1.5, boost: 2.5, watchdogMs: 300.5 },
+};
 const pCamera = { id: "camera", kind: "video", channels: ["color_image"] };
 const pPose = { id: "pose", kind: "readout", channels: ["odom"] };
 const longId = "x".repeat(65);
@@ -160,7 +178,7 @@ const manifestCases: Record<string, unknown> = {
     panels: [
       { ...pCamera, title: "Cameră față" },
       pPose,
-      { id: "drive", kind: "teleop", channels: [] },
+      { id: "drive", kind: "joystick", channels: [] },
       { id: "aux", kind: "readout", channels: ["odom"] },
     ],
     layout: { row: [{ col: ["camera", "pose"], shares: [2.5, 1.5] }, "drive"] },
@@ -307,6 +325,36 @@ const manifestCases: Record<string, unknown> = {
     channels: [chCostmap, { ...chOdom, dir: "tx" }],
     panels: [{ id: "map", kind: "map2d", channels: ["global_costmap", "odom"] }],
   },
+  teleop_panel_valid: {
+    version: 1,
+    channels: [chTwist],
+    panels: [{ id: "drive", kind: "teleop", channels: ["tele_cmd_vel"] }],
+  },
+  teleop_panel_no_channel: {
+    version: 1,
+    channels: [chTwist],
+    panels: [{ id: "drive", kind: "teleop", channels: [] }],
+  },
+  teleop_panel_two_channels: {
+    version: 1,
+    channels: [chTwist, chOdom],
+    panels: [{ id: "drive", kind: "teleop", channels: ["tele_cmd_vel", "odom"] }],
+  },
+  teleop_panel_rx_channel: {
+    version: 1,
+    channels: [{ ...chTwist, dir: "rx" }],
+    panels: [{ id: "drive", kind: "teleop", channels: ["tele_cmd_vel"] }],
+  },
+  teleop_panel_wrong_encoding: {
+    version: 1,
+    channels: [{ ...chOdom, dir: "tx" }],
+    panels: [{ id: "drive", kind: "teleop", channels: ["odom"] }],
+  },
+  teleop_panel_wrong_delivery: {
+    version: 1,
+    channels: [{ ...chTwist, delivery: "reliable" }],
+    panels: [{ id: "drive", kind: "teleop", channels: ["tele_cmd_vel"] }],
+  },
   layout_single_panel: { version: 1, channels: [chOdom], panels: [pPose], layout: "pose" },
   layout_row_shares: {
     version: 1,
@@ -319,7 +367,7 @@ const manifestCases: Record<string, unknown> = {
   layout_nested_tree: {
     version: 1,
     channels: [chImage, chOdom],
-    panels: [pCamera, pPose, { id: "drive", kind: "teleop", channels: [] }],
+    panels: [pCamera, pPose, { id: "drive", kind: "joystick", channels: [] }],
     layout: { col: [{ row: ["camera", "pose"], shares: [1.5, 2.5] }, "drive"] },
   },
   layout_null: { version: 1, channels: [chOdom], panels: [pPose], layout: null },

--- a/web/shared/fixtures/manifests.json
+++ b/web/shared/fixtures/manifests.json
@@ -94,7 +94,7 @@
           },
           {
             "id": "drive",
-            "kind": "teleop",
+            "kind": "joystick",
             "channels": []
           },
           {
@@ -165,7 +165,7 @@
           },
           {
             "id": "drive",
-            "kind": "teleop",
+            "kind": "joystick",
             "title": "",
             "channels": [],
             "params": {}
@@ -1319,6 +1319,221 @@
       "error": "invalid_map2d_panel"
     },
     {
+      "name": "teleop_panel_valid",
+      "data": {
+        "version": 1,
+        "channels": [
+          {
+            "ch": "tele_cmd_vel",
+            "dir": "tx",
+            "encoding": "twist.json.v1",
+            "delivery": "latest",
+            "maxHz": 15.5,
+            "params": {
+              "maxLinear": 0.85,
+              "maxAngular": 1.5,
+              "boost": 2.5,
+              "watchdogMs": 300.5
+            }
+          }
+        ],
+        "panels": [
+          {
+            "id": "drive",
+            "kind": "teleop",
+            "channels": [
+              "tele_cmd_vel"
+            ]
+          }
+        ]
+      },
+      "manifest": {
+        "version": 1,
+        "channels": [
+          {
+            "ch": "tele_cmd_vel",
+            "dir": "tx",
+            "encoding": "twist.json.v1",
+            "delivery": "latest",
+            "maxHz": 15.5,
+            "params": {
+              "maxLinear": 0.85,
+              "maxAngular": 1.5,
+              "boost": 2.5,
+              "watchdogMs": 300.5
+            }
+          }
+        ],
+        "panels": [
+          {
+            "id": "drive",
+            "kind": "teleop",
+            "title": "",
+            "channels": [
+              "tele_cmd_vel"
+            ],
+            "params": {}
+          }
+        ],
+        "layout": null,
+        "pages": []
+      }
+    },
+    {
+      "name": "teleop_panel_no_channel",
+      "data": {
+        "version": 1,
+        "channels": [
+          {
+            "ch": "tele_cmd_vel",
+            "dir": "tx",
+            "encoding": "twist.json.v1",
+            "delivery": "latest",
+            "maxHz": 15.5,
+            "params": {
+              "maxLinear": 0.85,
+              "maxAngular": 1.5,
+              "boost": 2.5,
+              "watchdogMs": 300.5
+            }
+          }
+        ],
+        "panels": [
+          {
+            "id": "drive",
+            "kind": "teleop",
+            "channels": []
+          }
+        ]
+      },
+      "error": "invalid_teleop_panel"
+    },
+    {
+      "name": "teleop_panel_two_channels",
+      "data": {
+        "version": 1,
+        "channels": [
+          {
+            "ch": "tele_cmd_vel",
+            "dir": "tx",
+            "encoding": "twist.json.v1",
+            "delivery": "latest",
+            "maxHz": 15.5,
+            "params": {
+              "maxLinear": 0.85,
+              "maxAngular": 1.5,
+              "boost": 2.5,
+              "watchdogMs": 300.5
+            }
+          },
+          {
+            "ch": "odom",
+            "encoding": "pose.json.v1",
+            "delivery": "reliable",
+            "maxHz": 20.5
+          }
+        ],
+        "panels": [
+          {
+            "id": "drive",
+            "kind": "teleop",
+            "channels": [
+              "tele_cmd_vel",
+              "odom"
+            ]
+          }
+        ]
+      },
+      "error": "invalid_teleop_panel"
+    },
+    {
+      "name": "teleop_panel_rx_channel",
+      "data": {
+        "version": 1,
+        "channels": [
+          {
+            "ch": "tele_cmd_vel",
+            "dir": "rx",
+            "encoding": "twist.json.v1",
+            "delivery": "latest",
+            "maxHz": 15.5,
+            "params": {
+              "maxLinear": 0.85,
+              "maxAngular": 1.5,
+              "boost": 2.5,
+              "watchdogMs": 300.5
+            }
+          }
+        ],
+        "panels": [
+          {
+            "id": "drive",
+            "kind": "teleop",
+            "channels": [
+              "tele_cmd_vel"
+            ]
+          }
+        ]
+      },
+      "error": "invalid_teleop_panel"
+    },
+    {
+      "name": "teleop_panel_wrong_encoding",
+      "data": {
+        "version": 1,
+        "channels": [
+          {
+            "ch": "odom",
+            "encoding": "pose.json.v1",
+            "delivery": "reliable",
+            "maxHz": 20.5,
+            "dir": "tx"
+          }
+        ],
+        "panels": [
+          {
+            "id": "drive",
+            "kind": "teleop",
+            "channels": [
+              "odom"
+            ]
+          }
+        ]
+      },
+      "error": "invalid_teleop_panel"
+    },
+    {
+      "name": "teleop_panel_wrong_delivery",
+      "data": {
+        "version": 1,
+        "channels": [
+          {
+            "ch": "tele_cmd_vel",
+            "dir": "tx",
+            "encoding": "twist.json.v1",
+            "delivery": "reliable",
+            "maxHz": 15.5,
+            "params": {
+              "maxLinear": 0.85,
+              "maxAngular": 1.5,
+              "boost": 2.5,
+              "watchdogMs": 300.5
+            }
+          }
+        ],
+        "panels": [
+          {
+            "id": "drive",
+            "kind": "teleop",
+            "channels": [
+              "tele_cmd_vel"
+            ]
+          }
+        ]
+      },
+      "error": "invalid_teleop_panel"
+    },
+    {
       "name": "layout_single_panel",
       "data": {
         "version": 1,
@@ -1501,7 +1716,7 @@
           },
           {
             "id": "drive",
-            "kind": "teleop",
+            "kind": "joystick",
             "channels": []
           }
         ],
@@ -1562,7 +1777,7 @@
           },
           {
             "id": "drive",
-            "kind": "teleop",
+            "kind": "joystick",
             "title": "",
             "channels": [],
             "params": {}

--- a/web/shared/manifest.ts
+++ b/web/shared/manifest.ts
@@ -306,6 +306,21 @@ export function parseManifest(value: unknown): Manifest {
         }
       }
     }
+    if (panel.kind === "teleop") {
+      if (panel.channels.length !== 1) {
+        throw new ManifestError(
+          "invalid_teleop_panel",
+          `teleop panel ${panel.id} must bind exactly one channel`,
+        );
+      }
+      const cmd = chIds.get(panel.channels[0])!;
+      if (cmd.encoding !== "twist.json.v1" || cmd.delivery !== "latest" || dirOf(cmd) !== "tx") {
+        throw new ManifestError(
+          "invalid_teleop_panel",
+          `teleop panel ${panel.id} needs a twist.json.v1 latest tx channel`,
+        );
+      }
+    }
   }
 
   const seen = new Set<string>();

--- a/web/shared/protocol.ts
+++ b/web/shared/protocol.ts
@@ -22,12 +22,17 @@ import { type Delivery, MAX_MANIFEST_ID_LEN } from "./manifest.ts";
 // consumers keep a single import surface.
 export type { ChannelSpec, Delivery, Dir, PanelSpec } from "./manifest.ts";
 
-// v3: the manifest travels as one opaque record nested in hello/manifest
-// messages (v2 carried flat channels/panels fields, which a v2 peer would
-// silently misread in both directions). v2: a reliable channel packs all its
-// frames onto one persistent stream. Bump on any change an old peer would
-// silently misparse.
-export const PROTOCOL_VERSION = 3;
+// v4: the twist datagram gains vy (strafe) and the teleop lease messages
+// (teleop_start/teleop_started/teleop_stop) enter the control plane;
+// robot-bound twist/stop/teleop_start/teleop_stop carry the relay-stamped
+// lease generation `gen` (amended into v4 pre-release: an older v4 peer
+// without gen gets dead teleop, never unsafe motion). v3: the
+// manifest travels as one opaque record nested in hello/manifest messages
+// (v2 carried flat channels/panels fields, which a v2 peer would silently
+// misread in both directions). v2: a reliable channel packs all its frames
+// onto one persistent stream. Bump on any change an old peer would silently
+// misparse.
+export const PROTOCOL_VERSION = 4;
 
 // Reject absurd header lengths before allocating.
 export const MAX_HEADER_LEN = 65536;
@@ -123,25 +128,51 @@ export interface SubsMsg {
   n: number;
 }
 
-// Teleop datagrams (carried from T6 on; declared here so the wire format is
-// pinned by fixtures from day one).
+// Teleop (T6). twist/stop ride datagrams viewer->relay->robot (loss-tolerant:
+// commands repeat and the bridge deadman covers silence). The lease messages
+// ride the viewer's control stream so they are ordered after watch:
+// teleop_start requests the per-robot exclusive lease (relay acks with
+// teleop_started, or replies error code "teleop_held"), teleop_stop releases
+// it. Robot-bound teleop messages are datagrams stamped with `gen`, the
+// relay-issued lease generation: teleop_start announces a granted lease,
+// teleop_stop means "the lease ended" (holder gone), twist/stop are the
+// forwarded holder commands. The bridge permanently rejects generations
+// below its floor, so a released holder's delayed datagrams cannot move the
+// robot after a stop. Viewer-authored messages never carry gen.
 export interface TwistMsg {
   t: "twist";
   vx: number;
+  vy: number;
   wz: number;
   seq: number;
   ts: number;
+  gen?: number;
 }
 
 export interface StopMsg {
   t: "stop";
   seq: number;
   ts: number;
+  gen?: number;
+}
+
+export interface TeleopStartMsg {
+  t: "teleop_start";
+  gen?: number;
+}
+
+export interface TeleopStartedMsg {
+  t: "teleop_started";
+}
+
+export interface TeleopStopMsg {
+  t: "teleop_stop";
+  gen?: number;
 }
 
 export type ControlMsg = HelloMsg | WelcomeMsg | PingMsg | PongMsg | ErrorMsg;
 export type SessionMsg = RobotsMsg | WatchMsg | ManifestMsg | SubMsg | UnsubMsg | SubsMsg;
-export type TeleopMsg = TwistMsg | StopMsg;
+export type TeleopMsg = TwistMsg | StopMsg | TeleopStartMsg | TeleopStartedMsg | TeleopStopMsg;
 export type Msg = ControlMsg | SessionMsg | TeleopMsg;
 
 // Data-plane frame header. `delivery` tells the relay how to forward frames
@@ -182,8 +213,11 @@ const MSG_FIELDS: Record<string, Record<string, "string" | "number">> = {
   sub: { ch: "string" },
   unsub: { ch: "string" },
   subs: { n: "number" },
-  twist: { vx: "number", wz: "number", seq: "number", ts: "number" },
+  twist: { vx: "number", vy: "number", wz: "number", seq: "number", ts: "number" },
   stop: { seq: "number", ts: "number" },
+  teleop_start: {},
+  teleop_started: {},
+  teleop_stop: {},
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -200,10 +234,12 @@ function isRobotInfo(value: unknown): value is RobotInfo {
 }
 
 // Structural checks for nested fields, run after the flat MSG_FIELDS pass.
-// Optional fields (hello.robot, hello/manifest.manifest) accept absent but
-// reject null: JSON encoders on both sides omit absent fields and never emit
-// null. The manifest is only checked for record-ness here -- its structure
-// belongs to parseManifest (see RobotManifest above).
+// Optional fields (hello.robot, hello/manifest.manifest, teleop gen) accept
+// absent but reject null: JSON encoders on both sides omit absent fields and
+// never emit null. The manifest is only checked for record-ness here -- its
+// structure belongs to parseManifest (see RobotManifest above).
+const genAbsentOrNumber = (v: Record<string, unknown>) =>
+  v.gen === undefined || typeof v.gen === "number";
 const MSG_VALIDATORS: Record<string, (value: Record<string, unknown>) => boolean> = {
   hello: (v) =>
     (v.robot === undefined || isRobotInfo(v.robot)) &&
@@ -211,6 +247,10 @@ const MSG_VALIDATORS: Record<string, (value: Record<string, unknown>) => boolean
   robots: (v) => Array.isArray(v.robots) && v.robots.every(isRobotInfo),
   manifest: (v) => v.manifest === undefined || isRecord(v.manifest),
   subs: (v) => Array.isArray(v.chs) && v.chs.every((c) => typeof c === "string"),
+  twist: genAbsentOrNumber,
+  stop: genAbsentOrNumber,
+  teleop_start: genAbsentOrNumber,
+  teleop_stop: genAbsentOrNumber,
 };
 
 /** Validated message from parsed JSON; null for unknown or malformed ones. */

--- a/web/shared/protocol_test.ts
+++ b/web/shared/protocol_test.ts
@@ -262,6 +262,14 @@ Deno.test("msgFromUnknown validates nested session-message shapes", () => {
   assertEquals(msgFromUnknown({ t: "subs", chs: ["a", "b"], n: 1 }) !== null, true);
   assertEquals(msgFromUnknown({ t: "subs", chs: ["a", 5], n: 1 }), null);
   assertEquals(msgFromUnknown({ t: "subs", chs: ["a"] }), null);
+  // Teleop gen mirrors hello.robot: absent ok, null/non-number rejected.
+  const twist = { t: "twist", vx: 0.5, vy: 0, wz: 0, seq: 1, ts: 2.5 };
+  assertEquals(msgFromUnknown(twist) !== null, true);
+  assertEquals(msgFromUnknown({ ...twist, gen: 3 }) !== null, true);
+  assertEquals(msgFromUnknown({ ...twist, gen: null }), null);
+  assertEquals(msgFromUnknown({ ...twist, gen: "1" }), null);
+  assertEquals(msgFromUnknown({ t: "teleop_start", gen: 3 }) !== null, true);
+  assertEquals(msgFromUnknown({ t: "teleop_stop", gen: null }), null);
 });
 
 Deno.test("frameHeaderFromUnknown validates the header shape", () => {


### PR DESCRIPTION
* Add keyboard teleop panel which drives the robot.
* Uses the same WASD and QE controls.
* This is the first viewer to robot channels.
* Only one cockpit can control at a time. The second one will get an error.

Closes DIM-1168