### PR TITLE
feat(cli): rich login/logout UX

### DIFF
--- a/dimos/cli/cloud.py
+++ b/dimos/cli/cloud.py
@@ -32,6 +32,9 @@ import urllib.error
 import urllib.parse
 import urllib.request
 
+from rich.console import Console
+from rich.panel import Panel
+from rich.text import Text
 import typer
 
 from dimos.constants import CREDENTIALS_PATH
@@ -39,6 +42,25 @@ from dimos.core.global_config import global_config
 
 _KEYRING_SERVICE = "dimos-cloud"
 _KEYRING_USER = "default"
+
+_console = Console(highlight=False)
+
+_LOGO = """\
+██████╗ ██╗███╗   ███╗ ██████╗ ███████╗
+██╔══██╗██║████╗ ████║██╔═══██╗██╔════╝
+██║  ██║██║██╔████╔██║██║   ██║███████╗
+██║  ██║██║██║╚██╔╝██║██║   ██║╚════██║
+██████╔╝██║██║ ╚═╝ ██║╚██████╔╝███████║
+╚═════╝ ╚═╝╚═╝     ╚═╝ ╚═════╝ ╚══════╝"""
+
+_GRADIENT = ["#00e5ff", "#00c4ff", "#3d9bff", "#5c7cff", "#7a5cff", "#9b40ff"]
+
+
+def _logo() -> Text:
+    art = Text()
+    for line, color in zip(_LOGO.splitlines(), _GRADIENT, strict=True):
+        art.append(line + "\n", style=f"bold {color}")
+    return art
 
 
 def _base() -> str:
@@ -110,19 +132,40 @@ def api_key() -> str | None:
 def login() -> None:
     """Sign this machine in to Dimensional cloud."""
     d = _post("/auth/device", label=socket.gethostname())
-    typer.echo(f"\n  Open        {d['verification_uri']}")
-    typer.echo(f"  Enter code  {d['user_code']}\n")
+    _console.print(
+        Panel(
+            Text.assemble(
+                ("Open        ", "dim"),
+                (d["verification_uri"], "bold cyan underline"),
+                "\n",
+                ("Enter code  ", "dim"),
+                (f" {d['user_code']} ", "bold black on cyan"),
+            ),
+            title="[bold]Dimensional Cloud[/]",
+            subtitle="[dim]approve from any signed-in browser[/]",
+            border_style="cyan",
+            padding=(1, 3),
+            expand=False,
+        )
+    )
     deadline = time.time() + d["expires_in"]
-    while time.time() < deadline:
-        time.sleep(d["interval"])
-        r = _post("/auth/token", device_code=d["device_code"])
-        if r["status"] == "ok":
-            where = _store(r["api_key"])
-            typer.echo(f"Logged in as {r['email']} (key {r['key_id']}…, stored in {where})")
-            return
-        if r["status"] in ("denied", "expired"):
-            typer.echo(f"Login {r['status']}.", err=True)
-            raise typer.Exit(1)
+    with _console.status("", spinner="dots") as status:
+        while time.time() < deadline:
+            left = int(deadline - time.time())
+            status.update(f"[cyan]Waiting for approval…[/] [dim]{left // 60}:{left % 60:02d}[/]")
+            time.sleep(d["interval"])
+            r = _post("/auth/token", device_code=d["device_code"])
+            if r["status"] == "ok":
+                where = _store(r["api_key"])
+                _console.print(_logo())
+                _console.print(
+                    f"[bold green]✔ Logged in[/] as [bold]{r['email']}[/] "
+                    f"[dim](key {r['key_id']}…, stored in {where})[/]"
+                )
+                return
+            if r["status"] in ("denied", "expired"):
+                typer.echo(f"Login {r['status']}.", err=True)
+                raise typer.Exit(1)
     typer.echo("Login timed out.", err=True)
     raise typer.Exit(1)
 
@@ -130,7 +173,10 @@ def login() -> None:
 def logout() -> None:
     """Forget the stored key. The key itself stays valid until revoked in the console."""
     if _forget():
-        typer.echo("Logged out. The key stays valid until you revoke it in the console.")
+        _console.print(
+            "[bold cyan]⏻[/] [bold]Logged out.[/]"
+            " [dim]The key stays valid until you revoke it in the console.[/]"
+        )
     else:
         typer.echo("Not logged in.")
 
@@ -155,4 +201,4 @@ def whoami() -> None:
             err=True,
         )
         raise typer.Exit(1) from e
-    typer.echo(f"{who['email']} (scopes: {who['scopes']})")
+    _console.print(f"[bold]{who['email']}[/] [dim](scopes: {who['scopes']})[/]")

--- a/dimos/cli/cloud.py
+++ b/dimos/cli/cloud.py
@@ -57,8 +57,13 @@ _GRADIENT = ["#00e5ff", "#00c4ff", "#3d9bff", "#5c7cff", "#7a5cff", "#9b40ff"]
 
 
 def _logo() -> Text:
+    """DIMENSIONAL wordmark when the terminal fits it, the compact DIMOS mark below."""
+    from dimos.cli import theme
+
+    wide = [ln for ln in theme.ascii_logo.splitlines() if ln.strip()]
+    lines = wide if _console.width >= max(map(len, wide)) else _LOGO.splitlines()
     art = Text()
-    for line, color in zip(_LOGO.splitlines(), _GRADIENT, strict=True):
+    for line, color in zip(lines, _GRADIENT, strict=True):
         art.append(line + "\n", style=f"bold {color}")
     return art
 
@@ -129,8 +134,26 @@ def api_key() -> str | None:
     return _load()
 
 
+def _key_owner(key: str) -> dict[str, Any] | None:
+    """Who the key belongs to, or None if it is invalid or the cloud is unreachable."""
+    req = urllib.request.Request(
+        f"{_base()}/auth/whoami", headers={"Authorization": f"Bearer {key}"}
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=global_config.dimos_http_timeout) as r:
+            return cast("dict[str, Any]", json.load(r))
+    except (urllib.error.URLError, TimeoutError, OSError):
+        return None
+
+
 def login() -> None:
     """Sign this machine in to Dimensional cloud."""
+    if (key := api_key()) and (who := _key_owner(key)):
+        _console.print(
+            f"[bold green]✔ Already logged in[/] as [bold]{who['email']}[/] "
+            "[dim]— `dimos logout` first to switch accounts[/]"
+        )
+        return
     d = _post("/auth/device", label=socket.gethostname())
     _console.print(
         Panel(

--- a/dimos/cli/cloud.py
+++ b/dimos/cli/cloud.py
@@ -32,6 +32,9 @@ import urllib.error
 import urllib.parse
 import urllib.request
 
+from rich.console import Console
+from rich.panel import Panel
+from rich.text import Text
 import typer
 
 from dimos.constants import CREDENTIALS_PATH
@@ -39,6 +42,25 @@ from dimos.core.global_config import global_config
 
 _KEYRING_SERVICE = "dimos-cloud"
 _KEYRING_USER = "default"
+
+_console = Console(highlight=False)
+
+_LOGO = """\
+██████╗ ██╗███╗   ███╗ ██████╗ ███████╗
+██╔══██╗██║████╗ ████║██╔═══██╗██╔════╝
+██║  ██║██║██╔████╔██║██║   ██║███████╗
+██║  ██║██║██║╚██╔╝██║██║   ██║╚════██║
+██████╔╝██║██║ ╚═╝ ██║╚██████╔╝███████║
+╚═════╝ ╚═╝╚═╝     ╚═╝ ╚═════╝ ╚══════╝"""
+
+_GRADIENT = ["#00e5ff", "#00c4ff", "#3d9bff", "#5c7cff", "#7a5cff", "#9b40ff"]
+
+
+def _logo() -> Text:
+    art = Text()
+    for line, color in zip(_LOGO.splitlines(), _GRADIENT, strict=True):
+        art.append(line + "\n", style=f"bold {color}")
+    return art
 
 
 def _base() -> str:
@@ -110,19 +132,40 @@ def api_key() -> str | None:
 def login() -> None:
     """Sign this machine in to Dimensional cloud."""
     d = _post("/auth/device", label=socket.gethostname())
-    typer.echo(f"\n  Open        {d['verification_uri']}")
-    typer.echo(f"  Enter code  {d['user_code']}\n")
+    _console.print(
+        Panel(
+            Text.assemble(
+                ("Open        ", "dim"),
+                (d["verification_uri"], "bold cyan underline"),
+                "\n",
+                ("Enter code  ", "dim"),
+                (f" {d['user_code']} ", "bold black on cyan"),
+            ),
+            title="[bold]Dimensional Cloud[/]",
+            subtitle="[dim]approve from any signed-in browser[/]",
+            border_style="cyan",
+            padding=(1, 3),
+            expand=False,
+        )
+    )
     deadline = time.time() + d["expires_in"]
-    while time.time() < deadline:
-        time.sleep(d["interval"])
-        r = _post("/auth/token", device_code=d["device_code"])
-        if r["status"] == "ok":
-            where = _store({"api_key": r["api_key"], "email": r["email"]})
-            typer.echo(f"Logged in as {r['email']} (key {r['key_id']}…, stored in {where})")
-            return
-        if r["status"] in ("denied", "expired"):
-            typer.echo(f"Login {r['status']}.", err=True)
-            raise typer.Exit(1)
+    with _console.status("", spinner="dots") as status:
+        while time.time() < deadline:
+            left = int(deadline - time.time())
+            status.update(f"[cyan]Waiting for approval…[/] [dim]{left // 60}:{left % 60:02d}[/]")
+            time.sleep(d["interval"])
+            r = _post("/auth/token", device_code=d["device_code"])
+            if r["status"] == "ok":
+                where = _store({"api_key": r["api_key"], "email": r["email"]})
+                _console.print(_logo())
+                _console.print(
+                    f"[bold green]✔ Logged in[/] as [bold]{r['email']}[/] "
+                    f"[dim](key {r['key_id']}…, stored in {where})[/]"
+                )
+                return
+            if r["status"] in ("denied", "expired"):
+                typer.echo(f"Login {r['status']}.", err=True)
+                raise typer.Exit(1)
     typer.echo("Login timed out.", err=True)
     raise typer.Exit(1)
 
@@ -130,7 +173,9 @@ def login() -> None:
 def logout() -> None:
     """Forget the stored key. Revoke it fully at login.dimensional.org/keys."""
     if _forget():
-        typer.echo(f"Logged out. Revoke the key at {_base()}/keys.")
+        _console.print(
+            f"[bold cyan]⏻[/] [bold]Logged out.[/] [dim]Revoke the key at {_base()}/keys.[/]"
+        )
     else:
         typer.echo("Not logged in.")
 
@@ -155,4 +200,4 @@ def whoami() -> None:
             err=True,
         )
         raise typer.Exit(1) from e
-    typer.echo(f"{who['email']} (scopes: {who['scopes']})")
+    _console.print(f"[bold]{who['email']}[/] [dim](scopes: {who['scopes']})[/]")

--- a/dimos/cli/test_cloud.py
+++ b/dimos/cli/test_cloud.py
@@ -108,6 +108,50 @@ def test_login_denied_exits(monkeypatch: pytest.MonkeyPatch, filestore: Path) ->
     assert not filestore.exists()
 
 
+def test_login_skips_when_already_logged_in(
+    monkeypatch: pytest.MonkeyPatch, filestore: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    filestore.write_text("dimos_sk_live\n")
+    monkeypatch.setattr(cloud, "_key_owner", lambda key: {"email": "e@x"})
+    monkeypatch.setattr(cloud, "_post", lambda *a, **k: pytest.fail("device flow started"))
+    cloud.login()
+    assert "Already logged in" in capsys.readouterr().out
+
+
+def test_login_runs_flow_when_stored_key_is_stale(
+    monkeypatch: pytest.MonkeyPatch, filestore: Path
+) -> None:
+    filestore.write_text("dimos_sk_dead\n")
+    monkeypatch.setattr(cloud, "_key_owner", lambda key: None)
+    monkeypatch.setattr(time, "sleep", lambda s: None)
+    monkeypatch.setattr(
+        cloud,
+        "_post",
+        _responses(
+            {
+                "device_code": "dc",
+                "user_code": "AAAA-BBBB",
+                "verification_uri": "u",
+                "interval": 5,
+                "expires_in": 900,
+            },
+            {"status": "ok", "api_key": "dimos_sk_new", "key_id": "dimos_sk_new", "email": "e@x"},
+        ),
+    )
+    cloud.login()
+    assert cloud.api_key() == "dimos_sk_new"
+
+
+def test_logo_switches_wordmark_to_terminal_width(monkeypatch: pytest.MonkeyPatch) -> None:
+    from rich.console import Console
+
+    monkeypatch.setattr(cloud, "_console", Console(width=120))
+    wide = max(map(len, cloud._logo().plain.splitlines()))
+    monkeypatch.setattr(cloud, "_console", Console(width=60))
+    narrow = max(map(len, cloud._logo().plain.splitlines()))
+    assert wide > 60 >= narrow  # DIMENSIONAL when it fits, DIMOS when it doesn't
+
+
 def test_global_config_key_overrides_stored(
     monkeypatch: pytest.MonkeyPatch, filestore: Path
 ) -> None:


### PR DESCRIPTION
Polishes the `dimos login` / `dimos logout` experience on top of #3522, using rich (already a typer dependency — no new deps):

- **login**: cyan panel with verification URL + device code chip, live spinner with mm:ss countdown while polling, gradient DIMOS wordmark + green confirmation on success
- **logout**: styled `⏻ Logged out.` line with dimmed revoke URL
- **whoami**: same text, bold email / dim scopes

rich degrades to plain text when stdout isn't a TTY, so robot and CI logs stay clean. Existing tests pass unchanged; mypy clean.