### PR TITLE
fix: ignore env vars for transports not declared by the current blueprint

### DIFF
--- a/dimos/core/coordination/blueprint_config/merging.py
+++ b/dimos/core/coordination/blueprint_config/merging.py
@@ -90,6 +90,7 @@ def merge_environment(
         roots[config_key(module.atom.name).lower()] = module.atom.name
         roots[module.atom.name.lower()] = module.atom.name
 
+    known_transports = {transport.name for transport in schema.transports}
     global_env_names = global_environment_names()
     targets = {target.identity: target for target in schema.targets}
     env_source: dict[str, Any] = {}
@@ -109,6 +110,8 @@ def merge_environment(
 
         parts = tuple(part.lower().replace("-", "_") for part in raw_name.split("__"))
         if len(parts) < 2 or parts[0] not in roots:
+            continue
+        if parts[0] == "transports" and (len(parts) < 3 or parts[1] not in known_transports):
             continue
         set_coerced((roots[parts[0]], *parts[1:]), raw_name, value)
 

--- a/dimos/core/coordination/blueprint_config/test_parser.py
+++ b/dimos/core/coordination/blueprint_config/test_parser.py
@@ -264,6 +264,20 @@ def test_transport_options_support_relative_full_and_environment_forms() -> None
     assert from_cli.transport_overrides() == {"provider": {"api_key": "cli-key", "retries": 3}}
 
 
+def test_environment_ignores_unknown_transport_section() -> None:
+    blueprint = PrimaryModule.blueprint()
+    parser = BlueprintConfigParser(blueprint)
+
+    parsed = parser.parse(
+        environ={
+            "TRANSPORTS__BROKER__BROKER_URL": "https://teleop.dimensionalos.com",
+            "TRANSPORTS__BROKER__API_KEY": "",
+        },
+    )
+
+    assert parsed.transport_configs == {}
+
+
 def test_environment_values_coerce_null_and_json_like_cli() -> None:
     parsed = BlueprintConfigParser(PrimaryModule.blueprint(map_file="pinned")).parse(
         environ={


### PR DESCRIPTION
## Issue
Blueprints that don't use the hosted-teleop `broker` transport fail with `Unknown transport configuration section(s): broker` when `.env` is copied from `default.env`.

## Why
`default.env` sets `TRANSPORTS__BROKER__*` unconditionally. `merge_environment` merges any `TRANSPORTS__<name>__*` var into the config regardless of whether the blueprint declares that transport, so it gets rejected. Module-name env vars already skip this way when irrelevant - transports didn't.

## What we did
Skip `TRANSPORTS__<name>__*` env vars when `<name>` isn't a transport the blueprint declares. Misconfigured fields inside a transport the blueprint *does* declare still raise (`extra="forbid"`) - validation only relaxes for sections that don't apply. Added a test; verified against real `unitree_go2_agentic` (fixed) and `teleop_hosted_go2_transport` (bad field still rejected).

## AI assistance

Used Claude Code (Sonnet 5) assistance throughout - diagnosis, fix, test, and local verification.


## Checklist

- [ ] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
