### PR TITLE
cuvslam: range-gated depth cloud output

### DIFF
--- a/dimos/mapping/cuvslam/cuvslam.py
+++ b/dimos/mapping/cuvslam/cuvslam.py
@@ -33,6 +33,7 @@ from dimos.msgs.sensor_msgs.CameraInfo import CameraInfo
 from dimos.msgs.sensor_msgs.Image import Image
 from dimos.msgs.sensor_msgs.Imu import Imu
 from dimos.msgs.sensor_msgs.ImuInfo import ImuInfo
+from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
 from dimos.msgs.tf2_msgs.TFMessage import TFMessage
 from dimos.utils.logging_config import setup_logger
 
@@ -206,6 +207,12 @@ class CuvslamConfig(NativeModuleConfig):
     # rgbd only: raw depth units per metre. cuVSLAM assumes 1, and depth images are
     # 16-bit millimetres.
     depth_units_per_meter: float = 1000.0
+    # Range gate on the published depth_cloud, in metres; 0 leaves the far side open.
+    # Stereo depth error grows as range squared, so the far gate is what decides whether
+    # the cloud is worth mapping with: on a D455 indoors, 4 m more than doubled voxel
+    # agreement with a lidar map over the ungated cloud.
+    depth_cloud_min_range: float = 0.0
+    depth_cloud_max_range: float = 4.0
 
 
 class CuvslamOdometry(NativeModule):
@@ -220,7 +227,8 @@ class CuvslamOdometry(NativeModule):
 
     ``odometry`` is one continuous ``odom`` -> ``base_link`` path; restarts after a
     tracking loss are rebased onto the last published pose. ``tf`` carries
-    ``odom`` -> ``base_link`` and an identity ``map`` -> ``odom``.
+    ``odom`` -> ``base_link`` and an identity ``map`` -> ``odom``. ``depth_cloud`` is
+    the range-gated depth cloud, in the depth sensor's own frame.
     """
 
     config: CuvslamConfig
@@ -233,4 +241,6 @@ class CuvslamOdometry(NativeModule):
     imu_info: In[ImuInfo]
 
     odometry: Out[Odometry]
+    # rgbd only: the depth sensor's own points, range-gated, in the depth frame.
+    depth_cloud: Out[PointCloud2]
     tf: IO[TFMessage]

--- a/dimos/mapping/cuvslam/cuvslam.py
+++ b/dimos/mapping/cuvslam/cuvslam.py
@@ -155,11 +155,11 @@ class CuvslamConfig(NativeModuleConfig):
     cwd: str | None = str(MODULE_DIR)
     executable: str = "result/bin/cuvslam_odometry"
     # The module lives in dimSLAM (cuVSLAM + the Rust module built on it); dimos just
-    # builds the pinned rev (fused-odom-rust tip; tag on merge). `nix build`
+    # builds the pinned rev (jeff/feat/depth_clean_cloud tip; tag on merge). `nix build`
     # drops the `result` symlink in the cwd.
     build_command: str | None = Field(
         default_factory=lambda: "nix build github:dimensionalOS/dimSLAM/"
-        f"f64e67879b6ef969360e8341c140ecbcb43f2637#{sdk_variant()}"
+        f"b8022eba82c9bd589a32b384dfe7f0c15e3c4189#{sdk_variant()}"
     )
     stdin_config: bool = True
     extra_env: dict[str, str] = Field(default_factory=_driver_env)


### PR DESCRIPTION
Stacked on #3538 (dimSLAM wheel+IMU/ESKF), which is stacked on #3391.

- `depth_cloud: Out[PointCloud2]` — the depth sensor's own points, in its own frame
- `depth_cloud_min_range` / `depth_cloud_max_range` config, default 0 / 4 m
- pins dimSLAM `b8022eb` (branch `jeff/feat/depth_clean_cloud`), which does the deprojection + gate

Measured on the Alfred recording, D455 depth vs a point-lio lidar voxel map (5 cm voxels): ungated IoU 0.0086, 4 m gate 0.0197.