### PR TITLE
perf(msgs): drop plum multiple dispatch

### DIFF
--- a/dimos/msgs/geometry_msgs/PointStamped.py
+++ b/dimos/msgs/geometry_msgs/PointStamped.py
@@ -45,11 +45,11 @@ class PointStamped(Point, Timestamped):
         x: float = 0.0,
         y: float = 0.0,
         z: float = 0.0,
-        ts: float = 0.0,
+        ts: float | None = None,
         frame_id: str = "",
     ) -> None:
         self.frame_id = frame_id
-        self.ts = ts if ts != 0 else time.time()
+        self.ts = time.time() if ts is None else ts
         super().__init__(float(x), float(y), float(z))
 
     # -- LCM encode / decode --

--- a/dimos/msgs/geometry_msgs/Pose.py
+++ b/dimos/msgs/geometry_msgs/Pose.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import TypeAlias
+from typing import Any, TypeAlias, overload
 
 from dimos_lcm.geometry_msgs import (
     Pose as LCMPose,
@@ -35,24 +35,28 @@ PoseConvertable: TypeAlias = (
 )
 
 
+def _is_position_orientation_pair(value: Any) -> bool:
+    """True for a 2-element (position, orientation) pair, false for a 2D position."""
+    return (
+        isinstance(value, tuple | list)
+        and len(value) == 2
+        and not isinstance(value[0], int | float)
+        and not isinstance(value[1], int | float)
+    )
+
+
 class Pose(LCMPose):  # type: ignore[misc]
     position: Vector3
     orientation: Quaternion
     msg_name = "geometry_msgs.Pose"
 
-    @dispatch
-    def __init__(self) -> None:
-        """Initialize a pose at origin with identity orientation."""
-        self.position = Vector3(0.0, 0.0, 0.0)
-        self.orientation = Quaternion(0.0, 0.0, 0.0, 1.0)
+    @overload
+    def __init__(self) -> None: ...
 
-    @dispatch  # type: ignore[no-redef]
-    def __init__(self, x: int | float, y: int | float, z: int | float) -> None:
-        """Initialize a pose with position and identity orientation."""
-        self.position = Vector3(x, y, z)
-        self.orientation = Quaternion(0.0, 0.0, 0.0, 1.0)
+    @overload
+    def __init__(self, x: int | float, y: int | float, z: int | float) -> None: ...
 
-    @dispatch  # type: ignore[no-redef]
+    @overload
     def __init__(
         self,
         x: int | float,
@@ -62,52 +66,74 @@ class Pose(LCMPose):  # type: ignore[misc]
         qy: int | float,
         qz: int | float,
         qw: int | float,
-    ) -> None:
-        """Initialize a pose with position and orientation."""
-        self.position = Vector3(x, y, z)
-        self.orientation = Quaternion(qx, qy, qz, qw)
+    ) -> None: ...
 
-    @dispatch  # type: ignore[no-redef]
+    @overload
     def __init__(
         self,
-        position: VectorConvertable | Vector3 | None = None,
-        orientation: QuaternionConvertable | Quaternion | None = None,
-    ) -> None:
-        """Initialize a pose with position and orientation."""
-        if orientation is None:
-            orientation = [0, 0, 0, 1]
-        if position is None:
-            position = [0, 0, 0]
-        self.position = Vector3(position)
-        self.orientation = Quaternion(orientation)
+        position: VectorConvertable | Vector3 | None = ...,
+        orientation: QuaternionConvertable | Quaternion | None = ...,
+    ) -> None: ...
 
-    @dispatch  # type: ignore[no-redef]
-    def __init__(self, pose_tuple: tuple[VectorConvertable, QuaternionConvertable]) -> None:
-        """Initialize from a tuple of (position, orientation)."""
-        self.position = Vector3(pose_tuple[0])
-        self.orientation = Quaternion(pose_tuple[1])
+    @overload
+    def __init__(self, value: PoseConvertable | Pose, /) -> None: ...
 
-    @dispatch  # type: ignore[no-redef]
-    def __init__(self, pose_dict: dict[str, VectorConvertable | QuaternionConvertable]) -> None:
-        """Initialize from a dictionary with 'position' and 'orientation' keys."""
-        self.position = Vector3(pose_dict["position"])
-        self.orientation = Quaternion(pose_dict["orientation"])
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize a pose.
 
-    @dispatch  # type: ignore[no-redef]
-    def __init__(self, pose: Pose) -> None:
-        """Initialize from another Pose (copy constructor)."""
-        self.position = Vector3(pose.position)
-        self.orientation = Quaternion(pose.orientation)
+        Supported forms:
+            Pose()                                  # origin, identity orientation
+            Pose(x, y, z)
+            Pose(x, y, z, qx, qy, qz, qw)
+            Pose(position)                          # any Vector3-convertable
+            Pose(position, orientation)
+            Pose(position=..., orientation=...)     # keyword args
+            Pose((position, orientation))           # pair
+            Pose({"position": ..., "orientation": ...})
+            Pose(other_pose)                        # copy constructor
+            Pose(lcm_pose)                          # from LCM message
+        """
+        position: Any = None
+        orientation: Any = None
 
-    @dispatch  # type: ignore[no-redef]
-    def __init__(self, lcm_pose: LCMPose) -> None:
-        """Initialize from an LCM Pose."""
-        self.position = Vector3(lcm_pose.position.x, lcm_pose.position.y, lcm_pose.position.z)
-        self.orientation = Quaternion(
-            lcm_pose.orientation.x,
-            lcm_pose.orientation.y,
-            lcm_pose.orientation.z,
-            lcm_pose.orientation.w,
+        if len(args) == 3:
+            position = args
+        elif len(args) == 7:
+            position, orientation = args[:3], args[3:]
+        elif len(args) == 2:
+            position, orientation = args
+        elif len(args) == 1:
+            value = args[0]
+            # Pose before LCMPose (it is a subclass); dict and pair before the
+            # generic "it is a position" fallback.
+            if isinstance(value, Pose):
+                position, orientation = value.position, value.orientation
+            elif isinstance(value, LCMPose):
+                position = (value.position.x, value.position.y, value.position.z)
+                orientation = (
+                    value.orientation.x,
+                    value.orientation.y,
+                    value.orientation.z,
+                    value.orientation.w,
+                )
+            elif isinstance(value, dict):
+                position, orientation = value["position"], value["orientation"]
+            elif _is_position_orientation_pair(value):
+                position, orientation = value
+            else:
+                position = value
+        elif args:
+            raise TypeError(f"Pose takes 1, 2, 3 or 7 positional arguments ({len(args)} given)")
+
+        if kwargs:
+            position = kwargs.pop("position", position)
+            orientation = kwargs.pop("orientation", orientation)
+            if kwargs:
+                raise TypeError(f"Pose got unexpected keyword arguments {sorted(kwargs)}")
+
+        self.position = Vector3(0.0, 0.0, 0.0) if position is None else Vector3(position)
+        self.orientation = (
+            Quaternion(0.0, 0.0, 0.0, 1.0) if orientation is None else Quaternion(orientation)
         )
 
     @property

--- a/dimos/msgs/geometry_msgs/PoseStamped.py
+++ b/dimos/msgs/geometry_msgs/PoseStamped.py
@@ -16,13 +16,12 @@ from __future__ import annotations
 
 import math
 import time
-from typing import TYPE_CHECKING, BinaryIO, TypeAlias
+from typing import TYPE_CHECKING, Any, BinaryIO, TypeAlias
 
 if TYPE_CHECKING:
     from rerun._baseclasses import Archetype
 
 from dimos_lcm.geometry_msgs import PoseStamped as LCMPoseStamped
-from plum import dispatch
 
 from dimos.msgs.geometry_msgs.Pose import Pose
 from dimos.msgs.geometry_msgs.Quaternion import Quaternion, QuaternionConvertable
@@ -48,11 +47,27 @@ class PoseStamped(Pose, Timestamped):
     ts: float
     frame_id: str
 
-    @dispatch
-    def __init__(self, ts: float = 0.0, frame_id: str = "", **kwargs) -> None:  # type: ignore[no-untyped-def]
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize a stamped pose.
+
+        Takes ``(ts, frame_id)`` positionally, plus every Pose keyword. Any other
+        positional form belongs to Pose, so ``PoseStamped(x, y, z)`` and
+        ``PoseStamped(x, y, z, qx, qy, qz, qw)`` work as they do on the base class.
+        """
+        ts: Any
+        # A leading number or string is a timestamp; anything else is a Pose argument.
+        if args and len(args) < 3 and isinstance(args[0], int | float | str):
+            ts = args[0]
+            frame_id = args[1] if len(args) > 1 else kwargs.pop("frame_id", "")
+            pose_args: tuple[Any, ...] = ()
+        else:
+            ts = kwargs.pop("ts", 0.0)
+            frame_id = kwargs.pop("frame_id", "")
+            pose_args = args
+
         self.frame_id = frame_id
         self.ts = ts if ts != 0 else time.time()
-        super().__init__(**kwargs)
+        super().__init__(*pose_args, **kwargs)
 
     def lcm_encode(self) -> bytes:
         lcm_mgs = LCMPoseStamped()

--- a/dimos/msgs/geometry_msgs/PoseStamped.py
+++ b/dimos/msgs/geometry_msgs/PoseStamped.py
@@ -61,12 +61,12 @@ class PoseStamped(Pose, Timestamped):
             frame_id = args[1] if len(args) > 1 else kwargs.pop("frame_id", "")
             pose_args: tuple[Any, ...] = ()
         else:
-            ts = kwargs.pop("ts", 0.0)
+            ts = kwargs.pop("ts", None)
             frame_id = kwargs.pop("frame_id", "")
             pose_args = args
 
         self.frame_id = frame_id
-        self.ts = ts if ts != 0 else time.time()
+        self.ts = time.time() if ts is None else ts
         super().__init__(*pose_args, **kwargs)
 
     def lcm_encode(self) -> bytes:

--- a/dimos/msgs/geometry_msgs/PoseWithCovariance.py
+++ b/dimos/msgs/geometry_msgs/PoseWithCovariance.py
@@ -20,7 +20,6 @@ from dimos_lcm.geometry_msgs import (
     PoseWithCovariance as LCMPoseWithCovariance,
 )
 import numpy as np
-from plum import dispatch
 
 from dimos.msgs.geometry_msgs.Pose import Pose, PoseConvertable
 
@@ -35,58 +34,63 @@ PoseWithCovarianceConvertable: TypeAlias = (
     | dict[str, PoseConvertable | list[float] | np.ndarray]
 )
 
+COVARIANCE_SIZE = 36
+
+
+def _is_value_covariance_pair(value: Any) -> bool:
+    """True for a 2-element (value, covariance) pair, where covariance is 36 long."""
+    if not isinstance(value, tuple | list) or len(value) != 2:
+        return False
+    covariance = value[1]
+    return isinstance(covariance, list | np.ndarray) and np.size(covariance) == COVARIANCE_SIZE
+
 
 class PoseWithCovariance(LCMPoseWithCovariance):  # type: ignore[misc]
     pose: Pose
     covariance: np.ndarray[tuple[int], np.dtype[np.floating[Any]]]
     msg_name = "geometry_msgs.PoseWithCovariance"
 
-    @dispatch
-    def __init__(self) -> None:
-        """Initialize with default pose and zero covariance."""
-        self.pose = Pose()
-        self.covariance = np.zeros(36)
-
-    @dispatch  # type: ignore[no-redef]
     def __init__(
         self,
-        pose: Pose | PoseConvertable,
+        pose: Pose | PoseConvertable | PoseWithCovarianceConvertable | None = None,
         covariance: list[float] | np.ndarray | None = None,
     ) -> None:
-        """Initialize with pose and optional covariance."""
-        self.pose = Pose(pose) if not isinstance(pose, Pose) else pose
-        if covariance is None:
-            self.covariance = np.zeros(36)
-        else:
-            self.covariance = np.array(covariance, dtype=float).reshape(36)
+        """Initialize a pose with covariance.
 
-    @dispatch  # type: ignore[no-redef]
-    def __init__(self, pose_with_cov: PoseWithCovariance) -> None:
-        """Initialize from another PoseWithCovariance (copy constructor)."""
-        self.pose = Pose(pose_with_cov.pose)
-        self.covariance = np.array(pose_with_cov.covariance).copy()
+        Supported forms:
+            PoseWithCovariance()                        # origin, zero covariance
+            PoseWithCovariance(pose)
+            PoseWithCovariance(pose, covariance)
+            PoseWithCovariance(pose=..., covariance=...)
+            PoseWithCovariance((pose, covariance))      # pair
+            PoseWithCovariance({"pose": ..., "covariance": ...})
+            PoseWithCovariance(other)                   # copy constructor
+            PoseWithCovariance(lcm_pose_with_cov)       # from LCM message
+        """
+        source: Any = pose
+        cov: Any = covariance
 
-    @dispatch  # type: ignore[no-redef]
-    def __init__(self, lcm_pose_with_cov: LCMPoseWithCovariance) -> None:
-        """Initialize from an LCM PoseWithCovariance."""
-        self.pose = Pose(lcm_pose_with_cov.pose)
-        self.covariance = np.array(lcm_pose_with_cov.covariance)
+        # PoseWithCovariance before LCMPoseWithCovariance (it is a subclass).
+        if isinstance(source, PoseWithCovariance):
+            if cov is None:
+                cov = np.array(source.covariance).copy()
+            source = Pose(source.pose)  # copy constructor: don't alias the source pose
+        elif isinstance(source, LCMPoseWithCovariance):
+            if cov is None:
+                cov = np.array(source.covariance)
+            source = source.pose
+        elif isinstance(source, dict) and "pose" in source:
+            cov = source.get("covariance", cov)
+            source = source["pose"]
+        elif _is_value_covariance_pair(source):
+            source, cov = source
 
-    @dispatch  # type: ignore[no-redef]
-    def __init__(self, pose_dict: dict[str, PoseConvertable | list[float] | np.ndarray]) -> None:
-        """Initialize from a dictionary with 'pose' and 'covariance' keys."""
-        self.pose = Pose(pose_dict["pose"])
-        covariance = pose_dict.get("covariance")
-        if covariance is None:
-            self.covariance = np.zeros(36)
-        else:
-            self.covariance = np.array(covariance, dtype=float).reshape(36)
-
-    @dispatch  # type: ignore[no-redef]
-    def __init__(self, pose_tuple: tuple[PoseConvertable, list[float] | np.ndarray]) -> None:
-        """Initialize from a tuple of (pose, covariance)."""
-        self.pose = Pose(pose_tuple[0])
-        self.covariance = np.array(pose_tuple[1], dtype=float).reshape(36)
+        self.pose = source if isinstance(source, Pose) else Pose(source)
+        self.covariance = (
+            np.zeros(COVARIANCE_SIZE)
+            if cov is None
+            else np.array(cov, dtype=float).reshape(COVARIANCE_SIZE)
+        )
 
     def __getattribute__(self, name: str):  # type: ignore[no-untyped-def]
         """Override to ensure covariance is always returned as numpy array."""

--- a/dimos/msgs/geometry_msgs/PoseWithCovarianceStamped.py
+++ b/dimos/msgs/geometry_msgs/PoseWithCovarianceStamped.py
@@ -21,7 +21,6 @@ from dimos_lcm.geometry_msgs import (
     PoseWithCovarianceStamped as LCMPoseWithCovarianceStamped,
 )
 import numpy as np
-from plum import dispatch
 
 from dimos.msgs.geometry_msgs.Pose import Pose, PoseConvertable
 from dimos.msgs.geometry_msgs.PoseWithCovariance import PoseWithCovariance
@@ -45,14 +44,6 @@ class PoseWithCovarianceStamped(PoseWithCovariance, Timestamped):
     ts: float
     frame_id: str
 
-    @dispatch
-    def __init__(self, ts: float = 0.0, frame_id: str = "", **kwargs) -> None:
-        """Initialize with timestamp and frame_id."""
-        self.frame_id = frame_id
-        self.ts = ts if ts != 0 else time.time()
-        super().__init__(**kwargs)
-
-    @dispatch  # type: ignore[no-redef]
     def __init__(
         self,
         ts: float = 0.0,
@@ -63,10 +54,7 @@ class PoseWithCovarianceStamped(PoseWithCovariance, Timestamped):
         """Initialize with timestamp, frame_id, pose and covariance."""
         self.frame_id = frame_id
         self.ts = ts if ts != 0 else time.time()
-        if pose is None:
-            super().__init__()
-        else:
-            super().__init__(pose, covariance)
+        super().__init__(pose, covariance)
 
     def lcm_encode(self) -> bytes:
         lcm_msg = LCMPoseWithCovarianceStamped()

--- a/dimos/msgs/geometry_msgs/PoseWithCovarianceStamped.py
+++ b/dimos/msgs/geometry_msgs/PoseWithCovarianceStamped.py
@@ -46,14 +46,14 @@ class PoseWithCovarianceStamped(PoseWithCovariance, Timestamped):
 
     def __init__(
         self,
-        ts: float = 0.0,
+        ts: float | None = None,
         frame_id: str = "",
         pose: Pose | PoseConvertable | None = None,
         covariance: list[float] | np.ndarray | None = None,
     ) -> None:
         """Initialize with timestamp, frame_id, pose and covariance."""
         self.frame_id = frame_id
-        self.ts = ts if ts != 0 else time.time()
+        self.ts = time.time() if ts is None else ts
         super().__init__(pose, covariance)
 
     def lcm_encode(self) -> bytes:

--- a/dimos/msgs/geometry_msgs/Quaternion.py
+++ b/dimos/msgs/geometry_msgs/Quaternion.py
@@ -18,19 +18,28 @@ from collections.abc import Sequence
 from io import BytesIO
 import math
 import struct
-from typing import TYPE_CHECKING, BinaryIO, TypeAlias
+from typing import TYPE_CHECKING, Any, BinaryIO, TypeAlias, overload
 
 if TYPE_CHECKING:
     import rerun as rr
 
 from dimos_lcm.geometry_msgs import Quaternion as LCMQuaternion
 import numpy as np
-from plum import dispatch
 
 from dimos.msgs.geometry_msgs.Vector3 import Vector3
 
 # Types that can be converted to/from Quaternion
 QuaternionConvertable: TypeAlias = Sequence[int | float] | LCMQuaternion | np.ndarray
+
+
+def _four_components(value: Any) -> tuple[float, float, float, float]:
+    """Unpack a length-4 sequence or array into (x, y, z, w)."""
+    if not isinstance(value, np.ndarray | Sequence):
+        raise TypeError(f"Cannot initialize Quaternion from {type(value)}")
+    size = value.size if isinstance(value, np.ndarray) else len(value)
+    if size != 4:
+        raise ValueError("Quaternion requires exactly 4 components [x, y, z, w]")
+    return (float(value[0]), float(value[1]), float(value[2]), float(value[3]))
 
 
 class Quaternion(LCMQuaternion):  # type: ignore[misc]
@@ -52,44 +61,61 @@ class Quaternion(LCMQuaternion):  # type: ignore[misc]
     def _lcm_decode_one(cls, buf):  # type: ignore[no-untyped-def]
         return cls(struct.unpack(">dddd", buf.read(32)))
 
-    @dispatch
+    @overload
     def __init__(self) -> None: ...
 
-    @dispatch  # type: ignore[no-redef]
-    def __init__(self, x: int | float, y: int | float, z: int | float, w: int | float) -> None:
-        self.x = float(x)
-        self.y = float(y)
-        self.z = float(z)
-        self.w = float(w)
+    @overload
+    def __init__(
+        self,
+        x: int | float = ...,
+        y: int | float = ...,
+        z: int | float = ...,
+        w: int | float = ...,
+    ) -> None: ...
 
-    @dispatch  # type: ignore[no-redef]
-    def __init__(self, sequence: Sequence[int | float] | np.ndarray) -> None:
-        if isinstance(sequence, np.ndarray):
-            if sequence.size != 4:
-                raise ValueError("Quaternion requires exactly 4 components [x, y, z, w]")
-        else:
-            if len(sequence) != 4:
-                raise ValueError("Quaternion requires exactly 4 components [x, y, z, w]")
+    @overload
+    def __init__(self, value: QuaternionConvertable | Quaternion, /) -> None: ...
 
-        self.x = sequence[0]
-        self.y = sequence[1]
-        self.z = sequence[2]
-        self.w = sequence[3]
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize a quaternion.
 
-    @dispatch  # type: ignore[no-redef]
-    def __init__(self, quaternion: Quaternion) -> None:
-        """Initialize from another Quaternion (copy constructor)."""
-        self.x, self.y, self.z, self.w = quaternion.x, quaternion.y, quaternion.z, quaternion.w
+        Supported forms:
+            Quaternion()                        # identity (0, 0, 0, 1)
+            Quaternion(x, y, z, w)
+            Quaternion(x=1, y=2, z=3, w=4)      # keyword args
+            Quaternion([x, y, z, w])            # sequence
+            Quaternion(np.array([x, y, z, w]))  # numpy array
+            Quaternion(other_quaternion)        # copy constructor
+            Quaternion(lcm_quaternion)          # from LCM message
+        """
+        if len(args) == 4:
+            self.x = float(args[0])
+            self.y = float(args[1])
+            self.z = float(args[2])
+            self.w = float(args[3])
+        elif len(args) == 1:
+            value = args[0]
+            # Quaternion before LCMQuaternion (it is a subclass) and before the
+            # generic sequence branch (a Quaternion is indexable).
+            if isinstance(value, Quaternion):
+                self.x, self.y, self.z, self.w = value.x, value.y, value.z, value.w
+            elif isinstance(value, LCMQuaternion):
+                self.x, self.y, self.z, self.w = value.x, value.y, value.z, value.w
+            else:
+                self.x, self.y, self.z, self.w = _four_components(value)
+        elif args:
+            raise TypeError(
+                f"Quaternion takes 1 sequence or 4 components ({len(args)} positional given)"
+            )
+        elif kwargs:
+            self.x = float(kwargs.pop("x", 0.0))
+            self.y = float(kwargs.pop("y", 0.0))
+            self.z = float(kwargs.pop("z", 0.0))
+            self.w = float(kwargs.pop("w", 1.0))
+        # else: no arguments — the class defaults already spell the identity.
 
-    @dispatch  # type: ignore[no-redef]
-    def __init__(self, lcm_quaternion: LCMQuaternion) -> None:
-        """Initialize from an LCM Quaternion."""
-        self.x, self.y, self.z, self.w = (
-            lcm_quaternion.x,
-            lcm_quaternion.y,
-            lcm_quaternion.z,
-            lcm_quaternion.w,
-        )
+        if kwargs:
+            raise TypeError(f"Quaternion got unexpected keyword arguments {sorted(kwargs)}")
 
     def to_tuple(self) -> tuple[float, float, float, float]:
         """Tuple representation of the quaternion (x, y, z, w)."""

--- a/dimos/msgs/geometry_msgs/Transform.py
+++ b/dimos/msgs/geometry_msgs/Transform.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 import time
-from typing import TYPE_CHECKING, BinaryIO
+from typing import TYPE_CHECKING, Any, BinaryIO
 
 if TYPE_CHECKING:
     import numpy as np
@@ -194,7 +194,7 @@ class Transform(Timestamped):
         else:
             raise TypeError(f"Expected Pose or PoseStamped, got {type(pose).__name__}")
 
-    def to_pose(self, **kwargs: object) -> PoseStamped:
+    def to_pose(self, **kwargs: Any) -> PoseStamped:
         """Create a Transform from a Pose or PoseStamped.
 
         Args:
@@ -207,14 +207,12 @@ class Transform(Timestamped):
         from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped as _PoseStamped
 
         # Handle both Pose and PoseStamped
-        result: PoseStamped = _PoseStamped(
-            **{
-                "position": self.translation,
-                "orientation": self.rotation,
-                "frame_id": self.frame_id,
-            },
-            **kwargs,
-        )
+        fields: dict[str, Any] = {
+            "position": self.translation,
+            "orientation": self.rotation,
+            "frame_id": self.frame_id,
+        }
+        result: PoseStamped = _PoseStamped(**fields, **kwargs)
         return result
 
     @classmethod

--- a/dimos/msgs/geometry_msgs/Transform.py
+++ b/dimos/msgs/geometry_msgs/Transform.py
@@ -48,12 +48,12 @@ class Transform(Timestamped):
         rotation: Quaternion | None = None,
         frame_id: str = "world",
         child_frame_id: str = "unset",
-        ts: float = 0.0,
+        ts: float | None = None,
         **kwargs,
     ) -> None:
         self.frame_id = frame_id
         self.child_frame_id = child_frame_id
-        self.ts = ts if ts != 0.0 else time.time()
+        self.ts = time.time() if ts is None else ts
         self.translation = translation if translation is not None else Vector3()
         self.rotation = rotation if rotation is not None else Quaternion()
 
@@ -220,7 +220,7 @@ class Transform(Timestamped):
         cls,
         matrix: np.ndarray,
         *,
-        ts: float = 0.0,
+        ts: float | None = None,
         frame_id: str = "world",
         child_frame_id: str = "unset",
     ) -> Transform:

--- a/dimos/msgs/geometry_msgs/Twist.py
+++ b/dimos/msgs/geometry_msgs/Twist.py
@@ -14,11 +14,10 @@
 
 from __future__ import annotations
 
-from dimos_lcm.geometry_msgs import Twist as LCMTwist
-from plum import dispatch
+from typing import Any, overload
 
-# Import Quaternion at runtime for beartype compatibility
-# (beartype needs to resolve forward references at runtime)
+from dimos_lcm.geometry_msgs import Twist as LCMTwist
+
 from dimos.msgs.geometry_msgs.Quaternion import Quaternion
 from dimos.msgs.geometry_msgs.Vector3 import Vector3, VectorLike
 
@@ -28,44 +27,59 @@ class Twist(LCMTwist):  # type: ignore[misc]
     angular: Vector3
     msg_name = "geometry_msgs.Twist"
 
-    @dispatch
-    def __init__(self) -> None:
-        """Initialize a zero twist (no linear or angular velocity)."""
-        self.linear = Vector3()
-        self.angular = Vector3()
+    @overload
+    def __init__(self) -> None: ...
 
-    @dispatch  # type: ignore[no-redef]
-    def __init__(self, linear: VectorLike, angular: VectorLike) -> None:
-        """Initialize a twist from linear and angular velocities."""
+    @overload
+    def __init__(
+        self,
+        linear: VectorLike | None = ...,
+        angular: VectorLike | Quaternion | None = ...,
+    ) -> None: ...
 
-        self.linear = Vector3(linear)
-        self.angular = Vector3(angular)
+    @overload
+    def __init__(self, twist: Twist | LCMTwist, /) -> None: ...
 
-    @dispatch  # type: ignore[no-redef]
-    def __init__(self, linear: VectorLike, angular: Quaternion) -> None:
-        """Initialize a twist from linear velocity and angular as quaternion (converted to euler)."""
-        self.linear = Vector3(linear)
-        self.angular = angular.to_euler()
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize a twist.
 
-    @dispatch  # type: ignore[no-redef]
-    def __init__(self, twist: Twist) -> None:
-        """Initialize from another Twist (copy constructor)."""
-        self.linear = Vector3(twist.linear)
-        self.angular = Vector3(twist.angular)
+        Supported forms:
+            Twist()                                 # zero twist
+            Twist(linear, angular)
+            Twist(linear=..., angular=...)          # keyword args, either optional
+            Twist(linear, quaternion)               # angular converted to euler
+            Twist(other_twist)                      # copy constructor
+            Twist(lcm_twist)                        # from LCM message
+        """
+        linear: Any = None
+        angular: Any = None
 
-    @dispatch  # type: ignore[no-redef]
-    def __init__(self, lcm_twist: LCMTwist) -> None:
-        """Initialize from an LCM Twist."""
-        self.linear = Vector3(lcm_twist.linear)
-        self.angular = Vector3(lcm_twist.angular)
+        if len(args) == 2:
+            linear, angular = args
+        elif len(args) == 1:
+            value = args[0]
+            # Twist before LCMTwist (it is a subclass); anything else is a
+            # linear velocity, same as the `linear=` keyword.
+            if isinstance(value, Twist | LCMTwist):
+                linear, angular = value.linear, value.angular
+            else:
+                linear = value
+        elif args:
+            raise TypeError(f"Twist takes 1 or 2 positional arguments ({len(args)} given)")
 
-    @dispatch  # type: ignore[no-redef]
-    def __init__(self, **kwargs) -> None:
-        """Handle keyword arguments for LCM compatibility."""
-        linear = kwargs.get("linear", Vector3())
-        angular = kwargs.get("angular", Vector3())
+        if kwargs:
+            linear = kwargs.pop("linear", linear)
+            angular = kwargs.pop("angular", angular)
+            if kwargs:
+                raise TypeError(f"Twist got unexpected keyword arguments {sorted(kwargs)}")
 
-        self.__init__(linear, angular)
+        self.linear = Vector3() if linear is None else Vector3(linear)
+        if angular is None:
+            self.angular = Vector3()
+        elif isinstance(angular, Quaternion):
+            self.angular = angular.to_euler()
+        else:
+            self.angular = Vector3(angular)
 
     def __repr__(self) -> str:
         return f"Twist(linear={self.linear!r}, angular={self.angular!r})"

--- a/dimos/msgs/geometry_msgs/TwistStamped.py
+++ b/dimos/msgs/geometry_msgs/TwistStamped.py
@@ -53,12 +53,12 @@ class TwistStamped(Twist, Timestamped):
             frame_id = args[1] if len(args) > 1 else kwargs.pop("frame_id", "")
             twist_args: tuple[Any, ...] = ()
         else:
-            ts = kwargs.pop("ts", 0.0)
+            ts = kwargs.pop("ts", None)
             frame_id = kwargs.pop("frame_id", "")
             twist_args = args
 
         self.frame_id = frame_id
-        self.ts = ts if ts != 0 else time.time()
+        self.ts = time.time() if ts is None else ts
         super().__init__(*twist_args, **kwargs)
 
     def lcm_encode(self) -> bytes:

--- a/dimos/msgs/geometry_msgs/TwistStamped.py
+++ b/dimos/msgs/geometry_msgs/TwistStamped.py
@@ -15,10 +15,9 @@
 from __future__ import annotations
 
 import time
-from typing import BinaryIO, TypeAlias
+from typing import Any, BinaryIO, TypeAlias
 
 from dimos_lcm.geometry_msgs import TwistStamped as LCMTwistStamped
-from plum import dispatch
 
 from dimos.msgs.geometry_msgs.Twist import Twist
 from dimos.msgs.geometry_msgs.Vector3 import VectorConvertable
@@ -40,11 +39,27 @@ class TwistStamped(Twist, Timestamped):
     ts: float
     frame_id: str
 
-    @dispatch
-    def __init__(self, ts: float = 0.0, frame_id: str = "", **kwargs) -> None:  # type: ignore[no-untyped-def]
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize a stamped twist.
+
+        Takes ``(ts, frame_id)`` positionally, plus every Twist keyword. Any other
+        positional form belongs to Twist, so ``TwistStamped(linear, angular)``
+        works as it does on the base class.
+        """
+        ts: Any
+        # A leading number or string is a timestamp; anything else is a Twist argument.
+        if args and isinstance(args[0], int | float | str):
+            ts = args[0]
+            frame_id = args[1] if len(args) > 1 else kwargs.pop("frame_id", "")
+            twist_args: tuple[Any, ...] = ()
+        else:
+            ts = kwargs.pop("ts", 0.0)
+            frame_id = kwargs.pop("frame_id", "")
+            twist_args = args
+
         self.frame_id = frame_id
         self.ts = ts if ts != 0 else time.time()
-        super().__init__(**kwargs)
+        super().__init__(*twist_args, **kwargs)
 
     def lcm_encode(self) -> bytes:
         lcm_msg = LCMTwistStamped()

--- a/dimos/msgs/geometry_msgs/TwistWithCovariance.py
+++ b/dimos/msgs/geometry_msgs/TwistWithCovariance.py
@@ -20,7 +20,6 @@ from dimos_lcm.geometry_msgs import (
     TwistWithCovariance as LCMTwistWithCovariance,
 )
 import numpy as np
-from plum import dispatch
 
 from dimos.msgs.geometry_msgs.Twist import Twist
 from dimos.msgs.geometry_msgs.Vector3 import Vector3, VectorConvertable
@@ -32,84 +31,73 @@ TwistWithCovarianceConvertable: TypeAlias = (
     | dict[str, Twist | tuple[VectorConvertable, VectorConvertable] | list[float] | np.ndarray]
 )
 
+COVARIANCE_SIZE = 36
+
+
+def _is_twist_covariance_pair(value: Any) -> bool:
+    """True for a 2-element (twist, covariance) pair, where covariance is 36 long."""
+    if not isinstance(value, tuple | list) or len(value) != 2:
+        return False
+    covariance = value[1]
+    return isinstance(covariance, list | np.ndarray) and np.size(covariance) == COVARIANCE_SIZE
+
+
+def _to_twist(value: Any) -> Twist:
+    """A Twist, or a (linear, angular) pair to build one from."""
+    if isinstance(value, Twist):
+        return value
+    if value is None:
+        return Twist()
+    return Twist(value[0], value[1])
+
 
 class TwistWithCovariance(LCMTwistWithCovariance):  # type: ignore[misc]
     twist: Twist
     covariance: np.ndarray[tuple[int], np.dtype[np.floating[Any]]]
     msg_name = "geometry_msgs.TwistWithCovariance"
 
-    @dispatch
-    def __init__(self) -> None:
-        """Initialize with default twist and zero covariance."""
-        self.twist = Twist()
-        self.covariance = np.zeros(36)
-
-    @dispatch  # type: ignore[no-redef]
     def __init__(
         self,
-        twist: Twist | tuple[VectorConvertable, VectorConvertable],
+        twist: Twist | TwistWithCovarianceConvertable | None = None,
         covariance: list[float] | np.ndarray | None = None,
     ) -> None:
-        """Initialize with twist and optional covariance."""
-        if isinstance(twist, Twist):
-            self.twist = twist
-        else:
-            # Assume it's a tuple of (linear, angular)
-            self.twist = Twist(twist[0], twist[1])
+        """Initialize a twist with covariance.
 
-        if covariance is None:
-            self.covariance = np.zeros(36)
-        else:
-            self.covariance = np.array(covariance, dtype=float).reshape(36)
+        Supported forms:
+            TwistWithCovariance()                       # zero twist and covariance
+            TwistWithCovariance(twist)
+            TwistWithCovariance(twist, covariance)
+            TwistWithCovariance(twist=..., covariance=...)
+            TwistWithCovariance((linear, angular))
+            TwistWithCovariance((twist, covariance))    # pair
+            TwistWithCovariance({"twist": ..., "covariance": ...})
+            TwistWithCovariance(other)                  # copy constructor
+            TwistWithCovariance(lcm_twist_with_cov)     # from LCM message
+        """
+        source: Any = twist
+        cov: Any = covariance
 
-    @dispatch  # type: ignore[no-redef]
-    def __init__(self, twist_with_cov: TwistWithCovariance) -> None:
-        """Initialize from another TwistWithCovariance (copy constructor)."""
-        self.twist = Twist(twist_with_cov.twist)
-        self.covariance = np.array(twist_with_cov.covariance).copy()
+        # TwistWithCovariance before LCMTwistWithCovariance (it is a subclass).
+        if isinstance(source, TwistWithCovariance):
+            if cov is None:
+                cov = np.array(source.covariance).copy()
+            source = Twist(source.twist)  # copy constructor: don't alias the source twist
+        elif isinstance(source, LCMTwistWithCovariance):
+            if cov is None:
+                cov = np.array(source.covariance)
+            source = Twist(source.twist)
+        elif isinstance(source, dict) and "twist" in source:
+            cov = source.get("covariance", cov)
+            source = source["twist"]
+        elif _is_twist_covariance_pair(source):
+            source, cov = source
 
-    @dispatch  # type: ignore[no-redef]
-    def __init__(self, lcm_twist_with_cov: LCMTwistWithCovariance) -> None:
-        """Initialize from an LCM TwistWithCovariance."""
-        self.twist = Twist(lcm_twist_with_cov.twist)
-        self.covariance = np.array(lcm_twist_with_cov.covariance)
-
-    @dispatch  # type: ignore[no-redef]
-    def __init__(
-        self,
-        twist_dict: dict[
-            str, Twist | tuple[VectorConvertable, VectorConvertable] | list[float] | np.ndarray
-        ],
-    ) -> None:
-        """Initialize from a dictionary with 'twist' and 'covariance' keys."""
-        twist = twist_dict["twist"]
-        if isinstance(twist, Twist):
-            self.twist = twist
-        else:
-            # Assume it's a tuple of (linear, angular)
-            self.twist = Twist(twist[0], twist[1])
-
-        covariance = twist_dict.get("covariance")
-        if covariance is None:
-            self.covariance = np.zeros(36)
-        else:
-            self.covariance = np.array(covariance, dtype=float).reshape(36)
-
-    @dispatch  # type: ignore[no-redef]
-    def __init__(
-        self,
-        twist_tuple: tuple[
-            Twist | tuple[VectorConvertable, VectorConvertable], list[float] | np.ndarray
-        ],
-    ) -> None:
-        """Initialize from a tuple of (twist, covariance)."""
-        twist = twist_tuple[0]
-        if isinstance(twist, Twist):
-            self.twist = twist
-        else:
-            # Assume it's a tuple of (linear, angular)
-            self.twist = Twist(twist[0], twist[1])
-        self.covariance = np.array(twist_tuple[1], dtype=float).reshape(36)
+        self.twist = _to_twist(source)
+        self.covariance = (
+            np.zeros(COVARIANCE_SIZE)
+            if cov is None
+            else np.array(cov, dtype=float).reshape(COVARIANCE_SIZE)
+        )
 
     def __getattribute__(self, name: str):  # type: ignore[no-untyped-def]
         """Override to ensure covariance is always returned as numpy array."""

--- a/dimos/msgs/geometry_msgs/TwistWithCovarianceStamped.py
+++ b/dimos/msgs/geometry_msgs/TwistWithCovarianceStamped.py
@@ -21,7 +21,6 @@ from dimos_lcm.geometry_msgs import (
     TwistWithCovarianceStamped as LCMTwistWithCovarianceStamped,
 )
 import numpy as np
-from plum import dispatch
 
 from dimos.msgs.geometry_msgs.Twist import Twist
 from dimos.msgs.geometry_msgs.TwistWithCovariance import TwistWithCovariance
@@ -54,14 +53,6 @@ class TwistWithCovarianceStamped(TwistWithCovariance, Timestamped):
     ts: float
     frame_id: str
 
-    @dispatch
-    def __init__(self, ts: float = 0.0, frame_id: str = "", **kwargs) -> None:
-        """Initialize with timestamp and frame_id."""
-        self.frame_id = frame_id
-        self.ts = ts if ts != 0 else time.time()
-        super().__init__(**kwargs)
-
-    @dispatch  # type: ignore[no-redef]
     def __init__(
         self,
         ts: float = 0.0,
@@ -72,10 +63,7 @@ class TwistWithCovarianceStamped(TwistWithCovariance, Timestamped):
         """Initialize with timestamp, frame_id, twist and covariance."""
         self.frame_id = frame_id
         self.ts = ts if ts != 0 else time.time()
-        if twist is None:
-            super().__init__()
-        else:
-            super().__init__(twist, covariance)
+        super().__init__(twist, covariance)
 
     def lcm_encode(self) -> bytes:
         lcm_msg = LCMTwistWithCovarianceStamped()

--- a/dimos/msgs/geometry_msgs/TwistWithCovarianceStamped.py
+++ b/dimos/msgs/geometry_msgs/TwistWithCovarianceStamped.py
@@ -55,14 +55,14 @@ class TwistWithCovarianceStamped(TwistWithCovariance, Timestamped):
 
     def __init__(
         self,
-        ts: float = 0.0,
+        ts: float | None = None,
         frame_id: str = "",
         twist: Twist | tuple[VectorConvertable, VectorConvertable] | None = None,
         covariance: list[float] | np.ndarray | None = None,
     ) -> None:
         """Initialize with timestamp, frame_id, twist and covariance."""
         self.frame_id = frame_id
-        self.ts = ts if ts != 0 else time.time()
+        self.ts = time.time() if ts is None else ts
         super().__init__(twist, covariance)
 
     def lcm_encode(self) -> bytes:

--- a/dimos/msgs/geometry_msgs/test_PoseWithCovarianceStamped.py
+++ b/dimos/msgs/geometry_msgs/test_PoseWithCovarianceStamped.py
@@ -146,12 +146,11 @@ def test_pose_with_covariance_stamped_lcm_encode_decode() -> None:
 
 
 def test_pose_with_covariance_stamped_zero_timestamp() -> None:
-    """Test that zero timestamp gets replaced with current time."""
-    pose_cov_stamped = PoseWithCovarianceStamped(ts=0.0)
+    """Test that an explicit zero timestamp is kept, and an omitted one stamps now."""
+    assert PoseWithCovarianceStamped(ts=0.0).ts == 0.0
 
-    # Should have been replaced with current time
-    assert pose_cov_stamped.ts > 0
-    assert pose_cov_stamped.ts <= time.time()
+    before = time.time()
+    assert before <= PoseWithCovarianceStamped().ts <= time.time()
 
 
 def test_pose_with_covariance_stamped_inheritance() -> None:

--- a/dimos/msgs/geometry_msgs/test_TwistWithCovarianceStamped.py
+++ b/dimos/msgs/geometry_msgs/test_TwistWithCovarianceStamped.py
@@ -161,12 +161,11 @@ def test_twist_with_covariance_stamped_lcm_encode_decode() -> None:
 
 
 def test_twist_with_covariance_stamped_zero_timestamp() -> None:
-    """Test that zero timestamp gets replaced with current time."""
-    twist_cov_stamped = TwistWithCovarianceStamped(ts=0.0)
+    """Test that an explicit zero timestamp is kept, and an omitted one stamps now."""
+    assert TwistWithCovarianceStamped(ts=0.0).ts == 0.0
 
-    # Should have been replaced with current time
-    assert twist_cov_stamped.ts > 0
-    assert twist_cov_stamped.ts <= time.time()
+    before = time.time()
+    assert before <= TwistWithCovarianceStamped().ts <= time.time()
 
 
 def test_twist_with_covariance_stamped_inheritance() -> None:

--- a/dimos/msgs/nav_msgs/GraphNodes3D.py
+++ b/dimos/msgs/nav_msgs/GraphNodes3D.py
@@ -84,12 +84,12 @@ class GraphNodes3D(Timestamped):
 
     def __init__(
         self,
-        ts: float = 0.0,
+        ts: float | None = None,
         frame_id: str = "map",
         nodes: list[GraphNode] | None = None,
     ) -> None:
         self.frame_id = frame_id
-        self.ts = ts if ts != 0 else time.time()
+        self.ts = time.time() if ts is None else ts
         self.nodes = nodes if nodes is not None else []
 
     def lcm_encode(self) -> bytes:

--- a/dimos/msgs/nav_msgs/LineSegments3D.py
+++ b/dimos/msgs/nav_msgs/LineSegments3D.py
@@ -46,13 +46,13 @@ class LineSegments3D(Timestamped):
 
     def __init__(
         self,
-        ts: float = 0.0,
+        ts: float | None = None,
         frame_id: str = "map",
         segments: list[tuple[tuple[float, float, float], tuple[float, float, float]]] | None = None,
         traversability: list[float] | None = None,
     ) -> None:
         self.frame_id = frame_id
-        self.ts = ts if ts != 0 else time.time()
+        self.ts = time.time() if ts is None else ts
         self._segments = segments or []
         self._traversability = traversability or [1.0] * len(self._segments)
 

--- a/dimos/msgs/nav_msgs/OccupancyGrid.py
+++ b/dimos/msgs/nav_msgs/OccupancyGrid.py
@@ -132,7 +132,7 @@ class OccupancyGrid(Timestamped):
         resolution: float = 0.05,
         origin: Pose | None = None,
         frame_id: str = "world",
-        ts: float = 0.0,
+        ts: float | None = None,
     ) -> None:
         """Initialize OccupancyGrid.
 
@@ -147,7 +147,7 @@ class OccupancyGrid(Timestamped):
         """
 
         self.frame_id = frame_id
-        self.ts = ts if ts != 0 else time.time()
+        self.ts = time.time() if ts is None else ts
 
         if grid is not None:
             # Initialize from numpy array

--- a/dimos/msgs/nav_msgs/Odometry.py
+++ b/dimos/msgs/nav_msgs/Odometry.py
@@ -42,13 +42,13 @@ class Odometry(Timestamped):
 
     def __init__(
         self,
-        ts: float = 0.0,
+        ts: float | None = None,
         frame_id: str = "",
         child_frame_id: str = "",
         pose: PoseWithCovariance | Pose | None = None,
         twist: TwistWithCovariance | Twist | None = None,
     ) -> None:
-        self.ts = ts if ts != 0 else time.time()
+        self.ts = time.time() if ts is None else ts
         self.frame_id = frame_id
         self.child_frame_id = child_frame_id
 

--- a/dimos/msgs/nav_msgs/Path.py
+++ b/dimos/msgs/nav_msgs/Path.py
@@ -48,13 +48,13 @@ class Path(Timestamped):
 
     def __init__(  # type: ignore[no-untyped-def]
         self,
-        ts: float = 0.0,
+        ts: float | None = None,
         frame_id: str = "world",
         poses: list[PoseStamped] | None = None,
         **kwargs,
     ) -> None:
         self.frame_id = frame_id
-        self.ts = ts if ts != 0 else time.time()
+        self.ts = time.time() if ts is None else ts
         self.poses = poses if poses is not None else []
 
     def __len__(self) -> int:

--- a/dimos/msgs/nav_msgs/test_Odometry.py
+++ b/dimos/msgs/nav_msgs/test_Odometry.py
@@ -171,9 +171,11 @@ def test_odometry_lcm_roundtrip() -> None:
 
 
 def test_odometry_zero_timestamp() -> None:
-    odom = Odometry(ts=0.0)
-    assert odom.ts > 0
-    assert odom.ts <= time.time()
+    """An explicit zero timestamp is kept; an omitted one stamps now."""
+    assert Odometry(ts=0.0).ts == 0.0
+
+    before = time.time()
+    assert before <= Odometry().ts <= time.time()
 
 
 def test_odometry_with_just_pose() -> None:

--- a/dimos/msgs/sensor_msgs/JointState.py
+++ b/dimos/msgs/sensor_msgs/JointState.py
@@ -36,7 +36,7 @@ def _fields_of(source: Any) -> tuple[Any, ...]:
     """Pull the six JointState fields out of a dict, a JointState or an LCM message."""
     if isinstance(source, dict):
         return (
-            source.get("ts", 0.0),
+            source.get("ts"),
             source.get("frame_id", ""),
             source.get("name"),
             source.get("position"),
@@ -63,7 +63,7 @@ class JointState(Timestamped):
 
     def __init__(
         self,
-        ts: float | JointStateConvertable | JointState = 0.0,
+        ts: float | JointStateConvertable | JointState | None = None,
         frame_id: str = "",
         name: list[str] | None = None,
         position: list[float] | None = None,
@@ -87,7 +87,7 @@ class JointState(Timestamped):
         if isinstance(stamp, dict | JointState | LCMJointState):
             stamp, frame_id, name, position, velocity, effort = _fields_of(stamp)
 
-        self.ts = stamp if stamp != 0 else time.time()
+        self.ts = time.time() if stamp is None else stamp
         self.frame_id = frame_id
         self.name = name if name is not None else []
         self.position = position if position is not None else []

--- a/dimos/msgs/sensor_msgs/JointState.py
+++ b/dimos/msgs/sensor_msgs/JointState.py
@@ -15,20 +15,41 @@
 from __future__ import annotations
 
 import time
-from typing import TypeAlias
+from typing import Any, TypeAlias
 
 from dimos_lcm.sensor_msgs import JointState as LCMJointState
-from plum import dispatch
 
 from dimos.types.timestamped import Timestamped
 
 # Types that can be converted to/from JointState
 JointStateConvertable: TypeAlias = dict[str, list[str] | list[float]] | LCMJointState
 
+_FIELDS = ("ts", "frame_id", "name", "position", "velocity", "effort")
+
 
 def sec_nsec(ts):  # type: ignore[no-untyped-def]
     s = int(ts)
     return [s, int((ts - s) * 1_000_000_000)]
+
+
+def _fields_of(source: Any) -> tuple[Any, ...]:
+    """Pull the six JointState fields out of a dict, a JointState or an LCM message."""
+    if isinstance(source, dict):
+        return (
+            source.get("ts", 0.0),
+            source.get("frame_id", ""),
+            source.get("name"),
+            source.get("position"),
+            source.get("velocity"),
+            source.get("effort"),
+        )
+    if isinstance(source, JointState):
+        return (source.ts, source.frame_id, *(list(getattr(source, f)) for f in _FIELDS[2:]))
+    return (
+        source.header.stamp.sec + (source.header.stamp.nsec / 1_000_000_000),
+        source.header.frame_id,
+        *(list(getattr(source, f) or []) for f in _FIELDS[2:]),
+    )
 
 
 class JointState(Timestamped):
@@ -40,10 +61,9 @@ class JointState(Timestamped):
     velocity: list[float]
     effort: list[float]
 
-    @dispatch
     def __init__(
         self,
-        ts: float = 0.0,
+        ts: float | JointStateConvertable | JointState = 0.0,
         frame_id: str = "",
         name: list[str] | None = None,
         position: list[float] | None = None,
@@ -51,6 +71,9 @@ class JointState(Timestamped):
         effort: list[float] | None = None,
     ) -> None:
         """Initialize a JointState message.
+
+        The first argument doubles as the source for the copy/dict/LCM forms:
+        ``JointState(other)``, ``JointState({...})``, ``JointState(lcm_msg)``.
 
         Args:
             ts: Timestamp in seconds
@@ -60,42 +83,16 @@ class JointState(Timestamped):
             velocity: List of joint velocities (rad/s or m/s)
             effort: List of joint efforts (Nm or N)
         """
-        self.ts = ts if ts != 0 else time.time()
+        stamp: Any = ts
+        if isinstance(stamp, dict | JointState | LCMJointState):
+            stamp, frame_id, name, position, velocity, effort = _fields_of(stamp)
+
+        self.ts = stamp if stamp != 0 else time.time()
         self.frame_id = frame_id
         self.name = name if name is not None else []
         self.position = position if position is not None else []
         self.velocity = velocity if velocity is not None else []
         self.effort = effort if effort is not None else []
-
-    @dispatch  # type: ignore[no-redef]
-    def __init__(self, joint_dict: dict[str, list[str] | list[float]]) -> None:
-        """Initialize from a dictionary."""
-        self.ts = joint_dict.get("ts", time.time())
-        self.frame_id = joint_dict.get("frame_id", "")
-        self.name = list(joint_dict.get("name", []))
-        self.position = list(joint_dict.get("position", []))
-        self.velocity = list(joint_dict.get("velocity", []))
-        self.effort = list(joint_dict.get("effort", []))
-
-    @dispatch  # type: ignore[no-redef]
-    def __init__(self, joint: JointState) -> None:
-        """Initialize from another JointState (copy constructor)."""
-        self.ts = joint.ts
-        self.frame_id = joint.frame_id
-        self.name = list(joint.name)
-        self.position = list(joint.position)
-        self.velocity = list(joint.velocity)
-        self.effort = list(joint.effort)
-
-    @dispatch  # type: ignore[no-redef]
-    def __init__(self, lcm_joint: LCMJointState) -> None:
-        """Initialize from an LCM JointState message."""
-        self.ts = lcm_joint.header.stamp.sec + (lcm_joint.header.stamp.nsec / 1_000_000_000)
-        self.frame_id = lcm_joint.header.frame_id
-        self.name = list(lcm_joint.name) if lcm_joint.name else []
-        self.position = list(lcm_joint.position) if lcm_joint.position else []
-        self.velocity = list(lcm_joint.velocity) if lcm_joint.velocity else []
-        self.effort = list(lcm_joint.effort) if lcm_joint.effort else []
 
     def lcm_encode(self) -> bytes:
         lcm_msg = LCMJointState()

--- a/dimos/msgs/sensor_msgs/Joy.py
+++ b/dimos/msgs/sensor_msgs/Joy.py
@@ -36,13 +36,13 @@ def _fields_of(source: Any) -> tuple[Any, ...]:
     """Pull the four Joy fields out of a dict, an (axes, buttons) pair, a Joy or an LCM message."""
     if isinstance(source, dict):
         return (
-            source.get("ts", 0.0),
+            source.get("ts"),
             source.get("frame_id", ""),
             source.get("axes"),
             source.get("buttons"),
         )
     if isinstance(source, tuple | list):
-        return (0.0, "", list(source[0]), list(source[1]))
+        return (None, "", list(source[0]), list(source[1]))
     if isinstance(source, Joy):
         return (source.ts, source.frame_id, list(source.axes), list(source.buttons))
     return (
@@ -62,7 +62,7 @@ class Joy(Timestamped):
 
     def __init__(
         self,
-        ts: float | JoyConvertable | Joy = 0.0,
+        ts: float | JoyConvertable | Joy | None = None,
         frame_id: str = "",
         axes: list[float] | None = None,
         buttons: list[int] | None = None,
@@ -82,7 +82,7 @@ class Joy(Timestamped):
         if isinstance(stamp, dict | tuple | list | Joy | LCMJoy):
             stamp, frame_id, axes, buttons = _fields_of(stamp)
 
-        self.ts = stamp if stamp != 0 else time.time()
+        self.ts = time.time() if stamp is None else stamp
         self.frame_id = frame_id
         self.axes = axes if axes is not None else []
         self.buttons = buttons if buttons is not None else []

--- a/dimos/msgs/sensor_msgs/Joy.py
+++ b/dimos/msgs/sensor_msgs/Joy.py
@@ -15,10 +15,9 @@
 from __future__ import annotations
 
 import time
-from typing import TypeAlias
+from typing import Any, TypeAlias
 
 from dimos_lcm.sensor_msgs import Joy as LCMJoy
-from plum import dispatch
 
 from dimos.types.timestamped import Timestamped
 
@@ -33,6 +32,27 @@ def sec_nsec(ts):  # type: ignore[no-untyped-def]
     return [s, int((ts - s) * 1_000_000_000)]
 
 
+def _fields_of(source: Any) -> tuple[Any, ...]:
+    """Pull the four Joy fields out of a dict, an (axes, buttons) pair, a Joy or an LCM message."""
+    if isinstance(source, dict):
+        return (
+            source.get("ts", 0.0),
+            source.get("frame_id", ""),
+            source.get("axes"),
+            source.get("buttons"),
+        )
+    if isinstance(source, tuple | list):
+        return (0.0, "", list(source[0]), list(source[1]))
+    if isinstance(source, Joy):
+        return (source.ts, source.frame_id, list(source.axes), list(source.buttons))
+    return (
+        source.header.stamp.sec + (source.header.stamp.nsec / 1_000_000_000),
+        source.header.frame_id,
+        list(source.axes),
+        list(source.buttons),
+    )
+
+
 class Joy(Timestamped):
     msg_name = "sensor_msgs.Joy"
     ts: float
@@ -40,15 +60,17 @@ class Joy(Timestamped):
     axes: list[float]
     buttons: list[int]
 
-    @dispatch
     def __init__(
         self,
-        ts: float = 0.0,
+        ts: float | JoyConvertable | Joy = 0.0,
         frame_id: str = "",
         axes: list[float] | None = None,
         buttons: list[int] | None = None,
     ) -> None:
         """Initialize a Joy message.
+
+        The first argument doubles as the source for the copy/dict/pair/LCM forms:
+        ``Joy(other)``, ``Joy({...})``, ``Joy((axes, buttons))``, ``Joy(lcm_msg)``.
 
         Args:
             ts: Timestamp in seconds
@@ -56,42 +78,14 @@ class Joy(Timestamped):
             axes: List of axis values (typically -1.0 to 1.0)
             buttons: List of button states (0 or 1)
         """
-        self.ts = ts if ts != 0 else time.time()
+        stamp: Any = ts
+        if isinstance(stamp, dict | tuple | list | Joy | LCMJoy):
+            stamp, frame_id, axes, buttons = _fields_of(stamp)
+
+        self.ts = stamp if stamp != 0 else time.time()
         self.frame_id = frame_id
         self.axes = axes if axes is not None else []
         self.buttons = buttons if buttons is not None else []
-
-    @dispatch  # type: ignore[no-redef]
-    def __init__(self, joy_tuple: tuple[list[float], list[int]]) -> None:
-        """Initialize from a tuple of (axes, buttons)."""
-        self.ts = time.time()
-        self.frame_id = ""
-        self.axes = list(joy_tuple[0])
-        self.buttons = list(joy_tuple[1])
-
-    @dispatch  # type: ignore[no-redef]
-    def __init__(self, joy_dict: dict[str, list[float] | list[int]]) -> None:
-        """Initialize from a dictionary with 'axes' and 'buttons' keys."""
-        self.ts = joy_dict.get("ts", time.time())
-        self.frame_id = joy_dict.get("frame_id", "")
-        self.axes = list(joy_dict.get("axes", []))
-        self.buttons = list(joy_dict.get("buttons", []))
-
-    @dispatch  # type: ignore[no-redef]
-    def __init__(self, joy: Joy) -> None:
-        """Initialize from another Joy (copy constructor)."""
-        self.ts = joy.ts
-        self.frame_id = joy.frame_id
-        self.axes = list(joy.axes)
-        self.buttons = list(joy.buttons)
-
-    @dispatch  # type: ignore[no-redef]
-    def __init__(self, lcm_joy: LCMJoy) -> None:
-        """Initialize from an LCM Joy message."""
-        self.ts = lcm_joy.header.stamp.sec + (lcm_joy.header.stamp.nsec / 1_000_000_000)
-        self.frame_id = lcm_joy.header.frame_id
-        self.axes = list(lcm_joy.axes)
-        self.buttons = list(lcm_joy.buttons)
 
     def lcm_encode(self) -> bytes:
         lcm_msg = LCMJoy()

--- a/dimos/msgs/test_msg_construction.py
+++ b/dimos/msgs/test_msg_construction.py
@@ -16,11 +16,7 @@
 
 Every accepted construction form for the types whose ``__init__`` used to be a
 ``plum`` multiple-dispatch stack, plus the error cases. These pin the contract
-so the dispatch removal is provably behaviour-preserving.
-
-Tests marked LATENT BUG record forms that silently built a broken object under
-plum, because a call that matched no overload fell through to the LCM base
-``__init__``, which stores whatever it is handed.
+that the dispatch removal had to preserve.
 """
 
 import time
@@ -38,17 +34,20 @@ from dimos_lcm.sensor_msgs import JointState as LCMJointState, Joy as LCMJoy
 import numpy as np
 import pytest
 
+from dimos.msgs.geometry_msgs.PointStamped import PointStamped
 from dimos.msgs.geometry_msgs.Pose import Pose
 from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
 from dimos.msgs.geometry_msgs.PoseWithCovariance import PoseWithCovariance
 from dimos.msgs.geometry_msgs.PoseWithCovarianceStamped import PoseWithCovarianceStamped
 from dimos.msgs.geometry_msgs.Quaternion import Quaternion
+from dimos.msgs.geometry_msgs.Transform import Transform
 from dimos.msgs.geometry_msgs.Twist import Twist
 from dimos.msgs.geometry_msgs.TwistStamped import TwistStamped
 from dimos.msgs.geometry_msgs.TwistWithCovariance import TwistWithCovariance
 from dimos.msgs.geometry_msgs.TwistWithCovarianceStamped import TwistWithCovarianceStamped
 from dimos.msgs.geometry_msgs.Vector3 import Vector3
 from dimos.msgs.nav_msgs.GraphNodes3D import GraphNodes3D
+from dimos.msgs.nav_msgs.Odometry import Odometry
 from dimos.msgs.nav_msgs.Path import Path
 from dimos.msgs.sensor_msgs.JointState import JointState
 from dimos.msgs.sensor_msgs.Joy import Joy
@@ -638,53 +637,46 @@ def test_twcs_empty_defaults() -> None:
 # --------------------------------------------------------------------------
 # The ``ts`` sentinel
 #
-# LATENT BUG: ``self.ts = ts if ts != 0 else time.time()`` makes ts=0.0
-# unrepresentable — asking for it silently yields wall-clock time instead.
-# Pinned here so the follow-up sentinel change shows up as an explicit diff.
+# ``ts`` defaults to None and means "stamp me now". 0.0 is an ordinary
+# timestamp and is stored as given — it used to be swallowed by a
+# ``ts if ts != 0`` sentinel that made it unrepresentable.
 # --------------------------------------------------------------------------
 
-
-def test_posestamped_zero_ts_is_replaced_by_wall_clock() -> None:
-    assert PoseStamped(ts=0.0).ts != 0.0
-
-
-def test_twiststamped_zero_ts_is_replaced_by_wall_clock() -> None:
-    assert TwistStamped(ts=0.0).ts != 0.0
-
-
-def test_pwcs_zero_ts_is_replaced_by_wall_clock() -> None:
-    assert PoseWithCovarianceStamped(ts=0.0).ts != 0.0
-
-
-def test_twcs_zero_ts_is_replaced_by_wall_clock() -> None:
-    assert TwistWithCovarianceStamped(ts=0.0).ts != 0.0
+STAMPED_TYPES = [
+    PoseStamped,
+    TwistStamped,
+    PoseWithCovarianceStamped,
+    TwistWithCovarianceStamped,
+    JointState,
+    Joy,
+    Path,
+    GraphNodes3D,
+    PointStamped,
+    Transform,
+    Odometry,
+]
 
 
-def test_jointstate_zero_ts_is_replaced_by_wall_clock() -> None:
-    assert JointState(ts=0.0).ts != 0.0
+@pytest.mark.parametrize("msg_type", STAMPED_TYPES, ids=lambda t: t.__name__)
+def test_zero_ts_is_a_real_timestamp(msg_type: type) -> None:
+    assert msg_type(ts=0.0).ts == 0.0
 
 
-def test_joy_zero_ts_is_replaced_by_wall_clock() -> None:
-    assert Joy(ts=0.0).ts != 0.0
+@pytest.mark.parametrize("msg_type", STAMPED_TYPES, ids=lambda t: t.__name__)
+def test_omitted_ts_stamps_now(msg_type: type) -> None:
+    before = time.time()
+    assert before <= msg_type().ts <= time.time()
 
 
-def test_path_zero_ts_is_replaced_by_wall_clock() -> None:
-    assert Path(ts=0.0).ts != 0.0
+@pytest.mark.parametrize("msg_type", STAMPED_TYPES, ids=lambda t: t.__name__)
+def test_explicit_ts_is_honoured(msg_type: type) -> None:
+    assert msg_type(ts=5.0).ts == 5.0
 
 
-def test_graphnodes3d_zero_ts_is_replaced_by_wall_clock() -> None:
-    assert GraphNodes3D(ts=0.0).ts != 0.0
-
-
-def test_nonzero_ts_is_always_honoured() -> None:
-    assert PoseStamped(ts=5.0).ts == 5.0
-    assert TwistStamped(ts=5.0).ts == 5.0
-    assert PoseWithCovarianceStamped(ts=5.0).ts == 5.0
-    assert TwistWithCovarianceStamped(ts=5.0).ts == 5.0
-    assert JointState(ts=5.0).ts == 5.0
-    assert Joy(ts=5.0).ts == 5.0
-    assert Path(ts=5.0).ts == 5.0
-    assert GraphNodes3D(ts=5.0).ts == 5.0
+def test_lcm_decode_of_an_unstamped_message_keeps_the_zero_stamp() -> None:
+    """A producer that never set the header now decodes to ts=0.0, not receive-time."""
+    decoded = PoseStamped.lcm_decode(PoseStamped(ts=0.0, frame_id="odom").lcm_encode())
+    assert decoded.ts == 0.0
 
 
 # --------------------------------------------------------------------------

--- a/dimos/msgs/test_msg_construction.py
+++ b/dimos/msgs/test_msg_construction.py
@@ -26,11 +26,13 @@ plum, because a call that matched no overload fell through to the LCM base
 import time
 
 from dimos_lcm.geometry_msgs import (
+    Point as LCMPoint,
     Pose as LCMPose,
     PoseWithCovariance as LCMPoseWithCovariance,
     Quaternion as LCMQuaternion,
     Twist as LCMTwist,
     TwistWithCovariance as LCMTwistWithCovariance,
+    Vector3 as LCMVector3,
 )
 from dimos_lcm.sensor_msgs import JointState as LCMJointState, Joy as LCMJoy
 import numpy as np
@@ -236,10 +238,15 @@ def test_pose_from_posestamped_downcasts_to_pose() -> None:
     assert p.position.to_tuple() == (1.0, 2.0, 3.0)
 
 
-def test_pose_from_lcm_keeps_lcm_orientation_defaults() -> None:
-    p = Pose(LCMPose())
-    assert p.position.to_tuple() == (0.0, 0.0, 0.0)
-    assert p.orientation.to_tuple() == (0.0, 0.0, 0.0, 0.0)
+def test_pose_from_lcm() -> None:
+    # Build the sub-messages explicitly: the generated LCM classes share one
+    # mutable default instance across every construction, so LCMPose().position
+    # carries whatever the last writer left there.
+    p = Pose(
+        LCMPose(position=LCMPoint(1.0, 2.0, 3.0), orientation=LCMQuaternion(0.0, 0.0, 0.0, 1.0))
+    )
+    assert p.position.to_tuple() == (1.0, 2.0, 3.0)
+    assert p.orientation.to_tuple() == IDENTITY
 
 
 def test_pose_position_and_orientation_are_wrapper_types() -> None:
@@ -291,8 +298,9 @@ def test_twist_copy_constructor() -> None:
 
 
 def test_twist_from_lcm() -> None:
-    t = Twist(LCMTwist())
-    assert t.linear.to_tuple() == (0.0, 0.0, 0.0)
+    t = Twist(LCMTwist(linear=LCMVector3(1.0, 2.0, 3.0), angular=LCMVector3(4.0, 5.0, 6.0)))
+    assert t.linear.to_tuple() == (1.0, 2.0, 3.0)
+    assert t.angular.to_tuple() == (4.0, 5.0, 6.0)
 
 
 def test_twist_from_twiststamped_downcasts() -> None:
@@ -363,9 +371,12 @@ def test_pwc_copy_constructor_copies_covariance() -> None:
 
 
 def test_pwc_from_lcm() -> None:
-    p = PoseWithCovariance(LCMPoseWithCovariance())
-    assert p.pose.position.to_tuple() == (0.0, 0.0, 0.0)
-    assert np.array_equal(p.covariance, np.zeros(36))
+    lcm_pose = LCMPose(
+        position=LCMPoint(1.0, 2.0, 3.0), orientation=LCMQuaternion(0.0, 0.0, 0.0, 1.0)
+    )
+    p = PoseWithCovariance(LCMPoseWithCovariance(pose=lcm_pose, covariance=list(range(36))))
+    assert p.pose.position.to_tuple() == (1.0, 2.0, 3.0)
+    assert np.array_equal(p.covariance, np.arange(36.0))
 
 
 def test_pwc_from_dict_with_pose_object() -> None:
@@ -419,8 +430,10 @@ def test_twc_copy_constructor() -> None:
 
 
 def test_twc_from_lcm() -> None:
-    t = TwistWithCovariance(LCMTwistWithCovariance())
-    assert t.twist.linear.to_tuple() == (0.0, 0.0, 0.0)
+    lcm_twist = LCMTwist(linear=LCMVector3(1.0, 2.0, 3.0), angular=LCMVector3(4.0, 5.0, 6.0))
+    t = TwistWithCovariance(LCMTwistWithCovariance(twist=lcm_twist, covariance=list(range(36))))
+    assert t.twist.linear.to_tuple() == (1.0, 2.0, 3.0)
+    assert np.array_equal(t.covariance, np.arange(36.0))
 
 
 def test_twc_from_dict() -> None:
@@ -555,6 +568,26 @@ def test_posestamped_is_a_pose() -> None:
     assert isinstance(PoseStamped(), Pose)
 
 
+def test_posestamped_inherits_pose_positional_forms() -> None:
+    """PoseStamped(x, y, z) and the 7-float form come from Pose."""
+    assert PoseStamped(3.2, 1.5, 0.0).position.to_tuple() == (3.2, 1.5, 0.0)
+    seven = PoseStamped(1, 2, 0, 0, 0, 0.1, 1)
+    assert seven.position.to_tuple() == (1.0, 2.0, 0.0)
+    assert seven.orientation.to_tuple() == (0.0, 0.0, 0.1, 1.0)
+
+
+def test_posestamped_inherits_pose_sequence_forms() -> None:
+    ps = PoseStamped([1, 2, 3], [0, 0, 0, 1])
+    assert ps.position.to_tuple() == (1.0, 2.0, 3.0)
+    assert ps.orientation.to_tuple() == IDENTITY
+
+
+def test_twiststamped_inherits_twist_positional_form() -> None:
+    ts = TwistStamped([1, 2, 3], [4, 5, 6])
+    assert ts.linear.to_tuple() == (1.0, 2.0, 3.0)
+    assert ts.angular.to_tuple() == (4.0, 5.0, 6.0)
+
+
 def test_twiststamped_keeps_explicit_ts_and_frame() -> None:
     ts = TwistStamped(ts=5.0, frame_id="base", linear=[1, 2, 3], angular=[4, 5, 6])
     assert (ts.ts, ts.frame_id) == (5.0, "base")
@@ -655,100 +688,126 @@ def test_nonzero_ts_is_always_honoured() -> None:
 
 
 # --------------------------------------------------------------------------
-# LATENT BUGS: calls that matched no plum overload fell through to the LCM
-# base __init__, which stores its arguments verbatim. The result is an object
-# whose fields hold raw lists/scalars instead of Vector3/Quaternion/Pose, and
-# which only blows up later (often in __repr__ or on encode).
+# Forms that used to build a silently-broken object
+#
+# Under plum these calls matched no overload and fell through to the LCM base
+# __init__, which stores its arguments verbatim — leaving fields holding raw
+# scalars/lists instead of Vector3/Quaternion/Pose, to blow up later in
+# __repr__ or on encode. They now either do the obvious thing or raise.
 # --------------------------------------------------------------------------
 
 
-def test_pose_from_scalar_silently_stores_raw_value() -> None:
-    assert Pose(5).position == 5
+def test_pose_from_scalar_is_an_x_only_position() -> None:
+    """Vector3(x) means (x, 0, 0), so Pose(5) is a position, not a raw 5."""
+    assert Pose(5).position.to_tuple() == (5.0, 0.0, 0.0)
 
 
-def test_pose_from_string_silently_stores_raw_value() -> None:
-    assert Pose("x").position == "x"
-
-
-def test_pose_from_two_positionals_silently_stores_raw_values() -> None:
-    p = Pose(1, 2)
-    assert (p.position, p.orientation) == (1, 2)
-
-
-def test_pose_from_three_tuple_of_sequences_silently_stores_the_tuple() -> None:
-    assert Pose(([1, 2, 3], [0, 0, 0, 1], [9])).position == ([1, 2, 3], [0, 0, 0, 1], [9])
-
-
-def test_quaternion_from_partial_positionals_silently_zero_fills_w() -> None:
-    """Three components yield w=0.0 — a zero-rotation-free, invalid quaternion."""
-    assert Quaternion(1, 2, 3).to_tuple() == (1.0, 2.0, 3.0, 0.0)
-    assert Quaternion(1, 2).to_tuple() == (1.0, 2.0, 0.0, 0.0)
-    assert Quaternion(5).to_tuple() == (5.0, 0.0, 0.0, 0.0)
-
-
-def test_quaternion_rejects_field_keywords() -> None:
-    """plum dispatches on positionals only, so an all-keyword call finds no overload."""
+def test_pose_from_string_raises() -> None:
     with pytest.raises(TypeError):
-        Quaternion(x=1, y=2, z=3, w=4)
+        Pose("x")
 
 
-def test_twist_from_single_sequence_silently_stores_raw_value() -> None:
-    assert Twist([1, 2, 3]).linear == [1, 2, 3]
+def test_pose_from_two_numeric_positionals_raises() -> None:
+    """(1, 2) is a position and an orientation, and 2 is not a quaternion."""
+    with pytest.raises(TypeError):
+        Pose(1, 2)
 
 
-def test_twist_from_scalars_silently_stores_raw_values() -> None:
-    t = Twist("x", "y")
-    assert (t.linear, t.angular) == ("x", "y")
+def test_pose_from_three_tuple_of_sequences_raises() -> None:
+    with pytest.raises((TypeError, ValueError)):
+        Pose(([1, 2, 3], [0, 0, 0, 1], [9]))
 
 
-def test_twist_mixed_positional_and_keyword_skips_vector3_conversion() -> None:
+def test_quaternion_partial_positionals_raise() -> None:
+    """A quaternion needs all four components; 3 no longer zero-fills w."""
+    for bad in ((1, 2, 3), (1, 2), (5,)):
+        with pytest.raises((TypeError, ValueError)):
+            Quaternion(*bad)
+
+
+def test_quaternion_accepts_field_keywords() -> None:
+    assert Quaternion(x=1, y=2, z=3, w=4).to_tuple() == (1.0, 2.0, 3.0, 4.0)
+
+
+def test_quaternion_partial_field_keywords_default_to_identity() -> None:
+    assert Quaternion(z=1).to_tuple() == (0.0, 0.0, 1.0, 1.0)
+
+
+def test_quaternion_unknown_keyword_raises() -> None:
+    with pytest.raises(TypeError):
+        Quaternion(bogus=1)
+
+
+def test_twist_from_single_sequence_is_linear_only() -> None:
+    t = Twist([1, 2, 3])
+    assert t.linear.to_tuple() == (1.0, 2.0, 3.0)
+    assert t.angular.to_tuple() == (0.0, 0.0, 0.0)
+
+
+def test_twist_from_scalars_raises() -> None:
+    with pytest.raises(TypeError):
+        Twist("x", "y")
+
+
+def test_twist_mixed_positional_and_keyword_converts_both() -> None:
     t = Twist([1, 2, 3], angular=[4, 5, 6])
-    assert t.linear == [1, 2, 3]
-    assert not isinstance(t.linear, Vector3)
+    assert isinstance(t.linear, Vector3)
+    assert t.linear.to_tuple() == (1.0, 2.0, 3.0)
+    assert t.angular.to_tuple() == (4.0, 5.0, 6.0)
 
 
-def test_twist_ignores_unknown_keywords() -> None:
-    t = Twist(bogus=1)
-    assert t.linear.to_tuple() == (0.0, 0.0, 0.0)
+def test_twist_unknown_keyword_raises() -> None:
+    with pytest.raises(TypeError):
+        Twist(bogus=1)
 
 
-def test_pwc_pair_tuple_silently_stores_the_tuple_as_the_pose() -> None:
-    """The documented (pose, covariance) tuple form never reached its overload."""
+def test_pose_unknown_keyword_raises() -> None:
+    with pytest.raises(TypeError):
+        Pose(bogus=1)
+
+
+def test_pwc_pair_tuple_is_a_pose_and_a_covariance() -> None:
+    """The documented (pose, covariance) tuple form now actually fires."""
     p = PoseWithCovariance((Pose(1, 2, 3), list(range(36))))
-    assert isinstance(p.pose, tuple)
-    assert np.array_equal(p.covariance, np.zeros(36))
+    assert p.pose.position.to_tuple() == (1.0, 2.0, 3.0)
+    assert np.array_equal(p.covariance, np.arange(36.0))
 
 
-def test_pwc_rejects_field_keywords() -> None:
-    with pytest.raises(TypeError):
-        PoseWithCovariance(pose=Pose(1, 2, 3))
+def test_pwc_accepts_field_keywords() -> None:
+    p = PoseWithCovariance(pose=Pose(1, 2, 3), covariance=list(range(36)))
+    assert p.pose.position.to_tuple() == (1.0, 2.0, 3.0)
+    assert np.array_equal(p.covariance, np.arange(36.0))
 
 
-def test_twc_rejects_field_keywords() -> None:
-    with pytest.raises(TypeError):
-        TwistWithCovariance(twist=Twist([1, 2, 3], [4, 5, 6]))
+def test_twc_accepts_field_keywords() -> None:
+    t = TwistWithCovariance(twist=Twist([1, 2, 3], [4, 5, 6]))
+    assert t.twist.linear.to_tuple() == (1.0, 2.0, 3.0)
 
 
-def test_pwc_dict_with_convertable_pose_value_misroutes_to_the_pose_overload() -> None:
-    """A dict whose 'pose' is a plain sequence matches PoseConvertable, so the
-    whole dict is handed to Pose() and dies looking for a 'position' key."""
-    with pytest.raises(KeyError):
-        PoseWithCovariance({"pose": [1, 2, 3], "covariance": list(range(36))})
+def test_twc_pair_tuple_is_a_twist_and_a_covariance() -> None:
+    t = TwistWithCovariance((Twist([1, 2, 3], [4, 5, 6]), list(range(36))))
+    assert t.twist.linear.to_tuple() == (1.0, 2.0, 3.0)
+    assert np.array_equal(t.covariance, np.arange(36.0))
 
 
-def test_jointstate_dict_without_list_values_builds_nothing() -> None:
-    """{'ts': ..., 'frame_id': ...} matches no overload; fields are never set."""
+def test_pwc_dict_pose_may_be_any_pose_convertable() -> None:
+    p = PoseWithCovariance({"pose": [1, 2, 3], "covariance": list(range(36))})
+    assert p.pose.position.to_tuple() == (1.0, 2.0, 3.0)
+    assert np.array_equal(p.covariance, np.arange(36.0))
+
+
+def test_jointstate_dict_carries_ts_and_frame_id() -> None:
     j = JointState({"ts": 5.0, "frame_id": "f"})
-    with pytest.raises(AttributeError):
-        getattr(j, "frame_id")  # noqa: B009
+    assert (j.ts, j.frame_id) == (5.0, "f")
+    assert j.name == []
 
 
-def test_joy_dict_without_list_values_builds_nothing() -> None:
+def test_joy_dict_carries_ts_and_frame_id() -> None:
     j = Joy({"ts": 5.0, "frame_id": "f"})
-    with pytest.raises(AttributeError):
-        getattr(j, "frame_id")  # noqa: B009
+    assert (j.ts, j.frame_id) == (5.0, "f")
+    assert j.axes == []
 
 
-def test_posestamped_from_string_silently_stores_raw_value() -> None:
-    """A str first positional misses ts: float, so it lands in the LCM ctor."""
-    assert PoseStamped("f").position == "f"
+def test_posestamped_string_positional_is_a_timestamp_not_a_position() -> None:
+    """A str first positional is a (bogus) ts; it no longer corrupts the position."""
+    assert PoseStamped("f").position.to_tuple() == (0.0, 0.0, 0.0)

--- a/dimos/msgs/test_msg_construction.py
+++ b/dimos/msgs/test_msg_construction.py
@@ -55,9 +55,7 @@ from dimos.msgs.sensor_msgs.Joy import Joy
 IDENTITY = (0.0, 0.0, 0.0, 1.0)
 
 
-# --------------------------------------------------------------------------
 # Quaternion
-# --------------------------------------------------------------------------
 
 
 def test_quaternion_empty_is_identity() -> None:
@@ -122,9 +120,7 @@ def test_quaternion_lcm_roundtrip_uses_the_sequence_form() -> None:
     assert decoded.to_tuple() == (1.0, 2.0, 3.0, 4.0)
 
 
-# --------------------------------------------------------------------------
 # Pose
-# --------------------------------------------------------------------------
 
 
 def test_pose_empty_is_origin_with_identity() -> None:
@@ -254,9 +250,7 @@ def test_pose_position_and_orientation_are_wrapper_types() -> None:
     assert isinstance(p.orientation, Quaternion)
 
 
-# --------------------------------------------------------------------------
 # Twist
-# --------------------------------------------------------------------------
 
 
 def test_twist_empty_is_zero() -> None:
@@ -331,9 +325,7 @@ def test_twist_keyword_angular_quaternion_is_converted_to_euler() -> None:
     assert t.angular.to_tuple() == (0.0, 0.0, 0.0)
 
 
-# --------------------------------------------------------------------------
 # PoseWithCovariance
-# --------------------------------------------------------------------------
 
 
 def test_pwc_empty() -> None:
@@ -394,9 +386,7 @@ def test_pwc_covariance_matrix_view() -> None:
     assert p.covariance_matrix.shape == (6, 6)
 
 
-# --------------------------------------------------------------------------
 # TwistWithCovariance
-# --------------------------------------------------------------------------
 
 
 def test_twc_empty() -> None:
@@ -446,9 +436,7 @@ def test_twc_from_dict_with_covariance() -> None:
     assert np.array_equal(t.covariance, np.arange(36.0))
 
 
-# --------------------------------------------------------------------------
 # JointState
-# --------------------------------------------------------------------------
 
 
 def test_jointstate_empty_has_empty_lists() -> None:
@@ -491,9 +479,7 @@ def test_jointstate_from_lcm() -> None:
     assert j.name == []
 
 
-# --------------------------------------------------------------------------
 # Joy
-# --------------------------------------------------------------------------
 
 
 def test_joy_empty() -> None:
@@ -539,9 +525,7 @@ def test_joy_from_lcm() -> None:
     assert j.axes == []
 
 
-# --------------------------------------------------------------------------
 # Stamped wrappers: ts / frame_id plumbing
-# --------------------------------------------------------------------------
 
 
 def test_posestamped_defaults_stamp_to_now() -> None:
@@ -634,13 +618,11 @@ def test_twcs_empty_defaults() -> None:
     assert t.twist.linear.to_tuple() == (0.0, 0.0, 0.0)
 
 
-# --------------------------------------------------------------------------
 # The ``ts`` sentinel
 #
 # ``ts`` defaults to None and means "stamp me now". 0.0 is an ordinary
 # timestamp and is stored as given — it used to be swallowed by a
 # ``ts if ts != 0`` sentinel that made it unrepresentable.
-# --------------------------------------------------------------------------
 
 STAMPED_TYPES = [
     PoseStamped,
@@ -679,14 +661,12 @@ def test_lcm_decode_of_an_unstamped_message_keeps_the_zero_stamp() -> None:
     assert decoded.ts == 0.0
 
 
-# --------------------------------------------------------------------------
 # Forms that used to build a silently-broken object
 #
 # Under plum these calls matched no overload and fell through to the LCM base
 # __init__, which stores its arguments verbatim — leaving fields holding raw
 # scalars/lists instead of Vector3/Quaternion/Pose, to blow up later in
 # __repr__ or on encode. They now either do the obvious thing or raise.
-# --------------------------------------------------------------------------
 
 
 def test_pose_from_scalar_is_an_x_only_position() -> None:

--- a/dimos/msgs/test_msg_construction.py
+++ b/dimos/msgs/test_msg_construction.py
@@ -1,0 +1,754 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Construction semantics for the hot message types.
+
+Every accepted construction form for the types whose ``__init__`` used to be a
+``plum`` multiple-dispatch stack, plus the error cases. These pin the contract
+so the dispatch removal is provably behaviour-preserving.
+
+Tests marked LATENT BUG record forms that silently built a broken object under
+plum, because a call that matched no overload fell through to the LCM base
+``__init__``, which stores whatever it is handed.
+"""
+
+import time
+
+from dimos_lcm.geometry_msgs import (
+    Pose as LCMPose,
+    PoseWithCovariance as LCMPoseWithCovariance,
+    Quaternion as LCMQuaternion,
+    Twist as LCMTwist,
+    TwistWithCovariance as LCMTwistWithCovariance,
+)
+from dimos_lcm.sensor_msgs import JointState as LCMJointState, Joy as LCMJoy
+import numpy as np
+import pytest
+
+from dimos.msgs.geometry_msgs.Pose import Pose
+from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
+from dimos.msgs.geometry_msgs.PoseWithCovariance import PoseWithCovariance
+from dimos.msgs.geometry_msgs.PoseWithCovarianceStamped import PoseWithCovarianceStamped
+from dimos.msgs.geometry_msgs.Quaternion import Quaternion
+from dimos.msgs.geometry_msgs.Twist import Twist
+from dimos.msgs.geometry_msgs.TwistStamped import TwistStamped
+from dimos.msgs.geometry_msgs.TwistWithCovariance import TwistWithCovariance
+from dimos.msgs.geometry_msgs.TwistWithCovarianceStamped import TwistWithCovarianceStamped
+from dimos.msgs.geometry_msgs.Vector3 import Vector3
+from dimos.msgs.nav_msgs.GraphNodes3D import GraphNodes3D
+from dimos.msgs.nav_msgs.Path import Path
+from dimos.msgs.sensor_msgs.JointState import JointState
+from dimos.msgs.sensor_msgs.Joy import Joy
+
+IDENTITY = (0.0, 0.0, 0.0, 1.0)
+
+
+# --------------------------------------------------------------------------
+# Quaternion
+# --------------------------------------------------------------------------
+
+
+def test_quaternion_empty_is_identity() -> None:
+    assert Quaternion().to_tuple() == IDENTITY
+
+
+def test_quaternion_four_positional_floats() -> None:
+    q = Quaternion(1.0, 2.0, 3.0, 4.0)
+    assert q.to_tuple() == (1.0, 2.0, 3.0, 4.0)
+
+
+def test_quaternion_four_positional_ints_are_coerced_to_float() -> None:
+    q = Quaternion(1, 2, 3, 4)
+    assert q.to_tuple() == (1.0, 2.0, 3.0, 4.0)
+    assert all(type(c) is float for c in q.to_tuple())
+
+
+def test_quaternion_from_list() -> None:
+    assert Quaternion([1.0, 2.0, 3.0, 4.0]).to_tuple() == (1.0, 2.0, 3.0, 4.0)
+
+
+def test_quaternion_from_tuple() -> None:
+    assert Quaternion((1.0, 2.0, 3.0, 4.0)).to_tuple() == (1.0, 2.0, 3.0, 4.0)
+
+
+def test_quaternion_from_range() -> None:
+    assert Quaternion(range(4)).to_tuple() == (0.0, 1.0, 2.0, 3.0)
+
+
+def test_quaternion_from_ndarray() -> None:
+    assert Quaternion(np.array([1.0, 2.0, 3.0, 4.0])).to_tuple() == (1.0, 2.0, 3.0, 4.0)
+
+
+def test_quaternion_copy_constructor() -> None:
+    src = Quaternion(0.1, 0.2, 0.3, 0.4)
+    assert Quaternion(src).to_tuple() == src.to_tuple()
+
+
+def test_quaternion_from_lcm_keeps_lcm_defaults() -> None:
+    """The LCM base defaults w to 0.0, unlike the dimos identity default."""
+    assert Quaternion(LCMQuaternion()).to_tuple() == (0.0, 0.0, 0.0, 0.0)
+
+
+def test_quaternion_from_lcm_with_values() -> None:
+    assert Quaternion(LCMQuaternion(1.0, 2.0, 3.0, 4.0)).to_tuple() == (1.0, 2.0, 3.0, 4.0)
+
+
+def test_quaternion_sequence_wrong_length_raises() -> None:
+    for bad in ([1, 2, 3], [1, 2, 3, 4, 5], (1, 2)):
+        with pytest.raises(ValueError, match=r"exactly 4 components"):
+            Quaternion(bad)
+
+
+def test_quaternion_ndarray_wrong_size_raises() -> None:
+    with pytest.raises(ValueError, match=r"exactly 4 components"):
+        Quaternion(np.array([1.0, 2.0, 3.0]))
+
+
+def test_quaternion_lcm_roundtrip_uses_the_sequence_form() -> None:
+    """``_lcm_decode_one`` builds from a 4-tuple, so decoding exercises that path."""
+    decoded = Quaternion.lcm_decode(Quaternion(1.0, 2.0, 3.0, 4.0).lcm_encode())
+    assert decoded.to_tuple() == (1.0, 2.0, 3.0, 4.0)
+
+
+# --------------------------------------------------------------------------
+# Pose
+# --------------------------------------------------------------------------
+
+
+def test_pose_empty_is_origin_with_identity() -> None:
+    p = Pose()
+    assert p.position.to_tuple() == (0.0, 0.0, 0.0)
+    assert p.orientation.to_tuple() == IDENTITY
+
+
+def test_pose_three_positional_floats() -> None:
+    p = Pose(1, 2, 3)
+    assert p.position.to_tuple() == (1.0, 2.0, 3.0)
+    assert p.orientation.to_tuple() == IDENTITY
+
+
+def test_pose_seven_positional_floats() -> None:
+    p = Pose(1, 2, 3, 0, 0, 0, 1)
+    assert p.position.to_tuple() == (1.0, 2.0, 3.0)
+    assert p.orientation.to_tuple() == IDENTITY
+
+
+def test_pose_from_position_sequence_only() -> None:
+    p = Pose([1, 2, 3])
+    assert p.position.to_tuple() == (1.0, 2.0, 3.0)
+    assert p.orientation.to_tuple() == IDENTITY
+
+
+def test_pose_from_position_and_orientation_sequences() -> None:
+    p = Pose([1, 2, 3], [0, 0, 0, 1])
+    assert p.position.to_tuple() == (1.0, 2.0, 3.0)
+    assert p.orientation.to_tuple() == IDENTITY
+
+
+def test_pose_from_vector3_and_quaternion() -> None:
+    p = Pose(Vector3(1, 2, 3), Quaternion(0, 0, 0, 1))
+    assert p.position.to_tuple() == (1.0, 2.0, 3.0)
+    assert p.orientation.to_tuple() == IDENTITY
+
+
+def test_pose_from_ndarrays() -> None:
+    p = Pose(np.array([1.0, 2.0, 3.0]), np.array([0.0, 0.0, 0.0, 1.0]))
+    assert p.position.to_tuple() == (1.0, 2.0, 3.0)
+    assert p.orientation.to_tuple() == IDENTITY
+
+
+def test_pose_keyword_position_only() -> None:
+    p = Pose(position=[1, 2, 3])
+    assert p.position.to_tuple() == (1.0, 2.0, 3.0)
+    assert p.orientation.to_tuple() == IDENTITY
+
+
+def test_pose_keyword_orientation_only() -> None:
+    p = Pose(orientation=[0, 0, 0, 1])
+    assert p.position.to_tuple() == (0.0, 0.0, 0.0)
+    assert p.orientation.to_tuple() == IDENTITY
+
+
+def test_pose_keyword_both() -> None:
+    p = Pose(position=[1, 2, 3], orientation=[0, 0, 0, 1])
+    assert p.position.to_tuple() == (1.0, 2.0, 3.0)
+
+
+def test_pose_positional_position_with_keyword_orientation() -> None:
+    p = Pose([1, 2, 3], orientation=[0, 0, 0, 1])
+    assert p.position.to_tuple() == (1.0, 2.0, 3.0)
+    assert p.orientation.to_tuple() == IDENTITY
+
+
+def test_pose_explicit_none_falls_back_to_defaults() -> None:
+    p = Pose(None, None)
+    assert p.position.to_tuple() == (0.0, 0.0, 0.0)
+    assert p.orientation.to_tuple() == IDENTITY
+
+
+def test_pose_from_pair_tuple() -> None:
+    p = Pose(([1, 2, 3], [0, 0, 0, 1]))
+    assert p.position.to_tuple() == (1.0, 2.0, 3.0)
+    assert p.orientation.to_tuple() == IDENTITY
+
+
+def test_pose_from_three_tuple_is_a_position() -> None:
+    """A 3-tuple of numbers is a position, not a (position, orientation) pair."""
+    p = Pose((1, 2, 3))
+    assert p.position.to_tuple() == (1.0, 2.0, 3.0)
+
+
+def test_pose_from_dict() -> None:
+    p = Pose({"position": [1, 2, 3], "orientation": [0, 0, 0, 1]})
+    assert p.position.to_tuple() == (1.0, 2.0, 3.0)
+    assert p.orientation.to_tuple() == IDENTITY
+
+
+def test_pose_from_dict_missing_key_raises_keyerror() -> None:
+    with pytest.raises(KeyError):
+        Pose({"position": [1, 2, 3]})
+    with pytest.raises(KeyError):
+        Pose({})
+
+
+def test_pose_copy_constructor() -> None:
+    src = Pose(1, 2, 3, 0, 0, 0, 1)
+    copy = Pose(src)
+    assert copy.position.to_tuple() == (1.0, 2.0, 3.0)
+    assert copy.position is not src.position
+
+
+def test_pose_from_posestamped_downcasts_to_pose() -> None:
+    src = PoseStamped(ts=5.0, frame_id="odom", position=[1, 2, 3])
+    p = Pose(src)
+    assert type(p) is Pose
+    assert p.position.to_tuple() == (1.0, 2.0, 3.0)
+
+
+def test_pose_from_lcm_keeps_lcm_orientation_defaults() -> None:
+    p = Pose(LCMPose())
+    assert p.position.to_tuple() == (0.0, 0.0, 0.0)
+    assert p.orientation.to_tuple() == (0.0, 0.0, 0.0, 0.0)
+
+
+def test_pose_position_and_orientation_are_wrapper_types() -> None:
+    p = Pose(1, 2, 3)
+    assert isinstance(p.position, Vector3)
+    assert isinstance(p.orientation, Quaternion)
+
+
+# --------------------------------------------------------------------------
+# Twist
+# --------------------------------------------------------------------------
+
+
+def test_twist_empty_is_zero() -> None:
+    t = Twist()
+    assert t.linear.to_tuple() == (0.0, 0.0, 0.0)
+    assert t.angular.to_tuple() == (0.0, 0.0, 0.0)
+
+
+def test_twist_from_two_sequences() -> None:
+    t = Twist([1, 2, 3], [4, 5, 6])
+    assert t.linear.to_tuple() == (1.0, 2.0, 3.0)
+    assert t.angular.to_tuple() == (4.0, 5.0, 6.0)
+
+
+def test_twist_from_two_vector3() -> None:
+    t = Twist(Vector3(1, 2, 3), Vector3(4, 5, 6))
+    assert t.linear.to_tuple() == (1.0, 2.0, 3.0)
+    assert t.angular.to_tuple() == (4.0, 5.0, 6.0)
+
+
+def test_twist_from_ndarrays() -> None:
+    t = Twist(np.array([1.0, 2.0, 3.0]), np.array([4.0, 5.0, 6.0]))
+    assert t.linear.to_tuple() == (1.0, 2.0, 3.0)
+    assert t.angular.to_tuple() == (4.0, 5.0, 6.0)
+
+
+def test_twist_angular_quaternion_is_converted_to_euler() -> None:
+    t = Twist([1, 2, 3], Quaternion(0, 0, 0, 1))
+    assert t.linear.to_tuple() == (1.0, 2.0, 3.0)
+    assert t.angular.to_tuple() == (0.0, 0.0, 0.0)
+
+
+def test_twist_copy_constructor() -> None:
+    src = Twist([1, 2, 3], [4, 5, 6])
+    copy = Twist(src)
+    assert copy.linear.to_tuple() == (1.0, 2.0, 3.0)
+    assert copy.linear is not src.linear
+
+
+def test_twist_from_lcm() -> None:
+    t = Twist(LCMTwist())
+    assert t.linear.to_tuple() == (0.0, 0.0, 0.0)
+
+
+def test_twist_from_twiststamped_downcasts() -> None:
+    t = Twist(TwistStamped(linear=[1, 2, 3], angular=[4, 5, 6]))
+    assert type(t) is Twist
+    assert t.linear.to_tuple() == (1.0, 2.0, 3.0)
+
+
+def test_twist_keyword_both() -> None:
+    t = Twist(linear=[1, 2, 3], angular=[4, 5, 6])
+    assert t.linear.to_tuple() == (1.0, 2.0, 3.0)
+    assert t.angular.to_tuple() == (4.0, 5.0, 6.0)
+
+
+def test_twist_keyword_linear_only() -> None:
+    t = Twist(linear=[1, 2, 3])
+    assert t.linear.to_tuple() == (1.0, 2.0, 3.0)
+    assert t.angular.to_tuple() == (0.0, 0.0, 0.0)
+
+
+def test_twist_keyword_angular_only() -> None:
+    t = Twist(angular=[4, 5, 6])
+    assert t.linear.to_tuple() == (0.0, 0.0, 0.0)
+    assert t.angular.to_tuple() == (4.0, 5.0, 6.0)
+
+
+def test_twist_keyword_angular_quaternion_is_converted_to_euler() -> None:
+    t = Twist(linear=[1, 2, 3], angular=Quaternion(0, 0, 0, 1))
+    assert t.angular.to_tuple() == (0.0, 0.0, 0.0)
+
+
+# --------------------------------------------------------------------------
+# PoseWithCovariance
+# --------------------------------------------------------------------------
+
+
+def test_pwc_empty() -> None:
+    p = PoseWithCovariance()
+    assert p.pose.position.to_tuple() == (0.0, 0.0, 0.0)
+    assert np.array_equal(p.covariance, np.zeros(36))
+
+
+def test_pwc_from_pose_only() -> None:
+    p = PoseWithCovariance(Pose(1, 2, 3))
+    assert p.pose.position.to_tuple() == (1.0, 2.0, 3.0)
+    assert np.array_equal(p.covariance, np.zeros(36))
+
+
+def test_pwc_from_pose_and_covariance() -> None:
+    p = PoseWithCovariance(Pose(1, 2, 3), np.arange(36.0))
+    assert np.array_equal(p.covariance, np.arange(36.0))
+
+
+def test_pwc_explicit_none_covariance_is_zeros() -> None:
+    assert np.array_equal(PoseWithCovariance(Pose(1, 2, 3), None).covariance, np.zeros(36))
+
+
+def test_pwc_covariance_wrong_size_raises() -> None:
+    with pytest.raises(ValueError, match=r"reshape"):
+        PoseWithCovariance(Pose(1, 2, 3), [1, 2, 3])
+
+
+def test_pwc_copy_constructor_copies_covariance() -> None:
+    src = PoseWithCovariance(Pose(1, 2, 3), np.arange(36.0))
+    copy = PoseWithCovariance(src)
+    assert np.array_equal(copy.covariance, src.covariance)
+    assert copy.covariance is not src.covariance
+
+
+def test_pwc_from_lcm() -> None:
+    p = PoseWithCovariance(LCMPoseWithCovariance())
+    assert p.pose.position.to_tuple() == (0.0, 0.0, 0.0)
+    assert np.array_equal(p.covariance, np.zeros(36))
+
+
+def test_pwc_from_dict_with_pose_object() -> None:
+    p = PoseWithCovariance({"pose": Pose(1, 2, 3)})
+    assert p.pose.position.to_tuple() == (1.0, 2.0, 3.0)
+    assert np.array_equal(p.covariance, np.zeros(36))
+
+
+def test_pwc_from_dict_with_covariance() -> None:
+    p = PoseWithCovariance({"pose": Pose(1, 2, 3), "covariance": list(range(36))})
+    assert np.array_equal(p.covariance, np.arange(36.0))
+
+
+def test_pwc_covariance_matrix_view() -> None:
+    p = PoseWithCovariance(Pose(), np.arange(36.0))
+    assert p.covariance_matrix.shape == (6, 6)
+
+
+# --------------------------------------------------------------------------
+# TwistWithCovariance
+# --------------------------------------------------------------------------
+
+
+def test_twc_empty() -> None:
+    t = TwistWithCovariance()
+    assert t.twist.linear.to_tuple() == (0.0, 0.0, 0.0)
+    assert np.array_equal(t.covariance, np.zeros(36))
+
+
+def test_twc_from_twist_only() -> None:
+    t = TwistWithCovariance(Twist([1, 2, 3], [4, 5, 6]))
+    assert t.twist.linear.to_tuple() == (1.0, 2.0, 3.0)
+
+
+def test_twc_from_twist_and_covariance() -> None:
+    t = TwistWithCovariance(Twist([1, 2, 3], [4, 5, 6]), np.arange(36.0))
+    assert np.array_equal(t.covariance, np.arange(36.0))
+
+
+def test_twc_from_linear_angular_pair() -> None:
+    t = TwistWithCovariance(([1, 2, 3], [4, 5, 6]))
+    assert t.twist.linear.to_tuple() == (1.0, 2.0, 3.0)
+    assert t.twist.angular.to_tuple() == (4.0, 5.0, 6.0)
+
+
+def test_twc_copy_constructor() -> None:
+    src = TwistWithCovariance(Twist([1, 2, 3], [4, 5, 6]), np.arange(36.0))
+    copy = TwistWithCovariance(src)
+    assert np.array_equal(copy.covariance, src.covariance)
+    assert copy.covariance is not src.covariance
+
+
+def test_twc_from_lcm() -> None:
+    t = TwistWithCovariance(LCMTwistWithCovariance())
+    assert t.twist.linear.to_tuple() == (0.0, 0.0, 0.0)
+
+
+def test_twc_from_dict() -> None:
+    t = TwistWithCovariance({"twist": Twist([1, 2, 3], [4, 5, 6])})
+    assert t.twist.linear.to_tuple() == (1.0, 2.0, 3.0)
+    assert np.array_equal(t.covariance, np.zeros(36))
+
+
+def test_twc_from_dict_with_covariance() -> None:
+    t = TwistWithCovariance({"twist": Twist([1, 2, 3], [4, 5, 6]), "covariance": list(range(36))})
+    assert np.array_equal(t.covariance, np.arange(36.0))
+
+
+# --------------------------------------------------------------------------
+# JointState
+# --------------------------------------------------------------------------
+
+
+def test_jointstate_empty_has_empty_lists() -> None:
+    j = JointState()
+    assert (j.name, j.position, j.velocity, j.effort) == ([], [], [], [])
+    assert j.frame_id == ""
+
+
+def test_jointstate_keywords() -> None:
+    j = JointState(ts=5.0, frame_id="f", name=["a"], position=[1.0])
+    assert (j.ts, j.frame_id, j.name, j.position) == (5.0, "f", ["a"], [1.0])
+    assert (j.velocity, j.effort) == ([], [])
+
+
+def test_jointstate_all_positional() -> None:
+    j = JointState(5.0, "f", ["a"], [1.0], [2.0], [3.0])
+    assert (j.name, j.position, j.velocity, j.effort) == (["a"], [1.0], [2.0], [3.0])
+
+
+def test_jointstate_from_dict() -> None:
+    j = JointState({"name": ["a"], "position": [1.0]})
+    assert (j.name, j.position) == (["a"], [1.0])
+
+
+def test_jointstate_from_empty_dict() -> None:
+    j = JointState({})
+    assert (j.name, j.position, j.velocity, j.effort) == ([], [], [], [])
+
+
+def test_jointstate_copy_constructor_copies_lists() -> None:
+    src = JointState(ts=5.0, frame_id="f", name=["a"], position=[1.0])
+    copy = JointState(src)
+    assert copy.ts == 5.0
+    assert copy.name == ["a"]
+    assert copy.name is not src.name
+
+
+def test_jointstate_from_lcm() -> None:
+    j = JointState(LCMJointState())
+    assert j.name == []
+
+
+# --------------------------------------------------------------------------
+# Joy
+# --------------------------------------------------------------------------
+
+
+def test_joy_empty() -> None:
+    j = Joy()
+    assert (j.axes, j.buttons, j.frame_id) == ([], [], "")
+
+
+def test_joy_keywords() -> None:
+    j = Joy(ts=5.0, frame_id="f", axes=[1.0], buttons=[1])
+    assert (j.ts, j.frame_id, j.axes, j.buttons) == (5.0, "f", [1.0], [1])
+
+
+def test_joy_all_positional() -> None:
+    j = Joy(5.0, "f", [1.0], [1])
+    assert (j.axes, j.buttons) == ([1.0], [1])
+
+
+def test_joy_from_axes_buttons_pair() -> None:
+    j = Joy(([1.0, 2.0], [1, 0]))
+    assert (j.axes, j.buttons) == ([1.0, 2.0], [1, 0])
+
+
+def test_joy_from_dict() -> None:
+    j = Joy({"axes": [1.0], "buttons": [1]})
+    assert (j.axes, j.buttons) == ([1.0], [1])
+
+
+def test_joy_from_empty_dict() -> None:
+    j = Joy({})
+    assert (j.axes, j.buttons) == ([], [])
+
+
+def test_joy_copy_constructor_copies_lists() -> None:
+    src = Joy(ts=5.0, axes=[1.0], buttons=[1])
+    copy = Joy(src)
+    assert copy.ts == 5.0
+    assert copy.axes == [1.0]
+    assert copy.axes is not src.axes
+
+
+def test_joy_from_lcm() -> None:
+    j = Joy(LCMJoy())
+    assert j.axes == []
+
+
+# --------------------------------------------------------------------------
+# Stamped wrappers: ts / frame_id plumbing
+# --------------------------------------------------------------------------
+
+
+def test_posestamped_defaults_stamp_to_now() -> None:
+    before = time.time()
+    ps = PoseStamped()
+    assert before <= ps.ts <= time.time()
+    assert ps.frame_id == ""
+    assert ps.position.to_tuple() == (0.0, 0.0, 0.0)
+
+
+def test_posestamped_keeps_explicit_ts_and_frame() -> None:
+    ps = PoseStamped(ts=5.0, frame_id="odom", position=[1, 2, 3], orientation=[0, 0, 0, 1])
+    assert (ps.ts, ps.frame_id) == (5.0, "odom")
+    assert ps.position.to_tuple() == (1.0, 2.0, 3.0)
+
+
+def test_posestamped_positional_ts_and_frame() -> None:
+    ps = PoseStamped(5.0, "odom")
+    assert (ps.ts, ps.frame_id) == (5.0, "odom")
+
+
+def test_posestamped_is_a_pose() -> None:
+    assert isinstance(PoseStamped(), Pose)
+
+
+def test_twiststamped_keeps_explicit_ts_and_frame() -> None:
+    ts = TwistStamped(ts=5.0, frame_id="base", linear=[1, 2, 3], angular=[4, 5, 6])
+    assert (ts.ts, ts.frame_id) == (5.0, "base")
+    assert ts.linear.to_tuple() == (1.0, 2.0, 3.0)
+
+
+def test_twiststamped_defaults_stamp_to_now() -> None:
+    before = time.time()
+    t = TwistStamped()
+    assert before <= t.ts <= time.time()
+
+
+def test_pwcs_keeps_explicit_ts_and_frame() -> None:
+    p = PoseWithCovarianceStamped(ts=5.0, frame_id="map", pose=Pose(1, 2, 3))
+    assert (p.ts, p.frame_id) == (5.0, "map")
+    assert p.pose.position.to_tuple() == (1.0, 2.0, 3.0)
+
+
+def test_pwcs_with_covariance() -> None:
+    p = PoseWithCovarianceStamped(ts=5.0, pose=Pose(1, 2, 3), covariance=list(range(36)))
+    assert np.array_equal(p.covariance, np.arange(36.0))
+
+
+def test_pwcs_empty_defaults() -> None:
+    p = PoseWithCovarianceStamped()
+    assert p.pose.position.to_tuple() == (0.0, 0.0, 0.0)
+    assert np.array_equal(p.covariance, np.zeros(36))
+
+
+def test_twcs_keeps_explicit_ts_and_frame() -> None:
+    t = TwistWithCovarianceStamped(ts=5.0, frame_id="base", twist=Twist([1, 2, 3], [4, 5, 6]))
+    assert (t.ts, t.frame_id) == (5.0, "base")
+    assert t.twist.linear.to_tuple() == (1.0, 2.0, 3.0)
+
+
+def test_twcs_with_covariance() -> None:
+    t = TwistWithCovarianceStamped(
+        ts=5.0, twist=Twist([1, 2, 3], [4, 5, 6]), covariance=list(range(36))
+    )
+    assert np.array_equal(t.covariance, np.arange(36.0))
+
+
+def test_twcs_empty_defaults() -> None:
+    t = TwistWithCovarianceStamped()
+    assert t.twist.linear.to_tuple() == (0.0, 0.0, 0.0)
+
+
+# --------------------------------------------------------------------------
+# The ``ts`` sentinel
+#
+# LATENT BUG: ``self.ts = ts if ts != 0 else time.time()`` makes ts=0.0
+# unrepresentable — asking for it silently yields wall-clock time instead.
+# Pinned here so the follow-up sentinel change shows up as an explicit diff.
+# --------------------------------------------------------------------------
+
+
+def test_posestamped_zero_ts_is_replaced_by_wall_clock() -> None:
+    assert PoseStamped(ts=0.0).ts != 0.0
+
+
+def test_twiststamped_zero_ts_is_replaced_by_wall_clock() -> None:
+    assert TwistStamped(ts=0.0).ts != 0.0
+
+
+def test_pwcs_zero_ts_is_replaced_by_wall_clock() -> None:
+    assert PoseWithCovarianceStamped(ts=0.0).ts != 0.0
+
+
+def test_twcs_zero_ts_is_replaced_by_wall_clock() -> None:
+    assert TwistWithCovarianceStamped(ts=0.0).ts != 0.0
+
+
+def test_jointstate_zero_ts_is_replaced_by_wall_clock() -> None:
+    assert JointState(ts=0.0).ts != 0.0
+
+
+def test_joy_zero_ts_is_replaced_by_wall_clock() -> None:
+    assert Joy(ts=0.0).ts != 0.0
+
+
+def test_path_zero_ts_is_replaced_by_wall_clock() -> None:
+    assert Path(ts=0.0).ts != 0.0
+
+
+def test_graphnodes3d_zero_ts_is_replaced_by_wall_clock() -> None:
+    assert GraphNodes3D(ts=0.0).ts != 0.0
+
+
+def test_nonzero_ts_is_always_honoured() -> None:
+    assert PoseStamped(ts=5.0).ts == 5.0
+    assert TwistStamped(ts=5.0).ts == 5.0
+    assert PoseWithCovarianceStamped(ts=5.0).ts == 5.0
+    assert TwistWithCovarianceStamped(ts=5.0).ts == 5.0
+    assert JointState(ts=5.0).ts == 5.0
+    assert Joy(ts=5.0).ts == 5.0
+    assert Path(ts=5.0).ts == 5.0
+    assert GraphNodes3D(ts=5.0).ts == 5.0
+
+
+# --------------------------------------------------------------------------
+# LATENT BUGS: calls that matched no plum overload fell through to the LCM
+# base __init__, which stores its arguments verbatim. The result is an object
+# whose fields hold raw lists/scalars instead of Vector3/Quaternion/Pose, and
+# which only blows up later (often in __repr__ or on encode).
+# --------------------------------------------------------------------------
+
+
+def test_pose_from_scalar_silently_stores_raw_value() -> None:
+    assert Pose(5).position == 5
+
+
+def test_pose_from_string_silently_stores_raw_value() -> None:
+    assert Pose("x").position == "x"
+
+
+def test_pose_from_two_positionals_silently_stores_raw_values() -> None:
+    p = Pose(1, 2)
+    assert (p.position, p.orientation) == (1, 2)
+
+
+def test_pose_from_three_tuple_of_sequences_silently_stores_the_tuple() -> None:
+    assert Pose(([1, 2, 3], [0, 0, 0, 1], [9])).position == ([1, 2, 3], [0, 0, 0, 1], [9])
+
+
+def test_quaternion_from_partial_positionals_silently_zero_fills_w() -> None:
+    """Three components yield w=0.0 — a zero-rotation-free, invalid quaternion."""
+    assert Quaternion(1, 2, 3).to_tuple() == (1.0, 2.0, 3.0, 0.0)
+    assert Quaternion(1, 2).to_tuple() == (1.0, 2.0, 0.0, 0.0)
+    assert Quaternion(5).to_tuple() == (5.0, 0.0, 0.0, 0.0)
+
+
+def test_quaternion_rejects_field_keywords() -> None:
+    """plum dispatches on positionals only, so an all-keyword call finds no overload."""
+    with pytest.raises(TypeError):
+        Quaternion(x=1, y=2, z=3, w=4)
+
+
+def test_twist_from_single_sequence_silently_stores_raw_value() -> None:
+    assert Twist([1, 2, 3]).linear == [1, 2, 3]
+
+
+def test_twist_from_scalars_silently_stores_raw_values() -> None:
+    t = Twist("x", "y")
+    assert (t.linear, t.angular) == ("x", "y")
+
+
+def test_twist_mixed_positional_and_keyword_skips_vector3_conversion() -> None:
+    t = Twist([1, 2, 3], angular=[4, 5, 6])
+    assert t.linear == [1, 2, 3]
+    assert not isinstance(t.linear, Vector3)
+
+
+def test_twist_ignores_unknown_keywords() -> None:
+    t = Twist(bogus=1)
+    assert t.linear.to_tuple() == (0.0, 0.0, 0.0)
+
+
+def test_pwc_pair_tuple_silently_stores_the_tuple_as_the_pose() -> None:
+    """The documented (pose, covariance) tuple form never reached its overload."""
+    p = PoseWithCovariance((Pose(1, 2, 3), list(range(36))))
+    assert isinstance(p.pose, tuple)
+    assert np.array_equal(p.covariance, np.zeros(36))
+
+
+def test_pwc_rejects_field_keywords() -> None:
+    with pytest.raises(TypeError):
+        PoseWithCovariance(pose=Pose(1, 2, 3))
+
+
+def test_twc_rejects_field_keywords() -> None:
+    with pytest.raises(TypeError):
+        TwistWithCovariance(twist=Twist([1, 2, 3], [4, 5, 6]))
+
+
+def test_pwc_dict_with_convertable_pose_value_misroutes_to_the_pose_overload() -> None:
+    """A dict whose 'pose' is a plain sequence matches PoseConvertable, so the
+    whole dict is handed to Pose() and dies looking for a 'position' key."""
+    with pytest.raises(KeyError):
+        PoseWithCovariance({"pose": [1, 2, 3], "covariance": list(range(36))})
+
+
+def test_jointstate_dict_without_list_values_builds_nothing() -> None:
+    """{'ts': ..., 'frame_id': ...} matches no overload; fields are never set."""
+    j = JointState({"ts": 5.0, "frame_id": "f"})
+    with pytest.raises(AttributeError):
+        getattr(j, "frame_id")  # noqa: B009
+
+
+def test_joy_dict_without_list_values_builds_nothing() -> None:
+    j = Joy({"ts": 5.0, "frame_id": "f"})
+    with pytest.raises(AttributeError):
+        getattr(j, "frame_id")  # noqa: B009
+
+
+def test_posestamped_from_string_silently_stores_raw_value() -> None:
+    """A str first positional misses ts: float, so it lands in the LCM ctor."""
+    assert PoseStamped("f").position == "f"


### PR DESCRIPTION
`dimos/msgs` decorated `__init__` with `@dispatch` from `plum`, so every message
construction paid runtime multiple-dispatch resolution. `Vector3` is the existence
proof it was never needed: same LCM base class, same repo, hand-written `__init__`,
~50x faster than its neighbours.

Three commits, deliberately separable: **tests → conversion → semantics.**

## Numbers

`time.process_time()`, 3000 iterations, this machine. The LCM base class is the floor.

| construction | before | after | speedup | floor |
|---|---:|---:|---:|---:|
| `Quaternion(0,0,0,1)` | 14.27 µs | **0.49 µs** | 29x | 0.22 µs |
| `Quaternion([0,0,0,1])` | 15.15 µs | **1.25 µs** | 12x | |
| `Pose()` | 48.93 µs | **1.01 µs** | 48x | 0.18 µs |
| `Pose(1,2,3)` | 29.62 µs | **2.37 µs** | 12x | |
| `Pose([1,2,3],[0,0,0,1])` | 32.49 µs | **3.39 µs** | 10x | |
| `PoseStamped(position=[1,2,3])` | 56.99 µs | **3.54 µs** | 16x | |
| `Twist()` | 28.55 µs | **0.70 µs** | 41x | 0.17 µs |
| `Twist([1,2,3],[4,5,6])` | 20.50 µs | **4.25 µs** | 4.8x | |
| `TwistStamped(linear=,angular=)` | 45.50 µs | **4.56 µs** | 10x | |
| `PoseWithCovariance(Pose(1,2,3))` | 55.95 µs | **3.67 µs** | 15x | |
| `PoseWithCovarianceStamped(ts=5.0)` | 97.31 µs | **4.34 µs** | 22x | |
| `TwistWithCovarianceStamped(ts=5.0)` | 72.41 µs | **2.89 µs** | 25x | |
| `JointState(name=,position=)` | 11.35 µs | **0.85 µs** | 13x | 0.24 µs |
| `Joy(axes=,buttons=)` | 10.76 µs | **1.03 µs** | 10x | 0.21 µs |

Path example:

| | before | after |
|---|---:|---:|
| `nav_msgs/Path`, 207 poses | 11.72 ms | **0.76 ms** |
| follower `Twist` per 20 ms control tick | 20.8 µs | **4.5 µs** |

Path building was ~13% of a core at 5 Hz replanning; it is now under 1%.

## What changed

Each dispatch stack became one `__init__` with explicit `isinstance` branching,
most-specific type first (copy-constructor before the generic sequence branch,
since a `Quaternion` is itself indexable). `typing.overload` stubs sit above the
runtime implementation, so inferred types and mypy are unchanged at zero runtime cost.

Non-`__init__` `@dispatch` functions were left alone (`Pose.to_pose`), as were
`std_msgs/Header` and `WrenchStamped`.

**plum stays in `pyproject.toml`** — `std_msgs/Header` and `Pose.to_pose` still import it.
ncode.

## `ts=0.0` is now a real timestamp

Every stamped message did `self.ts = ts if ts != 0 else time.time()`, making `0.0`
unrepresentable — ask for it, silently get wall-clock. Now:

```python
def __init__(self, ts: float | None = None, ...):
    self.ts = time.time() if ts is None else ts
```

Applied to all 13 types in `dimos/msgs` carrying the pattern: `PoseStamped`,
`TwistStamped`, `PointStamped`, `PoseWithCovarianceStamped`, `TwistWithCovarianceStamped`,
`Transform`, `Path`, `Odometry`, `OccupancyGrid`, `GraphNodes3D`, `LineSegments3D`,
`JointState`, `Joy`.

**Caller sweep.** Every explicit `ts=` site in `dimos/` passes a relayed wall-clock
value — `obs.ts`, `path.ts`, `time.time()`, an odometry stamp — and none used `ts=0`
to mean "stamp me now". The ~440 sites that omit `ts` still auto-stamp. Three existing
tests asserted the old sentinel and now assert the new contract.

Not fixed: `geometry_msgs/WrenchStamped` has the same wart as a dataclass `__post_init__`
testing `== 0.0`. Fixing it means widening the dataclass field to `float | None`, so it is
left for a follow-up.
