### PR TITLE
feat(eval): export Pi conversation transcripts

### DIFF
--- a/dimos/benchmark/evaluation/pi_process.py
+++ b/dimos/benchmark/evaluation/pi_process.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 import json
 import os
 from pathlib import Path
+import queue
 import subprocess
 import threading
 import time
@@ -37,6 +38,7 @@ from dimos.benchmark.evaluation.progress import (
 
 PI_VERSION = "0.80.10"
 MAX_STDERR_BYTES = 64 * 1024
+EXPORT_TIMEOUT_SECONDS = 30.0
 
 
 @dataclass(frozen=True)
@@ -49,9 +51,20 @@ class PiRunResult:
 
 
 class PiRunError(RuntimeError):
-    def __init__(self, message: str, *, stderr: str = "") -> None:
+    def __init__(
+        self,
+        message: str,
+        *,
+        stderr: str = "",
+        transcript_path: Path | None = None,
+    ) -> None:
         super().__init__(message)
         self.stderr = stderr
+        self.transcript_path = transcript_path
+
+
+class PiExportError(RuntimeError):
+    pass
 
 
 class PiCliRunner:
@@ -199,26 +212,190 @@ class PiCliRunner:
                     reader.join(timeout=1)
 
         stderr = "".join(stderr_parts)
+        transcript_path = _latest_transcript(session_dir)
         if timed_out:
             raise PiRunError(
                 f"Pi timed out after {self.timeout_s:g}s",
                 stderr=stderr,
+                transcript_path=transcript_path,
             )
         duration = time.monotonic() - started
         if process.returncode != 0:
-            raise PiRunError(f"Pi exited with status {process.returncode}", stderr=stderr)
+            raise PiRunError(
+                f"Pi exited with status {process.returncode}",
+                stderr=stderr,
+                transcript_path=transcript_path,
+            )
         if events.stop_error is not None:
-            raise PiRunError(events.stop_error, stderr=stderr)
+            raise PiRunError(
+                events.stop_error,
+                stderr=stderr,
+                transcript_path=transcript_path,
+            )
         if events.final_text is None:
-            raise PiRunError("Pi produced no final assistant response", stderr=stderr)
-        transcripts = sorted(session_dir.rglob("*.jsonl")) if session_dir.exists() else []
+            raise PiRunError(
+                "Pi produced no final assistant response",
+                stderr=stderr,
+                transcript_path=transcript_path,
+            )
         return PiRunResult(
             final_text=events.final_text,
             tool_call_count=events.tool_count,
             duration_seconds=duration,
-            transcript_path=transcripts[-1] if transcripts else None,
+            transcript_path=transcript_path,
             stderr=stderr,
         )
+
+    def export_transcript(
+        self,
+        *,
+        transcript_path: Path,
+        output_path: Path,
+        mcp_url: str,
+        api_key: str,
+    ) -> None:
+        """Export a saved session through Pi RPC so extension renderers are active."""
+        request_id = "dimos-transcript-export"
+        command = (
+            "node",
+            str(self.cli),
+            "--mode",
+            "rpc",
+            "--model",
+            f"openai/{self.model}",
+            "--thinking",
+            self.thinking_level,
+            "--session",
+            str(transcript_path),
+            "--no-builtin-tools",
+            "--tools",
+            "python_exec",
+            "--no-extensions",
+            "--extension",
+            str(self.extension),
+            "--no-skills",
+            "--no-prompt-templates",
+            "--no-themes",
+            "--no-context-files",
+            "--no-approve",
+            "--offline",
+        )
+        env = {
+            "PATH": os.environ.get("PATH", ""),
+            "OPENAI_API_KEY": api_key,
+            "DIMOS_CODE_POLICY_MCP_URL": mcp_url,
+            "PI_CODING_AGENT_DIR": str(transcript_path.parent / ".pi-agent-export"),
+            "PI_SKIP_VERSION_CHECK": "1",
+            "PI_TELEMETRY": "0",
+        }
+        process = subprocess.Popen(
+            command,
+            cwd=transcript_path.parent,
+            env=env,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+        )
+        stdin = process.stdin
+        stdout = process.stdout
+        stderr_stream = process.stderr
+        assert stdin is not None
+        assert stdout is not None
+        assert stderr_stream is not None
+        responses: queue.Queue[dict[str, Any]] = queue.Queue()
+        stderr_parts: list[str] = []
+
+        def read_stdout() -> None:
+            for line in stdout:
+                try:
+                    response = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(response, dict) and response.get("id") == request_id:
+                    responses.put(response)
+
+        def read_stderr() -> None:
+            retained = 0
+            for line in stderr_stream:
+                line = line.replace(api_key, "[REDACTED]")
+                remaining = MAX_STDERR_BYTES - retained
+                if remaining <= 0:
+                    continue
+                value = line.encode()[:remaining].decode(errors="ignore")
+                stderr_parts.append(value)
+                retained += len(value.encode())
+
+        readers = (
+            threading.Thread(target=read_stdout, name="pi-export-stdout", daemon=True),
+            threading.Thread(target=read_stderr, name="pi-export-stderr", daemon=True),
+        )
+        for reader in readers:
+            reader.start()
+        try:
+            stdin.write(
+                json.dumps(
+                    {
+                        "id": request_id,
+                        "type": "export_html",
+                        "outputPath": str(output_path),
+                    }
+                )
+                + "\n"
+            )
+            stdin.flush()
+            deadline = time.monotonic() + EXPORT_TIMEOUT_SECONDS
+            response = None
+            while response is None and time.monotonic() < deadline:
+                try:
+                    response = responses.get(timeout=min(0.1, deadline - time.monotonic()))
+                except queue.Empty:
+                    if process.poll() is not None:
+                        break
+            if response is None:
+                for reader in readers:
+                    reader.join(timeout=1)
+                detail = "".join(stderr_parts).strip()
+                suffix = f": {detail}" if detail else ""
+                if process.poll() is not None:
+                    raise PiExportError(
+                        f"Pi transcript exporter exited with status {process.returncode}{suffix}"
+                    )
+                raise PiExportError(
+                    f"Pi transcript export timed out after {EXPORT_TIMEOUT_SECONDS:g}s{suffix}"
+                )
+            if not response.get("success"):
+                message = str(response.get("error") or "Pi transcript export failed")
+                raise PiExportError(message.replace(api_key, "[REDACTED]"))
+            data = response.get("data")
+            exported = data.get("path") if isinstance(data, dict) else None
+            if not isinstance(exported, str) or Path(exported).resolve() != output_path.resolve():
+                raise PiExportError("Pi transcript export returned an unexpected output path")
+        finally:
+            stdin.close()
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.terminate()
+                try:
+                    process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait()
+            for reader, stream in zip(readers, (stdout, stderr_stream), strict=True):
+                reader.join(timeout=1)
+                if reader.is_alive():
+                    stream.close()
+                    reader.join(timeout=1)
+        if process.returncode != 0:
+            detail = "".join(stderr_parts).strip()
+            suffix = f": {detail}" if detail else ""
+            raise PiExportError(
+                f"Pi transcript exporter exited with status {process.returncode}{suffix}"
+            )
+        if not output_path.is_file():
+            raise PiExportError("Pi transcript exporter produced no HTML file")
 
 
 def parse_pi_events(stream: str) -> tuple[str | None, int, str | None]:
@@ -307,3 +484,8 @@ def _bounded_stderr(value: str) -> str:
     if len(encoded) <= MAX_STDERR_BYTES:
         return value
     return encoded[:MAX_STDERR_BYTES].decode(errors="ignore")
+
+
+def _latest_transcript(session_dir: Path) -> Path | None:
+    transcripts = sorted(session_dir.rglob("*.jsonl")) if session_dir.exists() else []
+    return transcripts[-1] if transcripts else None

--- a/dimos/benchmark/evaluation/runtime.py
+++ b/dimos/benchmark/evaluation/runtime.py
@@ -28,7 +28,7 @@ from typing import Any, Literal
 from dimos.agents.code_policy_server import CodePolicyMcpServer
 from dimos.benchmark.evaluation.models import ArtifactReference, RuntimeIdentity
 from dimos.benchmark.evaluation.pi_process import PI_VERSION, PiCliRunner, PiRunError
-from dimos.benchmark.evaluation.progress import ProgressSink
+from dimos.benchmark.evaluation.progress import ProgressSink, StatusProgress, emit_progress
 from dimos.benchmark.evaluation.protocol import (
     DebugTrialSubmitter,
     ExplorationOutcome,
@@ -144,13 +144,21 @@ class CodePolicyRuntimeFactory:
                 )
             except PiRunError as exc:
                 self._record_text(path, relative, "stderr.log", exc.stderr, "Pi stderr")
-                raise
-            if result.transcript_path is not None:
-                target = path / "pi-transcript.jsonl"
-                shutil.copy2(result.transcript_path, target)
-                self._runtime_artifacts.append(
-                    _artifact(relative / target.name, "Pi transcript", "application/x-ndjson")
+                self._record_pi_transcript(
+                    path=path,
+                    relative=relative,
+                    source=exc.transcript_path,
+                    runner=runner,
+                    mcp_url=server.mcp_url,
                 )
+                raise
+            self._record_pi_transcript(
+                path=path,
+                relative=relative,
+                source=result.transcript_path,
+                runner=runner,
+                mcp_url=server.mcp_url,
+            )
             if result.stderr:
                 self._record_text(path, relative, "stderr.log", result.stderr, "Pi stderr")
             policy = manager.last_policy
@@ -292,6 +300,49 @@ class CodePolicyRuntimeFactory:
             return
         (path / filename).write_text(value, encoding="utf-8")
         self._runtime_artifacts.append(_artifact(relative / filename, label, "text/plain"))
+
+    def _record_pi_transcript(
+        self,
+        *,
+        path: Path,
+        relative: Path,
+        source: Path | None,
+        runner: PiCliRunner,
+        mcp_url: str,
+    ) -> None:
+        if source is None:
+            return
+        transcript = path / "pi-transcript.jsonl"
+        shutil.copy2(source, transcript)
+        self._runtime_artifacts.append(
+            _artifact(relative / transcript.name, "Pi transcript", "application/x-ndjson")
+        )
+        viewer = path / "pi-transcript.html"
+        try:
+            runner.export_transcript(
+                transcript_path=source,
+                output_path=viewer,
+                mcp_url=mcp_url,
+                api_key=self.api_key,
+            )
+        except Exception as exc:
+            viewer.unlink(missing_ok=True)
+            message = f"{type(exc).__name__}: {exc}".replace(self.api_key, "[REDACTED]")
+            emit_progress(
+                self.progress,
+                StatusProgress(channel="pi", message=f"transcript export failed: {message}"),
+            )
+            self._record_text(
+                path,
+                relative,
+                "pi-transcript-export-error.log",
+                message + "\n",
+                "Pi transcript export error",
+            )
+            return
+        self._runtime_artifacts.append(
+            _artifact(relative / viewer.name, "Pi transcript viewer", "text/html")
+        )
 
 
 class _SubmissionManager:

--- a/dimos/benchmark/evaluation/test_pi_process.py
+++ b/dimos/benchmark/evaluation/test_pi_process.py
@@ -20,7 +20,12 @@ import threading
 
 import pytest
 
-from dimos.benchmark.evaluation.pi_process import PiCliRunner, PiRunError, parse_pi_events
+from dimos.benchmark.evaluation.pi_process import (
+    PiCliRunner,
+    PiExportError,
+    PiRunError,
+    parse_pi_events,
+)
 
 
 def test_parse_stock_pi_events_uses_final_message_and_counts_tools() -> None:
@@ -191,6 +196,9 @@ def test_stock_cli_timeout_terminates_the_child(mocker, tmp_path: Path) -> None:
         subprocess.TimeoutExpired("pi", 0.01),
         0,
     ]
+    transcript = tmp_path / "pi-session" / "session.jsonl"
+    transcript.parent.mkdir()
+    transcript.write_text('{"type":"session"}\n')
     mocker.patch("dimos.benchmark.evaluation.pi_process.subprocess.Popen", return_value=process)
     runner = PiCliRunner(
         cli=cli,
@@ -200,7 +208,7 @@ def test_stock_cli_timeout_terminates_the_child(mocker, tmp_path: Path) -> None:
         timeout_s=0.01,
     )
 
-    with pytest.raises(PiRunError, match="timed out"):
+    with pytest.raises(PiRunError, match="timed out") as caught:
         runner.run(
             prompt="Count",
             system_prompt="Use memory",
@@ -211,3 +219,92 @@ def test_stock_cli_timeout_terminates_the_child(mocker, tmp_path: Path) -> None:
 
     process.terminate.assert_called_once_with()
     process.kill.assert_not_called()
+    assert caught.value.transcript_path == transcript
+
+
+def test_stock_cli_exports_transcript_through_rpc_with_extension(mocker, tmp_path: Path) -> None:
+    cli = tmp_path / "cli.js"
+    extension = tmp_path / "extension.js"
+    transcript = tmp_path / "pi-transcript.jsonl"
+    output = tmp_path / "pi-transcript.html"
+    for path in (cli, extension, transcript, output):
+        path.touch()
+    process = mocker.Mock(returncode=0)
+    process.stdin = mocker.Mock()
+    process.stdout = StringIO(
+        json.dumps(
+            {
+                "id": "dimos-transcript-export",
+                "type": "response",
+                "success": True,
+                "data": {"path": str(output)},
+            }
+        )
+        + "\n"
+    )
+    process.stderr = StringIO()
+    process.wait.return_value = 0
+    popen = mocker.patch(
+        "dimos.benchmark.evaluation.pi_process.subprocess.Popen", return_value=process
+    )
+    runner = PiCliRunner(
+        cli=cli,
+        extension=extension,
+        model="gpt-5.6-luna",
+        thinking_level="medium",
+        timeout_s=10,
+    )
+
+    runner.export_transcript(
+        transcript_path=transcript,
+        output_path=output,
+        mcp_url="http://127.0.0.1:1234/mcp",
+        api_key="secret",
+    )
+
+    command = popen.call_args.args[0]
+    assert command[command.index("--mode") + 1] == "rpc"
+    assert command[command.index("--session") + 1] == str(transcript)
+    assert command[command.index("--extension") + 1] == str(extension)
+    assert "--offline" in command
+    assert "secret" not in command
+    request = json.loads(process.stdin.write.call_args.args[0])
+    assert request == {
+        "id": "dimos-transcript-export",
+        "type": "export_html",
+        "outputPath": str(output),
+    }
+    process.stdin.close.assert_called_once_with()
+
+
+def test_transcript_export_reports_redacted_startup_error(mocker, tmp_path: Path) -> None:
+    cli = tmp_path / "cli.js"
+    extension = tmp_path / "extension.js"
+    transcript = tmp_path / "pi-transcript.jsonl"
+    for path in (cli, extension, transcript):
+        path.touch()
+    process = mocker.Mock(returncode=1)
+    process.stdin = mocker.Mock()
+    process.stdout = StringIO()
+    process.stderr = StringIO("provider rejected secret\n")
+    process.poll.return_value = 1
+    process.wait.return_value = 1
+    mocker.patch("dimos.benchmark.evaluation.pi_process.subprocess.Popen", return_value=process)
+    runner = PiCliRunner(
+        cli=cli,
+        extension=extension,
+        model="gpt-5.6-luna",
+        thinking_level="medium",
+        timeout_s=10,
+    )
+
+    with pytest.raises(
+        PiExportError,
+        match=r"exited with status 1: provider rejected \[REDACTED\]",
+    ):
+        runner.export_transcript(
+            transcript_path=transcript,
+            output_path=tmp_path / "pi-transcript.html",
+            mcp_url="http://127.0.0.1:1234/mcp",
+            api_key="secret",
+        )

--- a/dimos/benchmark/evaluation/test_policy_runtime.py
+++ b/dimos/benchmark/evaluation/test_policy_runtime.py
@@ -21,7 +21,7 @@ import queue
 import cloudpickle
 import pytest
 
-from dimos.benchmark.evaluation.pi_process import PiRunResult
+from dimos.benchmark.evaluation.pi_process import PiRunError, PiRunResult
 from dimos.benchmark.evaluation.protocol import PolicyArtifact, TrialOutcome, TrialRun
 import dimos.benchmark.evaluation.runtime as runtime_module
 from dimos.benchmark.evaluation.runtime import (
@@ -35,6 +35,21 @@ from dimos.porcelain.dimos import Dimos
 
 def policy(app: Dimos) -> None:
     del app
+
+
+class _FakeCodePolicyServer:
+    current = None
+    mcp_url = "http://127.0.0.1:1/mcp"
+
+    def __init__(self, submission_handler) -> None:
+        self.submission_handler = submission_handler
+        _FakeCodePolicyServer.current = self
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
 
 
 def _trial(path: Path, number: int) -> TrialRun:
@@ -121,29 +136,15 @@ def test_policy_worker_connects_and_invokes_callable(mocker, tmp_path: Path) -> 
 
 
 def test_explore_freezes_last_of_five_debug_submissions(mocker, tmp_path: Path) -> None:
-    class FakeServer:
-        current = None
-        mcp_url = "http://127.0.0.1:1/mcp"
-
-        def __init__(self, submission_handler) -> None:
-            self.submission_handler = submission_handler
-            FakeServer.current = self
-
-        def start(self) -> None:
-            pass
-
-        def stop(self) -> None:
-            pass
-
     class FakePiRunner:
         def __init__(self, **_kwargs) -> None:
             pass
 
         def run(self, **_kwargs) -> PiRunResult:
-            assert FakeServer.current is not None
+            assert _FakeCodePolicyServer.current is not None
             serialized = cloudpickle.dumps(policy)
             for _ in range(5):
-                FakeServer.current.submission_handler(
+                _FakeCodePolicyServer.current.submission_handler(
                     "def policy(app: Dimos) -> None: ...",
                     serialized,
                 )
@@ -151,7 +152,7 @@ def test_explore_freezes_last_of_five_debug_submissions(mocker, tmp_path: Path) 
 
     marker = tmp_path / "pi"
     marker.touch()
-    mocker.patch.object(runtime_module, "CodePolicyMcpServer", FakeServer)
+    mocker.patch.object(runtime_module, "CodePolicyMcpServer", _FakeCodePolicyServer)
     mocker.patch.object(runtime_module, "PiCliRunner", FakePiRunner)
     mocker.patch.object(runtime_module, "_pi_paths", return_value=(marker, marker))
     runtime = CodePolicyRuntimeFactory(api_key="secret", workspace=tmp_path)
@@ -166,3 +167,114 @@ def test_explore_freezes_last_of_five_debug_submissions(mocker, tmp_path: Path) 
     assert len(outcome.trials) == 5
     assert outcome.policy is not None
     assert outcome.policy.serialized_path.parent.name == "submission-0005"
+
+
+def test_explore_publishes_jsonl_and_rendered_transcript(mocker, tmp_path: Path) -> None:
+    class FakePiRunner:
+        def __init__(self, **_kwargs) -> None:
+            pass
+
+        def run(self, **kwargs) -> PiRunResult:
+            transcript = kwargs["run_dir"] / "pi-session" / "session.jsonl"
+            transcript.parent.mkdir()
+            transcript.write_text('{"type":"session"}\n')
+            return PiRunResult("done", 1, 2.0, transcript, "")
+
+        def export_transcript(self, **kwargs) -> None:
+            kwargs["output_path"].write_text("<html>rendered</html>")
+
+    marker = tmp_path / "pi"
+    marker.touch()
+    mocker.patch.object(runtime_module, "CodePolicyMcpServer", _FakeCodePolicyServer)
+    mocker.patch.object(runtime_module, "PiCliRunner", FakePiRunner)
+    mocker.patch.object(runtime_module, "_pi_paths", return_value=(marker, marker))
+    runtime = CodePolicyRuntimeFactory(api_key="secret", workspace=tmp_path)
+
+    outcome = runtime.explore(
+        evaluation_protocol="Use normal DimOS information.",
+        task_input="Complete the task.",
+        submit_debug_trial=lambda _policy, number, path: _trial(path, number),
+    )
+
+    exploration = tmp_path / "runtime" / "exploration-0001"
+    assert outcome.status == "invalid"
+    assert (exploration / "pi-transcript.jsonl").read_text() == '{"type":"session"}\n'
+    assert (exploration / "pi-transcript.html").read_text() == "<html>rendered</html>"
+    artifacts = {artifact.path: artifact.media_type for artifact in runtime.runtime_artifacts}
+    assert artifacts["runtime/exploration-0001/pi-transcript.jsonl"] == ("application/x-ndjson")
+    assert artifacts["runtime/exploration-0001/pi-transcript.html"] == "text/html"
+
+
+def test_explore_retains_transcript_when_pi_fails(mocker, tmp_path: Path) -> None:
+    class FakePiRunner:
+        def __init__(self, **_kwargs) -> None:
+            pass
+
+        def run(self, **kwargs) -> PiRunResult:
+            transcript = kwargs["run_dir"] / "pi-session" / "session.jsonl"
+            transcript.parent.mkdir()
+            transcript.write_text('{"type":"session"}\n')
+            raise PiRunError("agent stopped", transcript_path=transcript)
+
+        def export_transcript(self, **kwargs) -> None:
+            kwargs["output_path"].write_text("<html>failure</html>")
+
+    marker = tmp_path / "pi"
+    marker.touch()
+    mocker.patch.object(runtime_module, "CodePolicyMcpServer", _FakeCodePolicyServer)
+    mocker.patch.object(runtime_module, "PiCliRunner", FakePiRunner)
+    mocker.patch.object(runtime_module, "_pi_paths", return_value=(marker, marker))
+    runtime = CodePolicyRuntimeFactory(api_key="secret", workspace=tmp_path)
+
+    with pytest.raises(PiRunError, match="agent stopped"):
+        runtime.explore(
+            evaluation_protocol="Use normal DimOS information.",
+            task_input="Complete the task.",
+            submit_debug_trial=lambda _policy, number, path: _trial(path, number),
+        )
+
+    exploration = tmp_path / "runtime" / "exploration-0001"
+    assert (exploration / "pi-transcript.jsonl").is_file()
+    assert (exploration / "pi-transcript.html").read_text() == "<html>failure</html>"
+
+
+def test_transcript_export_failure_is_diagnostic_only(mocker, tmp_path: Path) -> None:
+    class FakePiRunner:
+        def __init__(self, **_kwargs) -> None:
+            pass
+
+        def run(self, **kwargs) -> PiRunResult:
+            transcript = kwargs["run_dir"] / "pi-session" / "session.jsonl"
+            transcript.parent.mkdir()
+            transcript.write_text('{"type":"session"}\n')
+            return PiRunResult("done", 1, 2.0, transcript, "")
+
+        def export_transcript(self, **_kwargs) -> None:
+            raise RuntimeError("secret could not render")
+
+    marker = tmp_path / "pi"
+    marker.touch()
+    progress = []
+    mocker.patch.object(runtime_module, "CodePolicyMcpServer", _FakeCodePolicyServer)
+    mocker.patch.object(runtime_module, "PiCliRunner", FakePiRunner)
+    mocker.patch.object(runtime_module, "_pi_paths", return_value=(marker, marker))
+    runtime = CodePolicyRuntimeFactory(
+        api_key="secret", workspace=tmp_path, progress=progress.append
+    )
+
+    outcome = runtime.explore(
+        evaluation_protocol="Use normal DimOS information.",
+        task_input="Complete the task.",
+        submit_debug_trial=lambda _policy, number, path: _trial(path, number),
+    )
+
+    exploration = tmp_path / "runtime" / "exploration-0001"
+    assert outcome.status == "invalid"
+    assert (exploration / "pi-transcript.jsonl").is_file()
+    assert not (exploration / "pi-transcript.html").exists()
+    assert (exploration / "pi-transcript-export-error.log").read_text() == (
+        "RuntimeError: [REDACTED] could not render\n"
+    )
+    assert progress[-1].message == (
+        "transcript export failed: RuntimeError: [REDACTED] could not render"
+    )

--- a/packages/pi-code-policy-extension/package-lock.json
+++ b/packages/pi-code-policy-extension/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@earendil-works/pi-coding-agent": "0.80.10",
+        "@earendil-works/pi-tui": "0.80.10",
         "@modelcontextprotocol/client": "2.0.0",
         "typebox": "1.3.6"
       },

--- a/packages/pi-code-policy-extension/package.json
+++ b/packages/pi-code-policy-extension/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@earendil-works/pi-coding-agent": "0.80.10",
+    "@earendil-works/pi-tui": "0.80.10",
     "@modelcontextprotocol/client": "2.0.0",
     "typebox": "1.3.6"
   },

--- a/packages/pi-code-policy-extension/src/python-exec.ts
+++ b/packages/pi-code-policy-extension/src/python-exec.ts
@@ -3,7 +3,8 @@ import {
   StreamableHTTPClientTransport,
   type CallToolResult,
 } from "@modelcontextprotocol/client";
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { highlightCode, type ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 
 const TOOL_NAME = "python_exec";
@@ -59,6 +60,24 @@ export async function installPythonExec(
       { additionalProperties: false },
     ),
     executionMode: "sequential",
+    renderCall: (params, theme) => {
+      const title = theme.fg("toolTitle", theme.bold("Python"));
+      const code = highlightCode(params.code, "python").join("\n");
+      return new Text(`${title}\n${code}`, 0, 0);
+    },
+    renderResult: (result, _options, theme, context) => {
+      const output = result.content
+        .filter((item): item is Extract<typeof item, { type: "text" }> => item.type === "text")
+        .map((item) => item.text)
+        .join("\n");
+      const isError = context.isError;
+      const title = theme.fg(
+        isError ? "error" : "success",
+        theme.bold(isError ? "Python error" : "Python result"),
+      );
+      const body = highlightCode(output || "(completed)", "python").join("\n");
+      return new Text(`${title}\n${body}`, 0, 0);
+    },
     execute: async (_id, params) => {
       const timeoutSeconds = params.timeout_s ?? DEFAULT_TIMEOUT_SECONDS;
       const result = await client.callTool(

--- a/packages/pi-code-policy-extension/test/python-exec.test.ts
+++ b/packages/pi-code-policy-extension/test/python-exec.test.ts
@@ -44,6 +44,29 @@ test("registers one tool that calls MCP directly", async () => {
   await installPythonExec(pi, "http://127.0.0.1:1/mcp", async () => client);
   assert.equal(tool?.name, "python_exec");
   assert.equal(tool?.description, "Canonical CodePolicy description");
+  const theme = {
+    bold: (value: string) => value,
+    fg: (_color: string, value: string) => value,
+  } as never;
+  const call = tool!.renderCall!(
+    { code: "def policy():\n    return 1", timeout_s: 3 },
+    theme,
+    {} as never,
+  );
+  const renderedText = (lines: string[]) => lines.map((line) => line.trimEnd()).join("\n");
+  assert.equal(renderedText(call.render(200)), "Python\ndef policy():\n    return 1");
+  const recorded = "In [1] completed\n\nfirst line\nsecond line";
+  const renderResult = (expanded: boolean) =>
+    renderedText(
+      tool!.renderResult!(
+        { content: [{ type: "text", text: recorded }], details: {} },
+        { expanded, isPartial: false },
+        theme,
+        { isError: false } as never,
+      ).render(200),
+    );
+  assert.equal(renderResult(false), `Python result\n${recorded}`);
+  assert.equal(renderResult(true), `Python result\n${recorded}`);
   const result = await tool!.execute("call-1", { code: "1 + 1", timeout_s: 3 }, undefined, undefined, {} as never);
   assert.deepEqual(result.content, [{ type: "text", text: "2" }]);
   await shutdown!();


### PR DESCRIPTION
## Contribution path

- Linked PR: #3434
- Stacked on the code-policy evaluation runtime; merge #3434 first.

## Problem

Pi evaluation runs retain useful conversation history, but raw session JSONL is difficult to review. Generic transcript rendering also hides or truncates the Python REPL calls and results that matter most in code-policy evaluations.

## Solution

- retain native Pi session JSONL after successful and failed evaluations
- export a self-contained HTML conversation viewer while the evaluation workspace still exists
- render complete Python calls and results with syntax highlighting and no collapsed result state
- register the JSONL and HTML files as evaluation artifacts
- treat HTML export failures as nonfatal and retain a redacted diagnostic artifact

## How to Test

```bash
npm --prefix packages/pi-code-policy-extension test
uv run pytest \
  dimos/benchmark/evaluation/test_pi_process.py \
  dimos/benchmark/evaluation/test_policy_runtime.py -q
```

Validated after restacking: 14 focused Python tests and the Pi extension test pass.

## AI assistance

Codex with GPT-5.6 assisted with design discussion, implementation, tests, validation, and PR drafting. The author reviewed the behavior interactively against a real Pi transcript.

## Checklist

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
