### PR TITLE
Modifying relocalization and mapping for using mid360 lidar

### DIFF
--- a/dimos/core/global_config.py
+++ b/dimos/core/global_config.py
@@ -81,9 +81,10 @@ class GlobalConfig(BaseSettings):
     scene_package: str | None = None
     robot_model: str | None = None
     robot_id: str | None = None
-    # Voxel-map preset: ``mid360`` uses 3 cm voxels; ``default`` keeps 5 cm.
-    # Modules (e.g. VoxelGridMapper) and ``dimos map`` honor this unless an
-    # explicit ``--voxel`` / ``--voxel-size`` override is given.
+    # Lidar preset: ``mid360`` uses 3 cm voxels and tighter relocalization ICP
+    # (fine voxel 0.06 m, rerank dist 0.12 m); ``default`` keeps 5 cm / 0.1 / 0.15.
+    # Modules (e.g. VoxelGridMapper, RelocalizationModule) and ``dimos map`` honor
+    # this unless an explicit ``--voxel`` / ``--voxel-size`` override is given.
     lidar_config: Literal["default", "mid360"] = "default"
     robot_width: float = 0.3
     robot_rotation_diameter: float = 0.6

--- a/dimos/core/global_config.py
+++ b/dimos/core/global_config.py
@@ -81,6 +81,10 @@ class GlobalConfig(BaseSettings):
     scene_package: str | None = None
     robot_model: str | None = None
     robot_id: str | None = None
+    # Voxel-map preset: ``mid360`` uses 3 cm voxels; ``default`` keeps 5 cm.
+    # Modules (e.g. VoxelGridMapper) and ``dimos map`` honor this unless an
+    # explicit ``--voxel`` / ``--voxel-size`` override is given.
+    lidar_config: Literal["default", "mid360"] = "default"
     robot_width: float = 0.3
     robot_rotation_diameter: float = 0.6
     nerf_speed: float = 1.0

--- a/dimos/hardware/sensors/lidar/fastlio2/fastlio_blueprints.py
+++ b/dimos/hardware/sensors/lidar/fastlio2/fastlio_blueprints.py
@@ -16,20 +16,18 @@
 from dimos.core.coordination.blueprints import autoconnect
 from dimos.hardware.sensors.lidar.fastlio2.module import FastLio2
 from dimos.mapping.ray_tracing.module import RayTracingVoxelMap
+from dimos.mapping.voxels.lidar_defaults import MID360_VOXEL_SIZE
 from dimos.mapping.voxels.module import VoxelGridMapper
 from dimos.visualization.vis_module import vis_module
-
-voxel_size = 0.05
-
 
 mid360_fastlio = autoconnect(
     FastLio2.blueprint(),
     vis_module("rerun"),
-).global_config(n_workers=2, robot_model="mid360_fastlio2")
+).global_config(n_workers=2, robot_model="mid360_fastlio2", lidar_config="mid360")
 
 mid360_fastlio_voxels = autoconnect(
     FastLio2.blueprint(),
-    VoxelGridMapper.blueprint(voxel_size=voxel_size, carve_columns=False),
+    VoxelGridMapper.blueprint(voxel_size=MID360_VOXEL_SIZE, carve_columns=False),
     vis_module(
         "rerun",
         rerun_config={
@@ -38,7 +36,7 @@ mid360_fastlio_voxels = autoconnect(
             },
         },
     ),
-).global_config(n_workers=3, robot_model="mid360_fastlio2_voxels")
+).global_config(n_workers=3, robot_model="mid360_fastlio2_voxels", lidar_config="mid360")
 
 mid360_fastlio_voxels_native = autoconnect(
     FastLio2.blueprint(),
@@ -50,12 +48,12 @@ mid360_fastlio_voxels_native = autoconnect(
             },
         },
     ),
-).global_config(n_workers=2, robot_model="mid360_fastlio2")
+).global_config(n_workers=2, robot_model="mid360_fastlio2", lidar_config="mid360")
 
 
 mid360_fastlio_ray_trace = autoconnect(
     FastLio2.blueprint(),
-    RayTracingVoxelMap.blueprint(voxel_size=voxel_size),
+    RayTracingVoxelMap.blueprint(voxel_size=MID360_VOXEL_SIZE),
     vis_module(
         "rerun",
         rerun_config={
@@ -64,4 +62,4 @@ mid360_fastlio_ray_trace = autoconnect(
             },
         },
     ),
-).global_config(n_workers=5, robot_model="mid360_fastlio2_ray_trace")
+).global_config(n_workers=5, robot_model="mid360_fastlio2_ray_trace", lidar_config="mid360")

--- a/dimos/hardware/sensors/lidar/livox/cpp/flake.nix
+++ b/dimos/hardware/sensors/lidar/livox/cpp/flake.nix
@@ -70,6 +70,16 @@
 
           src = ./.;
 
+          # nix-portable/proot fails stdenv directory unpack (cp -p on 'cpp').
+          unpackPhase = ''
+            runHook preUnpack
+            mkdir source
+            cp -a --no-preserve=mode,ownership "$src"/. source/
+            chmod -R u+w source
+            cd source
+            runHook postUnpack
+          '';
+
           nativeBuildInputs = [ pkgs.cmake pkgs.pkg-config ];
           buildInputs = [ livox-sdk2 lcm pkgs.glib pkgs.nlohmann_json ];
 

--- a/dimos/hardware/sensors/lidar/livox/module.py
+++ b/dimos/hardware/sensors/lidar/livox/module.py
@@ -56,7 +56,7 @@ from dimos.spec import perception
 class Mid360Config(NativeModuleConfig):
     cwd: str | None = "cpp"
     executable: str = "result/bin/mid360_native"
-    build_command: str | None = "nix build -L .#mid360_native"
+    build_command: str | None = "NP_RUNTIME=proot nix build -L .#mid360_native"
     stdin_config: bool = True
     base_fields: frozenset[str] = frozenset({"frame_id"})
     host_ip: str | None = Field(default_factory=lambda: os.environ.get("DIMOS_MID360_HOST_IP"))

--- a/dimos/hardware/sensors/lidar/pointlio/module.py
+++ b/dimos/hardware/sensors/lidar/pointlio/module.py
@@ -71,7 +71,7 @@ IvoxNearbyType = Literal["center", "nearby6", "nearby18", "nearby26"]
 class PointLioConfig(NativeModuleConfig):
     cwd: str | None = "cpp"
     executable: str = "result/bin/pointlio_native"
-    build_command: str | None = "nix build -L .#pointlio_native"
+    build_command: str | None = "NP_RUNTIME=proot nix build -L .#pointlio_native"
     stdin_config: bool = True
     base_fields: frozenset[str] = frozenset({"frame_id"})
     # lidar_ip required; host_ip optional (auto-derived from lidar_ip's subnet).

--- a/dimos/hardware/sensors/lidar/pointlio/pointlio_blueprints.py
+++ b/dimos/hardware/sensors/lidar/pointlio/pointlio_blueprints.py
@@ -15,20 +15,18 @@
 
 from dimos.core.coordination.blueprints import autoconnect
 from dimos.hardware.sensors.lidar.pointlio.module import PointLio
+from dimos.mapping.voxels.lidar_defaults import MID360_VOXEL_SIZE
 from dimos.mapping.voxels.module import VoxelGridMapper
 from dimos.visualization.vis_module import vis_module
-
-voxel_size = 0.05
-
 
 mid360_pointlio = autoconnect(
     PointLio.blueprint(),
     vis_module("rerun"),
-).global_config(n_workers=2, robot_model="mid360_pointlio")
+).global_config(n_workers=2, robot_model="mid360_pointlio", lidar_config="mid360")
 
 mid360_pointlio_voxels = autoconnect(
     PointLio.blueprint(),
-    VoxelGridMapper.blueprint(voxel_size=voxel_size, carve_columns=False),
+    VoxelGridMapper.blueprint(voxel_size=MID360_VOXEL_SIZE, carve_columns=False),
     vis_module(
         "rerun",
         rerun_config={
@@ -37,4 +35,4 @@ mid360_pointlio_voxels = autoconnect(
             },
         },
     ),
-).global_config(n_workers=3, robot_model="mid360_pointlio_voxels")
+).global_config(n_workers=3, robot_model="mid360_pointlio_voxels", lidar_config="mid360")

--- a/dimos/mapping/cli/map.py
+++ b/dimos/mapping/cli/map.py
@@ -18,9 +18,11 @@ from collections.abc import Callable, Iterable
 import math
 from pathlib import Path
 import subprocess
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import typer
+
+from dimos.mapping.voxels.lidar_defaults import voxel_size_for_lidar
 
 if TYPE_CHECKING:
     from dimos.mapping.loop_closure.pgo import PoseGraph
@@ -339,12 +341,22 @@ def main(
     lidar_stream: str = typer.Option(
         "lidar", "--lidar", help="Lidar point-cloud stream to reconstruct"
     ),
+    lidar_config: Literal["default", "mid360"] = typer.Option(
+        "default",
+        "--lidar-config",
+        help="Lidar preset for default voxel size: 'default'→0.05 m, 'mid360'→0.03 m "
+        "(ignored when --voxel is set)",
+    ),
     seek: float = typer.Option(0.0, "--seek", help="Skip the first N seconds of the recording"),
     duration: float | None = typer.Option(
         None, "--duration", help="Use only N seconds from --seek (default: to the end)"
     ),
-    voxel: float = typer.Option(0.05, "--voxel", help="Voxel size for the rebuild"),
-    device: str = typer.Option(
+    voxel: float | None = typer.Option(
+        None,
+        "--voxel",
+        help="Voxel size for the rebuild (m). Default: 0.05, or 0.03 with --lidar-config mid360",
+    ),
+ device: str = typer.Option(
         "CUDA:0", "--device", help="Open3D compute device (e.g. CUDA:0, CPU:0)"
     ),
     pgo: bool = typer.Option(
@@ -472,6 +484,10 @@ def main(
         out = Path.cwd() / f"{db_path.stem}.rrd"
     if export or full_pgo:
         pgo = True
+
+    if voxel is None:
+        voxel = voxel_size_for_lidar(lidar_config)
+    print(f"voxel_size={voxel} (lidar_config={lidar_config!r})")
 
     lidar_stream = _resolve_lidar_stream(store, lidar_stream)
     lidar = store.stream(lidar_stream, PointCloud2).from_time(seek or None).to_time(duration)

--- a/dimos/mapping/cli/map.py
+++ b/dimos/mapping/cli/map.py
@@ -39,6 +39,41 @@ MARKER_STEM = 1.0
 # Conventional world frames tried in order when --frame isn't given.
 _WORLD_FRAMES = ("world", "map", "odom")
 
+# Default --lidar value. When that stream is missing/empty, try these
+# Point-LIO / Fast-LIO recorder names before failing.
+_DEFAULT_LIDAR_STREAM = "lidar"
+_LIDAR_FALLBACKS = ("pointlio_lidar", "fastlio_lidar")
+
+
+def _resolve_lidar_stream(store: Any, requested: str) -> str:
+    """Pick a non-empty lidar stream; auto-fallback when using the default name.
+
+    ``Store.stream`` creates missing streams, so we must consult
+    ``list_streams`` / counts before opening the reconstruction pipeline —
+    otherwise an empty default ``lidar`` stream yields a late
+    ``LookupError: No matching observation`` from PGO.
+    """
+    available = store.list_streams()
+    candidates: list[str] = [requested]
+    if requested == _DEFAULT_LIDAR_STREAM:
+        candidates.extend(name for name in _LIDAR_FALLBACKS if name not in candidates)
+
+    for name in candidates:
+        if name not in available:
+            continue
+        if store.stream(name).count() == 0:
+            continue
+        if name != requested:
+            print(f"using lidar stream {name!r} (default {requested!r} missing or empty)")
+        return name
+
+    known = ", ".join(sorted(available)) or "(none)"
+    raise typer.BadParameter(
+        f"lidar stream {requested!r} is missing or empty; available streams: {known}. "
+        "Pass --lidar <name> (Point-LIO recordings use --lidar pointlio_lidar).",
+        param_hint="--lidar",
+    )
+
 
 def _detect_world(tf_buf: Any, cloud_frame: str, ts: float) -> str | None:
     """Pick the first conventional world frame that resolves the cloud frame via tf."""
@@ -438,6 +473,7 @@ def main(
     if export or full_pgo:
         pgo = True
 
+    lidar_stream = _resolve_lidar_stream(store, lidar_stream)
     lidar = store.stream(lidar_stream, PointCloud2).from_time(seek or None).to_time(duration)
 
     print(lidar.summary())

--- a/dimos/mapping/cli/map.py
+++ b/dimos/mapping/cli/map.py
@@ -356,7 +356,7 @@ def main(
         "--voxel",
         help="Voxel size for the rebuild (m). Default: 0.05, or 0.03 with --lidar-config mid360",
     ),
- device: str = typer.Option(
+    device: str = typer.Option(
         "CUDA:0", "--device", help="Open3D compute device (e.g. CUDA:0, CPU:0)"
     ),
     pgo: bool = typer.Option(

--- a/dimos/mapping/cli/replay.py
+++ b/dimos/mapping/cli/replay.py
@@ -125,10 +125,17 @@ def main(
     duration: float | None = typer.Option(
         None, "--duration", help="Use only N seconds from --seek (default: to the end)"
     ),
-    voxel: float = typer.Option(
-        0.05,
+    lidar_config: str = typer.Option(
+        "default",
+        "--lidar-config",
+        help="Lidar preset for default voxel size: 'default'→0.05 m, 'mid360'→0.03 m "
+        "(ignored when --voxel is set)",
+    ),
+    voxel: float | None = typer.Option(
+        None,
         "--voxel",
-        help="Voxel grid resolution (m) for --map/--map-final; rendering follows the same size",
+        help="Voxel grid resolution (m) for --map/--map-final; default 0.05, or 0.03 with "
+        "--lidar-config mid360",
     ),
     point_mode: str = typer.Option(
         "spheres", "--point-mode", help="Render mode: 'spheres', 'boxes', or 'points'"
@@ -176,6 +183,7 @@ def main(
     """Dump a recording to .rrd (lidar clouds + camera frames) and open it in rerun."""
     import rerun as rr
 
+    from dimos.mapping.voxels.lidar_defaults import voxel_size_for_lidar
     from dimos.mapping.voxels.module import VoxelMapTransformer
     from dimos.memory2.cli.dataset import open_store, resolve_dataset, stream_payload_types
     from dimos.memory2.transform import throttle
@@ -184,6 +192,9 @@ def main(
     from dimos.msgs.sensor_msgs.Image import Image
     from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2, register_colormap_annotation
     from dimos.robot.unitree.go2.connection import _camera_info_static
+
+    if voxel is None:
+        voxel = voxel_size_for_lidar(lidar_config)
 
     src_path = resolve_dataset(dataset)
     store = open_store(src_path)

--- a/dimos/mapping/relocalization/module.py
+++ b/dimos/mapping/relocalization/module.py
@@ -63,6 +63,8 @@ class RelocalizationModule(Module):
         self._premap: PointCloud2 | None = None
         self._last_skip_log = 0.0
         self._world_to_map: Subject[Transform | None] = Subject()
+        self._first_reloc_logged = False
+        self._start_mono: float | None = None
 
     @rpc
     def start(self) -> None:
@@ -75,6 +77,7 @@ class RelocalizationModule(Module):
         path = resolve_named_path(self.config.map_file, MAP_SUFFIX)
         self._premap = PointCloud2.lcm_decode(path.read_bytes())
         self._premap.frame_id = FRAME_MAP
+        self._start_mono = time.monotonic()
 
         self.register_disposable(
             backpressure(
@@ -128,19 +131,35 @@ class RelocalizationModule(Module):
 
     def _try_relocalize(self, msg: PointCloud2) -> Transform | None:
         assert self._premap is not None
+        n_pts = len(msg)
+        log_first = not self._first_reloc_logged
+        if log_first:
+            self._first_reloc_logged = True
+            elapsed = (
+                time.monotonic() - self._start_mono if self._start_mono is not None else float("nan")
+            )
+            logger.info(
+                f"relocalize first event before ICP: elapsed_s={elapsed:.1f} voxels={n_pts}"
+            )
+
         t0 = time.monotonic()
         try:
-            T, fitness = _relocalize(self._premap.pointcloud, msg.pointcloud)
+            T, fitness, inlier_rmse = _relocalize(self._premap.pointcloud, msg.pointcloud)
         except Exception:
             logger.exception("relocalize() failed")
             return None
         dt = time.monotonic() - t0
-        n_pts = len(msg)
+
+        if log_first:
+            logger.info(
+                f"relocalize first event after ICP: fitness={fitness:.6f} "
+                f"inlier_rmse={inlier_rmse:.6f} time_cost={dt:.1f}s n_pts={n_pts}"
+            )
 
         if fitness < self.config.fitness_threshold:
             logger.warning(
                 f"relocalize rejected: fitness={fitness:.3f} < threshold={self.config.fitness_threshold} "
-                f"time_cost={dt:.1f}s n_pts={n_pts}"
+                f"inlier_rmse={inlier_rmse:.6f} time_cost={dt:.1f}s n_pts={n_pts}"
             )
             return None
 
@@ -155,7 +174,8 @@ class RelocalizationModule(Module):
             child_frame_id=FRAME_MAP,
         )
         logger.info(
-            f"relocalize: fitness={fitness:.3f} time_cost={dt:.1f}s n_pts={n_pts} "
+            f"relocalize: fitness={fitness:.3f} inlier_rmse={inlier_rmse:.6f} "
+            f"time_cost={dt:.1f}s n_pts={n_pts} "
             f"reloc_t={T[:3, 3].round(3).tolist()} "
             f"TF {FRAME_WORLD!r} -> {FRAME_MAP!r} "
             f"published_t={T_inv[:3, 3].round(3).tolist()} "

--- a/dimos/mapping/relocalization/module.py
+++ b/dimos/mapping/relocalization/module.py
@@ -22,8 +22,9 @@ from reactivex import Subject, combine_latest, operators as ops
 from dimos.core.core import rpc
 from dimos.core.module import Module, ModuleConfig
 from dimos.core.stream import In, Out
-from dimos.mapping.relocalization.relocalize import relocalize as _relocalize
+from dimos.mapping.relocalization.relocalize import relocalize as _relocalize, relocalize_scales
 from dimos.mapping.voxels.grid import VoxelGrid
+from dimos.mapping.voxels.lidar_defaults import LidarConfigName
 from dimos.msgs.geometry_msgs.Quaternion import Quaternion
 from dimos.msgs.geometry_msgs.Transform import Transform
 from dimos.msgs.geometry_msgs.Vector3 import Vector3
@@ -49,6 +50,21 @@ class Config(ModuleConfig):
     publish_loaded_map: bool = False
     fitness_threshold: float = 0.45
     use_carving: bool = True
+    # None → inherit GlobalConfig.lidar_config (``default`` / ``mid360``).
+    lidar_config: LidarConfigName | None = None
+    # None → derive from lidar_config (0.1 / 0.15 default, 0.06 / 0.12 for mid360).
+    fine_voxel: float | None = None
+    rerank_dist: float | None = None
+
+    def resolved_lidar_config(self) -> LidarConfigName:
+        return self.lidar_config if self.lidar_config is not None else self.g.lidar_config
+
+    def resolved_relocalize_scales(self) -> tuple[float, float]:
+        return relocalize_scales(
+            self.resolved_lidar_config(),
+            fine_voxel=self.fine_voxel,
+            rerank_dist=self.rerank_dist,
+        )
 
 
 class RelocalizationModule(Module):
@@ -106,9 +122,12 @@ class RelocalizationModule(Module):
             .subscribe(self._publish_periodic)
         )
 
+        fine_voxel, rerank_dist = self.config.resolved_relocalize_scales()
         logger.info(
             f"Relocalization module started: map_file={self.config.map_file!r}  "
-            f"loaded_map.frame_id={self._premap.frame_id!r}"
+            f"loaded_map.frame_id={self._premap.frame_id!r} "
+            f"fine_voxel={fine_voxel} rerank_dist={rerank_dist} "
+            f"(lidar_config={self.config.resolved_lidar_config()!r})"
         )
 
     def _maybe_log_skip(self, msg: PointCloud2) -> None:
@@ -146,7 +165,14 @@ class RelocalizationModule(Module):
 
         t0 = time.monotonic()
         try:
-            T, fitness, inlier_rmse = _relocalize(self._premap.pointcloud, msg.pointcloud)
+            fine_voxel, rerank_dist = self.config.resolved_relocalize_scales()
+            T, fitness, inlier_rmse = _relocalize(
+                self._premap.pointcloud,
+                msg.pointcloud,
+                lidar_config=self.config.resolved_lidar_config(),
+                fine_voxel=fine_voxel,
+                rerank_dist=rerank_dist,
+            )
         except Exception:
             logger.exception("relocalize() failed")
             return None

--- a/dimos/mapping/relocalization/module.py
+++ b/dimos/mapping/relocalization/module.py
@@ -136,7 +136,9 @@ class RelocalizationModule(Module):
         if log_first:
             self._first_reloc_logged = True
             elapsed = (
-                time.monotonic() - self._start_mono if self._start_mono is not None else float("nan")
+                time.monotonic() - self._start_mono
+                if self._start_mono is not None
+                else float("nan")
             )
             logger.info(
                 f"relocalize first event before ICP: elapsed_s={elapsed:.1f} voxels={n_pts}"

--- a/dimos/mapping/relocalization/relocalize.py
+++ b/dimos/mapping/relocalization/relocalize.py
@@ -22,6 +22,13 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from dimos.mapping.voxels.lidar_defaults import (
+    DEFAULT_FINE_VOXEL,
+    DEFAULT_RERANK_DIST,
+    fine_voxel_for_lidar,
+    rerank_dist_for_lidar,
+)
+
 if TYPE_CHECKING:
     import open3d as o3d  # type: ignore[import-untyped]
 
@@ -33,9 +40,27 @@ SCALE_PLAN: list[tuple[float, int]] = [
     (0.8, 1),
 ]
 RANSAC_ITERS = 500_000  # RANSAC iteration budget per scale
-FINE_VOXEL = 0.1  # voxel for the final ICP refinement
-RERANK_DIST = FINE_VOXEL * 1.5  # inlier dist for fine-scale candidate scoring
+FINE_VOXEL = DEFAULT_FINE_VOXEL  # voxel for the final ICP refinement
+RERANK_DIST = DEFAULT_RERANK_DIST  # inlier dist for fine-scale candidate scoring
 GRAVITY_TILT_MAX_DEG = 10.0  # reject candidates whose z-axis tilts more than this
+
+
+def relocalize_scales(
+    lidar_config: str | None = None,
+    *,
+    fine_voxel: float | None = None,
+    rerank_dist: float | None = None,
+) -> tuple[float, float]:
+    """Resolve ICP fine voxel and rerank distance for a lidar-config name.
+
+    ``mid360`` uses 0.06 m / 0.12 m. ``default`` (and ``None``) keep the
+    historical ``FINE_VOXEL`` / ``RERANK_DIST``. Explicit overrides win.
+    """
+    resolved_fine = fine_voxel if fine_voxel is not None else fine_voxel_for_lidar(lidar_config)
+    resolved_rerank = (
+        rerank_dist if rerank_dist is not None else rerank_dist_for_lidar(lidar_config)
+    )
+    return resolved_fine, resolved_rerank
 
 
 def _preprocess(
@@ -131,6 +156,10 @@ def _gravity_tilt_deg(T: np.ndarray) -> float:
 def relocalize(
     global_map: o3d.geometry.PointCloud,
     local_map: o3d.geometry.PointCloud,
+    *,
+    lidar_config: str | None = None,
+    fine_voxel: float | None = None,
+    rerank_dist: float | None = None,
 ) -> tuple[np.ndarray, float, float]:
     """Estimate the 4x4 transform placing ``local_map`` into ``global_map``.
 
@@ -139,19 +168,26 @@ def relocalize(
     rerank catches z-degenerate and wrong-room busts: at FINE_VOXEL a
     5m-off candidate has ~0 inliers while RANSAC reports it as fit.
 
+    ``lidar_config='mid360'`` (or GlobalConfig ``--lidar-config mid360``)
+    tightens the ICP fine voxel to 0.06 m and rerank distance to 0.12 m.
+    Defaults stay ``FINE_VOXEL`` / ``RERANK_DIST``.
+
     Returns:
         ``(T, fitness, inlier_rmse)`` from the final full-cloud ICP.
     """
     import open3d as o3d
 
     _reg = o3d.pipelines.registration
+    fine_voxel, rerank_dist = relocalize_scales(
+        lidar_config, fine_voxel=fine_voxel, rerank_dist=rerank_dist
+    )
 
     # Fine downsample once — used for both candidate scoring and the final ICP.
-    src_fine = local_map.voxel_down_sample(FINE_VOXEL)
+    src_fine = local_map.voxel_down_sample(fine_voxel)
     src_fine.estimate_normals(
-        o3d.geometry.KDTreeSearchParamHybrid(radius=FINE_VOXEL * 2, max_nn=30)
+        o3d.geometry.KDTreeSearchParamHybrid(radius=fine_voxel * 2, max_nn=30)
     )
-    tgt_fine = _global_fine(global_map, FINE_VOXEL)
+    tgt_fine = _global_fine(global_map, fine_voxel)
 
     candidates: list[np.ndarray] = []  # 4x4 transforms
     for vs, n_runs in SCALE_PLAN:
@@ -203,7 +239,7 @@ def relocalize(
 
     # Stage 1: rank all candidates by WALL-only fine-scale fitness.
     def fine_fitness(T: np.ndarray) -> float:
-        r = _reg.evaluate_registration(src_walls, tgt_walls, RERANK_DIST, T)
+        r = _reg.evaluate_registration(src_walls, tgt_walls, rerank_dist, T)
         return float(r.fitness)
 
     top_k = sorted(pool, key=fine_fitness, reverse=True)[:10]
@@ -211,13 +247,13 @@ def relocalize(
     # Stage 2: run a moderate-distance ICP on each top-10 on WALL clouds.
     # Wall correspondences drive yaw and xy; the rerank then picks the
     # candidate whose walls actually align (not the one whose floors agree).
-    tukey = _reg.TransformationEstimationPointToPlane(_reg.TukeyLoss(k=RERANK_DIST))
+    tukey = _reg.TransformationEstimationPointToPlane(_reg.TukeyLoss(k=rerank_dist))
     polished: list[tuple[float, np.ndarray]] = []
     for T0 in top_k:
         r = _reg.registration_icp(
             src_walls,
             tgt_walls,
-            RERANK_DIST,
+            rerank_dist,
             T0,
             tukey,
             _reg.ICPConvergenceCriteria(max_iteration=70),
@@ -229,7 +265,7 @@ def relocalize(
     final = _reg.registration_icp(
         src_fine,
         tgt_fine,
-        RERANK_DIST,
+        rerank_dist,
         best_T,
         tukey,
         _reg.ICPConvergenceCriteria(max_iteration=50),

--- a/dimos/mapping/relocalization/relocalize.py
+++ b/dimos/mapping/relocalization/relocalize.py
@@ -131,13 +131,16 @@ def _gravity_tilt_deg(T: np.ndarray) -> float:
 def relocalize(
     global_map: o3d.geometry.PointCloud,
     local_map: o3d.geometry.PointCloud,
-) -> tuple[np.ndarray, float]:
+) -> tuple[np.ndarray, float, float]:
     """Estimate the 4x4 transform placing ``local_map`` into ``global_map``.
 
     Multi-scale x multi-restart FPFH+RANSAC -> gravity-filtered, re-ranked by
     fine-scale inlier ratio (not RANSAC's own fitness) -> fine ICP. The
     rerank catches z-degenerate and wrong-room busts: at FINE_VOXEL a
     5m-off candidate has ~0 inliers while RANSAC reports it as fit.
+
+    Returns:
+        ``(T, fitness, inlier_rmse)`` from the final full-cloud ICP.
     """
     import open3d as o3d
 
@@ -220,7 +223,7 @@ def relocalize(
             _reg.ICPConvergenceCriteria(max_iteration=70),
         )
         polished.append((float(r.fitness), np.asarray(r.transformation)))
-    best_fit, best_T = max(polished, key=lambda fT: fT[0])
+    _best_wall_fit, best_T = max(polished, key=lambda fT: fT[0])
 
     # Stage 3: final ICP on full clouds, incl. floor/ceiling
     final = _reg.registration_icp(
@@ -231,4 +234,4 @@ def relocalize(
         tukey,
         _reg.ICPConvergenceCriteria(max_iteration=50),
     )
-    return np.asarray(final.transformation), best_fit
+    return np.asarray(final.transformation), float(final.fitness), float(final.inlier_rmse)

--- a/dimos/mapping/relocalization/test_relocalize.py
+++ b/dimos/mapping/relocalization/test_relocalize.py
@@ -1,0 +1,61 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pytest import MonkeyPatch
+
+from dimos.mapping.relocalization.module import Config
+from dimos.mapping.relocalization.relocalize import FINE_VOXEL, RERANK_DIST, relocalize_scales
+from dimos.mapping.voxels.lidar_defaults import (
+    DEFAULT_FINE_VOXEL,
+    DEFAULT_RERANK_DIST,
+    MID360_FINE_VOXEL,
+    MID360_RERANK_DIST,
+)
+
+
+def test_relocalize_scales_keep_defaults_without_mid360() -> None:
+    assert relocalize_scales(None) == (FINE_VOXEL, RERANK_DIST)
+    assert relocalize_scales("default") == (FINE_VOXEL, RERANK_DIST)
+    assert FINE_VOXEL == DEFAULT_FINE_VOXEL == 0.1
+    assert RERANK_DIST == DEFAULT_RERANK_DIST == DEFAULT_FINE_VOXEL * 1.5
+
+
+def test_relocalize_scales_mid360() -> None:
+    assert relocalize_scales("mid360") == (0.06, 0.12)
+    assert relocalize_scales("mid360") == (MID360_FINE_VOXEL, MID360_RERANK_DIST)
+
+
+def test_relocalize_scales_explicit_override_wins() -> None:
+    assert relocalize_scales("mid360", fine_voxel=0.2, rerank_dist=0.4) == (0.2, 0.4)
+    assert relocalize_scales("default", fine_voxel=0.08) == (0.08, RERANK_DIST)
+
+
+def test_relocalization_config_inherits_global_lidar_config(monkeypatch: MonkeyPatch) -> None:
+    cfg = Config()
+    monkeypatch.setattr(cfg.g, "lidar_config", "default")
+    assert cfg.resolved_lidar_config() == "default"
+    assert cfg.resolved_relocalize_scales() == (FINE_VOXEL, RERANK_DIST)
+
+    monkeypatch.setattr(cfg.g, "lidar_config", "mid360")
+    assert cfg.resolved_lidar_config() == "mid360"
+    assert cfg.resolved_relocalize_scales() == (MID360_FINE_VOXEL, MID360_RERANK_DIST)
+
+
+def test_relocalization_config_module_lidar_config_overrides_global(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    cfg = Config(lidar_config="mid360")
+    monkeypatch.setattr(cfg.g, "lidar_config", "default")
+    assert cfg.resolved_lidar_config() == "mid360"
+    assert cfg.resolved_relocalize_scales() == (MID360_FINE_VOXEL, MID360_RERANK_DIST)

--- a/dimos/mapping/voxels/lidar_defaults.py
+++ b/dimos/mapping/voxels/lidar_defaults.py
@@ -1,0 +1,45 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Lidar-config presets for voxel map resolution.
+
+``default`` keeps the historical 5 cm voxels (Go2 L1 / generic). ``mid360``
+uses 3 cm voxels to better preserve Mid-360 detail in premap build and live
+relocalization maps.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+LidarConfigName = Literal["default", "mid360"]
+
+DEFAULT_VOXEL_SIZE = 0.05
+MID360_VOXEL_SIZE = 0.03
+
+_VOXEL_SIZE_BY_LIDAR: dict[str, float] = {
+    "default": DEFAULT_VOXEL_SIZE,
+    "mid360": MID360_VOXEL_SIZE,
+}
+
+
+def voxel_size_for_lidar(lidar_config: str | None) -> float:
+    """Return the default voxel size for a lidar-config name."""
+    if lidar_config is None:
+        return DEFAULT_VOXEL_SIZE
+    try:
+        return _VOXEL_SIZE_BY_LIDAR[lidar_config]
+    except KeyError as e:
+        known = ", ".join(sorted(_VOXEL_SIZE_BY_LIDAR))
+        raise ValueError(f"unknown lidar_config {lidar_config!r}; expected one of: {known}") from e

--- a/dimos/mapping/voxels/lidar_defaults.py
+++ b/dimos/mapping/voxels/lidar_defaults.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Lidar-config presets for voxel map resolution.
+"""Lidar-config presets for voxel map and relocalization resolution.
 
 ``default`` keeps the historical 5 cm voxels (Go2 L1 / generic). ``mid360``
 uses 3 cm voxels to better preserve Mid-360 detail in premap build and live
-relocalization maps.
+relocalization maps, plus tighter ICP fine-voxel / rerank distance.
 """
 
 from __future__ import annotations
@@ -27,19 +27,45 @@ LidarConfigName = Literal["default", "mid360"]
 
 DEFAULT_VOXEL_SIZE = 0.05
 MID360_VOXEL_SIZE = 0.03
+DEFAULT_FINE_VOXEL = 0.1
+MID360_FINE_VOXEL = 0.06
+DEFAULT_RERANK_DIST = DEFAULT_FINE_VOXEL * 1.5
+MID360_RERANK_DIST = 0.12
 
 _VOXEL_SIZE_BY_LIDAR: dict[str, float] = {
     "default": DEFAULT_VOXEL_SIZE,
     "mid360": MID360_VOXEL_SIZE,
 }
+_FINE_VOXEL_BY_LIDAR: dict[str, float] = {
+    "default": DEFAULT_FINE_VOXEL,
+    "mid360": MID360_FINE_VOXEL,
+}
+_RERANK_DIST_BY_LIDAR: dict[str, float] = {
+    "default": DEFAULT_RERANK_DIST,
+    "mid360": MID360_RERANK_DIST,
+}
+
+
+def _preset(table: dict[str, float], lidar_config: str | None, default: float) -> float:
+    if lidar_config is None:
+        return default
+    try:
+        return table[lidar_config]
+    except KeyError as e:
+        known = ", ".join(sorted(table))
+        raise ValueError(f"unknown lidar_config {lidar_config!r}; expected one of: {known}") from e
 
 
 def voxel_size_for_lidar(lidar_config: str | None) -> float:
     """Return the default voxel size for a lidar-config name."""
-    if lidar_config is None:
-        return DEFAULT_VOXEL_SIZE
-    try:
-        return _VOXEL_SIZE_BY_LIDAR[lidar_config]
-    except KeyError as e:
-        known = ", ".join(sorted(_VOXEL_SIZE_BY_LIDAR))
-        raise ValueError(f"unknown lidar_config {lidar_config!r}; expected one of: {known}") from e
+    return _preset(_VOXEL_SIZE_BY_LIDAR, lidar_config, DEFAULT_VOXEL_SIZE)
+
+
+def fine_voxel_for_lidar(lidar_config: str | None) -> float:
+    """Return the relocalization ICP fine voxel for a lidar-config name."""
+    return _preset(_FINE_VOXEL_BY_LIDAR, lidar_config, DEFAULT_FINE_VOXEL)
+
+
+def rerank_dist_for_lidar(lidar_config: str | None) -> float:
+    """Return the relocalization rerank / ICP inlier distance for a lidar-config name."""
+    return _preset(_RERANK_DIST_BY_LIDAR, lidar_config, DEFAULT_RERANK_DIST)

--- a/dimos/mapping/voxels/module.py
+++ b/dimos/mapping/voxels/module.py
@@ -20,15 +20,19 @@ from dimos.core.core import rpc
 from dimos.core.module import ModuleConfig
 from dimos.core.stream import In, Out
 from dimos.mapping.voxels.grid import VoxelGrid
+from dimos.mapping.voxels.lidar_defaults import LidarConfigName, voxel_size_for_lidar
 from dimos.memory2.module import StreamModule
 from dimos.memory2.stream import Stream
 from dimos.memory2.transform import Transformer
 from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
+from dimos.utils.logging_config import setup_logger
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
     from dimos.memory2.type.observation import Observation
+
+logger = setup_logger()
 
 
 class VoxelMapTransformer(Transformer[PointCloud2, PointCloud2]):
@@ -53,10 +57,13 @@ class VoxelMapTransformer(Transformer[PointCloud2, PointCloud2]):
         self, grid: VoxelGrid, last_obs: Observation[PointCloud2], count: int
     ) -> Observation[PointCloud2]:
         # pose=None: the global map is in world frame, per-observation pose is meaningless
+        cloud = grid.get_global_pointcloud2()
+        n_voxels = grid.size()
+        logger.info(f"live map: frames={count} voxels={n_voxels}")
         return last_obs.derive(
-            data=grid.get_global_pointcloud2(),
+            data=cloud,
             pose=None,
-            tags={**last_obs.tags, "frame_count": count},
+            tags={**last_obs.tags, "frame_count": count, "voxel_count": n_voxels},
         )
 
     def __call__(
@@ -85,12 +92,21 @@ class VoxelMapTransformer(Transformer[PointCloud2, PointCloud2]):
 class VoxelGridMapperConfig(ModuleConfig):
     """Configuration for VoxelGridMapper."""
 
-    voxel_size: float = 0.05
+    # None → inherit GlobalConfig.lidar_config (``default`` / ``mid360``).
+    lidar_config: LidarConfigName | None = None
+    # None → derive from lidar_config (0.05 default, 0.03 for mid360).
+    voxel_size: float | None = None
     block_count: int = 2_000_000
     device: str = "CUDA:0"
     carve_columns: bool = True
     frame_id: str = "world"
     emit_every: int = 1
+
+    def resolved_voxel_size(self) -> float:
+        if self.voxel_size is not None:
+            return self.voxel_size
+        lidar = self.lidar_config if self.lidar_config is not None else self.g.lidar_config
+        return voxel_size_for_lidar(lidar)
 
 
 class VoxelGridMapper(StreamModule[PointCloud2, PointCloud2]):
@@ -101,6 +117,12 @@ class VoxelGridMapper(StreamModule[PointCloud2, PointCloud2]):
     def pipeline(self, stream: Stream[PointCloud2]) -> Stream[PointCloud2]:
         cfg = self.config.model_dump(
             include=set(VoxelGridMapperConfig.model_fields) - set(ModuleConfig.model_fields)
+        )
+        cfg.pop("lidar_config", None)
+        cfg["voxel_size"] = self.config.resolved_voxel_size()
+        logger.info(
+            f"VoxelGridMapper voxel_size={cfg['voxel_size']} "
+            f"(lidar_config={self.config.lidar_config or self.config.g.lidar_config!r})"
         )
         return stream.transform(VoxelMapTransformer(**cfg))
 

--- a/dimos/mapping/voxels/test_lidar_defaults.py
+++ b/dimos/mapping/voxels/test_lidar_defaults.py
@@ -1,0 +1,53 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from dimos.mapping.voxels.lidar_defaults import (
+    DEFAULT_FINE_VOXEL,
+    DEFAULT_RERANK_DIST,
+    DEFAULT_VOXEL_SIZE,
+    MID360_FINE_VOXEL,
+    MID360_RERANK_DIST,
+    MID360_VOXEL_SIZE,
+    fine_voxel_for_lidar,
+    rerank_dist_for_lidar,
+    voxel_size_for_lidar,
+)
+
+
+def test_default_lidar_presets() -> None:
+    assert voxel_size_for_lidar(None) == DEFAULT_VOXEL_SIZE
+    assert voxel_size_for_lidar("default") == DEFAULT_VOXEL_SIZE
+    assert fine_voxel_for_lidar(None) == DEFAULT_FINE_VOXEL
+    assert fine_voxel_for_lidar("default") == DEFAULT_FINE_VOXEL
+    assert rerank_dist_for_lidar(None) == DEFAULT_RERANK_DIST
+    assert rerank_dist_for_lidar("default") == DEFAULT_RERANK_DIST
+
+
+def test_mid360_lidar_presets() -> None:
+    assert voxel_size_for_lidar("mid360") == MID360_VOXEL_SIZE
+    assert fine_voxel_for_lidar("mid360") == MID360_FINE_VOXEL
+    assert rerank_dist_for_lidar("mid360") == MID360_RERANK_DIST
+    assert MID360_FINE_VOXEL == 0.06
+    assert MID360_RERANK_DIST == 0.12
+
+
+def test_unknown_lidar_config_raises() -> None:
+    with pytest.raises(ValueError, match="unknown lidar_config"):
+        voxel_size_for_lidar("hesai")
+    with pytest.raises(ValueError, match="unknown lidar_config"):
+        fine_voxel_for_lidar("hesai")
+    with pytest.raises(ValueError, match="unknown lidar_config"):
+        rerank_dist_for_lidar("hesai")

--- a/dimos/robot/all_blueprints.py
+++ b/dimos/robot/all_blueprints.py
@@ -134,6 +134,7 @@ all_blueprints = {
     "unitree-go2-markers": "dimos.robot.unitree.go2.blueprints.smart.unitree_go2:unitree_go2_markers",
     "unitree-go2-memory": "dimos.robot.unitree.go2.blueprints.smart.unitree_go2:unitree_go2_memory",
     "unitree-go2-mid360-record": "dimos.robot.unitree.go2.blueprints.basic.unitree_go2_mid360_record:unitree_go2_mid360_record",
+    "unitree-go2-mid360-relocalization": "dimos.robot.unitree.go2.blueprints.smart.unitree_go2:unitree_go2_mid360_relocalization",
     "unitree-go2-mls-htc": "dimos.robot.unitree.go2.blueprints.navigation.unitree_go2_mls_htc:unitree_go2_mls_htc",
     "unitree-go2-multi": "dimos.robot.unitree.go2.blueprints.basic.unitree_go2_multi:unitree_go2_multi",
     "unitree-go2-multi-teleop": "dimos.robot.unitree.go2.blueprints.basic.unitree_go2_multi_teleop:unitree_go2_multi_teleop",

--- a/dimos/robot/all_blueprints.py
+++ b/dimos/robot/all_blueprints.py
@@ -148,6 +148,7 @@ all_blueprints = {
     "unitree-go2-vlm-stream-test": "dimos.robot.unitree.go2.blueprints.smart.unitree_go2_vlm_stream_test:unitree_go2_vlm_stream_test",
     "unitree-go2-webrtc-keyboard-teleop": "dimos.robot.unitree.go2.blueprints.basic.unitree_go2_webrtc_keyboard_teleop:unitree_go2_webrtc_keyboard_teleop",
     "unitree-go2-webrtc-rage-keyboard-teleop": "dimos.robot.unitree.go2.blueprints.basic.unitree_go2_webrtc_rage_keyboard_teleop:unitree_go2_webrtc_rage_keyboard_teleop",
+    "unitree-mid360-basic": "dimos.robot.unitree.go2.blueprints.basic.unitree_mid360_basic:unitree_mid360_basic",
     "unity-sim": "dimos.simulation.unity.blueprint:unity_sim",
     "xarm-perception": "dimos.robot.manipulators.xarm.blueprints.perception:xarm_perception",
     "xarm-perception-agent": "dimos.robot.manipulators.xarm.blueprints.agentic:xarm_perception_agent",

--- a/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_mid360_record.py
+++ b/dimos/robot/unitree/go2/blueprints/basic/unitree_go2_mid360_record.py
@@ -99,7 +99,7 @@ unitree_go2_mid360_record = autoconnect(
             (KeyboardTeleop, "cmd_vel", "tele_cmd_vel"),
         ]
     ),
-).global_config(n_workers=12, robot_model="unitree_go2")
+).global_config(n_workers=12, robot_model="unitree_go2", lidar_config="mid360")
 
 if _RECORD_PCAP:
     unitree_go2_mid360_record = autoconnect(

--- a/dimos/robot/unitree/go2/blueprints/basic/unitree_mid360_basic.py
+++ b/dimos/robot/unitree/go2/blueprints/basic/unitree_mid360_basic.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Basic Go2 + Mid-360 / Point-LIO visualization blueprint.
+
+Same stack as ``unitree_go2_basic``, with Rerun tuned for Point-LIO worlds
+where the floor often sits at Z << 0 (start pose is the origin).
+"""
+
+from typing import Any
+
+from dimos.core.coordination.blueprints import autoconnect
+from dimos.core.global_config import global_config
+from dimos.robot.unitree.go2.connection import GO2Connection
+from dimos.visualization.vis_module import vis_module
+
+
+def _convert_camera_info(camera_info: Any) -> Any:
+    return camera_info.to_rerun(
+        image_topic="/world/color_image",
+        optical_frame="camera_optical",
+    )
+
+
+def _convert_global_map(grid: Any) -> Any:
+    # No bottom_cutoff: Point-LIO / Mid-360 worlds often have floor Z << 0
+    # (start pose is the origin), so cutting at z=0 hides most of the map.
+    return grid.to_rerun()
+
+
+def _convert_navigation_costmap(grid: Any) -> Any:
+    return grid.to_rerun(
+        colormap="Accent",
+        z_offset=0.015,
+        opacity=0.2,
+        background="#484981",
+    )
+
+
+def _static_base_link(rr: Any) -> list[Any]:
+    return [
+        rr.Boxes3D(
+            half_sizes=[0.35, 0.155, 0.2],
+            colors=[(0, 255, 127)],
+        ),
+        rr.Transform3D(parent_frame="tf#/base_link"),
+    ]
+
+
+def _mid360_rerun_blueprint() -> Any:
+    """Split layout: camera feed + 3D world view side by side."""
+    import rerun.blueprint as rrb
+
+    return rrb.Blueprint(
+        rrb.Horizontal(
+            # Kept even when the recording has no color_image (blank panel).
+            rrb.Spatial2DView(origin="world/color_image", name="Camera"),
+            rrb.Spatial3DView(
+                origin="world",
+                name="3D",
+                background=rrb.Background(kind="SolidColor", color=[0, 0, 0]),
+                # Hide the fixed XY grid: a plane at z≈0.5 sits *above* Point-LIO
+                # floors (often z≪0), which makes the live map look buried.
+                line_grid=rrb.LineGrid3D(visible=False),
+                # Track the Go2 box so reloc / map alignment stays in view as
+                # replay odometry moves base_link through the scene.
+                eye_controls=rrb.EyeControls3D(
+                    kind="Orbital",
+                    tracking_entity="world/tf/base_link",
+                ),
+                overrides={
+                    "world/lidar": rrb.EntityBehavior(visible=False),
+                },
+            ),
+            column_shares=[1, 2],
+        ),
+        rrb.TimePanel(state="hidden"),
+        rrb.SelectionPanel(state="hidden"),
+    )
+
+
+rerun_config: dict[str, Any] = {
+    "blueprint": _mid360_rerun_blueprint,
+    # Custom converters for specific rerun entity paths
+    # Normally all these would be specified in their respectative modules
+    # Until this is implemented we have central overrides here
+    #
+    # This is unsustainable once we move to multi robot etc
+    "visual_override": {
+        "world/camera_info": _convert_camera_info,
+        "world/global_map": _convert_global_map,
+        "world/merged_map": _convert_global_map,
+        "world/loaded_map": _convert_global_map,
+        "world/navigation_costmap": _convert_navigation_costmap,
+    },
+    "max_hz": {
+        "world/global_map": 0,  # publishes at ~7.8 Hz
+        "world/merged_map": 0,
+        "world/loaded_map": 1,  # prior map; low rate is enough
+        "world/color_image": 0,  # publishes at ~14 Hz
+        "world/global_costmap": 0,  # publishes at ~7.6 Hz
+        "world/lidar": 1,  # publishes at ~7.7 Hz; hidden by default in the blueprint
+    },
+    # slapping a go2 shaped box on top of tf/base_link
+    "static": {
+        "world/tf/base_link": _static_base_link,
+    },
+}
+
+_with_vis = autoconnect(
+    vis_module(
+        viewer_backend=global_config.viewer,
+        rerun_config=rerun_config,
+    ),
+)
+
+
+unitree_mid360_basic = (
+    autoconnect(
+        _with_vis,
+        GO2Connection.blueprint(),
+    ).global_config(n_workers=4, robot_model="unitree_go2")
+    # we temporarily disabled sensor timestamps
+    # and are derriving all timestmaps upon reception
+    # this is because image webrtc stream doesn't have timestamps,
+    # so it's difficult to corelate the streams otherwise
+    #
+    #    .configurators(ClockSyncConfigurator())
+)

--- a/dimos/robot/unitree/go2/blueprints/basic/unitree_mid360_basic.py
+++ b/dimos/robot/unitree/go2/blueprints/basic/unitree_mid360_basic.py
@@ -16,9 +16,10 @@
 
 """Basic Go2 + Mid-360 / Point-LIO visualization blueprint.
 
-Same stack as ``unitree_go2_basic``, with Rerun tuned for Point-LIO worlds
-where the floor often sits at Z << 0 (start pose is the origin), plus a
-``VoxelGridMapper`` at Mid-360 resolution (3 cm).
+Same stack as ``unitree_go2_basic``, with a ``VoxelGridMapper`` at Mid-360
+resolution (3 cm).
+
+Replay prefers ``pointlio_odometry`` over Go2 leg odom when both exist.
 """
 
 from typing import Any
@@ -27,7 +28,7 @@ from dimos.core.coordination.blueprints import autoconnect
 from dimos.core.global_config import global_config
 from dimos.mapping.voxels.lidar_defaults import MID360_VOXEL_SIZE
 from dimos.mapping.voxels.module import VoxelGridMapper
-from dimos.robot.unitree.go2.connection import GO2Connection
+from dimos.robot.unitree.go2.connection import GO2Connection, MID360_REPLAY_ODOM_STREAMS
 from dimos.visualization.vis_module import vis_module
 
 
@@ -39,9 +40,7 @@ def _convert_camera_info(camera_info: Any) -> Any:
 
 
 def _convert_global_map(grid: Any) -> Any:
-    # No bottom_cutoff: Point-LIO / Mid-360 worlds often have floor Z << 0
-    # (start pose is the origin), so cutting at z=0 hides most of the map.
-    return grid.to_rerun()
+    return grid.to_rerun(bottom_cutoff=0)
 
 
 def _convert_navigation_costmap(grid: Any) -> Any:
@@ -65,6 +64,7 @@ def _static_base_link(rr: Any) -> list[Any]:
 
 def _mid360_rerun_blueprint() -> Any:
     """Split layout: camera feed + 3D world view side by side."""
+    import rerun as rr
     import rerun.blueprint as rrb
 
     return rrb.Blueprint(
@@ -75,14 +75,8 @@ def _mid360_rerun_blueprint() -> Any:
                 origin="world",
                 name="3D",
                 background=rrb.Background(kind="SolidColor", color=[0, 0, 0]),
-                # Hide the fixed XY grid: a plane at z≈0.5 sits *above* Point-LIO
-                # floors (often z≪0), which makes the live map look buried.
-                line_grid=rrb.LineGrid3D(visible=False),
-                # Track the Go2 box so reloc / map alignment stays in view as
-                # replay odometry moves base_link through the scene.
-                eye_controls=rrb.EyeControls3D(
-                    kind="Orbital",
-                    tracking_entity="world/tf/base_link",
+                line_grid=rrb.LineGrid3D(
+                    plane=rr.components.Plane3D.XY.with_distance(0.5),
                 ),
                 overrides={
                     "world/lidar": rrb.EntityBehavior(visible=False),
@@ -134,7 +128,7 @@ _with_vis = autoconnect(
 unitree_mid360_basic = (
     autoconnect(
         _with_vis,
-        GO2Connection.blueprint(),
+        GO2Connection.blueprint(replay_odom_streams=MID360_REPLAY_ODOM_STREAMS),
         VoxelGridMapper.blueprint(emit_every=5, voxel_size=MID360_VOXEL_SIZE),
     ).global_config(n_workers=5, robot_model="unitree_go2", lidar_config="mid360")
     # we temporarily disabled sensor timestamps

--- a/dimos/robot/unitree/go2/blueprints/basic/unitree_mid360_basic.py
+++ b/dimos/robot/unitree/go2/blueprints/basic/unitree_mid360_basic.py
@@ -17,13 +17,16 @@
 """Basic Go2 + Mid-360 / Point-LIO visualization blueprint.
 
 Same stack as ``unitree_go2_basic``, with Rerun tuned for Point-LIO worlds
-where the floor often sits at Z << 0 (start pose is the origin).
+where the floor often sits at Z << 0 (start pose is the origin), plus a
+``VoxelGridMapper`` at Mid-360 resolution (3 cm).
 """
 
 from typing import Any
 
 from dimos.core.coordination.blueprints import autoconnect
 from dimos.core.global_config import global_config
+from dimos.mapping.voxels.lidar_defaults import MID360_VOXEL_SIZE
+from dimos.mapping.voxels.module import VoxelGridMapper
 from dimos.robot.unitree.go2.connection import GO2Connection
 from dimos.visualization.vis_module import vis_module
 
@@ -132,7 +135,8 @@ unitree_mid360_basic = (
     autoconnect(
         _with_vis,
         GO2Connection.blueprint(),
-    ).global_config(n_workers=4, robot_model="unitree_go2")
+        VoxelGridMapper.blueprint(emit_every=5, voxel_size=MID360_VOXEL_SIZE),
+    ).global_config(n_workers=5, robot_model="unitree_go2", lidar_config="mid360")
     # we temporarily disabled sensor timestamps
     # and are derriving all timestmaps upon reception
     # this is because image webrtc stream doesn't have timestamps,

--- a/dimos/robot/unitree/go2/blueprints/smart/test_unitree_go2_mid360_relocalization.py
+++ b/dimos/robot/unitree/go2/blueprints/smart/test_unitree_go2_mid360_relocalization.py
@@ -1,0 +1,46 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Composition tests for unitree_go2_mid360_relocalization base selection."""
+
+from dimos.mapping.voxels.module import VoxelGridMapper
+from dimos.robot.unitree.go2.blueprints.smart.unitree_go2 import (
+    unitree_go2_mid360_relocalization_base,
+)
+from dimos.robot.unitree.go2.connection import (
+    DEFAULT_REPLAY_ODOM_STREAMS,
+    GO2Connection,
+    MID360_REPLAY_ODOM_STREAMS,
+)
+
+
+def _go2_connection_kwargs(lidar_config: str) -> dict:  # type: ignore[type-arg]
+    base = unitree_go2_mid360_relocalization_base(lidar_config)
+    return next(atom.kwargs for atom in base.blueprints if atom.module is GO2Connection)
+
+
+def test_mid360_lidar_config_uses_pointlio_odom_preference() -> None:
+    kwargs = _go2_connection_kwargs("mid360")
+    assert kwargs.get("replay_odom_streams", DEFAULT_REPLAY_ODOM_STREAMS) == MID360_REPLAY_ODOM_STREAMS
+
+
+def test_default_lidar_config_uses_go2_odom_preference() -> None:
+    kwargs = _go2_connection_kwargs("default")
+    assert kwargs.get("replay_odom_streams", DEFAULT_REPLAY_ODOM_STREAMS) == DEFAULT_REPLAY_ODOM_STREAMS
+
+
+def test_mid360_base_has_single_voxel_mapper() -> None:
+    base = unitree_go2_mid360_relocalization_base("mid360")
+    voxels = [atom for atom in base.blueprints if atom.module is VoxelGridMapper]
+    assert len(voxels) == 1

--- a/dimos/robot/unitree/go2/blueprints/smart/unitree_go2.py
+++ b/dimos/robot/unitree/go2/blueprints/smart/unitree_go2.py
@@ -15,7 +15,8 @@
 
 from pathlib import Path
 
-from dimos.core.coordination.blueprints import autoconnect
+from dimos.core.coordination.blueprints import Blueprint, autoconnect
+from dimos.core.global_config import global_config
 from dimos.core.stream import In
 from dimos.core.transport import LCMTransport
 from dimos.mapping.costmapper import CostMapper
@@ -36,16 +37,22 @@ from dimos.navigation.replanning_a_star.module import ReplanningAStarPlanner
 from dimos.perception.fiducial.marker_detection_stream_module import MarkerDetectionStreamModule
 from dimos.perception.fiducial.marker_tf_module import MarkerTfModule
 from dimos.robot.unitree.go2.blueprints.basic.unitree_go2_basic import unitree_go2_basic
+from dimos.robot.unitree.go2.blueprints.basic.unitree_mid360_basic import unitree_mid360_basic
 from dimos.robot.unitree.go2.connection import GO2Connection
 
-unitree_go2 = autoconnect(
-    unitree_go2_basic,
-    VoxelGridMapper.blueprint(emit_every=5),
+# Shared navigation stack for the smart Go2 / Mid-360 reloc blueprints.
+_unitree_go2_navigation = autoconnect(
     CostMapper.blueprint(),
     ReplanningAStarPlanner.blueprint(),
     WavefrontFrontierExplorer.blueprint(),
     PatrollingModule.blueprint(),
     MovementManager.blueprint(),
+)
+
+unitree_go2 = autoconnect(
+    unitree_go2_basic,
+    VoxelGridMapper.blueprint(emit_every=5),
+    _unitree_go2_navigation,
 ).global_config(n_workers=10, robot_model="unitree_go2")
 
 
@@ -99,11 +106,28 @@ unitree_go2_relocalization = autoconnect(
     RelocalizationModule.blueprint(),
 ).global_config(n_workers=11)
 
-# Same stack as unitree_go2_relocalization with Mid-360 presets: 3 cm voxels,
-# relocalization FINE_VOXEL=0.06 / RERANK_DIST=0.12. Override at runtime with
-# ``--lidar-config default`` if needed.
+
+def unitree_go2_mid360_relocalization_base(lidar_config: str) -> Blueprint:
+    """Pick the reloc base stack from ``lidar_config``.
+
+    ``mid360`` → ``unitree_mid360_basic`` (Point-LIO odom preference + Mid-360
+    Rerun / 3 cm voxels) plus the shared nav stack. Anything else → standard
+    ``unitree_go2`` (``unitree_go2_basic`` + voxels + nav).
+
+    CLI/env are applied to ``global_config`` before blueprint import, so
+    ``--lidar-config mid360`` selects the Mid-360 base at composition time.
+    """
+    if lidar_config == "mid360":
+        # mid360_basic already includes VoxelGridMapper at Mid-360 resolution.
+        return autoconnect(unitree_mid360_basic, _unitree_go2_navigation)
+    return unitree_go2
+
+
+# Mid-360 presets (3 cm voxels, reloc FINE_VOXEL=0.06 / RERANK_DIST=0.12).
+# Base stack follows ``--lidar-config``: mid360 → unitree_mid360_basic, else
+# unitree_go2_basic via unitree_go2. Override with ``--lidar-config default``.
 unitree_go2_mid360_relocalization = autoconnect(
-    unitree_go2,
+    unitree_go2_mid360_relocalization_base(global_config.lidar_config),
     RelocalizationModule.blueprint(),
 ).global_config(n_workers=11, lidar_config="mid360")
 

--- a/dimos/robot/unitree/go2/blueprints/smart/unitree_go2.py
+++ b/dimos/robot/unitree/go2/blueprints/smart/unitree_go2.py
@@ -99,6 +99,13 @@ unitree_go2_relocalization = autoconnect(
     RelocalizationModule.blueprint(),
 ).global_config(n_workers=11)
 
+# Same stack as unitree_go2_relocalization; Mid-360 3 cm voxels via CLI
+# ``--lidar-config mid360`` (default remains 5 cm).
+unitree_go2_mid360_relocalization = autoconnect(
+    unitree_go2,
+    RelocalizationModule.blueprint(),
+).global_config(n_workers=11)
+
 unitree_go2_memory = autoconnect(
     unitree_go2,
     Go2Memory.blueprint(),

--- a/dimos/robot/unitree/go2/blueprints/smart/unitree_go2.py
+++ b/dimos/robot/unitree/go2/blueprints/smart/unitree_go2.py
@@ -99,12 +99,13 @@ unitree_go2_relocalization = autoconnect(
     RelocalizationModule.blueprint(),
 ).global_config(n_workers=11)
 
-# Same stack as unitree_go2_relocalization; Mid-360 3 cm voxels via CLI
-# ``--lidar-config mid360`` (default remains 5 cm).
+# Same stack as unitree_go2_relocalization with Mid-360 presets: 3 cm voxels,
+# relocalization FINE_VOXEL=0.06 / RERANK_DIST=0.12. Override at runtime with
+# ``--lidar-config default`` if needed.
 unitree_go2_mid360_relocalization = autoconnect(
     unitree_go2,
     RelocalizationModule.blueprint(),
-).global_config(n_workers=11)
+).global_config(n_workers=11, lidar_config="mid360")
 
 unitree_go2_memory = autoconnect(
     unitree_go2,

--- a/dimos/robot/unitree/go2/connection.py
+++ b/dimos/robot/unitree/go2/connection.py
@@ -235,9 +235,7 @@ class ReplayConnection(UnitreeWebRTCConnection, CompositeResource):
         available = self.replay.list_streams()
         present = [name for name in names if name in available]
         if not present:
-            raise KeyError(
-                f"None of {names!r} in dataset {self.dataset!r}; available: {available}"
-            )
+            raise KeyError(f"None of {names!r} in dataset {self.dataset!r}; available: {available}")
         for name in present:
             if self.replay.stream(name).count() > 0:
                 return name

--- a/dimos/robot/unitree/go2/connection.py
+++ b/dimos/robot/unitree/go2/connection.py
@@ -45,6 +45,7 @@ from dimos.msgs.sensor_msgs.Image import Image
 from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
 from dimos.msgs.tf2_msgs.TFMessage import TFMessage
 from dimos.robot.unitree.connection import UnitreeWebRTCConnection
+from dimos.robot.unitree.go2.go2_mid360_static_transforms import pointlio_odom_to_base_link_pose
 from dimos.robot.unitree.type.lowstate import LowStateMsg
 from dimos.spec.perception import Camera, Pointcloud
 from dimos.utils.decorators.decorators import cached_property, simple_mcache
@@ -63,6 +64,14 @@ class Go2Mode(str, Enum):
     RAGE = "rage"
 
 
+# Default replay stream preference: Go2 onboard first, Point-LIO last.
+# Mid-360 blueprints reverse odom preference via ConnectionConfig.
+DEFAULT_REPLAY_ODOM_STREAMS: tuple[str, ...] = ("go2_odom", "odom", "pointlio_odometry")
+DEFAULT_REPLAY_LIDAR_STREAMS: tuple[str, ...] = ("go2_lidar", "lidar", "pointlio_lidar")
+# Prefer Point-LIO odom for Mid-360 / Point-LIO recordings; fall back to Go2.
+MID360_REPLAY_ODOM_STREAMS: tuple[str, ...] = ("pointlio_odometry", "go2_odom", "odom")
+
+
 class ConnectionConfig(ModuleConfig):
     ip: str = Field(default_factory=lambda m: m["g"].robot_ip)
     mode: Go2Mode = Go2Mode.DEFAULT
@@ -79,6 +88,9 @@ class ConnectionConfig(ModuleConfig):
     # Turn off where another module owns the base_link edge. The odom port
     # keeps publishing either way.
     publish_tf: bool = True
+    # Replay: first non-empty matching stream wins (see ReplayConnection).
+    replay_odom_streams: tuple[str, ...] = DEFAULT_REPLAY_ODOM_STREAMS
+    replay_lidar_streams: tuple[str, ...] = DEFAULT_REPLAY_LIDAR_STREAMS
 
 
 class Go2ConnectionProtocol(Protocol):
@@ -140,12 +152,18 @@ def make_connection(
     cfg: GlobalConfig,
     aes_128_key: str | None = None,
     velocity_api: bool = False,
+    replay_odom_streams: tuple[str, ...] = DEFAULT_REPLAY_ODOM_STREAMS,
+    replay_lidar_streams: tuple[str, ...] = DEFAULT_REPLAY_LIDAR_STREAMS,
 ) -> Go2ConnectionProtocol:
     connection_type = cfg.unitree_connection_type.lower()
 
     if ip in ("fake", "mock", "replay") or connection_type == "replay":
         dataset = cfg.replay_db
-        return ReplayConnection(dataset=dataset)
+        return ReplayConnection(
+            dataset=dataset,
+            odom_streams=replay_odom_streams,
+            lidar_streams=replay_lidar_streams,
+        )
     elif ip == "mujoco" or connection_type in ("mujoco", "true"):
         from dimos.robot.unitree.mujoco_connection import MujocoConnection
 
@@ -169,9 +187,13 @@ class ReplayConnection(UnitreeWebRTCConnection, CompositeResource):
     def __init__(  # type: ignore[no-untyped-def]
         self,
         dataset: str = "go2_china_office",
+        odom_streams: tuple[str, ...] = DEFAULT_REPLAY_ODOM_STREAMS,
+        lidar_streams: tuple[str, ...] = DEFAULT_REPLAY_LIDAR_STREAMS,
         **kwargs,
     ) -> None:
         self.dataset = dataset
+        self._odom_streams = odom_streams
+        self._lidar_streams = lidar_streams
         self._loop = kwargs.get("loop", False)
         self._seek = kwargs.get("seek")
         self._duration = kwargs.get("duration")
@@ -224,13 +246,11 @@ class ReplayConnection(UnitreeWebRTCConnection, CompositeResource):
         return True
 
     def _stream_name(self, *names: str) -> str:
-        """Return the first of ``names`` present in the dataset (stream naming
-        changed over time: mid360 Point-LIO uses pointlio_*, mid360 Go2
-        recordings use go2_lidar/go2_odom, older ones lidar/odom).
+        """Return the first of ``names`` present and non-empty in the dataset.
 
-        Prefer a non-empty stream when an older empty table shares the DB
-        (e.g. Mid-360 recordings that create ``go2_lidar`` but only fill
-        ``pointlio_lidar``).
+        Stream naming changed over time (mid360 Point-LIO uses pointlio_*,
+        mid360 Go2 recordings use go2_lidar/go2_odom, older ones lidar/odom).
+        Preference order is caller-supplied (see ConnectionConfig).
         """
         available = self.replay.list_streams()
         present = [name for name in names if name in available]
@@ -243,7 +263,7 @@ class ReplayConnection(UnitreeWebRTCConnection, CompositeResource):
 
     @simple_mcache
     def lidar_stream(self) -> Observable[PointCloud2]:
-        name = self._stream_name("go2_lidar", "lidar", "pointlio_lidar")
+        name = self._stream_name(*self._lidar_streams)
         stream: ReplayStream[PointCloud2] = self.replay.stream(name)
         if name != "pointlio_lidar":
             return stream.observable()
@@ -276,11 +296,13 @@ class ReplayConnection(UnitreeWebRTCConnection, CompositeResource):
 
     @simple_mcache
     def odom_stream(self) -> Observable[PoseStamped]:
-        name = self._stream_name("go2_odom", "odom", "pointlio_odometry")
+        name = self._stream_name(*self._odom_streams)
         if name == "pointlio_odometry":
-            # Point-LIO stores nav_msgs/Odometry; navigation ports want PoseStamped.
+            # Point-LIO stores nav_msgs/Odometry in the mid360_link frame;
+            # convert to base_link so GO2Connection's world→base_link TF (and
+            # the Go2 box in Rerun) follows body heading, not lidar pitch.
             odom: ReplayStream[Odometry] = self.replay.stream(name)
-            return odom.observable().pipe(rxops.map(lambda msg: msg.to_pose_stamped()))
+            return odom.observable().pipe(rxops.map(pointlio_odom_to_base_link_pose))
         pose_stream: ReplayStream[PoseStamped] = self.replay.stream(name)
         return pose_stream.observable()
 
@@ -352,6 +374,8 @@ class GO2Connection(Module, Camera, Pointcloud):
             self.config.g,
             aes_128_key=self.config.aes_128_key,
             velocity_api=self.config.velocity_api,
+            replay_odom_streams=self.config.replay_odom_streams,
+            replay_lidar_streams=self.config.replay_lidar_streams,
         )
 
         if hasattr(self.connection, "camera_info_static"):

--- a/dimos/robot/unitree/go2/connection.py
+++ b/dimos/robot/unitree/go2/connection.py
@@ -18,10 +18,10 @@ from importlib import resources
 import sys
 from threading import Thread
 import time
-from typing import Any, Protocol
+from typing import Any, Protocol, cast
 
 from pydantic import Field
-from reactivex import empty
+from reactivex import empty, operators as rxops
 from reactivex.disposable import Disposable
 from reactivex.observable import Observable
 
@@ -39,6 +39,7 @@ from dimos.msgs.geometry_msgs.Quaternion import Quaternion
 from dimos.msgs.geometry_msgs.Transform import Transform
 from dimos.msgs.geometry_msgs.Twist import Twist
 from dimos.msgs.geometry_msgs.Vector3 import Vector3
+from dimos.msgs.nav_msgs.Odometry import Odometry
 from dimos.msgs.sensor_msgs.CameraInfo import CameraInfo
 from dimos.msgs.sensor_msgs.Image import Image
 from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
@@ -224,31 +225,81 @@ class ReplayConnection(UnitreeWebRTCConnection, CompositeResource):
 
     def _stream_name(self, *names: str) -> str:
         """Return the first of ``names`` present in the dataset (stream naming
-        changed over time: mid360 recordings use go2_lidar/go2_odom, older ones
-        lidar/odom)."""
+        changed over time: mid360 Point-LIO uses pointlio_*, mid360 Go2
+        recordings use go2_lidar/go2_odom, older ones lidar/odom).
+
+        Prefer a non-empty stream when an older empty table shares the DB
+        (e.g. Mid-360 recordings that create ``go2_lidar`` but only fill
+        ``pointlio_lidar``).
+        """
         available = self.replay.list_streams()
-        for name in names:
-            if name in available:
+        present = [name for name in names if name in available]
+        if not present:
+            raise KeyError(
+                f"None of {names!r} in dataset {self.dataset!r}; available: {available}"
+            )
+        for name in present:
+            if self.replay.stream(name).count() > 0:
                 return name
-        raise KeyError(f"None of {names!r} in dataset {self.dataset!r}; available: {available}")
+        return present[0]
 
     @simple_mcache
     def lidar_stream(self) -> Observable[PointCloud2]:
-        stream: ReplayStream[PointCloud2] = self.replay.stream(
-            self._stream_name("go2_lidar", "lidar")
-        )
+        name = self._stream_name("go2_lidar", "lidar", "pointlio_lidar")
+        stream: ReplayStream[PointCloud2] = self.replay.stream(name)
+        if name != "pointlio_lidar":
+            return stream.observable()
+
+        # Point-LIO clouds are sensor-frame (mid360_link) but often carry a
+        # baked odom pose on the Observation. Lift into odom so VoxelGridMapper
+        # / relocalization see world-frame clouds like native Go2 lidar.
+        # Decode from the full Observation (not a second sqlite stream) to
+        # avoid concurrent blob-store races.
+        def _decode(obs: Any) -> PointCloud2:
+            cloud = cast("PointCloud2", obs.data)
+            pose = obs.pose
+            if pose is None:
+                return cloud
+            tf = Transform.from_pose(
+                cloud.frame_id,
+                PoseStamped(
+                    ts=cloud.ts,
+                    frame_id="odom",
+                    position=pose.position,
+                    orientation=pose.orientation,
+                ),
+            )
+            out = cloud.transform(tf)
+            out.frame_id = "odom"
+            return out
+
+        stream._decode = _decode  # type: ignore[method-assign]
         return stream.observable()
 
     @simple_mcache
     def odom_stream(self) -> Observable[PoseStamped]:
-        stream: ReplayStream[PoseStamped] = self.replay.stream(
-            self._stream_name("go2_odom", "odom")
-        )
-        return stream.observable()
+        name = self._stream_name("go2_odom", "odom", "pointlio_odometry")
+        if name == "pointlio_odometry":
+            # Point-LIO stores nav_msgs/Odometry; navigation ports want PoseStamped.
+            odom: ReplayStream[Odometry] = self.replay.stream(name)
+            return odom.observable().pipe(rxops.map(lambda msg: msg.to_pose_stamped()))
+        pose_stream: ReplayStream[PoseStamped] = self.replay.stream(name)
+        return pose_stream.observable()
 
     @simple_mcache
     def video_stream(self) -> Observable[Image]:
+        if "color_image" not in self.replay.list_streams():
+            # Mid-360 Point-LIO datasets often have no camera stream.
+            return empty()
         return self.replay.streams.color_image.observable()
+
+    @simple_mcache
+    def tf_stream(self) -> Observable[TFMessage] | None:
+        """Dataset-recorded tf (e.g. odom→mid360_link), when present."""
+        if "tf" not in self.replay.list_streams():
+            return None
+        stream: ReplayStream[TFMessage] = self.replay.stream("tf")
+        return stream.observable()
 
     @simple_mcache
     def lowstate_stream(self) -> Observable:  # type: ignore[type-arg]
@@ -329,6 +380,13 @@ class GO2Connection(Module, Camera, Pointcloud):
 
         if self.config.lidar:
             self.register_disposable(self.connection.lidar_stream().subscribe(self.lidar.publish))
+
+        # Mid-360 Point-LIO recordings store odom→mid360_link on a `tf` stream —
+        # replay that for sensor-frame consumers. Always also drive odom→base_link
+        # from the odom stream so the Go2 box in Rerun (world/tf/base_link) moves.
+        replay_tf = getattr(self.connection, "tf_stream", lambda: None)()
+        if replay_tf is not None and self.config.publish_tf:
+            self.register_disposable(replay_tf.subscribe(self.tf.publish))
         self.register_disposable(self.connection.odom_stream().subscribe(self._publish_tf))
         self.register_disposable(self.connection.lowstate_stream().subscribe(self._on_lowstate))
         self.register_disposable(Disposable(self.cmd_vel.subscribe(self.move)))

--- a/dimos/robot/unitree/go2/go2_mid360_static_transforms.py
+++ b/dimos/robot/unitree/go2/go2_mid360_static_transforms.py
@@ -32,15 +32,25 @@ the live odom -> mid360_link edge writes. The tf buffer composes either directio
 from __future__ import annotations
 
 import math
+from functools import lru_cache
 
+from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
 from dimos.msgs.geometry_msgs.Transform import Transform
+from dimos.msgs.geometry_msgs.Vector3 import Vector3
+from dimos.msgs.nav_msgs.Odometry import Odometry
 from dimos.protocol.tf.static_tf_publisher import (
     FrameSpec,
     StaticTfPublisher,
     frames_to_edge_transforms,
 )
+from dimos.protocol.tf.tf import MultiTBuffer
 
 MID360_PITCH_DOWN = math.radians(60.0)
+# Point-LIO worlds use the start sensor pose as the origin (z≈0), not the floor.
+# A raw mid360→base_link compose drops the body below z=0, so the Go2 box looks
+# half-buried under bottom_cutoff=0 / the z=0.5 grid. Lift by the usual Go2
+# standing height so viz matches go2_odom (~0.32 m).
+POINTLIO_BASE_VIZ_Z_OFFSET = 0.32
 
 # rpy that maps a sensor frame to its optical frame (z-forward, x-right, y-down)
 OPTICAL_RPY = (-math.pi / 2, 0.0, -math.pi / 2)
@@ -57,6 +67,44 @@ def mount_transforms() -> list[Transform]:
     """The mount tree as published: rooted at mid360_link."""
     edges = {t.child_frame_id: t for t in frames_to_edge_transforms(FRAMES)}
     return [-edges["mid360_link"], -edges["front_camera"], edges["camera_optical"]]
+
+
+@lru_cache(maxsize=1)
+def mid360_link_to_base_link() -> Transform:
+    """Static ``mid360_link`` → ``base_link`` from the measured mount tree."""
+    buffer = MultiTBuffer()
+    buffer.receive_transform(*mount_transforms())
+    leg = buffer.get("mid360_link", "base_link")
+    if leg is None:
+        raise RuntimeError("failed to compose mid360_link → base_link from mount_transforms()")
+    return leg
+
+
+def pointlio_odom_to_base_link_pose(odom: Odometry) -> PoseStamped:
+    """Convert Point-LIO ``world``→``mid360_link`` odom to a ``base_link`` pose.
+
+    ``GO2Connection`` publishes replay odom as ``world``→``base_link`` for the
+    Go2 box. Point-LIO's child frame is the pitched lidar (~60° down); composing
+    through the mount puts the visualized robot along the body / motion axis.
+
+    Z is taken from the sensor height plus :data:`POINTLIO_BASE_VIZ_Z_OFFSET`
+    so the box is not half-cut by ``bottom_cutoff=0`` in Point-LIO worlds.
+    """
+    sensor_pose = odom.to_pose_stamped()
+    world_to_sensor = Transform.from_pose("mid360_link", sensor_pose)
+    world_to_base = world_to_sensor + mid360_link_to_base_link()
+    lifted = Transform(
+        translation=Vector3(
+            world_to_base.translation.x,
+            world_to_base.translation.y,
+            world_to_sensor.translation.z + POINTLIO_BASE_VIZ_Z_OFFSET,
+        ),
+        rotation=world_to_base.rotation,
+        frame_id=world_to_base.frame_id,
+        child_frame_id=world_to_base.child_frame_id,
+        ts=world_to_base.ts,
+    )
+    return lifted.to_pose(ts=odom.ts)
 
 
 class Go2Mid360StaticTf(StaticTfPublisher):

--- a/dimos/robot/unitree/go2/test_connection.py
+++ b/dimos/robot/unitree/go2/test_connection.py
@@ -27,7 +27,12 @@ import pytest
 from dimos.core.global_config import GlobalConfig
 from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
 from dimos.robot.unitree.go2 import connection as go2_conn
-from dimos.robot.unitree.go2.connection import ConnectionConfig, GO2Connection
+from dimos.robot.unitree.go2.connection import (
+    ConnectionConfig,
+    GO2Connection,
+    MID360_REPLAY_ODOM_STREAMS,
+    ReplayConnection,
+)
 
 
 @pytest.fixture
@@ -119,3 +124,62 @@ def test_odom_to_tf_prefixed() -> None:
         "robot0/camera_link",
         "robot0/camera_optical",
     )
+
+
+def test_mid360_replay_odom_prefers_pointlio_when_both_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """unitree_mid360_basic prefers pointlio_odometry over non-empty go2_odom."""
+    conn = ReplayConnection(
+        dataset="unused",
+        odom_streams=MID360_REPLAY_ODOM_STREAMS,
+    )
+    counts = {"pointlio_odometry": 10, "go2_odom": 5}
+
+    class _FakeReplay:
+        def list_streams(self) -> list[str]:
+            return list(counts)
+
+        def stream(self, name: str) -> SimpleNamespace:
+            return SimpleNamespace(count=lambda: counts[name])
+
+    monkeypatch.setattr(type(conn), "replay", property(lambda self: _FakeReplay()))
+    assert conn._stream_name(*conn._odom_streams) == "pointlio_odometry"
+
+
+def test_default_replay_odom_prefers_go2_when_both_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Default GO2Connection still prefers go2_odom when both streams are filled."""
+    conn = ReplayConnection(dataset="unused")
+    counts = {"pointlio_odometry": 10, "go2_odom": 5}
+
+    class _FakeReplay:
+        def list_streams(self) -> list[str]:
+            return list(counts)
+
+        def stream(self, name: str) -> SimpleNamespace:
+            return SimpleNamespace(count=lambda: counts[name])
+
+    monkeypatch.setattr(type(conn), "replay", property(lambda self: _FakeReplay()))
+    assert conn._stream_name(*conn._odom_streams) == "go2_odom"
+
+
+def test_mid360_replay_odom_falls_back_to_go2_when_pointlio_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = ReplayConnection(
+        dataset="unused",
+        odom_streams=MID360_REPLAY_ODOM_STREAMS,
+    )
+    counts = {"pointlio_odometry": 0, "go2_odom": 5}
+
+    class _FakeReplay:
+        def list_streams(self) -> list[str]:
+            return list(counts)
+
+        def stream(self, name: str) -> SimpleNamespace:
+            return SimpleNamespace(count=lambda: counts[name])
+
+    monkeypatch.setattr(type(conn), "replay", property(lambda self: _FakeReplay()))
+    assert conn._stream_name(*conn._odom_streams) == "go2_odom"

--- a/dimos/robot/unitree/go2/test_go2_mid360_static_transforms.py
+++ b/dimos/robot/unitree/go2/test_go2_mid360_static_transforms.py
@@ -21,10 +21,16 @@ in FRAMES. These pin the composed result, which is what nav actually uses.
 
 import math
 
+from dimos.msgs.geometry_msgs.Pose import Pose
+from dimos.msgs.geometry_msgs.Quaternion import Quaternion
+from dimos.msgs.geometry_msgs.Vector3 import Vector3
+from dimos.msgs.nav_msgs.Odometry import Odometry
 from dimos.protocol.tf.tf import MultiTBuffer
 from dimos.robot.unitree.go2.go2_mid360_static_transforms import (
     MID360_PITCH_DOWN,
+    POINTLIO_BASE_VIZ_Z_OFFSET,
     mount_transforms,
+    pointlio_odom_to_base_link_pose,
 )
 
 # base_link -> mid360_link, summed down the FRAMES chain.
@@ -62,3 +68,17 @@ def test_camera_optical_hangs_off_base_link() -> None:
     assert optical is not None
     assert abs(optical.translation.x - 0.32715) < 1e-6
     assert abs(optical.translation.z - 0.04297) < 1e-6
+
+
+def test_pointlio_odom_to_base_link_removes_mount_pitch() -> None:
+    """A pure lidar-pitch odom pose should land near level in base_link."""
+    pitched = Quaternion.from_euler(Vector3(0.0, MID360_PITCH_DOWN, 0.0))
+    odom = Odometry(
+        ts=1.0,
+        frame_id="world",
+        child_frame_id="mid360_link",
+        pose=Pose(position=Vector3(1.0, 2.0, 0.5), orientation=pitched),
+    )
+    base = pointlio_odom_to_base_link_pose(odom)
+    assert abs(base.orientation.euler.y) < 1e-6
+    assert abs(base.position.z - (0.5 + POINTLIO_BASE_VIZ_Z_OFFSET)) < 1e-6


### PR DESCRIPTION
## Contribution path

<!-- See CONTRIBUTING.md. Small, safe changes can skip the issue. -->

- Small, safe change that does not need a tracking issue
- Linked issue or discussion: DIM-XXX / #XXX / URL

A PR for some of the main things needed for incorporating a mid360 lidar instead of the go2 default.
PLEASE NOTE: Tests still need to be added and the code needs to be cleaned up, formatted

Video link of the relocalization with the 0.03 voxel size (...screen2) attached below

https://github.com/user-attachments/assets/a50a62a7-669e-47d0-862a-f566c17ad796

youtube link - https://youtu.be/cWDTVGVOkOM

Video link of the relocalization with all the changes for the mid360 0.03 voxel size, fine voxel adjustment and redist change - https://youtu.be/X0Blmo3WqXE

video link for all the changes with the 0.03 voxel size and pointlio odometry
https://youtu.be/XYFap8_wz-k


## Problem

Modifying relocalization specifically for mid360-

## Solution
Changed files to first accept the pointlio stream
Then changed voxel size for the more dense mid360 point cloud.
Added a config option for using mid360 settings as a user directly during map building, relocalization and more
Added some evaluation metrics that show the fitness, ICP RMSE values , log them
The changed fine_voxels and redist values for the relocalization for mid360
For mid360 also incorporated pointlio odometry instead of legged odometry in go2

## How to Test

<!-- Oneliner required to run the actual feature -->
Running the relocalization with the mid360 config

cd ~/dimos
source .venv/bin/activate
export LD_LIBRARY_PATH=$HOME/.local/lib:${LD_LIBRARY_PATH:-}

dimos --replay --replay-db=data/recording_mid360_1stofficetrial \
  --lidar-config mid360 \
  --viewer rerun \
  run unitree-go2-mid360-relocalization \
  --map-file=data/recording_mid360_1stofficetrial3


Command to build premap
dimos map global data/recording_mid360_1stofficetrial --export --lidar-config mid360

Logging fitness, and other values after first relocalization
dimos log -f | rg 'relocalize first event|relocalize:'


<!-- Key design decisions / tradeoffs -->
Using a more refined voxel size while keeping the number of voxels the same - imporves accuracy while just linearly increasing compute a little for mapping , while the ICP registration compute is still the same as number of voxels are the same
<img width="666" height="518" alt="image" src="https://github.com/user-attachments/assets/00035ae0-4c04-4843-a0d8-5afb1880ddc1" />

<img width="712" height="135" alt="image" src="https://github.com/user-attachments/assets/d680dac6-172c-45bf-9361-81b02eb0b3c6" />


Sensor Specs comparison mid360 with go2
<img width="718" height="396" alt="image" src="https://github.com/user-attachments/assets/8f6f6229-4012-4e8a-8993-6674b1e7114e" />


<!-- Keep it high-signal; deep planning belongs in the issue. -->




<!-- for example `dimos run unitree-go2-myfeature` -->
Test script and other testing still needs to be added (Ongoing)

FUTURE and NEXT STEPS
1) BUild and add a regression testing pipeline for such algorithm changes and the results from there
2) Add more unit tests for each function changed wherever tests are not added
3) Optimize /modify a bunch of more things like - ICP RMSE based rejection , ICP divergence check, 
all tuned for the mid360
4) Run a thorough optimization for finding the exact and most optimal values for each of the thresholds, voxel size and more for the mid360
5) Set some more variables like number of voxels minimum and more too
6) Adjust the athens lidar angle for those datasets
7) Adjust the pointlio lidar odometry mount angle to be set by the user
8) Format the code well
9) Incorporate production code aspects, safety aspects in the code
10) Format the code with comments too according to the google coding style or the tempate followed
11) Use a ground truth that is significantly better than pointlio for comparisons
12) Run multiple comparisons on more datasets to confirm similarity of results and inferences accross datasets


## AI assistance

<!-- Required by AI_POLICY.md. Name the tool and the model (e.g. "Claude Code with Opus 4.8") and how much they were involved. Write "None" if unassisted. -->
<!-- You sho-->
Used cursor

## Checklist

- [ ] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
