### PR TITLE
feat(evals): generate simulator-grounded VQA cases from RoboCasa

### DIFF
--- a/dimos/evals/cli.py
+++ b/dimos/evals/cli.py
@@ -18,6 +18,7 @@ command bodies (test_cli_startup budget)."""
 from __future__ import annotations
 
 import importlib
+from pathlib import Path
 
 import typer
 
@@ -26,9 +27,7 @@ app = typer.Typer(help="Run agent evals on recordings, sim, or a live robot.")
 
 @app.command("run")
 def run(
-    suite: str = typer.Argument(
-        help="Dotted suite module exporting SUITE, e.g. dimos.evals.suites.go2_smoke"
-    ),
+    suite: str = typer.Argument(help="Dotted suite module or generated VQA cases.json manifest"),
     tags: str = typer.Option("", help="Comma-separated tag filter"),
     model: str = typer.Option("", help="Override chat model"),
     blind: bool = typer.Option(False, help="Withhold observations (guessing ablation)"),
@@ -36,9 +35,14 @@ def run(
     limit: int = typer.Option(0, help="Run at most N cases"),
     live_db: str = typer.Option("recording.db", help="Live Recorder db (interactive cases)"),
 ) -> None:
+    from dimos.evals.generate import load_vqa_manifest
     from dimos.evals.runner import EvalRunner, summarize
 
-    cases = importlib.import_module(suite).SUITE
+    cases = (
+        load_vqa_manifest(suite)
+        if Path(suite).expanduser().suffix == ".json"
+        else importlib.import_module(suite).SUITE
+    )
     overrides: dict[str, object] = {"blind": blind, "attach": attach, "live_db": live_db}
     if model:
         overrides["model"] = model
@@ -66,3 +70,28 @@ def list_() -> None:
 
     for name in list_suites():
         typer.echo(name)
+
+
+@app.command("generate")
+def generate(
+    spec: Path = typer.Argument(
+        ..., exists=True, dir_okay=False, readable=True, help="VQA use-case YAML/JSON spec"
+    ),
+    source_python: str = typer.Option(
+        ..., "--source-python", help="Python interpreter from a prepared RoboCasa environment"
+    ),
+) -> None:
+    """Generate a simulator-grounded VQA manifest and Memory dataset."""
+    from dimos.evals.generate import generate_from_spec
+
+    output = generate_from_spec(spec, source_python=source_python)
+    typer.echo(f"Generated {output.accepted} VQA cases")
+    for family, count in output.accepted_by_family.items():
+        typer.echo(f"  {family}: {count}")
+    if output.rejected:
+        typer.echo("Rejected candidates:")
+        for reason, count in output.rejected.items():
+            typer.echo(f"  {reason}: {count}")
+    typer.echo(f"Manifest: {output.manifest}")
+    typer.echo(f"Dataset:  {output.dataset}")
+    typer.echo(f"Summary:  {output.summary}")

--- a/dimos/evals/generate.py
+++ b/dimos/evals/generate.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Eval-row generators — deferred feature (PRD: low priority), kept minimal.
+"""Deterministic eval-row and simulator-grounded VQA dataset generation.
 
 Ground truth is computed analytically from a *privileged* modality; the emitted
 case quizzes a different (or lossily-encoded) surface. Rows are pure data —
@@ -21,11 +21,390 @@ a suite module maps them onto typed :class:`PassiveEval` cases.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import TYPE_CHECKING, Any
 
+import yaml
+
+from dimos.evals.robocasa import export_robocasa_snapshots
+from dimos.evals.scorers import choice, exact, yes_no
+from dimos.evals.types import PassiveEval, Select, Suite
+from dimos.evals.vqa import (
+    SUPPORTED_QUESTION_FAMILIES,
+    GeneratedQuestion,
+    SceneSnapshot,
+    generate_questions,
+    normalize_category,
+)
 from dimos.memory.cli.dataset import open_dataset
+from dimos.memory.store.sqlite import SqliteStore
+from dimos.msgs.sensor_msgs.Image import Image, ImageFormat
+
+if TYPE_CHECKING:
+    from dimos.memory.store.base import Store
+    from dimos.memory.stream import Stream
 
 Row = dict[str, object]
+VQA_SCHEMA_VERSION = 1
+_SPEC_KEYS = frozenset(
+    {
+        "source",
+        "use_case",
+        "task",
+        "episodes",
+        "seed",
+        "camera",
+        "image_size",
+        "question_families",
+        "targets",
+        "output",
+        "split",
+        "robot",
+        "min_visible_pixels",
+        "min_horizontal_separation",
+        "max_bbox_overlap",
+        "max_spatial_pairs",
+    }
+)
+
+
+@dataclass(frozen=True, kw_only=True)
+class VqaGenerationSpec:
+    source: str
+    use_case: str
+    task: str
+    episodes: int
+    seed: int
+    camera: str
+    image_size: tuple[int, int]
+    question_families: tuple[str, ...]
+    targets: tuple[str, ...]
+    output: Path
+    split: str | None = "target"
+    robot: str = "PandaOmron"
+    min_visible_pixels: int = 64
+    min_horizontal_separation: float = 0.1
+    max_bbox_overlap: float = 0.5
+    max_spatial_pairs: int = 8
+
+    def __post_init__(self) -> None:
+        if self.source != "robocasa":
+            raise ValueError(f"unsupported VQA source: {self.source!r}")
+        if not self.use_case.strip() or not self.task.strip() or not self.camera.strip():
+            raise ValueError("use_case, task, and camera must not be empty")
+        object.__setattr__(self, "use_case", normalize_category(self.use_case))
+        if self.episodes <= 0:
+            raise ValueError("episodes must be positive")
+        if len(self.image_size) != 2 or any(size <= 0 for size in self.image_size):
+            raise ValueError("image_size must contain two positive integers")
+        if not self.question_families:
+            raise ValueError("question_families must not be empty")
+        unknown = set(self.question_families) - SUPPORTED_QUESTION_FAMILIES
+        if unknown:
+            raise ValueError(f"unsupported question families: {sorted(unknown)}")
+        if not self.targets:
+            raise ValueError("targets must not be empty")
+        object.__setattr__(
+            self,
+            "targets",
+            tuple(dict.fromkeys(normalize_category(target) for target in self.targets)),
+        )
+        if self.split not in {None, "all", "pretrain", "target"}:
+            raise ValueError("split must be one of: all, pretrain, target, or null")
+        if self.min_visible_pixels <= 0:
+            raise ValueError("min_visible_pixels must be positive")
+        if not 0 < self.min_horizontal_separation <= 1:
+            raise ValueError("min_horizontal_separation must be in (0, 1]")
+        if not 0 <= self.max_bbox_overlap <= 1:
+            raise ValueError("max_bbox_overlap must be in [0, 1]")
+        if self.max_spatial_pairs <= 0:
+            raise ValueError("max_spatial_pairs must be positive")
+
+
+@dataclass(frozen=True, kw_only=True)
+class GenerationOutput:
+    output_dir: Path
+    manifest: Path
+    dataset: Path
+    summary: Path
+    accepted: int
+    accepted_by_family: Mapping[str, int]
+    rejected: Mapping[str, int]
+
+
+@dataclass(frozen=True, kw_only=True)
+class _PendingCase:
+    snapshot_index: int
+    question: GeneratedQuestion
+
+
+def load_generation_spec(path: str | Path) -> VqaGenerationSpec:
+    spec_path = Path(path).expanduser().resolve()
+    raw = yaml.safe_load(spec_path.read_text())
+    if not isinstance(raw, dict):
+        raise TypeError("VQA generation spec must be a YAML/JSON object")
+    unknown = set(raw) - _SPEC_KEYS
+    if unknown:
+        raise ValueError(f"unknown VQA generation spec fields: {sorted(unknown)}")
+
+    required = {
+        "source",
+        "use_case",
+        "task",
+        "episodes",
+        "seed",
+        "camera",
+        "image_size",
+        "question_families",
+        "targets",
+        "output",
+    }
+    missing = required - set(raw)
+    if missing:
+        raise ValueError(f"missing VQA generation spec fields: {sorted(missing)}")
+
+    image_size = raw["image_size"]
+    families = raw["question_families"]
+    targets = raw["targets"]
+    if not isinstance(image_size, list) or len(image_size) != 2:
+        raise ValueError("image_size must be a two-item list")
+    if not isinstance(families, list) or not all(isinstance(v, str) for v in families):
+        raise ValueError("question_families must be a list of strings")
+    if not isinstance(targets, list) or not all(isinstance(v, str) for v in targets):
+        raise ValueError("targets must be a list of strings")
+
+    output = Path(str(raw["output"])).expanduser()
+    if not output.is_absolute():
+        output = spec_path.parent / output
+    return VqaGenerationSpec(
+        source=str(raw["source"]),
+        use_case=str(raw["use_case"]),
+        task=str(raw["task"]),
+        episodes=int(raw["episodes"]),
+        seed=int(raw["seed"]),
+        camera=str(raw["camera"]),
+        image_size=(int(image_size[0]), int(image_size[1])),
+        question_families=tuple(families),
+        targets=tuple(targets),
+        output=output.resolve(),
+        split=(str(raw.get("split", "target")) if raw.get("split", "target") is not None else None),
+        robot=str(raw.get("robot", "PandaOmron")),
+        min_visible_pixels=int(raw.get("min_visible_pixels", 64)),
+        min_horizontal_separation=float(raw.get("min_horizontal_separation", 0.1)),
+        max_bbox_overlap=float(raw.get("max_bbox_overlap", 0.5)),
+        max_spatial_pairs=int(raw.get("max_spatial_pairs", 8)),
+    )
+
+
+def generate_from_spec(path: str | Path, *, source_python: str) -> GenerationOutput:
+    spec = load_generation_spec(path)
+    snapshots = export_robocasa_snapshots(spec, source_python=source_python)
+    return materialize_vqa_dataset(spec, snapshots)
+
+
+def materialize_vqa_dataset(
+    spec: VqaGenerationSpec, snapshots: Sequence[SceneSnapshot]
+) -> GenerationOutput:
+    """Generate cases and atomically materialize a Memory dataset + manifest."""
+    if not snapshots:
+        raise ValueError("VQA source returned no scene snapshots")
+    if spec.output.exists():
+        raise FileExistsError(f"VQA output already exists: {spec.output}")
+
+    observed_categories = sorted(
+        {entity.category for snapshot in snapshots for entity in snapshot.entities}
+    )
+    pending: list[_PendingCase] = []
+    rejected: Counter[str] = Counter()
+    for snapshot_index, snapshot in enumerate(snapshots):
+        batch = generate_questions(
+            snapshot,
+            targets=spec.targets,
+            families=spec.question_families,
+            min_visible_pixels=spec.min_visible_pixels,
+            min_horizontal_separation=spec.min_horizontal_separation,
+            max_bbox_overlap=spec.max_bbox_overlap,
+            max_spatial_pairs=spec.max_spatial_pairs,
+        )
+        pending.extend(
+            _PendingCase(snapshot_index=snapshot_index, question=question)
+            for question in batch.questions
+        )
+        rejected.update(batch.rejected)
+
+    pending, balance_dropped = _balance_presence(pending)
+    if balance_dropped:
+        rejected["presence_balance"] += balance_dropped
+    accepted_by_family: Counter[str] = Counter(case.question.family for case in pending)
+    for family in spec.question_families:
+        if accepted_by_family[family] == 0:
+            detail = (
+                f"accepted={dict(sorted(accepted_by_family.items()))}, "
+                f"rejected={dict(sorted(rejected.items()))}, "
+                f"observed_categories={observed_categories}"
+            )
+            if family == "semantic_presence":
+                raise ValueError(
+                    "semantic_presence requires at least one accepted yes and one accepted no case; "
+                    + detail
+                )
+            raise ValueError(f"no answerable {family} cases were generated; {detail}")
+
+    spec.output.parent.mkdir(parents=True, exist_ok=True)
+    with TemporaryDirectory(prefix=f".{spec.output.name}-", dir=spec.output.parent) as temp:
+        temp_dir = Path(temp)
+        dataset = temp_dir / "observations.db"
+        manifest = temp_dir / "cases.json"
+        summary = temp_dir / "generation_summary.json"
+        rows = _write_dataset_and_rows(spec, snapshots, pending, dataset)
+        manifest.write_text(json.dumps(rows, indent=2) + "\n")
+        summary_payload = {
+            "schema_version": VQA_SCHEMA_VERSION,
+            "accepted": len(rows),
+            "accepted_by_family": dict(sorted(accepted_by_family.items())),
+            "accepted_by_answer": dict(
+                sorted(Counter(case.question.reference_outputs for case in pending).items())
+            ),
+            "rejected": dict(sorted(rejected.items())),
+            "observed_categories": observed_categories,
+            "episodes": len(snapshots),
+        }
+        summary.write_text(json.dumps(summary_payload, indent=2) + "\n")
+        temp_dir.rename(spec.output)
+
+    return GenerationOutput(
+        output_dir=spec.output,
+        manifest=spec.output / "cases.json",
+        dataset=spec.output / "observations.db",
+        summary=spec.output / "generation_summary.json",
+        accepted=len(pending),
+        accepted_by_family=dict(sorted(accepted_by_family.items())),
+        rejected=dict(sorted(rejected.items())),
+    )
+
+
+def load_vqa_manifest(path: str | Path) -> Suite:
+    """Load generated rows as ordinary ``PassiveEval`` cases."""
+    manifest = Path(path).expanduser().resolve()
+    raw = json.loads(manifest.read_text())
+    if not isinstance(raw, list) or not raw:
+        raise ValueError("VQA manifest must be a non-empty list")
+
+    cases: list[PassiveEval[str]] = []
+    for index, row in enumerate(raw):
+        if not isinstance(row, dict):
+            raise TypeError(f"VQA manifest row {index} must be an object")
+        if row.get("schema_version") != VQA_SCHEMA_VERSION:
+            raise ValueError(f"VQA manifest row {index} has unsupported schema_version")
+        answer_type = row.get("answer_type")
+        if answer_type == "yes_no":
+            parse = yes_no
+        elif answer_type == "choice":
+            parse = choice
+        else:
+            raise ValueError(f"VQA manifest row {index} has unsupported answer_type")
+        dataset = Path(str(row["dataset"])).expanduser()
+        if not dataset.is_absolute():
+            dataset = manifest.parent / dataset
+        stream = str(row["stream"])
+        frame_ts = float(row["frame_ts"])
+        tags = row.get("tags", [])
+        if not isinstance(tags, list) or not all(isinstance(tag, str) for tag in tags):
+            raise ValueError(f"VQA manifest row {index} tags must be strings")
+        cases.append(
+            PassiveEval(
+                id=str(row["id"]),
+                inputs=str(row["inputs"]),
+                expected=str(row["reference_outputs"]),
+                parse=parse,
+                score=exact,
+                context=(_select_frame(stream, frame_ts),),
+                dataset=str(dataset.resolve()),
+                tags=frozenset(tags),
+            )
+        )
+    return cases
+
+
+def _select_frame(name: str, ts: float) -> Select:
+    def select(store: Store) -> Stream[Any, Any]:
+        return store.streams[name].at(ts, tolerance=1e-6).limit(1)
+
+    return select
+
+
+def _balance_presence(cases: Sequence[_PendingCase]) -> tuple[list[_PendingCase], int]:
+    yes = [
+        case
+        for case in cases
+        if case.question.family == "semantic_presence" and case.question.reference_outputs == "yes"
+    ]
+    no = [
+        case
+        for case in cases
+        if case.question.family == "semantic_presence" and case.question.reference_outputs == "no"
+    ]
+    other = [case for case in cases if case.question.family != "semantic_presence"]
+    keep = min(len(yes), len(no))
+    balanced_presence = [item for pair in zip(yes[:keep], no[:keep], strict=True) for item in pair]
+    return [*balanced_presence, *other], len(yes) + len(no) - 2 * keep
+
+
+def _write_dataset_and_rows(
+    spec: VqaGenerationSpec,
+    snapshots: Sequence[SceneSnapshot],
+    cases: Sequence[_PendingCase],
+    dataset: Path,
+) -> list[dict[str, Any]]:
+    store = SqliteStore(path=str(dataset))
+    images = store.stream("color_image", Image)
+    rows: list[dict[str, Any]] = []
+    written_snapshots: set[int] = set()
+    family_ordinals: Counter[str] = Counter()
+    try:
+        for case in cases:
+            snapshot = snapshots[case.snapshot_index]
+            frame_ts = float(case.snapshot_index)
+            if case.snapshot_index not in written_snapshots:
+                images.append(
+                    Image.from_numpy(
+                        snapshot.image,
+                        format=ImageFormat.RGB,
+                        frame_id=spec.camera,
+                        ts=frame_ts,
+                    ),
+                    ts=frame_ts,
+                )
+                written_snapshots.add(case.snapshot_index)
+
+            question = case.question
+            ordinal = family_ordinals[question.family]
+            family_ordinals[question.family] += 1
+            provenance = dict(snapshot.provenance)
+            seed = int(provenance.get("seed", spec.seed + case.snapshot_index))
+            rows.append(
+                {
+                    "schema_version": VQA_SCHEMA_VERSION,
+                    "id": (f"{spec.use_case}-seed{seed:04d}-{question.family}-{ordinal:04d}"),
+                    "inputs": question.inputs,
+                    "reference_outputs": question.reference_outputs,
+                    "answer_type": question.answer_type,
+                    "dataset": "observations.db",
+                    "stream": "color_image",
+                    "frame_ts": frame_ts,
+                    "tags": ["generated", "vqa", *question.family.split("_", 1)],
+                    "provenance": provenance,
+                    "oracle": dict(question.oracle),
+                }
+            )
+    finally:
+        store.stop()
+    return rows
 
 
 def displacement_rows(dataset: str, windows: Sequence[tuple[float, float]]) -> list[Row]:

--- a/dimos/evals/robocasa.py
+++ b/dimos/evals/robocasa.py
@@ -1,0 +1,273 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""RoboCasa VQA source boundary.
+
+The normal dimOS process calls :func:`export_robocasa_snapshots`, which runs
+this same file with a separately prepared RoboCasa Python interpreter. Keep
+module-level imports limited to packages available in both environments.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.metadata
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+from tempfile import TemporaryDirectory
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from dimos.evals.generate import VqaGenerationSpec
+    from dimos.evals.vqa import SceneSnapshot
+
+_RUN_EXPORTER = (
+    "import runpy, sys; script = sys.argv.pop(1); runpy.run_path(script, run_name='__main__')"
+)
+ROBOCASA_EXPORT_SCHEMA_VERSION = 1
+
+
+def export_robocasa_snapshots(
+    spec: VqaGenerationSpec, *, source_python: str
+) -> list[SceneSnapshot]:
+    """Run RoboCasa out of process and load its private scene snapshots."""
+    interpreter = _resolve_interpreter(source_python)
+    timeout_s = max(300.0, spec.episodes * 120.0)
+    with TemporaryDirectory(prefix="dimos-robocasa-") as temp:
+        temp_dir = Path(temp)
+        config_path = temp_dir / "export.json"
+        export_dir = temp_dir / "snapshots"
+        config_path.write_text(
+            json.dumps(
+                {
+                    "task": spec.task,
+                    "episodes": spec.episodes,
+                    "seed": spec.seed,
+                    "camera": spec.camera,
+                    "image_size": list(spec.image_size),
+                    "split": spec.split,
+                    "robot": spec.robot,
+                },
+                indent=2,
+            )
+            + "\n"
+        )
+        completed = subprocess.run(
+            [
+                interpreter,
+                "-c",
+                _RUN_EXPORTER,
+                str(Path(__file__).resolve()),
+                "export",
+                str(config_path),
+                str(export_dir),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+        )
+        if completed.returncode != 0 or not (export_dir / "snapshots.jsonl").is_file():
+            detail = (completed.stderr or completed.stdout).strip()
+            raise RuntimeError(
+                f"RoboCasa exporter failed ({completed.returncode}): {detail[-2000:]}"
+            )
+        snapshots = _load_export(export_dir)
+    if len(snapshots) != spec.episodes:
+        raise RuntimeError(
+            f"RoboCasa exported {len(snapshots)} snapshots, expected {spec.episodes}"
+        )
+    return snapshots
+
+
+def _resolve_interpreter(value: str) -> str:
+    candidate = shutil.which(value)
+    if candidate is None:
+        path = Path(value).expanduser()
+        if path.is_file() and os.access(path, os.X_OK):
+            candidate = str(path.resolve())
+    if candidate is None:
+        raise FileNotFoundError(f"RoboCasa Python interpreter not found or executable: {value}")
+    return candidate
+
+
+def _load_export(path: Path) -> list[SceneSnapshot]:
+    from dimos.evals.vqa import SceneSnapshot
+
+    manifest = path / "snapshots.jsonl"
+    if not manifest.is_file():
+        raise RuntimeError("RoboCasa exporter did not create snapshots.jsonl")
+    root = path.resolve()
+    snapshots: list[SceneSnapshot] = []
+    for line_number, line in enumerate(manifest.read_text().splitlines(), start=1):
+        if not line.strip():
+            continue
+        value = json.loads(line)
+        if not isinstance(value, dict):
+            raise TypeError(f"RoboCasa snapshot line {line_number} must be an object")
+        if value.get("schema_version") != ROBOCASA_EXPORT_SCHEMA_VERSION:
+            raise ValueError(f"RoboCasa snapshot line {line_number} has unsupported schema_version")
+        image_path = (root / str(value["image"])).resolve()
+        if not image_path.is_relative_to(root) or not image_path.is_file():
+            raise ValueError(f"RoboCasa snapshot line {line_number} has an invalid image path")
+        image = np.load(image_path, allow_pickle=False)
+        snapshots.append(SceneSnapshot.from_mapping(value, image=image.copy()))
+    return snapshots
+
+
+def _export(config_path: Path, output: Path) -> None:
+    import mujoco
+    import robocasa  # type: ignore[import-not-found]
+    from robocasa.utils.env_utils import create_env  # type: ignore[import-not-found]
+
+    config = json.loads(config_path.read_text())
+    if output.exists():
+        raise FileExistsError(f"RoboCasa export output already exists: {output}")
+    output.mkdir(parents=True)
+    width, height = (int(value) for value in config["image_size"])
+    rows: list[dict[str, Any]] = []
+    try:
+        source_version = importlib.metadata.version("robocasa")
+    except importlib.metadata.PackageNotFoundError:
+        source_version = str(getattr(robocasa, "__version__", "unknown"))
+
+    for episode in range(int(config["episodes"])):
+        seed = int(config["seed"]) + episode
+        env = create_env(
+            env_name=str(config["task"]),
+            robots=str(config["robot"]),
+            camera_names=[str(config["camera"])],
+            camera_widths=width,
+            camera_heights=height,
+            seed=seed,
+            split=config.get("split"),
+        )
+        try:
+            env.reset()
+            rgb = env.sim.render(
+                width=width,
+                height=height,
+                camera_name=str(config["camera"]),
+            )[::-1].copy()
+            segmentation = env.sim.render(
+                width=width,
+                height=height,
+                camera_name=str(config["camera"]),
+                segmentation=True,
+            )[::-1].copy()
+            if segmentation.ndim != 3 or segmentation.shape[2] != 2:
+                raise RuntimeError(f"unexpected RoboCasa segmentation shape: {segmentation.shape}")
+            entities = _extract_entities(env, segmentation, mujoco)
+            image_name = f"frame-{episode:05d}.npy"
+            np.save(output / image_name, rgb, allow_pickle=False)
+            rows.append(
+                {
+                    "schema_version": ROBOCASA_EXPORT_SCHEMA_VERSION,
+                    "image": image_name,
+                    "entities": entities,
+                    "provenance": {
+                        "source": "robocasa",
+                        "source_version": source_version,
+                        "task": str(config["task"]),
+                        "seed": seed,
+                        "layout_id": _json_safe(env.layout_id),
+                        "style_id": _json_safe(env.style_id),
+                        "camera": str(config["camera"]),
+                    },
+                }
+            )
+        finally:
+            close = getattr(env, "close", None)
+            if callable(close):
+                close()
+
+    with (output / "snapshots.jsonl").open("w") as stream:
+        for row in rows:
+            stream.write(json.dumps(row) + "\n")
+
+
+def _extract_entities(
+    env: Any, segmentation: np.ndarray[Any, Any], mujoco: Any
+) -> list[dict[str, Any]]:
+    geom_type = int(mujoco.mjtObj.mjOBJ_GEOM)
+    roots = {int(body_id): name for name, body_id in env.obj_body_id.items()}
+    geom_owner: dict[int, str] = {}
+    for geom_id in range(int(env.sim.model.ngeom)):
+        body_id = int(env.sim.model.geom_bodyid[geom_id])
+        while body_id != 0:
+            owner = roots.get(body_id)
+            if owner is not None:
+                geom_owner[geom_id] = owner
+                break
+            body_id = int(env.sim.model.body_parentid[body_id])
+
+    geom_pixels = segmentation[:, :, 0] == geom_type
+    entities: list[dict[str, Any]] = []
+    for name in sorted(env.objects):
+        geom_ids = [geom_id for geom_id, owner in geom_owner.items() if owner == name]
+        mask = geom_pixels & np.isin(segmentation[:, :, 1], geom_ids)
+        ys, xs = np.nonzero(mask)
+        pixel_area = int(xs.size)
+        entity: dict[str, Any] = {
+            "id": name,
+            "category": _normalize_category(env.get_obj_lang(name)),
+            "pixel_area": pixel_area,
+            "centroid": None,
+            "bbox": None,
+        }
+        if pixel_area:
+            entity["centroid"] = [float(xs.mean()), float(ys.mean())]
+            entity["bbox"] = [int(xs.min()), int(ys.min()), int(xs.max()), int(ys.max())]
+        entities.append(entity)
+    return entities
+
+
+def _normalize_category(value: str) -> str:
+    normalized = re.sub(r"[^a-z0-9]+", "_", value.strip().lower()).strip("_")
+    if not normalized:
+        raise ValueError("RoboCasa object category must not be empty")
+    return normalized
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, dict):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(item) for item in value]
+    return value
+
+
+def _main() -> None:
+    parser = argparse.ArgumentParser(description="Export RoboCasa snapshots for dimOS VQA")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    export = subparsers.add_parser("export")
+    export.add_argument("config", type=Path)
+    export.add_argument("output", type=Path)
+    args = parser.parse_args()
+    if args.command == "export":
+        _export(args.config, args.output)
+
+
+if __name__ == "__main__":
+    _main()

--- a/dimos/evals/test_generate.py
+++ b/dimos/evals/test_generate.py
@@ -1,0 +1,372 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Offline tests for generated VQA schemas, quality gates, and eval wiring."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from langchain_core.language_models.fake_chat_models import FakeListChatModel
+import numpy as np
+import pytest
+from typer.testing import CliRunner
+
+from dimos.evals.cli import app
+from dimos.evals.generate import (
+    GenerationOutput,
+    VqaGenerationSpec,
+    generate_from_spec,
+    load_generation_spec,
+    load_vqa_manifest,
+    materialize_vqa_dataset,
+)
+from dimos.evals.runner import EvalRunner
+from dimos.evals.vqa import SceneEntity, SceneSnapshot, generate_questions
+
+
+def _snapshot(*, seed: int = 100) -> SceneSnapshot:
+    return SceneSnapshot(
+        image=np.zeros((100, 100, 3), dtype=np.uint8),
+        entities=(
+            SceneEntity(
+                id="cup_0",
+                category="cup",
+                pixel_area=400,
+                centroid=(20.0, 30.0),
+                bbox=(10, 20, 30, 40),
+            ),
+            SceneEntity(
+                id="bottled_drink_0",
+                category="bottled drink",
+                pixel_area=500,
+                centroid=(80.0, 30.0),
+                bbox=(70, 20, 90, 40),
+            ),
+            SceneEntity(id="plate_0", category="plate", pixel_area=0),
+        ),
+        provenance={
+            "source": "robocasa",
+            "source_version": "test",
+            "task": "BeverageOrganization",
+            "seed": seed,
+            "layout_id": 1,
+            "style_id": 1,
+            "camera": "robot0_agentview_center",
+        },
+    )
+
+
+def _spec(output: Path) -> VqaGenerationSpec:
+    return VqaGenerationSpec(
+        source="robocasa",
+        use_case="beverage inventory",
+        task="BeverageOrganization",
+        episodes=1,
+        seed=100,
+        camera="robot0_agentview_center",
+        image_size=(100, 100),
+        question_families=("semantic_presence", "spatial_left_right"),
+        targets=("cup", "bottled_drink", "plate"),
+        output=output,
+        min_visible_pixels=50,
+        min_horizontal_separation=0.1,
+        max_bbox_overlap=0.25,
+    )
+
+
+def test_question_families_use_visibility_and_image_coordinates() -> None:
+    batch = generate_questions(
+        _snapshot(),
+        targets=("cup", "bottled_drink", "plate"),
+        families=("semantic_presence", "spatial_left_right"),
+        min_visible_pixels=50,
+        min_horizontal_separation=0.1,
+        max_bbox_overlap=0.25,
+        max_spatial_pairs=8,
+    )
+
+    presence = [question for question in batch.questions if question.family == "semantic_presence"]
+    spatial = [question for question in batch.questions if question.family == "spatial_left_right"]
+    assert [question.reference_outputs for question in presence] == ["yes", "yes", "no"]
+    assert len(spatial) == 1
+    assert spatial[0].reference_outputs == "right"
+    assert spatial[0].oracle == {
+        "family": "spatial_left_right",
+        "subject": "bottled_drink_0",
+        "reference": "cup_0",
+    }
+
+
+def test_question_generation_rejects_small_and_ambiguous_entities() -> None:
+    snapshot = SceneSnapshot(
+        image=np.zeros((100, 100, 3), dtype=np.uint8),
+        entities=(
+            SceneEntity(
+                id="cup_0",
+                category="cup",
+                pixel_area=10,
+                centroid=(10.0, 10.0),
+                bbox=(8, 8, 12, 12),
+            ),
+            SceneEntity(
+                id="bottle_0",
+                category="bottle",
+                pixel_area=200,
+                centroid=(40.0, 20.0),
+                bbox=(30, 10, 50, 30),
+            ),
+            SceneEntity(
+                id="bottle_1",
+                category="bottle",
+                pixel_area=200,
+                centroid=(80.0, 20.0),
+                bbox=(70, 10, 90, 30),
+            ),
+        ),
+        provenance={"seed": 1},
+    )
+    batch = generate_questions(
+        snapshot,
+        targets=("cup", "bottle"),
+        families=("semantic_presence", "spatial_left_right"),
+        min_visible_pixels=50,
+        min_horizontal_separation=0.1,
+        max_bbox_overlap=0.25,
+        max_spatial_pairs=8,
+    )
+
+    assert batch.rejected == {
+        "presence_too_small": 1,
+        "spatial_ambiguous_label": 2,
+    }
+    assert not [question for question in batch.questions if question.family == "spatial_left_right"]
+
+
+def test_scene_entity_rejects_inconsistent_visibility() -> None:
+    with pytest.raises(ValueError, match="invisible entities"):
+        SceneEntity(
+            id="cup",
+            category="cup",
+            pixel_area=0,
+            centroid=(1.0, 1.0),
+            bbox=(0, 0, 2, 2),
+        )
+
+
+def test_load_generation_spec_resolves_output_and_rejects_unknown_fields(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "use_case.yaml"
+    path.write_text(
+        """source: robocasa
+use_case: beverage_inventory
+task: BeverageOrganization
+episodes: 2
+seed: 10
+camera: robot0_agentview_center
+image_size: [128, 96]
+question_families: [semantic_presence]
+targets: [cup, bottled_drink]
+output: generated/run
+"""
+    )
+    spec = load_generation_spec(path)
+    assert spec.output == (tmp_path / "generated/run").resolve()
+    assert spec.image_size == (128, 96)
+    assert spec.split == "target"
+
+    path.write_text(path.read_text() + "surprise: true\n")
+    with pytest.raises(ValueError, match="unknown VQA generation spec fields"):
+        load_generation_spec(path)
+
+
+def test_generate_from_spec_uses_source_adapter(tmp_path: Path, monkeypatch: Any) -> None:
+    path = tmp_path / "use_case.yaml"
+    path.write_text(
+        """source: robocasa
+use_case: beverage_inventory
+task: BeverageOrganization
+episodes: 1
+seed: 100
+camera: robot0_agentview_center
+image_size: [100, 100]
+question_families: [semantic_presence, spatial_left_right]
+targets: [cup, bottled_drink, plate]
+output: generated
+min_visible_pixels: 50
+min_horizontal_separation: 0.1
+max_bbox_overlap: 0.25
+"""
+    )
+    seen: dict[str, object] = {}
+
+    def export(spec: VqaGenerationSpec, *, source_python: str):
+        seen["spec"] = spec
+        seen["source_python"] = source_python
+        return [_snapshot()]
+
+    monkeypatch.setattr("dimos.evals.generate.export_robocasa_snapshots", export)
+
+    output = generate_from_spec(path, source_python="/external/python")
+
+    assert output.accepted == 3
+    assert seen["source_python"] == "/external/python"
+    assert isinstance(seen["spec"], VqaGenerationSpec)
+
+
+def test_materialize_load_and_run_generated_cases(tmp_path: Path) -> None:
+    output = materialize_vqa_dataset(_spec(tmp_path / "generated"), [_snapshot()])
+    rows = json.loads(output.manifest.read_text())
+    assert output.accepted == 3
+    assert output.accepted_by_family == {
+        "semantic_presence": 2,
+        "spatial_left_right": 1,
+    }
+    assert output.rejected == {"presence_balance": 1}
+    assert [row["reference_outputs"] for row in rows] == ["yes", "no", "right"]
+    assert all(row["dataset"] == "observations.db" for row in rows)
+    assert all(row["provenance"]["seed"] == 100 for row in rows)
+    assert all("oracle" in row for row in rows)
+    summary = json.loads(output.summary.read_text())
+    assert summary["accepted_by_answer"] == {"no": 1, "right": 1, "yes": 1}
+    assert summary["observed_categories"] == ["bottled_drink", "cup", "plate"]
+
+    cases = load_vqa_manifest(output.manifest)
+    assert len(cases) == 3
+
+    class TextOnlyRunner(EvalRunner):
+        def encode(self, stream: Any) -> list[dict[str, Any]]:
+            observations = list(stream)
+            assert len(observations) == 1
+            assert observations[0].data.shape == (100, 100, 3)
+            return [{"type": "text", "text": "one generated RGB observation"}]
+
+    runner = TextOnlyRunner(
+        chat_model=FakeListChatModel(responses=["yes", "no", "right"]),
+        out_dir=tmp_path / "eval-results",
+    )
+    results = runner.run(cases)
+    assert all(result.passed for result in results)
+    assert json.loads((runner.run_dir / "summary.json").read_text())["pass_rate"] == 1.0
+
+
+def test_generation_is_deterministic_and_refuses_overwrite(tmp_path: Path) -> None:
+    first = materialize_vqa_dataset(_spec(tmp_path / "first"), [_snapshot()])
+    second = materialize_vqa_dataset(_spec(tmp_path / "second"), [_snapshot()])
+    assert json.loads(first.manifest.read_text()) == json.loads(second.manifest.read_text())
+
+    with pytest.raises(FileExistsError, match="output already exists"):
+        materialize_vqa_dataset(_spec(tmp_path / "first"), [_snapshot()])
+
+
+def test_generation_requires_every_requested_family(tmp_path: Path) -> None:
+    spec = replace(
+        _spec(tmp_path / "generated"),
+        targets=("cup", "bottled_drink"),
+        question_families=("semantic_presence",),
+    )
+    with pytest.raises(ValueError, match="observed_categories=.*bottled_drink"):
+        materialize_vqa_dataset(spec, [_snapshot()])
+
+
+def test_manifest_rejects_unknown_answer_type(tmp_path: Path) -> None:
+    manifest = tmp_path / "cases.json"
+    manifest.write_text(
+        json.dumps(
+            [
+                {
+                    "schema_version": 1,
+                    "id": "bad",
+                    "inputs": "?",
+                    "reference_outputs": "x",
+                    "answer_type": "free_form",
+                    "dataset": "observations.db",
+                    "stream": "color_image",
+                    "frame_ts": 0,
+                    "tags": [],
+                }
+            ]
+        )
+    )
+    with pytest.raises(ValueError, match="unsupported answer_type"):
+        load_vqa_manifest(manifest)
+
+
+def test_cli_generate_reports_materialized_outputs(tmp_path: Path, monkeypatch: Any) -> None:
+    spec = tmp_path / "use_case.yaml"
+    spec.write_text("source: robocasa\n")
+    generated = tmp_path / "generated"
+    output = GenerationOutput(
+        output_dir=generated,
+        manifest=generated / "cases.json",
+        dataset=generated / "observations.db",
+        summary=generated / "generation_summary.json",
+        accepted=3,
+        accepted_by_family={"semantic_presence": 2, "spatial_left_right": 1},
+        rejected={"spatial_too_close": 1},
+    )
+    monkeypatch.setattr("dimos.evals.generate.generate_from_spec", lambda *args, **kwargs: output)
+
+    result = CliRunner().invoke(
+        app,
+        ["generate", str(spec), "--source-python", "/external/python"],
+    )
+
+    assert result.exit_code == 0
+    assert "Generated 3 VQA cases" in result.stdout
+    assert "semantic_presence: 2" in result.stdout
+    assert str(output.manifest) in result.stdout
+
+
+def test_cli_run_routes_json_manifests_to_existing_runner(tmp_path: Path, monkeypatch: Any) -> None:
+    manifest = tmp_path / "cases.json"
+    manifest.write_text("[]")
+    cases = [object()]
+    seen: dict[str, object] = {}
+
+    def load(path: str) -> list[object]:
+        seen["manifest"] = path
+        return cases
+
+    class FakeRunner:
+        run_dir = tmp_path / "run"
+
+        def __init__(self, **kwargs: object) -> None:
+            seen["runner_kwargs"] = kwargs
+
+        def run(self, values: object, **kwargs: object) -> list[object]:
+            seen["cases"] = values
+            seen["run_kwargs"] = kwargs
+            return []
+
+    monkeypatch.setattr("dimos.evals.generate.load_vqa_manifest", load)
+    monkeypatch.setattr("dimos.evals.runner.EvalRunner", FakeRunner)
+    monkeypatch.setattr(
+        "dimos.evals.runner.summarize",
+        lambda results: SimpleNamespace(
+            n=0, mean_score=0.0, pass_rate=0.0, errors=0, duration_s=0.0
+        ),
+    )
+
+    result = CliRunner().invoke(app, ["run", str(manifest), "--limit", "2"])
+
+    assert result.exit_code == 0
+    assert seen["manifest"] == str(manifest)
+    assert seen["cases"] is cases
+    assert seen["run_kwargs"] == {"tags": frozenset(), "limit": 2}

--- a/dimos/evals/test_robocasa.py
+++ b/dimos/evals/test_robocasa.py
@@ -1,0 +1,243 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Optional fixed-seed smoke test for a prepared external RoboCasa install."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import numpy as np
+import pytest
+
+from dimos.evals.generate import VqaGenerationSpec, materialize_vqa_dataset
+from dimos.evals.robocasa import (
+    ROBOCASA_EXPORT_SCHEMA_VERSION,
+    _export,
+    _extract_entities,
+    _load_export,
+    export_robocasa_snapshots,
+)
+
+
+def _spec(output: Path) -> VqaGenerationSpec:
+    return VqaGenerationSpec(
+        source="robocasa",
+        use_case="beverage_inventory_smoke",
+        task="BeverageOrganization",
+        episodes=3,
+        seed=100,
+        camera="robot0_agentview_center",
+        image_size=(128, 128),
+        question_families=("semantic_presence", "spatial_left_right"),
+        targets=("can", "liquor", "bottled_water", "milk", "beer", "pitcher"),
+        output=output,
+        min_visible_pixels=20,
+        min_horizontal_separation=0.05,
+        max_bbox_overlap=0.9,
+    )
+
+
+def test_extract_entities_maps_geom_instances_to_robocasa_objects() -> None:
+    model = SimpleNamespace(
+        ngeom=3,
+        geom_bodyid=np.array([1, 2, 3]),
+        body_parentid=np.array([0, 0, 1, 0]),
+    )
+
+    class FakeEnv:
+        sim = SimpleNamespace(model=model)
+        obj_body_id = {"cup_0": 1, "bottle_0": 3}
+        objects = {"cup_0": object(), "bottle_0": object()}
+
+        def get_obj_lang(self, name: str) -> str:
+            return {"cup_0": "Coffee Cup", "bottle_0": "Bottle"}[name]
+
+    segmentation = np.zeros((4, 4, 2), dtype=np.int32)
+    segmentation[:, :, 0] = 5
+    segmentation[0:2, 0:2, 1] = 0
+    segmentation[2:4, 0:2, 1] = 1
+    segmentation[:, 2:4, 1] = -1
+    mujoco = SimpleNamespace(mjtObj=SimpleNamespace(mjOBJ_GEOM=5))
+
+    entities = _extract_entities(FakeEnv(), segmentation, mujoco)
+
+    by_id: dict[str, dict[str, Any]] = {str(entity["id"]): entity for entity in entities}
+    assert by_id["cup_0"] == {
+        "id": "cup_0",
+        "category": "coffee_cup",
+        "pixel_area": 8,
+        "centroid": [0.5, 1.5],
+        "bbox": [0, 0, 1, 3],
+    }
+    assert by_id["bottle_0"]["pixel_area"] == 0
+
+
+def test_load_export_rejects_image_outside_export_directory(tmp_path: Path) -> None:
+    export = tmp_path / "export"
+    export.mkdir()
+    np.save(tmp_path / "outside.npy", np.zeros((2, 2, 3), dtype=np.uint8))
+    (export / "snapshots.jsonl").write_text(
+        '{"schema_version": 1, "image": "../outside.npy", "entities": [], "provenance": {}}\n'
+    )
+
+    with pytest.raises(ValueError, match="invalid image path"):
+        _load_export(export)
+
+
+def test_load_export_rejects_unknown_schema(tmp_path: Path) -> None:
+    export = tmp_path / "export"
+    export.mkdir()
+    np.save(export / "frame.npy", np.zeros((2, 2, 3), dtype=np.uint8))
+    (export / "snapshots.jsonl").write_text(
+        '{"schema_version": 2, "image": "frame.npy", "entities": [], "provenance": {}}\n'
+    )
+
+    with pytest.raises(ValueError, match="unsupported schema_version"):
+        _load_export(export)
+
+
+def test_external_exporter_loads_versioned_snapshot(tmp_path: Path, monkeypatch: Any) -> None:
+    def run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        export = Path(command[-1])
+        export.mkdir()
+        np.save(export / "frame.npy", np.zeros((128, 128, 3), dtype=np.uint8))
+        row = {
+            "schema_version": ROBOCASA_EXPORT_SCHEMA_VERSION,
+            "image": "frame.npy",
+            "entities": [],
+            "provenance": {"seed": 100},
+        }
+        (export / "snapshots.jsonl").write_text(json.dumps(row) + "\n")
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(subprocess, "run", run)
+    spec = replace(_spec(tmp_path / "unused"), episodes=1)
+
+    snapshots = export_robocasa_snapshots(spec, source_python=sys.executable)
+
+    assert len(snapshots) == 1
+    assert snapshots[0].provenance["seed"] == 100
+
+
+def test_external_exporter_rejects_missing_manifest(tmp_path: Path, monkeypatch: Any) -> None:
+    def run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(command, 0, "", "export traceback")
+
+    monkeypatch.setattr(subprocess, "run", run)
+    spec = replace(_spec(tmp_path / "unused"), episodes=1)
+
+    with pytest.raises(RuntimeError, match=r"failed \(0\).*export traceback"):
+        export_robocasa_snapshots(spec, source_python=sys.executable)
+
+
+def test_export_writes_rgb_entities_and_schema(tmp_path: Path, monkeypatch: Any) -> None:
+    model = SimpleNamespace(
+        ngeom=1,
+        geom_bodyid=np.array([1]),
+        body_parentid=np.array([0, 0]),
+    )
+
+    class FakeSim:
+        def __init__(self) -> None:
+            self.model = model
+
+        def render(self, *, width: int, height: int, segmentation: bool = False, **kwargs: object):
+            if not segmentation:
+                return np.zeros((height, width, 3), dtype=np.uint8)
+            value = np.zeros((height, width, 2), dtype=np.int32)
+            value[:, :, 0] = 5
+            return value
+
+    class FakeEnv:
+        sim = FakeSim()
+        obj_body_id = {"can_0": 1}
+        objects = {"can_0": object()}
+        layout_id = np.int64(2)
+        style_id = np.int64(3)
+        closed = False
+
+        def reset(self) -> None:
+            return None
+
+        def close(self) -> None:
+            self.closed = True
+
+        def get_obj_lang(self, name: str) -> str:
+            return "Can"
+
+    env = FakeEnv()
+    mujoco = ModuleType("mujoco")
+    mujoco.mjtObj = SimpleNamespace(mjOBJ_GEOM=5)  # type: ignore[attr-defined]
+    robocasa = ModuleType("robocasa")
+    robocasa.__version__ = "test"  # type: ignore[attr-defined]
+    robocasa.__path__ = []  # type: ignore[attr-defined]
+    utils = ModuleType("robocasa.utils")
+    utils.__path__ = []  # type: ignore[attr-defined]
+    env_utils = ModuleType("robocasa.utils.env_utils")
+    env_utils.create_env = lambda **kwargs: env  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "mujoco", mujoco)
+    monkeypatch.setitem(sys.modules, "robocasa", robocasa)
+    monkeypatch.setitem(sys.modules, "robocasa.utils", utils)
+    monkeypatch.setitem(sys.modules, "robocasa.utils.env_utils", env_utils)
+
+    config = tmp_path / "config.json"
+    config.write_text(
+        json.dumps(
+            {
+                "task": "BeverageOrganization",
+                "episodes": 1,
+                "seed": 100,
+                "camera": "robot0_agentview_center",
+                "image_size": [4, 3],
+                "split": "target",
+                "robot": "PandaOmron",
+            }
+        )
+    )
+    output = tmp_path / "export"
+
+    _export(config, output)
+
+    snapshots = _load_export(output)
+    assert snapshots[0].image.shape == (3, 4, 3)
+    assert snapshots[0].entities[0].category == "can"
+    assert snapshots[0].provenance["layout_id"] == 2
+    assert env.closed
+
+
+@pytest.mark.self_hosted
+@pytest.mark.mujoco
+def test_robocasa_exports_semantic_and_spatial_vqa(tmp_path: Path) -> None:
+    source_python = os.environ.get("ROBOCASA_PYTHON")
+    if not source_python:
+        pytest.skip("set ROBOCASA_PYTHON to a prepared RoboCasa interpreter")
+
+    spec = _spec(tmp_path / "generated")
+    snapshots = export_robocasa_snapshots(spec, source_python=source_python)
+    assert len(snapshots) == spec.episodes
+    assert all(snapshot.image.shape == (128, 128, 3) for snapshot in snapshots)
+
+    output = materialize_vqa_dataset(spec, snapshots)
+    assert output.accepted_by_family["semantic_presence"] >= 2
+    assert output.accepted_by_family["spatial_left_right"] >= 1
+    assert output.manifest.is_file()
+    assert output.dataset.is_file()

--- a/dimos/evals/vqa.py
+++ b/dimos/evals/vqa.py
@@ -1,0 +1,280 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Source-neutral VQA scene facts, question families, and quality gates."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from itertools import combinations
+import re
+from typing import Any, Literal
+
+import numpy as np
+
+AnswerType = Literal["yes_no", "choice"]
+QuestionFamily = Literal["semantic_presence", "spatial_left_right"]
+SUPPORTED_QUESTION_FAMILIES: frozenset[str] = frozenset({"semantic_presence", "spatial_left_right"})
+
+
+def normalize_category(value: str) -> str:
+    """Return the stable identifier used in specs, snapshots, and manifests."""
+    normalized = re.sub(r"[^a-z0-9]+", "_", value.strip().lower()).strip("_")
+    if not normalized:
+        raise ValueError("entity category must not be empty")
+    return normalized
+
+
+def humanize_category(value: str) -> str:
+    return normalize_category(value).replace("_", " ")
+
+
+@dataclass(frozen=True, kw_only=True)
+class SceneEntity:
+    """One simulator entity and its visibility in the exported RGB frame."""
+
+    id: str
+    category: str
+    pixel_area: int
+    centroid: tuple[float, float] | None = None
+    bbox: tuple[int, int, int, int] | None = None  # x1, y1, x2, y2; inclusive
+
+    def __post_init__(self) -> None:
+        if not self.id.strip():
+            raise ValueError("entity id must not be empty")
+        object.__setattr__(self, "category", normalize_category(self.category))
+        if self.pixel_area < 0:
+            raise ValueError("pixel_area must be non-negative")
+        if self.pixel_area == 0 and (self.centroid is not None or self.bbox is not None):
+            raise ValueError("invisible entities must not have a centroid or bbox")
+        if self.pixel_area > 0 and (self.centroid is None or self.bbox is None):
+            raise ValueError("visible entities require a centroid and bbox")
+        if self.bbox is not None:
+            x1, y1, x2, y2 = self.bbox
+            if x1 > x2 or y1 > y2:
+                raise ValueError("entity bbox bounds are inverted")
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> SceneEntity:
+        centroid = value.get("centroid")
+        bbox = value.get("bbox")
+        return cls(
+            id=str(value["id"]),
+            category=str(value["category"]),
+            pixel_area=int(value["pixel_area"]),
+            centroid=(float(centroid[0]), float(centroid[1])) if centroid is not None else None,
+            bbox=tuple(int(v) for v in bbox) if bbox is not None else None,  # type: ignore[arg-type]
+        )
+
+
+@dataclass(frozen=True, kw_only=True)
+class SceneSnapshot:
+    """One RGB observation plus private facts used only to derive labels."""
+
+    image: np.ndarray[Any, Any]
+    entities: tuple[SceneEntity, ...]
+    provenance: Mapping[str, Any]
+
+    def __post_init__(self) -> None:
+        if self.image.dtype != np.uint8 or self.image.ndim != 3 or self.image.shape[2] != 3:
+            raise ValueError("snapshot image must be an HxWx3 uint8 RGB array")
+        if self.image.shape[0] == 0 or self.image.shape[1] == 0:
+            raise ValueError("snapshot image must not be empty")
+        ids = [entity.id for entity in self.entities]
+        if len(ids) != len(set(ids)):
+            raise ValueError("snapshot entity ids must be unique")
+
+    @classmethod
+    def from_mapping(
+        cls, value: Mapping[str, Any], *, image: np.ndarray[Any, Any]
+    ) -> SceneSnapshot:
+        raw_entities = value.get("entities")
+        if not isinstance(raw_entities, list):
+            raise TypeError("snapshot entities must be a list")
+        provenance = value.get("provenance", {})
+        if not isinstance(provenance, dict):
+            raise TypeError("snapshot provenance must be an object")
+        return cls(
+            image=image,
+            entities=tuple(SceneEntity.from_mapping(entity) for entity in raw_entities),
+            provenance=provenance,
+        )
+
+
+@dataclass(frozen=True, kw_only=True)
+class GeneratedQuestion:
+    inputs: str
+    reference_outputs: str
+    answer_type: AnswerType
+    family: QuestionFamily
+    oracle: Mapping[str, str]
+
+
+@dataclass(frozen=True, kw_only=True)
+class QuestionBatch:
+    questions: tuple[GeneratedQuestion, ...]
+    rejected: Mapping[str, int]
+
+
+def generate_questions(
+    snapshot: SceneSnapshot,
+    *,
+    targets: Sequence[str],
+    families: Sequence[str],
+    min_visible_pixels: int,
+    min_horizontal_separation: float,
+    max_bbox_overlap: float,
+    max_spatial_pairs: int,
+) -> QuestionBatch:
+    """Generate deterministic, image-answerable questions from one snapshot."""
+    if min_visible_pixels <= 0:
+        raise ValueError("min_visible_pixels must be positive")
+    if not 0 < min_horizontal_separation <= 1:
+        raise ValueError("min_horizontal_separation must be in (0, 1]")
+    if not 0 <= max_bbox_overlap <= 1:
+        raise ValueError("max_bbox_overlap must be in [0, 1]")
+    if max_spatial_pairs <= 0:
+        raise ValueError("max_spatial_pairs must be positive")
+
+    unknown = set(families) - SUPPORTED_QUESTION_FAMILIES
+    if unknown:
+        raise ValueError(f"unsupported question families: {sorted(unknown)}")
+
+    questions: list[GeneratedQuestion] = []
+    rejected: Counter[str] = Counter()
+    normalized_targets = tuple(dict.fromkeys(normalize_category(target) for target in targets))
+
+    if "semantic_presence" in families:
+        questions.extend(
+            _presence_questions(
+                snapshot,
+                targets=normalized_targets,
+                min_visible_pixels=min_visible_pixels,
+                rejected=rejected,
+            )
+        )
+    if "spatial_left_right" in families:
+        questions.extend(
+            _left_right_questions(
+                snapshot,
+                targets=frozenset(normalized_targets),
+                min_visible_pixels=min_visible_pixels,
+                min_horizontal_separation=min_horizontal_separation,
+                max_bbox_overlap=max_bbox_overlap,
+                max_pairs=max_spatial_pairs,
+                rejected=rejected,
+            )
+        )
+    return QuestionBatch(questions=tuple(questions), rejected=dict(rejected))
+
+
+def _presence_questions(
+    snapshot: SceneSnapshot,
+    *,
+    targets: Sequence[str],
+    min_visible_pixels: int,
+    rejected: Counter[str],
+) -> list[GeneratedQuestion]:
+    by_category: dict[str, list[SceneEntity]] = {}
+    for entity in snapshot.entities:
+        by_category.setdefault(entity.category, []).append(entity)
+
+    questions: list[GeneratedQuestion] = []
+    for target in targets:
+        areas = [entity.pixel_area for entity in by_category.get(target, [])]
+        if areas and 0 < max(areas) < min_visible_pixels:
+            rejected["presence_too_small"] += 1
+            continue
+        answer = "yes" if any(area >= min_visible_pixels for area in areas) else "no"
+        questions.append(
+            GeneratedQuestion(
+                inputs=f"Is there a {humanize_category(target)} visible in the image?",
+                reference_outputs=answer,
+                answer_type="yes_no",
+                family="semantic_presence",
+                oracle={"family": "semantic_presence", "category": target},
+            )
+        )
+    return questions
+
+
+def _left_right_questions(
+    snapshot: SceneSnapshot,
+    *,
+    targets: frozenset[str],
+    min_visible_pixels: int,
+    min_horizontal_separation: float,
+    max_bbox_overlap: float,
+    max_pairs: int,
+    rejected: Counter[str],
+) -> list[GeneratedQuestion]:
+    eligible = [
+        entity
+        for entity in snapshot.entities
+        if entity.category in targets and entity.pixel_area >= min_visible_pixels
+    ]
+    category_counts = Counter(entity.category for entity in eligible)
+    eligible = [entity for entity in eligible if category_counts[entity.category] == 1]
+    ambiguous = sum(count for count in category_counts.values() if count > 1)
+    if ambiguous:
+        rejected["spatial_ambiguous_label"] += ambiguous
+
+    width = float(snapshot.image.shape[1])
+    questions: list[GeneratedQuestion] = []
+    pairs = tuple(combinations(sorted(eligible, key=lambda entity: entity.id), 2))
+    for pair_index, (subject, reference) in enumerate(pairs):
+        assert subject.centroid is not None and reference.centroid is not None
+        if abs(subject.centroid[0] - reference.centroid[0]) / width < min_horizontal_separation:
+            rejected["spatial_too_close"] += 1
+            continue
+        assert subject.bbox is not None and reference.bbox is not None
+        if _bbox_overlap(subject.bbox, reference.bbox) > max_bbox_overlap:
+            rejected["spatial_overlap"] += 1
+            continue
+        answer = "left" if subject.centroid[0] < reference.centroid[0] else "right"
+        questions.append(
+            GeneratedQuestion(
+                inputs=(
+                    f"Is the {humanize_category(subject.category)} to the left or right "
+                    f"of the {humanize_category(reference.category)}?"
+                ),
+                reference_outputs=answer,
+                answer_type="choice",
+                family="spatial_left_right",
+                oracle={
+                    "family": "spatial_left_right",
+                    "subject": subject.id,
+                    "reference": reference.id,
+                },
+            )
+        )
+        if len(questions) == max_pairs:
+            remaining = len(pairs) - pair_index - 1
+            if remaining > 0:
+                rejected["spatial_pair_limit"] += remaining
+            break
+    return questions
+
+
+def _bbox_overlap(a: tuple[int, int, int, int], b: tuple[int, int, int, int]) -> float:
+    ax1, ay1, ax2, ay2 = a
+    bx1, by1, bx2, by2 = b
+    intersection_w = max(0, min(ax2, bx2) - max(ax1, bx1) + 1)
+    intersection_h = max(0, min(ay2, by2) - max(ay1, by1) + 1)
+    intersection = intersection_w * intersection_h
+    area_a = (ax2 - ax1 + 1) * (ay2 - ay1 + 1)
+    area_b = (bx2 - bx1 + 1) * (by2 - by1 + 1)
+    return intersection / min(area_a, area_b)

--- a/docs/usage/evals.md
+++ b/docs/usage/evals.md
@@ -29,6 +29,62 @@ dimos evals list
 Each run prints a per-case table and writes `results.jsonl`, `summary.json`,
 and per-case transcripts to `~/.local/state/dimos/evals/run-*/`.
 
+## Generate VQA cases with RoboCasa
+
+The VQA generator turns a concrete simulator use case into ordinary passive
+eval cases. RoboCasa stays in a separate environment because its MuJoCo and
+asset requirements differ from dimOS; generating VQA does not add it to the
+default dimOS install.
+
+Create a YAML specification:
+
+```yaml
+source: robocasa
+use_case: beverage_inventory
+task: BeverageOrganization
+episodes: 3
+seed: 100
+camera: robot0_agentview_center
+image_size: [128, 128]  # width, height
+question_families: [semantic_presence, spatial_left_right]
+targets: [can, liquor, bottled_water, milk, beer, pitcher]
+min_visible_pixels: 20
+min_horizontal_separation: 0.05
+max_bbox_overlap: 0.9
+output: generated/beverage_inventory
+```
+
+Point the command at a prepared RoboCasa Python interpreter, then run the
+generated manifest through the normal eval runner:
+
+```bash
+dimos evals generate use_case.yaml \
+  --source-python /path/to/robocasa-env/bin/python
+dimos evals run generated/beverage_inventory/cases.json
+```
+
+On macOS, pass the environment's normal `bin/python` for this headless
+exporter. `mjpython` is intended for an interactive viewer and can fail when
+GLFW creates its Cocoa window from the worker thread.
+
+The output directory contains `observations.db`, `cases.json`, and
+`generation_summary.json`. The database stores only RGB observations shown to
+the evaluated model. Simulator segmentation and object identities derive the
+reference answers but remain private audit metadata in the manifest.
+The summary also lists the categories observed during generation so a
+developer can choose valid targets for a larger run.
+
+`semantic_presence` emits balanced visible/not-visible questions for the
+configured target categories. `spatial_left_right` uses segmentation
+centroids and rejects small, overlapping, horizontally close, or
+label-ambiguous object pairs. Generation is deterministic for a fixed source
+version, specification, and seed, refuses to overwrite an existing output,
+and fails if any requested question family produces no usable cases.
+
+These are the two built-in question families in the initial release. Adding a
+new family is a code extension to the source-neutral generator, not an
+arbitrary prompt supplied in YAML.
+
 ## Your first eval, end to end
 
 Build a tiny recording (any memory store works — this is the same API the


### PR DESCRIPTION
## Contribution path

- Linked foundation PR: #3411 (merged)
- Branch note: after #3411 merged, this branch was rebased onto the latest `main` with `git rebase --onto origin/main 0ddf8b493 feat/vqa-generation-framework`. The PR is now independent and contains one VQA feature commit (`ec449cec4`).

## Problem

#3411 adds the evaluation framework and its Memory-backed passive runner, but image VQA cases still need to be authored manually. A developer has no reproducible path from a simulator use case to rendered observations, grounded questions, reference answers, and a case manifest that the existing dimOS evaluation runner can consume.

## Solution

Add a small VQA generation layer that runs RoboCasa through an external Python environment and converts seeded simulator scenes into the existing dimOS evaluation inputs.

The generator exports RGB and instance-segmentation observations, normalizes simulator metadata into source-independent scene facts, and produces two initial question families: semantic presence and spatial left/right. Answerability gates reject ambiguous or visually weak cases using visibility, pixel area, label uniqueness, horizontal separation, and bounding-box overlap. Family balancing and deterministic seeds keep generated datasets reproducible.

The output contains a versioned `cases.json` manifest and a Memory `observations.db`, so it can be loaded directly by the existing passive evaluation path. RoboCasa, robosuite, and MuJoCo remain outside the dimOS runtime; this change adds no production dependency and avoids coupling the core package to a simulator-specific environment.

Developer workflow:

```bash
dimos evals generate use_case.yaml --source-python /path/to/robocasa/python
dimos evals run generated/use_case/cases.json
```

This PR deliberately does not add a new evaluation engine, scorer, agent loop, or generalized scene generator. It provides the necessary adapter and schema boundary for simulator-grounded VQA generation, with two concrete families that can be tested end to end.

## How to Test

```bash
uv run pytest dimos/evals/test_generate.py dimos/evals/test_robocasa.py -m 'not (self_hosted or mujoco)'

ROBOCASA_PYTHON=/path/to/robocasa/python \
  uv run pytest dimos/evals/test_robocasa.py -m 'self_hosted and mujoco'

uv run mypy \
  dimos/evals/cli.py dimos/evals/generate.py \
  dimos/evals/robocasa.py dimos/evals/vqa.py

uv run ruff check \
  dimos/evals/cli.py dimos/evals/generate.py dimos/evals/robocasa.py \
  dimos/evals/test_generate.py dimos/evals/test_robocasa.py dimos/evals/vqa.py

uv run ruff format --check \
  dimos/evals/cli.py dimos/evals/generate.py dimos/evals/robocasa.py \
  dimos/evals/test_generate.py dimos/evals/test_robocasa.py dimos/evals/vqa.py
```

Local verification completed with 32 relevant evaluation tests passing, including a real RoboCasa/MuJoCo fixed-seed run. Seeds 100-102 generated 18 accepted cases: 14 semantic-presence cases and 4 spatial left/right cases. Eight repository static checks also passed.

## Checklist

- [ ] I have read and approved the [Contributor License Agreement](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
