### PR TITLE
fix(cli): config default vs ~/.config/dimos directory collision

### DIFF
--- a/dimos/cli/dimos.py
+++ b/dimos/cli/dimos.py
@@ -83,6 +83,15 @@ load_dotenv()
 SIMULATORS = ("mujoco", "dimsim")
 
 
+def default_config_path() -> Path:
+    """~/.config/dimos used to BE the config file; it is now a directory (it holds
+    credentials.json since `dimos login`), so config moved inside it."""
+    legacy = CONFIG_DIR / "dimos"
+    if legacy.is_file():
+        return legacy
+    return legacy / "config.json"
+
+
 def _normalize_simulation_argv(argv: list[str]) -> list[str]:
     """Keep `--simulation` backwards compatible.
 
@@ -207,7 +216,7 @@ def run(
     daemon: bool = typer.Option(False, "--daemon", "-d", help="Run in background"),
     disable: list[str] = typer.Option([], "--disable", help="Module names to disable"),
     config_path: Path = typer.Option(
-        CONFIG_DIR / "dimos", "--config", "-c", help="Path to config file"
+        default_config_path(), "--config", "-c", help="Path to config file"
     ),
     local_relay: bool | None = typer.Option(
         None,

--- a/dimos/core/coordination/blueprint_config/sources.py
+++ b/dimos/core/coordination/blueprint_config/sources.py
@@ -66,7 +66,7 @@ def validate_global_values(values: Mapping[str, Any]) -> dict[str, Any]:
 def read_config_file(path: Path) -> Mapping[str, Any]:
     try:
         raw = path.read_text()
-    except FileNotFoundError:
+    except (FileNotFoundError, IsADirectoryError):
         return {}
     except OSError as error:
         raise BlueprintConfigError(f"Could not read config file {path}: {error}") from error


### PR DESCRIPTION
`dimos run`'s `--config` default was the FILE `~/.config/dimos`; since `dimos login` that path is a DIRECTORY (holds `credentials.json`), so `dimos run` with default config errors with `Is a directory` on any machine that has logged in (13 test_dimos failures locally). Default is now `~/.config/dimos/config.json` — a legacy config FILE at the old path is still honored — and `read_config_file` treats a directory as absent. Found while building `dimos data`; env-dependent, so CI never caught it.