### PR TITLE
fix: qwen vl model

### DIFF
--- a/dimos/models/qwen/video_query.py
+++ b/dimos/models/qwen/video_query.py
@@ -19,7 +19,7 @@ import json
 import numpy as np
 
 from dimos.models.qwen.bbox import BBox
-from dimos.models.vl.qwen import QwenVlModel
+from dimos.models.vl.qwen import DEFAULT_QWEN_VL_MODEL, QwenVlModel
 from dimos.msgs.sensor_msgs.Image import Image
 
 
@@ -27,7 +27,7 @@ def query_single_frame(
     image: np.ndarray,
     query: str = "Return the center coordinates of the fridge handle as a tuple (x,y)",
     api_key: str | None = None,
-    model_name: str = "qwen2.5-vl-72b-instruct",
+    model_name: str = DEFAULT_QWEN_VL_MODEL,
 ) -> str:
     """Process a single numpy image array with Qwen model.
 
@@ -35,7 +35,7 @@ def query_single_frame(
         image: A numpy array image to process, shape (H, W, 3)
         query: The query to ask about the image
         api_key: Alibaba API key. If None, falls back to the ALIBABA_API_KEY env var
-        model_name: The Qwen model to use. Defaults to qwen2.5-vl-72b-instruct
+        model_name: The Qwen model to use. Defaults to DEFAULT_QWEN_VL_MODEL
 
     Returns:
         str: The model's response

--- a/dimos/models/vl/README.md
+++ b/dimos/models/vl/README.md
@@ -4,7 +4,10 @@ This provides vision language model implementations for processing images and te
 
 ## QwenVL Model
 
-The `QwenVlModel` class provides access to Alibaba's Qwen2.5-VL model for vision-language tasks.
+The `QwenVlModel` class provides access to Alibaba's Qwen-VL models for vision-language tasks.
+The default is set by `DEFAULT_QWEN_VL_MODEL` in `qwen.py`; override it per instance with
+`QwenVlModel(model_name=...)`. Note that `query_detections` and `query_points` assume the model
+returns absolute pixel coordinates, which rules out the `qwen3-vl-*` models.
 
 ### Example Usage
 

--- a/dimos/models/vl/qwen.py
+++ b/dimos/models/vl/qwen.py
@@ -22,11 +22,16 @@ from openai import OpenAI
 from dimos.models.vl.base import VlModel, VlModelConfig
 from dimos.msgs.sensor_msgs.Image import Image
 
+# Must be a model that returns ABSOLUTE pixel coordinates. The qwen3-vl-* models return
+# normalized 0-1000 coordinates and ignore prompts asking for pixels, which silently breaks
+# query_detections, query_points and get_bbox_from_qwen_frame.
+DEFAULT_QWEN_VL_MODEL = "qwen-vl-max"
+
 
 class QwenVlModelConfig(VlModelConfig):
     """Configuration for Qwen VL model."""
 
-    model_name: str = "qwen2.5-vl-72b-instruct"
+    model_name: str = DEFAULT_QWEN_VL_MODEL
     api_key: str | None = None
 
 

--- a/dimos/skills/manipulation/pick_and_place.py
+++ b/dimos/skills/manipulation/pick_and_place.py
@@ -27,6 +27,7 @@ import numpy as np
 from pydantic import Field
 
 from dimos.models.qwen.video_query import query_single_frame
+from dimos.models.vl.qwen import DEFAULT_QWEN_VL_MODEL
 from dimos.skills.skills import AbstractRobotSkill
 from dimos.utils.logging_config import setup_logger
 
@@ -203,7 +204,7 @@ class PickAndPlace(AbstractRobotSkill):
     )
 
     model_name: str = Field(
-        "qwen2.5-vl-72b-instruct", description="Qwen model to use for visual queries"
+        DEFAULT_QWEN_VL_MODEL, description="Qwen model to use for visual queries"
     )
 
     def __init__(self, robot=None, **data) -> None:  # type: ignore[no-untyped-def]

--- a/uv.lock
+++ b/uv.lock
@@ -5231,7 +5231,7 @@ wheels = [
 
 [[package]]
 name = "mujoco-mjx"
-version = "3.5.0"
+version = "3.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "absl-py" },
@@ -5245,9 +5245,9 @@ dependencies = [
     { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "trimesh" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6c/3c/fc471adb5c83bb657c3634cf37c8c5cb5bb37c204d02192a4ee215132d1e/mujoco_mjx-3.5.0.tar.gz", hash = "sha256:42bdf3e80c0c4dfcfc78af97034f836d5292742e450a43a0dd9d44ada1e4bdc0", size = 6907429, upload-time = "2026-02-13T01:04:23.208Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/12/9a38fdf937c465e30824b01c015ea091dd2d66f7645b98e60e04b444f224/mujoco_mjx-3.10.0.tar.gz", hash = "sha256:f1a9d9b0e96d0678142d24b14d4d4d6c54b5766727468e4517227a7ca5938fe4", size = 7015200, upload-time = "2026-06-22T17:41:48.627Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dd/ec/ba408121d07200f4d588ae83033a99dcd197bba47e35e50165d260f2ef6c/mujoco_mjx-3.5.0-py3-none-any.whl", hash = "sha256:633aa801f84fa2becc17ea124d95ad3e34f59fdfaa3720b7ec18b427f3c5bf46", size = 6992318, upload-time = "2026-02-13T01:04:21.21Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/75/a5195ee4239baf62a5f2e6a40914c55ad78b0b429500ec67117bd41cded7/mujoco_mjx-3.10.0-py3-none-any.whl", hash = "sha256:ab7e92ababdbdb1b8202d27e428b266eda103466d8c30a234c34aa9c34a6dfa7", size = 7113829, upload-time = "2026-06-22T17:41:46.779Z" },
 ]
 
 [[package]]
@@ -9802,17 +9802,17 @@ wheels = [
 
 [[package]]
 name = "warp-lang"
-version = "1.11.1"
+version = "1.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/86/507cb6e0534422ff8437f71d676f6366ec907031db54751ad371f07c0b7f/warp_lang-1.11.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1ad11f1fa775269e991a3d55039152c8a504baf86701c849b485cb8e66c49d15", size = 24056749, upload-time = "2026-02-03T21:18:51.64Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/bb/21e9396a963d50171f539f4a4c9411435e7bb9c5131f4480f882d5e51dc6/warp_lang-1.11.1-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:8b098f41e71d421d80ee7562e38aa8380ff6b0d3b4c6ee866cfbdef733ac5bdc", size = 134843847, upload-time = "2026-02-03T21:19:14.318Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/ff/9ced2d69dc9db6cb6b1d3b80a3d2a81590e11ae368a7864aa5d6089fd820/warp_lang-1.11.1-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:5d0904b0eefcc81f39ba65375427a3de99006088aa43e24a9011263f07d0cd07", size = 136139429, upload-time = "2026-02-03T21:18:45.854Z" },
-    { url = "https://files.pythonhosted.org/packages/25/2f/2713f29bba5800b59835d97e136fa75d65a58b89734ae01de5a5f8f26482/warp_lang-1.11.1-py3-none-win_amd64.whl", hash = "sha256:15dc10aa51fb0fdbe1ca16d52e5fadca35a47ffd9d0c636826506f96bb2e7c41", size = 118951410, upload-time = "2026-02-03T21:19:02.038Z" },
+    { url = "https://files.pythonhosted.org/packages/94/be/b79000cb5b551803416bc10c4fa43a37d31b48062683662a6c134d7452bc/warp_lang-1.13.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:4375f572301991fe0fbf0af29fc84d76cd27d531432d6df8452b25088c21ea5a", size = 24584304, upload-time = "2026-05-04T04:30:03.621Z" },
+    { url = "https://files.pythonhosted.org/packages/58/8e/b42f0ddeaca25251e5bbf7db6a89351a0722432ce075ebcdece9118e955a/warp_lang-1.13.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:ac2479c70ad410d58deb088c2a64168792be588efc1bec22dc51f92238e8c8c3", size = 138337580, upload-time = "2026-05-04T04:30:36.286Z" },
+    { url = "https://files.pythonhosted.org/packages/53/19/87b3a3a1a5e07ad34a3886ec38e96b6865359fd17a2511e78e5430c6bace/warp_lang-1.13.0-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:476b54f0dcf6767f23305a328660a9a74d01e371b6b7c3d77e03e18b4a1bb1a5", size = 139812627, upload-time = "2026-05-04T04:31:03.731Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/79/e4117177b88df67d7967c993a2234a3888d0e388076652e1f2a50551f95a/warp_lang-1.13.0-py3-none-win_amd64.whl", hash = "sha256:47975ea07252d45a4d09d2d1a6cffc55002fa7fbde771c8dceb1baf4b32d4fb8", size = 121601324, upload-time = "2026-05-04T04:31:37.814Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

`qwen2.5-vl-72b-instruct` is no longer supported hosted and it was the default model for person follow. This means person follow doesn't work currently.

## Solution

* Switch to `qwen-vl-max`.
* Also fix the broken `mujoco` tests by updating `mujoco-mjx` to the right version. You can run them with `uv run pytest -m mujoco`