### PR TITLE
fix(config): preserve runtime objects in blueprint configuration

### DIFF
--- a/dimos/core/coordination/blueprint_config/parser.py
+++ b/dimos/core/coordination/blueprint_config/parser.py
@@ -75,6 +75,7 @@ from dimos.core.coordination.blueprint_config.values import (
     plain,
     plain_mapping,
     snapshot_mapping,
+    validated_model_values,
 )
 from dimos.core.coordination.blueprints import (
     Blueprint,
@@ -421,7 +422,7 @@ class BlueprintConfigParser:
                 raise BlueprintConfigError(
                     format_validation_error(module.atom.name, error)
                 ) from error
-            dumped = model.model_dump(mode="python", exclude_unset=True)
+            dumped = validated_model_values(model)
             dumped.pop("g", None)
             dumped.pop("instance_name", None)
             parsed[module.atom.name] = dumped

--- a/dimos/core/coordination/blueprint_config/test_parser.py
+++ b/dimos/core/coordination/blueprint_config/test_parser.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
+import pickle
 from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, Field
@@ -452,6 +454,14 @@ class Anchor:
         return "Anchor:\n  multi\n  line"
 
 
+@dataclass(frozen=True)
+class CallableAnchor:
+    prefix: str
+
+    def __call__(self, value: Any) -> str:
+        return f"{self.prefix}:{value}"
+
+
 class ArbitraryConfig(ModuleConfig):
     scaling: Anchor = Field(default_factory=Anchor)
     hybrid: Anchor | str = "fallback"
@@ -488,6 +498,18 @@ def test_blueprint_pinned_arbitrary_value_survives_filtering() -> None:
     parsed = BlueprintConfigParser(ArbitraryModule.blueprint(scaling=Anchor())).parse(environ={})
 
     assert isinstance(parsed.module_kwargs("arbitrarymodule")["scaling"], Anchor)
+
+
+def test_blueprint_pinned_callable_dataclass_survives_worker_serialization() -> None:
+    blueprint = ArbitraryModule.blueprint(handlers={"scene": CallableAnchor("render")})
+
+    parsed = BlueprintConfigParser(blueprint).parse(environ={})
+    worker_kwargs = pickle.loads(pickle.dumps(parsed.module_kwargs("arbitrarymodule")))
+    worker_config = ArbitraryConfig.model_validate(worker_kwargs)
+    handler = worker_config.handlers["scene"]
+
+    assert isinstance(handler, CallableAnchor)
+    assert handler("apartment") == "render:apartment"
 
 
 def test_format_help_uses_nested_parent_default_instance() -> None:

--- a/dimos/core/coordination/blueprint_config/values.py
+++ b/dimos/core/coordination/blueprint_config/values.py
@@ -55,6 +55,31 @@ def plain(value: Any) -> Any:
     return _copy_opaque(value)
 
 
+def validated_model_values(model: BaseModel) -> dict[str, Any]:
+    """Copy explicitly set validated fields without serializing runtime objects."""
+    return {
+        name: _validated_value(getattr(model, name))
+        for name in type(model).model_fields
+        if name in model.model_fields_set
+    }
+
+
+def _validated_value(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        return validated_model_values(value)
+    if isinstance(value, Mapping):
+        return {_copy_opaque(key): _validated_value(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_validated_value(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_validated_value(item) for item in value)
+    if isinstance(value, set):
+        return {_validated_value(item) for item in value}
+    if isinstance(value, frozenset):
+        return frozenset(_validated_value(item) for item in value)
+    return _copy_opaque(value)
+
+
 def deep_merge(destination: dict[str, Any], incoming: Mapping[str, Any]) -> None:
     for key, value in incoming.items():
         if key in destination and isinstance(destination[key], dict) and isinstance(value, Mapping):


### PR DESCRIPTION
## What changed

Preserve explicitly configured callable and opaque Python values after Pydantic validation instead of serializing them through `model_dump()`.

A regression test sends a callable dataclass through blueprint parsing, pickle worker serialization, and Pydantic reconstruction.

## Root cause

`BlueprintConfigParser` validated module configuration correctly, then `model_dump(mode="python")` converted nested dataclasses into plain dictionaries. Rerun callbacks and other runtime objects therefore stopped being callable after crossing the worker boundary.

## Validation

- `pytest dimos/core/coordination/blueprint_config/test_parser.py -q`
- 28 tests passed
- Repository pre-commit hooks passed