### PR TITLE
feat(evals): pointcloud VQA suite + PointCloud2.agent_encode

### DIFF
--- a/dimos/evals/cli.py
+++ b/dimos/evals/cli.py
@@ -35,6 +35,10 @@ def run(
     attach: bool = typer.Option(False, help="Drive an already-running dimos (interactive cases)"),
     limit: int = typer.Option(0, help="Run at most N cases"),
     live_db: str = typer.Option("recording.db", help="Live Recorder db (interactive cases)"),
+    min_mean: float = typer.Option(0.0, help="Exit non-zero if mean score falls below this"),
+    max_mean: float = typer.Option(
+        1.0, help="Exit non-zero if mean score exceeds this (blind-ablation ceiling)"
+    ),
 ) -> None:
     from dimos.evals.runner import EvalRunner, summarize
 
@@ -58,6 +62,9 @@ def run(
         f"\n{s.n} cases | mean {s.mean_score:.2f} | pass {s.pass_rate:.0%} "
         f"| errors {s.errors} | {s.duration_s:.0f}s | {runner.run_dir}"
     )
+    if not min_mean <= s.mean_score <= max_mean:
+        typer.echo(f"FAIL: mean {s.mean_score:.3f} outside [{min_mean}, {max_mean}]", err=True)
+        raise typer.Exit(1)
 
 
 @app.command("list")

--- a/dimos/evals/generate.py
+++ b/dimos/evals/generate.py
@@ -12,27 +12,72 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Eval-row generators — deferred feature (PRD: low priority), kept minimal.
+"""Eval-row generators.
 
-Ground truth is computed analytically from a *privileged* modality; the emitted
-case quizzes a different (or lossily-encoded) surface. Rows are pure data —
-a suite module maps them onto typed :class:`PassiveEval` cases.
+Ground truth is computed analytically from a *privileged* modality (full-res
+clouds, odom); the emitted case quizzes a different — or lossily encoded —
+surface. Rows are pure data; a suite module maps them onto typed
+:class:`~dimos.evals.types.PassiveEval` cases.
+
+Row schema::
+
+    {"id", "family", "type": "numeric"|"mcq", "q", "a",
+     "band" (numeric) | "choices" (mcq),
+     "context": [[stream, [t0, t1]], ...], "dataset"}
 """
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any, cast
 
+import numpy as np
+
+from dimos.evals.scorers import choice, exact, first_number, within
+from dimos.evals.types import PassiveEval
 from dimos.memory.cli.dataset import open_dataset
 
+if TYPE_CHECKING:
+    from dimos.memory.store.base import Store
+
 Row = dict[str, object]
+
+COMPASS = ("east", "northeast", "north", "northwest", "west", "southwest", "south", "southeast")
+BODY_Z = (0.15, 1.0)  # world-frame band: above floor returns, below robot cap
+VOXEL = 0.2
+
+
+@contextmanager
+def _dataset(name: str) -> Iterator[Store]:
+    store = open_dataset(name)
+    try:
+        yield store
+    finally:
+        store.stop()
+
+
+def _compass_of(v: np.ndarray) -> str:
+    return COMPASS[int(np.round(np.arctan2(v[1], v[0]) / (np.pi / 4))) % 8]
+
+
+def _voxels2d(pts: np.ndarray, cell: float = VOXEL) -> set[tuple[int, int]]:
+    return set(map(tuple, np.floor(pts[:, :2] / cell).astype(int)))
+
+
+def _cloud_at(store: Store, t: float) -> tuple[np.ndarray, list[list[object]]]:
+    """Points of the last cloud at or before ``t``, plus a context window that
+    selects that one frame."""
+    lidar = store.streams.lidar
+    obs = lidar.range_time(0, t).to_list()[-1]
+    ts = obs.ts - lidar.first().ts
+    return obs.data.points_f32(), [["lidar", [round(ts - 0.05, 2), round(ts + 0.05, 2)]]]
 
 
 def displacement_rows(dataset: str, windows: Sequence[tuple[float, float]]) -> list[Row]:
     """Straight-line displacement over each window (odom is the privileged truth;
     the case quizzes the encoded odom summary). Sampling-invariant ground truth."""
-    store = open_dataset(dataset)
-    try:
+    with _dataset(dataset) as store:
         rows: list[Row] = []
         for t1, t2 in windows:
             obs = store.streams.odom.range_time(t1, t2).to_list()
@@ -42,25 +87,24 @@ def displacement_rows(dataset: str, windows: Sequence[tuple[float, float]]) -> l
             rows.append(
                 {
                     "id": f"{dataset}_disp_{t1:g}_{t2:g}",
+                    "family": "displacement",
+                    "type": "numeric",
                     "q": "How far in a straight line is your final position from your "
-                    "position at the first shown observation, in meters?",
+                    "position at the first shown observation, in meters? Answer with a single "
+                    "number.",
                     "a": round(d, 1),
                     "band": max(1.0, d * 0.4),
-                    "stream": "odom",
-                    "window": [t1, t2],
+                    "context": [["odom", [t1, t2]]],
                     "dataset": dataset,
                 }
             )
         return rows
-    finally:
-        store.stop()
 
 
 def path_length_rows(dataset: str, windows: Sequence[tuple[float, float]]) -> list[Row]:
     """Integrated path length per window. Deliberately hard on a downsampled
     encoding — expect partial credit; that gap is the finding."""
-    store = open_dataset(dataset)
-    try:
+    with _dataset(dataset) as store:
         rows: list[Row] = []
         for t1, t2 in windows:
             path, prev = 0.0, None
@@ -74,15 +118,284 @@ def path_length_rows(dataset: str, windows: Sequence[tuple[float, float]]) -> li
             rows.append(
                 {
                     "id": f"{dataset}_path_{t1:g}_{t2:g}",
+                    "family": "path_length",
+                    "type": "numeric",
                     "q": "Roughly how many meters did you travel in total over these "
-                    "observations (path length, not displacement)?",
+                    "observations (path length, not displacement)? Answer with a single "
+                    "number.",
                     "a": round(path, 1),
                     "band": max(2.0, path * 0.5),
-                    "stream": "odom",
-                    "window": [t1, t2],
+                    "context": [["odom", [t1, t2]]],
                     "dataset": dataset,
                 }
             )
         return rows
-    finally:
-        store.stop()
+
+
+def extent_rows(dataset: str, timestamps: Sequence[float]) -> list[Row]:
+    """Largest horizontal bbox side of a single cloud."""
+    with _dataset(dataset) as store:
+        rows: list[Row] = []
+        for t in timestamps:
+            pts, context = _cloud_at(store, t)
+            a = round(float(max(np.ptp(pts[:, 0]), np.ptp(pts[:, 1]))), 2)
+            rows.append(
+                {
+                    "id": f"{dataset}_extent_t{t:g}",
+                    "family": "extent",
+                    "type": "numeric",
+                    "q": "Consider the mapped point cloud shown. What is its largest "
+                    "horizontal extent (the longer side of its axis-aligned "
+                    "bounding box in the x-y plane), in meters? Answer with a single number.",
+                    "a": a,
+                    "band": round(max(0.5, 0.10 * a), 2),
+                    "context": context,
+                    "dataset": dataset,
+                }
+            )
+        return rows
+
+
+def zspan_rows(dataset: str, timestamps: Sequence[float]) -> list[Row]:
+    """Vertical span of a single cloud."""
+    with _dataset(dataset) as store:
+        rows: list[Row] = []
+        for t in timestamps:
+            pts, context = _cloud_at(store, t)
+            rows.append(
+                {
+                    "id": f"{dataset}_zspan_t{t:g}",
+                    "family": "zspan",
+                    "type": "numeric",
+                    "q": "Consider the mapped point cloud shown. What is its vertical "
+                    "span (max z minus min z), in meters? Answer with a single number.",
+                    "a": round(float(np.ptp(pts[:, 2])), 2),
+                    "band": 0.3,
+                    "context": context,
+                    "dataset": dataset,
+                }
+            )
+        return rows
+
+
+def footprint_rows(dataset: str, timestamps: Sequence[float], *, cell: float = VOXEL) -> list[Row]:
+    """Mapped floor area of a single cloud (occupied x-y cells)."""
+    with _dataset(dataset) as store:
+        rows: list[Row] = []
+        for t in timestamps:
+            pts, context = _cloud_at(store, t)
+            area = round(len(_voxels2d(pts, cell)) * cell * cell, 1)
+            rows.append(
+                {
+                    "id": f"{dataset}_area_t{t:g}",
+                    "family": "area",
+                    "type": "numeric",
+                    "q": "Consider the local map point cloud shown. Roughly how many "
+                    "square meters of floor plan does it cover (footprint of the "
+                    "mapped points projected onto the x-y plane)? Answer with a single number.",
+                    "a": area,
+                    "band": round(max(3.0, 0.25 * area), 1),
+                    "context": context,
+                    "dataset": dataset,
+                }
+            )
+        return rows
+
+
+def nearest_obstacle_rows(
+    dataset: str, timestamps: Sequence[float], *, z_band: tuple[float, float] = BODY_Z
+) -> list[Row]:
+    """Horizontal clearance from the robot's own pose to the nearest body-height
+    point — the only family that needs two streams (cloud + odom)."""
+    with _dataset(dataset) as store:
+        rows: list[Row] = []
+        for t in timestamps:
+            pts, context = _cloud_at(store, t)
+            odom = store.streams.odom.range_time(0, t).to_list()[-1].data.position
+            band = pts[(pts[:, 2] >= z_band[0]) & (pts[:, 2] <= z_band[1])]
+            d = np.hypot(band[:, 0] - odom.x, band[:, 1] - odom.y)
+            d = d[d > 0.15]  # the robot's own return
+            a = round(float(d.min()), 2)
+            rows.append(
+                {
+                    "id": f"{dataset}_nearest_t{t:g}",
+                    "family": "nearest",
+                    "type": "numeric",
+                    "q": "You are the robot; your current pose is the odom observation "
+                    f"shown. Using the mapped point cloud, how far away is the "
+                    f"nearest obstacle point at body height (z between {z_band[0]} "
+                    f"and {z_band[1]} m), horizontal distance in meters? Answer with a single "
+                    "number.",
+                    "a": a,
+                    "band": round(max(0.25, 0.30 * a), 2),
+                    "context": [
+                        *context,
+                        ["odom", [round(max(0.0, t - 0.5), 2), round(t + 0.1, 2)]],
+                    ],
+                    "dataset": dataset,
+                }
+            )
+        return rows
+
+
+def map_shift_rows(dataset: str, windows: Sequence[tuple[float, float]]) -> list[Row]:
+    """How far the mapped region's center moved across a window. Meaningful only
+    where the cloud is a rolling local map, not an accumulated one."""
+    with _dataset(dataset) as store:
+        rows: list[Row] = []
+        for w0, w1 in windows:
+            frames = store.streams.lidar.range_time(w0, w1).to_list()
+            shift = frames[-1].data.points_f32()[:, :2].mean(axis=0) - frames[0].data.points_f32()[
+                :, :2
+            ].mean(axis=0)
+            s = round(float(np.hypot(*shift)), 1)
+            rows.append(
+                {
+                    "id": f"{dataset}_shift_{w0:g}_{w1:g}",
+                    "family": "shift",
+                    "type": "numeric",
+                    "q": "You are shown a sequence of local map point clouds over "
+                    "time (world coordinates). The local map follows the robot. "
+                    "Roughly how far did the center of the mapped region move "
+                    "from the first shown cloud to the last, in meters? Answer with a single "
+                    "number.",
+                    "a": s,
+                    "band": round(max(1.0, 0.30 * s), 1),
+                    "context": [["lidar", [w0, w1]]],
+                    "dataset": dataset,
+                }
+            )
+        return rows
+
+
+def map_direction_rows(
+    dataset: str, windows: Sequence[tuple[float, float]], *, min_shift: float = 1.0
+) -> list[Row]:
+    """Compass direction the mapped region's center travelled. Windows whose
+    shift is under ``min_shift`` are skipped — the answer would be noise."""
+    with _dataset(dataset) as store:
+        rows: list[Row] = []
+        for w0, w1 in windows:
+            frames = store.streams.lidar.range_time(w0, w1).to_list()
+            shift = frames[-1].data.points_f32()[:, :2].mean(axis=0) - frames[0].data.points_f32()[
+                :, :2
+            ].mean(axis=0)
+            if np.hypot(*shift) < min_shift:
+                continue
+            rows.append(
+                {
+                    "id": f"{dataset}_direction_{w0:g}_{w1:g}",
+                    "family": "direction",
+                    "type": "mcq",
+                    "q": "You are shown a sequence of local map point clouds over "
+                    "time (world frame: +x is east, +y is north). The local map "
+                    "follows the robot. In which compass direction did the "
+                    "mapped region's center move overall? Answer with exactly "
+                    "one of: " + ", ".join(COMPASS) + ".",
+                    "a": _compass_of(shift),
+                    "choices": list(COMPASS),
+                    "context": [["lidar", [w0, w1]]],
+                    "dataset": dataset,
+                }
+            )
+        return rows
+
+
+def area_trend_rows(dataset: str, windows: Sequence[tuple[float, float]]) -> list[Row]:
+    """Grow / shrink / same over a window — a 3-way MCQ, so a blind guess floors
+    at ~0.33 rather than the ~0.5 a yes/no would give away."""
+    with _dataset(dataset) as store:
+        rows: list[Row] = []
+        for w0, w1 in windows:
+            frames = store.streams.lidar.range_time(w0, w1).to_list()
+            first = _voxels2d(frames[0].data.points_f32())
+            last = _voxels2d(frames[-1].data.points_f32())
+            ratio = len(last) / max(1, len(first))
+            rows.append(
+                {
+                    "id": f"{dataset}_areatrend_{w0:g}_{w1:g}",
+                    "family": "areatrend",
+                    "type": "mcq",
+                    "q": "You are shown a sequence of mapped point clouds over time. "
+                    "From the first shown cloud to the last, does the mapped "
+                    "floor area grow, shrink, or stay about the same? Answer "
+                    "with exactly one word: grow, shrink, or same.",
+                    "a": "grow" if ratio > 1.05 else ("shrink" if ratio < 0.95 else "same"),
+                    "choices": ["grow", "shrink", "same"],
+                    "context": [["lidar", [w0, w1]]],
+                    "dataset": dataset,
+                }
+            )
+        return rows
+
+
+def coverage_direction_rows(
+    dataset: str, windows: Sequence[tuple[float, float]], *, min_new_cells: int = 50
+) -> list[Row]:
+    """Compass direction of newly mapped coverage, for accumulated maps (where
+    :func:`map_direction_rows` degenerates because the center barely moves)."""
+    with _dataset(dataset) as store:
+        rows: list[Row] = []
+        for w0, w1 in windows:
+            frames = store.streams.lidar.range_time(w0, w1).to_list()
+            first = _voxels2d(frames[0].data.points_f32())
+            new = np.array(sorted(_voxels2d(frames[-1].data.points_f32()) - first))
+            if len(new) < min_new_cells:
+                continue
+            gained = new.mean(axis=0) * VOXEL - np.array(sorted(first)).mean(axis=0) * VOXEL
+            rows.append(
+                {
+                    "id": f"{dataset}_coverage_{w0:g}_{w1:g}",
+                    "family": "direction",
+                    "type": "mcq",
+                    "q": "You are shown a sequence of mapped point clouds over time "
+                    "(world frame: +x is east, +y is north). In which compass "
+                    "direction, relative to the center of the first shown cloud, "
+                    "did the map gain most of its new coverage? Answer with "
+                    "exactly one of: " + ", ".join(COMPASS) + ".",
+                    "a": _compass_of(gained),
+                    "choices": list(COMPASS),
+                    "context": [["lidar", [w0, w1]]],
+                    "dataset": dataset,
+                }
+            )
+        return rows
+
+
+def cases(rows: Sequence[Row], *, tags: frozenset[str] = frozenset()) -> list[PassiveEval[Any]]:
+    """Rows -> typed cases. The mirror of the schema above: numeric rows score
+    on a band, mcq rows on exact match against the named options."""
+    out: list[PassiveEval[Any]] = []
+    for row in rows:
+        context = tuple(
+            (lambda s, n=str(name), w=tuple(window): s.streams[n].range_time(*w))
+            for name, window in cast("list[tuple[str, list[float]]]", row["context"])
+        )
+        case_tags = tags | {str(row["family"]), str(row["type"])}
+        if row["type"] == "numeric":
+            out.append(
+                PassiveEval(
+                    id=str(row["id"]),
+                    inputs=str(row["q"]),
+                    expected=float(cast("float", row["a"])),
+                    parse=first_number,
+                    score=within(float(cast("float", row["band"]))),
+                    context=context,
+                    dataset=str(row["dataset"]),
+                    tags=case_tags,
+                )
+            )
+        else:
+            out.append(
+                PassiveEval(
+                    id=str(row["id"]),
+                    inputs=str(row["q"]),
+                    expected=str(row["a"]),
+                    parse=choice(cast("list[str]", row["choices"])),
+                    score=exact,
+                    context=context,
+                    dataset=str(row["dataset"]),
+                    tags=case_tags,
+                )
+            )
+    return out

--- a/dimos/evals/scorers.py
+++ b/dimos/evals/scorers.py
@@ -57,9 +57,21 @@ def yes_no(text: str) -> str:
     raise ValueError(f"not a yes/no reply: {text[:80]!r}")
 
 
-def choice(text: str) -> str:
-    """Normalize a multiple-choice reply for exact comparison."""
-    return text.strip().lower().rstrip(".")
+def choice(options: Sequence[str]) -> Callable[[str], str]:
+    """Parser for a multiple-choice reply: the last option the model names, so
+    that reasoning before the answer does not decide it. Longest option first,
+    so "northeast" wins over "north"."""
+    import re
+
+    pattern = re.compile(r"\b(" + "|".join(sorted(options, key=len, reverse=True)) + r")\b", re.I)
+
+    def parse(text: str) -> str:
+        found = pattern.findall(text)
+        if not found:
+            raise ValueError(f"no option from {list(options)} in reply: {text[:80]!r}")
+        return str(found[-1]).lower()
+
+    return parse
 
 
 def within(band: float) -> Callable[[float, float], float]:

--- a/dimos/evals/suites/go2_pointcloud.py
+++ b/dimos/evals/suites/go2_pointcloud.py
@@ -1,0 +1,70 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Pointcloud geometry VQA over the go2 replays.
+
+Rows (``go2_pointcloud_vqa.json``) are pure data emitted by :func:`rows` —
+ground truth computed analytically from full-resolution clouds plus odom,
+quizzing whatever lossy encoding the agent receives for a ``PointCloud2``.
+
+``go2_short`` maps its whole room in the first frame (an accumulated map);
+``go2_bigoffice`` is a 292 s exploration whose lidar is a rolling ~6 m local
+window, which is why the two datasets take different stream families.
+
+Regenerate (needs both recordings)::
+
+    python -m dimos.evals.suites.go2_pointcloud
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from dimos.evals import generate
+from dimos.evals.types import Suite
+
+_JSON = Path(__file__).parent / "go2_pointcloud_vqa.json"
+
+SUITE: Suite = generate.cases(json.loads(_JSON.read_text()), tags=frozenset({"pointcloud"}))
+
+_SHORT_TS = [5.0, 20.0, 40.0, 58.0]
+_SHORT_WINDOWS = [(0.0, 20.0), (15.0, 45.0), (30.0, 59.0), (0.0, 59.0)]
+_BIGOFFICE_TS = [10.0, 80.0, 150.0, 220.0, 285.0]
+_BIGOFFICE_WINDOWS = [(0.0, 60.0), (60.0, 150.0), (150.0, 240.0), (200.0, 291.0), (0.0, 291.0)]
+
+
+def rows() -> list[generate.Row]:
+    """The generator calls behind the committed JSON.
+
+    ponytail: go2_short gets no shift/extent-change families — it maps the room
+    in frame 1, so those truths degenerate to ~0 and a blind "0" wins.
+    """
+    short, big = "go2_short", "go2_bigoffice"
+    return [
+        *generate.extent_rows(short, _SHORT_TS),
+        *generate.zspan_rows(short, _SHORT_TS),
+        *generate.nearest_obstacle_rows(short, _SHORT_TS),
+        *generate.area_trend_rows(short, _SHORT_WINDOWS),
+        *generate.coverage_direction_rows(short, _SHORT_WINDOWS),
+        *generate.nearest_obstacle_rows(big, _BIGOFFICE_TS),
+        *generate.footprint_rows(big, _BIGOFFICE_TS),
+        *generate.map_shift_rows(big, _BIGOFFICE_WINDOWS),
+        *generate.map_direction_rows(big, _BIGOFFICE_WINDOWS),
+    ]
+
+
+if __name__ == "__main__":
+    _JSON.write_text(json.dumps(rows(), indent=2) + "\n")

--- a/dimos/evals/suites/go2_pointcloud_vqa.json
+++ b/dimos/evals/suites/go2_pointcloud_vqa.json
@@ -1,0 +1,882 @@
+[
+  {
+    "id": "go2_short_extent_t5",
+    "family": "extent",
+    "type": "numeric",
+    "q": "Consider the mapped point cloud shown. What is its largest horizontal extent (the longer side of its axis-aligned bounding box in the x-y plane), in meters? Answer with a single number.",
+    "a": 6.3,
+    "band": 0.63,
+    "context": [
+      [
+        "lidar",
+        [
+          4.89,
+          4.99
+        ]
+      ]
+    ],
+    "dataset": "go2_short"
+  },
+  {
+    "id": "go2_short_zspan_t5",
+    "family": "zspan",
+    "type": "numeric",
+    "q": "Consider the mapped point cloud shown. What is its vertical span (max z minus min z), in meters? Answer with a single number.",
+    "a": 1.4,
+    "band": 0.3,
+    "context": [
+      [
+        "lidar",
+        [
+          4.89,
+          4.99
+        ]
+      ]
+    ],
+    "dataset": "go2_short"
+  },
+  {
+    "id": "go2_short_nearest_t5",
+    "family": "nearest",
+    "type": "numeric",
+    "q": "You are the robot; your current pose is the odom observation shown. Using the mapped point cloud, how far away is the nearest obstacle point at body height (z between 0.15 and 1.0 m), horizontal distance in meters? Answer with a single number.",
+    "a": 0.66,
+    "band": 0.25,
+    "context": [
+      [
+        "lidar",
+        [
+          4.89,
+          4.99
+        ]
+      ],
+      [
+        "odom",
+        [
+          4.5,
+          5.1
+        ]
+      ]
+    ],
+    "dataset": "go2_short"
+  },
+  {
+    "id": "go2_short_extent_t20",
+    "family": "extent",
+    "type": "numeric",
+    "q": "Consider the mapped point cloud shown. What is its largest horizontal extent (the longer side of its axis-aligned bounding box in the x-y plane), in meters? Answer with a single number.",
+    "a": 6.35,
+    "band": 0.64,
+    "context": [
+      [
+        "lidar",
+        [
+          19.85,
+          19.95
+        ]
+      ]
+    ],
+    "dataset": "go2_short"
+  },
+  {
+    "id": "go2_short_zspan_t20",
+    "family": "zspan",
+    "type": "numeric",
+    "q": "Consider the mapped point cloud shown. What is its vertical span (max z minus min z), in meters? Answer with a single number.",
+    "a": 1.25,
+    "band": 0.3,
+    "context": [
+      [
+        "lidar",
+        [
+          19.85,
+          19.95
+        ]
+      ]
+    ],
+    "dataset": "go2_short"
+  },
+  {
+    "id": "go2_short_nearest_t20",
+    "family": "nearest",
+    "type": "numeric",
+    "q": "You are the robot; your current pose is the odom observation shown. Using the mapped point cloud, how far away is the nearest obstacle point at body height (z between 0.15 and 1.0 m), horizontal distance in meters? Answer with a single number.",
+    "a": 0.62,
+    "band": 0.25,
+    "context": [
+      [
+        "lidar",
+        [
+          19.85,
+          19.95
+        ]
+      ],
+      [
+        "odom",
+        [
+          19.5,
+          20.1
+        ]
+      ]
+    ],
+    "dataset": "go2_short"
+  },
+  {
+    "id": "go2_short_extent_t40",
+    "family": "extent",
+    "type": "numeric",
+    "q": "Consider the mapped point cloud shown. What is its largest horizontal extent (the longer side of its axis-aligned bounding box in the x-y plane), in meters? Answer with a single number.",
+    "a": 6.35,
+    "band": 0.64,
+    "context": [
+      [
+        "lidar",
+        [
+          39.87,
+          39.97
+        ]
+      ]
+    ],
+    "dataset": "go2_short"
+  },
+  {
+    "id": "go2_short_zspan_t40",
+    "family": "zspan",
+    "type": "numeric",
+    "q": "Consider the mapped point cloud shown. What is its vertical span (max z minus min z), in meters? Answer with a single number.",
+    "a": 1.3,
+    "band": 0.3,
+    "context": [
+      [
+        "lidar",
+        [
+          39.87,
+          39.97
+        ]
+      ]
+    ],
+    "dataset": "go2_short"
+  },
+  {
+    "id": "go2_short_nearest_t40",
+    "family": "nearest",
+    "type": "numeric",
+    "q": "You are the robot; your current pose is the odom observation shown. Using the mapped point cloud, how far away is the nearest obstacle point at body height (z between 0.15 and 1.0 m), horizontal distance in meters? Answer with a single number.",
+    "a": 0.5,
+    "band": 0.25,
+    "context": [
+      [
+        "lidar",
+        [
+          39.87,
+          39.97
+        ]
+      ],
+      [
+        "odom",
+        [
+          39.5,
+          40.1
+        ]
+      ]
+    ],
+    "dataset": "go2_short"
+  },
+  {
+    "id": "go2_short_extent_t58",
+    "family": "extent",
+    "type": "numeric",
+    "q": "Consider the mapped point cloud shown. What is its largest horizontal extent (the longer side of its axis-aligned bounding box in the x-y plane), in meters? Answer with a single number.",
+    "a": 6.35,
+    "band": 0.64,
+    "context": [
+      [
+        "lidar",
+        [
+          57.94,
+          58.04
+        ]
+      ]
+    ],
+    "dataset": "go2_short"
+  },
+  {
+    "id": "go2_short_zspan_t58",
+    "family": "zspan",
+    "type": "numeric",
+    "q": "Consider the mapped point cloud shown. What is its vertical span (max z minus min z), in meters? Answer with a single number.",
+    "a": 1.4,
+    "band": 0.3,
+    "context": [
+      [
+        "lidar",
+        [
+          57.94,
+          58.04
+        ]
+      ]
+    ],
+    "dataset": "go2_short"
+  },
+  {
+    "id": "go2_short_nearest_t58",
+    "family": "nearest",
+    "type": "numeric",
+    "q": "You are the robot; your current pose is the odom observation shown. Using the mapped point cloud, how far away is the nearest obstacle point at body height (z between 0.15 and 1.0 m), horizontal distance in meters? Answer with a single number.",
+    "a": 0.89,
+    "band": 0.27,
+    "context": [
+      [
+        "lidar",
+        [
+          57.94,
+          58.04
+        ]
+      ],
+      [
+        "odom",
+        [
+          57.5,
+          58.1
+        ]
+      ]
+    ],
+    "dataset": "go2_short"
+  },
+  {
+    "id": "go2_short_areatrend_0_20",
+    "family": "areatrend",
+    "type": "mcq",
+    "q": "You are shown a sequence of mapped point clouds over time. From the first shown cloud to the last, does the mapped floor area grow, shrink, or stay about the same? Answer with exactly one word: grow, shrink, or same.",
+    "a": "shrink",
+    "choices": [
+      "grow",
+      "shrink",
+      "same"
+    ],
+    "context": [
+      [
+        "lidar",
+        [
+          0.0,
+          20.0
+        ]
+      ]
+    ],
+    "dataset": "go2_short"
+  },
+  {
+    "id": "go2_short_coverage_0_20",
+    "family": "direction",
+    "type": "mcq",
+    "q": "You are shown a sequence of mapped point clouds over time (world frame: +x is east, +y is north). In which compass direction, relative to the center of the first shown cloud, did the map gain most of its new coverage? Answer with exactly one of: east, northeast, north, northwest, west, southwest, south, southeast.",
+    "a": "north",
+    "choices": [
+      "east",
+      "northeast",
+      "north",
+      "northwest",
+      "west",
+      "southwest",
+      "south",
+      "southeast"
+    ],
+    "context": [
+      [
+        "lidar",
+        [
+          0.0,
+          20.0
+        ]
+      ]
+    ],
+    "dataset": "go2_short"
+  },
+  {
+    "id": "go2_short_areatrend_15_45",
+    "family": "areatrend",
+    "type": "mcq",
+    "q": "You are shown a sequence of mapped point clouds over time. From the first shown cloud to the last, does the mapped floor area grow, shrink, or stay about the same? Answer with exactly one word: grow, shrink, or same.",
+    "a": "grow",
+    "choices": [
+      "grow",
+      "shrink",
+      "same"
+    ],
+    "context": [
+      [
+        "lidar",
+        [
+          15.0,
+          45.0
+        ]
+      ]
+    ],
+    "dataset": "go2_short"
+  },
+  {
+    "id": "go2_short_coverage_15_45",
+    "family": "direction",
+    "type": "mcq",
+    "q": "You are shown a sequence of mapped point clouds over time (world frame: +x is east, +y is north). In which compass direction, relative to the center of the first shown cloud, did the map gain most of its new coverage? Answer with exactly one of: east, northeast, north, northwest, west, southwest, south, southeast.",
+    "a": "south",
+    "choices": [
+      "east",
+      "northeast",
+      "north",
+      "northwest",
+      "west",
+      "southwest",
+      "south",
+      "southeast"
+    ],
+    "context": [
+      [
+        "lidar",
+        [
+          15.0,
+          45.0
+        ]
+      ]
+    ],
+    "dataset": "go2_short"
+  },
+  {
+    "id": "go2_short_areatrend_30_59",
+    "family": "areatrend",
+    "type": "mcq",
+    "q": "You are shown a sequence of mapped point clouds over time. From the first shown cloud to the last, does the mapped floor area grow, shrink, or stay about the same? Answer with exactly one word: grow, shrink, or same.",
+    "a": "grow",
+    "choices": [
+      "grow",
+      "shrink",
+      "same"
+    ],
+    "context": [
+      [
+        "lidar",
+        [
+          30.0,
+          59.0
+        ]
+      ]
+    ],
+    "dataset": "go2_short"
+  },
+  {
+    "id": "go2_short_coverage_30_59",
+    "family": "direction",
+    "type": "mcq",
+    "q": "You are shown a sequence of mapped point clouds over time (world frame: +x is east, +y is north). In which compass direction, relative to the center of the first shown cloud, did the map gain most of its new coverage? Answer with exactly one of: east, northeast, north, northwest, west, southwest, south, southeast.",
+    "a": "southwest",
+    "choices": [
+      "east",
+      "northeast",
+      "north",
+      "northwest",
+      "west",
+      "southwest",
+      "south",
+      "southeast"
+    ],
+    "context": [
+      [
+        "lidar",
+        [
+          30.0,
+          59.0
+        ]
+      ]
+    ],
+    "dataset": "go2_short"
+  },
+  {
+    "id": "go2_short_areatrend_0_59",
+    "family": "areatrend",
+    "type": "mcq",
+    "q": "You are shown a sequence of mapped point clouds over time. From the first shown cloud to the last, does the mapped floor area grow, shrink, or stay about the same? Answer with exactly one word: grow, shrink, or same.",
+    "a": "grow",
+    "choices": [
+      "grow",
+      "shrink",
+      "same"
+    ],
+    "context": [
+      [
+        "lidar",
+        [
+          0.0,
+          59.0
+        ]
+      ]
+    ],
+    "dataset": "go2_short"
+  },
+  {
+    "id": "go2_short_coverage_0_59",
+    "family": "direction",
+    "type": "mcq",
+    "q": "You are shown a sequence of mapped point clouds over time (world frame: +x is east, +y is north). In which compass direction, relative to the center of the first shown cloud, did the map gain most of its new coverage? Answer with exactly one of: east, northeast, north, northwest, west, southwest, south, southeast.",
+    "a": "southwest",
+    "choices": [
+      "east",
+      "northeast",
+      "north",
+      "northwest",
+      "west",
+      "southwest",
+      "south",
+      "southeast"
+    ],
+    "context": [
+      [
+        "lidar",
+        [
+          0.0,
+          59.0
+        ]
+      ]
+    ],
+    "dataset": "go2_short"
+  },
+  {
+    "id": "go2_bigoffice_nearest_t10",
+    "family": "nearest",
+    "type": "numeric",
+    "q": "You are the robot; your current pose is the odom observation shown. Using the mapped point cloud, how far away is the nearest obstacle point at body height (z between 0.15 and 1.0 m), horizontal distance in meters? Answer with a single number.",
+    "a": 0.95,
+    "band": 0.28,
+    "context": [
+      [
+        "lidar",
+        [
+          9.94,
+          10.04
+        ]
+      ],
+      [
+        "odom",
+        [
+          9.5,
+          10.1
+        ]
+      ]
+    ],
+    "dataset": "go2_bigoffice"
+  },
+  {
+    "id": "go2_bigoffice_area_t10",
+    "family": "area",
+    "type": "numeric",
+    "q": "Consider the local map point cloud shown. Roughly how many square meters of floor plan does it cover (footprint of the mapped points projected onto the x-y plane)? Answer with a single number.",
+    "a": 32.5,
+    "band": 8.1,
+    "context": [
+      [
+        "lidar",
+        [
+          9.94,
+          10.04
+        ]
+      ]
+    ],
+    "dataset": "go2_bigoffice"
+  },
+  {
+    "id": "go2_bigoffice_nearest_t80",
+    "family": "nearest",
+    "type": "numeric",
+    "q": "You are the robot; your current pose is the odom observation shown. Using the mapped point cloud, how far away is the nearest obstacle point at body height (z between 0.15 and 1.0 m), horizontal distance in meters? Answer with a single number.",
+    "a": 0.29,
+    "band": 0.25,
+    "context": [
+      [
+        "lidar",
+        [
+          79.84,
+          79.94
+        ]
+      ],
+      [
+        "odom",
+        [
+          79.5,
+          80.1
+        ]
+      ]
+    ],
+    "dataset": "go2_bigoffice"
+  },
+  {
+    "id": "go2_bigoffice_area_t80",
+    "family": "area",
+    "type": "numeric",
+    "q": "Consider the local map point cloud shown. Roughly how many square meters of floor plan does it cover (footprint of the mapped points projected onto the x-y plane)? Answer with a single number.",
+    "a": 29.8,
+    "band": 7.5,
+    "context": [
+      [
+        "lidar",
+        [
+          79.84,
+          79.94
+        ]
+      ]
+    ],
+    "dataset": "go2_bigoffice"
+  },
+  {
+    "id": "go2_bigoffice_nearest_t150",
+    "family": "nearest",
+    "type": "numeric",
+    "q": "You are the robot; your current pose is the odom observation shown. Using the mapped point cloud, how far away is the nearest obstacle point at body height (z between 0.15 and 1.0 m), horizontal distance in meters? Answer with a single number.",
+    "a": 0.97,
+    "band": 0.29,
+    "context": [
+      [
+        "lidar",
+        [
+          149.83,
+          149.93
+        ]
+      ],
+      [
+        "odom",
+        [
+          149.5,
+          150.1
+        ]
+      ]
+    ],
+    "dataset": "go2_bigoffice"
+  },
+  {
+    "id": "go2_bigoffice_area_t150",
+    "family": "area",
+    "type": "numeric",
+    "q": "Consider the local map point cloud shown. Roughly how many square meters of floor plan does it cover (footprint of the mapped points projected onto the x-y plane)? Answer with a single number.",
+    "a": 34.7,
+    "band": 8.7,
+    "context": [
+      [
+        "lidar",
+        [
+          149.83,
+          149.93
+        ]
+      ]
+    ],
+    "dataset": "go2_bigoffice"
+  },
+  {
+    "id": "go2_bigoffice_nearest_t220",
+    "family": "nearest",
+    "type": "numeric",
+    "q": "You are the robot; your current pose is the odom observation shown. Using the mapped point cloud, how far away is the nearest obstacle point at body height (z between 0.15 and 1.0 m), horizontal distance in meters? Answer with a single number.",
+    "a": 0.61,
+    "band": 0.25,
+    "context": [
+      [
+        "lidar",
+        [
+          219.89,
+          219.99
+        ]
+      ],
+      [
+        "odom",
+        [
+          219.5,
+          220.1
+        ]
+      ]
+    ],
+    "dataset": "go2_bigoffice"
+  },
+  {
+    "id": "go2_bigoffice_area_t220",
+    "family": "area",
+    "type": "numeric",
+    "q": "Consider the local map point cloud shown. Roughly how many square meters of floor plan does it cover (footprint of the mapped points projected onto the x-y plane)? Answer with a single number.",
+    "a": 29.9,
+    "band": 7.5,
+    "context": [
+      [
+        "lidar",
+        [
+          219.89,
+          219.99
+        ]
+      ]
+    ],
+    "dataset": "go2_bigoffice"
+  },
+  {
+    "id": "go2_bigoffice_nearest_t285",
+    "family": "nearest",
+    "type": "numeric",
+    "q": "You are the robot; your current pose is the odom observation shown. Using the mapped point cloud, how far away is the nearest obstacle point at body height (z between 0.15 and 1.0 m), horizontal distance in meters? Answer with a single number.",
+    "a": 0.57,
+    "band": 0.25,
+    "context": [
+      [
+        "lidar",
+        [
+          284.83,
+          284.93
+        ]
+      ],
+      [
+        "odom",
+        [
+          284.5,
+          285.1
+        ]
+      ]
+    ],
+    "dataset": "go2_bigoffice"
+  },
+  {
+    "id": "go2_bigoffice_area_t285",
+    "family": "area",
+    "type": "numeric",
+    "q": "Consider the local map point cloud shown. Roughly how many square meters of floor plan does it cover (footprint of the mapped points projected onto the x-y plane)? Answer with a single number.",
+    "a": 22.5,
+    "band": 5.6,
+    "context": [
+      [
+        "lidar",
+        [
+          284.83,
+          284.93
+        ]
+      ]
+    ],
+    "dataset": "go2_bigoffice"
+  },
+  {
+    "id": "go2_bigoffice_shift_0_60",
+    "family": "shift",
+    "type": "numeric",
+    "q": "You are shown a sequence of local map point clouds over time (world coordinates). The local map follows the robot. Roughly how far did the center of the mapped region move from the first shown cloud to the last, in meters? Answer with a single number.",
+    "a": 18.4,
+    "band": 5.5,
+    "context": [
+      [
+        "lidar",
+        [
+          0.0,
+          60.0
+        ]
+      ]
+    ],
+    "dataset": "go2_bigoffice"
+  },
+  {
+    "id": "go2_bigoffice_direction_0_60",
+    "family": "direction",
+    "type": "mcq",
+    "q": "You are shown a sequence of local map point clouds over time (world frame: +x is east, +y is north). The local map follows the robot. In which compass direction did the mapped region's center move overall? Answer with exactly one of: east, northeast, north, northwest, west, southwest, south, southeast.",
+    "a": "southeast",
+    "choices": [
+      "east",
+      "northeast",
+      "north",
+      "northwest",
+      "west",
+      "southwest",
+      "south",
+      "southeast"
+    ],
+    "context": [
+      [
+        "lidar",
+        [
+          0.0,
+          60.0
+        ]
+      ]
+    ],
+    "dataset": "go2_bigoffice"
+  },
+  {
+    "id": "go2_bigoffice_shift_60_150",
+    "family": "shift",
+    "type": "numeric",
+    "q": "You are shown a sequence of local map point clouds over time (world coordinates). The local map follows the robot. Roughly how far did the center of the mapped region move from the first shown cloud to the last, in meters? Answer with a single number.",
+    "a": 10.6,
+    "band": 3.2,
+    "context": [
+      [
+        "lidar",
+        [
+          60.0,
+          150.0
+        ]
+      ]
+    ],
+    "dataset": "go2_bigoffice"
+  },
+  {
+    "id": "go2_bigoffice_direction_60_150",
+    "family": "direction",
+    "type": "mcq",
+    "q": "You are shown a sequence of local map point clouds over time (world frame: +x is east, +y is north). The local map follows the robot. In which compass direction did the mapped region's center move overall? Answer with exactly one of: east, northeast, north, northwest, west, southwest, south, southeast.",
+    "a": "south",
+    "choices": [
+      "east",
+      "northeast",
+      "north",
+      "northwest",
+      "west",
+      "southwest",
+      "south",
+      "southeast"
+    ],
+    "context": [
+      [
+        "lidar",
+        [
+          60.0,
+          150.0
+        ]
+      ]
+    ],
+    "dataset": "go2_bigoffice"
+  },
+  {
+    "id": "go2_bigoffice_shift_150_240",
+    "family": "shift",
+    "type": "numeric",
+    "q": "You are shown a sequence of local map point clouds over time (world coordinates). The local map follows the robot. Roughly how far did the center of the mapped region move from the first shown cloud to the last, in meters? Answer with a single number.",
+    "a": 23.3,
+    "band": 7.0,
+    "context": [
+      [
+        "lidar",
+        [
+          150.0,
+          240.0
+        ]
+      ]
+    ],
+    "dataset": "go2_bigoffice"
+  },
+  {
+    "id": "go2_bigoffice_direction_150_240",
+    "family": "direction",
+    "type": "mcq",
+    "q": "You are shown a sequence of local map point clouds over time (world frame: +x is east, +y is north). The local map follows the robot. In which compass direction did the mapped region's center move overall? Answer with exactly one of: east, northeast, north, northwest, west, southwest, south, southeast.",
+    "a": "north",
+    "choices": [
+      "east",
+      "northeast",
+      "north",
+      "northwest",
+      "west",
+      "southwest",
+      "south",
+      "southeast"
+    ],
+    "context": [
+      [
+        "lidar",
+        [
+          150.0,
+          240.0
+        ]
+      ]
+    ],
+    "dataset": "go2_bigoffice"
+  },
+  {
+    "id": "go2_bigoffice_shift_200_291",
+    "family": "shift",
+    "type": "numeric",
+    "q": "You are shown a sequence of local map point clouds over time (world coordinates). The local map follows the robot. Roughly how far did the center of the mapped region move from the first shown cloud to the last, in meters? Answer with a single number.",
+    "a": 13.1,
+    "band": 3.9,
+    "context": [
+      [
+        "lidar",
+        [
+          200.0,
+          291.0
+        ]
+      ]
+    ],
+    "dataset": "go2_bigoffice"
+  },
+  {
+    "id": "go2_bigoffice_direction_200_291",
+    "family": "direction",
+    "type": "mcq",
+    "q": "You are shown a sequence of local map point clouds over time (world frame: +x is east, +y is north). The local map follows the robot. In which compass direction did the mapped region's center move overall? Answer with exactly one of: east, northeast, north, northwest, west, southwest, south, southeast.",
+    "a": "west",
+    "choices": [
+      "east",
+      "northeast",
+      "north",
+      "northwest",
+      "west",
+      "southwest",
+      "south",
+      "southeast"
+    ],
+    "context": [
+      [
+        "lidar",
+        [
+          200.0,
+          291.0
+        ]
+      ]
+    ],
+    "dataset": "go2_bigoffice"
+  },
+  {
+    "id": "go2_bigoffice_shift_0_291",
+    "family": "shift",
+    "type": "numeric",
+    "q": "You are shown a sequence of local map point clouds over time (world coordinates). The local map follows the robot. Roughly how far did the center of the mapped region move from the first shown cloud to the last, in meters? Answer with a single number.",
+    "a": 13.9,
+    "band": 4.2,
+    "context": [
+      [
+        "lidar",
+        [
+          0.0,
+          291.0
+        ]
+      ]
+    ],
+    "dataset": "go2_bigoffice"
+  },
+  {
+    "id": "go2_bigoffice_direction_0_291",
+    "family": "direction",
+    "type": "mcq",
+    "q": "You are shown a sequence of local map point clouds over time (world frame: +x is east, +y is north). The local map follows the robot. In which compass direction did the mapped region's center move overall? Answer with exactly one of: east, northeast, north, northwest, west, southwest, south, southeast.",
+    "a": "south",
+    "choices": [
+      "east",
+      "northeast",
+      "north",
+      "northwest",
+      "west",
+      "southwest",
+      "south",
+      "southeast"
+    ],
+    "context": [
+      [
+        "lidar",
+        [
+          0.0,
+          291.0
+        ]
+      ]
+    ],
+    "dataset": "go2_bigoffice"
+  }
+]

--- a/dimos/evals/suites/go2_smoke.py
+++ b/dimos/evals/suites/go2_smoke.py
@@ -40,7 +40,7 @@ SUITE: Suite = [
         inputs="At the start of these observations, which furniture is most numerous? "
         "Answer with one of: chairs, sofas, beds, desks.",
         expected="chairs",
-        parse=choice,
+        parse=choice(["chairs", "sofas", "beds", "desks"]),
         score=exact,
         context=(lambda s: s.streams.color_image.range_time(0, 8),),
         dataset="go2_short",
@@ -72,7 +72,7 @@ SUITE: Suite = [
         inputs="Which of these did you NOT see anywhere in the observations? "
         "Answer with one of: a couch, store shelves, a swimming pool, an office chair.",
         expected="a swimming pool",
-        parse=choice,
+        parse=choice(["a couch", "store shelves", "a swimming pool", "an office chair"]),
         score=exact,
         context=(lambda s: s.streams.color_image,),
         dataset="go2_hongkong_office",

--- a/dimos/evals/suites/go2_vqa.json
+++ b/dimos/evals/suites/go2_vqa.json
@@ -1,85 +1,127 @@
 [
   {
     "id": "go2_short_disp_0_60",
-    "q": "How far in a straight line is your final position from your position at the first shown observation, in meters?",
+    "family": "displacement",
+    "type": "numeric",
+    "q": "How far in a straight line is your final position from your position at the first shown observation, in meters? Answer with a single number.",
     "a": 1.7,
     "band": 1.0,
-    "stream": "odom",
-    "window": [
-      0,
-      60
+    "context": [
+      [
+        "odom",
+        [
+          0,
+          60
+        ]
+      ]
     ],
     "dataset": "go2_short"
   },
   {
     "id": "go2_short_disp_0_30",
-    "q": "How far in a straight line is your final position from your position at the first shown observation, in meters?",
+    "family": "displacement",
+    "type": "numeric",
+    "q": "How far in a straight line is your final position from your position at the first shown observation, in meters? Answer with a single number.",
     "a": 11.4,
     "band": 4.543036677935427,
-    "stream": "odom",
-    "window": [
-      0,
-      30
+    "context": [
+      [
+        "odom",
+        [
+          0,
+          30
+        ]
+      ]
     ],
     "dataset": "go2_short"
   },
   {
     "id": "go2_short_disp_30_60",
-    "q": "How far in a straight line is your final position from your position at the first shown observation, in meters?",
+    "family": "displacement",
+    "type": "numeric",
+    "q": "How far in a straight line is your final position from your position at the first shown observation, in meters? Answer with a single number.",
     "a": 11.8,
     "band": 4.738980277235515,
-    "stream": "odom",
-    "window": [
-      30,
-      60
+    "context": [
+      [
+        "odom",
+        [
+          30,
+          60
+        ]
+      ]
     ],
     "dataset": "go2_short"
   },
   {
     "id": "go2_short_path_0_60",
-    "q": "Roughly how many meters did you travel in total over these observations (path length, not displacement)?",
+    "family": "path_length",
+    "type": "numeric",
+    "q": "Roughly how many meters did you travel in total over these observations (path length, not displacement)? Answer with a single number.",
     "a": 37.9,
     "band": 18.963056711366217,
-    "stream": "odom",
-    "window": [
-      0,
-      60
+    "context": [
+      [
+        "odom",
+        [
+          0,
+          60
+        ]
+      ]
     ],
     "dataset": "go2_short"
   },
   {
     "id": "go2_hongkong_office_disp_0_558",
-    "q": "How far in a straight line is your final position from your position at the first shown observation, in meters?",
+    "family": "displacement",
+    "type": "numeric",
+    "q": "How far in a straight line is your final position from your position at the first shown observation, in meters? Answer with a single number.",
     "a": 9.6,
     "band": 3.8486174236058126,
-    "stream": "odom",
-    "window": [
-      0,
-      558
+    "context": [
+      [
+        "odom",
+        [
+          0,
+          558
+        ]
+      ]
     ],
     "dataset": "go2_hongkong_office"
   },
   {
     "id": "go2_hongkong_office_disp_100_300",
-    "q": "How far in a straight line is your final position from your position at the first shown observation, in meters?",
+    "family": "displacement",
+    "type": "numeric",
+    "q": "How far in a straight line is your final position from your position at the first shown observation, in meters? Answer with a single number.",
     "a": 27.5,
     "band": 11.016777380908813,
-    "stream": "odom",
-    "window": [
-      100,
-      300
+    "context": [
+      [
+        "odom",
+        [
+          100,
+          300
+        ]
+      ]
     ],
     "dataset": "go2_hongkong_office"
   },
   {
     "id": "go2_hongkong_office_path_0_558",
-    "q": "Roughly how many meters did you travel in total over these observations (path length, not displacement)?",
+    "family": "path_length",
+    "type": "numeric",
+    "q": "Roughly how many meters did you travel in total over these observations (path length, not displacement)? Answer with a single number.",
     "a": 192.5,
     "band": 96.26788393075581,
-    "stream": "odom",
-    "window": [
-      0,
-      558
+    "context": [
+      [
+        "odom",
+        [
+          0,
+          558
+        ]
+      ]
     ],
     "dataset": "go2_hongkong_office"
   }

--- a/dimos/evals/suites/go2_vqa.py
+++ b/dimos/evals/suites/go2_vqa.py
@@ -12,11 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 """Generated VQA suite over the go2 replays.
 
 Rows (``go2_vqa.json``) are pure data emitted by :mod:`dimos.evals.generate` —
 ground truth computed analytically from odom, quizzing the encoded odom
-summary. Typing and scoring live here; the JSON stays behavior-free.
+summary. Scoring lives in :func:`dimos.evals.generate.cases`; the JSON stays
+behavior-free.
+
+Regenerate::
+
+    python -m dimos.evals.suites.go2_vqa
 """
 
 from __future__ import annotations
@@ -24,27 +30,13 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from dimos.evals.scorers import exact, first_number, within, yes_no
+from dimos.evals import generate
+from dimos.evals.scorers import exact, yes_no
 from dimos.evals.types import PassiveEval, Suite
 
-_ROWS = json.loads((Path(__file__).parent / "go2_vqa.json").read_text())
-
-_generated: list[PassiveEval[float]] = [
-    PassiveEval(
-        id=str(row["id"]),
-        inputs=str(row["q"]),
-        expected=float(row["a"]),  # type: ignore[arg-type]
-        parse=first_number,
-        score=within(float(row["band"])),  # type: ignore[arg-type]
-        context=(
-            lambda s, name=str(row["stream"]), w=tuple(row["window"]):  # type: ignore[misc]
-            s.streams[name].range_time(*w),
-        ),
-        dataset=str(row["dataset"]),
-        tags=frozenset({"generated", "odom", "numeric"}),
-    )
-    for row in _ROWS
-]
+_JSON = Path(__file__).parent / "go2_vqa.json"
+_SHORT = [(0.0, 60.0), (0.0, 30.0), (30.0, 60.0)]
+_HONGKONG = [(0.0, 558.0), (100.0, 300.0)]
 
 # Hand-labeled presence questions, verified against the recording imagery.
 _hand: list[PassiveEval[str]] = [
@@ -70,4 +62,21 @@ _hand: list[PassiveEval[str]] = [
     ),
 ]
 
-SUITE: Suite = [*_generated, *_hand]
+SUITE: Suite = [
+    *generate.cases(json.loads(_JSON.read_text()), tags=frozenset({"generated", "odom"})),
+    *_hand,
+]
+
+
+def rows() -> list[generate.Row]:
+    """The generator calls behind the committed JSON."""
+    return [
+        *generate.displacement_rows("go2_short", _SHORT),
+        *generate.path_length_rows("go2_short", _SHORT[:1]),
+        *generate.displacement_rows("go2_hongkong_office", _HONGKONG),
+        *generate.path_length_rows("go2_hongkong_office", _HONGKONG[:1]),
+    ]
+
+
+if __name__ == "__main__":
+    _JSON.write_text(json.dumps(rows(), indent=2) + "\n")

--- a/dimos/evals/test_evals.py
+++ b/dimos/evals/test_evals.py
@@ -147,7 +147,11 @@ def test_parsers() -> None:
     assert yes_no("no") == "no"
     with pytest.raises(ValueError):
         yes_no("maybe")
-    assert choice(" Chairs. ") == "chairs"
+    compass = choice(["north", "northeast", "east"])
+    assert compass(" Northeast. ") == "northeast"
+    assert compass("it drifts north, then finally east") == "east"  # last named wins
+    with pytest.raises(ValueError):
+        compass("no idea")
 
 
 # -- case dispatch ---------------------------------------------------------------------
@@ -306,9 +310,9 @@ def test_runner_encode_budget(dataset: str, tmp_path: Path) -> None:
 
 def test_suites_importable() -> None:
     """Suite modules construct without data or network (lambdas stay lazy)."""
-    from dimos.evals.suites import dimsim_house, examples, go2_smoke, go2_vqa
+    from dimos.evals.suites import dimsim_house, examples, go2_pointcloud, go2_smoke, go2_vqa
 
-    for module in (examples, go2_smoke, go2_vqa, dimsim_house):
+    for module in (examples, go2_smoke, go2_vqa, go2_pointcloud, dimsim_house):
         assert module.SUITE, module.__name__
 
 

--- a/dimos/msgs/sensor_msgs/PointCloud2.py
+++ b/dimos/msgs/sensor_msgs/PointCloud2.py
@@ -314,6 +314,99 @@ class PointCloud2(Timestamped):
     def __str__(self) -> str:
         return f"PointCloud2(frame_id='{self.frame_id}', num_points={len(self)})"
 
+    def agent_encode(self) -> dict[str, object]:
+        """Compact, spatially structured encoding for LLM consumption.
+
+        World-frame meters throughout. Carries the cloud's horizontal centroid
+        (so consecutive frames reveal motion of the mapped region) and exact
+        world-meter bounding boxes of body-height obstacle clusters (so
+        clearance around a given world position is closed-form point-to-box).
+        """
+        pts = self.points_f32()
+        n = int(pts.shape[0])
+        out: dict[str, object] = {"frame_id": self.frame_id, "num_points": n}
+        if n == 0:
+            return out
+        xy = pts[:, :2]
+        cx, cy = xy.mean(axis=0)
+        out["centroid_xy_m"] = [round(float(cx), 2), round(float(cy), 2)]
+        mins = pts.min(axis=0)
+        maxs = pts.max(axis=0)
+        # Distinct occupied 0.2 m x-y cells of THIS frame's cloud alone.
+        floor_cells = np.unique(np.floor(xy / 0.2).astype(np.int64), axis=0)
+        out["exact_stats"] = {
+            "note": "exact full-cloud values in meters; for numeric extent/span/area "
+            "answers use these, not the body-height interval map below",
+            "x_range": [round(float(mins[0]), 2), round(float(maxs[0]), 2)],
+            "y_range": [round(float(mins[1]), 2), round(float(maxs[1]), 2)],
+            "z_range": [round(float(mins[2]), 2), round(float(maxs[2]), 2)],
+            "horizontal_extent_m": round(float(max(maxs[0] - mins[0], maxs[1] - mins[1])), 2),
+            "vertical_span_m": round(float(maxs[2] - mins[2]), 2),
+            "occupied_floor_footprint_m2": round(float(floor_cells.shape[0]) * 0.2 * 0.2, 1),
+            "footprint_note": "mapped floor area of this frame's cloud only (distinct "
+            "occupied 0.2 m x-y cells); use it, not bbox area, for floor coverage. For "
+            "area trends compare each frame's own footprint value across frames -- it "
+            "can decrease as well as increase; do not accumulate coverage over frames",
+        }
+        out["compass"] = (
+            "8-way direction of motion (dx,dy = last minus first): if |dx|>2.41*|dy| "
+            "then east (dx>0) or west (dx<0); if |dy|>2.41*|dx| then north (dy>0) or "
+            "south (dy<0); otherwise diagonal by signs (northeast, northwest, "
+            "southeast, southwest). For any question about which direction the map "
+            "moved or gained coverage, take dx,dy from centroid_xy_m of the last "
+            "minus the first frame; range edges are too noisy for direction"
+        )
+        z = pts[:, 2]
+        band = xy[(z >= 0.15) & (z <= 1.0)]
+        grid = self._body_height_occupancy(band)
+        if grid is not None:
+            out["body_height_occupancy"] = grid
+        return out
+
+    @staticmethod
+    def _body_height_occupancy(xy: np.ndarray, max_cells: int = 28) -> dict[str, object] | None:
+        """Exact bounding boxes of body-height obstacle clusters, world meters.
+
+        ponytail: y binned into bands only to segment clusters; the emitted
+        extents are exact point min/max, so clearance is closed-form
+        point-to-box in both axes.
+        """
+        if xy.shape[0] == 0:
+            return None
+        lo = xy.min(axis=0)
+        hi = xy.max(axis=0)
+        span = float(max(hi[0] - lo[0], hi[1] - lo[1]))
+        cell = next((c for c in (0.25, 0.4, 0.8, 1.6, 3.2) if span / c < max_cells), 6.4)
+        iy = np.floor((xy[:, 1] - lo[1]) / cell).astype(int)
+        parts = []
+        for r in range(int(iy.max()), -1, -1):
+            sel = xy[iy == r]
+            if sel.shape[0] == 0:
+                continue
+            sel = sel[np.argsort(sel[:, 0])]
+            rx = sel[:, 0]
+            breaks = np.flatnonzero(np.diff(rx) > cell)
+            starts = np.concatenate(([0], breaks + 1))
+            ends = np.concatenate((breaks, [rx.size - 1]))
+            for s, e in zip(starts, ends, strict=False):
+                a, b = f"{rx[s]:.2f}", f"{rx[e]:.2f}"
+                run = a if a == b else f"{a}:{b}"
+                ry = sel[s : e + 1, 1]
+                ya, yb = f"{ry.min():.2f}", f"{ry.max():.2f}"
+                run += f"@{ya}" if ya == yb else f"@{ya}:{yb}"
+                parts.append(run)
+        return {
+            "desc": "Exact bounding boxes (world meters) of obstacle points at "
+            "body height (z 0.15..1.0 m), listed north to south. Each box "
+            "xmin:xmax@ymin:ymax is the exact extent of its points (+x east, "
+            "+y north; a lone value = zero-width, a thin obstacle). "
+            "Horizontal clearance from a query point (qx,qy) = min over all "
+            "boxes of hypot(dx,dy), where dx = max(0, xmin-qx, qx-xmax) and "
+            "dy = max(0, ymin-qy, qy-ymax) (each term is zero only when the "
+            "query lies inside that extent).",
+            "boxes": ",".join(parts),
+        }
+
     @functools.cached_property
     def center(self) -> Vector3:
         """Calculate the center of the pointcloud in world frame."""

--- a/dimos/msgs/sensor_msgs/test_PointCloud2.py
+++ b/dimos/msgs/sensor_msgs/test_PointCloud2.py
@@ -180,3 +180,36 @@ def test_bounding_box_intersects() -> None:
     except Exception:
         # If it raises an exception, that's also acceptable for empty clouds
         pass
+
+
+def test_agent_encode_scalars_are_exact() -> None:
+    """The scalars the eval suite quizzes must match numpy, not approximate it —
+    a slab wall at x=2, plus floor points that must not enter the body band."""
+    wall = np.stack(
+        [
+            np.full(200, 2.0),
+            np.linspace(-1.0, 1.0, 200),
+            np.linspace(0.2, 0.9, 200),
+        ],
+        axis=1,
+    )
+    floor = np.stack([np.linspace(-3, 3, 100), np.linspace(-3, 3, 100), np.zeros(100)], axis=1)
+    encoded = PointCloud2.from_numpy(np.vstack([wall, floor])).agent_encode()
+
+    stats = encoded["exact_stats"]
+    assert isinstance(stats, dict)
+    assert encoded["num_points"] == 300
+    assert stats["x_range"] == [-3.0, 3.0]
+    assert stats["horizontal_extent_m"] == 6.0
+    assert stats["vertical_span_m"] == 0.9
+    occupancy = encoded["body_height_occupancy"]
+    assert isinstance(occupancy, dict)
+    # body-height boxes see the wall only: x pinned at 2.0, floor (z=0) excluded
+    assert all(b.startswith("2.00@") for b in str(occupancy["boxes"]).split(","))
+    assert encoded["centroid_xy_m"] == [1.33, 0.0]  # 200 wall pts at x=2, 100 floor at mean 0
+
+
+def test_agent_encode_empty_cloud() -> None:
+    encoded = PointCloud2.from_numpy(np.zeros((0, 3))).agent_encode()
+    assert encoded["num_points"] == 0
+    assert "exact_stats" not in encoded

--- a/docs/usage/evals.md
+++ b/docs/usage/evals.md
@@ -118,16 +118,18 @@ not a class:
 from dimos.evals.scorers import choice, exact, first_number, ramp, within, yes_no
 
 print(exact("yes", "yes"), within(2.0)(10.0, 11.0), ramp(1.0, band=2.0))
-print(first_number("around 12.5 m"), yes_no("Yes, clearly."), choice(" Chairs. "))
+print(first_number("around 12.5 m"), yes_no("Yes, clearly."))
+print(choice(["north", "northeast"])("it drifted north, then northeast"))
 ```
 
 ```results
 1.0 0.5 0.5
-12.5 yes chairs
+12.5 yes
+northeast
 ```
 
-- `exact` — equality (the default). Pair with a parser (`yes_no`, `choice`,
-  `int`) so formatting noise doesn't fail a correct answer.
+- `exact` — equality (the default). Pair with a parser (`yes_no`,
+  `choice(options)`, `int`) so formatting noise doesn't fail a correct answer.
 - `within(band)` — graded numeric credit: 1.0 exact, 0.5 halfway, 0 outside.
 - `ramp(distance, band)` — same ramp over meters; msg types support
   arithmetic, so physical scorers stay one-liners:


### PR DESCRIPTION
## Problem
No way to measure whether an agent can read pointcloud geometry — and it couldn't: `str(PointCloud2)` hands the model `num_points` and nothing else. Baseline on the VQA suite: **0.136**, identical to blind guessing (0.138).

## Solution
**1. Pointcloud VQA suite** (`dimos/evals/suites/go2_pointcloud.py` + `go2_pointcloud_vqa.json`): 40 generated cases across 7 question families (extent, z-span, nearest-obstacle, direction, area-trend, area, shift) over the go2_short and go2_bigoffice datasets, regenerable from `dimos/evals/generate.py`.

**2. `PointCloud2.agent_encode()`**: per-x-interval geometry summary (y-extent per interval, exact point-to-box clearance on both axes) replacing the information-free str(). Suite score: **0.96**.

Squashed history, rebased on main; 18 tests passing, mypy strict clean.