### PR TITLE
feat(agents): compact agent history when it outgrows the context window

### DIFF
--- a/dimos/agents/compaction.py
+++ b/dimos/agents/compaction.py
@@ -1,0 +1,387 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Compaction of agent conversation history.
+
+An agent that runs for a while accumulates history faster than it is aware of:
+every tool call and every tool result is appended verbatim. Once the history no
+longer fits in the model's context window the next request fails outright, which
+kills a long-running session.
+
+This module keeps the history under control by dropping the oldest messages and
+replacing them with a summary, so the agent retains the gist of what happened
+without carrying every byte of it.
+
+The entry point is :func:`compact_history`. It is pure: it takes a list of
+messages and returns a new list, so it can be tested without a model or a
+network. Summarisation is injected via the *summarizer* argument; when it is
+omitted a deterministic, offline digest is used instead.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+from langchain_core.messages.base import BaseMessage
+
+from dimos.utils.logging_config import setup_logger
+
+logger = setup_logger()
+
+Summarizer = Callable[[Sequence[BaseMessage]], str]
+TokenCounter = Callable[[Sequence[BaseMessage]], int]
+
+#: Marker prefix identifying a message produced by compaction. Used to recognise
+#: (and re-summarise) an earlier summary when compaction runs more than once.
+COMPACTION_MARKER = "[compacted history]"
+
+#: Fallback context window for models we do not know about. Deliberately
+#: conservative: over-compacting costs a little fidelity, under-compacting
+#: fails the request.
+DEFAULT_CONTEXT_WINDOW = 128_000
+
+#: Known context windows, matched by longest prefix against the model name.
+MODEL_CONTEXT_WINDOWS: dict[str, int] = {
+    "gpt-3.5": 16_385,
+    "gpt-4-turbo": 128_000,
+    "gpt-4o": 128_000,
+    "gpt-4.1": 1_047_576,
+    "gpt-4": 8_192,
+    "gpt-5": 400_000,
+    "o1": 200_000,
+    "o3": 200_000,
+    "o4": 200_000,
+    "claude-3": 200_000,
+    "claude-4": 200_000,
+    "claude-sonnet": 200_000,
+    "claude-opus": 200_000,
+    "claude-haiku": 200_000,
+    "gemini-1.5": 1_048_576,
+    "gemini-2": 1_048_576,
+    "llama3": 8_192,
+    "llama3.1": 131_072,
+    "qwen2.5": 32_768,
+    "mistral": 32_768,
+}
+
+#: Rough bytes-per-token ratio for English text, used by the offline estimator.
+_CHARS_PER_TOKEN = 4
+
+#: Per-message envelope cost (role, delimiters, function-call scaffolding).
+_MESSAGE_OVERHEAD_TOKENS = 4
+
+#: Flat cost charged for an image part. Real cost is resolution-dependent; this
+#: is a deliberate over-estimate so images trigger compaction early rather than
+#: late.
+_IMAGE_TOKENS = 1_500
+
+
+def resolve_context_window(model_name: str | None) -> int:
+    """Return the context window for *model_name* in tokens.
+
+    Matching is by longest known prefix, after stripping any ``provider:``
+    prefix, so ``ollama:llama3.1:8b`` resolves via ``llama3.1``. Unknown models
+    fall back to :data:`DEFAULT_CONTEXT_WINDOW`.
+    """
+    if not model_name:
+        return DEFAULT_CONTEXT_WINDOW
+
+    name = model_name.split(":", 1)[1] if ":" in model_name else model_name
+    name = name.strip().lower()
+
+    best: str | None = None
+    for prefix in MODEL_CONTEXT_WINDOWS:
+        if name.startswith(prefix) and (best is None or len(prefix) > len(best)):
+            best = prefix
+
+    if best is None:
+        logger.debug("Unknown context window for model %r; using default", model_name)
+        return DEFAULT_CONTEXT_WINDOW
+    return MODEL_CONTEXT_WINDOWS[best]
+
+
+def _content_tokens(content: Any) -> int:
+    """Estimate the token cost of a message ``content`` field."""
+    if content is None:
+        return 0
+    if isinstance(content, str):
+        return len(content) // _CHARS_PER_TOKEN
+    if isinstance(content, list):
+        total = 0
+        for part in content:
+            if isinstance(part, dict):
+                kind = part.get("type")
+                if kind in ("image_url", "image"):
+                    total += _IMAGE_TOKENS
+                    continue
+                if kind == "text":
+                    total += len(str(part.get("text", ""))) // _CHARS_PER_TOKEN
+                    continue
+            total += len(str(part)) // _CHARS_PER_TOKEN
+        return total
+    return len(str(content)) // _CHARS_PER_TOKEN
+
+
+def estimate_tokens(messages: Sequence[BaseMessage]) -> int:
+    """Estimate the token cost of *messages* without calling a tokenizer.
+
+    This is intentionally cheap and approximate. It runs on every turn, so an
+    exact count is not worth the cost; the trigger ratio absorbs the error.
+    """
+    total = 0
+    for message in messages:
+        total += _MESSAGE_OVERHEAD_TOKENS + _content_tokens(getattr(message, "content", None))
+        for call in getattr(message, "tool_calls", None) or []:
+            total += len(str(call.get("args", ""))) // _CHARS_PER_TOKEN
+            total += len(str(call.get("name", ""))) // _CHARS_PER_TOKEN
+    return total
+
+
+def _default_summarizer(messages: Sequence[BaseMessage]) -> str:
+    """Summarise *messages* offline, without a model.
+
+    Produces a compact per-message digest. Used when no model-backed summarizer
+    is supplied, and as the fallback when one fails.
+    """
+    human = sum(1 for m in messages if isinstance(m, HumanMessage))
+    ai = sum(1 for m in messages if isinstance(m, AIMessage))
+    tools_used: list[str] = []
+    for message in messages:
+        for call in getattr(message, "tool_calls", None) or []:
+            name = call.get("name")
+            if name and name not in tools_used:
+                tools_used.append(str(name))
+
+    lines = [
+        (
+            f"{len(messages)} earlier messages were removed to stay within the "
+            f"context window ({human} from the user, {ai} from the assistant)."
+        ),
+    ]
+    if tools_used:
+        lines.append(f"Tools used in that period: {', '.join(tools_used)}.")
+
+    first_human = next((m for m in messages if isinstance(m, HumanMessage)), None)
+    if first_human is not None:
+        text = _first_text(first_human)
+        if text:
+            lines.append(f"The earliest request was: {text[:200]}")
+
+    last_ai = next(
+        (m for m in reversed(messages) if isinstance(m, AIMessage) and _first_text(m)), None
+    )
+    if last_ai is not None:
+        lines.append(f"The last thing the assistant reported was: {_first_text(last_ai)[:200]}")
+
+    return "\n".join(lines)
+
+
+def _first_text(message: BaseMessage) -> str:
+    """Return the first textual chunk of *message*, or an empty string."""
+    content = getattr(message, "content", None)
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, list):
+        for part in content:
+            if isinstance(part, dict) and part.get("type") == "text":
+                return str(part.get("text", "")).strip()
+    return ""
+
+
+def _split_index(
+    messages: Sequence[BaseMessage], target_tokens: int, token_counter: TokenCounter
+) -> int:
+    """Return the index at which to cut *messages* so the suffix is valid.
+
+    The suffix ``messages[index:]`` is the newest run of messages that fits in
+    *target_tokens*, adjusted so it never begins with a :class:`ToolMessage`.
+    An orphaned tool result — one whose originating tool call was dropped — is
+    rejected by the OpenAI API, so those are dropped along with their call.
+
+    Always keeps at least the final message: sending an empty history is worse
+    than sending an oversized one.
+    """
+    index = len(messages)
+    used = 0
+    for i in range(len(messages) - 1, -1, -1):
+        cost = token_counter([messages[i]])
+        if used + cost > target_tokens and i != len(messages) - 1:
+            break
+        used += cost
+        index = i
+
+    while index < len(messages) - 1 and isinstance(messages[index], ToolMessage):
+        index += 1
+
+    return index
+
+
+@dataclass
+class CompactionResult:
+    """Outcome of a :func:`compact_history` call."""
+
+    messages: list[BaseMessage]
+    compacted: bool
+    tokens_before: int
+    tokens_after: int
+    dropped_messages: int = 0
+    summary: str | None = field(default=None, repr=False)
+
+
+def compact_history(
+    history: Sequence[BaseMessage],
+    *,
+    context_window: int,
+    trigger_ratio: float = 0.8,
+    keep_ratio: float = 0.35,
+    summarizer: Summarizer | None = None,
+    token_counter: TokenCounter | None = None,
+) -> CompactionResult:
+    """Shrink *history* to fit in *context_window*, summarising what is dropped.
+
+    Args:
+        history: Conversation so far, oldest first. Not mutated.
+        context_window: Size of the model's context window, in tokens.
+        trigger_ratio: Fraction of the window at which compaction kicks in.
+            Below this the history is returned untouched.
+        keep_ratio: Fraction of the window the compacted history should target.
+            Must be smaller than *trigger_ratio*, otherwise compaction would
+            re-trigger on every turn.
+        summarizer: Called with the dropped messages to produce the summary
+            text. Defaults to an offline digest. If it raises, the offline
+            digest is used instead — a failed summary must not fail the turn.
+        token_counter: Token estimator. Defaults to :func:`estimate_tokens`.
+
+    Returns:
+        A :class:`CompactionResult`. When nothing was dropped, ``messages`` is
+        a copy of *history* and ``compacted`` is ``False``.
+
+    Raises:
+        ValueError: If the ratios are outside ``(0, 1]`` or *keep_ratio* is not
+            smaller than *trigger_ratio*, or if *context_window* is not
+            positive.
+    """
+    if context_window <= 0:
+        raise ValueError(f"context_window must be positive, got {context_window}")
+    if not 0 < trigger_ratio <= 1:
+        raise ValueError(f"trigger_ratio must be in (0, 1], got {trigger_ratio}")
+    if not 0 < keep_ratio <= 1:
+        raise ValueError(f"keep_ratio must be in (0, 1], got {keep_ratio}")
+    if keep_ratio >= trigger_ratio:
+        raise ValueError(
+            f"keep_ratio ({keep_ratio}) must be smaller than trigger_ratio "
+            f"({trigger_ratio}), otherwise compaction re-triggers every turn"
+        )
+
+    count = token_counter or estimate_tokens
+    tokens_before = count(history)
+    messages = list(history)
+
+    if tokens_before <= context_window * trigger_ratio or len(messages) <= 1:
+        return CompactionResult(
+            messages=messages,
+            compacted=False,
+            tokens_before=tokens_before,
+            tokens_after=tokens_before,
+        )
+
+    # A leading system message is instruction, not conversation: never drop it.
+    preserved: list[BaseMessage] = []
+    body = messages
+    if messages and isinstance(messages[0], SystemMessage):
+        preserved = [messages[0]]
+        body = messages[1:]
+
+    target = int(context_window * keep_ratio)
+    split = _split_index(body, target, count)
+    dropped = body[:split]
+    kept = body[split:]
+
+    if not dropped:
+        return CompactionResult(
+            messages=messages,
+            compacted=False,
+            tokens_before=tokens_before,
+            tokens_after=tokens_before,
+        )
+
+    summary_text: str
+    if summarizer is None:
+        summary_text = _default_summarizer(dropped)
+    else:
+        try:
+            summary_text = summarizer(dropped)
+        except Exception:
+            logger.warning(
+                "History summarizer failed; falling back to offline digest", exc_info=True
+            )
+            summary_text = _default_summarizer(dropped)
+
+    summary_message = HumanMessage(content=f"{COMPACTION_MARKER}\n{summary_text}")
+    compacted = [*preserved, summary_message, *kept]
+    tokens_after = count(compacted)
+
+    logger.info(
+        "Compacted agent history: %d -> %d messages, ~%d -> ~%d tokens (window %d, trigger %.0f%%)",
+        len(messages),
+        len(compacted),
+        tokens_before,
+        tokens_after,
+        context_window,
+        trigger_ratio * 100,
+    )
+
+    return CompactionResult(
+        messages=compacted,
+        compacted=True,
+        tokens_before=tokens_before,
+        tokens_after=tokens_after,
+        dropped_messages=len(dropped),
+        summary=summary_text,
+    )
+
+
+def make_model_summarizer(model: Any, *, max_chars: int = 6_000) -> Summarizer:
+    """Build a :data:`Summarizer` that asks *model* to summarise the history.
+
+    The transcript handed to the model is truncated to *max_chars* so that
+    summarising an oversized history does not itself overflow the window.
+    """
+
+    def _summarize(messages: Sequence[BaseMessage]) -> str:
+        transcript_parts = []
+        for message in messages:
+            text = _first_text(message)
+            if not text:
+                continue
+            transcript_parts.append(f"{message.__class__.__name__}: {text}")
+        transcript = "\n".join(transcript_parts)
+        if len(transcript) > max_chars:
+            # Keep the tail: recent context matters more than the opening.
+            transcript = "...\n" + transcript[-max_chars:]
+
+        prompt = (
+            "Summarise the following portion of an agent conversation. It is "
+            "being removed to free up context, so preserve anything the agent "
+            "still needs: the user's goals, decisions taken, tools run and "
+            "their outcomes, and any unfinished work. Be concise and factual.\n\n"
+            f"{transcript}"
+        )
+        response = model.invoke([HumanMessage(content=prompt)])
+        return _first_text(response) or _default_summarizer(messages)
+
+    return _summarize

--- a/dimos/agents/mcp/README.md
+++ b/dimos/agents/mcp/README.md
@@ -53,3 +53,32 @@ uv run dimos run unitree-go2-agentic
 1. `McpServer` in the blueprint starts a FastAPI server on port 9990
 2. Claude Code connects directly to `http://localhost:9990/mcp`
 3. Skills are exposed as MCP tools (e.g., `relative_move`, `navigate_with_text`)
+
+## History compaction
+
+`McpClient` keeps the full conversation and replays it on every turn, so a long
+session eventually outgrows the model's context window and every subsequent
+request fails. To prevent that, the history is compacted before each model call:
+the oldest messages are dropped and replaced with a summary, keeping the recent
+turns verbatim.
+
+Compaction is on by default and is configured on `McpClientConfig`:
+
+| Option | Default | Meaning |
+| -- | -- | -- |
+| `compaction_enabled` | `True` | Turn compaction off entirely |
+| `context_window` | `None` | Window size in tokens; `None` resolves it from `model` |
+| `compaction_trigger_ratio` | `0.8` | Compact once the history passes this fraction of the window |
+| `compaction_keep_ratio` | `0.35` | Target size of the history after compaction |
+| `compaction_summarize_with_model` | `True` | Summarise with the model; otherwise use an offline digest |
+
+Notes:
+
+- Tool results are never separated from the tool call that produced them, so a
+  compacted history stays valid for the OpenAI API.
+- A leading system message is never dropped.
+- If summarisation fails, an offline digest is used instead; if compaction
+  itself fails, the turn proceeds uncompacted. Compaction never fails a turn.
+- The window for an unrecognised model falls back to a conservative default.
+  Add known models to `MODEL_CONTEXT_WINDOWS` in `dimos/agents/compaction.py`.
+

--- a/dimos/agents/mcp/mcp_client.py
+++ b/dimos/agents/mcp/mcp_client.py
@@ -29,6 +29,11 @@ from langgraph.graph.state import CompiledStateGraph
 from reactivex.disposable import Disposable
 import requests
 
+from dimos.agents.compaction import (
+    compact_history,
+    make_model_summarizer,
+    resolve_context_window,
+)
 from dimos.agents.mcp import tool_stream
 from dimos.agents.system_prompt import SYSTEM_PROMPT
 from dimos.agents.utils import pretty_print_langchain_message
@@ -63,6 +68,19 @@ class McpClientConfig(ModuleConfig):
     model_fixture: str | None = None
     mcp_server_url: str = "http://localhost:9990/mcp"
 
+    # History compaction. Long sessions otherwise grow the history past the
+    # model's context window and every subsequent request fails.
+    compaction_enabled: bool = True
+    # Context window in tokens. None resolves it from `model`.
+    context_window: int | None = None
+    # Compact once the history exceeds this fraction of the window...
+    compaction_trigger_ratio: float = 0.8
+    # ...down to roughly this fraction of it.
+    compaction_keep_ratio: float = 0.35
+    # Summarise the dropped messages with the model instead of an offline
+    # digest. Costs an extra model call each time compaction fires.
+    compaction_summarize_with_model: bool = True
+
 
 class McpClient(Module):
     config: McpClientConfig
@@ -80,6 +98,7 @@ class McpClient(Module):
     _http_client: requests.Session
     _seq_ids: SequentialIds
     _tool_stream_cleanup: Callable[[], None] | None
+    _model: Any | None
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
@@ -97,6 +116,7 @@ class McpClient(Module):
         self._http_client = requests.Session()
         self._seq_ids = SequentialIds()
         self._tool_stream_cleanup = None
+        self._model = None
 
     def __reduce__(self) -> Any:
         return (self.__class__, (), {})
@@ -236,6 +256,7 @@ class McpClient(Module):
             model = _init_model(self.config.model)
 
         with self._lock:
+            self._model = model
             self._state_graph = create_agent(
                 model=model,
                 tools=tools,
@@ -332,6 +353,42 @@ class McpClient(Module):
                     raise ValueError("No state graph initialized")
                 self._process_message(self._state_graph, message)
 
+    def _compact_history_if_needed(self) -> None:
+        """Shrink the history in place if it is close to the context window.
+
+        Runs before every model invocation. Failures are swallowed: a turn that
+        would have succeeded must not be lost to a compaction bug.
+        """
+        if not self.config.compaction_enabled or len(self._history) <= 1:
+            return
+
+        summarizer = None
+        if self.config.compaction_summarize_with_model and self._model is not None:
+            summarizer = make_model_summarizer(self._model)
+
+        try:
+            result = compact_history(
+                self._history,
+                context_window=(
+                    self.config.context_window or resolve_context_window(self.config.model)
+                ),
+                trigger_ratio=self.config.compaction_trigger_ratio,
+                keep_ratio=self.config.compaction_keep_ratio,
+                summarizer=summarizer,
+            )
+        except Exception:
+            logger.warning("History compaction failed; continuing uncompacted", exc_info=True)
+            return
+
+        if result.compacted:
+            self._history = result.messages
+            logger.info(
+                "Agent history compacted.",
+                dropped_messages=result.dropped_messages,
+                tokens_before=result.tokens_before,
+                tokens_after=result.tokens_after,
+            )
+
     def _process_message(
         self, state_graph: CompiledStateGraph[Any, Any, Any, Any], message: BaseMessage
     ) -> None:
@@ -339,6 +396,8 @@ class McpClient(Module):
         self._history.append(message)
         pretty_print_langchain_message(message)
         self.agent.publish(message)
+
+        self._compact_history_if_needed()
 
         for update in state_graph.stream({"messages": self._history}, stream_mode="updates"):
             for node_output in update.values():

--- a/dimos/agents/test_compaction.py
+++ b/dimos/agents/test_compaction.py
@@ -1,0 +1,385 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+from langchain_core.messages.base import BaseMessage
+import pytest
+
+from dimos.agents.compaction import (
+    COMPACTION_MARKER,
+    DEFAULT_CONTEXT_WINDOW,
+    compact_history,
+    estimate_tokens,
+    make_model_summarizer,
+    resolve_context_window,
+)
+
+
+def _human(text: str) -> HumanMessage:
+    return HumanMessage(content=text)
+
+
+def _ai(text: str) -> AIMessage:
+    return AIMessage(content=text)
+
+
+def _ai_tool_call(name: str, call_id: str, args: dict | None = None) -> AIMessage:
+    return AIMessage(
+        content="",
+        tool_calls=[{"name": name, "args": args or {}, "id": call_id, "type": "tool_call"}],
+    )
+
+
+def _tool_result(text: str, call_id: str) -> ToolMessage:
+    return ToolMessage(content=text, tool_call_id=call_id)
+
+
+def _long_history(turns: int, chars: int = 400) -> list[BaseMessage]:
+    history: list[BaseMessage] = []
+    for i in range(turns):
+        history.append(_human(f"request {i} " + "x" * chars))
+        history.append(_ai(f"response {i} " + "y" * chars))
+    return history
+
+
+class TestResolveContextWindow:
+    def test_known_models(self) -> None:
+        assert resolve_context_window("gpt-4o") == 128_000
+        assert resolve_context_window("gpt-4o-mini") == 128_000
+        assert resolve_context_window("o3-mini") == 200_000
+
+    def test_longest_prefix_wins(self) -> None:
+        # "gpt-4.1" must not be resolved by the shorter "gpt-4" entry.
+        assert resolve_context_window("gpt-4.1") == 1_047_576
+        assert resolve_context_window("gpt-4") == 8_192
+
+    def test_strips_provider_prefix(self) -> None:
+        assert resolve_context_window("ollama:llama3.1:8b") == 131_072
+
+    def test_case_insensitive(self) -> None:
+        assert resolve_context_window("GPT-4O") == 128_000
+
+    def test_unknown_and_empty_fall_back_to_default(self) -> None:
+        assert resolve_context_window("some-new-model") == DEFAULT_CONTEXT_WINDOW
+        assert resolve_context_window(None) == DEFAULT_CONTEXT_WINDOW
+        assert resolve_context_window("") == DEFAULT_CONTEXT_WINDOW
+
+
+class TestEstimateTokens:
+    def test_empty_history_is_free(self) -> None:
+        assert estimate_tokens([]) == 0
+
+    def test_grows_with_content(self) -> None:
+        small = estimate_tokens([_human("hi")])
+        large = estimate_tokens([_human("hi " * 1000)])
+        assert large > small
+
+    def test_counts_every_message(self) -> None:
+        one = estimate_tokens([_human("a" * 400)])
+        two = estimate_tokens([_human("a" * 400), _human("a" * 400)])
+        assert two > one
+
+    def test_counts_tool_call_arguments(self) -> None:
+        bare = estimate_tokens([_ai_tool_call("navigate", "1")])
+        with_args = estimate_tokens(
+            [_ai_tool_call("navigate", "1", {"destination": "kitchen " * 100})]
+        )
+        assert with_args > bare
+
+    def test_images_are_charged_heavily(self) -> None:
+        image_msg = HumanMessage(
+            content=[
+                {"type": "text", "text": "what is this?"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+            ]
+        )
+        assert estimate_tokens([image_msg]) > 1_000
+
+
+class TestCompactHistoryNoOp:
+    def test_short_history_is_untouched(self) -> None:
+        history = [_human("hello"), _ai("hi")]
+        result = compact_history(history, context_window=100_000)
+
+        assert result.compacted is False
+        assert result.messages == history
+        assert result.dropped_messages == 0
+
+    def test_single_message_is_never_compacted(self) -> None:
+        history = [_human("x" * 10_000_000)]
+        result = compact_history(history, context_window=1_000)
+
+        assert result.compacted is False
+        assert result.messages == history
+
+    def test_input_history_is_not_mutated(self) -> None:
+        history = _long_history(80)
+        original = list(history)
+
+        compact_history(history, context_window=2_000)
+
+        assert history == original
+
+    def test_returns_a_copy_not_the_same_list(self) -> None:
+        history = [_human("hello")]
+        result = compact_history(history, context_window=100_000)
+
+        assert result.messages is not history
+
+
+class TestCompactHistoryTriggers:
+    def test_compacts_when_over_the_trigger(self) -> None:
+        history = _long_history(80)
+        result = compact_history(history, context_window=2_000)
+
+        assert result.compacted is True
+        assert result.dropped_messages > 0
+        assert len(result.messages) < len(history)
+
+    def test_result_fits_the_target(self) -> None:
+        history = _long_history(200)
+        window = 4_000
+        result = compact_history(history, context_window=window, keep_ratio=0.35)
+
+        assert result.tokens_after < window * 0.5
+        assert result.tokens_after < result.tokens_before
+
+    def test_newest_messages_are_kept(self) -> None:
+        history = _long_history(80)
+        result = compact_history(history, context_window=2_000)
+
+        assert result.messages[-1] == history[-1]
+        assert result.messages[-2] == history[-2]
+
+    def test_oldest_messages_are_dropped(self) -> None:
+        history = _long_history(80)
+        result = compact_history(history, context_window=2_000)
+
+        assert history[0] not in result.messages
+
+    def test_summary_is_inserted_first(self) -> None:
+        history = _long_history(80)
+        result = compact_history(history, context_window=2_000)
+
+        assert isinstance(result.messages[0], HumanMessage)
+        assert COMPACTION_MARKER in result.messages[0].content
+
+    def test_default_summary_describes_what_was_dropped(self) -> None:
+        history = _long_history(80)
+        result = compact_history(history, context_window=2_000)
+
+        assert result.summary is not None
+        assert "messages were removed" in result.summary
+
+    def test_repeated_compaction_is_stable(self) -> None:
+        history = _long_history(200)
+        window = 4_000
+
+        first = compact_history(history, context_window=window)
+        assert first.compacted is True
+
+        # Compacting the already-compacted history must be a no-op, otherwise
+        # every turn would pay for a summarisation.
+        second = compact_history(first.messages, context_window=window)
+        assert second.compacted is False
+
+
+class TestToolCallIntegrity:
+    def test_kept_history_never_starts_with_a_tool_result(self) -> None:
+        """An orphaned ToolMessage is rejected by the OpenAI API."""
+        history: list[BaseMessage] = []
+        for i in range(120):
+            history.append(_human(f"do thing {i} " + "x" * 300))
+            history.append(_ai_tool_call("navigate", f"call-{i}", {"to": "x" * 300}))
+            history.append(_tool_result("arrived " + "y" * 300, f"call-{i}"))
+
+        result = compact_history(history, context_window=3_000)
+
+        assert result.compacted is True
+        first_real = result.messages[1]  # index 0 is the summary
+        assert not isinstance(first_real, ToolMessage)
+
+    def test_every_kept_tool_result_has_its_originating_call(self) -> None:
+        history: list[BaseMessage] = []
+        for i in range(120):
+            history.append(_human(f"do thing {i} " + "x" * 300))
+            history.append(_ai_tool_call("navigate", f"call-{i}", {"to": "x" * 300}))
+            history.append(_tool_result("arrived " + "y" * 300, f"call-{i}"))
+
+        result = compact_history(history, context_window=3_000)
+
+        seen_call_ids: set[str] = set()
+        for message in result.messages:
+            for call in getattr(message, "tool_calls", None) or []:
+                seen_call_ids.add(call["id"])
+            if isinstance(message, ToolMessage):
+                assert message.tool_call_id in seen_call_ids, (
+                    f"tool result {message.tool_call_id} kept without its call"
+                )
+
+    def test_parallel_tool_results_stay_with_their_call(self) -> None:
+        history: list[BaseMessage] = _long_history(100)
+        history.append(
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {"name": "a", "args": {}, "id": "p1", "type": "tool_call"},
+                    {"name": "b", "args": {}, "id": "p2", "type": "tool_call"},
+                ],
+            )
+        )
+        history.append(_tool_result("ra", "p1"))
+        history.append(_tool_result("rb", "p2"))
+        history.append(_ai("done"))
+
+        result = compact_history(history, context_window=2_000)
+
+        kept_ids = {
+            c["id"] for m in result.messages for c in (getattr(m, "tool_calls", None) or [])
+        }
+        for message in result.messages:
+            if isinstance(message, ToolMessage):
+                assert message.tool_call_id in kept_ids
+
+
+class TestSystemMessage:
+    def test_leading_system_message_survives(self) -> None:
+        history: list[BaseMessage] = [SystemMessage(content="You are a robot.")]
+        history.extend(_long_history(80))
+
+        result = compact_history(history, context_window=2_000)
+
+        assert result.compacted is True
+        assert isinstance(result.messages[0], SystemMessage)
+        assert result.messages[0].content == "You are a robot."
+        assert COMPACTION_MARKER in result.messages[1].content
+
+
+class TestSummarizer:
+    def test_custom_summarizer_receives_only_dropped_messages(self) -> None:
+        history = _long_history(80)
+        seen: list[Sequence[BaseMessage]] = []
+
+        def summarizer(messages: Sequence[BaseMessage]) -> str:
+            seen.append(messages)
+            return "custom summary"
+
+        result = compact_history(history, context_window=2_000, summarizer=summarizer)
+
+        assert result.summary == "custom summary"
+        assert "custom summary" in result.messages[0].content
+        assert len(seen) == 1
+        assert len(seen[0]) == result.dropped_messages
+        # The kept tail must not have been handed to the summarizer.
+        assert history[-1] not in seen[0]
+
+    def test_summarizer_failure_falls_back_to_offline_digest(self) -> None:
+        history = _long_history(80)
+
+        def broken(_messages: Sequence[BaseMessage]) -> str:
+            raise RuntimeError("model is down")
+
+        result = compact_history(history, context_window=2_000, summarizer=broken)
+
+        assert result.compacted is True
+        assert result.summary is not None
+        assert "messages were removed" in result.summary
+
+    def test_model_summarizer_uses_the_model_response(self) -> None:
+        class FakeModel:
+            def __init__(self) -> None:
+                self.calls: list[list[BaseMessage]] = []
+
+            def invoke(self, messages: list[BaseMessage]) -> AIMessage:
+                self.calls.append(messages)
+                return AIMessage(content="the robot drove to the kitchen")
+
+        model = FakeModel()
+        summarizer = make_model_summarizer(model)
+        summary = summarizer([_human("go to the kitchen"), _ai("on my way")])
+
+        assert summary == "the robot drove to the kitchen"
+        assert len(model.calls) == 1
+
+    def test_model_summarizer_truncates_a_huge_transcript(self) -> None:
+        class CapturingModel:
+            def __init__(self) -> None:
+                self.prompt = ""
+
+            def invoke(self, messages: list[BaseMessage]) -> AIMessage:
+                self.prompt = messages[0].content
+                return AIMessage(content="summary")
+
+        model = CapturingModel()
+        summarizer = make_model_summarizer(model, max_chars=500)
+        summarizer(_long_history(200))
+
+        assert len(model.prompt) < 2_000
+
+    def test_model_summarizer_falls_back_on_empty_response(self) -> None:
+        class EmptyModel:
+            def invoke(self, _messages: list[BaseMessage]) -> AIMessage:
+                return AIMessage(content="")
+
+        summarizer = make_model_summarizer(EmptyModel())
+        summary = summarizer(_long_history(3))
+
+        assert "messages were removed" in summary
+
+
+class TestValidation:
+    @pytest.mark.parametrize("window", [0, -1])
+    def test_rejects_non_positive_context_window(self, window: int) -> None:
+        with pytest.raises(ValueError, match="context_window must be positive"):
+            compact_history([_human("a")], context_window=window)
+
+    @pytest.mark.parametrize("ratio", [0, -0.5, 1.5])
+    def test_rejects_invalid_trigger_ratio(self, ratio: float) -> None:
+        with pytest.raises(ValueError, match="trigger_ratio"):
+            compact_history([_human("a")], context_window=1_000, trigger_ratio=ratio)
+
+    @pytest.mark.parametrize("ratio", [0, -0.5, 1.5])
+    def test_rejects_invalid_keep_ratio(self, ratio: float) -> None:
+        with pytest.raises(ValueError, match="keep_ratio"):
+            compact_history([_human("a")], context_window=1_000, keep_ratio=ratio)
+
+    def test_rejects_keep_ratio_above_trigger_ratio(self) -> None:
+        with pytest.raises(ValueError, match="must be smaller than trigger_ratio"):
+            compact_history([_human("a")], context_window=1_000, trigger_ratio=0.5, keep_ratio=0.9)
+
+
+class TestRealisticSession:
+    def test_a_long_tool_heavy_session_stays_within_budget(self) -> None:
+        """Simulates many command turns and checks the history never overflows."""
+        window = 8_000
+        history: list[BaseMessage] = []
+        max_seen = 0
+
+        for i in range(300):
+            history.append(_human(f"drive to waypoint {i} " + "d" * 200))
+            history.append(_ai_tool_call("navigate", f"c{i}", {"waypoint": i}))
+            history.append(_tool_result("arrived at waypoint " + "r" * 400, f"c{i}"))
+
+            result = compact_history(history, context_window=window)
+            history = result.messages
+            max_seen = max(max_seen, estimate_tokens(history))
+
+        assert max_seen <= window, f"history peaked at {max_seen} tokens, window is {window}"
+        # The most recent turn must still be intact.
+        assert isinstance(history[-1], ToolMessage)
+        assert history[-1].tool_call_id == "c299"


### PR DESCRIPTION
Refs #1899

## Problem

`McpClient._process_message` appends every message to `self._history` and replays the whole list on each turn:

```python
for update in state_graph.stream({"messages": self._history}, stream_mode="updates"):
```

Nothing bounds that list. Tool-heavy sessions grow it fastest, because each command adds a human turn, an `AIMessage` carrying the tool call, and a `ToolMessage` carrying the full result. Once the history passes the model's context window the request fails, and because the history is never trimmed, every subsequent turn fails too. The session is dead until someone restarts it.

## Approach

New module `dimos/agents/compaction.py`. Once the history passes a configurable fraction of the context window, the oldest messages are dropped and replaced by a single summary message; recent turns are kept verbatim.

`compact_history()` is pure â€” it takes a list of messages and returns a new one, and takes no model. Summarisation is injected via a `summarizer` callable, which is what makes the whole thing testable offline.

Three details that drove the design:

1. **Tool-call integrity.** Cutting the history at an arbitrary index can leave a `ToolMessage` whose originating `AIMessage` was dropped. The OpenAI API rejects an orphaned tool result, so naive truncation trades a context-overflow error for a 400. `_split_index` advances the cut past any leading `ToolMessage`, so a dropped tool call always takes its results with it. Two tests cover this, including parallel tool calls.

2. **Compaction must not re-trigger every turn.** `keep_ratio` has to be meaningfully below `trigger_ratio` or every turn pays for a summarisation. This is validated at the API boundary rather than left as a footgun, and `test_repeated_compaction_is_stable` asserts a compacted history is not immediately re-compacted.

3. **Compaction must never fail a turn.** A summarizer failure falls back to the offline digest, and a failure inside compaction itself is logged and the turn proceeds uncompacted. A bug here should degrade the session, not kill it.

Also: a leading `SystemMessage` is treated as instruction rather than conversation and is never dropped, and `estimate_tokens` charges images a flat 1500 tokens so image-carrying histories compact early rather than late.

## Context windows

`resolve_context_window()` maps a model name to its window by longest-prefix match, stripping any `provider:` prefix so `ollama:llama3.1:8b` resolves via `llama3.1`. Longest-prefix matters: `gpt-4.1` must not resolve through the `gpt-4` entry and get an 8k window. Unknown models fall back to a conservative 128k â€” over-compacting costs some fidelity, under-compacting fails the request.

## Configuration

On `McpClientConfig`, enabled by default:

| Option | Default |
| -- | -- |
| `compaction_enabled` | `True` |
| `context_window` | `None` (resolved from `model`) |
| `compaction_trigger_ratio` | `0.8` |
| `compaction_keep_ratio` | `0.35` |
| `compaction_summarize_with_model` | `True` |

## Checks I ran

- `dimos/agents/test_compaction.py` â€” 40 tests, all passing.
- `ruff check` and `ruff format --check` clean on all four changed files. One pre-existing `BLE001` remains in `mcp_client.py` at the `dispatch_continuation` handler; it is untouched by this PR and present on `main`.

Honest limitations:

- I could **not** run the full `uv run pytest` suite in my environment, so the existing `McpClient` tests are unverified against this change. The integration is small and additive â€” one config block, one guarded method, one call site before `state_graph.stream` â€” but it does deserve a CI run.
- No hardware and no simulation was involved. This touches agent conversation bookkeeping only; nothing in the control, driver, planner or motion path is affected.

The issue asks for this to be "tested to see how well it works in practice with real commands". `test_a_long_tool_heavy_session_stays_within_budget` is my stand-in: it drives 300 command turns through the real compaction path and asserts the history never exceeds the window and the newest turn survives intact. That is a simulation of the shape of the load, not a substitute for running it against a live model, which I could not do here.

## Notes

- This is an open question I would rather flag than silently decide: `compaction_summarize_with_model` defaults to `True`, which spends an extra model call each time compaction fires. If you would rather compaction be free by default, flipping it to `False` uses the offline digest and needs no other change.
- Per `AI_POLICY.md`: this was written with AI assistance. Happy to walk through any part of it, and equally happy to adjust the design if you would rather compaction live somewhere other than `McpClient`.