### PR TITLE
refactor(robot): extract Go2 camera calibration

### DIFF
--- a/dimos/evals/vqa/author.py
+++ b/dimos/evals/vqa/author.py
@@ -44,11 +44,14 @@ class OpenAIQuestionAuthor:
         self._model = model
 
     def propose(self, image: Image, families: Sequence[FamilySpec]) -> Sequence[QuestionProposal]:
-        available_names = {family.name for family in families}
+        available = {family.name: family for family in families}
         family_shapes = [
             {
                 "family": family.name,
-                "required_fields": family.required_fields,
+                "required_fields": ("object_names",),
+                "min_objects": family.min_objects,
+                "max_objects": family.max_objects,
+                "distinct_objects": family.distinct_objects,
                 "description": family.description,
             }
             for family in families
@@ -58,7 +61,8 @@ class OpenAIQuestionAuthor:
             "Use any applicable families and object names, preferring specific families when their "
             "requirements are clearly satisfied. "
             "Return only a JSON array of objects matching the available deterministic families. "
-            "Do not duplicate a family/object pair. Do not answer questions or add fields. "
+            "Populate exactly the required fields. Do not duplicate proposals, answer questions, "
+            "or add fields. "
             f"Available families: {json.dumps(family_shapes)}"
         )
         payload: object = self._model.query_json(image, prompt)
@@ -70,6 +74,12 @@ class OpenAIQuestionAuthor:
                 proposal = QuestionProposal.model_validate(item)
             except ValidationError:
                 continue
-            if proposal.family in available_names:
-                proposals.append(proposal)
+            family = available.get(proposal.family)
+            if family is None:
+                continue
+            try:
+                family.validate(proposal)
+            except ValueError:
+                continue
+            proposals.append(proposal)
         return tuple(proposals)

--- a/dimos/evals/vqa/author.py
+++ b/dimos/evals/vqa/author.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, Protocol
 
 from pydantic import ValidationError
 
-from dimos.evals.vqa.families import FamilySpec, QuestionProposal
+from dimos.evals.vqa.contracts import FamilySpec, QuestionProposal
 
 if TYPE_CHECKING:
     from dimos.models.vl.base import VlModel

--- a/dimos/evals/vqa/author.py
+++ b/dimos/evals/vqa/author.py
@@ -44,6 +44,7 @@ class OpenAIQuestionAuthor:
         self._model = model
 
     def propose(self, image: Image, families: Sequence[FamilySpec]) -> Sequence[QuestionProposal]:
+        available_names = {family.name for family in families}
         family_shapes = [
             {
                 "family": family.name,
@@ -66,7 +67,9 @@ class OpenAIQuestionAuthor:
         proposals: list[QuestionProposal] = []
         for item in payload:
             try:
-                proposals.append(QuestionProposal.model_validate(item))
+                proposal = QuestionProposal.model_validate(item)
             except ValidationError:
                 continue
+            if proposal.family in available_names:
+                proposals.append(proposal)
         return tuple(proposals)

--- a/dimos/evals/vqa/cli.py
+++ b/dimos/evals/vqa/cli.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Literal
 
 import typer
 
@@ -30,6 +31,12 @@ def generate(
     start: int | None = typer.Option(None, min=0, help="First color_image index in range mode"),
     stop: int | None = typer.Option(None, min=1, help="Exclusive color_image stop index"),
     stride: int | None = typer.Option(None, min=1, help="Frame stride in range mode"),
+    calibration_profile: Literal["go2"] | None = typer.Option(
+        None, help="Explicit calibration profile for legacy recordings (go2)"
+    ),
+    sync_tolerance: float = typer.Option(
+        0.1, min=0.001, help="Maximum image-to-pointcloud timestamp delta"
+    ),
     output: Path | None = typer.Option(None, help="Override the generated dataset directory"),
 ) -> None:
     """Generate questions for one image or an indexed image range."""
@@ -43,6 +50,8 @@ def generate(
         start=start,
         stop=stop,
         stride=stride,
+        calibration_profile=calibration_profile,
+        synchronization_tolerance_s=sync_tolerance,
     )
     result = generate_dataset(request)
     typer.echo(f"Generated {len(result.cases)} VQA case(s) in {result.output}")

--- a/dimos/evals/vqa/cli.py
+++ b/dimos/evals/vqa/cli.py
@@ -32,10 +32,7 @@ def generate(
     stop: int | None = typer.Option(None, min=1, help="Exclusive color_image stop index"),
     stride: int | None = typer.Option(None, min=1, help="Frame stride in range mode"),
     calibration_profile: Literal["go2"] | None = typer.Option(
-        None, help="Explicit calibration profile for legacy recordings (go2)"
-    ),
-    sync_tolerance: float = typer.Option(
-        0.1, min=0.001, help="Maximum image-to-pointcloud timestamp delta"
+        None, help="Explicit Go2 fallback for recordings without calibration streams"
     ),
     output: Path | None = typer.Option(None, help="Override the generated dataset directory"),
 ) -> None:
@@ -51,7 +48,6 @@ def generate(
         stop=stop,
         stride=stride,
         calibration_profile=calibration_profile,
-        synchronization_tolerance_s=sync_tolerance,
     )
     result = generate_dataset(request)
     typer.echo(f"Generated {len(result.cases)} VQA case(s) in {result.output}")

--- a/dimos/evals/vqa/contracts.py
+++ b/dimos/evals/vqa/contracts.py
@@ -29,6 +29,9 @@ from pydantic import (
 )
 
 if TYPE_CHECKING:
+    from dimos.evals.vqa.preprocessing import CalibratedFrame
+    from dimos.evals.vqa.primitives.edgetam import ObjectMaskEvidence
+    from dimos.evals.vqa.primitives.range import ObjectRangeEvidence
     from dimos.msgs.sensor_msgs.Image import Image
     from dimos.perception.detection.type.detection2d.imageDetections2D import ImageDetections2D
 
@@ -115,3 +118,19 @@ class ObjectDetector(Protocol):
     """Object evidence required by visual question families."""
 
     def detect(self, image: Image, object_name: str) -> ImageDetections2D: ...
+
+
+class ObjectMaskEstimator(Protocol):
+    """Estimate object masks from an image."""
+
+    def estimate(self, image: Image, object_name: str) -> ObjectMaskEvidence: ...
+
+    def estimate_many(
+        self, image: Image, object_names: tuple[str, ...]
+    ) -> tuple[ObjectMaskEvidence, ...]: ...
+
+
+class ObjectRangeEstimator(Protocol):
+    """Estimate object range from an explicit canonical frame."""
+
+    def estimate(self, frame: CalibratedFrame, object_name: str) -> ObjectRangeEvidence: ...

--- a/dimos/evals/vqa/contracts.py
+++ b/dimos/evals/vqa/contracts.py
@@ -1,0 +1,117 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared domain contracts for deterministic VQA generation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Annotated, Literal, Protocol
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    JsonValue,
+    StringConstraints,
+    model_validator,
+)
+
+if TYPE_CHECKING:
+    from dimos.msgs.sensor_msgs.Image import Image
+    from dimos.perception.detection.type.detection2d.imageDetections2D import ImageDetections2D
+
+NonEmptyString = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+FamilyName = Literal[
+    "presence",
+    "horizontal_direction",
+    "object_count",
+    "image_coverage",
+    "largest_visible_area",
+    "object_distance",
+    "closest_object",
+]
+
+
+class QuestionProposal(BaseModel):
+    """A model-authored request constrained to a deterministic family."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    family: FamilyName
+    object_names: tuple[NonEmptyString, ...] = Field(min_length=1)
+
+
+class FamilyAnswer(BaseModel):
+    """A public question and its privately derived choice answer."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    question: NonEmptyString
+    choices: tuple[NonEmptyString, ...]
+    answer: NonEmptyString
+    evidence: dict[str, JsonValue] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def answer_is_a_choice(self) -> FamilyAnswer:
+        if len(self.choices) < 2:
+            raise ValueError("a VQA question requires at least two choices")
+        if len(set(self.choices)) != len(self.choices):
+            raise ValueError("VQA choices must be unique")
+        if self.answer not in self.choices:
+            raise ValueError("the answer must be one of the choices")
+        return self
+
+
+@dataclass(frozen=True)
+class FamilySpec:
+    """The proposal shape exposed to the image-only question author."""
+
+    name: FamilyName
+    description: str
+    min_objects: int = 1
+    max_objects: int = 1
+    distinct_objects: bool = False
+    requires_masks: bool = False
+    requires_pointcloud: bool = False
+    object_order_matters: bool = True
+
+    def validate(self, proposal: QuestionProposal) -> None:
+        """Validate a structurally parsed proposal against this family contract."""
+        if proposal.family != self.name:
+            raise ValueError(
+                f"proposal family {proposal.family!r} does not match specification {self.name!r}"
+            )
+        count = len(proposal.object_names)
+        if not self.min_objects <= count <= self.max_objects:
+            if self.min_objects == self.max_objects:
+                requirement = f"exactly {self.min_objects} object name"
+            else:
+                requirement = f"{self.min_objects} to {self.max_objects} object names"
+            raise ValueError(f"{self.name} requires {requirement}")
+        if (
+            self.distinct_objects
+            and len({name.casefold() for name in proposal.object_names}) != count
+        ):
+            raise ValueError(f"{self.name} requires distinct object names")
+
+
+class InsufficientEvidenceError(ValueError):
+    """A family cannot derive an answer from the available primitive evidence."""
+
+
+class ObjectDetector(Protocol):
+    """Object evidence required by visual question families."""
+
+    def detect(self, image: Image, object_name: str) -> ImageDetections2D: ...

--- a/dimos/evals/vqa/families.py
+++ b/dimos/evals/vqa/families.py
@@ -12,97 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Contracts for deterministic VQA question families."""
+"""Specifications and answer rules for deterministic VQA question families."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Annotated, Literal, Protocol, cast
+from typing import TYPE_CHECKING, cast
 
-from pydantic import (
-    BaseModel,
-    ConfigDict,
-    Field,
-    JsonValue,
-    StringConstraints,
-    model_validator,
+from pydantic import JsonValue
+
+from dimos.evals.vqa.contracts import (
+    FamilyAnswer,
+    FamilyName,
+    FamilySpec,
+    InsufficientEvidenceError,
+    ObjectDetector,
+    QuestionProposal,
 )
 
 if TYPE_CHECKING:
     from dimos.evals.vqa.preprocessing import CalibratedFrame
+    from dimos.evals.vqa.primitives.edgetam import ObjectMaskEstimator
     from dimos.evals.vqa.primitives.range import ObjectRangeEstimator
     from dimos.msgs.sensor_msgs.Image import Image
-    from dimos.perception.detection.type.detection2d.imageDetections2D import ImageDetections2D
-
-NonEmptyString = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
-FamilyName = Literal[
-    "presence",
-    "horizontal_direction",
-    "object_count",
-    "object_distance",
-    "closest_object",
-]
-
-
-class QuestionProposal(BaseModel):
-    """A model-authored request constrained to a deterministic family."""
-
-    model_config = ConfigDict(extra="forbid", frozen=True)
-
-    family: FamilyName
-    object_names: tuple[NonEmptyString, ...] = Field(min_length=1)
-
-
-class FamilyAnswer(BaseModel):
-    """A public question and its privately derived choice answer."""
-
-    model_config = ConfigDict(extra="forbid", frozen=True)
-
-    question: NonEmptyString
-    choices: tuple[NonEmptyString, ...]
-    answer: NonEmptyString
-    evidence: dict[str, JsonValue] = Field(default_factory=dict)
-
-    @model_validator(mode="after")
-    def answer_is_a_choice(self) -> FamilyAnswer:
-        if len(self.choices) < 2:
-            raise ValueError("a VQA question requires at least two choices")
-        if len(set(self.choices)) != len(self.choices):
-            raise ValueError("VQA choices must be unique")
-        if self.answer not in self.choices:
-            raise ValueError("the answer must be one of the choices")
-        return self
-
-
-@dataclass(frozen=True)
-class FamilySpec:
-    """The proposal shape exposed to the image-only question author."""
-
-    name: FamilyName
-    description: str
-    min_objects: int = 1
-    max_objects: int = 1
-    distinct_objects: bool = False
-    requires_pointcloud: bool = False
-
-    def validate(self, proposal: QuestionProposal) -> None:
-        """Validate a structurally parsed proposal against this family contract."""
-        if proposal.family != self.name:
-            raise ValueError(
-                f"proposal family {proposal.family!r} does not match specification {self.name!r}"
-            )
-        count = len(proposal.object_names)
-        if not self.min_objects <= count <= self.max_objects:
-            if self.min_objects == self.max_objects:
-                requirement = f"exactly {self.min_objects} object name"
-            else:
-                requirement = f"{self.min_objects} to {self.max_objects} object names"
-            raise ValueError(f"{self.name} requires {requirement}")
-        if (
-            self.distinct_objects
-            and len({name.casefold() for name in proposal.object_names}) != count
-        ):
-            raise ValueError(f"{self.name} requires distinct object names")
 
 
 PRESENCE_FAMILY = FamilySpec(
@@ -116,6 +47,26 @@ HORIZONTAL_DIRECTION_FAMILY = FamilySpec(
 OBJECT_COUNT_FAMILY = FamilySpec(
     name="object_count",
     description="Count a small number of clearly visible, distinct object instances.",
+)
+IMAGE_COVERAGE_FAMILY = FamilySpec(
+    name="image_coverage",
+    description=(
+        "Estimate how much of the image one clearly visible object occupies from its segmentation "
+        "mask. Do not estimate the percentage yourself."
+    ),
+    requires_masks=True,
+)
+LARGEST_VISIBLE_AREA_FAMILY = FamilySpec(
+    name="largest_visible_area",
+    description=(
+        "Choose which of two to five distinct, clearly visible object references occupies the "
+        "largest segmented image area. Do not infer which reference is largest."
+    ),
+    min_objects=2,
+    max_objects=5,
+    distinct_objects=True,
+    requires_masks=True,
+    object_order_matters=False,
 )
 OBJECT_DISTANCE_FAMILY = FamilySpec(
     name="object_distance",
@@ -133,11 +84,14 @@ CLOSEST_OBJECT_FAMILY = FamilySpec(
     max_objects=5,
     distinct_objects=True,
     requires_pointcloud=True,
+    object_order_matters=False,
 )
 AVAILABLE_FAMILIES = (
     PRESENCE_FAMILY,
     HORIZONTAL_DIRECTION_FAMILY,
     OBJECT_COUNT_FAMILY,
+    IMAGE_COVERAGE_FAMILY,
+    LARGEST_VISIBLE_AREA_FAMILY,
     OBJECT_DISTANCE_FAMILY,
     CLOSEST_OBJECT_FAMILY,
 )
@@ -149,22 +103,13 @@ def _family_spec(name: FamilyName) -> FamilySpec:
     return _FAMILIES_BY_NAME[name]
 
 
-class InsufficientEvidenceError(ValueError):
-    """A family cannot derive an answer from the available primitive evidence."""
-
-
-class ObjectDetector(Protocol):
-    """Object evidence required by visual question families."""
-
-    def detect(self, image: Image, object_name: str) -> ImageDetections2D: ...
-
-
 def answer_question(
     proposal: QuestionProposal,
     image: Image,
     detector: ObjectDetector,
     calibrated_frame: CalibratedFrame | None = None,
     range_estimator: ObjectRangeEstimator | None = None,
+    mask_estimator: ObjectMaskEstimator | None = None,
 ) -> FamilyAnswer:
     """Dispatch one constrained proposal to its deterministic family."""
     _family_spec(proposal.family).validate(proposal)
@@ -174,6 +119,16 @@ def answer_question(
         return _answer_horizontal_direction(proposal, image, detector)
     if proposal.family == "object_count":
         return _answer_object_count(proposal, image, detector)
+    if proposal.family == "image_coverage":
+        if mask_estimator is None:
+            raise InsufficientEvidenceError("image coverage requires segmentation-mask evidence")
+        return _answer_image_coverage(proposal, image, mask_estimator)
+    if proposal.family == "largest_visible_area":
+        if mask_estimator is None:
+            raise InsufficientEvidenceError(
+                "largest visible area requires segmentation-mask evidence"
+            )
+        return _answer_largest_visible_area(proposal, image, mask_estimator)
     if proposal.family == "object_distance":
         if calibrated_frame is None or range_estimator is None:
             raise InsufficientEvidenceError(
@@ -299,6 +254,101 @@ def _answer_object_distance(
         evidence={
             "primitive": "edgetam_lidar_range",
             **evidence.model_dump(mode="json"),
+        },
+    )
+
+
+_COVERAGE_SCHEMES = (
+    (
+        (25.0, 50.0, 75.0),
+        ("under 25%", "25% to under 50%", "50% to under 75%", "75% or more"),
+    ),
+    (
+        (15.0, 35.0, 65.0, 85.0),
+        (
+            "under 15%",
+            "15% to under 35%",
+            "35% to under 65%",
+            "65% to under 85%",
+            "85% or more",
+        ),
+    ),
+)
+
+
+def _answer_image_coverage(
+    proposal: QuestionProposal,
+    image: Image,
+    mask_estimator: ObjectMaskEstimator,
+) -> FamilyAnswer:
+    object_name = proposal.object_names[0]
+    evidence = mask_estimator.estimate(image, object_name)
+    image_area = image.width * image.height
+    coverage = 100.0 * evidence.mask_area_px / image_area
+    boundaries, choices = max(
+        _COVERAGE_SCHEMES,
+        key=lambda scheme: min(abs(coverage - boundary) for boundary in scheme[0]),
+    )
+    boundary_margin = min(abs(coverage - boundary) for boundary in boundaries)
+    answer_index = sum(coverage >= boundary for boundary in boundaries)
+    return FamilyAnswer(
+        question=(
+            f"Approximately what percentage of the image is occupied by the visible {object_name}?"
+        ),
+        choices=choices,
+        answer=choices[answer_index],
+        evidence={
+            "primitive": "edgetam_mask_area",
+            "object_name": object_name,
+            "mask_area_px": evidence.mask_area_px,
+            "image_area_px": image_area,
+            "coverage_percent": coverage,
+            "bucket_boundaries_percent": cast("JsonValue", list(boundaries)),
+            "nearest_boundary_margin_percent": boundary_margin,
+            "prompt_bbox_xyxy": cast("JsonValue", list(evidence.prompt_bbox_xyxy)),
+            "mask_bbox_xyxy": cast("JsonValue", list(evidence.mask_bbox_xyxy)),
+        },
+    )
+
+
+def _answer_largest_visible_area(
+    proposal: QuestionProposal,
+    image: Image,
+    mask_estimator: ObjectMaskEstimator,
+) -> FamilyAnswer:
+    object_names = proposal.object_names
+    masks = mask_estimator.estimate_many(image, object_names)
+    if tuple(mask.object_name for mask in masks) != object_names:
+        raise ValueError("mask estimator results do not match the requested object order")
+    ranked = sorted(range(len(masks)), key=lambda index: masks[index].mask_area_px, reverse=True)
+    winner_index, runner_up_index = ranked[:2]
+    winner_area = masks[winner_index].mask_area_px
+    runner_up_area = masks[runner_up_index].mask_area_px
+    if 5 * winner_area < 6 * runner_up_area:
+        raise InsufficientEvidenceError(
+            "visible mask areas do not establish an object that is at least 20% larger"
+        )
+    image_area = image.width * image.height
+    return FamilyAnswer(
+        question="Which object occupies the largest visible area in the image?",
+        choices=object_names,
+        answer=object_names[winner_index],
+        evidence={
+            "primitive": "edgetam_mask_area",
+            "comparison_rule": "winner_at_least_20_percent_larger",
+            "objects": cast(
+                "JsonValue",
+                [
+                    {
+                        "choice": object_name,
+                        "mask_area_px": mask.mask_area_px,
+                        "coverage_percent": 100.0 * mask.mask_area_px / image_area,
+                        "prompt_bbox_xyxy": list(mask.prompt_bbox_xyxy),
+                        "mask_bbox_xyxy": list(mask.mask_bbox_xyxy),
+                    }
+                    for object_name, mask in zip(object_names, masks, strict=True)
+                ],
+            ),
         },
     )
 

--- a/dimos/evals/vqa/families.py
+++ b/dimos/evals/vqa/families.py
@@ -22,6 +22,8 @@ from typing import TYPE_CHECKING, Annotated, Literal, Protocol, cast
 from pydantic import BaseModel, ConfigDict, Field, JsonValue, StringConstraints, model_validator
 
 if TYPE_CHECKING:
+    from dimos.evals.vqa.preprocessing import CalibratedFrame
+    from dimos.evals.vqa.primitives.edgetam import ObjectRangeEstimator
     from dimos.msgs.sensor_msgs.Image import Image
     from dimos.perception.detection.type.detection2d.imageDetections2D import ImageDetections2D
 
@@ -33,7 +35,7 @@ class QuestionProposal(BaseModel):
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    family: Literal["presence", "horizontal_direction", "object_count"]
+    family: Literal["presence", "horizontal_direction", "object_count", "object_distance"]
     object_name: NonEmptyString
 
 
@@ -82,7 +84,17 @@ OBJECT_COUNT_FAMILY = FamilySpec(
     required_fields=("object_name",),
     description="Count a small number of clearly visible, distinct object instances.",
 )
-AVAILABLE_FAMILIES = (PRESENCE_FAMILY, HORIZONTAL_DIRECTION_FAMILY, OBJECT_COUNT_FAMILY)
+OBJECT_DISTANCE_FAMILY = FamilySpec(
+    name="object_distance",
+    required_fields=("object_name",),
+    description="Estimate the range to one clearly visible object instance.",
+)
+AVAILABLE_FAMILIES = (
+    PRESENCE_FAMILY,
+    HORIZONTAL_DIRECTION_FAMILY,
+    OBJECT_COUNT_FAMILY,
+    OBJECT_DISTANCE_FAMILY,
+)
 
 
 class InsufficientEvidenceError(ValueError):
@@ -96,7 +108,11 @@ class ObjectDetector(Protocol):
 
 
 def answer_question(
-    proposal: QuestionProposal, image: Image, detector: ObjectDetector
+    proposal: QuestionProposal,
+    image: Image,
+    detector: ObjectDetector,
+    calibrated_frame: CalibratedFrame | None = None,
+    range_estimator: ObjectRangeEstimator | None = None,
 ) -> FamilyAnswer:
     """Dispatch one constrained proposal to its deterministic family."""
     if proposal.family == "presence":
@@ -105,6 +121,12 @@ def answer_question(
         return _answer_horizontal_direction(proposal, image, detector)
     if proposal.family == "object_count":
         return _answer_object_count(proposal, image, detector)
+    if proposal.family == "object_distance":
+        if calibrated_frame is None or range_estimator is None:
+            raise InsufficientEvidenceError(
+                "object distance requires calibrated point-cloud evidence"
+            )
+        return _answer_object_distance(proposal, calibrated_frame, range_estimator)
     raise ValueError(f"unsupported VQA family: {proposal.family}")
 
 
@@ -188,3 +210,43 @@ def _answer_object_count(
             "boxes": cast("JsonValue", boxes),
         },
     )
+
+
+def _answer_object_distance(
+    proposal: QuestionProposal,
+    calibrated_frame: CalibratedFrame,
+    range_estimator: ObjectRangeEstimator,
+) -> FamilyAnswer:
+    """Answer an object-distance proposal from EdgeTAM and point-cloud evidence."""
+    evidence = range_estimator.estimate(calibrated_frame, proposal.object_name)
+    choices = (
+        "under 1 meter",
+        "1 to under 2 meters",
+        "2 to under 3 meters",
+        "3 meters or more",
+    )
+    lower_quartile, _, upper_quartile = evidence.range_quartiles_m
+    if _distance_bucket(lower_quartile) != _distance_bucket(upper_quartile):
+        raise InsufficientEvidenceError(
+            "object range uncertainty crosses a distance answer boundary"
+        )
+    answer = choices[_distance_bucket(evidence.camera_range_m)]
+    return FamilyAnswer(
+        question=f"Approximately how far is the visible {proposal.object_name} from the camera?",
+        choices=choices,
+        answer=answer,
+        evidence={
+            "primitive": "edgetam_lidar_range",
+            **evidence.model_dump(mode="json"),
+        },
+    )
+
+
+def _distance_bucket(distance_m: float) -> int:
+    if distance_m < 1:
+        return 0
+    if distance_m < 2:
+        return 1
+    if distance_m < 3:
+        return 2
+    return 3

--- a/dimos/evals/vqa/families.py
+++ b/dimos/evals/vqa/families.py
@@ -19,15 +19,29 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Annotated, Literal, Protocol, cast
 
-from pydantic import BaseModel, ConfigDict, Field, JsonValue, StringConstraints, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    JsonValue,
+    StringConstraints,
+    model_validator,
+)
 
 if TYPE_CHECKING:
     from dimos.evals.vqa.preprocessing import CalibratedFrame
-    from dimos.evals.vqa.primitives.edgetam import ObjectRangeEstimator
+    from dimos.evals.vqa.primitives.range import ObjectRangeEstimator
     from dimos.msgs.sensor_msgs.Image import Image
     from dimos.perception.detection.type.detection2d.imageDetections2D import ImageDetections2D
 
 NonEmptyString = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+FamilyName = Literal[
+    "presence",
+    "horizontal_direction",
+    "object_count",
+    "object_distance",
+    "closest_object",
+]
 
 
 class QuestionProposal(BaseModel):
@@ -35,8 +49,8 @@ class QuestionProposal(BaseModel):
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    family: Literal["presence", "horizontal_direction", "object_count", "object_distance"]
-    object_name: NonEmptyString
+    family: FamilyName
+    object_names: tuple[NonEmptyString, ...] = Field(min_length=1)
 
 
 class FamilyAnswer(BaseModel):
@@ -64,37 +78,75 @@ class FamilyAnswer(BaseModel):
 class FamilySpec:
     """The proposal shape exposed to the image-only question author."""
 
-    name: str
-    required_fields: tuple[str, ...]
+    name: FamilyName
     description: str
+    min_objects: int = 1
+    max_objects: int = 1
+    distinct_objects: bool = False
+    requires_pointcloud: bool = False
+
+    def validate(self, proposal: QuestionProposal) -> None:
+        """Validate a structurally parsed proposal against this family contract."""
+        if proposal.family != self.name:
+            raise ValueError(
+                f"proposal family {proposal.family!r} does not match specification {self.name!r}"
+            )
+        count = len(proposal.object_names)
+        if not self.min_objects <= count <= self.max_objects:
+            if self.min_objects == self.max_objects:
+                requirement = f"exactly {self.min_objects} object name"
+            else:
+                requirement = f"{self.min_objects} to {self.max_objects} object names"
+            raise ValueError(f"{self.name} requires {requirement}")
+        if (
+            self.distinct_objects
+            and len({name.casefold() for name in proposal.object_names}) != count
+        ):
+            raise ValueError(f"{self.name} requires distinct object names")
 
 
 PRESENCE_FAMILY = FamilySpec(
     name="presence",
-    required_fields=("object_name",),
     description="Ask whether a clearly visible object category is present.",
 )
 HORIZONTAL_DIRECTION_FAMILY = FamilySpec(
     name="horizontal_direction",
-    required_fields=("object_name",),
     description="Use only for one clearly visible object instance.",
 )
 OBJECT_COUNT_FAMILY = FamilySpec(
     name="object_count",
-    required_fields=("object_name",),
     description="Count a small number of clearly visible, distinct object instances.",
 )
 OBJECT_DISTANCE_FAMILY = FamilySpec(
     name="object_distance",
-    required_fields=("object_name",),
     description="Estimate the range to one clearly visible object instance.",
+    requires_pointcloud=True,
+)
+CLOSEST_OBJECT_FAMILY = FamilySpec(
+    name="closest_object",
+    description=(
+        "Choose the closest of two to five distinct object references with exactly one visible "
+        "match each. Spatial descriptions such as 'left person' and 'right person' may distinguish "
+        "instances of one category. Do not infer which reference is closest."
+    ),
+    min_objects=2,
+    max_objects=5,
+    distinct_objects=True,
+    requires_pointcloud=True,
 )
 AVAILABLE_FAMILIES = (
     PRESENCE_FAMILY,
     HORIZONTAL_DIRECTION_FAMILY,
     OBJECT_COUNT_FAMILY,
     OBJECT_DISTANCE_FAMILY,
+    CLOSEST_OBJECT_FAMILY,
 )
+
+_FAMILIES_BY_NAME = {family.name: family for family in AVAILABLE_FAMILIES}
+
+
+def _family_spec(name: FamilyName) -> FamilySpec:
+    return _FAMILIES_BY_NAME[name]
 
 
 class InsufficientEvidenceError(ValueError):
@@ -115,6 +167,7 @@ def answer_question(
     range_estimator: ObjectRangeEstimator | None = None,
 ) -> FamilyAnswer:
     """Dispatch one constrained proposal to its deterministic family."""
+    _family_spec(proposal.family).validate(proposal)
     if proposal.family == "presence":
         return _answer_presence(proposal, image, detector)
     if proposal.family == "horizontal_direction":
@@ -127,25 +180,30 @@ def answer_question(
                 "object distance requires calibrated point-cloud evidence"
             )
         return _answer_object_distance(proposal, calibrated_frame, range_estimator)
+    if proposal.family == "closest_object":
+        if calibrated_frame is None or range_estimator is None:
+            raise InsufficientEvidenceError(
+                "closest object requires calibrated point-cloud evidence"
+            )
+        return _answer_closest_object(proposal, calibrated_frame, range_estimator)
     raise ValueError(f"unsupported VQA family: {proposal.family}")
 
 
 def _answer_presence(
     proposal: QuestionProposal, image: Image, detector: ObjectDetector
 ) -> FamilyAnswer:
-    detections = detector.detect(image, proposal.object_name)
+    object_name = proposal.object_names[0]
+    detections = detector.detect(image, object_name)
     if not detections.detections:
-        raise InsufficientEvidenceError(
-            f"object detector did not confirm visible {proposal.object_name!r}"
-        )
+        raise InsufficientEvidenceError(f"object detector did not confirm visible {object_name!r}")
     boxes = [list(map(float, detection.bbox)) for detection in detections.detections]
     return FamilyAnswer(
-        question=f"Does the image contain any {proposal.object_name}?",
+        question=f"Does the image contain any {object_name}?",
         choices=("yes", "no"),
         answer="yes",
         evidence={
             "primitive": "object_detector",
-            "object_name": proposal.object_name,
+            "object_name": object_name,
             "detection_count": len(detections),
             "boxes": cast("JsonValue", boxes),
         },
@@ -155,10 +213,11 @@ def _answer_presence(
 def _answer_horizontal_direction(
     proposal: QuestionProposal, image: Image, detector: ObjectDetector
 ) -> FamilyAnswer:
-    detections = detector.detect(image, proposal.object_name)
+    object_name = proposal.object_names[0]
+    detections = detector.detect(image, object_name)
     if len(detections) != 1:
         raise InsufficientEvidenceError(
-            f"horizontal direction requires exactly one detected {proposal.object_name!r}, "
+            f"horizontal direction requires exactly one detected {object_name!r}, "
             f"got {len(detections)}"
         )
 
@@ -172,12 +231,12 @@ def _answer_horizontal_direction(
     else:
         answer = "right"
     return FamilyAnswer(
-        question=f"Which horizontal region contains the visible {proposal.object_name}?",
+        question=f"Which horizontal region contains the visible {object_name}?",
         choices=("left", "center", "right"),
         answer=answer,
         evidence={
             "primitive": "object_detector",
-            "object_name": proposal.object_name,
+            "object_name": object_name,
             "detection_count": 1,
             "box": cast("JsonValue", list(map(float, box))),
             "center_x_px": center_x,
@@ -189,23 +248,24 @@ def _answer_horizontal_direction(
 def _answer_object_count(
     proposal: QuestionProposal, image: Image, detector: ObjectDetector
 ) -> FamilyAnswer:
-    detections = detector.detect(image, proposal.object_name)
+    object_name = proposal.object_names[0]
+    detections = detector.detect(image, object_name)
     count = len(detections)
     if count == 0:
         raise InsufficientEvidenceError(
-            f"object detector did not confirm visible {proposal.object_name!r} to count"
+            f"object detector did not confirm visible {object_name!r} to count"
         )
 
     choices = ("one", "two", "three", "four or more")
     answer = choices[min(count, 4) - 1]
     boxes = [list(map(float, detection.bbox)) for detection in detections.detections]
     return FamilyAnswer(
-        question=f"How many instances of {proposal.object_name} are visible in the image?",
+        question=f"How many instances of {object_name} are visible in the image?",
         choices=choices,
         answer=answer,
         evidence={
             "primitive": "object_detector",
-            "object_name": proposal.object_name,
+            "object_name": object_name,
             "detection_count": count,
             "boxes": cast("JsonValue", boxes),
         },
@@ -218,7 +278,8 @@ def _answer_object_distance(
     range_estimator: ObjectRangeEstimator,
 ) -> FamilyAnswer:
     """Answer an object-distance proposal from EdgeTAM and point-cloud evidence."""
-    evidence = range_estimator.estimate(calibrated_frame, proposal.object_name)
+    object_name = proposal.object_names[0]
+    evidence = range_estimator.estimate(calibrated_frame, object_name)
     choices = (
         "under 1 meter",
         "1 to under 2 meters",
@@ -232,12 +293,61 @@ def _answer_object_distance(
         )
     answer = choices[_distance_bucket(evidence.camera_range_m)]
     return FamilyAnswer(
-        question=f"Approximately how far is the visible {proposal.object_name} from the camera?",
+        question=f"Approximately how far is the visible {object_name} from the camera?",
         choices=choices,
         answer=answer,
         evidence={
             "primitive": "edgetam_lidar_range",
             **evidence.model_dump(mode="json"),
+        },
+    )
+
+
+def _answer_closest_object(
+    proposal: QuestionProposal,
+    calibrated_frame: CalibratedFrame,
+    range_estimator: ObjectRangeEstimator,
+) -> FamilyAnswer:
+    """Choose the closest named object when its range interval is unambiguous."""
+    object_names = proposal.object_names
+    estimate_many = getattr(range_estimator, "estimate_many", None)
+    if estimate_many is None:
+        ranges = tuple(
+            range_estimator.estimate(calibrated_frame, object_name) for object_name in object_names
+        )
+    else:
+        ranges = estimate_many(calibrated_frame, object_names)
+    if len(ranges) != len(object_names):
+        raise ValueError("range estimator returned the wrong number of object ranges")
+    if tuple(evidence.object_name for evidence in ranges) != object_names:
+        raise ValueError("range estimator results do not match the requested object order")
+
+    winner_index = min(range(len(ranges)), key=lambda index: ranges[index].camera_range_m)
+    winner = ranges[winner_index]
+    winner_upper = winner.range_quartiles_m[2]
+    if any(
+        winner_upper >= evidence.range_quartiles_m[0]
+        for index, evidence in enumerate(ranges)
+        if index != winner_index
+    ):
+        raise InsufficientEvidenceError(
+            "object range uncertainty does not establish a closest object"
+        )
+
+    return FamilyAnswer(
+        question="Which object is closest to the camera?",
+        choices=object_names,
+        answer=object_names[winner_index],
+        evidence={
+            "primitive": "edgetam_lidar_closest_range",
+            "comparison_rule": "closest_non_overlapping_interquartile_range",
+            "objects": cast(
+                "JsonValue",
+                [
+                    {"choice": object_name, **evidence.model_dump(mode="json")}
+                    for object_name, evidence in zip(object_names, ranges, strict=True)
+                ],
+            ),
         },
     )
 

--- a/dimos/evals/vqa/families.py
+++ b/dimos/evals/vqa/families.py
@@ -26,13 +26,13 @@ from dimos.evals.vqa.contracts import (
     FamilySpec,
     InsufficientEvidenceError,
     ObjectDetector,
+    ObjectMaskEstimator,
+    ObjectRangeEstimator,
     QuestionProposal,
 )
 
 if TYPE_CHECKING:
     from dimos.evals.vqa.preprocessing import CalibratedFrame
-    from dimos.evals.vqa.primitives.edgetam import ObjectMaskEstimator
-    from dimos.evals.vqa.primitives.range import ObjectRangeEstimator
     from dimos.msgs.sensor_msgs.Image import Image
 
 

--- a/dimos/evals/vqa/generate.py
+++ b/dimos/evals/vqa/generate.py
@@ -44,6 +44,10 @@ from dimos.evals.vqa.primitives.moondream import MoondreamObjectDetector
 from dimos.memory.cli.dataset import open_dataset
 from dimos.msgs.sensor_msgs.Image import Image
 
+_UNORDERED_FAMILIES = frozenset(
+    family.name for family in AVAILABLE_FAMILIES if not family.object_order_matters
+)
+
 if TYPE_CHECKING:
     from dimos.evals.vqa.preprocessing import CalibratedFrame
     from dimos.evals.vqa.primitives.edgetam import ObjectMaskEstimator
@@ -374,12 +378,9 @@ def _generate_frame(
 
 def _deduplicate_proposals(proposals: Sequence[QuestionProposal]) -> tuple[QuestionProposal, ...]:
     unique: list[QuestionProposal] = []
-    unordered_families = {
-        family.name for family in AVAILABLE_FAMILIES if not family.object_order_matters
-    }
     seen_object_sets: set[tuple[str, frozenset[str]]] = set()
     for proposal in proposals:
-        if proposal.family in unordered_families:
+        if proposal.family in _UNORDERED_FAMILIES:
             object_set = (
                 proposal.family,
                 frozenset(name.casefold() for name in proposal.object_names),
@@ -396,8 +397,11 @@ def _case_ids(image_index: int, proposals: tuple[QuestionProposal, ...]) -> tupl
     counts: dict[str, int] = {}
     identifiers: list[str] = []
     for proposal in proposals:
-        object_names = "-vs-".join(proposal.object_names)
-        object_id = re.sub(r"[^a-z0-9]+", "-", object_names.casefold()).strip("-")
+        object_names = proposal.object_names
+        if proposal.family in _UNORDERED_FAMILIES:
+            object_names = tuple(sorted(object_names, key=str.casefold))
+        joined_names = "-vs-".join(object_names)
+        object_id = re.sub(r"[^a-z0-9]+", "-", joined_names.casefold()).strip("-")
         base = f"frame-{image_index:06d}-{object_id or 'object'}-{proposal.family}"
         count = counts.get(base, 0) + 1
         counts[base] = count

--- a/dimos/evals/vqa/generate.py
+++ b/dimos/evals/vqa/generate.py
@@ -44,7 +44,7 @@ from dimos.msgs.sensor_msgs.Image import Image
 
 if TYPE_CHECKING:
     from dimos.evals.vqa.preprocessing import CalibratedFrame
-    from dimos.evals.vqa.primitives.edgetam import ObjectRangeEstimator
+    from dimos.evals.vqa.primitives.range import ObjectRangeEstimator
 
 
 class GenerationRequest(BaseModel):
@@ -139,7 +139,8 @@ def generate_dataset(request: GenerationRequest) -> GenerationResult:
         FrameGeometryUnavailableError,
         RecordingFramePreprocessor,
     )
-    from dimos.evals.vqa.primitives.edgetam import EdgeTamLidarRangeEstimator
+    from dimos.evals.vqa.primitives.edgetam import EdgeTamObjectMaskEstimator
+    from dimos.evals.vqa.primitives.range import LidarRangeEstimator
 
     # Load optional model dependencies only when generation is requested.
     from dimos.models.vl.moondream import MoondreamVlModel
@@ -216,7 +217,7 @@ def generate_dataset(request: GenerationRequest) -> GenerationResult:
                 calibrated_frames(),
                 OpenAIQuestionAuthor(author_model),
                 detector,
-                EdgeTamLidarRangeEstimator(detector),
+                LidarRangeEstimator(EdgeTamObjectMaskEstimator(detector)),
                 model_names=model_names,
             )
     finally:
@@ -303,7 +304,7 @@ def _generate_frame(
     families = (
         AVAILABLE_FAMILIES
         if source.calibrated is not None and range_estimator is not None
-        else tuple(family for family in AVAILABLE_FAMILIES if family.name != "object_distance")
+        else tuple(family for family in AVAILABLE_FAMILIES if not family.requires_pointcloud)
     )
     proposals = _deduplicate_proposals(author.propose(image, families))
     answered: list[tuple[QuestionProposal, FamilyAnswer]] = []
@@ -320,7 +321,7 @@ def _generate_frame(
         except InsufficientEvidenceError as exc:
             audit_rows.append(
                 {
-                    "proposal": proposal.model_dump(mode="json"),
+                    "proposal": proposal.model_dump(mode="json", exclude_none=True),
                     "status": "rejected",
                     "reason": str(exc),
                 }
@@ -329,7 +330,7 @@ def _generate_frame(
             answered.append((proposal, answer))
             audit_rows.append(
                 {
-                    "proposal": proposal.model_dump(mode="json"),
+                    "proposal": proposal.model_dump(mode="json", exclude_none=True),
                     "status": "answered",
                     "answer": answer.model_dump(mode="json"),
                 }
@@ -361,7 +362,13 @@ def _generate_frame(
 
 def _deduplicate_proposals(proposals: Sequence[QuestionProposal]) -> tuple[QuestionProposal, ...]:
     unique: list[QuestionProposal] = []
+    closest_object_sets: set[frozenset[str]] = set()
     for proposal in proposals:
+        if proposal.family == "closest_object":
+            object_set = frozenset(name.casefold() for name in proposal.object_names)
+            if object_set in closest_object_sets:
+                continue
+            closest_object_sets.add(object_set)
         if proposal not in unique:
             unique.append(proposal)
     return tuple(unique)
@@ -371,7 +378,8 @@ def _case_ids(image_index: int, proposals: tuple[QuestionProposal, ...]) -> tupl
     counts: dict[str, int] = {}
     identifiers: list[str] = []
     for proposal in proposals:
-        object_id = re.sub(r"[^a-z0-9]+", "-", proposal.object_name.casefold()).strip("-")
+        object_names = "-vs-".join(proposal.object_names)
+        object_id = re.sub(r"[^a-z0-9]+", "-", object_names.casefold()).strip("-")
         base = f"frame-{image_index:06d}-{object_id or 'object'}-{proposal.family}"
         count = counts.get(base, 0) + 1
         counts[base] = count

--- a/dimos/evals/vqa/generate.py
+++ b/dimos/evals/vqa/generate.py
@@ -34,6 +34,8 @@ from dimos.evals.vqa.contracts import (
     InsufficientEvidenceError,
     NonEmptyString,
     ObjectDetector,
+    ObjectMaskEstimator,
+    ObjectRangeEstimator,
     QuestionProposal,
 )
 from dimos.evals.vqa.families import (
@@ -50,8 +52,6 @@ _UNORDERED_FAMILIES = frozenset(
 
 if TYPE_CHECKING:
     from dimos.evals.vqa.preprocessing import CalibratedFrame
-    from dimos.evals.vqa.primitives.edgetam import ObjectMaskEstimator
-    from dimos.evals.vqa.primitives.range import ObjectRangeEstimator
 
 
 class GenerationRequest(BaseModel):
@@ -66,7 +66,6 @@ class GenerationRequest(BaseModel):
     stop: int | None = Field(default=None, gt=0)
     stride: int | None = Field(default=None, ge=1)
     calibration_profile: Literal["go2"] | None = None
-    synchronization_tolerance_s: float = Field(default=0.1, gt=0)
 
     @model_validator(mode="after")
     def valid_selection(self) -> GenerationRequest:
@@ -90,6 +89,14 @@ class GenerationRequest(BaseModel):
         if self.output is not None:
             return self.output.expanduser()
         return STATE_DIR / "datasets" / "vqa" / f"{Path(self.dataset).stem}-frames"
+
+
+class VqaGenerationConfig(BaseModel):
+    """Processing policy shared by VQA generation runs."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    synchronization_tolerance_s: float = Field(default=0.1, gt=0)
 
 
 class PublicCase(BaseModel):
@@ -140,27 +147,32 @@ class _GeneratedFrame:
     families: tuple[FamilySpec, ...]
 
 
-def generate_dataset(request: GenerationRequest) -> GenerationResult:
+def generate_dataset(
+    request: GenerationRequest,
+    config: VqaGenerationConfig | None = None,
+) -> GenerationResult:
     """Generate a standalone dataset from selected Memory images."""
     from dimos.evals.vqa.preprocessing import (
         FrameGeometryUnavailableError,
         RecordingFramePreprocessor,
+        recorded_calibration_available,
     )
-    from dimos.evals.vqa.primitives.edgetam import EdgeTamObjectMaskEstimator
+    from dimos.evals.vqa.primitives.edgetam import EdgeTamObjectMaskPipeline
     from dimos.evals.vqa.primitives.range import LidarRangeEstimator
 
     # Load optional model dependencies only when generation is requested.
     from dimos.models.vl.moondream import MoondreamVlModel
     from dimos.models.vl.openai import OpenAIVlModel
 
+    config = config or VqaGenerationConfig()
     indices = request.frame_indices()
     probe = open_dataset(request.dataset)
     try:
         streams = set(probe.list_streams())
     finally:
         probe.stop()
-    has_recorded_geometry = (
-        "camera_info" in streams and "tf" in streams and bool({"pointlio_lidar", "lidar"} & streams)
+    has_recorded_geometry = recorded_calibration_available(streams) and bool(
+        {"pointlio_lidar", "lidar"} & streams
     )
     use_geometry = request.calibration_profile is not None or has_recorded_geometry
 
@@ -172,7 +184,7 @@ def generate_dataset(request: GenerationRequest) -> GenerationResult:
             "author": author_model.config.model_name,
             "detector": detector_model.config.model_name,
         }
-        mask_estimator = EdgeTamObjectMaskEstimator(detector)
+        mask_estimator = EdgeTamObjectMaskPipeline(detector)
         if not use_geometry:
             store = open_dataset(request.dataset)
             try:
@@ -196,6 +208,7 @@ def generate_dataset(request: GenerationRequest) -> GenerationResult:
                     OpenAIQuestionAuthor(author_model),
                     detector,
                     mask_estimator=mask_estimator,
+                    config=config,
                     model_names=model_names,
                 )
             finally:
@@ -204,7 +217,7 @@ def generate_dataset(request: GenerationRequest) -> GenerationResult:
         with RecordingFramePreprocessor(
             request.dataset,
             calibration_profile=request.calibration_profile,
-            tolerance_s=request.synchronization_tolerance_s,
+            tolerance_s=config.synchronization_tolerance_s,
         ) as preprocessor:
             image_count = preprocessor.image_count
             if indices[-1] >= image_count:
@@ -228,6 +241,7 @@ def generate_dataset(request: GenerationRequest) -> GenerationResult:
                 detector,
                 LidarRangeEstimator(mask_estimator),
                 mask_estimator,
+                config=config,
                 model_names=model_names,
             )
     finally:
@@ -251,9 +265,11 @@ def generate_frames_dataset(
     range_estimator: ObjectRangeEstimator | None = None,
     mask_estimator: ObjectMaskEstimator | None = None,
     *,
+    config: VqaGenerationConfig | None = None,
     model_names: dict[str, str] | None = None,
 ) -> GenerationResult:
     """Generate and write one dataset from already loaded indexed images."""
+    config = config or VqaGenerationConfig()
     output = request.output_directory()
     _prepare_output(output)
     output.parent.mkdir(parents=True, exist_ok=True)
@@ -289,6 +305,7 @@ def generate_frames_dataset(
             staging / "audit" / "run.json",
             {
                 "generation": request.model_dump(mode="json", exclude={"output"}),
+                "configuration": config.model_dump(mode="json"),
                 "families": [
                     family.name for family in AVAILABLE_FAMILIES if family.name in used_family_names
                 ],

--- a/dimos/evals/vqa/generate.py
+++ b/dimos/evals/vqa/generate.py
@@ -22,6 +22,7 @@ import json
 from pathlib import Path
 import re
 import tempfile
+from typing import TYPE_CHECKING, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -30,6 +31,7 @@ from dimos.evals.vqa.author import OpenAIQuestionAuthor, QuestionAuthor
 from dimos.evals.vqa.families import (
     AVAILABLE_FAMILIES,
     FamilyAnswer,
+    FamilySpec,
     InsufficientEvidenceError,
     NonEmptyString,
     ObjectDetector,
@@ -39,6 +41,10 @@ from dimos.evals.vqa.families import (
 from dimos.evals.vqa.primitives.moondream import MoondreamObjectDetector
 from dimos.memory.cli.dataset import open_dataset
 from dimos.msgs.sensor_msgs.Image import Image
+
+if TYPE_CHECKING:
+    from dimos.evals.vqa.preprocessing import CalibratedFrame
+    from dimos.evals.vqa.primitives.edgetam import ObjectRangeEstimator
 
 
 class GenerationRequest(BaseModel):
@@ -52,6 +58,8 @@ class GenerationRequest(BaseModel):
     start: int | None = Field(default=None, ge=0)
     stop: int | None = Field(default=None, gt=0)
     stride: int | None = Field(default=None, ge=1)
+    calibration_profile: Literal["go2"] | None = None
+    synchronization_tolerance_s: float = Field(default=0.1, gt=0)
 
     @model_validator(mode="after")
     def valid_selection(self) -> GenerationRequest:
@@ -107,49 +115,111 @@ class GenerationResult(BaseModel):
 
 
 @dataclass(frozen=True)
+class GenerationFrame:
+    """One indexed image with optional calibrated point-cloud evidence."""
+
+    index: int
+    image: Image
+    calibrated: CalibratedFrame | None = None
+
+
+@dataclass(frozen=True)
 class _GeneratedFrame:
     index: int
     image: Image
     cases: tuple[PublicCase, ...]
     labels: tuple[PrivateLabel, ...]
     audit_rows: tuple[dict[str, object], ...]
+    families: tuple[FamilySpec, ...]
 
 
 def generate_dataset(request: GenerationRequest) -> GenerationResult:
     """Generate a standalone dataset from selected Memory images."""
+    from dimos.evals.vqa.preprocessing import (
+        FrameGeometryUnavailableError,
+        RecordingFramePreprocessor,
+    )
+    from dimos.evals.vqa.primitives.edgetam import EdgeTamLidarRangeEstimator
+
     # Load optional model dependencies only when generation is requested.
     from dimos.models.vl.moondream import MoondreamVlModel
     from dimos.models.vl.openai import OpenAIVlModel
 
     indices = request.frame_indices()
-    store = open_dataset(request.dataset)
+    probe = open_dataset(request.dataset)
+    try:
+        streams = set(probe.list_streams())
+    finally:
+        probe.stop()
+    has_recorded_geometry = (
+        "camera_info" in streams and "tf" in streams and bool({"pointlio_lidar", "lidar"} & streams)
+    )
+    use_geometry = request.calibration_profile is not None or has_recorded_geometry
+
     author_model = OpenAIVlModel()
     detector_model = MoondreamVlModel()
     try:
-        images = store.streams.color_image
-        image_count = images.count()
-        if indices[-1] >= image_count:
-            raise IndexError(
-                f"color_image index {indices[-1]} is out of range for {image_count} images"
+        detector = MoondreamObjectDetector(detector_model)
+        model_names = {
+            "author": author_model.config.model_name,
+            "detector": detector_model.config.model_name,
+        }
+        if not use_geometry:
+            store = open_dataset(request.dataset)
+            try:
+                images = store.streams.color_image
+                image_count = images.count()
+                if indices[-1] >= image_count:
+                    raise IndexError(
+                        f"color_image index {indices[-1]} is out of range for {image_count} images"
+                    )
+
+                def visual_frames() -> Iterable[GenerationFrame]:
+                    for index in indices:
+                        observation = images.offset(index).first()
+                        yield GenerationFrame(
+                            index, _copy_observation_image(observation.data, observation.ts)
+                        )
+
+                return generate_frames_dataset(
+                    request,
+                    visual_frames(),
+                    OpenAIQuestionAuthor(author_model),
+                    detector,
+                    model_names=model_names,
+                )
+            finally:
+                store.stop()
+
+        with RecordingFramePreprocessor(
+            request.dataset,
+            calibration_profile=request.calibration_profile,
+            tolerance_s=request.synchronization_tolerance_s,
+        ) as preprocessor:
+            image_count = preprocessor.image_count
+            if indices[-1] >= image_count:
+                raise IndexError(
+                    f"color_image index {indices[-1]} is out of range for {image_count} images"
+                )
+
+            def calibrated_frames() -> Iterable[GenerationFrame]:
+                for index in indices:
+                    try:
+                        calibrated = preprocessor.load(index)
+                    except FrameGeometryUnavailableError:
+                        yield GenerationFrame(index, preprocessor.load_image(index))
+                    else:
+                        yield GenerationFrame(index, calibrated.image, calibrated)
+
+            return generate_frames_dataset(
+                request,
+                calibrated_frames(),
+                OpenAIQuestionAuthor(author_model),
+                detector,
+                EdgeTamLidarRangeEstimator(detector),
+                model_names=model_names,
             )
-
-        def selected_frames() -> Iterable[tuple[int, Image]]:
-            for index in indices:
-                observation = images.offset(index).first()
-                yield index, _copy_observation_image(observation.data, observation.ts)
-
-        return generate_frames_dataset(
-            request,
-            selected_frames(),
-            OpenAIQuestionAuthor(author_model),
-            MoondreamObjectDetector(detector_model),
-            model_names={
-                "author": author_model.config.model_name,
-                "detector": detector_model.config.model_name,
-            },
-        )
     finally:
-        store.stop()
         author_model.stop()
         detector_model.stop()
 
@@ -164,9 +234,10 @@ def _copy_observation_image(value: object, timestamp: float) -> Image:
 
 def generate_frames_dataset(
     request: GenerationRequest,
-    frames: Iterable[tuple[int, Image]],
+    frames: Iterable[GenerationFrame],
     author: QuestionAuthor,
     detector: ObjectDetector,
+    range_estimator: ObjectRangeEstimator | None = None,
     *,
     model_names: dict[str, str] | None = None,
 ) -> GenerationResult:
@@ -180,12 +251,14 @@ def generate_frames_dataset(
         all_labels: list[PrivateLabel] = []
         frame_count = 0
         rejected_count = 0
-        for index, image in frames:
-            frame = _generate_frame(index, image, author, detector)
+        used_family_names: set[str] = set()
+        for source in frames:
+            frame = _generate_frame(source, author, detector, range_estimator)
             _write_frame(staging, frame)
             all_cases.extend(frame.cases)
             all_labels.extend(frame.labels)
             frame_count += 1
+            used_family_names.update(family.name for family in frame.families)
             rejected_count += sum(row.get("status") == "rejected" for row in frame.audit_rows)
 
         if frame_count == 0:
@@ -204,7 +277,9 @@ def generate_frames_dataset(
             staging / "audit" / "run.json",
             {
                 "generation": request.model_dump(mode="json", exclude={"output"}),
-                "families": [family.name for family in AVAILABLE_FAMILIES],
+                "families": [
+                    family.name for family in AVAILABLE_FAMILIES if family.name in used_family_names
+                ],
                 "models": model_names or {},
                 "frame_count": frame_count,
                 "question_count": len(all_cases),
@@ -218,17 +293,30 @@ def generate_frames_dataset(
 
 
 def _generate_frame(
-    image_index: int,
-    image: Image,
+    source: GenerationFrame,
     author: QuestionAuthor,
     detector: ObjectDetector,
+    range_estimator: ObjectRangeEstimator | None,
 ) -> _GeneratedFrame:
-    proposals = _deduplicate_proposals(author.propose(image, AVAILABLE_FAMILIES))
+    image_index = source.index
+    image = source.image
+    families = (
+        AVAILABLE_FAMILIES
+        if source.calibrated is not None and range_estimator is not None
+        else tuple(family for family in AVAILABLE_FAMILIES if family.name != "object_distance")
+    )
+    proposals = _deduplicate_proposals(author.propose(image, families))
     answered: list[tuple[QuestionProposal, FamilyAnswer]] = []
     audit_rows: list[dict[str, object]] = []
     for proposal in proposals:
         try:
-            answer = answer_question(proposal, image, detector)
+            answer = answer_question(
+                proposal,
+                image,
+                detector,
+                source.calibrated,
+                range_estimator,
+            )
         except InsufficientEvidenceError as exc:
             audit_rows.append(
                 {
@@ -267,6 +355,7 @@ def _generate_frame(
         cases=cases,
         labels=labels,
         audit_rows=tuple(audit_rows),
+        families=tuple(families),
     )
 
 

--- a/dimos/evals/vqa/generate.py
+++ b/dimos/evals/vqa/generate.py
@@ -28,14 +28,16 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from dimos.constants import STATE_DIR
 from dimos.evals.vqa.author import OpenAIQuestionAuthor, QuestionAuthor
-from dimos.evals.vqa.families import (
-    AVAILABLE_FAMILIES,
+from dimos.evals.vqa.contracts import (
     FamilyAnswer,
     FamilySpec,
     InsufficientEvidenceError,
     NonEmptyString,
     ObjectDetector,
     QuestionProposal,
+)
+from dimos.evals.vqa.families import (
+    AVAILABLE_FAMILIES,
     answer_question,
 )
 from dimos.evals.vqa.primitives.moondream import MoondreamObjectDetector
@@ -44,6 +46,7 @@ from dimos.msgs.sensor_msgs.Image import Image
 
 if TYPE_CHECKING:
     from dimos.evals.vqa.preprocessing import CalibratedFrame
+    from dimos.evals.vqa.primitives.edgetam import ObjectMaskEstimator
     from dimos.evals.vqa.primitives.range import ObjectRangeEstimator
 
 
@@ -165,6 +168,7 @@ def generate_dataset(request: GenerationRequest) -> GenerationResult:
             "author": author_model.config.model_name,
             "detector": detector_model.config.model_name,
         }
+        mask_estimator = EdgeTamObjectMaskEstimator(detector)
         if not use_geometry:
             store = open_dataset(request.dataset)
             try:
@@ -187,6 +191,7 @@ def generate_dataset(request: GenerationRequest) -> GenerationResult:
                     visual_frames(),
                     OpenAIQuestionAuthor(author_model),
                     detector,
+                    mask_estimator=mask_estimator,
                     model_names=model_names,
                 )
             finally:
@@ -217,7 +222,8 @@ def generate_dataset(request: GenerationRequest) -> GenerationResult:
                 calibrated_frames(),
                 OpenAIQuestionAuthor(author_model),
                 detector,
-                LidarRangeEstimator(EdgeTamObjectMaskEstimator(detector)),
+                LidarRangeEstimator(mask_estimator),
+                mask_estimator,
                 model_names=model_names,
             )
     finally:
@@ -239,6 +245,7 @@ def generate_frames_dataset(
     author: QuestionAuthor,
     detector: ObjectDetector,
     range_estimator: ObjectRangeEstimator | None = None,
+    mask_estimator: ObjectMaskEstimator | None = None,
     *,
     model_names: dict[str, str] | None = None,
 ) -> GenerationResult:
@@ -254,7 +261,7 @@ def generate_frames_dataset(
         rejected_count = 0
         used_family_names: set[str] = set()
         for source in frames:
-            frame = _generate_frame(source, author, detector, range_estimator)
+            frame = _generate_frame(source, author, detector, range_estimator, mask_estimator)
             _write_frame(staging, frame)
             all_cases.extend(frame.cases)
             all_labels.extend(frame.labels)
@@ -298,13 +305,17 @@ def _generate_frame(
     author: QuestionAuthor,
     detector: ObjectDetector,
     range_estimator: ObjectRangeEstimator | None,
+    mask_estimator: ObjectMaskEstimator | None,
 ) -> _GeneratedFrame:
     image_index = source.index
     image = source.image
-    families = (
-        AVAILABLE_FAMILIES
-        if source.calibrated is not None and range_estimator is not None
-        else tuple(family for family in AVAILABLE_FAMILIES if not family.requires_pointcloud)
+    families = tuple(
+        family
+        for family in AVAILABLE_FAMILIES
+        if not (family.requires_masks and mask_estimator is None)
+        and not (
+            family.requires_pointcloud and (source.calibrated is None or range_estimator is None)
+        )
     )
     proposals = _deduplicate_proposals(author.propose(image, families))
     answered: list[tuple[QuestionProposal, FamilyAnswer]] = []
@@ -317,6 +328,7 @@ def _generate_frame(
                 detector,
                 source.calibrated,
                 range_estimator,
+                mask_estimator,
             )
         except InsufficientEvidenceError as exc:
             audit_rows.append(
@@ -362,13 +374,19 @@ def _generate_frame(
 
 def _deduplicate_proposals(proposals: Sequence[QuestionProposal]) -> tuple[QuestionProposal, ...]:
     unique: list[QuestionProposal] = []
-    closest_object_sets: set[frozenset[str]] = set()
+    unordered_families = {
+        family.name for family in AVAILABLE_FAMILIES if not family.object_order_matters
+    }
+    seen_object_sets: set[tuple[str, frozenset[str]]] = set()
     for proposal in proposals:
-        if proposal.family == "closest_object":
-            object_set = frozenset(name.casefold() for name in proposal.object_names)
-            if object_set in closest_object_sets:
+        if proposal.family in unordered_families:
+            object_set = (
+                proposal.family,
+                frozenset(name.casefold() for name in proposal.object_names),
+            )
+            if object_set in seen_object_sets:
                 continue
-            closest_object_sets.add(object_set)
+            seen_object_sets.add(object_set)
         if proposal not in unique:
             unique.append(proposal)
     return tuple(unique)

--- a/dimos/evals/vqa/preprocessing.py
+++ b/dimos/evals/vqa/preprocessing.py
@@ -32,7 +32,7 @@ from dimos.msgs.geometry_msgs.Transform import Transform
 from dimos.msgs.sensor_msgs.CameraInfo import CameraInfo
 from dimos.msgs.sensor_msgs.Image import Image
 from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
-from dimos.robot.unitree.go2.connection import BASE_TO_OPTICAL, GO2Connection
+from dimos.robot.unitree.go2.calibration import BASE_TO_OPTICAL, camera_info_static
 
 if TYPE_CHECKING:
     from dimos.memory.stream import Stream
@@ -231,9 +231,7 @@ class RecordingFramePreprocessor:
                 raise FrameGeometryUnavailableError(
                     "recording has no synchronized odometry within tolerance"
                 ) from exc
-            image, camera_info = self._rectifier.rectify(
-                source_image, GO2Connection.camera_info_static
-            )
+            image, camera_info = self._rectifier.rectify(source_image, camera_info_static())
             pointcloud_to_camera = _profile_pointcloud_to_camera(odom_obs, lidar_obs)
 
         return CalibratedFrame(
@@ -259,7 +257,7 @@ class RecordingFramePreprocessor:
         camera_info = (
             self._recorded_camera_info
             if self._calibration_source == "recorded"
-            else GO2Connection.camera_info_static
+            else camera_info_static()
         )
         if camera_info is None:
             raise RuntimeError("camera calibration was not initialized")

--- a/dimos/evals/vqa/preprocessing.py
+++ b/dimos/evals/vqa/preprocessing.py
@@ -1,0 +1,386 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Canonical calibrated-frame boundary for point-cloud VQA generation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from types import TracebackType
+from typing import TYPE_CHECKING, Any, Literal, Protocol, cast
+
+import cv2
+import numpy as np
+
+from dimos.memory.cli.dataset import open_dataset
+from dimos.memory.store.base import Store
+from dimos.memory.tf import StreamTF
+from dimos.msgs.geometry_msgs.Transform import Transform
+from dimos.msgs.sensor_msgs.CameraInfo import CameraInfo
+from dimos.msgs.sensor_msgs.Image import Image
+from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
+from dimos.robot.unitree.go2.connection import BASE_TO_OPTICAL, GO2Connection
+
+if TYPE_CHECKING:
+    from dimos.memory.stream import Stream
+    from dimos.memory.type.observation import Observation
+    from dimos.protocol.tf.tf import TFLookup
+
+
+@dataclass(frozen=True)
+class CalibratedFrame:
+    """One rectified image and synchronized point cloud ready for VQA primitives."""
+
+    index: int
+    image: Image
+    pointcloud: PointCloud2
+    camera_info: CameraInfo
+    pointcloud_to_camera: Transform
+    image_observation_timestamp: float
+    pointcloud_observation_timestamp: float
+    calibration_source: str
+
+    @property
+    def synchronization_delta_s(self) -> float:
+        return abs(self.image_observation_timestamp - self.pointcloud_observation_timestamp)
+
+
+class CalibratedFrameLoader(Protocol):
+    """Prepare canonical frames without exposing recording details downstream."""
+
+    def load(self, frame_index: int) -> CalibratedFrame: ...
+
+
+CalibrationProfile = Literal["go2"]
+
+
+class FrameGeometryUnavailableError(ValueError):
+    """A selected image lacks the recorded evidence needed for metric geometry."""
+
+
+class SynchronizedPointCloudNotFoundError(FrameGeometryUnavailableError):
+    """No point cloud is close enough to the selected image observation."""
+
+
+class RecordingFramePreprocessor:
+    """Load synchronized, rectified frames from one open Memory recording."""
+
+    def __init__(
+        self,
+        recording: str | Path,
+        calibration_profile: CalibrationProfile | None = None,
+        tolerance_s: float = 0.1,
+    ) -> None:
+        if not recording:
+            raise ValueError("recording must be set")
+        if calibration_profile not in (None, "go2"):
+            raise ValueError(f"unsupported calibration profile: {calibration_profile!r}")
+        if tolerance_s <= 0:
+            raise ValueError("tolerance_s must be positive")
+        self._recording = recording
+        self._calibration_profile = calibration_profile
+        self._tolerance_s = tolerance_s
+        self._store: Store | None = None
+        self._images: Stream[Image] | None = None
+        self._lidar: Stream[PointCloud2] | None = None
+        self._recorded_camera_info: CameraInfo | None = None
+        self._recorded_tf: TFLookup | None = None
+        self._calibration_source: str | None = None
+        self._rectifier = _ImageRectifier()
+
+    def __enter__(self) -> RecordingFramePreprocessor:
+        return self.start()
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        self.stop()
+
+    def start(self) -> RecordingFramePreprocessor:
+        """Open the recording and cache all stream and calibration handles."""
+        if self._store is not None:
+            return self
+
+        store = open_dataset(self._recording)
+        store.start()
+        try:
+            streams = set(store.list_streams())
+            if "color_image" not in streams:
+                raise ValueError("recording has no 'color_image' stream")
+            lidar_name = next(
+                (name for name in ("pointlio_lidar", "lidar") if name in streams), None
+            )
+            if lidar_name is None:
+                raise ValueError("recording has no 'pointlio_lidar' or 'lidar' stream")
+
+            self._images = store.stream("color_image", Image).order_by("ts")
+            self._lidar = store.stream(lidar_name, PointCloud2).order_by("ts")
+
+            if "camera_info" in streams and "tf" in streams:
+                try:
+                    self._recorded_camera_info = (
+                        store.stream("camera_info", CameraInfo).order_by("ts").first().data
+                    )
+                except LookupError as exc:
+                    raise ValueError("recorded camera_info stream is empty") from exc
+                self._recorded_tf = StreamTF.from_store(store)
+                self._calibration_source = "recorded"
+            elif self._calibration_profile == "go2":
+                self._calibration_source = "profile:go2"
+            else:
+                raise ValueError(
+                    "recording does not contain both camera_info and tf calibration; "
+                    "set calibration_profile='go2' explicitly to use the Go2 profile"
+                )
+            self._store = store
+        except BaseException:
+            store.stop()
+            self._clear_state()
+            raise
+        return self
+
+    def stop(self) -> None:
+        """Close the recording and release cached stream handles."""
+        store = self._store
+        self._clear_state()
+        if store is not None:
+            store.stop()
+
+    @property
+    def image_count(self) -> int:
+        if self._images is None:
+            raise RuntimeError("frame preprocessor must be started before reading image_count")
+        return self._images.count()
+
+    def _clear_state(self) -> None:
+        self._store = None
+        self._images = None
+        self._lidar = None
+        self._recorded_camera_info = None
+        self._recorded_tf = None
+        self._calibration_source = None
+
+    def load(self, frame_index: int) -> CalibratedFrame:
+        """Load the indexed image and its nearest calibrated point cloud."""
+        if frame_index < 0:
+            raise ValueError("frame_index must be non-negative")
+        if self._images is None or self._lidar is None or self._calibration_source is None:
+            raise RuntimeError("frame preprocessor must be started before loading frames")
+
+        image_query = self._images.offset(frame_index).limit(1)
+        image_obs = image_query.first()
+        lidar_obs = _align_one(image_query, self._lidar, self._tolerance_s)
+        source_image = image_obs.data.copy()
+        source_image.ts = image_obs.ts
+
+        if self._calibration_source == "recorded":
+            source_camera_info = self._recorded_camera_info
+            if source_camera_info is None or self._recorded_tf is None:
+                raise RuntimeError("recorded calibration was not initialized")
+            image, camera_info = self._rectifier.rectify(source_image, source_camera_info)
+            pointcloud_to_camera = _recorded_pointcloud_to_camera(
+                image_obs,
+                lidar_obs,
+                camera_info.frame_id,
+                self._recorded_tf,
+                self._tolerance_s,
+            )
+        else:
+            image, camera_info = self._rectifier.rectify(
+                source_image, GO2Connection.camera_info_static
+            )
+            pointcloud_to_camera = _profile_pointcloud_to_camera(image_obs, lidar_obs)
+
+        return CalibratedFrame(
+            index=frame_index,
+            image=image,
+            pointcloud=lidar_obs.data,
+            camera_info=camera_info,
+            pointcloud_to_camera=pointcloud_to_camera,
+            image_observation_timestamp=image_obs.ts,
+            pointcloud_observation_timestamp=lidar_obs.ts,
+            calibration_source=self._calibration_source,
+        )
+
+    def load_image(self, frame_index: int) -> Image:
+        """Load a rectified image when synchronized point-cloud evidence is unavailable."""
+        if frame_index < 0:
+            raise ValueError("frame_index must be non-negative")
+        if self._images is None or self._calibration_source is None:
+            raise RuntimeError("frame preprocessor must be started before loading frames")
+        observation = self._images.offset(frame_index).limit(1).first()
+        image = observation.data.copy()
+        image.ts = observation.ts
+        camera_info = (
+            self._recorded_camera_info
+            if self._calibration_source == "recorded"
+            else GO2Connection.camera_info_static
+        )
+        if camera_info is None:
+            raise RuntimeError("camera calibration was not initialized")
+        return self._rectifier.rectify(image, camera_info)[0]
+
+
+class _ImageRectifier:
+    """Rectify images while caching maps for static camera calibration."""
+
+    def __init__(self) -> None:
+        self._maps: dict[tuple[Any, ...], tuple[np.ndarray, np.ndarray, np.ndarray]] = {}
+
+    def rectify(self, image: Image, source: CameraInfo) -> tuple[Image, CameraInfo]:
+        if (source.width, source.height) != (image.width, image.height):
+            raise ValueError(
+                "camera calibration dimensions "
+                f"{source.width}x{source.height} do not match image dimensions "
+                f"{image.width}x{image.height}"
+            )
+        key = (
+            image.width,
+            image.height,
+            source.distortion_model,
+            tuple(source.K),
+            tuple(source.D),
+            tuple(source.R),
+            tuple(source.P),
+        )
+        maps = self._maps.get(key)
+        if maps is None:
+            maps = _rectification_maps(image, source)
+            self._maps[key] = maps
+        map_x, map_y, output_matrix = maps
+        data = cv2.remap(image.data, map_x, map_y, interpolation=cv2.INTER_LINEAR)
+        frame_id = source.frame_id or image.frame_id
+        if not frame_id:
+            raise ValueError("camera calibration requires a camera frame_id")
+        camera_info = CameraInfo.from_intrinsics(
+            output_matrix[0, 0],
+            output_matrix[1, 1],
+            output_matrix[0, 2],
+            output_matrix[1, 2],
+            image.width,
+            image.height,
+            frame_id=frame_id,
+        ).with_ts(image.ts)
+        return Image(data=data, format=image.format, frame_id=frame_id, ts=image.ts), camera_info
+
+
+def _align_one(
+    primary: Stream[Any], secondary: Stream[Any], tolerance_s: float
+) -> Observation[Any]:
+    """Return the nearest secondary using observation/database timestamps."""
+    try:
+        pair = primary.align(secondary, tolerance=tolerance_s).first().data
+    except LookupError as exc:
+        raise SynchronizedPointCloudNotFoundError(
+            "recording has no synchronized point cloud within tolerance"
+        ) from exc
+    return cast("Observation[Any]", pair[1])
+
+
+def _recorded_pointcloud_to_camera(
+    image_obs: Observation[Image],
+    lidar_obs: Observation[PointCloud2],
+    camera_frame: str,
+    tf: TFLookup,
+    tolerance_s: float,
+) -> Transform:
+    cloud_frame = lidar_obs.data.frame_id
+    if not cloud_frame:
+        raise FrameGeometryUnavailableError("recorded point cloud requires a frame_id")
+    camera_from_world = tf.get(
+        camera_frame,
+        "world",
+        time_point=image_obs.ts,
+        time_tolerance=tolerance_s,
+    )
+    if camera_from_world is None:
+        raise FrameGeometryUnavailableError(
+            f"recorded tf cannot resolve {camera_frame!r} <- 'world' "
+            f"at image timestamp {image_obs.ts}"
+        )
+    if cloud_frame == "world":
+        return camera_from_world
+    world_from_cloud = tf.get(
+        "world",
+        cloud_frame,
+        time_point=lidar_obs.ts,
+        time_tolerance=tolerance_s,
+    )
+    if world_from_cloud is None:
+        raise FrameGeometryUnavailableError(
+            f"recorded tf cannot resolve 'world' <- {cloud_frame!r} "
+            f"at point-cloud timestamp {lidar_obs.ts}"
+        )
+    return camera_from_world + world_from_cloud
+
+
+def _profile_pointcloud_to_camera(
+    image_obs: Observation[Image], lidar_obs: Observation[PointCloud2]
+) -> Transform:
+    """Resolve the explicit Go2 profile from captured poses and its static mount."""
+    image_pose = image_obs.pose
+    if image_pose is None:
+        raise FrameGeometryUnavailableError(
+            "Go2 calibration profile requires an image observation pose"
+        )
+    # Legacy Go2 recordings store the robot pose on image observations even though
+    # the payload frame is camera_optical, so the static mount is still required.
+    world_from_camera = Transform.from_pose("base_link", image_pose) + BASE_TO_OPTICAL
+    camera_from_world = -world_from_camera
+    cloud_frame = lidar_obs.data.frame_id
+    if not cloud_frame:
+        raise FrameGeometryUnavailableError("recorded point cloud requires a frame_id")
+    if cloud_frame == "world":
+        return camera_from_world
+
+    cloud_pose = lidar_obs.pose
+    if cloud_pose is None:
+        raise FrameGeometryUnavailableError(
+            "Go2 calibration profile requires a point-cloud observation pose"
+        )
+    world_from_cloud = Transform(
+        translation=cloud_pose.position,
+        rotation=cloud_pose.orientation,
+        frame_id="world",
+        child_frame_id=cloud_frame,
+        ts=lidar_obs.ts,
+    )
+    return camera_from_world + world_from_cloud
+
+
+def _rectification_maps(
+    image: Image, source: CameraInfo
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    matrix = np.asarray(source.K, dtype=np.float64).reshape(3, 3)
+    distortion = np.asarray(source.D, dtype=np.float64)
+    rectification = np.asarray(source.R, dtype=np.float64).reshape(3, 3)
+    projection = np.asarray(source.P, dtype=np.float64).reshape(3, 4)[:, :3]
+    output_matrix = projection if projection[0, 0] > 0 and projection[1, 1] > 0 else matrix
+    size = (image.width, image.height)
+    model = source.distortion_model.strip().lower()
+    if model in ("equidistant", "fisheye", "kannala_brandt"):
+        map_x, map_y = cv2.fisheye.initUndistortRectifyMap(
+            matrix, distortion, rectification, output_matrix, size, cv2.CV_32FC1
+        )
+    elif model in ("", "plumb_bob", "rational_polynomial"):
+        map_x, map_y = cv2.initUndistortRectifyMap(
+            matrix, distortion, rectification, output_matrix, size, cv2.CV_32FC1
+        )
+    else:
+        raise ValueError(f"unsupported camera distortion model: {source.distortion_model}")
+    return map_x, map_y, output_matrix

--- a/dimos/evals/vqa/preprocessing.py
+++ b/dimos/evals/vqa/preprocessing.py
@@ -27,6 +27,7 @@ import numpy as np
 from dimos.memory.cli.dataset import open_dataset
 from dimos.memory.store.base import Store
 from dimos.memory.tf import StreamTF
+from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
 from dimos.msgs.geometry_msgs.Transform import Transform
 from dimos.msgs.sensor_msgs.CameraInfo import CameraInfo
 from dimos.msgs.sensor_msgs.Image import Image
@@ -107,6 +108,7 @@ class RecordingFramePreprocessor:
         self._store: Store | None = None
         self._images: Stream[Image] | None = None
         self._lidar: Stream[PointCloud2] | None = None
+        self._odom: Stream[PoseStamped] | None = None
         self._recorded_camera_info: CameraInfo | None = None
         self._recorded_tf: TFLookup | None = None
         self._calibration_source: str | None = None
@@ -154,6 +156,9 @@ class RecordingFramePreprocessor:
                 self._recorded_tf = StreamTF.from_store(store)
                 self._calibration_source = "recorded"
             elif self._calibration_profile == "go2":
+                if "odom" not in streams:
+                    raise ValueError("Go2 calibration profile requires an 'odom' stream")
+                self._odom = store.stream("odom", PoseStamped).order_by("ts")
                 self._calibration_source = "profile:go2"
             else:
                 raise ValueError(
@@ -184,6 +189,7 @@ class RecordingFramePreprocessor:
         self._store = None
         self._images = None
         self._lidar = None
+        self._odom = None
         self._recorded_camera_info = None
         self._recorded_tf = None
         self._calibration_source = None
@@ -214,10 +220,21 @@ class RecordingFramePreprocessor:
                 self._tolerance_s,
             )
         else:
+            if self._odom is None:
+                raise RuntimeError("Go2 calibration profile was not initialized")
+            try:
+                odom_obs = cast(
+                    "Observation[PoseStamped]",
+                    image_query.align(self._odom, tolerance=self._tolerance_s).first().data[1],
+                )
+            except LookupError as exc:
+                raise FrameGeometryUnavailableError(
+                    "recording has no synchronized odometry within tolerance"
+                ) from exc
             image, camera_info = self._rectifier.rectify(
                 source_image, GO2Connection.camera_info_static
             )
-            pointcloud_to_camera = _profile_pointcloud_to_camera(image_obs, lidar_obs)
+            pointcloud_to_camera = _profile_pointcloud_to_camera(odom_obs, lidar_obs)
 
         return CalibratedFrame(
             index=frame_index,
@@ -346,37 +363,22 @@ def _recorded_pointcloud_to_camera(
 
 
 def _profile_pointcloud_to_camera(
-    image_obs: Observation[Image], lidar_obs: Observation[PointCloud2]
+    odom_obs: Observation[PoseStamped], lidar_obs: Observation[PointCloud2]
 ) -> Transform:
-    """Resolve the explicit Go2 profile from captured poses and its static mount."""
-    image_pose = image_obs.pose
-    if image_pose is None:
+    """Resolve the explicit Go2 profile from base odometry and its static mount."""
+    odom = odom_obs.data
+    if odom.frame_id != "world":
         raise FrameGeometryUnavailableError(
-            "Go2 calibration profile requires an image observation pose"
+            "Go2 calibration profile requires odometry with frame_id='world'"
         )
-    # This fallback defines image observation poses as world <- base_link, so the
-    # static camera mount is still required even if the payload names camera_optical.
-    world_from_camera = Transform.from_pose("base_link", image_pose) + BASE_TO_OPTICAL
+    world_from_camera = Transform.from_pose("base_link", odom) + BASE_TO_OPTICAL
     camera_from_world = -world_from_camera
     cloud_frame = lidar_obs.data.frame_id
-    if not cloud_frame:
-        raise FrameGeometryUnavailableError("recorded point cloud requires a frame_id")
-    if cloud_frame == "world":
-        return camera_from_world
-
-    cloud_pose = lidar_obs.pose
-    if cloud_pose is None:
+    if cloud_frame != "world":
         raise FrameGeometryUnavailableError(
-            "Go2 calibration profile requires a point-cloud observation pose"
+            "Go2 calibration profile requires a world-frame point cloud"
         )
-    world_from_cloud = Transform(
-        translation=cloud_pose.position,
-        rotation=cloud_pose.orientation,
-        frame_id="world",
-        child_frame_id=cloud_frame,
-        ts=lidar_obs.ts,
-    )
-    return camera_from_world + world_from_cloud
+    return camera_from_world
 
 
 def _rectification_maps(

--- a/dimos/evals/vqa/preprocessing.py
+++ b/dimos/evals/vqa/preprocessing.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Collection
 from dataclasses import dataclass
 from pathlib import Path
 from types import TracebackType
@@ -63,6 +64,18 @@ class CalibratedFrameLoader(Protocol):
 
 
 CalibrationProfile = Literal["go2"]
+
+
+def recorded_calibration_available(streams: Collection[str]) -> bool:
+    """Return whether a recording contains the complete calibration stream pair."""
+    has_camera_info = "camera_info" in streams
+    has_tf = "tf" in streams
+    if has_camera_info != has_tf:
+        raise ValueError(
+            "recording calibration is incomplete; camera_info and tf streams must both be present "
+            "or both be absent"
+        )
+    return has_camera_info
 
 
 class FrameGeometryUnavailableError(ValueError):
@@ -121,6 +134,7 @@ class RecordingFramePreprocessor:
             streams = set(store.list_streams())
             if "color_image" not in streams:
                 raise ValueError("recording has no 'color_image' stream")
+            has_recorded_calibration = recorded_calibration_available(streams)
             lidar_name = next(
                 (name for name in ("pointlio_lidar", "lidar") if name in streams), None
             )
@@ -130,7 +144,7 @@ class RecordingFramePreprocessor:
             self._images = store.stream("color_image", Image).order_by("ts")
             self._lidar = store.stream(lidar_name, PointCloud2).order_by("ts")
 
-            if "camera_info" in streams and "tf" in streams:
+            if has_recorded_calibration:
                 try:
                     self._recorded_camera_info = (
                         store.stream("camera_info", CameraInfo).order_by("ts").first().data
@@ -143,7 +157,7 @@ class RecordingFramePreprocessor:
                 self._calibration_source = "profile:go2"
             else:
                 raise ValueError(
-                    "recording does not contain both camera_info and tf calibration; "
+                    "recording has no camera_info or tf calibration streams; "
                     "set calibration_profile='go2' explicitly to use the Go2 profile"
                 )
             self._store = store
@@ -340,8 +354,8 @@ def _profile_pointcloud_to_camera(
         raise FrameGeometryUnavailableError(
             "Go2 calibration profile requires an image observation pose"
         )
-    # Legacy Go2 recordings store the robot pose on image observations even though
-    # the payload frame is camera_optical, so the static mount is still required.
+    # This fallback defines image observation poses as world <- base_link, so the
+    # static camera mount is still required even if the payload names camera_optical.
     world_from_camera = Transform.from_pose("base_link", image_pose) + BASE_TO_OPTICAL
     camera_from_world = -world_from_camera
     cloud_frame = lidar_obs.data.frame_id

--- a/dimos/evals/vqa/preprocessing.py
+++ b/dimos/evals/vqa/preprocessing.py
@@ -21,7 +21,6 @@ from pathlib import Path
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, Literal, Protocol, cast
 
-import cv2
 import numpy as np
 
 from dimos.memory.cli.dataset import open_dataset
@@ -243,6 +242,9 @@ class _ImageRectifier:
         self._maps: dict[tuple[Any, ...], tuple[np.ndarray, np.ndarray, np.ndarray]] = {}
 
     def rectify(self, image: Image, source: CameraInfo) -> tuple[Image, CameraInfo]:
+        # OpenCV is intentionally lazy because importing it loads a large native library.
+        import cv2
+
         if (source.width, source.height) != (image.width, image.height):
             raise ValueError(
                 "camera calibration dimensions "
@@ -366,6 +368,9 @@ def _profile_pointcloud_to_camera(
 def _rectification_maps(
     image: Image, source: CameraInfo
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    # OpenCV is intentionally lazy because importing it loads a large native library.
+    import cv2
+
     matrix = np.asarray(source.K, dtype=np.float64).reshape(3, 3)
     distortion = np.asarray(source.D, dtype=np.float64)
     rectification = np.asarray(source.R, dtype=np.float64).reshape(3, 3)

--- a/dimos/evals/vqa/primitives/edgetam.py
+++ b/dimos/evals/vqa/primitives/edgetam.py
@@ -1,0 +1,221 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""EdgeTAM-segmented LiDAR range evidence for VQA object questions."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Annotated, Any, Protocol
+
+import numpy as np
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints
+
+from dimos.evals.vqa.families import InsufficientEvidenceError
+from dimos.perception.detection.type.detection2d.bbox import Detection2DBBox
+from dimos.perception.detection.type.detection2d.imageDetections2D import ImageDetections2D
+
+ObjectName = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+
+if TYPE_CHECKING:
+    from dimos.evals.vqa.families import ObjectDetector
+    from dimos.evals.vqa.preprocessing import CalibratedFrame
+
+
+class ObjectRangeEvidence(BaseModel):
+    """Median Euclidean camera-origin range supported by foreground points."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, allow_inf_nan=False)
+
+    object_name: ObjectName
+    camera_range_m: float = Field(ge=0)
+    supporting_point_count: int = Field(ge=1)
+    prompt_bbox_xyxy: tuple[float, float, float, float]
+    mask_bbox_xyxy: tuple[float, float, float, float]
+    mask_area_px: int = Field(ge=1)
+    range_quartiles_m: tuple[float, float, float]
+    synchronization_delta_s: float = Field(ge=0)
+    calibration_source: str = Field(min_length=1)
+
+
+class EdgeTAMImageSegmenterCompatible(Protocol):
+    """The box-prompt operation used from ``EdgeTAMImageSegmenter``."""
+
+    def segment(
+        self, detections: ImageDetections2D[Detection2DBBox]
+    ) -> ImageDetections2D[Detection2DBBox]: ...
+
+
+class EdgeTamLidarRangeEstimator:
+    """Estimate object range from box-prompted masks and calibrated LiDAR points."""
+
+    def __init__(
+        self,
+        detector: ObjectDetector,
+        segmenter: EdgeTAMImageSegmenterCompatible | None = None,
+        min_supporting_points: int = 5,
+    ) -> None:
+        if min_supporting_points < 1:
+            raise ValueError("min_supporting_points must be at least 1")
+        self._detector = detector
+        self._segmenter = segmenter
+        self._min_supporting_points = min_supporting_points
+        self._cached_frame: CalibratedFrame | None = None
+        self._cached_pixels = np.empty((0, 2), dtype=np.intp)
+        self._cached_camera_points = np.empty((0, 3), dtype=np.float64)
+
+    def estimate(self, frame: CalibratedFrame, object_name: str) -> ObjectRangeEvidence:
+        """Estimate robust camera-origin range to one detected object."""
+        if not isinstance(object_name, str):
+            raise TypeError("object_name must be a string")
+        normalized_name = object_name.strip()
+        if not normalized_name:
+            raise ValueError("object_name must not be blank")
+
+        detections = self._detector.detect(frame.image, normalized_name)
+        valid_detections = [detection for detection in detections if detection.is_valid()]
+        if len(valid_detections) != 1:
+            raise InsufficientEvidenceError(
+                f"object range requires exactly one valid detected {normalized_name!r}, "
+                f"got {len(valid_detections)}"
+            )
+        detection = valid_detections[0]
+
+        prompted = ImageDetections2D(frame.image, [detection])
+        segmented = self._get_segmenter().segment(prompted)
+        valid_masks: list[tuple[Detection2DBBox, np.ndarray[Any, Any]]] = []
+        expected_shape = (frame.image.height, frame.image.width)
+        for candidate in segmented:
+            mask = getattr(candidate, "mask", None)
+            if (
+                candidate.is_valid()
+                and isinstance(mask, np.ndarray)
+                and mask.ndim == 2
+                and mask.shape == expected_shape
+                and bool(np.any(mask))
+            ):
+                valid_masks.append((candidate, mask))
+        if len(valid_masks) != 1:
+            raise InsufficientEvidenceError(
+                "object range requires exactly one valid segmentation mask matching "
+                f"the rectified image, got {len(valid_masks)}"
+            )
+        segmented_detection, mask = valid_masks[0]
+
+        pixels, camera_points = self._project_frame(frame)
+        covered = mask[pixels[:, 1], pixels[:, 0]] != 0
+        supporting_points = camera_points[covered]
+        if len(supporting_points) < self._min_supporting_points:
+            raise InsufficientEvidenceError(
+                f"object range requires at least {self._min_supporting_points} supporting "
+                f"points, got {len(supporting_points)}"
+            )
+
+        ranges = np.linalg.norm(supporting_points, axis=1)
+        quartiles = np.quantile(ranges, (0.25, 0.5, 0.75))
+        bbox = detection.bbox
+        mask_bbox = segmented_detection.bbox
+        return ObjectRangeEvidence(
+            object_name=normalized_name,
+            camera_range_m=float(quartiles[1]),
+            supporting_point_count=len(supporting_points),
+            prompt_bbox_xyxy=(float(bbox[0]), float(bbox[1]), float(bbox[2]), float(bbox[3])),
+            mask_bbox_xyxy=(
+                float(mask_bbox[0]),
+                float(mask_bbox[1]),
+                float(mask_bbox[2]),
+                float(mask_bbox[3]),
+            ),
+            mask_area_px=int(np.count_nonzero(mask)),
+            range_quartiles_m=(
+                float(quartiles[0]),
+                float(quartiles[1]),
+                float(quartiles[2]),
+            ),
+            synchronization_delta_s=float(frame.synchronization_delta_s),
+            calibration_source=frame.calibration_source,
+        )
+
+    def _get_segmenter(self) -> EdgeTAMImageSegmenterCompatible:
+        if self._segmenter is None:
+            from dimos.models.segmentation.edge_tam import EdgeTAMImageSegmenter
+
+            self._segmenter = EdgeTAMImageSegmenter()
+        return self._segmenter
+
+    def _project_frame(
+        self, frame: CalibratedFrame
+    ) -> tuple[np.ndarray[Any, np.dtype[np.intp]], np.ndarray[Any, np.dtype[np.float64]]]:
+        if frame is self._cached_frame:
+            return self._cached_pixels, self._cached_camera_points
+
+        image_height, image_width = frame.image.height, frame.image.width
+        camera_info = frame.camera_info
+        if (camera_info.height, camera_info.width) != (image_height, image_width):
+            raise ValueError("camera calibration dimensions do not match the rectified image")
+
+        intrinsics = np.asarray(camera_info.K, dtype=np.float64)
+        if intrinsics.size != 9:
+            raise ValueError("camera intrinsics must contain nine values")
+        intrinsics = intrinsics.reshape(3, 3)
+        if not np.all(np.isfinite(intrinsics)) or intrinsics[0, 0] <= 0 or intrinsics[1, 1] <= 0:
+            raise ValueError("camera intrinsics must be finite with positive focal lengths")
+
+        raw_points, _ = frame.pointcloud.as_numpy()
+        points = np.asarray(raw_points, dtype=np.float64)
+        if points.ndim != 2 or points.shape[1] != 3:
+            raise ValueError("point cloud positions must have shape (N, 3)")
+
+        transform = np.asarray(frame.pointcloud_to_camera.to_matrix(), dtype=np.float64)
+        if transform.shape != (4, 4) or not np.all(np.isfinite(transform)):
+            raise ValueError("pointcloud_to_camera must be a finite 4x4 transform")
+
+        finite = np.all(np.isfinite(points), axis=1)
+        points = points[finite]
+        homogeneous = np.column_stack((points, np.ones(len(points), dtype=np.float64)))
+        camera_points = (transform @ homogeneous.T).T[:, :3]
+        camera_points = camera_points[np.all(np.isfinite(camera_points), axis=1)]
+        camera_points = camera_points[camera_points[:, 2] > 0]
+
+        projected = (intrinsics @ camera_points.T).T
+        image_points = projected[:, :2] / projected[:, 2, np.newaxis]
+        in_frame = (
+            np.all(np.isfinite(image_points), axis=1)
+            & (image_points[:, 0] >= 0)
+            & (image_points[:, 0] < image_width)
+            & (image_points[:, 1] >= 0)
+            & (image_points[:, 1] < image_height)
+        )
+        camera_points = camera_points[in_frame]
+        pixels = image_points[in_frame].astype(np.intp)
+
+        # Sort each pixel by camera Z and retain its nearest visible return.
+        linear_pixels = pixels[:, 1] * image_width + pixels[:, 0]
+        order = np.lexsort((camera_points[:, 2], linear_pixels))
+        sorted_linear = linear_pixels[order]
+        first_per_pixel = np.empty(len(order), dtype=bool)
+        if len(order):
+            first_per_pixel[0] = True
+            first_per_pixel[1:] = sorted_linear[1:] != sorted_linear[:-1]
+        keep = order[first_per_pixel]
+
+        self._cached_frame = frame
+        self._cached_pixels = pixels[keep]
+        self._cached_camera_points = camera_points[keep]
+        return self._cached_pixels, self._cached_camera_points
+
+
+class ObjectRangeEstimator(Protocol):
+    """Estimate object range from an explicit canonical frame."""
+
+    def estimate(self, frame: CalibratedFrame, object_name: str) -> ObjectRangeEvidence: ...

--- a/dimos/evals/vqa/primitives/edgetam.py
+++ b/dimos/evals/vqa/primitives/edgetam.py
@@ -21,12 +21,12 @@ from typing import TYPE_CHECKING, Protocol, cast
 
 import numpy as np
 
-from dimos.evals.vqa.families import InsufficientEvidenceError
+from dimos.evals.vqa.contracts import InsufficientEvidenceError
 from dimos.perception.detection.type.detection2d.bbox import Detection2DBBox
 from dimos.perception.detection.type.detection2d.imageDetections2D import ImageDetections2D
 
 if TYPE_CHECKING:
-    from dimos.evals.vqa.families import ObjectDetector
+    from dimos.evals.vqa.contracts import ObjectDetector
     from dimos.msgs.sensor_msgs.Image import Image
 
 

--- a/dimos/evals/vqa/primitives/edgetam.py
+++ b/dimos/evals/vqa/primitives/edgetam.py
@@ -24,6 +24,7 @@ from pydantic import BaseModel, ConfigDict, Field, StringConstraints
 from dimos.evals.vqa.families import InsufficientEvidenceError
 from dimos.perception.detection.type.detection2d.bbox import Detection2DBBox
 from dimos.perception.detection.type.detection2d.imageDetections2D import ImageDetections2D
+from dimos.perception.detection.type.detection3d.pointcloud import ProjectedPointCloud
 
 ObjectName = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
 
@@ -71,8 +72,8 @@ class EdgeTamLidarRangeEstimator:
         self._segmenter = segmenter
         self._min_supporting_points = min_supporting_points
         self._cached_frame: CalibratedFrame | None = None
-        self._cached_pixels = np.empty((0, 2), dtype=np.intp)
-        self._cached_camera_points = np.empty((0, 3), dtype=np.float64)
+        self._cached_projection: ProjectedPointCloud | None = None
+        self._cached_evidence: dict[str, ObjectRangeEvidence] = {}
 
     def estimate(self, frame: CalibratedFrame, object_name: str) -> ObjectRangeEvidence:
         """Estimate robust camera-origin range to one detected object."""
@@ -81,6 +82,13 @@ class EdgeTamLidarRangeEstimator:
         normalized_name = object_name.strip()
         if not normalized_name:
             raise ValueError("object_name must not be blank")
+        if frame is not self._cached_frame:
+            self._cached_frame = frame
+            self._cached_projection = None
+            self._cached_evidence.clear()
+        cache_key = normalized_name
+        if cached := self._cached_evidence.get(cache_key):
+            return cached
 
         detections = self._detector.detect(frame.image, normalized_name)
         valid_detections = [detection for detection in detections if detection.is_valid()]
@@ -112,9 +120,21 @@ class EdgeTamLidarRangeEstimator:
             )
         segmented_detection, mask = valid_masks[0]
 
-        pixels, camera_points = self._project_frame(frame)
-        covered = mask[pixels[:, 1], pixels[:, 0]] != 0
-        supporting_points = camera_points[covered]
+        if (frame.camera_info.height, frame.camera_info.width) != (
+            frame.image.height,
+            frame.image.width,
+        ):
+            raise ValueError("camera calibration dimensions do not match the rectified image")
+        if self._cached_projection is None:
+            self._cached_projection = ProjectedPointCloud.from_pointcloud(
+                frame.pointcloud,
+                frame.camera_info,
+                frame.pointcloud_to_camera,
+            )
+        _, supporting_points = self._cached_projection.points_in_detection(
+            segmented_detection,
+            nearest_per_pixel=True,
+        )
         if len(supporting_points) < self._min_supporting_points:
             raise InsufficientEvidenceError(
                 f"object range requires at least {self._min_supporting_points} supporting "
@@ -125,7 +145,7 @@ class EdgeTamLidarRangeEstimator:
         quartiles = np.quantile(ranges, (0.25, 0.5, 0.75))
         bbox = detection.bbox
         mask_bbox = segmented_detection.bbox
-        return ObjectRangeEvidence(
+        evidence = ObjectRangeEvidence(
             object_name=normalized_name,
             camera_range_m=float(quartiles[1]),
             supporting_point_count=len(supporting_points),
@@ -145,6 +165,8 @@ class EdgeTamLidarRangeEstimator:
             synchronization_delta_s=float(frame.synchronization_delta_s),
             calibration_source=frame.calibration_source,
         )
+        self._cached_evidence[cache_key] = evidence
+        return evidence
 
     def _get_segmenter(self) -> EdgeTAMImageSegmenterCompatible:
         if self._segmenter is None:
@@ -152,67 +174,6 @@ class EdgeTamLidarRangeEstimator:
 
             self._segmenter = EdgeTAMImageSegmenter()
         return self._segmenter
-
-    def _project_frame(
-        self, frame: CalibratedFrame
-    ) -> tuple[np.ndarray[Any, np.dtype[np.intp]], np.ndarray[Any, np.dtype[np.float64]]]:
-        if frame is self._cached_frame:
-            return self._cached_pixels, self._cached_camera_points
-
-        image_height, image_width = frame.image.height, frame.image.width
-        camera_info = frame.camera_info
-        if (camera_info.height, camera_info.width) != (image_height, image_width):
-            raise ValueError("camera calibration dimensions do not match the rectified image")
-
-        intrinsics = np.asarray(camera_info.K, dtype=np.float64)
-        if intrinsics.size != 9:
-            raise ValueError("camera intrinsics must contain nine values")
-        intrinsics = intrinsics.reshape(3, 3)
-        if not np.all(np.isfinite(intrinsics)) or intrinsics[0, 0] <= 0 or intrinsics[1, 1] <= 0:
-            raise ValueError("camera intrinsics must be finite with positive focal lengths")
-
-        raw_points, _ = frame.pointcloud.as_numpy()
-        points = np.asarray(raw_points, dtype=np.float64)
-        if points.ndim != 2 or points.shape[1] != 3:
-            raise ValueError("point cloud positions must have shape (N, 3)")
-
-        transform = np.asarray(frame.pointcloud_to_camera.to_matrix(), dtype=np.float64)
-        if transform.shape != (4, 4) or not np.all(np.isfinite(transform)):
-            raise ValueError("pointcloud_to_camera must be a finite 4x4 transform")
-
-        finite = np.all(np.isfinite(points), axis=1)
-        points = points[finite]
-        homogeneous = np.column_stack((points, np.ones(len(points), dtype=np.float64)))
-        camera_points = (transform @ homogeneous.T).T[:, :3]
-        camera_points = camera_points[np.all(np.isfinite(camera_points), axis=1)]
-        camera_points = camera_points[camera_points[:, 2] > 0]
-
-        projected = (intrinsics @ camera_points.T).T
-        image_points = projected[:, :2] / projected[:, 2, np.newaxis]
-        in_frame = (
-            np.all(np.isfinite(image_points), axis=1)
-            & (image_points[:, 0] >= 0)
-            & (image_points[:, 0] < image_width)
-            & (image_points[:, 1] >= 0)
-            & (image_points[:, 1] < image_height)
-        )
-        camera_points = camera_points[in_frame]
-        pixels = image_points[in_frame].astype(np.intp)
-
-        # Sort each pixel by camera Z and retain its nearest visible return.
-        linear_pixels = pixels[:, 1] * image_width + pixels[:, 0]
-        order = np.lexsort((camera_points[:, 2], linear_pixels))
-        sorted_linear = linear_pixels[order]
-        first_per_pixel = np.empty(len(order), dtype=bool)
-        if len(order):
-            first_per_pixel[0] = True
-            first_per_pixel[1:] = sorted_linear[1:] != sorted_linear[:-1]
-        keep = order[first_per_pixel]
-
-        self._cached_frame = frame
-        self._cached_pixels = pixels[keep]
-        self._cached_camera_points = camera_points[keep]
-        return self._cached_pixels, self._cached_camera_points
 
 
 class ObjectRangeEstimator(Protocol):

--- a/dimos/evals/vqa/primitives/edgetam.py
+++ b/dimos/evals/vqa/primitives/edgetam.py
@@ -28,6 +28,7 @@ from dimos.perception.detection.type.detection2d.imageDetections2D import ImageD
 if TYPE_CHECKING:
     from dimos.evals.vqa.contracts import ObjectDetector
     from dimos.msgs.sensor_msgs.Image import Image
+    from dimos.perception.detection.type.detection2d.seg import Detection2DSeg
 
 
 @dataclass(frozen=True)
@@ -53,10 +54,10 @@ class EdgeTAMImageSegmenterCompatible(Protocol):
 
     def segment(
         self, detections: ImageDetections2D[Detection2DBBox]
-    ) -> ImageDetections2D[Detection2DBBox]: ...
+    ) -> ImageDetections2D[Detection2DSeg]: ...
 
 
-class EdgeTamObjectMaskEstimator:
+class EdgeTamObjectMaskPipeline:
     """Detect and batch-segment named objects, caching evidence per image."""
 
     def __init__(
@@ -116,10 +117,9 @@ class EdgeTamObjectMaskEstimator:
                 )
             expected_shape = (image.height, image.width)
             for (object_name, detection), candidate in zip(pending, segmented, strict=True):
-                mask = getattr(candidate, "mask", None)
+                mask = candidate.mask
                 if not (
                     candidate.is_valid()
-                    and isinstance(mask, np.ndarray)
                     and mask.ndim == 2
                     and mask.shape == expected_shape
                     and bool(np.any(mask))
@@ -148,13 +148,3 @@ class EdgeTamObjectMaskEstimator:
 
             self._segmenter = EdgeTAMImageSegmenter()
         return self._segmenter
-
-
-class ObjectMaskEstimator(Protocol):
-    """Estimate object masks from an image."""
-
-    def estimate(self, image: Image, object_name: str) -> ObjectMaskEvidence: ...
-
-    def estimate_many(
-        self, image: Image, object_names: tuple[str, ...]
-    ) -> tuple[ObjectMaskEvidence, ...]: ...

--- a/dimos/evals/vqa/primitives/edgetam.py
+++ b/dimos/evals/vqa/primitives/edgetam.py
@@ -16,37 +16,36 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Annotated, Any, Protocol
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol, cast
 
 import numpy as np
-from pydantic import BaseModel, ConfigDict, Field, StringConstraints
 
 from dimos.evals.vqa.families import InsufficientEvidenceError
 from dimos.perception.detection.type.detection2d.bbox import Detection2DBBox
 from dimos.perception.detection.type.detection2d.imageDetections2D import ImageDetections2D
-from dimos.perception.detection.type.detection3d.pointcloud import ProjectedPointCloud
-
-ObjectName = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
 
 if TYPE_CHECKING:
     from dimos.evals.vqa.families import ObjectDetector
-    from dimos.evals.vqa.preprocessing import CalibratedFrame
+    from dimos.msgs.sensor_msgs.Image import Image
 
 
-class ObjectRangeEvidence(BaseModel):
-    """Median Euclidean camera-origin range supported by foreground points."""
+@dataclass(frozen=True)
+class ObjectMaskEvidence:
+    """One validated box-prompted object mask."""
 
-    model_config = ConfigDict(extra="forbid", frozen=True, allow_inf_nan=False)
-
-    object_name: ObjectName
-    camera_range_m: float = Field(ge=0)
-    supporting_point_count: int = Field(ge=1)
+    object_name: str
     prompt_bbox_xyxy: tuple[float, float, float, float]
-    mask_bbox_xyxy: tuple[float, float, float, float]
-    mask_area_px: int = Field(ge=1)
-    range_quartiles_m: tuple[float, float, float]
-    synchronization_delta_s: float = Field(ge=0)
-    calibration_source: str = Field(min_length=1)
+    detection: Detection2DBBox
+    mask: np.ndarray
+
+    @property
+    def mask_bbox_xyxy(self) -> tuple[float, float, float, float]:
+        return cast("tuple[float, float, float, float]", tuple(map(float, self.detection.bbox)))
+
+    @property
+    def mask_area_px(self) -> int:
+        return int(np.count_nonzero(self.mask))
 
 
 class EdgeTAMImageSegmenterCompatible(Protocol):
@@ -57,116 +56,91 @@ class EdgeTAMImageSegmenterCompatible(Protocol):
     ) -> ImageDetections2D[Detection2DBBox]: ...
 
 
-class EdgeTamLidarRangeEstimator:
-    """Estimate object range from box-prompted masks and calibrated LiDAR points."""
+class EdgeTamObjectMaskEstimator:
+    """Detect and batch-segment named objects, caching evidence per image."""
 
     def __init__(
         self,
         detector: ObjectDetector,
         segmenter: EdgeTAMImageSegmenterCompatible | None = None,
-        min_supporting_points: int = 5,
     ) -> None:
-        if min_supporting_points < 1:
-            raise ValueError("min_supporting_points must be at least 1")
         self._detector = detector
         self._segmenter = segmenter
-        self._min_supporting_points = min_supporting_points
-        self._cached_frame: CalibratedFrame | None = None
-        self._cached_projection: ProjectedPointCloud | None = None
-        self._cached_evidence: dict[str, ObjectRangeEvidence] = {}
+        self._cached_image_key: tuple[int, int, float] | None = None
+        self._cached_evidence: dict[str, ObjectMaskEvidence] = {}
 
-    def estimate(self, frame: CalibratedFrame, object_name: str) -> ObjectRangeEvidence:
-        """Estimate robust camera-origin range to one detected object."""
-        if not isinstance(object_name, str):
-            raise TypeError("object_name must be a string")
-        normalized_name = object_name.strip()
-        if not normalized_name:
-            raise ValueError("object_name must not be blank")
-        if frame is not self._cached_frame:
-            self._cached_frame = frame
-            self._cached_projection = None
+    def estimate(self, image: Image, object_name: str) -> ObjectMaskEvidence:
+        """Return one named object's validated mask."""
+        return self.estimate_many(image, (object_name,))[0]
+
+    def estimate_many(
+        self,
+        image: Image,
+        object_names: tuple[str, ...],
+    ) -> tuple[ObjectMaskEvidence, ...]:
+        """Return several object masks from one EdgeTAM segmentation pass."""
+        if not object_names:
+            raise ValueError("object_names must not be empty")
+        normalized_names = tuple(name.strip() for name in object_names)
+        if any(not name for name in normalized_names):
+            raise ValueError("object names must not be blank")
+        if len({name.casefold() for name in normalized_names}) != len(normalized_names):
+            raise ValueError("object names must be distinct")
+
+        image_key = (id(image), id(image.data), image.ts)
+        if image_key != self._cached_image_key:
+            self._cached_image_key = image_key
             self._cached_evidence.clear()
-        cache_key = normalized_name
-        if cached := self._cached_evidence.get(cache_key):
-            return cached
 
-        detections = self._detector.detect(frame.image, normalized_name)
-        valid_detections = [detection for detection in detections if detection.is_valid()]
-        if len(valid_detections) != 1:
-            raise InsufficientEvidenceError(
-                f"object range requires exactly one valid detected {normalized_name!r}, "
-                f"got {len(valid_detections)}"
-            )
-        detection = valid_detections[0]
+        pending: list[tuple[str, Detection2DBBox]] = []
+        for object_name in normalized_names:
+            if object_name in self._cached_evidence:
+                continue
+            detected = self._detector.detect(image, object_name)
+            valid_detections = [detection for detection in detected if detection.is_valid()]
+            if len(valid_detections) != 1:
+                raise InsufficientEvidenceError(
+                    f"object mask requires exactly one valid detected {object_name!r}, "
+                    f"got {len(valid_detections)}"
+                )
+            pending.append((object_name, valid_detections[0]))
 
-        prompted = ImageDetections2D(frame.image, [detection])
-        segmented = self._get_segmenter().segment(prompted)
-        valid_masks: list[tuple[Detection2DBBox, np.ndarray[Any, Any]]] = []
-        expected_shape = (frame.image.height, frame.image.width)
-        for candidate in segmented:
-            mask = getattr(candidate, "mask", None)
-            if (
-                candidate.is_valid()
-                and isinstance(mask, np.ndarray)
-                and mask.ndim == 2
-                and mask.shape == expected_shape
-                and bool(np.any(mask))
-            ):
-                valid_masks.append((candidate, mask))
-        if len(valid_masks) != 1:
-            raise InsufficientEvidenceError(
-                "object range requires exactly one valid segmentation mask matching "
-                f"the rectified image, got {len(valid_masks)}"
+        if pending:
+            segmented = self._get_segmenter().segment(
+                ImageDetections2D(image, [detection for _, detection in pending])
             )
-        segmented_detection, mask = valid_masks[0]
-
-        if (frame.camera_info.height, frame.camera_info.width) != (
-            frame.image.height,
-            frame.image.width,
-        ):
-            raise ValueError("camera calibration dimensions do not match the rectified image")
-        if self._cached_projection is None:
-            self._cached_projection = ProjectedPointCloud.from_pointcloud(
-                frame.pointcloud,
-                frame.camera_info,
-                frame.pointcloud_to_camera,
-            )
-        _, supporting_points = self._cached_projection.points_in_detection(
-            segmented_detection,
-            nearest_per_pixel=True,
-        )
-        if len(supporting_points) < self._min_supporting_points:
-            raise InsufficientEvidenceError(
-                f"object range requires at least {self._min_supporting_points} supporting "
-                f"points, got {len(supporting_points)}"
-            )
-
-        ranges = np.linalg.norm(supporting_points, axis=1)
-        quartiles = np.quantile(ranges, (0.25, 0.5, 0.75))
-        bbox = detection.bbox
-        mask_bbox = segmented_detection.bbox
-        evidence = ObjectRangeEvidence(
-            object_name=normalized_name,
-            camera_range_m=float(quartiles[1]),
-            supporting_point_count=len(supporting_points),
-            prompt_bbox_xyxy=(float(bbox[0]), float(bbox[1]), float(bbox[2]), float(bbox[3])),
-            mask_bbox_xyxy=(
-                float(mask_bbox[0]),
-                float(mask_bbox[1]),
-                float(mask_bbox[2]),
-                float(mask_bbox[3]),
-            ),
-            mask_area_px=int(np.count_nonzero(mask)),
-            range_quartiles_m=(
-                float(quartiles[0]),
-                float(quartiles[1]),
-                float(quartiles[2]),
-            ),
-            synchronization_delta_s=float(frame.synchronization_delta_s),
-            calibration_source=frame.calibration_source,
-        )
-        self._cached_evidence[cache_key] = evidence
-        return evidence
+            if len(segmented) != len(pending):
+                raise InsufficientEvidenceError(
+                    "object mask requires one segmentation result per detected object, "
+                    f"got {len(segmented)} for {len(pending)} objects"
+                )
+            expected_shape = (image.height, image.width)
+            for (object_name, detection), candidate in zip(pending, segmented, strict=True):
+                mask = getattr(candidate, "mask", None)
+                if not (
+                    candidate.is_valid()
+                    and isinstance(mask, np.ndarray)
+                    and mask.ndim == 2
+                    and mask.shape == expected_shape
+                    and bool(np.any(mask))
+                ):
+                    raise InsufficientEvidenceError(
+                        "object mask requires one valid segmentation mask matching "
+                        f"the rectified image for {object_name!r}"
+                    )
+                bbox = detection.bbox
+                self._cached_evidence[object_name] = ObjectMaskEvidence(
+                    object_name=object_name,
+                    prompt_bbox_xyxy=(
+                        float(bbox[0]),
+                        float(bbox[1]),
+                        float(bbox[2]),
+                        float(bbox[3]),
+                    ),
+                    detection=candidate,
+                    mask=mask,
+                )
+        return tuple(self._cached_evidence[name] for name in normalized_names)
 
     def _get_segmenter(self) -> EdgeTAMImageSegmenterCompatible:
         if self._segmenter is None:
@@ -176,7 +150,11 @@ class EdgeTamLidarRangeEstimator:
         return self._segmenter
 
 
-class ObjectRangeEstimator(Protocol):
-    """Estimate object range from an explicit canonical frame."""
+class ObjectMaskEstimator(Protocol):
+    """Estimate object masks from an image."""
 
-    def estimate(self, frame: CalibratedFrame, object_name: str) -> ObjectRangeEvidence: ...
+    def estimate(self, image: Image, object_name: str) -> ObjectMaskEvidence: ...
+
+    def estimate_many(
+        self, image: Image, object_names: tuple[str, ...]
+    ) -> tuple[ObjectMaskEvidence, ...]: ...

--- a/dimos/evals/vqa/primitives/range.py
+++ b/dimos/evals/vqa/primitives/range.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING, Annotated, Protocol
 import numpy as np
 from pydantic import BaseModel, ConfigDict, Field, StringConstraints
 
-from dimos.evals.vqa.families import InsufficientEvidenceError
+from dimos.evals.vqa.contracts import InsufficientEvidenceError
 from dimos.perception.detection.type.detection3d.pointcloud import ProjectedPointCloud
 
 if TYPE_CHECKING:

--- a/dimos/evals/vqa/primitives/range.py
+++ b/dimos/evals/vqa/primitives/range.py
@@ -16,17 +16,16 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Annotated, Protocol
+from typing import TYPE_CHECKING, Annotated
 
 import numpy as np
 from pydantic import BaseModel, ConfigDict, Field, StringConstraints
 
-from dimos.evals.vqa.contracts import InsufficientEvidenceError
+from dimos.evals.vqa.contracts import InsufficientEvidenceError, ObjectMaskEstimator
 from dimos.perception.detection.type.detection3d.pointcloud import ProjectedPointCloud
 
 if TYPE_CHECKING:
     from dimos.evals.vqa.preprocessing import CalibratedFrame
-    from dimos.evals.vqa.primitives.edgetam import ObjectMaskEstimator
 
 ObjectName = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
 
@@ -115,9 +114,3 @@ class LidarRangeEstimator:
                     calibration_source=frame.calibration_source,
                 )
         return tuple(self._cached_evidence[mask.object_name] for mask in masks)
-
-
-class ObjectRangeEstimator(Protocol):
-    """Estimate object range from an explicit canonical frame."""
-
-    def estimate(self, frame: CalibratedFrame, object_name: str) -> ObjectRangeEvidence: ...

--- a/dimos/evals/vqa/primitives/range.py
+++ b/dimos/evals/vqa/primitives/range.py
@@ -1,0 +1,123 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""LiDAR range evidence derived from cached object masks."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Annotated, Protocol
+
+import numpy as np
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints
+
+from dimos.evals.vqa.families import InsufficientEvidenceError
+from dimos.perception.detection.type.detection3d.pointcloud import ProjectedPointCloud
+
+if TYPE_CHECKING:
+    from dimos.evals.vqa.preprocessing import CalibratedFrame
+    from dimos.evals.vqa.primitives.edgetam import ObjectMaskEstimator
+
+ObjectName = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+
+
+class ObjectRangeEvidence(BaseModel):
+    """Median Euclidean camera-origin range supported by foreground points."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, allow_inf_nan=False)
+
+    object_name: ObjectName
+    camera_range_m: float = Field(ge=0)
+    supporting_point_count: int = Field(ge=1)
+    prompt_bbox_xyxy: tuple[float, float, float, float]
+    mask_bbox_xyxy: tuple[float, float, float, float]
+    mask_area_px: int = Field(ge=1)
+    range_quartiles_m: tuple[float, float, float]
+    synchronization_delta_s: float = Field(ge=0)
+    calibration_source: str = Field(min_length=1)
+
+
+class LidarRangeEstimator:
+    """Add calibrated LiDAR range statistics to object-mask evidence."""
+
+    def __init__(self, masks: ObjectMaskEstimator, min_supporting_points: int = 5) -> None:
+        if min_supporting_points < 1:
+            raise ValueError("min_supporting_points must be at least 1")
+        self._masks = masks
+        self._min_supporting_points = min_supporting_points
+        self._cached_frame: CalibratedFrame | None = None
+        self._cached_projection: ProjectedPointCloud | None = None
+        self._cached_evidence: dict[str, ObjectRangeEvidence] = {}
+
+    def estimate(self, frame: CalibratedFrame, object_name: str) -> ObjectRangeEvidence:
+        """Estimate robust camera-origin range to one detected object."""
+        return self.estimate_many(frame, (object_name,))[0]
+
+    def estimate_many(
+        self, frame: CalibratedFrame, object_names: tuple[str, ...]
+    ) -> tuple[ObjectRangeEvidence, ...]:
+        """Estimate several ranges with cached masks and one projected cloud."""
+        masks = self._masks.estimate_many(frame.image, object_names)
+        if frame is not self._cached_frame:
+            self._cached_frame = frame
+            self._cached_projection = None
+            self._cached_evidence.clear()
+        if (frame.camera_info.height, frame.camera_info.width) != (
+            frame.image.height,
+            frame.image.width,
+        ):
+            raise ValueError("camera calibration dimensions do not match the rectified image")
+
+        pending = [mask for mask in masks if mask.object_name not in self._cached_evidence]
+        if pending:
+            projection = self._cached_projection
+            if projection is None:
+                projection = ProjectedPointCloud.from_pointcloud(
+                    frame.pointcloud,
+                    frame.camera_info,
+                    frame.pointcloud_to_camera,
+                )
+                self._cached_projection = projection
+            for mask in pending:
+                _, points = projection.points_in_detection(
+                    mask.detection,
+                    nearest_per_pixel=True,
+                )
+                if len(points) < self._min_supporting_points:
+                    raise InsufficientEvidenceError(
+                        f"object range requires at least {self._min_supporting_points} supporting "
+                        f"points for {mask.object_name!r}, got {len(points)}"
+                    )
+                quartiles = np.quantile(np.linalg.norm(points, axis=1), (0.25, 0.5, 0.75))
+                self._cached_evidence[mask.object_name] = ObjectRangeEvidence(
+                    object_name=mask.object_name,
+                    camera_range_m=float(quartiles[1]),
+                    supporting_point_count=len(points),
+                    prompt_bbox_xyxy=mask.prompt_bbox_xyxy,
+                    mask_bbox_xyxy=mask.mask_bbox_xyxy,
+                    mask_area_px=mask.mask_area_px,
+                    range_quartiles_m=(
+                        float(quartiles[0]),
+                        float(quartiles[1]),
+                        float(quartiles[2]),
+                    ),
+                    synchronization_delta_s=float(frame.synchronization_delta_s),
+                    calibration_source=frame.calibration_source,
+                )
+        return tuple(self._cached_evidence[mask.object_name] for mask in masks)
+
+
+class ObjectRangeEstimator(Protocol):
+    """Estimate object range from an explicit canonical frame."""
+
+    def estimate(self, frame: CalibratedFrame, object_name: str) -> ObjectRangeEvidence: ...

--- a/dimos/evals/vqa/primitives/test_edgetam.py
+++ b/dimos/evals/vqa/primitives/test_edgetam.py
@@ -21,7 +21,7 @@ import pytest
 
 from dimos.evals.vqa.contracts import InsufficientEvidenceError
 from dimos.evals.vqa.preprocessing import CalibratedFrame
-from dimos.evals.vqa.primitives.edgetam import EdgeTamObjectMaskEstimator
+from dimos.evals.vqa.primitives.edgetam import EdgeTamObjectMaskPipeline
 from dimos.evals.vqa.primitives.range import LidarRangeEstimator
 from dimos.msgs.geometry_msgs.Transform import Transform
 from dimos.msgs.geometry_msgs.Vector3 import Vector3
@@ -99,7 +99,7 @@ class _Segmenter:
 
     def segment(
         self, detections: ImageDetections2D[Detection2DBBox]
-    ) -> ImageDetections2D[Detection2DBBox]:
+    ) -> ImageDetections2D[Detection2DSeg]:
         self.call_count += 1
         self.prompted_boxes.extend(prompt.bbox for prompt in detections)
         masks = (
@@ -107,7 +107,7 @@ class _Segmenter:
             if len(self._masks) == 1
             else self._masks[: len(detections)]
         )
-        segmented: list[Detection2DBBox] = [
+        segmented: list[Detection2DSeg] = [
             Detection2DSeg(
                 bbox=prompt.bbox,
                 track_id=prompt.track_id,
@@ -156,7 +156,7 @@ def _range_estimator(
     min_supporting_points: int = 5,
 ) -> LidarRangeEstimator:
     return LidarRangeEstimator(
-        EdgeTamObjectMaskEstimator(detector, segmenter),
+        EdgeTamObjectMaskPipeline(detector, segmenter),
         min_supporting_points,
     )
 
@@ -168,7 +168,7 @@ def test_mask_estimator_batches_and_caches_without_pointcloud() -> None:
     left_mask[:, :4] = 1
     right_mask[:, 5:] = 1
     segmenter = _Segmenter([left_mask, right_mask])
-    estimator = EdgeTamObjectMaskEstimator(
+    estimator = EdgeTamObjectMaskPipeline(
         _NamedDetector(
             {
                 "left person": (0.0, 0.0, 4.0, 9.0),

--- a/dimos/evals/vqa/primitives/test_edgetam.py
+++ b/dimos/evals/vqa/primitives/test_edgetam.py
@@ -40,6 +40,8 @@ class _PointCloud:
     def __init__(self, points: np.ndarray) -> None:
         self._points = points
         self.read_count = 0
+        self.frame_id = "lidar"
+        self.ts = 9.98
 
     def as_numpy(self) -> tuple[np.ndarray, None]:
         self.read_count += 1
@@ -187,6 +189,31 @@ def test_rejects_too_few_mask_supporting_points() -> None:
         estimator.estimate(_frame(pointcloud), "bottle")
 
 
+def test_rejects_invalid_camera_intrinsics_before_projection() -> None:
+    frame = _frame(_PointCloud(np.array([[0.0, 0.0, 1.0]])))
+    frame.camera_info.K[0] = 0.0
+
+    estimator = EdgeTamLidarRangeEstimator(
+        _Detector([(0.0, 0.0, 10.0, 10.0)]),
+        _Segmenter(_full_mask()),
+        min_supporting_points=1,
+    )
+
+    with pytest.raises(ValueError, match="positive focal lengths"):
+        estimator.estimate(frame, "bottle")
+
+
+def test_rejects_segmentation_mask_with_wrong_dimensions() -> None:
+    estimator = EdgeTamLidarRangeEstimator(
+        _Detector([(0.0, 0.0, 10.0, 10.0)]),
+        _Segmenter(np.ones((9, 10), dtype=np.uint8)),
+        min_supporting_points=1,
+    )
+
+    with pytest.raises(InsufficientEvidenceError, match="exactly one valid segmentation mask"):
+        estimator.estimate(_frame(_PointCloud(np.array([[0.0, 0.0, 1.0]]))), "bottle")
+
+
 def test_returns_median_euclidean_range_and_auditable_quartiles() -> None:
     points = np.array([[u * z, 0.0, z] for u, z in zip(range(1, 6), [1, 2, 3, 4, 20], strict=True)])
     expected_ranges = np.linalg.norm(points, axis=1)
@@ -206,7 +233,7 @@ def test_returns_median_euclidean_range_and_auditable_quartiles() -> None:
     assert evidence.model_dump(mode="json")["mask_bbox_xyxy"] == [0.0, 0.0, 9.0, 9.0]
 
 
-def test_projection_cache_reuses_only_the_same_explicit_frame() -> None:
+def test_projection_cache_reuses_across_objects_only_for_the_same_explicit_frame() -> None:
     points = np.array([[float(2 * x), 0.0, 2.0] for x in range(5)])
     first_cloud = _PointCloud(points)
     second_cloud = _PointCloud(points)
@@ -217,7 +244,7 @@ def test_projection_cache_reuses_only_the_same_explicit_frame() -> None:
     )
 
     estimator.estimate(first_frame, "box")
-    estimator.estimate(first_frame, "box")
+    estimator.estimate(first_frame, "crate")
     estimator.estimate(second_frame, "box")
 
     assert first_cloud.read_count == 1

--- a/dimos/evals/vqa/primitives/test_edgetam.py
+++ b/dimos/evals/vqa/primitives/test_edgetam.py
@@ -1,0 +1,224 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+import numpy as np
+import pytest
+
+from dimos.evals.vqa.families import InsufficientEvidenceError
+from dimos.evals.vqa.preprocessing import CalibratedFrame
+from dimos.evals.vqa.primitives.edgetam import EdgeTamLidarRangeEstimator
+from dimos.msgs.geometry_msgs.Transform import Transform
+from dimos.msgs.geometry_msgs.Vector3 import Vector3
+from dimos.msgs.sensor_msgs.CameraInfo import CameraInfo
+from dimos.msgs.sensor_msgs.Image import Image
+from dimos.perception.detection.type.detection2d.bbox import Detection2DBBox
+from dimos.perception.detection.type.detection2d.imageDetections2D import ImageDetections2D
+from dimos.perception.detection.type.detection2d.seg import Detection2DSeg
+
+if TYPE_CHECKING:
+    from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
+
+BBox = tuple[float, float, float, float]
+
+
+class _PointCloud:
+    def __init__(self, points: np.ndarray) -> None:
+        self._points = points
+        self.read_count = 0
+
+    def as_numpy(self) -> tuple[np.ndarray, None]:
+        self.read_count += 1
+        return self._points, None
+
+
+class _Detector:
+    def __init__(self, boxes: list[BBox]) -> None:
+        self._boxes = boxes
+
+    def detect(self, image: Image, object_name: str) -> ImageDetections2D[Detection2DBBox]:
+        detections = [
+            Detection2DBBox(
+                bbox=box,
+                track_id=index,
+                class_id=0,
+                confidence=1.0,
+                name=object_name,
+                ts=image.ts,
+                image=image,
+            )
+            for index, box in enumerate(self._boxes)
+        ]
+        return ImageDetections2D(image, detections)
+
+
+class _Segmenter:
+    def __init__(self, mask: np.ndarray) -> None:
+        self._mask = mask
+        self.prompted_boxes: list[BBox] = []
+
+    def segment(
+        self, detections: ImageDetections2D[Detection2DBBox]
+    ) -> ImageDetections2D[Detection2DBBox]:
+        prompt = detections[0]
+        self.prompted_boxes.append(prompt.bbox)
+        segmented: list[Detection2DBBox] = [
+            Detection2DSeg(
+                bbox=prompt.bbox,
+                track_id=prompt.track_id,
+                class_id=prompt.class_id,
+                confidence=prompt.confidence,
+                name=prompt.name,
+                ts=prompt.ts,
+                image=detections.image,
+                mask=self._mask,
+            )
+        ]
+        return ImageDetections2D(detections.image, segmented)
+
+
+def _frame(
+    pointcloud: _PointCloud,
+    *,
+    index: int = 0,
+    transform: Transform | None = None,
+    fx: float = 2.0,
+    fy: float = 2.0,
+    cx: float = 5.0,
+    cy: float = 5.0,
+) -> CalibratedFrame:
+    image = Image(data=np.zeros((10, 10, 3), dtype=np.uint8), ts=10.0)
+    return CalibratedFrame(
+        index=index,
+        image=image,
+        pointcloud=cast("PointCloud2", pointcloud),
+        camera_info=CameraInfo.from_intrinsics(fx, fy, cx, cy, 10, 10),
+        pointcloud_to_camera=transform or Transform.identity(),
+        image_observation_timestamp=10.0,
+        pointcloud_observation_timestamp=9.98,
+        calibration_source="synthetic-calibration",
+    )
+
+
+def _full_mask() -> np.ndarray:
+    return np.ones((10, 10), dtype=np.uint8)
+
+
+def test_projects_transformed_points_and_rejects_invalid_projections() -> None:
+    pointcloud = _PointCloud(
+        np.array(
+            [
+                [0.0, 0.0, 1.0],
+                [0.0, 0.0, -2.0],
+                [10.0, 0.0, 1.0],
+            ]
+        )
+    )
+    frame = _frame(
+        pointcloud,
+        transform=Transform(translation=Vector3(1.0, 0.0, 0.0)),
+        cx=0.0,
+        cy=0.0,
+    )
+    mask = np.zeros((10, 10), dtype=np.uint8)
+    mask[0, 2] = 1
+
+    evidence = EdgeTamLidarRangeEstimator(
+        _Detector([(0.0, 0.0, 3.0, 2.0)]), _Segmenter(mask), min_supporting_points=1
+    ).estimate(frame, "crate")
+
+    assert evidence.camera_range_m == pytest.approx(np.sqrt(2.0))
+    assert evidence.supporting_point_count == 1
+
+
+def test_mask_selection_uses_nearest_camera_z_point_per_pixel() -> None:
+    pointcloud = _PointCloud(
+        np.array(
+            [
+                [0.0, 0.0, 1.0],
+                [0.0, 0.0, 3.0],
+                [1.0, 0.0, 1.0],
+            ]
+        )
+    )
+    mask = np.zeros((10, 10), dtype=np.uint8)
+    mask[5, 5] = 1
+
+    evidence = EdgeTamLidarRangeEstimator(
+        _Detector([(0.0, 0.0, 10.0, 10.0)]), _Segmenter(mask), min_supporting_points=1
+    ).estimate(_frame(pointcloud), "chair")
+
+    assert evidence.supporting_point_count == 1
+    assert evidence.camera_range_m == pytest.approx(1.0)
+    assert evidence.mask_area_px == 1
+
+
+@pytest.mark.parametrize("boxes", [[], [(0.0, 0.0, 4.0, 4.0), (5.0, 5.0, 9.0, 9.0)]])
+def test_requires_exactly_one_valid_detection(boxes: list[BBox]) -> None:
+    estimator = EdgeTamLidarRangeEstimator(_Detector(boxes), _Segmenter(_full_mask()))
+
+    with pytest.raises(InsufficientEvidenceError, match="exactly one valid detected"):
+        estimator.estimate(_frame(_PointCloud(np.array([[0.0, 0.0, 1.0]]))), "cup")
+
+
+def test_rejects_too_few_mask_supporting_points() -> None:
+    pointcloud = _PointCloud(
+        np.array([[-2.0, 0.0, 1.0], [-1.5, 0.0, 1.0], [-1.0, 0.0, 1.0], [-0.5, 0.0, 1.0]])
+    )
+    estimator = EdgeTamLidarRangeEstimator(
+        _Detector([(0.0, 0.0, 10.0, 10.0)]), _Segmenter(_full_mask())
+    )
+
+    with pytest.raises(InsufficientEvidenceError, match="at least 5 supporting points, got 4"):
+        estimator.estimate(_frame(pointcloud), "bottle")
+
+
+def test_returns_median_euclidean_range_and_auditable_quartiles() -> None:
+    points = np.array([[u * z, 0.0, z] for u, z in zip(range(1, 6), [1, 2, 3, 4, 20], strict=True)])
+    expected_ranges = np.linalg.norm(points, axis=1)
+    frame = _frame(_PointCloud(points), fx=1.0, fy=1.0, cx=0.0, cy=0.0)
+
+    evidence = EdgeTamLidarRangeEstimator(
+        _Detector([(0.0, 0.0, 9.0, 9.0)]), _Segmenter(_full_mask())
+    ).estimate(frame, "cone")
+
+    assert evidence.camera_range_m == pytest.approx(np.median(expected_ranges))
+    assert evidence.range_quartiles_m == pytest.approx(
+        np.quantile(expected_ranges, [0.25, 0.5, 0.75])
+    )
+    assert evidence.synchronization_delta_s == pytest.approx(0.02)
+    assert evidence.calibration_source == "synthetic-calibration"
+    assert evidence.model_dump(mode="json")["prompt_bbox_xyxy"] == [0.0, 0.0, 9.0, 9.0]
+    assert evidence.model_dump(mode="json")["mask_bbox_xyxy"] == [0.0, 0.0, 9.0, 9.0]
+
+
+def test_projection_cache_reuses_only_the_same_explicit_frame() -> None:
+    points = np.array([[float(2 * x), 0.0, 2.0] for x in range(5)])
+    first_cloud = _PointCloud(points)
+    second_cloud = _PointCloud(points)
+    first_frame = _frame(first_cloud, index=3, fx=1.0, fy=1.0, cx=0.0, cy=0.0)
+    second_frame = _frame(second_cloud, index=3, fx=1.0, fy=1.0, cx=0.0, cy=0.0)
+    estimator = EdgeTamLidarRangeEstimator(
+        _Detector([(0.0, 0.0, 9.0, 9.0)]), _Segmenter(_full_mask())
+    )
+
+    estimator.estimate(first_frame, "box")
+    estimator.estimate(first_frame, "box")
+    estimator.estimate(second_frame, "box")
+
+    assert first_cloud.read_count == 1
+    assert second_cloud.read_count == 1

--- a/dimos/evals/vqa/primitives/test_edgetam.py
+++ b/dimos/evals/vqa/primitives/test_edgetam.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, cast
 import numpy as np
 import pytest
 
-from dimos.evals.vqa.families import InsufficientEvidenceError
+from dimos.evals.vqa.contracts import InsufficientEvidenceError
 from dimos.evals.vqa.preprocessing import CalibratedFrame
 from dimos.evals.vqa.primitives.edgetam import EdgeTamObjectMaskEstimator
 from dimos.evals.vqa.primitives.range import LidarRangeEstimator

--- a/dimos/evals/vqa/primitives/test_edgetam.py
+++ b/dimos/evals/vqa/primitives/test_edgetam.py
@@ -21,7 +21,8 @@ import pytest
 
 from dimos.evals.vqa.families import InsufficientEvidenceError
 from dimos.evals.vqa.preprocessing import CalibratedFrame
-from dimos.evals.vqa.primitives.edgetam import EdgeTamLidarRangeEstimator
+from dimos.evals.vqa.primitives.edgetam import EdgeTamObjectMaskEstimator
+from dimos.evals.vqa.primitives.range import LidarRangeEstimator
 from dimos.msgs.geometry_msgs.Transform import Transform
 from dimos.msgs.geometry_msgs.Vector3 import Vector3
 from dimos.msgs.sensor_msgs.CameraInfo import CameraInfo
@@ -68,16 +69,44 @@ class _Detector:
         return ImageDetections2D(image, detections)
 
 
+class _NamedDetector:
+    def __init__(self, boxes: dict[str, BBox]) -> None:
+        self._boxes = boxes
+
+    def detect(self, image: Image, object_name: str) -> ImageDetections2D[Detection2DBBox]:
+        box = self._boxes[object_name]
+        return ImageDetections2D(
+            image,
+            [
+                Detection2DBBox(
+                    bbox=box,
+                    track_id=len(object_name),
+                    class_id=0,
+                    confidence=1.0,
+                    name=object_name,
+                    ts=image.ts,
+                    image=image,
+                )
+            ],
+        )
+
+
 class _Segmenter:
-    def __init__(self, mask: np.ndarray) -> None:
-        self._mask = mask
+    def __init__(self, mask: np.ndarray | list[np.ndarray]) -> None:
+        self._masks = mask if isinstance(mask, list) else [mask]
         self.prompted_boxes: list[BBox] = []
+        self.call_count = 0
 
     def segment(
         self, detections: ImageDetections2D[Detection2DBBox]
     ) -> ImageDetections2D[Detection2DBBox]:
-        prompt = detections[0]
-        self.prompted_boxes.append(prompt.bbox)
+        self.call_count += 1
+        self.prompted_boxes.extend(prompt.bbox for prompt in detections)
+        masks = (
+            self._masks * len(detections)
+            if len(self._masks) == 1
+            else self._masks[: len(detections)]
+        )
         segmented: list[Detection2DBBox] = [
             Detection2DSeg(
                 bbox=prompt.bbox,
@@ -87,8 +116,9 @@ class _Segmenter:
                 name=prompt.name,
                 ts=prompt.ts,
                 image=detections.image,
-                mask=self._mask,
+                mask=mask,
             )
+            for prompt, mask in zip(detections, masks, strict=True)
         ]
         return ImageDetections2D(detections.image, segmented)
 
@@ -120,6 +150,48 @@ def _full_mask() -> np.ndarray:
     return np.ones((10, 10), dtype=np.uint8)
 
 
+def _range_estimator(
+    detector: _Detector | _NamedDetector,
+    segmenter: _Segmenter,
+    min_supporting_points: int = 5,
+) -> LidarRangeEstimator:
+    return LidarRangeEstimator(
+        EdgeTamObjectMaskEstimator(detector, segmenter),
+        min_supporting_points,
+    )
+
+
+def test_mask_estimator_batches_and_caches_without_pointcloud() -> None:
+    image = Image(data=np.zeros((10, 10, 3), dtype=np.uint8), ts=10.0)
+    left_mask = np.zeros((10, 10), dtype=np.uint8)
+    right_mask = np.zeros((10, 10), dtype=np.uint8)
+    left_mask[:, :4] = 1
+    right_mask[:, 5:] = 1
+    segmenter = _Segmenter([left_mask, right_mask])
+    estimator = EdgeTamObjectMaskEstimator(
+        _NamedDetector(
+            {
+                "left person": (0.0, 0.0, 4.0, 9.0),
+                "right person": (5.0, 0.0, 9.0, 9.0),
+            }
+        ),
+        segmenter,
+    )
+
+    left, right = estimator.estimate_many(image, ("left person", "right person"))
+    cached = estimator.estimate(image, "left person")
+
+    assert left.mask_area_px == 40
+    assert right.mask_area_px == 50
+    assert cached is left
+    assert segmenter.call_count == 1
+
+    image.ts = 11.0
+    estimator.estimate(image, "left person")
+
+    assert segmenter.call_count == 2
+
+
 def test_projects_transformed_points_and_rejects_invalid_projections() -> None:
     pointcloud = _PointCloud(
         np.array(
@@ -139,7 +211,7 @@ def test_projects_transformed_points_and_rejects_invalid_projections() -> None:
     mask = np.zeros((10, 10), dtype=np.uint8)
     mask[0, 2] = 1
 
-    evidence = EdgeTamLidarRangeEstimator(
+    evidence = _range_estimator(
         _Detector([(0.0, 0.0, 3.0, 2.0)]), _Segmenter(mask), min_supporting_points=1
     ).estimate(frame, "crate")
 
@@ -160,7 +232,7 @@ def test_mask_selection_uses_nearest_camera_z_point_per_pixel() -> None:
     mask = np.zeros((10, 10), dtype=np.uint8)
     mask[5, 5] = 1
 
-    evidence = EdgeTamLidarRangeEstimator(
+    evidence = _range_estimator(
         _Detector([(0.0, 0.0, 10.0, 10.0)]), _Segmenter(mask), min_supporting_points=1
     ).estimate(_frame(pointcloud), "chair")
 
@@ -171,21 +243,22 @@ def test_mask_selection_uses_nearest_camera_z_point_per_pixel() -> None:
 
 @pytest.mark.parametrize("boxes", [[], [(0.0, 0.0, 4.0, 4.0), (5.0, 5.0, 9.0, 9.0)]])
 def test_requires_exactly_one_valid_detection(boxes: list[BBox]) -> None:
-    estimator = EdgeTamLidarRangeEstimator(_Detector(boxes), _Segmenter(_full_mask()))
+    cloud = _PointCloud(np.array([[0.0, 0.0, 1.0]]))
+    estimator = _range_estimator(_Detector(boxes), _Segmenter(_full_mask()))
 
     with pytest.raises(InsufficientEvidenceError, match="exactly one valid detected"):
-        estimator.estimate(_frame(_PointCloud(np.array([[0.0, 0.0, 1.0]]))), "cup")
+        estimator.estimate(_frame(cloud), "cup")
+
+    assert cloud.read_count == 0
 
 
 def test_rejects_too_few_mask_supporting_points() -> None:
     pointcloud = _PointCloud(
         np.array([[-2.0, 0.0, 1.0], [-1.5, 0.0, 1.0], [-1.0, 0.0, 1.0], [-0.5, 0.0, 1.0]])
     )
-    estimator = EdgeTamLidarRangeEstimator(
-        _Detector([(0.0, 0.0, 10.0, 10.0)]), _Segmenter(_full_mask())
-    )
+    estimator = _range_estimator(_Detector([(0.0, 0.0, 10.0, 10.0)]), _Segmenter(_full_mask()))
 
-    with pytest.raises(InsufficientEvidenceError, match="at least 5 supporting points, got 4"):
+    with pytest.raises(InsufficientEvidenceError, match="at least 5 supporting points.*got 4"):
         estimator.estimate(_frame(pointcloud), "bottle")
 
 
@@ -193,7 +266,7 @@ def test_rejects_invalid_camera_intrinsics_before_projection() -> None:
     frame = _frame(_PointCloud(np.array([[0.0, 0.0, 1.0]])))
     frame.camera_info.K[0] = 0.0
 
-    estimator = EdgeTamLidarRangeEstimator(
+    estimator = _range_estimator(
         _Detector([(0.0, 0.0, 10.0, 10.0)]),
         _Segmenter(_full_mask()),
         min_supporting_points=1,
@@ -204,13 +277,13 @@ def test_rejects_invalid_camera_intrinsics_before_projection() -> None:
 
 
 def test_rejects_segmentation_mask_with_wrong_dimensions() -> None:
-    estimator = EdgeTamLidarRangeEstimator(
+    estimator = _range_estimator(
         _Detector([(0.0, 0.0, 10.0, 10.0)]),
         _Segmenter(np.ones((9, 10), dtype=np.uint8)),
         min_supporting_points=1,
     )
 
-    with pytest.raises(InsufficientEvidenceError, match="exactly one valid segmentation mask"):
+    with pytest.raises(InsufficientEvidenceError, match="one valid segmentation mask"):
         estimator.estimate(_frame(_PointCloud(np.array([[0.0, 0.0, 1.0]]))), "bottle")
 
 
@@ -219,7 +292,7 @@ def test_returns_median_euclidean_range_and_auditable_quartiles() -> None:
     expected_ranges = np.linalg.norm(points, axis=1)
     frame = _frame(_PointCloud(points), fx=1.0, fy=1.0, cx=0.0, cy=0.0)
 
-    evidence = EdgeTamLidarRangeEstimator(
+    evidence = _range_estimator(
         _Detector([(0.0, 0.0, 9.0, 9.0)]), _Segmenter(_full_mask())
     ).estimate(frame, "cone")
 
@@ -239,9 +312,7 @@ def test_projection_cache_reuses_across_objects_only_for_the_same_explicit_frame
     second_cloud = _PointCloud(points)
     first_frame = _frame(first_cloud, index=3, fx=1.0, fy=1.0, cx=0.0, cy=0.0)
     second_frame = _frame(second_cloud, index=3, fx=1.0, fy=1.0, cx=0.0, cy=0.0)
-    estimator = EdgeTamLidarRangeEstimator(
-        _Detector([(0.0, 0.0, 9.0, 9.0)]), _Segmenter(_full_mask())
-    )
+    estimator = _range_estimator(_Detector([(0.0, 0.0, 9.0, 9.0)]), _Segmenter(_full_mask()))
 
     estimator.estimate(first_frame, "box")
     estimator.estimate(first_frame, "crate")
@@ -249,3 +320,30 @@ def test_projection_cache_reuses_across_objects_only_for_the_same_explicit_frame
 
     assert first_cloud.read_count == 1
     assert second_cloud.read_count == 1
+
+
+def test_estimate_many_batches_masks_and_reuses_one_projection() -> None:
+    cloud = _PointCloud(np.array([[-1.5, 0.0, 1.0], [3.0, 0.0, 3.0]]))
+    left_mask = np.zeros((10, 10), dtype=np.uint8)
+    right_mask = np.zeros((10, 10), dtype=np.uint8)
+    left_mask[5, 2] = 1
+    right_mask[5, 7] = 1
+    segmenter = _Segmenter([left_mask, right_mask])
+    estimator = _range_estimator(
+        _NamedDetector(
+            {
+                "chair": (0.0, 0.0, 4.0, 9.0),
+                "table": (5.0, 0.0, 9.0, 9.0),
+            }
+        ),
+        segmenter,
+        min_supporting_points=1,
+    )
+
+    left, right = estimator.estimate_many(_frame(cloud), ("chair", "table"))
+
+    assert left.object_name == "chair"
+    assert right.object_name == "table"
+    assert left.camera_range_m < right.camera_range_m
+    assert segmenter.call_count == 1
+    assert cloud.read_count == 1

--- a/dimos/evals/vqa/test_cli.py
+++ b/dimos/evals/vqa/test_cli.py
@@ -45,7 +45,7 @@ def test_vqa_generate_cli_declares_single_image_input() -> None:
     assert "--stop" in output
     assert "--stride" in output
     assert "--calibration-profile" in output
-    assert "--sync-tolerance" in output
+    assert "--sync-tolerance" not in output
     assert "--output" in output
 
 

--- a/dimos/evals/vqa/test_cli.py
+++ b/dimos/evals/vqa/test_cli.py
@@ -44,6 +44,8 @@ def test_vqa_generate_cli_declares_single_image_input() -> None:
     assert "--start" in output
     assert "--stop" in output
     assert "--stride" in output
+    assert "--calibration-profile" in output
+    assert "--sync-tolerance" in output
     assert "--output" in output
 
 

--- a/dimos/evals/vqa/test_contracts.py
+++ b/dimos/evals/vqa/test_contracts.py
@@ -36,7 +36,6 @@ from dimos.evals.vqa.families import (
     AVAILABLE_FAMILIES,
     CLOSEST_OBJECT_FAMILY,
     LARGEST_VISIBLE_AREA_FAMILY,
-    OBJECT_DISTANCE_FAMILY,
     PRESENCE_FAMILY,
     answer_question,
 )
@@ -386,13 +385,6 @@ def test_presence_proposal_matches_available_family() -> None:
         "object_names": ["chair"],
     }
     assert proposal.family in [family.name for family in AVAILABLE_FAMILIES]
-
-
-def test_object_distance_family_is_available() -> None:
-    proposal = QuestionProposal(family="object_distance", object_names=("chair",))
-
-    assert OBJECT_DISTANCE_FAMILY.name == proposal.family
-    assert OBJECT_DISTANCE_FAMILY in AVAILABLE_FAMILIES
 
 
 def test_closest_object_proposal_requires_two_to_five_distinct_references() -> None:

--- a/dimos/evals/vqa/test_contracts.py
+++ b/dimos/evals/vqa/test_contracts.py
@@ -28,7 +28,9 @@ from dimos.evals.types import EvalRig
 from dimos.evals.vqa.author import OpenAIQuestionAuthor, QuestionAuthor
 from dimos.evals.vqa.families import (
     AVAILABLE_FAMILIES,
+    CLOSEST_OBJECT_FAMILY,
     OBJECT_DISTANCE_FAMILY,
+    PRESENCE_FAMILY,
     FamilyAnswer,
     FamilySpec,
     InsufficientEvidenceError,
@@ -42,7 +44,7 @@ from dimos.evals.vqa.generate import (
     PublicCase,
     generate_frames_dataset,
 )
-from dimos.evals.vqa.primitives.edgetam import ObjectRangeEvidence
+from dimos.evals.vqa.primitives.range import ObjectRangeEvidence
 from dimos.evals.vqa.suite import load_suite
 from dimos.msgs.sensor_msgs.Image import Image
 from dimos.perception.detection.type.detection2d.bbox import Detection2DBBox
@@ -55,20 +57,44 @@ if TYPE_CHECKING:
 
 class _Author:
     def propose(self, image: Image, families: Sequence[FamilySpec]) -> Sequence[QuestionProposal]:
-        return (QuestionProposal(family="presence", object_name="chair"),)
+        return (QuestionProposal(family="presence", object_names=("chair",)),)
 
 
 class _MixedAuthor:
     def propose(self, image: Image, families: Sequence[FamilySpec]) -> Sequence[QuestionProposal]:
         return (
-            QuestionProposal(family="horizontal_direction", object_name="chair"),
-            QuestionProposal(family="presence", object_name="chair"),
+            QuestionProposal(family="horizontal_direction", object_names=("chair",)),
+            QuestionProposal(family="presence", object_names=("chair",)),
         )
 
 
 class _DistanceAuthor:
     def propose(self, image: Image, families: Sequence[FamilySpec]) -> Sequence[QuestionProposal]:
-        return (QuestionProposal(family="object_distance", object_name="chair"),)
+        return (QuestionProposal(family="object_distance", object_names=("chair",)),)
+
+
+class _ClosestObjectAuthor:
+    def propose(self, image: Image, families: Sequence[FamilySpec]) -> Sequence[QuestionProposal]:
+        return (
+            QuestionProposal(
+                family="closest_object",
+                object_names=("left person", "right person", "chair"),
+            ),
+        )
+
+
+class _DuplicateClosestObjectAuthor:
+    def propose(self, image: Image, families: Sequence[FamilySpec]) -> Sequence[QuestionProposal]:
+        return (
+            QuestionProposal(
+                family="closest_object",
+                object_names=("left person", "right person", "chair"),
+            ),
+            QuestionProposal(
+                family="closest_object",
+                object_names=("chair", "right person", "left person"),
+            ),
+        )
 
 
 class _RecordingAuthor(_Author):
@@ -84,15 +110,15 @@ class _EmptyThenAuthor:
     def propose(self, image: Image, families: Sequence[FamilySpec]) -> Sequence[QuestionProposal]:
         if image.ts == 1.0:
             return ()
-        return (QuestionProposal(family="presence", object_name="chair"),)
+        return (QuestionProposal(family="presence", object_names=("chair",)),)
 
 
 class _CollidingAuthor:
     def propose(self, image: Image, families: Sequence[FamilySpec]) -> Sequence[QuestionProposal]:
         return (
-            QuestionProposal(family="presence", object_name="Chair"),
-            QuestionProposal(family="presence", object_name="chair"),
-            QuestionProposal(family="presence", object_name="Chair"),
+            QuestionProposal(family="presence", object_names=("Chair",)),
+            QuestionProposal(family="presence", object_names=("chair",)),
+            QuestionProposal(family="presence", object_names=("Chair",)),
         )
 
 
@@ -140,32 +166,38 @@ class _BoxesDetector:
 
 
 class _QuestionModel:
-    def query_json(self, image: Image, prompt: str) -> list[dict[str, str]]:
+    def query_json(self, image: Image, prompt: str) -> list[dict[str, object]]:
         assert "presence" in prompt
         assert "horizontal_direction" in prompt
         assert "object_count" in prompt
         assert "object_distance" in prompt
+        assert "closest_object" in prompt
         assert "JSON array" in prompt
         return [
-            {"family": "presence", "object_name": "chair"},
-            {"family": "horizontal_direction", "object_name": "robot"},
-            {"family": "object_count", "object_name": "box"},
-            {"family": "object_distance", "object_name": "chair"},
+            {"family": "presence", "object_names": ["chair"]},
+            {"family": "horizontal_direction", "object_names": ["robot"]},
+            {"family": "object_count", "object_names": ["box"]},
+            {"family": "object_distance", "object_names": ["chair"]},
+            {
+                "family": "closest_object",
+                "object_names": ["left person", "right person", "chair"],
+            },
         ]
 
 
 class _PartlyInvalidQuestionModel:
     def query_json(self, image: Image, prompt: str) -> list[object]:
         return [
-            {"family": "presence", "object_name": "chair"},
-            {"family": "unsupported", "object_name": "table"},
-            {"family": "presence", "object_name": "door", "answer": "yes"},
+            {"family": "presence", "object_names": ["chair"]},
+            {"family": "unsupported", "object_names": ["table"]},
+            {"family": "presence", "object_names": ["door"], "answer": "yes"},
         ]
 
 
 class _UnavailableFamilyQuestionModel:
-    def query_json(self, image: Image, prompt: str) -> list[dict[str, str]]:
-        return [{"family": "object_distance", "object_name": "chair"}]
+    def query_json(self, image: Image, prompt: str) -> list[dict[str, object]]:
+        assert "For closest_object" not in prompt
+        return [{"family": "object_distance", "object_names": ["chair"]}]
 
 
 class _BrokenDetector:
@@ -203,6 +235,78 @@ class _RangeEstimator:
             calibration_source="test",
         )
 
+    def estimate_many(
+        self, frame: CalibratedFrame, object_names: tuple[str, ...]
+    ) -> tuple[ObjectRangeEvidence, ...]:
+        return tuple(self.estimate(frame, object_name) for object_name in object_names)
+
+
+class _ClosestRangeEstimator:
+    def __init__(self, *quartiles: tuple[float, float, float]) -> None:
+        self._quartiles = quartiles
+
+    def estimate(self, frame: CalibratedFrame, object_name: str) -> ObjectRangeEvidence:
+        quartiles = self._quartiles[0]
+        box = (0.0, 0.0, 2.0, 2.0)
+        return ObjectRangeEvidence(
+            object_name=object_name,
+            camera_range_m=quartiles[1],
+            supporting_point_count=7,
+            prompt_bbox_xyxy=box,
+            mask_bbox_xyxy=box,
+            mask_area_px=4,
+            range_quartiles_m=quartiles,
+            synchronization_delta_s=0.02,
+            calibration_source="test",
+        )
+
+    def estimate_many(
+        self, frame: CalibratedFrame, object_names: tuple[str, ...]
+    ) -> tuple[ObjectRangeEvidence, ...]:
+        return tuple(
+            ObjectRangeEvidence(
+                object_name=object_name,
+                camera_range_m=quartiles[1],
+                supporting_point_count=7,
+                prompt_bbox_xyxy=(0.0, 0.0, 2.0, 2.0),
+                mask_bbox_xyxy=(0.0, 0.0, 2.0, 2.0),
+                mask_area_px=4,
+                range_quartiles_m=quartiles,
+                synchronization_delta_s=0.02,
+                calibration_source="test",
+            )
+            for object_name, quartiles in zip(
+                object_names,
+                self._quartiles,
+                strict=True,
+            )
+        )
+
+
+class _SingleOnlyClosestRangeEstimator:
+    def estimate(self, frame: CalibratedFrame, object_name: str) -> ObjectRangeEvidence:
+        closest = object_name == "left person"
+        quartiles = (1.0, 1.1, 1.2) if closest else (2.0, 2.1, 2.2)
+        box = (0.0, 0.0, 2.0, 2.0)
+        return ObjectRangeEvidence(
+            object_name=object_name,
+            camera_range_m=quartiles[1],
+            supporting_point_count=7,
+            prompt_bbox_xyxy=box,
+            mask_bbox_xyxy=box,
+            mask_area_px=4,
+            range_quartiles_m=quartiles,
+            synchronization_delta_s=0.02,
+            calibration_source="test",
+        )
+
+
+class _ReorderedClosestRangeEstimator(_ClosestRangeEstimator):
+    def estimate_many(
+        self, frame: CalibratedFrame, object_names: tuple[str, ...]
+    ) -> tuple[ObjectRangeEvidence, ...]:
+        return tuple(reversed(super().estimate_many(frame, object_names)))
+
 
 class _Rig:
     blind = False
@@ -214,22 +318,68 @@ class _Rig:
 
 
 def test_presence_proposal_matches_available_family() -> None:
-    proposal = QuestionProposal(family="presence", object_name="  chair  ")
+    proposal = QuestionProposal(family="presence", object_names=("  chair  ",))
 
-    assert proposal.object_name == "chair"
+    assert proposal.object_names == ("chair",)
+    assert proposal.model_dump(mode="json") == {
+        "family": "presence",
+        "object_names": ["chair"],
+    }
     assert proposal.family in [family.name for family in AVAILABLE_FAMILIES]
 
 
 def test_object_distance_family_is_available() -> None:
-    proposal = QuestionProposal(family="object_distance", object_name="chair")
+    proposal = QuestionProposal(family="object_distance", object_names=("chair",))
 
     assert OBJECT_DISTANCE_FAMILY.name == proposal.family
     assert OBJECT_DISTANCE_FAMILY in AVAILABLE_FAMILIES
 
 
+def test_closest_object_proposal_requires_two_to_five_distinct_references() -> None:
+    proposal = QuestionProposal(
+        family="closest_object",
+        object_names=("  left person ", "right person", "chair"),
+    )
+
+    assert proposal.object_names == ("left person", "right person", "chair")
+    assert proposal.model_dump(mode="json") == {
+        "family": "closest_object",
+        "object_names": ["left person", "right person", "chair"],
+    }
+    assert CLOSEST_OBJECT_FAMILY in AVAILABLE_FAMILIES
+    with pytest.raises(ValueError, match="distinct object names"):
+        CLOSEST_OBJECT_FAMILY.validate(
+            QuestionProposal(
+                family="closest_object",
+                object_names=("person", "Person"),
+            )
+        )
+    with pytest.raises(ValueError, match="2 to 5"):
+        CLOSEST_OBJECT_FAMILY.validate(
+            QuestionProposal(family="closest_object", object_names=("chair",))
+        )
+    with pytest.raises(ValueError, match="2 to 5"):
+        CLOSEST_OBJECT_FAMILY.validate(
+            QuestionProposal(
+                family="closest_object",
+                object_names=("a", "b", "c", "d", "e", "f"),
+            )
+        )
+    with pytest.raises(ValidationError):
+        QuestionProposal(
+            family="closest_object",
+            object_name="chair",
+            object_names=("chair", "table"),
+        )
+    with pytest.raises(ValueError, match="exactly 1 object name"):
+        PRESENCE_FAMILY.validate(
+            QuestionProposal(family="presence", object_names=("chair", "table"))
+        )
+
+
 def test_object_distance_requires_range_evidence() -> None:
     image = Image.from_numpy(np.zeros((4, 4, 3), dtype=np.uint8))
-    proposal = QuestionProposal(family="object_distance", object_name="chair")
+    proposal = QuestionProposal(family="object_distance", object_names=("chair",))
 
     with pytest.raises(InsufficientEvidenceError, match="calibrated point-cloud"):
         answer_question(proposal, image, _Detector(present=True))
@@ -246,7 +396,7 @@ def test_object_distance_requires_range_evidence() -> None:
 )
 def test_object_distance_buckets_range_evidence(range_m: float, expected: str) -> None:
     image = Image.from_numpy(np.zeros((4, 4, 3), dtype=np.uint8))
-    proposal = QuestionProposal(family="object_distance", object_name="chair")
+    proposal = QuestionProposal(family="object_distance", object_names=("chair",))
 
     answer = answer_question(
         proposal,
@@ -263,7 +413,7 @@ def test_object_distance_buckets_range_evidence(range_m: float, expected: str) -
 
 def test_object_distance_rejects_evidence_crossing_bucket_boundary() -> None:
     image = Image.from_numpy(np.zeros((4, 4, 3), dtype=np.uint8))
-    proposal = QuestionProposal(family="object_distance", object_name="chair")
+    proposal = QuestionProposal(family="object_distance", object_names=("chair",))
 
     with pytest.raises(InsufficientEvidenceError, match="uncertainty crosses"):
         answer_question(
@@ -275,10 +425,101 @@ def test_object_distance_rejects_evidence_crossing_bucket_boundary() -> None:
         )
 
 
+@pytest.mark.parametrize(
+    ("quartiles", "expected"),
+    (
+        (
+            ((1.0, 1.1, 1.2), (2.0, 2.1, 2.2), (3.0, 3.1, 3.2)),
+            "left person",
+        ),
+        (
+            ((3.0, 3.1, 3.2), (2.0, 2.1, 2.2), (1.0, 1.1, 1.2)),
+            "chair",
+        ),
+    ),
+)
+def test_closest_object_compares_multiple_named_references(
+    quartiles: tuple[tuple[float, float, float], ...],
+    expected: str,
+) -> None:
+    image = Image.from_numpy(np.zeros((4, 10, 3), dtype=np.uint8))
+    proposal = QuestionProposal(
+        family="closest_object",
+        object_names=("left person", "right person", "chair"),
+    )
+
+    answer = answer_question(
+        proposal,
+        image,
+        _Detector(present=True),
+        cast("CalibratedFrame", object()),
+        _ClosestRangeEstimator(*quartiles),
+    )
+
+    assert answer.answer == expected
+    assert answer.choices == ("left person", "right person", "chair")
+    assert answer.question == "Which object is closest to the camera?"
+    assert answer.evidence["comparison_rule"] == "closest_non_overlapping_interquartile_range"
+
+
+def test_closest_object_rejects_overlapping_range_intervals() -> None:
+    image = Image.from_numpy(np.zeros((4, 10, 3), dtype=np.uint8))
+    proposal = QuestionProposal(
+        family="closest_object",
+        object_names=("left person", "right person", "chair"),
+    )
+
+    with pytest.raises(InsufficientEvidenceError, match="does not establish"):
+        answer_question(
+            proposal,
+            image,
+            _Detector(present=True),
+            cast("CalibratedFrame", object()),
+            _ClosestRangeEstimator(
+                (1.0, 1.1, 1.2),
+                (1.1, 1.3, 1.5),
+                (3.0, 3.1, 3.2),
+            ),
+        )
+
+
+def test_closest_object_supports_single_object_range_estimators() -> None:
+    proposal = QuestionProposal(
+        family="closest_object",
+        object_names=("left person", "right person"),
+    )
+
+    answer = answer_question(
+        proposal,
+        Image.from_numpy(np.zeros((4, 10, 3), dtype=np.uint8)),
+        _Detector(present=True),
+        cast("CalibratedFrame", object()),
+        _SingleOnlyClosestRangeEstimator(),
+    )
+
+    assert answer.answer == "left person"
+
+
+def test_closest_object_rejects_reordered_range_results() -> None:
+    proposal = QuestionProposal(
+        family="closest_object",
+        object_names=("left person", "right person"),
+    )
+
+    with pytest.raises(ValueError, match="requested object order"):
+        answer_question(
+            proposal,
+            Image.from_numpy(np.zeros((4, 10, 3), dtype=np.uint8)),
+            _Detector(present=True),
+            cast("CalibratedFrame", object()),
+            _ReorderedClosestRangeEstimator((1.0, 1.1, 1.2), (2.0, 2.1, 2.2)),
+        )
+
+
 def test_question_proposal_rejects_unknown_fields() -> None:
     with pytest.raises(ValidationError):
         QuestionProposal.model_validate(
-            {"family": "presence", "object_name": "chair", "answer": "yes"}
+            {"family": "presence", "object_names": ["chair"], "answer": "yes"}
         )
 
 
@@ -293,7 +534,7 @@ def test_family_answer_requires_an_allowed_choice() -> None:
 
 def test_presence_family_derives_answer_from_detector_evidence() -> None:
     image = Image.from_numpy(np.zeros((4, 4, 3), dtype=np.uint8))
-    proposal = QuestionProposal(family="presence", object_name="chair")
+    proposal = QuestionProposal(family="presence", object_names=("chair",))
 
     present = answer_question(proposal, image, _Detector(present=True))
 
@@ -319,7 +560,7 @@ def test_horizontal_direction_uses_detection_center(
     box: tuple[float, float, float, float], expected: str
 ) -> None:
     image = Image.from_numpy(np.zeros((60, 90, 3), dtype=np.uint8))
-    proposal = QuestionProposal(family="horizontal_direction", object_name="robot")
+    proposal = QuestionProposal(family="horizontal_direction", object_names=("robot",))
 
     answer = answer_question(proposal, image, _BoxesDetector((box,)))
 
@@ -330,7 +571,7 @@ def test_horizontal_direction_uses_detection_center(
 
 def test_horizontal_direction_rejects_ambiguous_instances() -> None:
     image = Image.from_numpy(np.zeros((60, 90, 3), dtype=np.uint8))
-    proposal = QuestionProposal(family="horizontal_direction", object_name="chair")
+    proposal = QuestionProposal(family="horizontal_direction", object_names=("chair",))
     detector = _BoxesDetector(
         (
             (0.0, 0.0, 20.0, 20.0),
@@ -348,7 +589,7 @@ def test_horizontal_direction_rejects_ambiguous_instances() -> None:
 )
 def test_object_count_buckets_detected_instances(count: int, expected: str) -> None:
     image = Image.from_numpy(np.zeros((60, 90, 3), dtype=np.uint8))
-    proposal = QuestionProposal(family="object_count", object_name="box")
+    proposal = QuestionProposal(family="object_count", object_names=("box",))
     boxes = tuple((float(index), 0.0, float(index + 1), 1.0) for index in range(count))
 
     answer = answer_question(proposal, image, _BoxesDetector(boxes))
@@ -361,7 +602,7 @@ def test_object_count_buckets_detected_instances(count: int, expected: str) -> N
 
 def test_object_count_requires_at_least_one_detection() -> None:
     image = Image.from_numpy(np.zeros((60, 90, 3), dtype=np.uint8))
-    proposal = QuestionProposal(family="object_count", object_name="box")
+    proposal = QuestionProposal(family="object_count", object_names=("box",))
 
     with pytest.raises(InsufficientEvidenceError, match="to count"):
         answer_question(proposal, image, _BoxesDetector(()))
@@ -374,10 +615,14 @@ def test_openai_author_parses_constrained_proposals() -> None:
     proposals = author.propose(image, AVAILABLE_FAMILIES)
 
     assert proposals == (
-        QuestionProposal(family="presence", object_name="chair"),
-        QuestionProposal(family="horizontal_direction", object_name="robot"),
-        QuestionProposal(family="object_count", object_name="box"),
-        QuestionProposal(family="object_distance", object_name="chair"),
+        QuestionProposal(family="presence", object_names=("chair",)),
+        QuestionProposal(family="horizontal_direction", object_names=("robot",)),
+        QuestionProposal(family="object_count", object_names=("box",)),
+        QuestionProposal(family="object_distance", object_names=("chair",)),
+        QuestionProposal(
+            family="closest_object",
+            object_names=("left person", "right person", "chair"),
+        ),
     )
 
 
@@ -387,7 +632,7 @@ def test_openai_author_keeps_valid_items_from_partly_invalid_response() -> None:
 
     proposals = author.propose(image, AVAILABLE_FAMILIES)
 
-    assert proposals == (QuestionProposal(family="presence", object_name="chair"),)
+    assert proposals == (QuestionProposal(family="presence", object_names=("chair",)),)
 
 
 def test_openai_author_skips_unavailable_family() -> None:
@@ -509,6 +754,57 @@ def test_generate_distance_case_from_calibrated_frame(tmp_path: Path) -> None:
     )
     labels = [json.loads(line) for line in (output / "labels.jsonl").read_text().splitlines()]
     assert labels == [{"id": "frame-000004-chair-object_distance", "answer": "1 to under 2 meters"}]
+
+
+def test_generate_closest_object_case_from_calibrated_frame(tmp_path: Path) -> None:
+    output = tmp_path / "vqa"
+    image = Image.from_numpy(np.zeros((4, 10, 3), dtype=np.uint8), ts=12.5)
+    request = GenerationRequest(dataset="recording.db", image_index=4, output=output)
+
+    result = generate_frames_dataset(
+        request,
+        (GenerationFrame(4, image, cast("CalibratedFrame", object())),),
+        cast("QuestionAuthor", _ClosestObjectAuthor()),
+        _Detector(present=True),
+        _ClosestRangeEstimator(
+            (1.0, 1.1, 1.2),
+            (2.0, 2.1, 2.2),
+            (3.0, 3.1, 3.2),
+        ),
+    )
+
+    case_id = "frame-000004-left-person-vs-right-person-vs-chair-closest_object"
+    assert result.cases[0].id == case_id
+    assert result.cases[0].choices == ("left person", "right person", "chair")
+    labels = [json.loads(line) for line in (output / "labels.jsonl").read_text().splitlines()]
+    assert labels == [
+        {
+            "id": case_id,
+            "answer": "left person",
+        }
+    ]
+
+
+def test_generation_deduplicates_reordered_closest_object_references(tmp_path: Path) -> None:
+    result = generate_frames_dataset(
+        GenerationRequest(dataset="recording.db", image_index=4, output=tmp_path / "vqa"),
+        (
+            GenerationFrame(
+                4,
+                Image.from_numpy(np.zeros((4, 10, 3), dtype=np.uint8)),
+                cast("CalibratedFrame", object()),
+            ),
+        ),
+        cast("QuestionAuthor", _DuplicateClosestObjectAuthor()),
+        _Detector(present=True),
+        _ClosestRangeEstimator(
+            (1.0, 1.1, 1.2),
+            (2.0, 2.1, 2.2),
+            (3.0, 3.1, 3.2),
+        ),
+    )
+
+    assert len(result.cases) == 1
 
 
 def test_uncalibrated_frame_does_not_expose_distance_family(tmp_path: Path) -> None:

--- a/dimos/evals/vqa/test_contracts.py
+++ b/dimos/evals/vqa/test_contracts.py
@@ -923,7 +923,7 @@ def test_generate_closest_object_case_from_calibrated_frame(tmp_path: Path) -> N
         ),
     )
 
-    case_id = "frame-000004-left-person-vs-right-person-vs-chair-closest_object"
+    case_id = "frame-000004-chair-vs-left-person-vs-right-person-closest_object"
     assert result.cases[0].id == case_id
     assert result.cases[0].choices == ("left person", "right person", "chair")
     labels = [json.loads(line) for line in (output / "labels.jsonl").read_text().splitlines()]
@@ -972,6 +972,9 @@ def test_generation_deduplicates_reordered_closest_object_references(tmp_path: P
     )
 
     assert len(result.cases) == 1
+    assert result.cases[0].id == (
+        "frame-000004-chair-vs-left-person-vs-right-person-closest_object"
+    )
 
 
 def test_generation_deduplicates_reordered_largest_area_references(tmp_path: Path) -> None:
@@ -984,6 +987,7 @@ def test_generation_deduplicates_reordered_largest_area_references(tmp_path: Pat
     )
 
     assert len(result.cases) == 1
+    assert result.cases[0].id == "frame-000004-box-vs-chair-vs-table-largest_visible_area"
 
 
 def test_uncalibrated_frame_does_not_expose_distance_family(tmp_path: Path) -> None:

--- a/dimos/evals/vqa/test_contracts.py
+++ b/dimos/evals/vqa/test_contracts.py
@@ -28,6 +28,7 @@ from dimos.evals.types import EvalRig
 from dimos.evals.vqa.author import OpenAIQuestionAuthor, QuestionAuthor
 from dimos.evals.vqa.families import (
     AVAILABLE_FAMILIES,
+    OBJECT_DISTANCE_FAMILY,
     FamilyAnswer,
     FamilySpec,
     InsufficientEvidenceError,
@@ -35,17 +36,20 @@ from dimos.evals.vqa.families import (
     answer_question,
 )
 from dimos.evals.vqa.generate import (
+    GenerationFrame,
     GenerationRequest,
     PrivateLabel,
     PublicCase,
     generate_frames_dataset,
 )
+from dimos.evals.vqa.primitives.edgetam import ObjectRangeEvidence
 from dimos.evals.vqa.suite import load_suite
 from dimos.msgs.sensor_msgs.Image import Image
 from dimos.perception.detection.type.detection2d.bbox import Detection2DBBox
 from dimos.perception.detection.type.detection2d.imageDetections2D import ImageDetections2D
 
 if TYPE_CHECKING:
+    from dimos.evals.vqa.preprocessing import CalibratedFrame
     from dimos.models.vl.base import VlModel
 
 
@@ -60,6 +64,20 @@ class _MixedAuthor:
             QuestionProposal(family="horizontal_direction", object_name="chair"),
             QuestionProposal(family="presence", object_name="chair"),
         )
+
+
+class _DistanceAuthor:
+    def propose(self, image: Image, families: Sequence[FamilySpec]) -> Sequence[QuestionProposal]:
+        return (QuestionProposal(family="object_distance", object_name="chair"),)
+
+
+class _RecordingAuthor(_Author):
+    def __init__(self) -> None:
+        self.family_names: tuple[str, ...] = ()
+
+    def propose(self, image: Image, families: Sequence[FamilySpec]) -> Sequence[QuestionProposal]:
+        self.family_names = tuple(family.name for family in families)
+        return super().propose(image, families)
 
 
 class _EmptyThenAuthor:
@@ -126,11 +144,13 @@ class _QuestionModel:
         assert "presence" in prompt
         assert "horizontal_direction" in prompt
         assert "object_count" in prompt
+        assert "object_distance" in prompt
         assert "JSON array" in prompt
         return [
             {"family": "presence", "object_name": "chair"},
             {"family": "horizontal_direction", "object_name": "robot"},
             {"family": "object_count", "object_name": "box"},
+            {"family": "object_distance", "object_name": "chair"},
         ]
 
 
@@ -141,6 +161,11 @@ class _PartlyInvalidQuestionModel:
             {"family": "unsupported", "object_name": "table"},
             {"family": "presence", "object_name": "door", "answer": "yes"},
         ]
+
+
+class _UnavailableFamilyQuestionModel:
+    def query_json(self, image: Image, prompt: str) -> list[dict[str, str]]:
+        return [{"family": "object_distance", "object_name": "chair"}]
 
 
 class _BrokenDetector:
@@ -160,6 +185,25 @@ class _FailsSecondDetector(_Detector):
         return super().detect(image, object_name)
 
 
+class _RangeEstimator:
+    def __init__(self, range_m: float, quartiles: tuple[float, float, float] | None = None) -> None:
+        self._range_m = range_m
+        self._quartiles = quartiles or (range_m, range_m, range_m)
+
+    def estimate(self, frame: CalibratedFrame, object_name: str) -> ObjectRangeEvidence:
+        return ObjectRangeEvidence(
+            object_name=object_name,
+            camera_range_m=self._range_m,
+            supporting_point_count=7,
+            prompt_bbox_xyxy=(0.0, 0.0, 2.0, 2.0),
+            mask_bbox_xyxy=(0.0, 0.0, 2.0, 2.0),
+            mask_area_px=4,
+            range_quartiles_m=self._quartiles,
+            synchronization_delta_s=0.02,
+            calibration_source="test",
+        )
+
+
 class _Rig:
     blind = False
 
@@ -174,6 +218,61 @@ def test_presence_proposal_matches_available_family() -> None:
 
     assert proposal.object_name == "chair"
     assert proposal.family in [family.name for family in AVAILABLE_FAMILIES]
+
+
+def test_object_distance_family_is_available() -> None:
+    proposal = QuestionProposal(family="object_distance", object_name="chair")
+
+    assert OBJECT_DISTANCE_FAMILY.name == proposal.family
+    assert OBJECT_DISTANCE_FAMILY in AVAILABLE_FAMILIES
+
+
+def test_object_distance_requires_range_evidence() -> None:
+    image = Image.from_numpy(np.zeros((4, 4, 3), dtype=np.uint8))
+    proposal = QuestionProposal(family="object_distance", object_name="chair")
+
+    with pytest.raises(InsufficientEvidenceError, match="calibrated point-cloud"):
+        answer_question(proposal, image, _Detector(present=True))
+
+
+@pytest.mark.parametrize(
+    ("range_m", "expected"),
+    (
+        (0.99, "under 1 meter"),
+        (1.0, "1 to under 2 meters"),
+        (2.0, "2 to under 3 meters"),
+        (3.0, "3 meters or more"),
+    ),
+)
+def test_object_distance_buckets_range_evidence(range_m: float, expected: str) -> None:
+    image = Image.from_numpy(np.zeros((4, 4, 3), dtype=np.uint8))
+    proposal = QuestionProposal(family="object_distance", object_name="chair")
+
+    answer = answer_question(
+        proposal,
+        image,
+        _Detector(present=True),
+        cast("CalibratedFrame", object()),
+        _RangeEstimator(range_m),
+    )
+
+    assert answer.answer == expected
+    assert answer.evidence["camera_range_m"] == range_m
+    assert answer.evidence["supporting_point_count"] == 7
+
+
+def test_object_distance_rejects_evidence_crossing_bucket_boundary() -> None:
+    image = Image.from_numpy(np.zeros((4, 4, 3), dtype=np.uint8))
+    proposal = QuestionProposal(family="object_distance", object_name="chair")
+
+    with pytest.raises(InsufficientEvidenceError, match="uncertainty crosses"):
+        answer_question(
+            proposal,
+            image,
+            _Detector(present=True),
+            cast("CalibratedFrame", object()),
+            _RangeEstimator(2.01, (1.8, 2.01, 2.2)),
+        )
 
 
 def test_question_proposal_rejects_unknown_fields() -> None:
@@ -278,6 +377,7 @@ def test_openai_author_parses_constrained_proposals() -> None:
         QuestionProposal(family="presence", object_name="chair"),
         QuestionProposal(family="horizontal_direction", object_name="robot"),
         QuestionProposal(family="object_count", object_name="box"),
+        QuestionProposal(family="object_distance", object_name="chair"),
     )
 
 
@@ -288,6 +388,15 @@ def test_openai_author_keeps_valid_items_from_partly_invalid_response() -> None:
     proposals = author.propose(image, AVAILABLE_FAMILIES)
 
     assert proposals == (QuestionProposal(family="presence", object_name="chair"),)
+
+
+def test_openai_author_skips_unavailable_family() -> None:
+    image = Image.from_numpy(np.zeros((4, 4, 3), dtype=np.uint8))
+    author = OpenAIQuestionAuthor(cast("VlModel", _UnavailableFamilyQuestionModel()))
+
+    proposals = author.propose(image, (AVAILABLE_FAMILIES[0],))
+
+    assert proposals == ()
 
 
 def test_generation_request_selects_one_memory_image() -> None:
@@ -358,7 +467,7 @@ def test_generate_and_evaluate_one_image(tmp_path: Path) -> None:
 
     result = generate_frames_dataset(
         request,
-        ((4, image),),
+        (GenerationFrame(4, image),),
         cast("QuestionAuthor", _Author()),
         _Detector(present=True),
     )
@@ -378,6 +487,49 @@ def test_generate_and_evaluate_one_image(tmp_path: Path) -> None:
     assert evaluation.score == 1.0
 
 
+def test_generate_distance_case_from_calibrated_frame(tmp_path: Path) -> None:
+    output = tmp_path / "vqa"
+    image = Image.from_numpy(np.zeros((4, 4, 3), dtype=np.uint8), ts=12.5)
+    request = GenerationRequest(dataset="recording.db", image_index=4, output=output)
+
+    result = generate_frames_dataset(
+        request,
+        (GenerationFrame(4, image, cast("CalibratedFrame", object())),),
+        cast("QuestionAuthor", _DistanceAuthor()),
+        _Detector(present=True),
+        _RangeEstimator(1.5),
+    )
+
+    assert result.cases[0].id == "frame-000004-chair-object_distance"
+    assert result.cases[0].choices == (
+        "under 1 meter",
+        "1 to under 2 meters",
+        "2 to under 3 meters",
+        "3 meters or more",
+    )
+    labels = [json.loads(line) for line in (output / "labels.jsonl").read_text().splitlines()]
+    assert labels == [{"id": "frame-000004-chair-object_distance", "answer": "1 to under 2 meters"}]
+
+
+def test_uncalibrated_frame_does_not_expose_distance_family(tmp_path: Path) -> None:
+    output = tmp_path / "vqa"
+    image = Image.from_numpy(np.zeros((4, 4, 3), dtype=np.uint8), ts=12.5)
+    request = GenerationRequest(dataset="recording.db", image_index=4, output=output)
+    author = _RecordingAuthor()
+
+    generate_frames_dataset(
+        request,
+        (GenerationFrame(4, image),),
+        cast("QuestionAuthor", author),
+        _Detector(present=True),
+        _RangeEstimator(1.5),
+    )
+
+    assert author.family_names == ("presence", "horizontal_direction", "object_count")
+    run = json.loads((output / "audit" / "run.json").read_text())
+    assert run["families"] == ["presence", "horizontal_direction", "object_count"]
+
+
 def test_generate_multiple_images_aggregates_frame_artifacts(tmp_path: Path) -> None:
     output = tmp_path / "vqa"
     request = GenerationRequest(
@@ -388,8 +540,8 @@ def test_generate_multiple_images_aggregates_frame_artifacts(tmp_path: Path) -> 
         output=output,
     )
     frames = (
-        (1, Image.from_numpy(np.zeros((4, 4, 3), dtype=np.uint8), ts=1.0)),
-        (3, Image.from_numpy(np.zeros((4, 4, 3), dtype=np.uint8), ts=3.0)),
+        GenerationFrame(1, Image.from_numpy(np.zeros((4, 4, 3), dtype=np.uint8), ts=1.0)),
+        GenerationFrame(3, Image.from_numpy(np.zeros((4, 4, 3), dtype=np.uint8), ts=3.0)),
     )
 
     result = generate_frames_dataset(
@@ -424,8 +576,8 @@ def test_empty_frame_does_not_count_as_rejected_question(tmp_path: Path) -> None
     output = tmp_path / "vqa"
     request = GenerationRequest(dataset="recording.db", start=1, stop=3, output=output)
     frames = (
-        (1, Image.from_numpy(np.zeros((4, 4, 3), dtype=np.uint8), ts=1.0)),
-        (2, Image.from_numpy(np.zeros((4, 4, 3), dtype=np.uint8), ts=2.0)),
+        GenerationFrame(1, Image.from_numpy(np.zeros((4, 4, 3), dtype=np.uint8), ts=1.0)),
+        GenerationFrame(2, Image.from_numpy(np.zeros((4, 4, 3), dtype=np.uint8), ts=2.0)),
     )
 
     generate_frames_dataset(
@@ -454,7 +606,7 @@ def test_generation_keeps_answered_questions_and_audits_rejections(tmp_path: Pat
 
     result = generate_frames_dataset(
         request,
-        ((4, image),),
+        (GenerationFrame(4, image),),
         cast("QuestionAuthor", _MixedAuthor()),
         detector,
     )
@@ -473,7 +625,7 @@ def test_generation_propagates_detector_failures(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="detector broke"):
         generate_frames_dataset(
             request,
-            ((4, image),),
+            (GenerationFrame(4, image),),
             cast("QuestionAuthor", _Author()),
             _BrokenDetector(),
         )
@@ -485,8 +637,8 @@ def test_later_frame_failure_does_not_publish_partial_dataset(tmp_path: Path) ->
     output = tmp_path / "vqa"
     request = GenerationRequest(dataset="recording.db", start=1, stop=3, output=output)
     frames = (
-        (1, Image.from_numpy(np.zeros((4, 4, 3), dtype=np.uint8), ts=1.0)),
-        (2, Image.from_numpy(np.zeros((4, 4, 3), dtype=np.uint8), ts=2.0)),
+        GenerationFrame(1, Image.from_numpy(np.zeros((4, 4, 3), dtype=np.uint8), ts=1.0)),
+        GenerationFrame(2, Image.from_numpy(np.zeros((4, 4, 3), dtype=np.uint8), ts=2.0)),
     )
 
     with pytest.raises(ValueError, match="detector broke"):
@@ -507,7 +659,7 @@ def test_generation_deduplicates_proposals_and_suffixes_id_collisions(tmp_path: 
 
     result = generate_frames_dataset(
         request,
-        ((4, image),),
+        (GenerationFrame(4, image),),
         cast("QuestionAuthor", _CollidingAuthor()),
         _Detector(present=True),
     )

--- a/dimos/evals/vqa/test_contracts.py
+++ b/dimos/evals/vqa/test_contracts.py
@@ -44,6 +44,7 @@ from dimos.evals.vqa.generate import (
     GenerationRequest,
     PrivateLabel,
     PublicCase,
+    VqaGenerationConfig,
     generate_frames_dataset,
 )
 from dimos.evals.vqa.primitives.edgetam import ObjectMaskEvidence
@@ -800,6 +801,12 @@ def test_generation_request_defaults_output_under_state_directory() -> None:
     assert request.output_directory() == STATE_DIR / "datasets" / "vqa" / "go2_short-frames"
 
 
+def test_generation_config_validates_synchronization_tolerance() -> None:
+    assert VqaGenerationConfig().synchronization_tolerance_s == 0.1
+    with pytest.raises(ValidationError):
+        VqaGenerationConfig(synchronization_tolerance_s=0.0)
+
+
 def test_generation_request_selects_frame_range() -> None:
     request = GenerationRequest(
         dataset="go2_short",
@@ -1044,6 +1051,7 @@ def test_generate_multiple_images_aggregates_frame_artifacts(tmp_path: Path) -> 
         frames,
         cast("QuestionAuthor", _Author()),
         _Detector(present=True),
+        config=VqaGenerationConfig(synchronization_tolerance_s=0.025),
         model_names={"author": "gpt-4o-mini", "detector": "vikhyatk/moondream2"},
     )
 
@@ -1061,6 +1069,7 @@ def test_generate_multiple_images_aggregates_frame_artifacts(tmp_path: Path) -> 
     assert run["generation"]["start"] == 1
     assert run["generation"]["stop"] == 5
     assert run["generation"]["stride"] == 2
+    assert run["configuration"] == {"synchronization_tolerance_s": 0.025}
     assert run["models"] == {
         "author": "gpt-4o-mini",
         "detector": "vikhyatk/moondream2",

--- a/dimos/evals/vqa/test_contracts.py
+++ b/dimos/evals/vqa/test_contracts.py
@@ -26,15 +26,18 @@ import pytest
 from dimos.constants import STATE_DIR
 from dimos.evals.types import EvalRig
 from dimos.evals.vqa.author import OpenAIQuestionAuthor, QuestionAuthor
-from dimos.evals.vqa.families import (
-    AVAILABLE_FAMILIES,
-    CLOSEST_OBJECT_FAMILY,
-    OBJECT_DISTANCE_FAMILY,
-    PRESENCE_FAMILY,
+from dimos.evals.vqa.contracts import (
     FamilyAnswer,
     FamilySpec,
     InsufficientEvidenceError,
     QuestionProposal,
+)
+from dimos.evals.vqa.families import (
+    AVAILABLE_FAMILIES,
+    CLOSEST_OBJECT_FAMILY,
+    LARGEST_VISIBLE_AREA_FAMILY,
+    OBJECT_DISTANCE_FAMILY,
+    PRESENCE_FAMILY,
     answer_question,
 )
 from dimos.evals.vqa.generate import (
@@ -44,6 +47,7 @@ from dimos.evals.vqa.generate import (
     PublicCase,
     generate_frames_dataset,
 )
+from dimos.evals.vqa.primitives.edgetam import ObjectMaskEvidence
 from dimos.evals.vqa.primitives.range import ObjectRangeEvidence
 from dimos.evals.vqa.suite import load_suite
 from dimos.msgs.sensor_msgs.Image import Image
@@ -79,6 +83,25 @@ class _ClosestObjectAuthor:
             QuestionProposal(
                 family="closest_object",
                 object_names=("left person", "right person", "chair"),
+            ),
+        )
+
+
+class _CoverageAuthor:
+    def propose(self, image: Image, families: Sequence[FamilySpec]) -> Sequence[QuestionProposal]:
+        return (QuestionProposal(family="image_coverage", object_names=("chair",)),)
+
+
+class _DuplicateLargestVisibleAreaAuthor:
+    def propose(self, image: Image, families: Sequence[FamilySpec]) -> Sequence[QuestionProposal]:
+        return (
+            QuestionProposal(
+                family="largest_visible_area",
+                object_names=("chair", "table", "box"),
+            ),
+            QuestionProposal(
+                family="largest_visible_area",
+                object_names=("box", "chair", "table"),
             ),
         )
 
@@ -170,6 +193,8 @@ class _QuestionModel:
         assert "presence" in prompt
         assert "horizontal_direction" in prompt
         assert "object_count" in prompt
+        assert "image_coverage" in prompt
+        assert "largest_visible_area" in prompt
         assert "object_distance" in prompt
         assert "closest_object" in prompt
         assert "JSON array" in prompt
@@ -177,6 +202,11 @@ class _QuestionModel:
             {"family": "presence", "object_names": ["chair"]},
             {"family": "horizontal_direction", "object_names": ["robot"]},
             {"family": "object_count", "object_names": ["box"]},
+            {"family": "image_coverage", "object_names": ["chair"]},
+            {
+                "family": "largest_visible_area",
+                "object_names": ["chair", "table", "box"],
+            },
             {"family": "object_distance", "object_names": ["chair"]},
             {
                 "family": "closest_object",
@@ -239,6 +269,36 @@ class _RangeEstimator:
         self, frame: CalibratedFrame, object_names: tuple[str, ...]
     ) -> tuple[ObjectRangeEvidence, ...]:
         return tuple(self.estimate(frame, object_name) for object_name in object_names)
+
+
+class _MaskEstimator:
+    def __init__(self, areas: dict[str, int]) -> None:
+        self._areas = areas
+
+    def estimate(self, image: Image, object_name: str) -> ObjectMaskEvidence:
+        mask = np.zeros((image.height, image.width), dtype=bool)
+        mask.flat[: self._areas[object_name]] = True
+        box = (0.0, 0.0, float(image.width), float(image.height))
+        detection = Detection2DBBox(
+            bbox=box,
+            track_id=0,
+            class_id=-1,
+            confidence=1.0,
+            name=object_name,
+            ts=image.ts,
+            image=image,
+        )
+        return ObjectMaskEvidence(
+            object_name=object_name,
+            prompt_bbox_xyxy=box,
+            detection=detection,
+            mask=mask,
+        )
+
+    def estimate_many(
+        self, image: Image, object_names: tuple[str, ...]
+    ) -> tuple[ObjectMaskEvidence, ...]:
+        return tuple(self.estimate(image, object_name) for object_name in object_names)
 
 
 class _ClosestRangeEstimator:
@@ -608,6 +668,91 @@ def test_object_count_requires_at_least_one_detection() -> None:
         answer_question(proposal, image, _BoxesDetector(()))
 
 
+@pytest.mark.parametrize(
+    ("area", "expected", "boundaries", "margin"),
+    (
+        (24, "15% to under 35%", [15.0, 35.0, 65.0, 85.0], 9.0),
+        (40, "25% to under 50%", [25.0, 50.0, 75.0], 10.0),
+    ),
+)
+def test_image_coverage_chooses_scheme_with_largest_boundary_margin(
+    area: int,
+    expected: str,
+    boundaries: list[float],
+    margin: float,
+) -> None:
+    image = Image.from_numpy(np.zeros((10, 10, 3), dtype=np.uint8))
+    proposal = QuestionProposal(family="image_coverage", object_names=("chair",))
+
+    answer = answer_question(
+        proposal,
+        image,
+        _Detector(present=True),
+        mask_estimator=_MaskEstimator({"chair": area}),
+    )
+
+    assert answer.answer == expected
+    assert answer.evidence["coverage_percent"] == float(area)
+    assert answer.evidence["bucket_boundaries_percent"] == boundaries
+    assert answer.evidence["nearest_boundary_margin_percent"] == margin
+
+
+def test_image_coverage_requires_mask_evidence() -> None:
+    proposal = QuestionProposal(family="image_coverage", object_names=("chair",))
+
+    with pytest.raises(InsufficientEvidenceError, match="segmentation-mask"):
+        answer_question(
+            proposal,
+            Image.from_numpy(np.zeros((10, 10, 3), dtype=np.uint8)),
+            _Detector(present=True),
+        )
+
+
+def test_largest_visible_area_requires_distinct_references() -> None:
+    with pytest.raises(ValueError, match="distinct object names"):
+        LARGEST_VISIBLE_AREA_FAMILY.validate(
+            QuestionProposal(
+                family="largest_visible_area",
+                object_names=("chair", "Chair"),
+            )
+        )
+
+
+def test_largest_visible_area_accepts_winner_at_twenty_percent_margin() -> None:
+    image = Image.from_numpy(np.zeros((10, 10, 3), dtype=np.uint8))
+    proposal = QuestionProposal(
+        family="largest_visible_area",
+        object_names=("chair", "table", "box"),
+    )
+
+    answer = answer_question(
+        proposal,
+        image,
+        _Detector(present=True),
+        mask_estimator=_MaskEstimator({"chair": 50, "table": 60, "box": 10}),
+    )
+
+    assert answer.answer == "table"
+    assert answer.choices == ("chair", "table", "box")
+    assert answer.evidence["comparison_rule"] == "winner_at_least_20_percent_larger"
+
+
+def test_largest_visible_area_rejects_close_mask_areas() -> None:
+    image = Image.from_numpy(np.zeros((10, 10, 3), dtype=np.uint8))
+    proposal = QuestionProposal(
+        family="largest_visible_area",
+        object_names=("chair", "table"),
+    )
+
+    with pytest.raises(InsufficientEvidenceError, match="at least 20% larger"):
+        answer_question(
+            proposal,
+            image,
+            _Detector(present=True),
+            mask_estimator=_MaskEstimator({"chair": 50, "table": 59}),
+        )
+
+
 def test_openai_author_parses_constrained_proposals() -> None:
     image = Image.from_numpy(np.zeros((4, 4, 3), dtype=np.uint8))
     author = OpenAIQuestionAuthor(cast("VlModel", _QuestionModel()))
@@ -618,6 +763,11 @@ def test_openai_author_parses_constrained_proposals() -> None:
         QuestionProposal(family="presence", object_names=("chair",)),
         QuestionProposal(family="horizontal_direction", object_names=("robot",)),
         QuestionProposal(family="object_count", object_names=("box",)),
+        QuestionProposal(family="image_coverage", object_names=("chair",)),
+        QuestionProposal(
+            family="largest_visible_area",
+            object_names=("chair", "table", "box"),
+        ),
         QuestionProposal(family="object_distance", object_names=("chair",)),
         QuestionProposal(
             family="closest_object",
@@ -785,6 +935,23 @@ def test_generate_closest_object_case_from_calibrated_frame(tmp_path: Path) -> N
     ]
 
 
+def test_generate_image_coverage_case_without_pointcloud(tmp_path: Path) -> None:
+    output = tmp_path / "vqa"
+    image = Image.from_numpy(np.zeros((10, 10, 3), dtype=np.uint8), ts=12.5)
+
+    result = generate_frames_dataset(
+        GenerationRequest(dataset="recording.db", image_index=4, output=output),
+        (GenerationFrame(4, image),),
+        cast("QuestionAuthor", _CoverageAuthor()),
+        _Detector(present=True),
+        mask_estimator=_MaskEstimator({"chair": 24}),
+    )
+
+    assert result.cases[0].id == "frame-000004-chair-image_coverage"
+    labels = [json.loads(line) for line in (output / "labels.jsonl").read_text().splitlines()]
+    assert labels == [{"id": "frame-000004-chair-image_coverage", "answer": "15% to under 35%"}]
+
+
 def test_generation_deduplicates_reordered_closest_object_references(tmp_path: Path) -> None:
     result = generate_frames_dataset(
         GenerationRequest(dataset="recording.db", image_index=4, output=tmp_path / "vqa"),
@@ -807,6 +974,18 @@ def test_generation_deduplicates_reordered_closest_object_references(tmp_path: P
     assert len(result.cases) == 1
 
 
+def test_generation_deduplicates_reordered_largest_area_references(tmp_path: Path) -> None:
+    result = generate_frames_dataset(
+        GenerationRequest(dataset="recording.db", image_index=4, output=tmp_path / "vqa"),
+        (GenerationFrame(4, Image.from_numpy(np.zeros((10, 10, 3), dtype=np.uint8))),),
+        cast("QuestionAuthor", _DuplicateLargestVisibleAreaAuthor()),
+        _Detector(present=True),
+        mask_estimator=_MaskEstimator({"chair": 60, "table": 40, "box": 10}),
+    )
+
+    assert len(result.cases) == 1
+
+
 def test_uncalibrated_frame_does_not_expose_distance_family(tmp_path: Path) -> None:
     output = tmp_path / "vqa"
     image = Image.from_numpy(np.zeros((4, 4, 3), dtype=np.uint8), ts=12.5)
@@ -824,6 +1003,30 @@ def test_uncalibrated_frame_does_not_expose_distance_family(tmp_path: Path) -> N
     assert author.family_names == ("presence", "horizontal_direction", "object_count")
     run = json.loads((output / "audit" / "run.json").read_text())
     assert run["families"] == ["presence", "horizontal_direction", "object_count"]
+
+
+def test_uncalibrated_frame_exposes_mask_families_when_masks_are_available(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "vqa"
+    image = Image.from_numpy(np.zeros((10, 10, 3), dtype=np.uint8), ts=12.5)
+    author = _RecordingAuthor()
+
+    generate_frames_dataset(
+        GenerationRequest(dataset="recording.db", image_index=4, output=output),
+        (GenerationFrame(4, image),),
+        cast("QuestionAuthor", author),
+        _Detector(present=True),
+        mask_estimator=_MaskEstimator({"chair": 24}),
+    )
+
+    assert author.family_names == (
+        "presence",
+        "horizontal_direction",
+        "object_count",
+        "image_coverage",
+        "largest_visible_area",
+    )
 
 
 def test_generate_multiple_images_aggregates_frame_artifacts(tmp_path: Path) -> None:

--- a/dimos/evals/vqa/test_preprocessing.py
+++ b/dimos/evals/vqa/test_preprocessing.py
@@ -34,7 +34,7 @@ from dimos.msgs.sensor_msgs.CameraInfo import CameraInfo
 from dimos.msgs.sensor_msgs.Image import Image
 from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
 from dimos.msgs.tf2_msgs.TFMessage import TFMessage
-from dimos.robot.unitree.go2.connection import BASE_TO_OPTICAL
+from dimos.robot.unitree.go2.calibration import BASE_TO_OPTICAL
 
 
 def test_align_one_rejects_observation_outside_tolerance() -> None:

--- a/dimos/evals/vqa/test_preprocessing.py
+++ b/dimos/evals/vqa/test_preprocessing.py
@@ -20,6 +20,7 @@ import numpy as np
 import pytest
 
 from dimos.evals.vqa.preprocessing import (
+    FrameGeometryUnavailableError,
     RecordingFramePreprocessor,
     _align_one,
     _profile_pointcloud_to_camera,
@@ -27,6 +28,7 @@ from dimos.evals.vqa.preprocessing import (
 from dimos.memory.store.memory import MemoryStore
 from dimos.memory.store.sqlite import SqliteStore
 from dimos.memory.type.observation import Observation
+from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
 from dimos.msgs.geometry_msgs.Transform import Transform
 from dimos.msgs.sensor_msgs.CameraInfo import CameraInfo
 from dimos.msgs.sensor_msgs.Image import Image
@@ -63,6 +65,17 @@ def test_go2_profile_must_be_explicit_for_uncalibrated_recording(tmp_path: Path)
         preprocessor.start()
 
 
+def test_go2_profile_requires_odom_stream(tmp_path: Path) -> None:
+    recording = tmp_path / "recording.db"
+    with SqliteStore(path=recording) as store:
+        store.stream("color_image", Image)
+        store.stream("lidar", PointCloud2)
+
+    preprocessor = RecordingFramePreprocessor(recording, calibration_profile="go2")
+    with pytest.raises(ValueError, match="requires an 'odom' stream"):
+        preprocessor.start()
+
+
 @pytest.mark.parametrize(
     ("stream_name", "stream_type"), (("camera_info", CameraInfo), ("tf", TFMessage))
 )
@@ -80,21 +93,89 @@ def test_rejects_incomplete_recorded_calibration(
         preprocessor.start()
 
 
-def test_go2_profile_treats_image_observation_pose_as_world_from_base() -> None:
-    image = Observation[Image](
+def test_go2_profile_applies_camera_mount_once_to_world_from_base_odometry() -> None:
+    odom = Observation[PoseStamped](
         ts=10.0,
-        pose_tuple=(1.0, 2.0, 0.5, 0.0, 0.0, 0.0, 1.0),
-        _data=cast("Image", object()),
+        _data=PoseStamped(
+            ts=10.0,
+            frame_id="world",
+            position=(1.0, 2.0, 0.5),
+            orientation=(0.0, 0.0, 0.0, 1.0),
+        ),
     )
     lidar = Observation[PointCloud2](
         ts=10.0,
         _data=cast("PointCloud2", SimpleNamespace(frame_id="world")),
     )
 
-    pointcloud_to_camera = _profile_pointcloud_to_camera(image, lidar)
+    pointcloud_to_camera = _profile_pointcloud_to_camera(odom, lidar)
 
-    assert image.pose is not None
-    expected = -(Transform.from_pose("base_link", image.pose) + BASE_TO_OPTICAL)
+    expected = -(Transform.from_pose("base_link", odom.data) + BASE_TO_OPTICAL)
     assert pointcloud_to_camera.frame_id == "camera_optical"
     assert pointcloud_to_camera.child_frame_id == "world"
     assert np.allclose(pointcloud_to_camera.to_matrix(), expected.to_matrix())
+
+
+def test_go2_profile_load_uses_nearest_odom_instead_of_optical_image_pose(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    recording = tmp_path / "recording.db"
+    image = Image.from_numpy(
+        np.zeros((2, 2, 3), dtype=np.uint8),
+        frame_id="camera_optical",
+        ts=10.0,
+    )
+    cloud = PointCloud2.from_numpy(
+        np.array([[0.0, 0.0, 1.0]]),
+        frame_id="world",
+        timestamp=10.0,
+    )
+    nearest_odom = PoseStamped(
+        ts=10.01,
+        frame_id="world",
+        position=(1.0, 2.0, 0.5),
+        orientation=(0.0, 0.0, 0.0, 1.0),
+    )
+    world_from_camera = Transform.from_pose("base_link", nearest_odom) + BASE_TO_OPTICAL
+
+    with SqliteStore(path=recording) as store:
+        store.stream("color_image", Image).append(image, ts=10.0, pose=world_from_camera.to_pose())
+        store.stream("lidar", PointCloud2).append(cloud, ts=10.0)
+        odom = store.stream("odom", PoseStamped)
+        odom.append(PoseStamped(ts=9.95, frame_id="world", position=(9.0, 9.0, 0.0)), ts=9.95)
+        odom.append(nearest_odom, ts=10.01)
+
+    preprocessor = RecordingFramePreprocessor(recording, calibration_profile="go2")
+    output_info = CameraInfo.from_intrinsics(
+        1.0, 1.0, 0.0, 0.0, image.width, image.height, frame_id="camera_optical"
+    )
+    monkeypatch.setattr(
+        preprocessor._rectifier,
+        "rectify",
+        lambda source, calibration: (source, output_info),
+    )
+    with preprocessor:
+        frame = preprocessor.load(0)
+
+    correct = -world_from_camera
+    double_mounted = -(
+        Transform.from_pose("base_link", world_from_camera.to_pose()) + BASE_TO_OPTICAL
+    )
+    assert np.allclose(frame.pointcloud_to_camera.to_matrix(), correct.to_matrix())
+    assert not np.allclose(frame.pointcloud_to_camera.to_matrix(), double_mounted.to_matrix())
+
+
+def test_go2_profile_rejects_ambiguous_odometry_and_pointcloud_frames() -> None:
+    lidar = Observation[PointCloud2](
+        ts=10.0,
+        _data=cast("PointCloud2", SimpleNamespace(frame_id="world")),
+    )
+    odom = Observation[PoseStamped](ts=10.0, _data=PoseStamped(ts=10.0, frame_id="odom"))
+
+    with pytest.raises(FrameGeometryUnavailableError, match="frame_id='world'"):
+        _profile_pointcloud_to_camera(odom, lidar)
+
+    odom.data.frame_id = "world"
+    lidar.data.frame_id = "lidar"
+    with pytest.raises(FrameGeometryUnavailableError, match="world-frame point cloud"):
+        _profile_pointcloud_to_camera(odom, lidar)

--- a/dimos/evals/vqa/test_preprocessing.py
+++ b/dimos/evals/vqa/test_preprocessing.py
@@ -13,15 +13,24 @@
 # limitations under the License.
 
 from pathlib import Path
-from typing import Any
+from types import SimpleNamespace
+from typing import Any, cast
 
+import numpy as np
 import pytest
 
-from dimos.evals.vqa.preprocessing import RecordingFramePreprocessor, _align_one
+from dimos.evals.vqa.preprocessing import (
+    RecordingFramePreprocessor,
+    _align_one,
+    _profile_pointcloud_to_camera,
+)
 from dimos.memory.store.memory import MemoryStore
 from dimos.memory.store.sqlite import SqliteStore
+from dimos.memory.type.observation import Observation
+from dimos.msgs.geometry_msgs.Transform import Transform
 from dimos.msgs.sensor_msgs.Image import Image
 from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
+from dimos.robot.unitree.go2.connection import BASE_TO_OPTICAL
 
 
 def test_align_one_uses_nearest_observation_timestamp() -> None:
@@ -65,3 +74,23 @@ def test_go2_profile_must_be_explicit_for_uncalibrated_recording(tmp_path: Path)
     preprocessor = RecordingFramePreprocessor(recording)
     with pytest.raises(ValueError, match="calibration_profile='go2'"):
         preprocessor.start()
+
+
+def test_go2_profile_treats_legacy_image_pose_as_world_from_base() -> None:
+    image = Observation[Image](
+        ts=10.0,
+        pose_tuple=(1.0, 2.0, 0.5, 0.0, 0.0, 0.0, 1.0),
+        _data=cast("Image", object()),
+    )
+    lidar = Observation[PointCloud2](
+        ts=10.0,
+        _data=cast("PointCloud2", SimpleNamespace(frame_id="world")),
+    )
+
+    pointcloud_to_camera = _profile_pointcloud_to_camera(image, lidar)
+
+    assert image.pose is not None
+    expected = -(Transform.from_pose("base_link", image.pose) + BASE_TO_OPTICAL)
+    assert pointcloud_to_camera.frame_id == "camera_optical"
+    assert pointcloud_to_camera.child_frame_id == "world"
+    assert np.allclose(pointcloud_to_camera.to_matrix(), expected.to_matrix())

--- a/dimos/evals/vqa/test_preprocessing.py
+++ b/dimos/evals/vqa/test_preprocessing.py
@@ -28,8 +28,10 @@ from dimos.memory.store.memory import MemoryStore
 from dimos.memory.store.sqlite import SqliteStore
 from dimos.memory.type.observation import Observation
 from dimos.msgs.geometry_msgs.Transform import Transform
+from dimos.msgs.sensor_msgs.CameraInfo import CameraInfo
 from dimos.msgs.sensor_msgs.Image import Image
 from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
+from dimos.msgs.tf2_msgs.TFMessage import TFMessage
 from dimos.robot.unitree.go2.connection import BASE_TO_OPTICAL
 
 
@@ -61,7 +63,24 @@ def test_go2_profile_must_be_explicit_for_uncalibrated_recording(tmp_path: Path)
         preprocessor.start()
 
 
-def test_go2_profile_treats_legacy_image_pose_as_world_from_base() -> None:
+@pytest.mark.parametrize(
+    ("stream_name", "stream_type"), (("camera_info", CameraInfo), ("tf", TFMessage))
+)
+def test_rejects_incomplete_recorded_calibration(
+    stream_name: str, stream_type: type[Any], tmp_path: Path
+) -> None:
+    recording = tmp_path / "recording.db"
+    with SqliteStore(path=recording) as store:
+        store.stream("color_image", Image)
+        store.stream("lidar", PointCloud2)
+        store.stream(stream_name, stream_type)
+
+    preprocessor = RecordingFramePreprocessor(recording, calibration_profile="go2")
+    with pytest.raises(ValueError, match="camera_info and tf streams must both be present"):
+        preprocessor.start()
+
+
+def test_go2_profile_treats_image_observation_pose_as_world_from_base() -> None:
     image = Observation[Image](
         ts=10.0,
         pose_tuple=(1.0, 2.0, 0.5, 0.0, 0.0, 0.0, 1.0),

--- a/dimos/evals/vqa/test_preprocessing.py
+++ b/dimos/evals/vqa/test_preprocessing.py
@@ -33,21 +33,6 @@ from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
 from dimos.robot.unitree.go2.connection import BASE_TO_OPTICAL
 
 
-def test_align_one_uses_nearest_observation_timestamp() -> None:
-    with MemoryStore() as store:
-        images = store.stream("color_image", str)
-        lidar = store.stream("lidar", str)
-        images.append("payload timestamp is irrelevant", ts=10.0)
-        lidar.append("early", ts=9.8)
-        lidar.append("nearest", ts=9.97)
-        lidar.append("late", ts=10.08)
-
-        aligned = _align_one(images.order_by("ts"), lidar.order_by("ts"), 0.1)
-
-    assert aligned.data == "nearest"
-    assert aligned.ts == 9.97
-
-
 def test_align_one_rejects_observation_outside_tolerance() -> None:
     with MemoryStore() as store:
         images = store.stream("color_image", str)

--- a/dimos/evals/vqa/test_preprocessing.py
+++ b/dimos/evals/vqa/test_preprocessing.py
@@ -1,0 +1,67 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from dimos.evals.vqa.preprocessing import RecordingFramePreprocessor, _align_one
+from dimos.memory.store.memory import MemoryStore
+from dimos.memory.store.sqlite import SqliteStore
+from dimos.msgs.sensor_msgs.Image import Image
+from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
+
+
+def test_align_one_uses_nearest_observation_timestamp() -> None:
+    with MemoryStore() as store:
+        images = store.stream("color_image", str)
+        lidar = store.stream("lidar", str)
+        images.append("payload timestamp is irrelevant", ts=10.0)
+        lidar.append("early", ts=9.8)
+        lidar.append("nearest", ts=9.97)
+        lidar.append("late", ts=10.08)
+
+        aligned = _align_one(images.order_by("ts"), lidar.order_by("ts"), 0.1)
+
+    assert aligned.data == "nearest"
+    assert aligned.ts == 9.97
+
+
+def test_align_one_rejects_observation_outside_tolerance() -> None:
+    with MemoryStore() as store:
+        images = store.stream("color_image", str)
+        lidar = store.stream("lidar", str)
+        images.append("image", ts=10.0)
+        lidar.append("cloud", ts=10.11)
+
+        with pytest.raises(ValueError, match="within tolerance"):
+            _align_one(images.order_by("ts"), lidar.order_by("ts"), 0.1)
+
+
+@pytest.mark.parametrize("profile", ["GO2", "robot", ""])
+def test_calibration_profile_validation(profile: Any, tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="unsupported calibration profile"):
+        RecordingFramePreprocessor(tmp_path / "recording.db", calibration_profile=profile)
+
+
+def test_go2_profile_must_be_explicit_for_uncalibrated_recording(tmp_path: Path) -> None:
+    recording = tmp_path / "recording.db"
+    with SqliteStore(path=recording) as store:
+        store.stream("color_image", Image)
+        store.stream("lidar", PointCloud2)
+
+    preprocessor = RecordingFramePreprocessor(recording)
+    with pytest.raises(ValueError, match="calibration_profile='go2'"):
+        preprocessor.start()

--- a/dimos/models/segmentation/edge_tam.py
+++ b/dimos/models/segmentation/edge_tam.py
@@ -174,12 +174,14 @@ class EdgeTAMImageSegmenter:
         ]
         return ImageDetections2D(image, [det for det in detections if det.is_valid()])
 
-    def segment(self, detections: ImageDetections2D) -> ImageDetections2D:
+    def segment(
+        self, detections: ImageDetections2D[Detection2DBBox]
+    ) -> ImageDetections2D[Detection2DSeg]:
         """Refine box detections into mask detections (Detection2DSeg)."""
         import cv2
 
         if not len(detections):
-            return detections
+            return ImageDetections2D(detections.image, [])
 
         image = detections.image
         rgb = cv2.cvtColor(image.to_opencv(), cv2.COLOR_BGR2RGB)
@@ -196,7 +198,7 @@ class EdgeTAMImageSegmenter:
             masks, _, _ = self._predictor.predict(box=boxes, multimask_output=False)
 
         masks = masks.reshape(-1, *masks.shape[-2:])  # (N, H, W) regardless of batch dim
-        segmented: list[Detection2DBBox] = [
+        segmented: list[Detection2DSeg] = [
             Detection2DSeg.from_sam2_result(
                 mask,
                 det.track_id,

--- a/dimos/perception/detection/type/detection3d/pointcloud.py
+++ b/dimos/perception/detection/type/detection3d/pointcloud.py
@@ -39,6 +39,108 @@ if TYPE_CHECKING:
     from dimos.perception.detection.type.detection2d.bbox import Detection2DBBox
 
 
+@dataclass(frozen=True)
+class ProjectedPointCloud:
+    """Point-cloud samples projected once into a calibrated image."""
+
+    source_points: np.ndarray
+    camera_points: np.ndarray
+    image_points: np.ndarray
+    image_width: int
+    image_height: int
+
+    @classmethod
+    def from_pointcloud(
+        cls,
+        pointcloud: PointCloud2,
+        camera_info: CameraInfo,
+        pointcloud_to_camera: Transform,
+    ) -> ProjectedPointCloud:
+        """Transform and project valid points into image coordinates."""
+        intrinsics = np.asarray(camera_info.K, dtype=np.float64)
+        if intrinsics.size != 9:
+            raise ValueError("camera intrinsics must contain nine values")
+        intrinsics = intrinsics.reshape(3, 3)
+        if not np.all(np.isfinite(intrinsics)) or intrinsics[0, 0] <= 0 or intrinsics[1, 1] <= 0:
+            raise ValueError("camera intrinsics must be finite with positive focal lengths")
+        if camera_info.width <= 0 or camera_info.height <= 0:
+            raise ValueError("camera calibration dimensions must be positive")
+
+        raw_points, _ = pointcloud.as_numpy()
+        source_points = np.asarray(raw_points, dtype=np.float64)
+        if source_points.ndim != 2 or source_points.shape[1] != 3:
+            raise ValueError("point cloud positions must have shape (N, 3)")
+        source_points = source_points[np.all(np.isfinite(source_points), axis=1)]
+
+        transform = np.asarray(pointcloud_to_camera.to_matrix(), dtype=np.float64)
+        if transform.shape != (4, 4) or not np.all(np.isfinite(transform)):
+            raise ValueError("pointcloud_to_camera must be a finite 4x4 transform")
+        homogeneous = np.column_stack(
+            (source_points, np.ones(len(source_points), dtype=np.float64))
+        )
+        camera_points = (transform @ homogeneous.T).T[:, :3]
+        in_front = np.all(np.isfinite(camera_points), axis=1) & (camera_points[:, 2] > 0)
+        source_points = source_points[in_front]
+        camera_points = camera_points[in_front]
+
+        projected = (intrinsics @ camera_points.T).T
+        image_points = projected[:, :2] / projected[:, 2, np.newaxis]
+        in_image = (
+            np.all(np.isfinite(image_points), axis=1)
+            & (image_points[:, 0] >= 0)
+            & (image_points[:, 0] < camera_info.width)
+            & (image_points[:, 1] >= 0)
+            & (image_points[:, 1] < camera_info.height)
+        )
+        return cls(
+            source_points=source_points[in_image],
+            camera_points=camera_points[in_image],
+            image_points=image_points[in_image],
+            image_width=camera_info.width,
+            image_height=camera_info.height,
+        )
+
+    def points_in_detection(
+        self,
+        detection: Detection2DBBox,
+        *,
+        nearest_per_pixel: bool = False,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Return source- and camera-frame points inside one mask or box."""
+        mask = getattr(detection, "mask", None)
+        if mask is not None:
+            mask = np.asarray(mask)
+            if mask.ndim != 2 or mask.shape != (self.image_height, self.image_width):
+                raise ValueError("segmentation mask dimensions must match the calibrated image")
+            pixels = self.image_points.astype(np.intp)
+            selected = mask[pixels[:, 1], pixels[:, 0]] > 0
+        else:
+            x_min, y_min, x_max, y_max = detection.bbox
+            margin = 5
+            selected = (
+                (self.image_points[:, 0] >= x_min - margin)
+                & (self.image_points[:, 0] <= x_max + margin)
+                & (self.image_points[:, 1] >= y_min - margin)
+                & (self.image_points[:, 1] <= y_max + margin)
+            )
+
+        source_points = self.source_points[selected]
+        camera_points = self.camera_points[selected]
+        image_points = self.image_points[selected]
+        if nearest_per_pixel and len(image_points):
+            pixels = image_points.astype(np.intp)
+            linear_pixels = pixels[:, 1] * self.image_width + pixels[:, 0]
+            order = np.lexsort((camera_points[:, 2], linear_pixels))
+            sorted_linear = linear_pixels[order]
+            first_per_pixel = np.empty(len(order), dtype=bool)
+            first_per_pixel[0] = True
+            first_per_pixel[1:] = sorted_linear[1:] != sorted_linear[:-1]
+            keep = order[first_per_pixel]
+            source_points = source_points[keep]
+            camera_points = camera_points[keep]
+        return source_points, camera_points
+
+
 @dataclass
 class Detection3DPC(Detection3D):
     pointcloud: PointCloud2 = field(default_factory=PointCloud2)
@@ -235,65 +337,10 @@ class Detection3DPC(Detection3D):
                 statistical(),
             ]
 
-        # Extract camera parameters
-        fx, fy = camera_info.K[0], camera_info.K[4]
-        cx, cy = camera_info.K[2], camera_info.K[5]
-        image_width = camera_info.width
-        image_height = camera_info.height
-
-        camera_matrix = np.array([[fx, 0, cx], [0, fy, cy], [0, 0, 1]])
-
-        # Convert pointcloud to numpy array
-        world_points, _ = world_pointcloud.as_numpy()
-
-        # Project points to camera frame
-        points_homogeneous = np.hstack([world_points, np.ones((world_points.shape[0], 1))])
-        extrinsics_matrix = world_to_optical_transform.to_matrix()
-        points_camera = (extrinsics_matrix @ points_homogeneous.T).T
-
-        # Filter out points behind the camera
-        valid_mask = points_camera[:, 2] > 0
-        points_camera = points_camera[valid_mask]
-        world_points = world_points[valid_mask]
-
-        if len(world_points) == 0:
-            return None
-
-        # Project to 2D
-        points_2d_homogeneous = (camera_matrix @ points_camera[:, :3].T).T
-        points_2d = points_2d_homogeneous[:, :2] / points_2d_homogeneous[:, 2:3]
-
-        # Filter points within image bounds
-        in_image_mask = (
-            (points_2d[:, 0] >= 0)
-            & (points_2d[:, 0] < image_width)
-            & (points_2d[:, 1] >= 0)
-            & (points_2d[:, 1] < image_height)
+        projected = ProjectedPointCloud.from_pointcloud(
+            world_pointcloud, camera_info, world_to_optical_transform
         )
-        points_2d = points_2d[in_image_mask]
-        world_points = world_points[in_image_mask]
-
-        if len(world_points) == 0:
-            return None
-
-        # Find points within this detection — segmentation mask if present
-        # (Detection2DSeg), else bbox with a small margin
-        seg_mask = getattr(det, "mask", None)
-        if seg_mask is not None:
-            cols = np.minimum(points_2d[:, 0].astype(int), seg_mask.shape[1] - 1)
-            rows = np.minimum(points_2d[:, 1].astype(int), seg_mask.shape[0] - 1)
-            in_det_mask = seg_mask[rows, cols] > 0
-        else:
-            x_min, y_min, x_max, y_max = det.bbox
-            margin = 5  # pixels
-            in_det_mask = (
-                (points_2d[:, 0] >= x_min - margin)
-                & (points_2d[:, 0] <= x_max + margin)
-                & (points_2d[:, 1] >= y_min - margin)
-                & (points_2d[:, 1] <= y_max + margin)
-            )
-
-        detection_points = world_points[in_det_mask]
+        detection_points, _ = projected.points_in_detection(det)
 
         if detection_points.shape[0] == 0:
             # print(f"No points found in detection bbox after projection. {det.name}")

--- a/dimos/perception/detection/type/detection3d/test_pointcloud.py
+++ b/dimos/perception/detection/type/detection3d/test_pointcloud.py
@@ -12,14 +12,108 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Any
+
 import numpy as np
 import pytest
+
+from dimos.msgs.geometry_msgs.Transform import Transform
+from dimos.msgs.sensor_msgs.CameraInfo import CameraInfo
+from dimos.msgs.sensor_msgs.Image import Image
+from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
+from dimos.perception.detection.type.detection2d.bbox import Detection2DBBox
+from dimos.perception.detection.type.detection2d.seg import Detection2DSeg
+from dimos.perception.detection.type.detection3d.pointcloud import Detection3DPC
 
 pytestmark = pytest.mark.self_hosted
 
 
+def _projection_context() -> tuple[Image, CameraInfo, Transform]:
+    image = Image.from_numpy(np.zeros((10, 10, 3), dtype=np.uint8), ts=3.0)
+    camera_info = CameraInfo.from_intrinsics(
+        1.0,
+        1.0,
+        0.0,
+        0.0,
+        image.width,
+        image.height,
+        frame_id="camera_optical",
+    )
+    world_to_optical = Transform(
+        frame_id="camera_optical",
+        child_frame_id="world",
+        ts=image.ts,
+    )
+    return image, camera_info, world_to_optical
+
+
+def test_from_2d_selects_bbox_points_and_preserves_cloud_metadata() -> None:
+    image, camera_info, world_to_optical = _projection_context()
+    detection = Detection2DBBox(
+        bbox=(0.0, 0.0, 1.0, 1.0),
+        track_id=4,
+        class_id=2,
+        confidence=0.9,
+        name="object",
+        ts=image.ts,
+        image=image,
+    )
+    cloud = PointCloud2.from_numpy(
+        np.asarray(((1.0, 1.0, 1.0), (6.0, 6.0, 1.0), (8.0, 8.0, 1.0))),
+        frame_id="world",
+        timestamp=2.0,
+    )
+
+    result = Detection3DPC.from_2d(
+        detection,
+        cloud,
+        camera_info,
+        world_to_optical,
+        filters=[],
+    )
+
+    assert result is not None
+    points, _ = result.pointcloud.as_numpy()
+    assert np.allclose(points, ((1.0, 1.0, 1.0), (6.0, 6.0, 1.0)))
+    assert result.pointcloud.frame_id == "world"
+    assert result.pointcloud.ts == 2.0
+    assert result.ts == image.ts
+
+
+def test_from_2d_prefers_segmentation_mask_over_bbox() -> None:
+    image, camera_info, world_to_optical = _projection_context()
+    mask = np.zeros((image.height, image.width), dtype=np.uint8)
+    mask[2, 2] = 255
+    detection = Detection2DSeg(
+        bbox=(0.0, 0.0, 9.0, 9.0),
+        track_id=0,
+        class_id=0,
+        confidence=1.0,
+        name="object",
+        ts=image.ts,
+        image=image,
+        mask=mask,
+    )
+    cloud = PointCloud2.from_numpy(
+        np.asarray(((1.0, 1.0, 1.0), (2.0, 2.0, 1.0))),
+        timestamp=2.0,
+    )
+
+    result = Detection3DPC.from_2d(
+        detection,
+        cloud,
+        camera_info,
+        world_to_optical,
+        filters=[],
+    )
+
+    assert result is not None
+    points, _ = result.pointcloud.as_numpy()
+    assert np.allclose(points, ((2.0, 2.0, 1.0),))
+
+
 @pytest.mark.skipif_macos_bug
-def test_detection3dpc(detection3dpc) -> None:
+def test_detection3dpc(detection3dpc: Any) -> None:
     # def test_oriented_bounding_box(detection3dpc):
     """Test oriented bounding box calculation and values."""
     obb = detection3dpc.get_oriented_bounding_box()

--- a/dimos/perception/detection/type/detection3d/test_pointcloud.py
+++ b/dimos/perception/detection/type/detection3d/test_pointcloud.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any
-
 import numpy as np
 import pytest
 
@@ -24,8 +22,6 @@ from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
 from dimos.perception.detection.type.detection2d.bbox import Detection2DBBox
 from dimos.perception.detection.type.detection2d.seg import Detection2DSeg
 from dimos.perception.detection.type.detection3d.pointcloud import Detection3DPC
-
-pytestmark = pytest.mark.self_hosted
 
 
 def _projection_context() -> tuple[Image, CameraInfo, Transform]:
@@ -112,8 +108,9 @@ def test_from_2d_prefers_segmentation_mask_over_bbox() -> None:
     assert np.allclose(points, ((2.0, 2.0, 1.0),))
 
 
+@pytest.mark.self_hosted
 @pytest.mark.skipif_macos_bug
-def test_detection3dpc(detection3dpc: Any) -> None:
+def test_detection3dpc(detection3dpc) -> None:
     # def test_oriented_bounding_box(detection3dpc):
     """Test oriented bounding box calculation and values."""
     obb = detection3dpc.get_oriented_bounding_box()

--- a/dimos/robot/unitree/go2/calibration.py
+++ b/dimos/robot/unitree/go2/calibration.py
@@ -1,0 +1,46 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Static front-camera calibration for the Unitree Go2."""
+
+from importlib import resources
+
+from dimos.msgs.geometry_msgs.Quaternion import Quaternion
+from dimos.msgs.geometry_msgs.Transform import Transform
+from dimos.msgs.geometry_msgs.Vector3 import Vector3
+from dimos.msgs.sensor_msgs.CameraInfo import CameraInfo
+
+_FRONT_CAMERA_720_YAML = resources.files("dimos.robot.unitree.go2").joinpath(
+    "front_camera_720.yaml"
+)
+
+
+def camera_info_static() -> CameraInfo:
+    """Load the calibrated front-camera intrinsics."""
+    with resources.as_file(_FRONT_CAMERA_720_YAML) as yaml_path:
+        return CameraInfo.from_yaml(str(yaml_path))
+
+
+# Static camera mount chain: base_link -> camera_link -> camera_optical.
+BASE_TO_OPTICAL: Transform = Transform(
+    translation=Vector3(0.3, 0.0, 0.0),
+    rotation=Quaternion(0.0, 0.0, 0.0, 1.0),
+    frame_id="base_link",
+    child_frame_id="camera_link",
+) + Transform(
+    translation=Vector3(0.0, 0.0, 0.0),
+    rotation=Quaternion(-0.5, 0.5, -0.5, 0.5),
+    frame_id="camera_link",
+    child_frame_id="camera_optical",
+)

--- a/dimos/robot/unitree/go2/connection.py
+++ b/dimos/robot/unitree/go2/connection.py
@@ -14,7 +14,6 @@
 
 import copy
 from enum import Enum
-from importlib import resources
 import sys
 from threading import Thread
 import time
@@ -44,6 +43,10 @@ from dimos.msgs.sensor_msgs.Image import Image
 from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
 from dimos.msgs.tf2_msgs.TFMessage import TFMessage
 from dimos.robot.unitree.connection import UnitreeWebRTCConnection
+from dimos.robot.unitree.go2.calibration import (
+    BASE_TO_OPTICAL as BASE_TO_OPTICAL,
+    camera_info_static as _camera_info_static,
+)
 from dimos.robot.unitree.type.lowstate import LowStateMsg
 from dimos.spec.perception import Camera, Pointcloud
 from dimos.utils.decorators.decorators import cached_property, simple_mcache
@@ -102,36 +105,11 @@ class Go2ConnectionProtocol(Protocol):
     def publish_request(self, topic: str, data: dict) -> dict: ...  # type: ignore[type-arg]
 
 
-_FRONT_CAMERA_720_YAML = resources.files("dimos.robot.unitree.go2").joinpath(
-    "front_camera_720.yaml"
-)
-
-
-def _camera_info_static() -> CameraInfo:
-    with resources.as_file(_FRONT_CAMERA_720_YAML) as yaml_path:
-        return CameraInfo.from_yaml(str(yaml_path))
-
-
 def _prefixed(prefix: str | None, name: str) -> str:
     """Apply a TF namespace prefix (ModuleConfig.frame_id_prefix) to a frame name."""
     if not prefix or not name:
         return name
     return f"{prefix}/{name}"
-
-
-# Static camera mount chain: base_link -> camera_link -> camera_optical.
-# TODO we need a standardized way to specify this for all cameras in dimos
-BASE_TO_OPTICAL: Transform = Transform(
-    translation=Vector3(0.3, 0.0, 0.0),
-    rotation=Quaternion(0.0, 0.0, 0.0, 1.0),
-    frame_id="base_link",
-    child_frame_id="camera_link",
-) + Transform(
-    translation=Vector3(0.0, 0.0, 0.0),
-    rotation=Quaternion(-0.5, 0.5, -0.5, 0.5),
-    frame_id="camera_link",
-    child_frame_id="camera_optical",
-)
 
 
 def make_connection(

--- a/dimos/robot/unitree/go2/test_calibration.py
+++ b/dimos/robot/unitree/go2/test_calibration.py
@@ -1,0 +1,25 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dimos.robot.unitree.go2.calibration import BASE_TO_OPTICAL, camera_info_static
+
+
+def test_front_camera_calibration() -> None:
+    camera_info = camera_info_static()
+
+    assert camera_info_static() is not camera_info
+    assert camera_info.frame_id == "camera_optical"
+    assert (camera_info.width, camera_info.height) == (1280, 720)
+    assert BASE_TO_OPTICAL.frame_id == "base_link"
+    assert BASE_TO_OPTICAL.child_frame_id == "camera_optical"

--- a/docs/usage/vqa.md
+++ b/docs/usage/vqa.md
@@ -29,7 +29,8 @@ Generated datasets default to:
 
 Use `--output <directory>` to override that location. The destination must be empty.
 
-Go2 recordings without `camera_info` and `tf` require the explicit fallback profile:
+Go2 recordings without `camera_info` and `tf` require the explicit fallback profile and a recorded
+`odom` stream:
 
 ```bash skip
 dimos evals vqa generate go2_short.db --image-index 500 --calibration-profile go2

--- a/docs/usage/vqa.md
+++ b/docs/usage/vqa.md
@@ -60,7 +60,7 @@ Distance questions require one Moondream detection, one EdgeTAM mask, and at lea
 LiDAR points. Evidence whose range quartiles cross an answer boundary is rejected.
 Closest-object questions accept references such as `left person`, `right person`, and `chair`, which
 lets Moondream distinguish repeated categories. They are rejected unless every reference has exactly
-one detection or the closest range interval overlaps any other candidate.
+one detection and the closest range interval does not overlap any other candidate.
 
 Image-coverage questions choose between two bucket schemes so the measured mask coverage is as far
 as possible from the nearest answer boundary. Largest-visible-area questions are rejected unless the

--- a/docs/usage/vqa.md
+++ b/docs/usage/vqa.md
@@ -48,6 +48,8 @@ answers. Every proposal uses `object_names`; single-object families require one 
 | `presence` | yes, no | At least one Moondream detection |
 | `horizontal_direction` | left, center, right | Exactly one detection; use its horizontal center |
 | `object_count` | one, two, three, four or more | Count Moondream detections |
+| `image_coverage` | Adaptive percentage buckets | Divide EdgeTAM mask pixels by image pixels |
+| `largest_visible_area` | Two to five authored object references | Select a mask at least 20% larger than the runner-up |
 | `object_distance` | under 1 m, 1 to under 2 m, 2 to under 3 m, 3 m or more | Median LiDAR range inside an EdgeTAM mask |
 | `closest_object` | Two to five authored object references | Select the smallest unambiguous LiDAR range |
 
@@ -59,6 +61,11 @@ LiDAR points. Evidence whose range quartiles cross an answer boundary is rejecte
 Closest-object questions accept references such as `left person`, `right person`, and `chair`, which
 lets Moondream distinguish repeated categories. They are rejected unless every reference has exactly
 one detection or the closest range interval overlaps any other candidate.
+
+Image-coverage questions choose between two bucket schemes so the measured mask coverage is as far
+as possible from the nearest answer boundary. Largest-visible-area questions are rejected unless the
+winning EdgeTAM mask contains at least 20% more pixels than the runner-up. Both families work without
+point-cloud data.
 
 ## Dataset Layout
 
@@ -93,9 +100,11 @@ writes results under `~/.local/state/dimos/evals/run-*/`.
 ## Architecture
 
 - `author.py` proposes constrained family inputs from an image.
+- `contracts.py` defines shared proposals, answers, family metadata, and the detector interface.
 - `families.py` owns question text, choices, and deterministic answer rules.
 - `preprocessing.py` synchronizes and calibrates image and point-cloud frames.
-- `primitives/edgetam.py` segments objects and estimates LiDAR-backed range.
+- `primitives/edgetam.py` detects and segments objects with a shared per-image mask cache.
+- `primitives/range.py` combines cached masks with projected point clouds for range evidence.
 - `primitives/moondream.py` supplies private object detections.
 - `generate.py` loads frames, reuses models, and writes datasets atomically.
 - `suite.py` validates generated artifacts and creates shared evaluation cases.

--- a/docs/usage/vqa.md
+++ b/docs/usage/vqa.md
@@ -40,7 +40,8 @@ Image and LiDAR observations must be within `--sync-tolerance` seconds, which de
 ## Question Families
 
 The image-only question author selects object names and applicable families. It does not produce
-answers.
+answers. Every proposal uses `object_names`; single-object families require one entry, while
+`closest_object` requires two to five.
 
 | Family | Choices | Evidence rule |
 |---|---|---|
@@ -48,12 +49,16 @@ answers.
 | `horizontal_direction` | left, center, right | Exactly one detection; use its horizontal center |
 | `object_count` | one, two, three, four or more | Count Moondream detections |
 | `object_distance` | under 1 m, 1 to under 2 m, 2 to under 3 m, 3 m or more | Median LiDAR range inside an EdgeTAM mask |
+| `closest_object` | Two to five authored object references | Select the smallest unambiguous LiDAR range |
 
 Proposals without sufficient evidence are rejected and retained in the private audit. If no proposal
 can be answered, generation fails without publishing a dataset.
 
 Distance questions require one Moondream detection, one EdgeTAM mask, and at least five projected
 LiDAR points. Evidence whose range quartiles cross an answer boundary is rejected.
+Closest-object questions accept references such as `left person`, `right person`, and `chair`, which
+lets Moondream distinguish repeated categories. They are rejected unless every reference has exactly
+one detection or the closest range interval overlaps any other candidate.
 
 ## Dataset Layout
 

--- a/docs/usage/vqa.md
+++ b/docs/usage/vqa.md
@@ -29,6 +29,14 @@ Generated datasets default to:
 
 Use `--output <directory>` to override that location. The destination must be empty.
 
+Legacy Go2 recordings without `camera_info` and `tf` require explicit calibration:
+
+```bash skip
+dimos evals vqa generate go2_short.db --image-index 500 --calibration-profile go2
+```
+
+Image and LiDAR observations must be within `--sync-tolerance` seconds, which defaults to `0.1`.
+
 ## Question Families
 
 The image-only question author selects object names and applicable families. It does not produce
@@ -39,9 +47,13 @@ answers.
 | `presence` | yes, no | At least one Moondream detection |
 | `horizontal_direction` | left, center, right | Exactly one detection; use its horizontal center |
 | `object_count` | one, two, three, four or more | Count Moondream detections |
+| `object_distance` | under 1 m, 1 to under 2 m, 2 to under 3 m, 3 m or more | Median LiDAR range inside an EdgeTAM mask |
 
 Proposals without sufficient evidence are rejected and retained in the private audit. If no proposal
 can be answered, generation fails without publishing a dataset.
+
+Distance questions require one Moondream detection, one EdgeTAM mask, and at least five projected
+LiDAR points. Evidence whose range quartiles cross an answer boundary is rejected.
 
 ## Dataset Layout
 
@@ -77,6 +89,8 @@ writes results under `~/.local/state/dimos/evals/run-*/`.
 
 - `author.py` proposes constrained family inputs from an image.
 - `families.py` owns question text, choices, and deterministic answer rules.
+- `preprocessing.py` synchronizes and calibrates image and point-cloud frames.
+- `primitives/edgetam.py` segments objects and estimates LiDAR-backed range.
 - `primitives/moondream.py` supplies private object detections.
 - `generate.py` loads frames, reuses models, and writes datasets atomically.
 - `suite.py` validates generated artifacts and creates shared evaluation cases.

--- a/docs/usage/vqa.md
+++ b/docs/usage/vqa.md
@@ -29,13 +29,14 @@ Generated datasets default to:
 
 Use `--output <directory>` to override that location. The destination must be empty.
 
-Legacy Go2 recordings without `camera_info` and `tf` require explicit calibration:
+Go2 recordings without `camera_info` and `tf` require the explicit fallback profile:
 
 ```bash skip
 dimos evals vqa generate go2_short.db --image-index 500 --calibration-profile go2
 ```
 
-Image and LiDAR observations must be within `--sync-tolerance` seconds, which defaults to `0.1`.
+Recordings containing only one calibration stream are rejected. The VQA generation configuration
+requires image and LiDAR observations to be within `0.1` seconds by default.
 
 ## Question Families
 
@@ -100,10 +101,10 @@ writes results under `~/.local/state/dimos/evals/run-*/`.
 ## Architecture
 
 - `author.py` proposes constrained family inputs from an image.
-- `contracts.py` defines shared proposals, answers, family metadata, and the detector interface.
+- `contracts.py` defines shared proposals, answers, family metadata, and evidence interfaces.
 - `families.py` owns question text, choices, and deterministic answer rules.
 - `preprocessing.py` synchronizes and calibrates image and point-cloud frames.
-- `primitives/edgetam.py` detects and segments objects with a shared per-image mask cache.
+- `primitives/edgetam.py` runs the detection-to-segmentation pipeline with a per-image mask cache.
 - `primitives/range.py` combines cached masks with projected point clouds for range evidence.
 - `primitives/moondream.py` supplies private object detections.
 - `generate.py` loads frames, reuses models, and writes datasets atomically.


### PR DESCRIPTION
## Summary
- extract the Go2 front-camera intrinsics and base-to-optical transform into a lightweight calibration module
- preserve the existing connection exports and fresh CameraInfo factory behavior
- let VQA preprocessing use Go2 calibration without importing Go2Connection or WebRTC dependencies

## Why
The VQA recording fallback only needs static calibration. Importing the robot connection for those values unnecessarily loads the WebRTC connection stack.

## Testing
- `uv run --no-sync pytest dimos/evals/vqa dimos/robot/unitree/go2/test_calibration.py dimos/robot/unitree/go2/test_connection.py dimos/codebase_checks/test_inline_heavy_imports.py dimos/perception/detection/type/detection3d/test_pointcloud.py -m "not self_hosted"` (98 passed, 1 deselected)
- `uv run --no-sync mypy dimos/evals/vqa dimos/robot/unitree/go2/calibration.py dimos/robot/unitree/go2/connection.py dimos/perception/detection/type/detection3d/pointcloud.py`
- `uv run --no-sync pre-commit run --all-files`
- verified importing `dimos.evals.vqa.preprocessing` does not import `dimos.robot.unitree.go2.connection` or `unitree_webrtc_connect`

## Stack
- depends on #3492
- merge #3492 first