### PR TITLE
updated WrenchStamped messages to add lcm encode and decode

### DIFF
--- a/dimos/msgs/geometry_msgs/Wrench.py
+++ b/dimos/msgs/geometry_msgs/Wrench.py
@@ -14,27 +14,108 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from collections.abc import Sequence
+from typing import Any, overload
 
-from dimos.msgs.geometry_msgs.Vector3 import Vector3
+from dimos_lcm.geometry_msgs import Wrench as LCMWrench
+import numpy as np
+
+from dimos.msgs.geometry_msgs.Vector3 import Vector3, VectorLike
 
 
-@dataclass
-class Wrench:
-    """
-    Represents a force and torque in 3D space.
+class Wrench(LCMWrench):  # type: ignore[misc]
+    """Force (N) and torque (Nm) in 3D space."""
 
-    This is equivalent to ROS geometry_msgs/Wrench.
-    """
+    force: Vector3
+    torque: Vector3
+    msg_name = "geometry_msgs.Wrench"
 
-    force: Vector3 = None  # type: ignore[assignment]  # Force vector (N)
-    torque: Vector3 = None  # type: ignore[assignment]  # Torque vector (Nm)
+    @overload
+    def __init__(self) -> None: ...
 
-    def __post_init__(self) -> None:
-        if self.force is None:
-            self.force = Vector3(0.0, 0.0, 0.0)
-        if self.torque is None:
-            self.torque = Vector3(0.0, 0.0, 0.0)
+    @overload
+    def __init__(
+        self,
+        force: VectorLike | None = ...,
+        torque: VectorLike | None = ...,
+    ) -> None: ...
+
+    @overload
+    def __init__(self, wrench: Wrench | LCMWrench, /) -> None: ...
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize a wrench.
+
+        Supported forms:
+            Wrench()                                # zero wrench
+            Wrench(force, torque)
+            Wrench(force=..., torque=...)           # keyword args, either optional
+            Wrench(other_wrench)                    # copy constructor
+            Wrench(lcm_wrench)                      # from LCM message
+        """
+        force: Any = None
+        torque: Any = None
+
+        if len(args) == 2:
+            force, torque = args
+        elif len(args) == 1:
+            value = args[0]
+            # Wrench before LCMWrench (it is a subclass); anything else is a
+            # force, same as the `force=` keyword.
+            if isinstance(value, Wrench | LCMWrench):
+                force, torque = value.force, value.torque
+            else:
+                force = value
+        elif args:
+            raise TypeError(f"Wrench takes 1 or 2 positional arguments ({len(args)} given)")
+
+        if kwargs:
+            force = kwargs.pop("force", force)
+            torque = kwargs.pop("torque", torque)
+            if kwargs:
+                raise TypeError(f"Wrench got unexpected keyword arguments {sorted(kwargs)}")
+
+        self.force = Vector3() if force is None else Vector3(force)
+        self.torque = Vector3() if torque is None else Vector3(torque)
+
+    @classmethod
+    def from_array(cls, ft: Sequence[float] | np.ndarray) -> Wrench:
+        """Build from a 6-element ``[fx, fy, fz, tx, ty, tz]`` sensor reading."""
+        if len(ft) != 6:
+            raise ValueError(f"Expected 6 elements [fx, fy, fz, tx, ty, tz], got {len(ft)}")
+        return cls(force=ft[:3], torque=ft[3:])
+
+    def to_array(self) -> np.ndarray:
+        """``[fx, fy, fz, tx, ty, tz]``."""
+        return np.concatenate([self.force.to_numpy(), self.torque.to_numpy()])
+
+    @classmethod
+    def zero(cls) -> Wrench:
+        return cls()
+
+    def is_zero(self) -> bool:
+        return self.force.is_zero() and self.torque.is_zero()
+
+    def __add__(self, other: Wrench) -> Wrench:
+        if not isinstance(other, Wrench):
+            return NotImplemented
+        return Wrench(force=self.force + other.force, torque=self.torque + other.torque)
+
+    def __sub__(self, other: Wrench) -> Wrench:
+        if not isinstance(other, Wrench):
+            return NotImplemented
+        return Wrench(force=self.force - other.force, torque=self.torque - other.torque)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Wrench):
+            return False
+        return self.force == other.force and self.torque == other.torque
+
+    def __bool__(self) -> bool:
+        return not self.is_zero()
 
     def __repr__(self) -> str:
-        return f"Wrench(force={self.force}, torque={self.torque})"
+        return f"Wrench(force={self.force!r}, torque={self.torque!r})"
+
+    def __str__(self) -> str:
+        return f"Wrench:\n  Force: {self.force}\n  Torque: {self.torque}"

--- a/dimos/msgs/geometry_msgs/WrenchStamped.py
+++ b/dimos/msgs/geometry_msgs/WrenchStamped.py
@@ -14,62 +14,84 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from collections.abc import Sequence
 import time
+from typing import Any, BinaryIO
 
-from dimos.msgs.geometry_msgs.Vector3 import Vector3
+from dimos_lcm.geometry_msgs import WrenchStamped as LCMWrenchStamped
+import numpy as np
+
 from dimos.msgs.geometry_msgs.Wrench import Wrench
 from dimos.types.timestamped import Timestamped
 
 
-@dataclass
-class WrenchStamped(Timestamped):
-    """
-    Represents a stamped force/torque measurement.
-
-    This is equivalent to ROS geometry_msgs/WrenchStamped.
-    """
+class WrenchStamped(Wrench, Timestamped):
+    """A force/torque measurement with a timestamp and frame_id."""
 
     msg_name = "geometry_msgs.WrenchStamped"
-    ts: float = 0.0
-    frame_id: str = ""
-    wrench: Wrench = None  # type: ignore[assignment]
+    ts: float
+    frame_id: str
 
-    def __post_init__(self) -> None:
-        if self.ts == 0.0:
-            self.ts = time.time()
-        if self.wrench is None:
-            self.wrench = Wrench()
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize a stamped wrench.
+
+        Takes ``(ts, frame_id)`` positionally, plus every Wrench keyword. Any other
+        positional form belongs to Wrench, so ``WrenchStamped(force, torque)`` works
+        as it does on the base class.
+        """
+        ts: Any
+        # A leading number or string is a timestamp; anything else is a Wrench argument.
+        if args and isinstance(args[0], int | float | str):
+            ts = args[0]
+            frame_id = args[1] if len(args) > 1 else kwargs.pop("frame_id", "")
+            wrench_args: tuple[Any, ...] = ()
+        else:
+            ts = kwargs.pop("ts", None)
+            frame_id = kwargs.pop("frame_id", "")
+            wrench_args = args
+
+        self.frame_id = frame_id
+        self.ts = time.time() if ts is None else ts
+        super().__init__(*wrench_args, **kwargs)
 
     @classmethod
-    def from_force_torque_array(  # type: ignore[no-untyped-def]
+    def from_array(  # type: ignore[override]
         cls,
-        ft_data: list,  # type: ignore[type-arg]
+        ft: Sequence[float] | np.ndarray,
         frame_id: str = "ft_sensor",
         ts: float | None = None,
-    ):
-        """
-        Create WrenchStamped from a 6-element force/torque array.
+    ) -> WrenchStamped:
+        """Build from a 6-element ``[fx, fy, fz, tx, ty, tz]`` sensor reading."""
+        if len(ft) != 6:
+            raise ValueError(f"Expected 6 elements [fx, fy, fz, tx, ty, tz], got {len(ft)}")
+        return cls(ts=ts, frame_id=frame_id, force=ft[:3], torque=ft[3:])
 
-        Args:
-            ft_data: [fx, fy, fz, tx, ty, tz]
-            frame_id: Reference frame
-            ts: Timestamp (defaults to current time)
+    def lcm_encode(self) -> bytes:
+        lcm_msg = LCMWrenchStamped()
+        lcm_msg.wrench = self
+        [lcm_msg.header.stamp.sec, lcm_msg.header.stamp.nsec] = self.ros_timestamp()
+        lcm_msg.header.frame_id = self.frame_id
+        return lcm_msg.lcm_encode()  # type: ignore[no-any-return]
 
-        Returns:
-            WrenchStamped instance
-        """
-        if len(ft_data) != 6:
-            raise ValueError(f"Expected 6 elements, got {len(ft_data)}")
-
+    @classmethod
+    def lcm_decode(cls, data: bytes | BinaryIO) -> WrenchStamped:
+        lcm_msg = LCMWrenchStamped.lcm_decode(data)
         return cls(
-            ts=ts if ts is not None else time.time(),
-            frame_id=frame_id,
-            wrench=Wrench(
-                force=Vector3(x=ft_data[0], y=ft_data[1], z=ft_data[2]),
-                torque=Vector3(x=ft_data[3], y=ft_data[4], z=ft_data[5]),
-            ),
+            ts=lcm_msg.header.stamp.sec + (lcm_msg.header.stamp.nsec / 1_000_000_000),
+            frame_id=lcm_msg.header.frame_id,
+            force=[lcm_msg.wrench.force.x, lcm_msg.wrench.force.y, lcm_msg.wrench.force.z],
+            torque=[lcm_msg.wrench.torque.x, lcm_msg.wrench.torque.y, lcm_msg.wrench.torque.z],
         )
 
     def __repr__(self) -> str:
-        return f"WrenchStamped(ts={self.ts}, frame_id='{self.frame_id}', wrench={self.wrench})"
+        return (
+            f"WrenchStamped(force={self.force!r}, torque={self.torque!r}, "
+            f"ts={self.ts}, frame_id={self.frame_id!r})"
+        )
+
+    def __str__(self) -> str:
+        return (
+            f"WrenchStamped(force=[{self.force.x:.3f}, {self.force.y:.3f}, {self.force.z:.3f}], "
+            f"torque=[{self.torque.x:.3f}, {self.torque.y:.3f}, {self.torque.z:.3f}], "
+            f"frame_id={self.frame_id!r})"
+        )

--- a/dimos/msgs/geometry_msgs/test_WrenchStamped.py
+++ b/dimos/msgs/geometry_msgs/test_WrenchStamped.py
@@ -1,0 +1,140 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pickle
+import time
+
+import numpy as np
+import pytest
+
+from dimos.msgs.geometry_msgs.Vector3 import Vector3
+from dimos.msgs.geometry_msgs.Wrench import Wrench
+from dimos.msgs.geometry_msgs.WrenchStamped import WrenchStamped
+
+
+def test_wrench_empty_is_zero():
+    w = Wrench()
+    assert w.force.to_tuple() == (0.0, 0.0, 0.0)
+    assert w.torque.to_tuple() == (0.0, 0.0, 0.0)
+    assert w.is_zero()
+    assert not w
+
+
+def test_wrench_from_two_sequences():
+    w = Wrench([1, 2, 3], [4, 5, 6])
+    assert w.force.to_tuple() == (1.0, 2.0, 3.0)
+    assert w.torque.to_tuple() == (4.0, 5.0, 6.0)
+
+
+def test_wrench_from_two_vector3():
+    w = Wrench(Vector3(1, 2, 3), Vector3(4, 5, 6))
+    assert w.force.to_tuple() == (1.0, 2.0, 3.0)
+    assert w.torque.to_tuple() == (4.0, 5.0, 6.0)
+
+
+def test_wrench_keywords():
+    assert Wrench(force=[1, 2, 3]).torque.to_tuple() == (0.0, 0.0, 0.0)
+    assert Wrench(torque=[4, 5, 6]).force.to_tuple() == (0.0, 0.0, 0.0)
+
+
+def test_wrench_copy_constructor():
+    src = Wrench([1, 2, 3], [4, 5, 6])
+    copy = Wrench(src)
+    assert copy == src
+    assert copy.force is not src.force
+
+
+def test_wrench_unknown_keyword_raises():
+    with pytest.raises(TypeError):
+        Wrench(bogus=1)
+
+
+def test_wrench_array_roundtrip():
+    ft = [1.0, 2.0, 3.0, 0.1, 0.2, 0.3]
+    assert np.allclose(Wrench.from_array(ft).to_array(), ft)
+
+
+def test_wrench_from_array_wrong_length_raises():
+    with pytest.raises(ValueError, match="6 elements"):
+        Wrench.from_array([1.0, 2.0, 3.0])
+
+
+def test_wrench_add_and_sub():
+    a = Wrench([1, 2, 3], [4, 5, 6])
+    b = Wrench([1, 1, 1], [1, 1, 1])
+    assert (a + b).force.to_tuple() == (2.0, 3.0, 4.0)
+    assert (a - b).torque.to_tuple() == (3.0, 4.0, 5.0)
+
+
+def test_stamped_is_a_wrench():
+    assert isinstance(WrenchStamped(), Wrench)
+
+
+def test_stamped_inherits_wrench_positional_form():
+    ws = WrenchStamped([1, 2, 3], [4, 5, 6])
+    assert ws.force.to_tuple() == (1.0, 2.0, 3.0)
+    assert ws.torque.to_tuple() == (4.0, 5.0, 6.0)
+
+
+def test_stamped_keeps_explicit_ts_and_frame():
+    ws = WrenchStamped(ts=5.0, frame_id="ft_sensor", force=[1, 2, 3], torque=[4, 5, 6])
+    assert (ws.ts, ws.frame_id) == (5.0, "ft_sensor")
+    assert ws.force.to_tuple() == (1.0, 2.0, 3.0)
+
+
+def test_stamped_positional_ts_and_frame():
+    ws = WrenchStamped(5.0, "ft_sensor")
+    assert (ws.ts, ws.frame_id) == (5.0, "ft_sensor")
+
+
+def test_stamped_defaults_stamp_to_now():
+    before = time.time()
+    assert before <= WrenchStamped().ts <= time.time()
+
+
+def test_stamped_zero_ts_is_a_real_timestamp():
+    assert WrenchStamped(ts=0.0).ts == 0.0
+
+
+def test_stamped_from_array():
+    ws = WrenchStamped.from_array([1.0, 2.0, 3.0, 0.1, 0.2, 0.3], frame_id="tool0", ts=5.0)
+    assert (ws.ts, ws.frame_id) == (5.0, "tool0")
+    assert ws.force.to_tuple() == (1.0, 2.0, 3.0)
+    assert ws.torque.to_tuple() == (0.1, 0.2, 0.3)
+
+
+def test_lcm_encode_decode():
+    source = WrenchStamped(
+        ts=5.25, frame_id="ft_sensor", force=(1.0, 2.0, 3.0), torque=(0.1, 0.2, 0.3)
+    )
+    dest = WrenchStamped.lcm_decode(source.lcm_encode())
+
+    assert isinstance(dest, WrenchStamped)
+    assert dest is not source
+    assert dest == source
+    assert dest.frame_id == "ft_sensor"
+    assert dest.ts == pytest.approx(5.25)
+
+
+def test_lcm_decode_of_an_unstamped_message_keeps_the_zero_stamp():
+    decoded = WrenchStamped.lcm_decode(WrenchStamped(ts=0.0, frame_id="f").lcm_encode())
+    assert decoded.ts == 0.0
+
+
+def test_pickle_encode_decode():
+    source = WrenchStamped(ts=time.time(), force=(1.0, 2.0, 3.0), torque=(0.1, 0.2, 0.3))
+    dest = pickle.loads(pickle.dumps(source))
+    assert isinstance(dest, WrenchStamped)
+    assert dest is not source
+    assert dest == source


### PR DESCRIPTION
## Problem

A wrench is a force and torque reading. DimOS had a WrenchStamped type, but it had no way to turn itself into bytes,
It was also built differently from every other stamped message in dimos.

Issue: #

---

## Solution

Rebuilt both types on top of the generated LCM classes, the same way Twist and
TwistStamped already work.
---

## Breaking Changes

The reading used to be nested under `.wrench`. It's now flat — `ws.force`, `ws.torque` —
matching PoseStamped and TwistStamped. Nothing in the repo used the old form.

---

## How to Test

1. `.venv/bin/python -m pytest dimos/msgs/geometry_msgs/test_WrenchStamped.py`
2. Confirm a roundtrip: `WrenchStamped.lcm_decode(WrenchStamped.from_array([1,2,3,.1,.2,.3]).lcm_encode())`
3. Confirm port resolution: `resolve_msg_type("geometry_msgs.WrenchStamped")` returns the class.
