### PR TITLE
fix(core): match module refs by IS-A so a subclass provider resolves

### DIFF
--- a/dimos/core/coordination/module_coordinator.py
+++ b/dimos/core/coordination/module_coordinator.py
@@ -942,7 +942,12 @@ def _resolve_single_ref(
     is_class_ref = is_module_type(spec)
 
     def satisfies(cls: type) -> bool:
-        return cls is spec if is_class_ref else spec_structural_compliance(cls, spec)
+        # A subclass IS-A the declared provider, so a deployment that swaps in a
+        # subclass (extra ports, per-instance I/O) still satisfies the ref. Exact
+        # identity would resolve to None here, silently.
+        if is_class_ref:
+            return isinstance(cls, type) and issubclass(cls, spec)
+        return spec_structural_compliance(cls, spec)
 
     def module_of(candidate: Any) -> type[ModuleBase]:
         return candidate.module if isinstance(candidate, BlueprintAtom) else candidate

--- a/dimos/core/coordination/test_module_coordinator.py
+++ b/dimos/core/coordination/test_module_coordinator.py
@@ -209,6 +209,11 @@ class Mod2(Module):
     def stop(self) -> None: ...
 
 
+# How a deployment specializes a provider: extra I/O, same RPC surface.
+class Calculator1WithPort(Calculator1):
+    extra_in: In[Image]
+
+
 def _build_without_rerun(blueprint: Blueprint) -> ModuleCoordinator:
     """Build with a parsed viewer override so tests never spawn Rerun."""
     parsed = BlueprintConfigParser(blueprint).parse(
@@ -492,6 +497,26 @@ def test_module_ref_direct() -> None:
         assert mod1 is not None
         assert mod1.calc.compute1(2, 3) == 5
         assert mod1.calc.compute2(1.5, 2.5) == 4.0
+    finally:
+        coordinator.stop()
+
+
+def test_module_ref_direct_accepts_a_subclass_provider() -> None:
+    # A deployment may swap in a subclass to add per-instance ports. Matching
+    # the ref by exact class identity would leave Mod1.calc set to None, with
+    # no error at wiring time and an AttributeError at first use.
+    coordinator = _build_without_rerun(
+        autoconnect(
+            Calculator1WithPort.blueprint(),
+            Mod1.blueprint(),
+        )
+    )
+
+    try:
+        mod1 = coordinator.get_instance(Mod1)
+        assert mod1 is not None
+        assert mod1.calc is not None
+        assert mod1.calc.compute1(2, 3) == 5
     finally:
         coordinator.stop()
 


### PR DESCRIPTION
## Problem

A module can declare that it depends on another module by naming that module's class. The wiring layer matched that dependency by exact class. If a deployment swapped in a subclass, the match failed and the dependency was quietly set to
nothing at all. 

## Solution

Match with `issubclass`, which is what declaring the dependency means.

Only two modules in the tree are depended on by concrete class this way:
`ControlCoordinator` and `GO2Connection`. Every other dependency is declared
through a `*Spec`, which already matched structurally and so accepted subclasses.
That is why this never surfaced before: no deployment had yet subclassed either
one in a blueprint that also contained a module depending on it.


---

## Breaking Changes

None.

---

## How to Test

1. `pytest dimos/core/coordination/test_module_coordinator.py` — 48 pass.
2. The added `test_module_ref_direct_accepts_a_subclass_provider` is the regression
   guard; revert the one-line change and it fails, which is how it was verified.
3. `pytest dimos/core` — one unrelated pre-existing failure, `test_module_reloading`,
   which fails identically on a clean `main` checkout.
EOF
gh pr create --repo dimensionalOS/dimos --base main --head core-module-ref-subclass-match --title "fix(core): match module refs by IS-A so a subclass provider resolves" --body-file /tmp/claude-1001/-home-mustafa-dimos/2e38385f-08b5-4bd8-ac72-4fd29234694d/scratchpad/core-pr.md 2>&1 | tail -3