### PR TITLE
fix: fall back to GitHub for LFS downloads

### DIFF
--- a/dimos/utils/data.py
+++ b/dimos/utils/data.py
@@ -29,6 +29,8 @@ from dimos.utils.logging_config import setup_logger
 
 logger = setup_logger()
 
+GITHUB_LFS_URL = "https://github.com/dimensionalOS/dimos.git/info/lfs"
+
 
 def _get_user_data_dir() -> Path:
     """Get platform-specific user data directory."""
@@ -213,9 +215,32 @@ def _lfs_pull(file_path: Path, repo_root: Path, *, retries: int = 2) -> None:
             if attempt <= retries:
                 time.sleep(attempt)  # 1s, 2s backoff
 
-    raise RuntimeError(
-        f"Failed to pull LFS file {file_path} after {retries + 1} attempts: {last_err}"
+    logger.warning(
+        "Primary LFS endpoint failed; trying GitHub LFS",
+        file_path=str(relative_path),
+        attempts=retries + 1,
     )
+    try:
+        subprocess.run(
+            [
+                "git",
+                "-c",
+                f"lfs.url={GITHUB_LFS_URL}",
+                "lfs",
+                "pull",
+                "--include",
+                str(relative_path),
+            ],
+            cwd=repo_root,
+            check=True,
+            env=env,
+        )
+        return
+    except subprocess.CalledProcessError as fallback_err:
+        raise RuntimeError(
+            f"Failed to pull LFS file {file_path} from both the primary endpoint "
+            f"({retries + 1} attempts: {last_err}) and GitHub LFS ({fallback_err})"
+        ) from fallback_err
 
 
 def _decompress_archive(filename: str | Path) -> Path:

--- a/dimos/utils/test_data.py
+++ b/dimos/utils/test_data.py
@@ -16,8 +16,10 @@ import hashlib
 import os
 from pathlib import Path
 import subprocess
+from unittest.mock import call
 
 import pytest
+from pytest_mock import MockerFixture
 
 from dimos.utils import data
 from dimos.utils.data import LfsPath, backup_file
@@ -98,6 +100,58 @@ def test_backup_file_keep_last_zero_removes_all(tmp_path: Path) -> None:
     assert backup_file(db, keep_last=0) is None
 
     assert list(tmp_path.glob("recording_go2.*.db")) == []
+
+
+def test_lfs_pull_falls_back_to_github_without_changing_config(
+    tmp_path: Path, mocker: MockerFixture
+) -> None:
+    archive = tmp_path / "data" / ".lfs" / "sim.tar.gz"
+    run = mocker.patch(
+        "dimos.utils.data.subprocess.run",
+        side_effect=[subprocess.CalledProcessError(2, "git"), None],
+    )
+    mocker.patch("dimos.utils.data.time.sleep")
+
+    data._lfs_pull(archive, tmp_path, retries=0)
+
+    env = os.environ.copy()
+    env["GIT_LFS_FORCE_PROGRESS"] = "1"
+    assert run.call_args_list == [
+        call(
+            ["git", "lfs", "pull", "--include", "data/.lfs/sim.tar.gz"],
+            cwd=tmp_path,
+            check=True,
+            env=env,
+        ),
+        call(
+            [
+                "git",
+                "-c",
+                f"lfs.url={data.GITHUB_LFS_URL}",
+                "lfs",
+                "pull",
+                "--include",
+                "data/.lfs/sim.tar.gz",
+            ],
+            cwd=tmp_path,
+            check=True,
+            env=env,
+        ),
+    ]
+
+
+def test_lfs_pull_reports_both_endpoint_failures(tmp_path: Path, mocker: MockerFixture) -> None:
+    archive = tmp_path / "data" / ".lfs" / "sim.tar.gz"
+    mocker.patch(
+        "dimos.utils.data.subprocess.run",
+        side_effect=[
+            subprocess.CalledProcessError(2, "primary"),
+            subprocess.CalledProcessError(2, "fallback"),
+        ],
+    )
+
+    with pytest.raises(RuntimeError, match="both the primary endpoint.*and GitHub LFS"):
+        data._lfs_pull(archive, tmp_path, retries=0)
 
 
 @pytest.mark.self_hosted


### PR DESCRIPTION
## Contribution path

- Linked issue or discussion: #2495

## Problem

The configured `lfs.dimensionalos.com` endpoint can return 404 for objects that are still available from GitHub LFS. After retrying only the primary endpoint, `get_data()` raises and simulation startup fails. Users currently have to discover and persist a local `lfs.url` workaround themselves.

## Solution

After the existing primary-endpoint retries are exhausted, retry the same object once through the repository’s GitHub LFS endpoint using a per-command `git -c lfs.url=...` override. This does not modify local or global Git configuration. If both endpoints fail, the exception reports both failures.

Tests cover a successful fallback, the exact non-persistent command, and the combined-error path.

## How to Test

```bash
uv run pytest dimos/utils/test_data.py -k lfs_pull
```

I also verified the fallback endpoint against the known `cafe.jpg.tar.gz` LFS object with:

```bash
git -c lfs.url=https://github.com/dimensionalOS/dimos.git/info/lfs lfs fetch origin --include=data/.lfs/cafe.jpg.tar.gz
```

## AI assistance

OpenAI Codex with GPT-5 assisted with codebase analysis, implementation, adversarial review, and test generation. The change is intentionally kept as a draft for final human review before requesting maintainer review.

## Checklist

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).

Closes #2495