### PR TITLE
fix: zenoh forking issue

### DIFF
--- a/dimos/cli/dimos.py
+++ b/dimos/cli/dimos.py
@@ -19,8 +19,10 @@ import inspect
 import json
 import os
 from pathlib import Path
+import signal
 import sys
 import time
+import traceback
 import types
 from typing import TYPE_CHECKING, Any, Literal, cast, get_args, get_origin
 
@@ -55,7 +57,13 @@ from dimos.cli.cloud import login as cloud_login, logout as cloud_logout, whoami
 from dimos.cli.hardware_cli import app as hardware_app
 from dimos.cli.shell import shell
 from dimos.constants import CONFIG_DIR, LOG_DIR
-from dimos.core.daemon import daemonize, install_signal_handlers
+from dimos.core.daemon import (
+    fork_daemon,
+    install_signal_handlers,
+    read_daemon_status,
+    redirect_stdio_to_devnull,
+    write_daemon_status,
+)
 from dimos.core.global_config import GlobalConfig, global_config
 from dimos.core.run_registry import get_most_recent, is_pid_alive, stop_entry
 from dimos.mapping.cli.map import main as _map_main
@@ -64,7 +72,7 @@ from dimos.mapping.cli.rename import main as _map_rename_main
 from dimos.mapping.cli.replay import main as _map_replay_main
 from dimos.mapping.cli.replay_marker import main as _map_replay_marker_main
 from dimos.robot.unitree.go2.cli.go2tool import app as go2tool_app
-from dimos.utils.cache import cache_usage_locked
+from dimos.utils.cache import cache_usage_guard, cache_usage_locked
 from dimos.utils.logging_config import setup_logger
 from dimos.visualization.rerun.constants import RerunOpenOption
 
@@ -328,43 +336,87 @@ def run(
     # Workers inherit DIMOS_RUN_LOG_DIR env var via forkserver.
     set_run_log_dir(log_dir)
 
-    coordinator = ModuleCoordinator.build(blueprint, parsed_config)
-
     if daemon:
-        # Health check before daemonizing — catch early crashes
-        if not coordinator.health_check():
-            typer.echo("Error: health check failed — a worker process died.", err=True)
-            coordinator.stop()
-            raise typer.Exit(1)
+        # Fork before building: zenoh's process-global runtime does not survive
+        # fork, so the daemon must open every session itself (issue #3395).
+        daemon_pgid, status_fd = fork_daemon(log_dir)
 
-        n_modules = coordinator.n_modules
-        typer.echo(f"✓ All modules started ({n_modules} modules)")
-        typer.echo("✓ Health check passed")
-        typer.echo("✓ DimOS running in background\n")
-        typer.echo(f"  Run ID:    {run_id}")
-        typer.echo(f"  Log:       {log_dir}")
-        typer.echo("  Stop:      dimos stop")
-        typer.echo("  Status:    dimos status")
+        if daemon_pgid:
+            # Launcher: wait for the daemon to report build/health outcome. Its
+            # build output streams to this terminal via the inherited stdio.
+            try:
+                status = read_daemon_status(status_fd)
+            except KeyboardInterrupt:
+                try:
+                    os.killpg(daemon_pgid, signal.SIGTERM)
+                except ProcessLookupError:
+                    pass
+                typer.echo("Interrupted; daemon startup aborted.", err=True)
+                raise typer.Exit(130) from None
+            if not status or not status.get("ok"):
+                message = (status or {}).get("error") or "daemon exited during startup"
+                typer.echo(f"Error: {message}", err=True)
+                raise typer.Exit(1)
 
-        coordinator.suppress_console()
+            typer.echo(f"✓ All modules started ({status['n_modules']} modules)")
+            typer.echo("✓ Health check passed")
+            typer.echo("✓ DimOS running in background\n")
+            typer.echo(f"  Run ID:    {run_id}")
+            typer.echo(f"  Log:       {log_dir}")
+            typer.echo("  Stop:      dimos stop")
+            typer.echo("  Status:    dimos status")
+            return
 
-        daemonize(log_dir)
-
-        entry = RunEntry(
-            run_id=run_id,
-            pid=os.getpid(),
-            blueprint=blueprint_name,
-            started_at=datetime.now(timezone.utc).isoformat(),
-            log_dir=str(log_dir),
-            cli_args=list(blueprint_names),
-            config_overrides=global_option_overrides,
-            original_argv=sys.argv,
-        )
-        entry.save()
-        spawn_watchdog(run_id, log_dir=log_dir)
-        install_signal_handlers(entry, coordinator)
-        coordinator.loop()
+        # Daemon grandchild — stdio still attached so build output streams.
+        coordinator = None
+        try:
+            coordinator = ModuleCoordinator.build(blueprint, parsed_config)
+            if not coordinator.health_check():
+                write_daemon_status(
+                    status_fd,
+                    {"ok": False, "error": "health check failed — a worker process died."},
+                )
+                coordinator.stop()
+                os._exit(1)
+            # Workers dup2 /dev/null over the terminal fds they inherited.
+            coordinator.suppress_console()
+            # Idempotent with loop(); serving now means the success status below
+            # guarantees Coordinator RPC is actually reachable.
+            coordinator.start_rpc_service()
+            entry = RunEntry(
+                run_id=run_id,
+                pid=os.getpid(),
+                blueprint=blueprint_name,
+                started_at=datetime.now(timezone.utc).isoformat(),
+                log_dir=str(log_dir),
+                cli_args=list(blueprint_names),
+                config_overrides=global_option_overrides,
+                original_argv=sys.argv,
+            )
+            entry.save()
+            spawn_watchdog(run_id, log_dir=log_dir)
+            install_signal_handlers(entry, coordinator)
+            redirect_stdio_to_devnull()
+        except Exception as exc:
+            traceback.print_exc()
+            write_daemon_status(status_fd, {"ok": False, "error": f"{type(exc).__name__}: {exc}"})
+            if coordinator is not None:
+                try:
+                    coordinator.stop()
+                except Exception:
+                    logger.error("Error stopping coordinator", exc_info=True)
+            sys.stderr.flush()
+            # os._exit: never unwind the launcher's typer/atexit state in a
+            # forked image.
+            os._exit(1)
+        write_daemon_status(status_fd, {"ok": True, "n_modules": coordinator.n_modules})
+        os.close(status_fd)
+        # The launcher's exit released the pre-fork cache-usage marker (shared
+        # flock); hold a fresh one for the daemon's lifetime.
+        with cache_usage_guard():
+            coordinator.loop()
     else:
+        coordinator = ModuleCoordinator.build(blueprint, parsed_config)
         entry = RunEntry(
             run_id=run_id,
             pid=os.getpid(),

--- a/dimos/core/daemon.py
+++ b/dimos/core/daemon.py
@@ -16,10 +16,11 @@
 
 from __future__ import annotations
 
+import json
 import os
 import signal
 import sys
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from dimos.core.coordination.process_lifecycle import kill_run_processes
 from dimos.utils.logging_config import setup_logger
@@ -42,29 +43,43 @@ def health_check(coordinator: ModuleCoordinator) -> bool:
     return coordinator.health_check()
 
 
-def daemonize(log_dir: Path) -> None:
-    """Double-fork daemonize the current process.
+def fork_daemon(log_dir: Path) -> tuple[int, int]:
+    """Double-fork into a daemon, keeping a status pipe to the launcher.
 
-    After this call the *caller* is the daemon grandchild.
-    stdin/stdout/stderr are redirected to ``/dev/null`` — all real
-    logging goes through structlog's FileHandler to ``main.jsonl``.
-    The two intermediate parents call ``os._exit(0)``.
+    Returns ``(daemon_pgid, read_fd)`` in the launcher and ``(0, write_fd)``
+    in the daemon grandchild — test the first element like ``os.fork()``.
+    The intermediate child calls ``setsid`` before forking again, so
+    ``daemon_pgid`` covers the grandchild and everything it spawns.
+
+    Building must happen in the grandchild: zenoh's process-global runtime
+    does not survive fork, so the daemon must not inherit any open sessions.
+    The grandchild keeps the launcher's stdio so startup output still reaches
+    the terminal; it must call ``redirect_stdio_to_devnull`` and
+    ``write_daemon_status`` once startup succeeds or fails.
     """
     log_dir.mkdir(parents=True, exist_ok=True)
+    # Anything buffered would otherwise be flushed by both processes.
+    sys.stdout.flush()
+    sys.stderr.flush()
+    read_fd, write_fd = os.pipe()
 
-    # First fork — detach from terminal
     pid = os.fork()
     if pid > 0:
-        os._exit(0)
+        os.close(write_fd)
+        os.waitpid(pid, 0)  # The intermediate exits immediately; don't leave a zombie.
+        return pid, read_fd
 
+    os.close(read_fd)
     os.setsid()
 
     # Second fork — can never reacquire a controlling terminal
-    pid = os.fork()
-    if pid > 0:
+    if os.fork() > 0:
         os._exit(0)
+    return 0, write_fd
 
-    # Redirect all stdio to /dev/null — structlog FileHandler is the log path
+
+def redirect_stdio_to_devnull() -> None:
+    """Point stdin/stdout/stderr at /dev/null — logging goes to ``main.jsonl``."""
     sys.stdout.flush()
     sys.stderr.flush()
 
@@ -73,6 +88,24 @@ def daemonize(log_dir: Path) -> None:
     os.dup2(devnull.fileno(), sys.stdout.fileno())
     os.dup2(devnull.fileno(), sys.stderr.fileno())
     devnull.close()
+
+
+def write_daemon_status(fd: int, status: dict[str, Any]) -> None:
+    """Send one JSON status line to the launcher; tolerate a vanished reader."""
+    try:
+        os.write(fd, (json.dumps(status) + "\n").encode())
+    except BrokenPipeError:
+        pass
+
+
+def read_daemon_status(fd: int) -> dict[str, Any] | None:
+    """Read the daemon's status line; ``None`` if it died before reporting."""
+    with os.fdopen(fd) as pipe:
+        line = pipe.readline()
+    try:
+        return json.loads(line)  # type: ignore[no-any-return]
+    except json.JSONDecodeError:
+        return None
 
 
 def install_signal_handlers(

--- a/dimos/core/demos/stress_test_module.py
+++ b/dimos/core/demos/stress_test_module.py
@@ -51,6 +51,3 @@ class StressTestModule(Module):
         import os
 
         return f"pid={os.getpid()}, module={self.__class__.__name__}"
-
-    def start(self) -> None:
-        super().start()

--- a/dimos/core/test_daemon.py
+++ b/dimos/core/test_daemon.py
@@ -173,24 +173,59 @@ class TestHealthCheck:
         assert coord.health_check() is False
 
 
-from dimos.core.daemon import daemonize, install_signal_handlers
+from dimos.core.daemon import (
+    fork_daemon,
+    install_signal_handlers,
+    read_daemon_status,
+    write_daemon_status,
+)
 
 
-class TestDaemonize:
-    """test_daemonize_creates_log_dir."""
+class TestForkDaemon:
+    """Launcher-side fork_daemon behavior and the status pipe protocol."""
 
-    def test_daemonize_creates_log_dir(self, tmp_path: Path):
+    def test_launcher_gets_pgid_and_readable_pipe(self, tmp_path: Path):
         log_dir = tmp_path / "nested" / "logs"
-        assert not log_dir.exists()
 
-        # We can't actually double-fork in tests (child would continue running
-        # pytest), so we mock os.fork to return >0 both times (parent path).
-        with mock.patch("os.fork", return_value=1), pytest.raises(SystemExit):
-            # Parent calls os._exit(0) which we let raise
-            with mock.patch("os._exit", side_effect=SystemExit(0)):
-                daemonize(log_dir)
+        # We can't actually double-fork in tests (the child's setsid would
+        # detach the pytest worker), so exercise only the launcher path.
+        with (
+            mock.patch("os.fork", return_value=12345),
+            mock.patch("os.waitpid") as waitpid,
+        ):
+            daemon_pgid, read_fd = fork_daemon(log_dir)
 
         assert log_dir.exists()
+        assert daemon_pgid == 12345
+        waitpid.assert_called_once_with(12345, 0)
+        # The write end is closed in the launcher, so the pipe reports EOF.
+        assert read_daemon_status(read_fd) is None
+
+    def test_status_roundtrip(self):
+        read_fd, write_fd = os.pipe()
+        write_daemon_status(write_fd, {"ok": True, "n_modules": 3})
+        os.close(write_fd)
+        assert read_daemon_status(read_fd) == {"ok": True, "n_modules": 3}
+
+    def test_status_error_roundtrip(self):
+        read_fd, write_fd = os.pipe()
+        write_daemon_status(write_fd, {"ok": False, "error": "boom"})
+        os.close(write_fd)
+        assert read_daemon_status(read_fd) == {"ok": False, "error": "boom"}
+
+    def test_status_garbage_is_none(self):
+        read_fd, write_fd = os.pipe()
+        os.write(write_fd, b"not json\n")
+        os.close(write_fd)
+        assert read_daemon_status(read_fd) is None
+
+    def test_write_tolerates_closed_reader(self):
+        read_fd, write_fd = os.pipe()
+        os.close(read_fd)
+        # os.write raises BrokenPipeError (SIGPIPE is ignored in Python);
+        # write_daemon_status must swallow it.
+        write_daemon_status(write_fd, {"ok": True})
+        os.close(write_fd)
 
 
 class TestSignalHandler:

--- a/dimos/core/test_daemon_zenoh.py
+++ b/dimos/core/test_daemon_zenoh.py
@@ -1,0 +1,114 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""E2e regression test for issue #3395: `dimos run --daemon` with zenoh.
+
+Everything runs in subprocesses: the daemon must survive a real double fork
+(zenoh's tokio runtime does not survive fork, so the daemon process must not
+inherit any zenoh state), and the client must be a genuinely separate process.
+This also keeps zenoh threads out of the pytest process.
+
+Assumption: the zenoh `Coordinator/*` RPC keys are host-global over loopback
+multicast (not namespaced per run). No other test serves or connects a zenoh
+Coordinator, and `--dist=loadfile` keeps this file on a single xdist worker.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import signal
+import subprocess
+import sys
+import time
+
+_CLIENT = """
+from dimos.core.coordination.coordinator_rpc import CoordinatorRPC
+
+client = CoordinatorRPC.connect(timeout=30)
+print(client.call("ping"))
+client.stop()
+"""
+
+
+def _sweep_leftover_daemons(state_dir: Path) -> None:
+    """Kill any daemon process group a failed run left behind."""
+    for entry_path in state_dir.glob("dimos/runs/*.json"):
+        try:
+            pid = json.loads(entry_path.read_text())["pid"]
+        except (json.JSONDecodeError, KeyError, OSError):
+            continue
+        for sig in (signal.SIGTERM, signal.SIGKILL):
+            try:
+                os.killpg(os.getpgid(pid), sig)
+            except (ProcessLookupError, PermissionError):
+                break
+            time.sleep(1.0)
+
+
+def test_daemon_serves_coordinator_ping_over_zenoh(tmp_path: Path) -> None:
+    env = os.environ | {
+        "DIMOS_TRANSPORT": "zenoh",
+        # Never touch the developer's real registry/config, even without xdist.
+        "XDG_STATE_HOME": str(tmp_path / "state"),
+        "XDG_CONFIG_HOME": str(tmp_path / "config"),
+    }
+    # File, not pipe: the daemon's forkserver inherits the CLI's stdout/stderr
+    # and holds them open forever, so a pipe would block subprocess.run.
+    run_log = tmp_path / "run.log"
+    try:
+        with run_log.open("w") as log:
+            run = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "dimos.cli.dimos",
+                    "run",
+                    "demo-mcp-stress-test",
+                    "--daemon",
+                    "--disable",
+                    "mcp-server",
+                    "--viewer",
+                    "none",
+                    "--n-workers",
+                    "1",
+                ],
+                env=env,
+                stdin=subprocess.DEVNULL,
+                stdout=log,
+                stderr=log,
+                timeout=120,
+            )
+        assert run.returncode == 0, f"dimos run --daemon failed:\n{run_log.read_text()}"
+
+        client = subprocess.run(
+            [sys.executable, "-c", _CLIENT],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert "pong" in client.stdout, (
+            f"Coordinator/ping unreachable from an out-of-process zenoh client:\n"
+            f"{client.stdout}\n{client.stderr}"
+        )
+    finally:
+        subprocess.run(
+            [sys.executable, "-m", "dimos.cli.dimos", "stop"],
+            env=env,
+            capture_output=True,
+            timeout=60,
+        )
+        _sweep_leftover_daemons(tmp_path / "state")

--- a/dimos/protocol/service/test_zenohservice.py
+++ b/dimos/protocol/service/test_zenohservice.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import Any
 
 import pytest
@@ -128,6 +129,16 @@ def test_two_services_share_session(session_pool) -> None:
     svc1.start()
     svc2.start()
     assert svc1.session is svc2.session
+
+
+def test_acquire_after_fork_raises(session_pool, mocker) -> None:
+    mocker.patch("dimos.protocol.service.zenohservice.zenoh.open", return_value=mocker.MagicMock())
+    config = ZenohConfig()
+    session_pool.acquire(config)
+
+    mocker.patch("os.getpid", return_value=os.getpid() + 1)
+    with pytest.raises(RuntimeError, match="does not survive fork"):
+        session_pool.acquire(config)
 
 
 def test_stop_does_not_close_shared_session(session_pool) -> None:

--- a/dimos/protocol/service/zenohservice.py
+++ b/dimos/protocol/service/zenohservice.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import json
+import os
 import platform
 import socket
 import threading
@@ -207,14 +208,25 @@ class ZenohSessionPool:
     def __init__(self) -> None:
         self._sessions: dict[str, zenoh.Session] = {}
         self._lock = threading.Lock()
+        self._opened_in_pid: int | None = None
 
     def acquire(self, config: ZenohConfig) -> zenoh.Session:
         """Open a session for this config, or return the existing shared one."""
         key = config.session_key
         with self._lock:
+            if self._opened_in_pid not in (None, os.getpid()):
+                # Fail fast: both inherited sessions and new zenoh.open() calls
+                # deadlock in a fork child because zenoh's process-global
+                # runtime loses its threads at fork.
+                raise RuntimeError(
+                    f"zenoh sessions were opened in pid {self._opened_in_pid} before this "
+                    "process forked; zenoh's runtime does not survive fork. "
+                    "Fork or daemonize before any zenoh use."
+                )
             if key not in self._sessions:
                 _warn_client_single_link(config)
                 self._sessions[key] = zenoh.open(_zenoh_config(config))
+                self._opened_in_pid = os.getpid()
                 logger.info(
                     "Zenoh session opened",
                     mode=config.mode,


### PR DESCRIPTION
## Problem

The Coordinator RPC is broken when using Zenoh.

Closes #3395

## Solution

Start the Zenoh sessions (i.e. call `ModuleCoordinator.build`) only after forking.

