### PR TITLE
feat(manipulation): add live grasp visualization

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -59,3 +59,19 @@ _Avoid_: Coordinated arm-gripper plan, validated finger sweep
 **Candidate Rejection Reason (MVP)**:
 Candidate rejection is reported by failed sequence stage: `pre_grasp_infeasible`, `grasp_infeasible`, or `retreat_infeasible`. Detailed IK and planner outcomes remain diagnostic logs rather than public skill-result categories.
 _Avoid_: Backend-specific public failure codes
+
+**Visualization Layer**:
+A display-only, named collection of visual elements owned by exactly one producer. Publishing replaces its contents, while clearing leaves the layer registered and preserves viewer-owned visibility; the layer cannot affect collision checking or other planning behavior.
+_Avoid_: Collision layer, shared scene state, visualization object
+
+**Visual Element**:
+A backend-neutral drawable contained in a Visualization Layer, initially a point cloud or line set. It carries no collision or planning authority.
+_Avoid_: Grasp visualization command, Viser handle, collision object
+
+**Visualization Layer Group**:
+A viewer-only grouping of independently replaceable and toggleable Visualization Layers that share a name prefix, such as `grasp/object-cloud` and `grasp/proposals`.
+_Avoid_: Compound layer, element-level visibility
+
+**Accepted Collision Projection**:
+A display-only representation published after the planning world accepts a collision-object change. Its presence, absence, or rendering failure never changes collision checking.
+_Avoid_: Collision authority, visualization obstacle

--- a/dimos/manipulation/pick_and_place_module.py
+++ b/dimos/manipulation/pick_and_place_module.py
@@ -23,6 +23,8 @@ Extends ManipulationModule with perception integration and long-horizon skills:
 from __future__ import annotations
 
 from collections import Counter
+from collections.abc import Sequence
+from contextlib import suppress
 from dataclasses import dataclass, field
 from enum import Enum
 import math
@@ -38,11 +40,17 @@ from dimos.agents.skill_result import SkillResult
 from dimos.core.core import rpc
 from dimos.core.stream import In
 from dimos.manipulation.grasping.grasp_gen_spec import GraspGenSpec
+from dimos.manipulation.grasping.grasp_gen_x import (
+    IDENTITY_TRANSFORM,
+    RigidTransform,
+    SweepVolumeGripperConfig,
+)
 from dimos.manipulation.manipulation_module import (
     ManipulationModule,
     ManipulationModuleConfig,
 )
 from dimos.manipulation.skill_errors import ManipulationSkillError
+from dimos.manipulation.visualization import grasp_layers
 from dimos.msgs.geometry_msgs.Pose import Pose
 from dimos.msgs.geometry_msgs.Quaternion import Quaternion
 from dimos.msgs.geometry_msgs.Vector3 import Vector3
@@ -111,6 +119,12 @@ class PickAndPlaceModuleConfig(ManipulationModuleConfig):
     grasp_retreat_offset: FiniteFloat | None = Field(default=None, gt=0.0)
     grasp_approach_vector: tuple[FiniteFloat, FiniteFloat, FiniteFloat] = (0.0, 0.0, -1.0)
     grasp_verification: GraspVerificationConfig = Field(default_factory=GraspVerificationConfig)
+    # Gripper geometry for grasp visualization only. Source from the same config
+    # object as the grasp generator: grasp_gen_x bakes grasp_frame_to_tcp into
+    # candidate poses and the wireframe un-applies it, so a divergence would
+    # draw correct-looking grasps while the robot goes elsewhere.
+    grasp_viz_gripper: SweepVolumeGripperConfig | None = None
+    grasp_viz_frame_to_tcp: RigidTransform = IDENTITY_TRANSFORM
 
     @model_validator(mode="after")
     def _validate_grasp_pipeline(self) -> PickAndPlaceModuleConfig:
@@ -668,7 +682,52 @@ then refreshes perception obstacles.
                 "GRASP_GENERATION_FAILED",
                 f"No grasp proposals were generated for '{detection.name}'",
             )
-        return sorted(proposals.candidates, key=lambda candidate: candidate.score, reverse=True)
+        ranked = sorted(proposals.candidates, key=lambda candidate: candidate.score, reverse=True)
+        self._publish_cloud_layer(points)
+        self._publish_candidate_layers(ranked[: self.config.max_grasp_candidates_to_check])
+        return ranked
+
+    def _grasp_viz(self) -> Any | None:
+        """Visualization backend, or None when disabled or gripper geometry is unset."""
+        if self._world_monitor is None or self.config.grasp_viz_gripper is None:
+            return None
+        return self._world_monitor.visualization
+
+    def _publish_cloud_layer(self, points: Any) -> None:
+        vis = self._grasp_viz()
+        if vis is None:
+            return
+        with suppress(Exception):
+            vis.set_layer(grasp_layers.cloud_layer(points, self.config.planning_frame))
+
+    def _publish_candidate_layers(self, candidates: Sequence[GraspCandidate]) -> None:
+        vis = self._grasp_viz()
+        if vis is None:
+            return
+        with suppress(Exception):
+            vis.set_layer(
+                grasp_layers.candidates_layer(
+                    candidates,
+                    self.config.grasp_viz_gripper,
+                    self.config.grasp_viz_frame_to_tcp,
+                    self.config.planning_frame,
+                )
+            )
+
+    def _publish_attempt_layer(self, grasp: Pose, pre_grasp: Pose) -> None:
+        vis = self._grasp_viz()
+        if vis is None:
+            return
+        with suppress(Exception):
+            vis.set_layer(
+                grasp_layers.attempt_layer(
+                    grasp,
+                    pre_grasp,
+                    self.config.grasp_viz_gripper,
+                    self.config.grasp_viz_frame_to_tcp,
+                    self.config.planning_frame,
+                )
+            )
 
     @staticmethod
     def _valid_candidate(candidate: GraspCandidate) -> bool:
@@ -710,6 +769,7 @@ then refreshes perception obstacles.
                 continue
             pre_grasp = self._compute_pre_grasp_pose(candidate.pose, pre_offset, vector)
             retreat = self._compute_pre_grasp_pose(candidate.pose, retreat_offset, vector)
+            self._publish_attempt_layer(candidate.pose, pre_grasp)
             rejections = (
                 _CandidateRejection.PRE_GRASP_INFEASIBLE,
                 _CandidateRejection.GRASP_INFEASIBLE,

--- a/dimos/manipulation/planning/monitor/test_world_monitor.py
+++ b/dimos/manipulation/planning/monitor/test_world_monitor.py
@@ -35,6 +35,7 @@ from dimos.manipulation.planning.spec.models import (
     VisualizationStateFrame,
 )
 from dimos.manipulation.planning.spec.protocols import VisualizationSpec
+from dimos.manipulation.visualization.layers import VisualizationLayer
 from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
 from dimos.msgs.geometry_msgs.Quaternion import Quaternion
 from dimos.msgs.geometry_msgs.Vector3 import Vector3
@@ -219,6 +220,12 @@ class FakeViz:
 
     def clear_vis_obstacles(self) -> None:
         self.calls.append(("clear_vis_obstacles",))
+
+    def set_layer(self, layer: VisualizationLayer) -> None:
+        self.calls.append(("set_layer", layer))
+
+    def clear_layer(self, layer_id: str) -> None:
+        self.calls.append(("clear_layer", layer_id))
 
 
 def _robot_config() -> RobotModelConfig:

--- a/dimos/manipulation/planning/spec/protocols.py
+++ b/dimos/manipulation/planning/spec/protocols.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
         VisualizationStateFrame,
         WorldRobotID,
     )
+    from dimos.manipulation.visualization.layers import VisualizationLayer
     from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
     from dimos.msgs.sensor_msgs.JointState import JointState
     from dimos.msgs.trajectory_msgs.JointTrajectory import JointTrajectory
@@ -222,6 +223,14 @@ class VisualizationSpec(Protocol):
 
     def clear_vis_obstacles(self) -> None:
         """Clear obstacle representations from the visualization."""
+        ...
+
+    def set_layer(self, layer: VisualizationLayer) -> None:
+        """Replace one complete display-only visualization layer."""
+        ...
+
+    def clear_layer(self, layer_id: str) -> None:
+        """Clear one display-only layer while retaining viewer-owned state."""
         ...
 
     def get_visualization_url(self) -> str | None:

--- a/dimos/manipulation/planning/world/drake_world.py
+++ b/dimos/manipulation/planning/world/drake_world.py
@@ -57,6 +57,7 @@ if TYPE_CHECKING:
         VisualizationSession,
         VisualizationStateFrame,
     )
+    from dimos.manipulation.visualization.layers import VisualizationLayer
 
 try:
     from pydrake.geometry import (
@@ -1206,6 +1207,14 @@ class DrakeWorld(WorldSpec, VisualizationSpec):
 
     def clear_vis_obstacles(self) -> None:
         """Embedded Meshcat observes native WorldSpec obstacle mutations."""
+        return None
+
+    def set_layer(self, layer: VisualizationLayer) -> None:
+        """Embedded Meshcat ignores generic display-only layers."""
+        return None
+
+    def clear_layer(self, layer_id: str) -> None:
+        """Embedded Meshcat ignores generic display-only layers."""
         return None
 
     def get_visualization_url(self) -> str | None:

--- a/dimos/manipulation/visualization/grasp_layers.py
+++ b/dimos/manipulation/visualization/grasp_layers.py
@@ -25,7 +25,6 @@ from dimos.manipulation.visualization.layers import (
     PointCloudElement,
     VisualizationLayer,
 )
-from dimos.msgs.manipulation_msgs.GraspCandidate import GraspCandidate
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -44,10 +43,61 @@ _PATH_COLOR = (255, 255, 255)
 _MAX_CLOUD_POINTS = 20000
 
 
-def _wireframe(pose: Pose, gripper: Any, grasp_frame_to_tcp: Any) -> tuple[np.ndarray, np.ndarray]:
-    from dimos.manipulation.demo_graspgenx.render import gripper_wireframe_geometry
+def _rotation(q: Any) -> np.ndarray:
+    x, y, z, w = (float(q.x), float(q.y), float(q.z), float(q.w))
+    return np.asarray(
+        [
+            [1 - 2 * (y * y + z * z), 2 * (x * y - z * w), 2 * (x * z + y * w)],
+            [2 * (x * y + z * w), 1 - 2 * (x * x + z * z), 2 * (y * z - x * w)],
+            [2 * (x * z - y * w), 2 * (y * z + x * w), 1 - 2 * (x * x + y * y)],
+        ],
+        dtype=float,
+    )
 
-    return gripper_wireframe_geometry(GraspCandidate(pose, 0.0), gripper, grasp_frame_to_tcp)
+
+def _fork_strips_local(gripper: Any) -> tuple[np.ndarray, ...]:
+    open_extents = np.asarray(gripper.extents_open, dtype=float)
+    half_extents = np.asarray(gripper.extents_half_open, dtype=float)
+    open_offset = np.asarray(gripper.offset_open, dtype=float)
+    half_offset = np.asarray(gripper.offset_half_open, dtype=float)
+
+    rear_center = np.asarray([half_offset[0], 0.0, half_offset[2] - half_extents[2] / 2.0])
+    mouth_center = np.asarray([open_offset[0], 0.0, open_offset[2] + open_extents[2] / 2.0])
+    if mouth_center[2] <= rear_center[2]:
+        raise ValueError("configured sweep profiles must open toward increasing local +Z")
+
+    rear_half_width = max(float(half_extents[0]) / 2.0, 1e-6)
+    mouth_half_width = max(float(open_extents[0]) / 2.0, rear_half_width)
+    rear_left = rear_center + np.asarray([-rear_half_width, 0.0, 0.0])
+    rear_right = rear_center + np.asarray([rear_half_width, 0.0, 0.0])
+    mouth_left = mouth_center + np.asarray([-mouth_half_width, 0.0, 0.0])
+    mouth_right = mouth_center + np.asarray([mouth_half_width, 0.0, 0.0])
+    return (
+        np.asarray([rear_center, [0.0, 0.0, 0.0]]),
+        np.asarray([rear_left, rear_right]),
+        np.asarray([rear_left, mouth_left]),
+        np.asarray([rear_right, mouth_right]),
+    )
+
+
+def _wireframe(pose: Pose, gripper: Any, grasp_frame_to_tcp: Any) -> tuple[np.ndarray, np.ndarray]:
+    world_to_tcp = np.eye(4, dtype=float)
+    world_to_tcp[:3, :3] = _rotation(pose.orientation)
+    world_to_tcp[:3, 3] = np.asarray(
+        [pose.position.x, pose.position.y, pose.position.z], dtype=float
+    )
+    grasp_to_tcp = np.asarray(grasp_frame_to_tcp, dtype=float)
+    if grasp_to_tcp.shape != (4, 4):
+        raise ValueError("grasp_frame_to_tcp must have shape (4, 4)")
+    world_to_grasp = world_to_tcp @ np.linalg.inv(grasp_to_tcp)
+    rotation = world_to_grasp[:3, :3]
+    translation = world_to_grasp[:3, 3]
+    strips = tuple(
+        (rotation @ strip.T).T + translation for strip in _fork_strips_local(gripper)
+    )
+    vertices = np.vstack(strips).astype(np.float32)
+    edges = np.arange(len(vertices), dtype=np.int32).reshape((-1, 2))
+    return vertices, edges
 
 
 def _rank_color(index: int, total: int) -> tuple[int, int, int]:

--- a/dimos/manipulation/visualization/grasp_layers.py
+++ b/dimos/manipulation/visualization/grasp_layers.py
@@ -92,9 +92,7 @@ def _wireframe(pose: Pose, gripper: Any, grasp_frame_to_tcp: Any) -> tuple[np.nd
     world_to_grasp = world_to_tcp @ np.linalg.inv(grasp_to_tcp)
     rotation = world_to_grasp[:3, :3]
     translation = world_to_grasp[:3, 3]
-    strips = tuple(
-        (rotation @ strip.T).T + translation for strip in _fork_strips_local(gripper)
-    )
+    strips = tuple((rotation @ strip.T).T + translation for strip in _fork_strips_local(gripper))
     vertices = np.vstack(strips).astype(np.float32)
     edges = np.arange(len(vertices), dtype=np.int32).reshape((-1, 2))
     return vertices, edges

--- a/dimos/manipulation/visualization/grasp_layers.py
+++ b/dimos/manipulation/visualization/grasp_layers.py
@@ -1,0 +1,151 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Display-only Viser layers for the live pick grasp pipeline."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from dimos.manipulation.visualization.layers import (
+    LineSetElement,
+    PointCloudElement,
+    VisualizationLayer,
+)
+from dimos.msgs.manipulation_msgs.GraspCandidate import GraspCandidate
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from dimos.msgs.geometry_msgs.Pose import Pose
+
+CLOUD_LAYER = "pick/object-cloud"
+CANDIDATES_LAYER = "pick/candidates"
+ATTEMPT_LAYER = "pick/attempt"
+PATH_LAYER = "pick/approach-path"
+
+_GRASP_COLOR = (0, 220, 255)
+_PRE_GRASP_COLOR = (255, 0, 200)
+_LINK_COLOR = (150, 150, 150)
+_PATH_COLOR = (255, 255, 255)
+_MAX_CLOUD_POINTS = 20000
+
+
+def _wireframe(pose: Pose, gripper: Any, grasp_frame_to_tcp: Any) -> tuple[np.ndarray, np.ndarray]:
+    from dimos.manipulation.demo_graspgenx.render import gripper_wireframe_geometry
+
+    return gripper_wireframe_geometry(GraspCandidate(pose, 0.0), gripper, grasp_frame_to_tcp)
+
+
+def _rank_color(index: int, total: int) -> tuple[int, int, int]:
+    """Best rank green, worst orange."""
+    t = 0.0 if total <= 1 else index / (total - 1)
+    return (int(60 + 195 * t), int(220 - 60 * t), 60)
+
+
+def _segment(a: Pose, b: Pose) -> tuple[np.ndarray, np.ndarray]:
+    vertices = np.asarray(
+        [[a.position.x, a.position.y, a.position.z], [b.position.x, b.position.y, b.position.z]],
+        dtype=np.float32,
+    )
+    return vertices, np.asarray([[0, 1]], dtype=np.int32)
+
+
+def cloud_layer(points: np.ndarray, frame_id: str) -> VisualizationLayer:
+    """The object cloud the grasp generator consumed."""
+    array = np.asarray(points, dtype=np.float32).reshape((-1, 3))
+    if len(array) > _MAX_CLOUD_POINTS:
+        array = array[:: int(np.ceil(len(array) / _MAX_CLOUD_POINTS))]
+    return VisualizationLayer(
+        CLOUD_LAYER, frame_id, (PointCloudElement("object", array, None, 0.004),)
+    )
+
+
+def candidates_layer(
+    candidates: Sequence[Any], gripper: Any, grasp_frame_to_tcp: Any, frame_id: str
+) -> VisualizationLayer:
+    """Every ranked proposal as a gripper wireframe, best green through worst orange."""
+    elements = []
+    total = len(candidates)
+    for index, candidate in enumerate(candidates):
+        vertices, edges = _wireframe(candidate.pose, gripper, grasp_frame_to_tcp)
+        elements.append(
+            LineSetElement(
+                f"rank-{index + 1}",
+                vertices,
+                edges,
+                colors=np.asarray(_rank_color(index, total), dtype=np.uint8),
+                line_width=1.5,
+            )
+        )
+    return VisualizationLayer(CANDIDATES_LAYER, frame_id, tuple(elements))
+
+
+def attempt_layer(
+    grasp: Pose, pre_grasp: Pose, gripper: Any, grasp_frame_to_tcp: Any, frame_id: str
+) -> VisualizationLayer:
+    """The candidate currently being feasibility-checked, and its pregrasp."""
+    grasp_vertices, grasp_edges = _wireframe(grasp, gripper, grasp_frame_to_tcp)
+    pre_vertices, pre_edges = _wireframe(pre_grasp, gripper, grasp_frame_to_tcp)
+    link_vertices, link_edges = _segment(pre_grasp, grasp)
+    return VisualizationLayer(
+        ATTEMPT_LAYER,
+        frame_id,
+        (
+            LineSetElement(
+                "grasp",
+                grasp_vertices,
+                grasp_edges,
+                colors=np.asarray(_GRASP_COLOR, dtype=np.uint8),
+                line_width=3.0,
+            ),
+            LineSetElement(
+                "pre-grasp",
+                pre_vertices,
+                pre_edges,
+                colors=np.asarray(_PRE_GRASP_COLOR, dtype=np.uint8),
+                line_width=3.0,
+            ),
+            LineSetElement(
+                "link",
+                link_vertices,
+                link_edges,
+                colors=np.asarray(_LINK_COLOR, dtype=np.uint8),
+                line_width=1.5,
+            ),
+        ),
+    )
+
+
+def path_layer(positions: Sequence[Sequence[float]], frame_id: str) -> VisualizationLayer:
+    """Planned end-effector polyline for the approach."""
+    vertices = np.asarray(positions, dtype=np.float32).reshape((-1, 3))
+    edges = np.column_stack(
+        [np.arange(len(vertices) - 1, dtype=np.int32), np.arange(1, len(vertices), dtype=np.int32)]
+    )
+    return VisualizationLayer(
+        PATH_LAYER,
+        frame_id,
+        (
+            LineSetElement(
+                "approach",
+                vertices,
+                edges,
+                colors=np.asarray(_PATH_COLOR, dtype=np.uint8),
+                line_width=2.0,
+            ),
+        ),
+    )

--- a/dimos/manipulation/visualization/layers.py
+++ b/dimos/manipulation/visualization/layers.py
@@ -1,0 +1,174 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Backend-neutral, display-only manipulation visualization layers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+import re
+from typing import TypeAlias
+
+import numpy as np
+from numpy.typing import NDArray
+
+_ID_SEGMENT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+
+
+def _validate_id(value: str, *, hierarchical: bool) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError("visualization ID must be a nonempty string")
+    segments = value.split("/") if hierarchical else [value]
+    if any(not _ID_SEGMENT.fullmatch(segment) for segment in segments):
+        kind = "layer" if hierarchical else "element"
+        raise ValueError(f"{kind} ID contains an invalid segment: {value!r}")
+    return value
+
+
+def _snapshot_positions(value: NDArray[np.generic], *, name: str) -> NDArray[np.float32]:
+    result = np.array(value, dtype=np.float32, copy=True)
+    if result.ndim != 2 or result.shape[1:] != (3,):
+        raise ValueError(f"{name} must have shape (N, 3)")
+    if not np.all(np.isfinite(result)):
+        raise ValueError(f"{name} must contain only finite values")
+    result.setflags(write=False)
+    return result
+
+
+def _snapshot_colors(
+    value: NDArray[np.generic] | None,
+    *,
+    count: int,
+    allow_uniform: bool,
+) -> NDArray[np.uint8] | None:
+    if value is None:
+        return None
+    source = np.asarray(value)
+    valid_shapes: set[tuple[int, ...]] = {(count, 3)}
+    if allow_uniform:
+        valid_shapes.add((3,))
+    if source.shape not in valid_shapes:
+        expected = "(3,) or (N, 3)" if allow_uniform else "(N, 3)"
+        raise ValueError(f"colors must have shape {expected}")
+    if not np.issubdtype(source.dtype, np.number):
+        raise ValueError("colors must be numeric RGB values")
+    numeric = np.asarray(source, dtype=np.float64)
+    if not np.all(np.isfinite(numeric)):
+        raise ValueError("colors must contain only finite values")
+    if np.issubdtype(source.dtype, np.floating) and np.all((numeric >= 0.0) & (numeric <= 1.0)):
+        numeric = np.rint(numeric * 255.0)
+    if np.any(numeric < 0.0) or np.any(numeric > 255.0):
+        raise ValueError("colors must be in [0, 1] or [0, 255]")
+    if not np.all(numeric == np.rint(numeric)):
+        raise ValueError("colors above 1 must be integer RGB values")
+    result = np.array(numeric, dtype=np.uint8, copy=True)
+    result.setflags(write=False)
+    return result
+
+
+def _validate_size(value: float | None, *, name: str) -> float | None:
+    if value is None:
+        return None
+    result = float(value)
+    if not math.isfinite(result) or result <= 0.0:
+        raise ValueError(f"{name} must be finite and positive")
+    return result
+
+
+@dataclass(frozen=True)
+class PointCloudElement:
+    """A generic colored point cloud with no planning authority."""
+
+    id: str
+    points: NDArray[np.generic]
+    colors: NDArray[np.generic] | None = None
+    point_size: float | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "id", _validate_id(self.id, hierarchical=False))
+        points = _snapshot_positions(self.points, name="points")
+        object.__setattr__(self, "points", points)
+        object.__setattr__(
+            self,
+            "colors",
+            _snapshot_colors(self.colors, count=len(points), allow_uniform=False),
+        )
+        object.__setattr__(self, "point_size", _validate_size(self.point_size, name="point_size"))
+
+
+@dataclass(frozen=True)
+class LineSetElement:
+    """Indexed line geometry with optional uniform or per-line RGB."""
+
+    id: str
+    vertices: NDArray[np.generic]
+    edges: NDArray[np.generic]
+    colors: NDArray[np.generic] | None = None
+    line_width: float | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "id", _validate_id(self.id, hierarchical=False))
+        vertices = _snapshot_positions(self.vertices, name="vertices")
+        object.__setattr__(self, "vertices", vertices)
+
+        source_edges = np.asarray(self.edges)
+        if source_edges.ndim != 2 or source_edges.shape[1:] != (2,):
+            raise ValueError("edges must have shape (M, 2)")
+        if not np.issubdtype(source_edges.dtype, np.number):
+            raise ValueError("edges must contain integer indices")
+        numeric_edges = np.asarray(source_edges, dtype=np.float64)
+        if not np.all(np.isfinite(numeric_edges)) or not np.all(
+            numeric_edges == np.rint(numeric_edges)
+        ):
+            raise ValueError("edges must contain finite integer indices")
+        if np.any(numeric_edges < 0) or (
+            numeric_edges.size and np.any(numeric_edges >= len(vertices))
+        ):
+            raise ValueError("edges contain an out-of-range vertex index")
+        edges = np.array(numeric_edges, dtype=np.int32, copy=True)
+        edges.setflags(write=False)
+        object.__setattr__(self, "edges", edges)
+        object.__setattr__(
+            self,
+            "colors",
+            _snapshot_colors(self.colors, count=len(edges), allow_uniform=True),
+        )
+        object.__setattr__(self, "line_width", _validate_size(self.line_width, name="line_width"))
+
+
+VisualizationElement: TypeAlias = PointCloudElement | LineSetElement
+
+
+@dataclass(frozen=True)
+class VisualizationLayer:
+    """A complete, owner-scoped set of display-only visual elements."""
+
+    id: str
+    frame_id: str
+    elements: tuple[VisualizationElement, ...]
+    default_visible: bool = True
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "id", _validate_id(self.id, hierarchical=True))
+        if not isinstance(self.frame_id, str) or not self.frame_id.strip():
+            raise ValueError("frame_id must be a nonempty string")
+        object.__setattr__(self, "frame_id", self.frame_id.strip())
+        elements = tuple(self.elements)
+        if any(not isinstance(item, (PointCloudElement, LineSetElement)) for item in elements):
+            raise TypeError("elements must be point-cloud or line-set elements")
+        ids = [item.id for item in elements]
+        if len(ids) != len(set(ids)):
+            raise ValueError("element IDs must be unique within a layer")
+        object.__setattr__(self, "elements", elements)

--- a/dimos/manipulation/visualization/test_factory.py
+++ b/dimos/manipulation/visualization/test_factory.py
@@ -41,6 +41,7 @@ from dimos.manipulation.visualization.config import (
     NoManipulationVisualizationConfig,
 )
 from dimos.manipulation.visualization.factory import create_manipulation_visualization
+from dimos.manipulation.visualization.layers import VisualizationLayer
 from dimos.manipulation.visualization.viser.config import ViserVisualizationConfig
 from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
 from dimos.msgs.sensor_msgs.JointState import JointState
@@ -81,6 +82,12 @@ class FakeVisualization:
         return None
 
     def clear_vis_obstacles(self) -> None:
+        return None
+
+    def set_layer(self, layer: VisualizationLayer) -> None:
+        return None
+
+    def clear_layer(self, layer_id: str) -> None:
         return None
 
 
@@ -237,6 +244,12 @@ class FakeMeshcatWorld(FakeWorld):
     def clear_vis_obstacles(self) -> None:
         self.visualization_calls.append(("clear_vis_obstacles",))
 
+    def set_layer(self, layer: VisualizationLayer) -> None:
+        self.visualization_calls.append(("set_layer", layer))
+
+    def clear_layer(self, layer_id: str) -> None:
+        self.visualization_calls.append(("clear_layer", layer_id))
+
 
 def test_config_defaults_to_no_visualization() -> None:
     config = ManipulationModuleConfig()
@@ -307,6 +320,7 @@ def test_create_visualization_meshcat_accepts_structural_world() -> None:
         pose=PoseStamped(),
         dimensions=(1.0, 1.0, 1.0),
     )
+    layer = VisualizationLayer("debug/cloud", "world", ())
     visualization.initialize(session)
     assert visualization.get_visualization_url() == "meshcat://test"
     visualization.update_state(frame)
@@ -316,6 +330,8 @@ def test_create_visualization_meshcat_accepts_structural_world() -> None:
     visualization.add_vis_obstacle("box", obstacle)
     visualization.remove_vis_obstacle("box")
     visualization.clear_vis_obstacles()
+    visualization.set_layer(layer)
+    visualization.clear_layer(layer.id)
     assert fake_world.visualization_calls == [
         ("initialize", session),
         ("get_visualization_url",),
@@ -326,6 +342,8 @@ def test_create_visualization_meshcat_accepts_structural_world() -> None:
         ("add_vis_obstacle", "box", obstacle),
         ("remove_vis_obstacle", "box"),
         ("clear_vis_obstacles",),
+        ("set_layer", layer),
+        ("clear_layer", layer.id),
     ]
     assert fake_world.native_calls == []
 

--- a/dimos/manipulation/visualization/test_grasp_layers.py
+++ b/dimos/manipulation/visualization/test_grasp_layers.py
@@ -1,0 +1,37 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import numpy as np
+
+from dimos.manipulation.visualization.grasp_layers import _wireframe
+from dimos.msgs.geometry_msgs.Pose import Pose
+
+
+def test_wireframe_converts_tcp_pose_back_to_grasp_frame() -> None:
+    pose = Pose(1.0, 2.0, 3.0)
+    gripper = SimpleNamespace(
+        extents_open=(0.08, 0.03, 0.06),
+        offset_open=(0.0, 0.0, 0.09),
+        extents_half_open=(0.04, 0.03, 0.04),
+        offset_half_open=(0.0, 0.0, 0.02),
+    )
+    grasp_frame_to_tcp = np.eye(4)
+    grasp_frame_to_tcp[0, 3] = 0.2
+
+    vertices, edges = _wireframe(pose, gripper, grasp_frame_to_tcp)
+
+    np.testing.assert_allclose(vertices[1], [0.8, 2.0, 3.0], atol=1e-6)
+    np.testing.assert_array_equal(edges, [[0, 1], [2, 3], [4, 5], [6, 7]])

--- a/dimos/manipulation/visualization/test_layers.py
+++ b/dimos/manipulation/visualization/test_layers.py
@@ -1,0 +1,155 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for backend-neutral visualization layers."""
+
+from dataclasses import FrozenInstanceError
+
+import numpy as np
+import pytest
+
+from dimos.manipulation.visualization.layers import (
+    LineSetElement,
+    PointCloudElement,
+    VisualizationLayer,
+)
+
+
+def test_point_cloud_snapshots_positions_and_normalizes_colors() -> None:
+    points = np.asarray([[1.0, 2.0, 3.0]], dtype=np.float64)
+    colors = np.asarray([[0.0, 0.5, 1.0]], dtype=np.float32)
+
+    element = PointCloudElement("object", points, colors, point_size=0.005)
+    points[:] = 9.0
+    colors[:] = 0.0
+
+    np.testing.assert_array_equal(element.points, [[1.0, 2.0, 3.0]])
+    np.testing.assert_array_equal(element.colors, [[0, 128, 255]])
+    assert element.points.dtype == np.float32
+    assert element.points.flags.writeable is False
+    assert element.colors is not None and element.colors.flags.writeable is False
+    with pytest.raises(ValueError, match="read-only"):
+        element.points[0, 0] = 4.0
+    with pytest.raises(FrozenInstanceError):
+        element.point_size = 1.0  # type: ignore[misc]
+
+
+def test_line_set_accepts_uniform_and_per_line_colors() -> None:
+    vertices = np.asarray([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0]])
+    edges = np.asarray([[0, 1], [1, 2]])
+
+    uniform = LineSetElement("uniform", vertices, edges, colors=np.asarray([255, 0, 0]))
+    per_line = LineSetElement(
+        "rank-1",
+        vertices,
+        edges,
+        colors=np.asarray([[0, 255, 0], [255, 128, 0]]),
+        line_width=2.0,
+    )
+
+    np.testing.assert_array_equal(uniform.colors, [255, 0, 0])
+    np.testing.assert_array_equal(per_line.colors, [[0, 255, 0], [255, 128, 0]])
+    assert per_line.edges.dtype == np.int32
+    assert per_line.edges.flags.writeable is False
+
+
+@pytest.mark.parametrize("value", ["", "/grasp", "grasp/", "grasp//cloud", "grasp cloud"])
+def test_layer_rejects_invalid_id(value: str) -> None:
+    with pytest.raises(ValueError, match="layer ID|visualization ID"):
+        VisualizationLayer(value, "world", ())
+
+
+@pytest.mark.parametrize("value", ["", "rank/1", "rank 1"])
+def test_element_rejects_invalid_id(value: str) -> None:
+    with pytest.raises(ValueError, match="element ID|visualization ID"):
+        PointCloudElement(value, np.empty((0, 3)))
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"points": np.zeros((3,))}, "shape"),
+        ({"points": np.asarray([[np.nan, 0.0, 0.0]])}, "finite"),
+        (
+            {
+                "points": np.zeros((2, 3)),
+                "colors": np.zeros((1, 3)),
+            },
+            "colors",
+        ),
+        (
+            {
+                "points": np.zeros((1, 3)),
+                "colors": np.asarray([[256, 0, 0]]),
+            },
+            "colors",
+        ),
+        ({"points": np.zeros((1, 3)), "point_size": 0.0}, "positive"),
+    ],
+)
+def test_point_cloud_rejects_invalid_geometry(kwargs: dict[str, object], message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        PointCloudElement("cloud", **kwargs)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("edges", "message"),
+    [
+        (np.zeros((2, 3)), "shape"),
+        (np.asarray([[0.5, 1.0]]), "integer"),
+        (np.asarray([[-1, 0]]), "out-of-range"),
+        (np.asarray([[0, 2]]), "out-of-range"),
+    ],
+)
+def test_line_set_rejects_invalid_edges(edges: np.ndarray, message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        LineSetElement(
+            "lines",
+            np.asarray([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]]),
+            edges,
+        )
+
+
+def test_line_set_rejects_invalid_appearance() -> None:
+    with pytest.raises(ValueError, match="colors"):
+        LineSetElement(
+            "lines",
+            np.asarray([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]]),
+            np.asarray([[0, 1]]),
+            colors=np.asarray([[0, 0, 0], [255, 255, 255]]),
+        )
+    with pytest.raises(ValueError, match="positive"):
+        LineSetElement(
+            "lines",
+            np.asarray([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]]),
+            np.asarray([[0, 1]]),
+            line_width=float("nan"),
+        )
+
+
+def test_layer_rejects_empty_frame_and_duplicate_elements() -> None:
+    element = PointCloudElement("object", np.empty((0, 3)))
+    with pytest.raises(ValueError, match="frame_id"):
+        VisualizationLayer("grasp/object-cloud", " ", (element,))
+    with pytest.raises(ValueError, match="unique"):
+        VisualizationLayer("grasp/object-cloud", "world", (element, element))
+
+
+def test_layer_owns_element_tuple() -> None:
+    source = [PointCloudElement("object", np.empty((0, 3)))]
+
+    layer = VisualizationLayer("grasp/object-cloud", "world", source)  # type: ignore[arg-type]
+    source.clear()
+
+    assert [item.id for item in layer.elements] == ["object"]

--- a/dimos/manipulation/visualization/viser/layers.py
+++ b/dimos/manipulation/visualization/viser/layers.py
@@ -1,0 +1,277 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Latest-wins Viser registry for generic visualization layers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from threading import Condition, Thread
+import time
+from typing import Any
+
+from dimos.manipulation.visualization.layers import VisualizationLayer
+from dimos.manipulation.visualization.viser.scene import ViserManipulationScene
+from dimos.utils.logging_config import setup_logger
+
+logger = setup_logger()
+
+
+def _display_name(segment: str) -> str:
+    return segment.replace("-", " ").replace("_", " ").title()
+
+
+@dataclass
+class _LayerState:
+    visible: bool
+    generation: int = 0
+    warning: str | None = None
+
+
+@dataclass(frozen=True)
+class _LayerOperation:
+    sequence: int
+    layer: VisualizationLayer | None
+
+
+class ViserLayerManager:
+    """Own Viser layer state, controls, and asynchronous scene reconciliation."""
+
+    def __init__(self, server: Any, scene: ViserManipulationScene) -> None:
+        self._server = server
+        self._scene = scene
+        self._condition = Condition()
+        self._states: dict[str, _LayerState] = {}
+        self._pending: dict[str, _LayerOperation] = {}
+        self._sequence = 0
+        self._processing = False
+        self._closed = False
+        self._leaf_handles: dict[str, Any] = {}
+        self._group_folders: dict[str, Any] = {}
+        self._group_handles: dict[str, Any] = {}
+        self._control_sync_depth = 0
+        self._root_folder = server.gui.add_folder("Visualization Layers", expand_by_default=True)
+        self._worker = Thread(
+            target=self._run,
+            name="viser-visualization-layers",
+            daemon=True,
+        )
+        self._worker.start()
+
+    @property
+    def layer_ids(self) -> tuple[str, ...]:
+        with self._condition:
+            return tuple(sorted(self._states))
+
+    def visibility(self, layer_id: str) -> bool | None:
+        with self._condition:
+            state = self._states.get(layer_id)
+            return None if state is None else state.visible
+
+    def warning(self, layer_id: str) -> str | None:
+        with self._condition:
+            state = self._states.get(layer_id)
+            return None if state is None else state.warning
+
+    def set_layer(self, layer: VisualizationLayer) -> None:
+        """Queue a complete replacement without waiting for scene rendering."""
+        with self._condition:
+            if self._closed:
+                return
+            if layer.id not in self._states:
+                self._states[layer.id] = _LayerState(visible=layer.default_visible)
+                self._rebuild_controls()
+            self._sequence += 1
+            self._pending[layer.id] = _LayerOperation(self._sequence, layer)
+            self._condition.notify()
+
+    def clear_layer(self, layer_id: str) -> None:
+        """Queue a clear for a known layer while retaining its viewer state."""
+        with self._condition:
+            if self._closed or layer_id not in self._states:
+                return
+            self._sequence += 1
+            self._pending[layer_id] = _LayerOperation(self._sequence, None)
+            self._condition.notify()
+
+    def set_visible(self, layer_id: str, visible: bool) -> None:
+        with self._condition:
+            state = self._states.get(layer_id)
+            if self._closed or state is None:
+                return
+            state.visible = bool(visible)
+            handle = self._leaf_handles.get(layer_id)
+            if handle is not None:
+                self._set_control_value(handle, state.visible)
+            self._sync_parent_controls(layer_id)
+        self._scene.set_visualization_layer_visible(layer_id, bool(visible))
+
+    def set_group_visible(self, group_id: str, visible: bool) -> None:
+        descendants = [
+            layer_id for layer_id in self.layer_ids if layer_id.startswith(f"{group_id}/")
+        ]
+        for layer_id in descendants:
+            self.set_visible(layer_id, visible)
+
+    def wait_idle(self, timeout: float = 2.0) -> bool:
+        deadline = time.monotonic() + timeout
+        with self._condition:
+            while self._pending or self._processing:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0.0:
+                    return False
+                self._condition.wait(remaining)
+            return True
+
+    def close(self) -> None:
+        with self._condition:
+            if self._closed:
+                return
+            self._closed = True
+            self._pending.clear()
+            self._condition.notify_all()
+        self._worker.join(timeout=2.0)
+        self._scene.clear_visualization_layers()
+        for handle in (
+            *self._leaf_handles.values(),
+            *self._group_handles.values(),
+            *reversed(self._group_folders.values()),
+            self._root_folder,
+        ):
+            remove = getattr(handle, "remove", None)
+            if callable(remove):
+                remove()
+        self._leaf_handles.clear()
+        self._group_handles.clear()
+        self._group_folders.clear()
+
+    def _run(self) -> None:
+        while True:
+            with self._condition:
+                while not self._pending and not self._closed:
+                    self._condition.wait()
+                if self._closed:
+                    self._processing = False
+                    self._condition.notify_all()
+                    return
+                layer_id = next(iter(self._pending))
+                operation = self._pending.pop(layer_id)
+                state = self._states[layer_id]
+                state.generation += 1
+                generation = state.generation
+                visible = state.visible
+                self._processing = True
+            try:
+                if operation.layer is None:
+                    self._scene.clear_visualization_layer(layer_id)
+                else:
+                    self._scene.replace_visualization_layer(
+                        operation.layer,
+                        generation=generation,
+                        visible=visible,
+                    )
+                warning = None
+            except Exception as error:
+                warning = str(error)
+                logger.warning(
+                    "Visualization layer update failed for '%s': %s",
+                    layer_id,
+                    error,
+                    exc_info=True,
+                )
+            with self._condition:
+                state.warning = warning
+                self._processing = False
+                self._condition.notify_all()
+
+    def _add_layer_controls(self, layer_id: str) -> None:
+        segments = layer_id.split("/")
+        parent = self._root_folder
+        for index, segment in enumerate(segments[:-1], start=1):
+            group_id = "/".join(segments[:index])
+            folder = self._group_folders.get(group_id)
+            if folder is None:
+                with parent:
+                    folder = self._server.gui.add_folder(
+                        _display_name(segment), expand_by_default=True
+                    )
+                self._group_folders[group_id] = folder
+                with folder:
+                    group_handle = self._server.gui.add_checkbox("All", initial_value=True)
+                group_handle.on_update(
+                    lambda event, selected_group=group_id: self._on_group_update(
+                        selected_group,
+                        bool(event.target.value),
+                    )
+                )
+                self._group_handles[group_id] = group_handle
+            parent = folder
+        state = self._states[layer_id]
+        with parent:
+            leaf = self._server.gui.add_checkbox(
+                _display_name(segments[-1]), initial_value=state.visible
+            )
+        leaf.on_update(
+            lambda event, selected_layer=layer_id: self._on_leaf_update(
+                selected_layer,
+                bool(event.target.value),
+            )
+        )
+        self._leaf_handles[layer_id] = leaf
+        self._sync_parent_controls(layer_id)
+
+    def _rebuild_controls(self) -> None:
+        for handle in (
+            *self._leaf_handles.values(),
+            *self._group_handles.values(),
+            *reversed(self._group_folders.values()),
+        ):
+            remove = getattr(handle, "remove", None)
+            if callable(remove):
+                remove()
+        self._leaf_handles.clear()
+        self._group_handles.clear()
+        self._group_folders.clear()
+        for layer_id in sorted(self._states):
+            self._add_layer_controls(layer_id)
+
+    def _sync_parent_controls(self, layer_id: str) -> None:
+        segments = layer_id.split("/")
+        for index in range(1, len(segments)):
+            group_id = "/".join(segments[:index])
+            handle = self._group_handles.get(group_id)
+            if handle is None:
+                continue
+            descendants = [
+                state.visible
+                for candidate, state in self._states.items()
+                if candidate.startswith(f"{group_id}/")
+            ]
+            self._set_control_value(handle, bool(descendants) and all(descendants))
+
+    def _set_control_value(self, handle: Any, value: bool) -> None:
+        """Update Viser state without treating its callback as a user action."""
+        self._control_sync_depth += 1
+        try:
+            handle.value = value
+        finally:
+            self._control_sync_depth -= 1
+
+    def _on_leaf_update(self, layer_id: str, visible: bool) -> None:
+        if self._control_sync_depth == 0:
+            self.set_visible(layer_id, visible)
+
+    def _on_group_update(self, group_id: str, visible: bool) -> None:
+        if self._control_sync_depth == 0:
+            self.set_group_visible(group_id, visible)

--- a/dimos/manipulation/visualization/viser/scene.py
+++ b/dimos/manipulation/visualization/viser/scene.py
@@ -29,6 +29,7 @@ from typing import Any, Protocol, TypeAlias, cast
 import xml.etree.ElementTree as ET
 
 import numpy as np
+from numpy.typing import NDArray
 import trimesh
 from yourdfpy import URDF  # type: ignore[import-untyped]
 
@@ -37,6 +38,11 @@ from dimos.manipulation.planning.spec.config import RobotModelConfig
 from dimos.manipulation.planning.spec.enums import ObstacleType
 from dimos.manipulation.planning.spec.models import DEFAULT_OBSTACLE_RGBA, Obstacle
 from dimos.manipulation.planning.utils.mesh_utils import prepare_urdf_for_drake
+from dimos.manipulation.visualization.layers import (
+    LineSetElement,
+    PointCloudElement,
+    VisualizationLayer,
+)
 from dimos.manipulation.visualization.viser.animation import (
     GroupPreviewAnimation,
     PreviewFrame,
@@ -102,6 +108,12 @@ OBSTACLE_DEFAULT_RGBA = DEFAULT_OBSTACLE_RGBA
 OBSTACLE_FALLBACK_COLOR = (55, 190, 210)
 OBSTACLE_FALLBACK_OPACITY = 0.55
 OBSTACLE_PROXY_COLOR = (255, 45, 25)
+VISUALIZATION_LAYER_NAMESPACE = "/manipulation/layers"
+VISUALIZATION_POINT_CAP = 20_000
+VISUALIZATION_DEFAULT_POINT_SIZE = 0.005
+VISUALIZATION_DEFAULT_POINT_COLOR = (0, 204, 204)
+VISUALIZATION_DEFAULT_LINE_COLOR = (255, 255, 255)
+VISUALIZATION_DEFAULT_LINE_WIDTH = 1.0
 
 
 class RobotDisplayMode(StrEnum):
@@ -147,6 +159,8 @@ class ViserManipulationScene:
         self._obstacles_visible = True
         self._obstacle_gui_handles: list[object] = []
         self._obstacle_warning_handle: Any | None = None
+        self._visualization_layer_handles: dict[str, list[Any]] = {}
+        self._visualization_layer_visibility: dict[str, bool] = {}
         self._closed = False
         self._ensure_obstacle_control()
         self._ensure_reference_grid()
@@ -160,6 +174,116 @@ class ViserManipulationScene:
             for handles in self._obstacle_handles.values():
                 for handle in handles:
                     self._set_handle_visibility(handle, self._obstacles_visible)
+
+    @staticmethod
+    def _visualization_path_segment(value: str) -> str:
+        return f"id-{value.encode('utf-8').hex()}"
+
+    def replace_visualization_layer(
+        self,
+        layer: VisualizationLayer,
+        *,
+        generation: int,
+        visible: bool,
+    ) -> None:
+        """Atomically replace a display-only layer with one complete generation."""
+        if layer.frame_id != "world":
+            raise ValueError(
+                f"Viser visualization layer '{layer.id}' requires frame 'world', "
+                f"got '{layer.frame_id}'"
+            )
+        base_path = (
+            f"{VISUALIZATION_LAYER_NAMESPACE}/"
+            f"{self._visualization_path_segment(layer.id)}/generation-{generation}"
+        )
+        pending: list[Any] = []
+        with self._scene_lock:
+            if self._closed:
+                raise RuntimeError("Viser scene is closed")
+            try:
+                for element in layer.elements:
+                    path = f"{base_path}/{self._visualization_path_segment(element.id)}"
+                    if isinstance(element, PointCloudElement):
+                        handle = self._render_point_cloud_element(path, element)
+                    elif isinstance(element, LineSetElement):
+                        handle = self._render_line_set_element(path, element)
+                    else:
+                        raise TypeError(f"unsupported visualization element: {type(element)!r}")
+                    if handle is not None:
+                        self._set_handle_visibility(handle, False)
+                        pending.append(handle)
+            except Exception:
+                for handle in pending:
+                    self._remove_scene_handle(handle)
+                raise
+
+            previous = self._visualization_layer_handles.get(layer.id, [])
+            for handle in pending:
+                self._set_handle_visibility(handle, visible)
+            self._visualization_layer_handles[layer.id] = pending
+            self._visualization_layer_visibility[layer.id] = visible
+            for handle in previous:
+                self._remove_scene_handle(handle)
+
+    def clear_visualization_layer(self, layer_id: str) -> None:
+        """Remove one layer's handles while retaining its visibility."""
+        with self._scene_lock:
+            for handle in self._visualization_layer_handles.pop(layer_id, []):
+                self._remove_scene_handle(handle)
+
+    def clear_visualization_layers(self) -> None:
+        """Remove every generic layer handle."""
+        with self._scene_lock:
+            for layer_id in list(self._visualization_layer_handles):
+                self.clear_visualization_layer(layer_id)
+
+    def set_visualization_layer_visible(self, layer_id: str, visible: bool) -> None:
+        """Apply viewer-owned visibility to a layer's current generation."""
+        with self._scene_lock:
+            self._visualization_layer_visibility[layer_id] = bool(visible)
+            for handle in self._visualization_layer_handles.get(layer_id, []):
+                self._set_handle_visibility(handle, bool(visible))
+
+    def _render_point_cloud_element(self, path: str, element: PointCloudElement) -> Any | None:
+        if len(element.points) == 0:
+            return None
+        stride = max(1, math.ceil(len(element.points) / VISUALIZATION_POINT_CAP))
+        points = element.points[::stride]
+        colors: NDArray[np.uint8] | tuple[int, int, int]
+        if element.colors is None:
+            colors = VISUALIZATION_DEFAULT_POINT_COLOR
+        else:
+            colors = np.asarray(element.colors[::stride], dtype=np.uint8)
+        return self.server.scene.add_point_cloud(
+            path,
+            points=points,
+            colors=colors,
+            point_size=element.point_size or VISUALIZATION_DEFAULT_POINT_SIZE,
+            point_shape="circle",
+            visible=False,
+        )
+
+    def _render_line_set_element(self, path: str, element: LineSetElement) -> Any | None:
+        if len(element.edges) == 0:
+            return None
+        points = element.vertices[element.edges]
+        colors: NDArray[np.uint8] | tuple[int, int, int]
+        if element.colors is None:
+            colors = VISUALIZATION_DEFAULT_LINE_COLOR
+        elif element.colors.ndim == 1:
+            colors = np.asarray(element.colors, dtype=np.uint8)
+        else:
+            colors = np.asarray(
+                np.repeat(element.colors[:, np.newaxis, :], 2, axis=1),
+                dtype=np.uint8,
+            )
+        return self.server.scene.add_line_segments(
+            path,
+            points=points,
+            colors=colors,
+            line_width=element.line_width or VISUALIZATION_DEFAULT_LINE_WIDTH,
+            visible=False,
+        )
 
     def add_vis_obstacle(self, obstacle_id: str, obstacle: Obstacle) -> None:
         """Render one accepted planner obstacle under the local obstacle namespace."""
@@ -665,6 +789,8 @@ class ViserManipulationScene:
             self._obstacle_handles.clear()
             self._obstacles.clear()
             self._obstacle_render_failures.clear()
+            self.clear_visualization_layers()
+            self._visualization_layer_visibility.clear()
             for key in list(self._handles):
                 self._remove_handle(key)
             if self._grid_handle is not None:
@@ -676,7 +802,8 @@ class ViserManipulationScene:
                 self._remove_scene_handle(frame)
             for urdf in self._collision_fallback_urdfs.values():
                 self._remove_scene_handle(urdf)
-            for handle in self._obstacle_gui_handles:
+            # Viser folders own their children, so remove children before folders.
+            for handle in reversed(self._obstacle_gui_handles):
                 self._remove_scene_handle(handle)
             self._obstacle_gui_handles.clear()
             self._urdfs.clear()

--- a/dimos/manipulation/visualization/viser/test_layers.py
+++ b/dimos/manipulation/visualization/viser/test_layers.py
@@ -1,0 +1,415 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Hermetic Viser tests for generic visualization layers."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass, field
+from threading import Event
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from pytest_mock import MockerFixture
+
+pytest.importorskip("viser", reason="Viser optional dependency is not installed")
+
+from dimos.manipulation.visualization.layers import (
+    LineSetElement,
+    PointCloudElement,
+    VisualizationLayer,
+)
+from dimos.manipulation.visualization.viser.layers import ViserLayerManager
+from dimos.manipulation.visualization.viser.scene import ViserManipulationScene
+
+
+@dataclass
+class Handle:
+    name: str
+    visible: bool = True
+    value: bool = True
+    callback: Callable[[object], None] | None = None
+    removed: bool = False
+    callback_on_assignment: bool = False
+    _initialized: bool = field(default=False, init=False)
+
+    def __post_init__(self) -> None:
+        self._initialized = True
+
+    def __setattr__(self, name: str, value: object) -> None:
+        previous = getattr(self, name, None)
+        object.__setattr__(self, name, value)
+        if (
+            name == "value"
+            and getattr(self, "_initialized", False)
+            and getattr(self, "callback_on_assignment", False)
+            and previous != value
+            and self.callback is not None
+        ):
+            self.callback(SimpleNamespace(target=self))
+
+    def on_update(self, callback: Callable[[object], None]) -> None:
+        self.callback = callback
+
+    def remove(self) -> None:
+        self.removed = True
+
+    def trigger(self, value: bool) -> None:
+        self.value = value
+        if not self.callback_on_assignment:
+            assert self.callback is not None
+            self.callback(SimpleNamespace(target=self))
+
+
+class Folder(Handle):
+    def __enter__(self) -> Folder:
+        return self
+
+    def __exit__(self, *_args: object) -> bool:
+        return False
+
+
+class Gui:
+    def __init__(self, *, callback_on_assignment: bool = False) -> None:
+        self.folders: list[Folder] = []
+        self.checkboxes: list[Handle] = []
+        self.callback_on_assignment = callback_on_assignment
+
+    def add_folder(self, label: str, **_kwargs: object) -> Folder:
+        handle = Folder(label)
+        self.folders.append(handle)
+        return handle
+
+    def add_checkbox(self, label: str, *, initial_value: bool) -> Handle:
+        handle = Handle(
+            label,
+            value=initial_value,
+            callback_on_assignment=self.callback_on_assignment,
+        )
+        self.checkboxes.append(handle)
+        return handle
+
+
+class SceneApi:
+    def __init__(self) -> None:
+        self.handles: list[Handle] = []
+        self.calls: list[tuple[str, str, dict[str, object]]] = []
+        self.fail_on_name: str | None = None
+
+    def add_grid(self, name: str, **_kwargs: object) -> Handle:
+        return self._add("grid", name, {})
+
+    def add_point_cloud(self, name: str, **kwargs: object) -> Handle:
+        return self._add("point_cloud", name, kwargs)
+
+    def add_line_segments(self, name: str, **kwargs: object) -> Handle:
+        return self._add("line_segments", name, kwargs)
+
+    def _add(self, kind: str, name: str, kwargs: dict[str, object]) -> Handle:
+        if self.fail_on_name is not None and self.fail_on_name in name:
+            raise RuntimeError("injected render failure")
+        handle = Handle(name, visible=bool(kwargs.get("visible", True)))
+        for key, value in kwargs.items():
+            setattr(handle, key, value)
+        self.handles.append(handle)
+        self.calls.append((kind, name, kwargs))
+        return handle
+
+
+class Server:
+    def __init__(self, *, callback_on_assignment: bool = False) -> None:
+        self.gui = Gui(callback_on_assignment=callback_on_assignment)
+        self.scene = SceneApi()
+
+
+class Urdf:
+    pass
+
+
+@pytest.fixture
+def scene() -> Iterator[ViserManipulationScene]:
+    value = ViserManipulationScene(Server(), Urdf)  # type: ignore[arg-type]
+    try:
+        yield value
+    finally:
+        value.close()
+
+
+@pytest.fixture
+def manager(
+    scene: ViserManipulationScene,
+) -> Iterator[ViserLayerManager]:
+    value = ViserLayerManager(scene.server, scene)
+    try:
+        yield value
+    finally:
+        value.close()
+
+
+def point_layer(
+    value: float = 0.0,
+    *,
+    visible: bool = True,
+    count: int = 1,
+    colors: np.ndarray | None = None,
+) -> VisualizationLayer:
+    points = np.full((count, 3), value, dtype=np.float32)
+    return VisualizationLayer(
+        "grasp/object-cloud",
+        "world",
+        (PointCloudElement("object", points, colors),),
+        default_visible=visible,
+    )
+
+
+def test_scene_renders_cloud_with_paired_cap_and_fallback_color(
+    scene: ViserManipulationScene, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("dimos.manipulation.visualization.viser.scene.VISUALIZATION_POINT_CAP", 2)
+    colors = np.asarray(
+        [[0, 1, 2], [3, 4, 5], [6, 7, 8], [9, 10, 11], [12, 13, 14]],
+        dtype=np.uint8,
+    )
+    layer = point_layer(count=5, colors=colors)
+
+    scene.replace_visualization_layer(layer, generation=1, visible=True)
+    cloud_call = next(call for call in scene.server.scene.calls if call[0] == "point_cloud")
+
+    np.testing.assert_array_equal(
+        cloud_call[2]["points"],
+        np.asarray([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]], dtype=np.float32),
+    )
+    np.testing.assert_array_equal(cloud_call[2]["colors"], colors[::3])
+    assert cloud_call[2]["point_size"] == pytest.approx(0.005)
+    assert scene.server.scene.handles[-1].visible is True
+
+    scene.replace_visualization_layer(point_layer(value=1.0), generation=2, visible=True)
+    fallback = scene.server.scene.calls[-1][2]
+    assert fallback["colors"] == (0, 204, 204)
+
+
+def test_scene_renders_indexed_line_set_and_encodes_logical_ids(
+    scene: ViserManipulationScene,
+) -> None:
+    element = LineSetElement(
+        "rank-1",
+        np.asarray([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0]]),
+        np.asarray([[0, 1], [1, 2]]),
+        colors=np.asarray([[0, 255, 0], [255, 128, 0]]),
+        line_width=2.5,
+    )
+    layer = VisualizationLayer("grasp/proposals", "world", (element,))
+
+    scene.replace_visualization_layer(layer, generation=7, visible=True)
+    kind, name, kwargs = scene.server.scene.calls[-1]
+
+    assert kind == "line_segments"
+    assert "grasp/proposals" not in name
+    assert "rank-1" not in name
+    assert "generation-7" in name
+    np.testing.assert_array_equal(
+        kwargs["points"],
+        np.asarray(
+            [
+                [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
+                [[1.0, 0.0, 0.0], [1.0, 1.0, 0.0]],
+            ]
+        ),
+    )
+    np.testing.assert_array_equal(
+        kwargs["colors"],
+        np.asarray(
+            [
+                [[0, 255, 0], [0, 255, 0]],
+                [[255, 128, 0], [255, 128, 0]],
+            ]
+        ),
+    )
+    assert kwargs["line_width"] == pytest.approx(2.5)
+
+
+def test_scene_failed_replacement_retains_previous_generation(
+    scene: ViserManipulationScene,
+) -> None:
+    scene.replace_visualization_layer(point_layer(), generation=1, visible=True)
+    previous = scene.server.scene.handles[-1]
+    first = PointCloudElement("first", np.asarray([[1.0, 0.0, 0.0]]))
+    failing = PointCloudElement("fail", np.asarray([[2.0, 0.0, 0.0]]))
+    replacement = VisualizationLayer("grasp/object-cloud", "world", (first, failing))
+    scene.server.scene.fail_on_name = "6661696c"  # "fail" in hexadecimal
+
+    with pytest.raises(RuntimeError, match="injected"):
+        scene.replace_visualization_layer(replacement, generation=2, visible=True)
+
+    assert previous.removed is False
+    partial = next(handle for handle in scene.server.scene.handles if "generation-2" in handle.name)
+    assert partial.removed is True
+
+
+def test_manager_registers_hierarchy_and_preserves_hidden_state(
+    manager: ViserLayerManager,
+    scene: ViserManipulationScene,
+) -> None:
+    manager.set_layer(point_layer(visible=False))
+    manager.set_layer(
+        VisualizationLayer(
+            "grasp/proposals",
+            "world",
+            (
+                LineSetElement(
+                    "rank-1",
+                    np.asarray([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]]),
+                    np.asarray([[0, 1]]),
+                ),
+            ),
+        )
+    )
+    assert manager.wait_idle()
+
+    assert manager.layer_ids == ("grasp/object-cloud", "grasp/proposals")
+    assert manager.visibility("grasp/object-cloud") is False
+    assert [folder.name for folder in scene.server.gui.folders if not folder.removed].count(
+        "Grasp"
+    ) == 1
+    object_handle = next(
+        handle
+        for handle in scene.server.gui.checkboxes
+        if handle.name == "Object Cloud" and not handle.removed
+    )
+    object_handle.trigger(True)
+    assert manager.visibility("grasp/object-cloud") is True
+
+    manager.set_visible("grasp/object-cloud", False)
+    manager.set_layer(point_layer(value=2.0, visible=True))
+    assert manager.wait_idle()
+    assert manager.visibility("grasp/object-cloud") is False
+    assert scene.server.scene.handles[-1].visible is False
+
+    manager.clear_layer("grasp/object-cloud")
+    assert manager.wait_idle()
+    assert "grasp/object-cloud" in manager.layer_ids
+    assert manager.visibility("grasp/object-cloud") is False
+
+
+def test_manager_parent_toggle_updates_all_descendants(
+    manager: ViserLayerManager,
+    scene: ViserManipulationScene,
+) -> None:
+    manager.set_layer(point_layer())
+    manager.set_layer(VisualizationLayer("grasp/proposals", "world", ()))
+    assert manager.wait_idle()
+    parent = next(
+        handle
+        for handle in scene.server.gui.checkboxes
+        if handle.name == "All" and not handle.removed
+    )
+
+    parent.trigger(False)
+
+    assert manager.visibility("grasp/object-cloud") is False
+    assert manager.visibility("grasp/proposals") is False
+
+
+def test_manager_leaf_toggle_does_not_cascade_through_reactive_parent() -> None:
+    scene = ViserManipulationScene(Server(callback_on_assignment=True), Urdf)  # type: ignore[arg-type]
+    manager = ViserLayerManager(scene.server, scene)
+    try:
+        manager.set_layer(point_layer())
+        manager.set_layer(VisualizationLayer("grasp/proposals", "world", ()))
+        assert manager.wait_idle()
+        object_handle = next(
+            handle
+            for handle in scene.server.gui.checkboxes
+            if handle.name == "Object Cloud" and not handle.removed
+        )
+
+        object_handle.trigger(False)
+
+        assert manager.visibility("grasp/object-cloud") is False
+        assert manager.visibility("grasp/proposals") is True
+    finally:
+        manager.close()
+        scene.close()
+
+
+def test_manager_latest_pending_operation_wins(
+    manager: ViserLayerManager,
+    scene: ViserManipulationScene,
+    mocker: MockerFixture,
+) -> None:
+    entered = Event()
+    release = Event()
+    original = scene.replace_visualization_layer
+
+    def block_first(layer: VisualizationLayer, *, generation: int, visible: bool) -> None:
+        if not entered.is_set():
+            entered.set()
+            assert release.wait(2.0)
+        original(layer, generation=generation, visible=visible)
+
+    mocker.patch.object(scene, "replace_visualization_layer", side_effect=block_first)
+    manager.set_layer(point_layer(value=1.0))
+    assert entered.wait(2.0)
+    manager.set_layer(point_layer(value=2.0))
+    manager.clear_layer("grasp/object-cloud")
+    release.set()
+
+    assert manager.wait_idle()
+    assert not any(
+        not handle.removed and "generation-" in handle.name for handle in scene.server.scene.handles
+    )
+
+
+def test_manager_failure_is_contained_and_cross_layer_remains_independent(
+    manager: ViserLayerManager,
+    scene: ViserManipulationScene,
+) -> None:
+    scene.server.scene.fail_on_name = "6661696c"
+    manager.set_layer(
+        VisualizationLayer(
+            "debug/failing",
+            "world",
+            (PointCloudElement("fail", np.asarray([[0.0, 0.0, 0.0]])),),
+        )
+    )
+    manager.set_layer(point_layer())
+
+    assert manager.wait_idle()
+    assert "injected render failure" in (manager.warning("debug/failing") or "")
+    assert manager.warning("grasp/object-cloud") is None
+    assert any(
+        not handle.removed and "generation-" in handle.name for handle in scene.server.scene.handles
+    )
+
+
+def test_scene_rejects_unsupported_frame_without_replacing_current(
+    scene: ViserManipulationScene,
+) -> None:
+    scene.replace_visualization_layer(point_layer(), generation=1, visible=True)
+    previous = scene.server.scene.handles[-1]
+
+    with pytest.raises(ValueError, match="requires frame 'world'"):
+        scene.replace_visualization_layer(
+            VisualizationLayer(
+                "grasp/object-cloud",
+                "camera",
+                (PointCloudElement("object", np.asarray([[0.0, 0.0, 0.0]])),),
+            ),
+            generation=2,
+            visible=True,
+        )
+
+    assert previous.removed is False

--- a/dimos/manipulation/visualization/viser/visualizer.py
+++ b/dimos/manipulation/visualization/viser/visualizer.py
@@ -18,6 +18,7 @@ from collections.abc import Sequence
 from contextlib import suppress
 from typing import TYPE_CHECKING
 
+from dimos.manipulation.visualization.layers import VisualizationLayer
 from dimos.manipulation.visualization.viser.animation import (
     GroupPreviewAnimation,
     PreviewFrame,
@@ -25,6 +26,7 @@ from dimos.manipulation.visualization.viser.animation import (
 )
 from dimos.manipulation.visualization.viser.config import ViserVisualizationConfig
 from dimos.manipulation.visualization.viser.gui import ViserPanelGui
+from dimos.manipulation.visualization.viser.layers import ViserLayerManager
 from dimos.manipulation.visualization.viser.runtime import (
     VISER_URDF_INSTALL_HINT,
     ViserRuntime,
@@ -73,6 +75,7 @@ class ViserManipulationVisualizer:
         self._server: ViserServer | None = None
         self._scene: ViserManipulationScene | None = None
         self._gui: ViserPanelGui | None = None
+        self._layer_manager: ViserLayerManager | None = None
         self._session_scene: PlanningSceneInfo | None = None
         self._operator: object | None = None
         self._current_states: dict[str, JointState] = {}
@@ -120,6 +123,7 @@ class ViserManipulationVisualizer:
             self._server = None
             self._scene = None
             self._gui = None
+            self._layer_manager = None
             self._closed = True
             raise
         self._runtime = runtime
@@ -128,6 +132,15 @@ class ViserManipulationVisualizer:
         self._gui = gui
         self._closed = False
         logger.info(f"Viser manipulation visualization: {self.get_visualization_url()}")
+
+    def _ensure_layer_manager(self) -> ViserLayerManager | None:
+        """Create generic layer resources only when a layer is first published."""
+        if self._layer_manager is not None:
+            return self._layer_manager
+        if self._server is None or self._scene is None or self._closed:
+            return None
+        self._layer_manager = ViserLayerManager(self._server, self._scene)
+        return self._layer_manager
 
     def initialize(self, session: VisualizationSession) -> None:
         """Initialize Viser robot visuals from a one-shot visualization session."""
@@ -227,6 +240,37 @@ class ViserManipulationVisualizer:
         if self._scene is not None:
             self._scene.clear_vis_obstacles()
 
+    def set_layer(self, layer: VisualizationLayer) -> None:
+        """Queue one complete display-only layer replacement."""
+        if self._closed:
+            return
+        try:
+            self._ensure_started()
+            manager = self._ensure_layer_manager()
+            if manager is not None:
+                manager.set_layer(layer)
+        except Exception:
+            logger.warning(
+                "Visualization layer submission failed for '%s'",
+                layer.id,
+                exc_info=True,
+            )
+
+    def clear_layer(self, layer_id: str) -> None:
+        """Queue a display-only layer clear while retaining viewer state."""
+        if self._closed:
+            return
+        try:
+            self._ensure_started()
+            if self._layer_manager is not None:
+                self._layer_manager.clear_layer(layer_id)
+        except Exception:
+            logger.warning(
+                "Visualization layer clear failed for '%s'",
+                layer_id,
+                exc_info=True,
+            )
+
     def update_state(self, frame: VisualizationStateFrame) -> None:
         """Update current robot render state from a pushed state frame."""
         if self._closed:
@@ -322,6 +366,11 @@ class ViserManipulationVisualizer:
         self._closed = True
         errors: list[BaseException] = []
         try:
+            if self._layer_manager is not None:
+                try:
+                    self._layer_manager.close()
+                except Exception as e:
+                    errors.append(e)
             if self._gui is not None:
                 try:
                     self._gui.close()
@@ -342,5 +391,6 @@ class ViserManipulationVisualizer:
             self._server = None
             self._scene = None
             self._gui = None
+            self._layer_manager = None
         if errors:
             raise errors[0]

--- a/openspec/specs/manipulation-visualization-layers/spec.md
+++ b/openspec/specs/manipulation-visualization-layers/spec.md
@@ -1,0 +1,129 @@
+# Manipulation Visualization Layers
+
+## Purpose
+
+Define display-only manipulation visualization layers, their backend-neutral
+geometry models, Viser lifecycle and rendering behavior, and the standalone
+banana grasp-proposal visualization workflow.
+
+## Requirements
+
+### Requirement: Display-only visualization layer interface
+The manipulation visualization interface SHALL accept complete `VisualizationLayer` replacements through `set_layer` and SHALL clear a layer's rendered contents through `clear_layer`. These operations MUST NOT mutate the planning world, create collision geometry, or affect collision and motion-planning results.
+
+#### Scenario: Visual layer is published
+- **WHEN** a caller submits a valid visualization layer
+- **THEN** the visualization backend accepts the layer for display without invoking planning-world mutation
+
+#### Scenario: Layer is cleared
+- **WHEN** a caller clears a registered visualization layer
+- **THEN** its visual elements disappear while its registration and visibility preference remain
+
+#### Scenario: Visualization and collision representations share a source object
+- **WHEN** a display-only element and a planning obstacle describe the same physical object
+- **THEN** adding, replacing, clearing, or failing to render the visual element does not add, replace, remove, or otherwise modify the planning obstacle
+
+### Requirement: Backend-neutral layer and element models
+A `VisualizationLayer` SHALL have a nonempty stable hierarchical ID, one nonempty coordinate frame, a first-registration default visibility value, and elements with IDs unique within that layer. The initial supported element types SHALL be point clouds and line sets represented by owned NumPy array snapshots rather than backend handles or robotics-domain messages.
+
+#### Scenario: Valid point cloud
+- **WHEN** a point-cloud element contains finite `N x 3` points and either no colors or matching RGB colors
+- **THEN** the model snapshots and accepts the element
+
+#### Scenario: Valid line set
+- **WHEN** a line-set element contains finite `N x 3` vertices and `M x 2` in-range vertex indices
+- **THEN** the model snapshots and accepts the element
+
+#### Scenario: Caller mutates source arrays
+- **WHEN** a caller changes a source NumPy array after constructing or submitting an element
+- **THEN** the accepted visual snapshot remains unchanged
+
+#### Scenario: Invalid geometry
+- **WHEN** an element has non-finite coordinates, inconsistent color counts, invalid edge indices, or a non-positive explicit size
+- **THEN** the layer is rejected before any current rendered generation is modified
+
+#### Scenario: Duplicate element identity
+- **WHEN** one layer contains two elements with the same ID
+- **THEN** the layer is rejected
+
+### Requirement: Complete and atomic layer replacement
+Publishing a layer with an existing ID SHALL replace its complete contents. Viser MUST expose either the previous valid generation or the complete new generation and MUST NOT expose a partial mixture when validation or rendering fails.
+
+#### Scenario: Successful replacement
+- **WHEN** every element in a replacement layer renders successfully
+- **THEN** Viser displays the complete new generation and removes the previous generation
+
+#### Scenario: Failed replacement
+- **WHEN** any element in a replacement layer fails validation or rendering
+- **THEN** Viser removes partial replacement handles, retains the complete previous valid generation, and reports a visualization warning
+
+#### Scenario: Empty replacement
+- **WHEN** a registered layer is cleared
+- **THEN** Viser removes its element handles but retains the layer entry and viewer state
+
+### Requirement: Best-effort latest-wins updates
+Layer submission SHALL NOT wait for Viser scene rendering. Viser SHALL retain at most the newest pending operation for each layer, SHALL order replacement and clear operations for the same layer, and SHALL contain visualization failures without failing a caller's robotics operation.
+
+#### Scenario: Replacements arrive faster than rendering
+- **WHEN** multiple replacements for one layer arrive before its pending update renders
+- **THEN** Viser may skip intermediate replacements but eventually renders the newest layer value
+
+#### Scenario: Clear supersedes replacement
+- **WHEN** a clear operation supersedes an older pending replacement for the same layer
+- **THEN** the older replacement does not reappear after the clear
+
+#### Scenario: Renderer is unavailable
+- **WHEN** Viser is disconnected, closed, or raises while processing an update
+- **THEN** the caller is not failed or blocked on scene rendering and the failure is logged as a visualization warning
+
+### Requirement: Hierarchical layer selector
+Viser SHALL derive a hierarchical selector from slash-separated layer IDs. Leaf layers SHALL be independently toggleable, group controls SHALL toggle all descendants, and replacing or clearing contents SHALL preserve viewer-owned visibility.
+
+#### Scenario: Hierarchical registration
+- **WHEN** layers `grasp/object-cloud` and `grasp/proposals` are first submitted
+- **THEN** Viser displays them as independently controlled children of a `Grasp` group
+
+#### Scenario: Hidden layer is replaced
+- **WHEN** a user hides a layer and its producer publishes replacement contents
+- **THEN** Viser updates the contents while leaving the layer hidden
+
+#### Scenario: Parent group is toggled
+- **WHEN** a user changes a group checkbox
+- **THEN** Viser applies that visibility to every descendant leaf layer
+
+#### Scenario: Multiple clients view the selector
+- **WHEN** more than one Viser client is connected
+- **THEN** they observe the same server-global layer visibility state
+
+### Requirement: Viser point-cloud rendering
+Viser SHALL render point-cloud elements with source RGB when present and cyan otherwise. It SHALL use a default point size of 5 mm unless overridden and SHALL cap display at 20,000 points per element without modifying the submitted element.
+
+#### Scenario: Colored cloud under the cap
+- **WHEN** a point-cloud element provides RGB colors and at most 20,000 points
+- **THEN** Viser renders every point with its matching source color
+
+#### Scenario: Uncolored cloud
+- **WHEN** a point-cloud element provides no colors
+- **THEN** Viser renders it using the cyan fallback
+
+#### Scenario: Cloud exceeds the render cap
+- **WHEN** a point-cloud element contains more than 20,000 points
+- **THEN** Viser deterministically samples at most 20,000 points, applies the same sample to colors, and leaves the source element unchanged
+
+### Requirement: Viser line-set rendering
+Viser SHALL render generic line-set elements from vertices and indexed edges, preserving supplied uniform or per-line colors and explicit positive line width.
+
+#### Scenario: Gripper wireframe line set
+- **WHEN** a line set describes a parallel-jaw gripper proposal
+- **THEN** Viser renders every indexed segment at the supplied pose and appearance
+
+#### Scenario: Multiple proposal elements
+- **WHEN** a layer contains line sets with unique IDs for multiple grasp ranks
+- **THEN** Viser renders each proposal independently within the same layer lifecycle
+
+### Requirement: Visualization-focused verification
+Automated verification SHALL cover layer-model validation and ownership, Viser rendering and lifecycle, hierarchical visibility, atomic failure behavior, and latest-wins ordering without requiring a browser, robot, planner, or live perception system.
+
+#### Scenario: Automated test environment
+- **WHEN** the visualization test suite runs with fake Viser scene handles
+- **THEN** it validates the specified behavior without launching a browser or executing robot motion


### PR DESCRIPTION
## Contribution path

- Linked issue: [DIM-1401](https://linear.app/dimensional/issue/DIM-1401/land-the-manipulation-grasp-sprint-pr-stack)

## Problem

Operators cannot inspect ranked grasp candidates, the selected grasp, its approach path, or execution state through the manipulation visualizer. This makes planning failures and unexpected selections difficult to diagnose.

## Solution

- Add reusable manipulation visualization layers.
- Render ranked candidates, the selected grasp, approach paths, and live execution state.
- Add Viser integration and hermetic tests.
- Keep production grasp geometry self-contained instead of importing demo code.

This is stack 4 of 5. Previous: #3364. Next: #3366. Review the diff against `feat/grasp-03-connected-plans`.

## How to Test

`uv run pytest dimos/manipulation/visualization dimos/manipulation/planning/monitor/test_world_monitor.py -v`

Verified: 168 generic visualization and world-monitor tests passed; 78 focused live-grasp visualization and pick tests passed; Ruff passed.

## AI assistance

OpenAI Codex with GPT-5 was used extensively for branch extraction, implementation cleanup, verification, and this description.

## Checklist

- [ ] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).