### PR TITLE
feat(cli): ~/.config/dimos becomes a real config directory

### DIFF
--- a/dimos/cli/cloud.py
+++ b/dimos/cli/cloud.py
@@ -34,7 +34,7 @@ import urllib.request
 
 import typer
 
-from dimos.constants import CREDENTIALS_PATH, reject_legacy_config
+from dimos.constants import CREDENTIALS_PATH
 from dimos.core.global_config import global_config
 
 _KEYRING_SERVICE = "dimos-cloud"
@@ -67,7 +67,6 @@ def _store(key: str) -> str:
     if kr := _keyring():
         kr.set_password(_KEYRING_SERVICE, _KEYRING_USER, key)
         return "system keyring"
-    reject_legacy_config()
     CREDENTIALS_PATH.parent.mkdir(parents=True, exist_ok=True)
     # No keyring backend (typical on robots): owner-only file, the same convention
     # gh / aws / kubectl use for exactly this situation.

--- a/dimos/cli/cloud.py
+++ b/dimos/cli/cloud.py
@@ -34,7 +34,7 @@ import urllib.request
 
 import typer
 
-from dimos.constants import CREDENTIALS_PATH, migrate_legacy_config
+from dimos.constants import CREDENTIALS_PATH, reject_legacy_config
 from dimos.core.global_config import global_config
 
 _KEYRING_SERVICE = "dimos-cloud"
@@ -67,7 +67,7 @@ def _store(key: str) -> str:
     if kr := _keyring():
         kr.set_password(_KEYRING_SERVICE, _KEYRING_USER, key)
         return "system keyring"
-    migrate_legacy_config()
+    reject_legacy_config()
     CREDENTIALS_PATH.parent.mkdir(parents=True, exist_ok=True)
     # No keyring backend (typical on robots): owner-only file, the same convention
     # gh / aws / kubectl use for exactly this situation.

--- a/dimos/cli/cloud.py
+++ b/dimos/cli/cloud.py
@@ -34,7 +34,7 @@ import urllib.request
 
 import typer
 
-from dimos.constants import CREDENTIALS_PATH
+from dimos.constants import CREDENTIALS_PATH, migrate_legacy_config
 from dimos.core.global_config import global_config
 
 _KEYRING_SERVICE = "dimos-cloud"
@@ -67,6 +67,7 @@ def _store(key: str) -> str:
     if kr := _keyring():
         kr.set_password(_KEYRING_SERVICE, _KEYRING_USER, key)
         return "system keyring"
+    migrate_legacy_config()
     CREDENTIALS_PATH.parent.mkdir(parents=True, exist_ok=True)
     # No keyring backend (typical on robots): owner-only file, the same convention
     # gh / aws / kubectl use for exactly this situation.

--- a/dimos/cli/dimos.py
+++ b/dimos/cli/dimos.py
@@ -82,12 +82,12 @@ load_dotenv()
 
 SIMULATORS = ("mujoco", "dimsim")
 
-DEFAULT_CONFIG_PATH = CONFIG_DIR / "dimos" / "config.json"
+DEFAULT_CONFIG_PATH = CONFIG_DIR / "dimos" / "config"
 
 
 def _migrate_legacy_config() -> None:
     """~/.config/dimos used to BE the config file; it is now a directory holding
-    config.json (and future per-machine config). Move an old flat file inside."""
+    `config` (and future per-machine config). Move an old flat file inside."""
     legacy = CONFIG_DIR / "dimos"
     if not legacy.is_file():
         return
@@ -95,8 +95,8 @@ def _migrate_legacy_config() -> None:
         tmp = legacy.with_name("dimos.migrating")
         legacy.rename(tmp)
         legacy.mkdir()
-        tmp.rename(legacy / "config.json")
-        typer.echo(f"config migrated: {legacy} -> {legacy / 'config.json'}", err=True)
+        tmp.rename(legacy / "config")
+        typer.echo(f"config migrated: {legacy} -> {legacy / 'config'}", err=True)
     except OSError:
         # ponytail: lost a migration race with a concurrent dimos run; the winner
         # already moved it.

--- a/dimos/cli/dimos.py
+++ b/dimos/cli/dimos.py
@@ -234,7 +234,8 @@ def run(
     show_help: bool = typer.Option(False, "--help"),
 ) -> None:
     """Start a robot blueprint"""
-    _reject_legacy_config()
+    if config_path == DEFAULT_CONFIG_PATH:
+        _reject_legacy_config()
     from dimos.core.coordination.blueprint_config.errors import BlueprintConfigError
     from dimos.core.coordination.blueprint_config.parser import (
         BlueprintConfigParser,

--- a/dimos/cli/dimos.py
+++ b/dimos/cli/dimos.py
@@ -82,6 +82,26 @@ load_dotenv()
 
 SIMULATORS = ("mujoco", "dimsim")
 
+DEFAULT_CONFIG_PATH = CONFIG_DIR / "dimos" / "config.json"
+
+
+def _migrate_legacy_config() -> None:
+    """~/.config/dimos used to BE the config file; it is now a directory holding
+    config.json (and future per-machine config). Move an old flat file inside."""
+    legacy = CONFIG_DIR / "dimos"
+    if not legacy.is_file():
+        return
+    try:
+        tmp = legacy.with_name("dimos.migrating")
+        legacy.rename(tmp)
+        legacy.mkdir()
+        tmp.rename(legacy / "config.json")
+        typer.echo(f"config migrated: {legacy} -> {legacy / 'config.json'}", err=True)
+    except OSError:
+        # ponytail: lost a migration race with a concurrent dimos run; the winner
+        # already moved it.
+        pass
+
 
 def _normalize_simulation_argv(argv: list[str]) -> list[str]:
     """Keep `--simulation` backwards compatible.
@@ -207,7 +227,7 @@ def run(
     daemon: bool = typer.Option(False, "--daemon", "-d", help="Run in background"),
     disable: list[str] = typer.Option([], "--disable", help="Module names to disable"),
     config_path: Path = typer.Option(
-        CONFIG_DIR / "dimos", "--config", "-c", help="Path to config file"
+        DEFAULT_CONFIG_PATH, "--config", "-c", help="Path to config file"
     ),
     local_relay: bool | None = typer.Option(
         None,
@@ -220,6 +240,7 @@ def run(
     show_help: bool = typer.Option(False, "--help"),
 ) -> None:
     """Start a robot blueprint"""
+    _migrate_legacy_config()
     from dimos.core.coordination.blueprint_config.errors import BlueprintConfigError
     from dimos.core.coordination.blueprint_config.parser import (
         BlueprintConfigParser,

--- a/dimos/cli/dimos.py
+++ b/dimos/cli/dimos.py
@@ -53,7 +53,7 @@ from dimos.cli.cache import app as cache_app
 from dimos.cli.cloud import login as cloud_login, logout as cloud_logout, whoami as cloud_whoami
 from dimos.cli.hardware_cli import app as hardware_app
 from dimos.cli.shell import shell
-from dimos.constants import CONFIG_DIR, LOG_DIR
+from dimos.constants import CONFIG_DIR, LOG_DIR, migrate_legacy_config
 from dimos.core.daemon import daemonize, install_signal_handlers
 from dimos.core.global_config import GlobalConfig, global_config
 from dimos.core.run_registry import get_most_recent, is_pid_alive, stop_entry
@@ -86,19 +86,8 @@ DEFAULT_CONFIG_PATH = CONFIG_DIR / "dimos" / "config"
 
 
 def _migrate_legacy_config() -> None:
-    """~/.config/dimos used to BE the config file; it is now a directory holding
-    `config` (and future per-machine config). Move an old flat file inside."""
-    legacy = CONFIG_DIR / "dimos"
-    if not legacy.is_file():
-        return
-    try:
-        tmp = legacy.with_name("dimos.migrating")
-        legacy.rename(tmp)
-        legacy.mkdir()
-        tmp.rename(legacy / "config")
-        typer.echo(f"config migrated: {legacy} -> {legacy / 'config'}", err=True)
-    except OSError:
-        pass  # lost a migration race; the winner already moved it
+    if migrate_legacy_config():
+        typer.echo(f"config migrated into {CONFIG_DIR / 'dimos'}", err=True)
 
 
 def _normalize_simulation_argv(argv: list[str]) -> list[str]:

--- a/dimos/cli/dimos.py
+++ b/dimos/cli/dimos.py
@@ -53,7 +53,7 @@ from dimos.cli.cache import app as cache_app
 from dimos.cli.cloud import login as cloud_login, logout as cloud_logout, whoami as cloud_whoami
 from dimos.cli.hardware_cli import app as hardware_app
 from dimos.cli.shell import shell
-from dimos.constants import CONFIG_DIR, LOG_DIR, reject_legacy_config
+from dimos.constants import CONFIG_DIR, LOG_DIR
 from dimos.core.daemon import daemonize, install_signal_handlers
 from dimos.core.global_config import GlobalConfig, global_config
 from dimos.core.run_registry import get_most_recent, is_pid_alive, stop_entry
@@ -86,11 +86,15 @@ DEFAULT_CONFIG_PATH = CONFIG_DIR / "dimos" / "config"
 
 
 def _reject_legacy_config() -> None:
-    try:
-        reject_legacy_config()
-    except RuntimeError as e:
-        typer.echo(str(e), err=True)
-        raise typer.Exit(2) from None
+    """~/.config/dimos used to BE the config file; it is now a directory."""
+    legacy = CONFIG_DIR / "dimos"
+    if legacy.is_file():
+        typer.echo(
+            f"config found at old path {legacy}, which is now a directory; move it:\n"
+            f"  mv {legacy} {legacy}.tmp && mkdir {legacy} && mv {legacy}.tmp {legacy}/config",
+            err=True,
+        )
+        raise typer.Exit(2)
 
 
 def _normalize_simulation_argv(argv: list[str]) -> list[str]:

--- a/dimos/cli/dimos.py
+++ b/dimos/cli/dimos.py
@@ -53,7 +53,7 @@ from dimos.cli.cache import app as cache_app
 from dimos.cli.cloud import login as cloud_login, logout as cloud_logout, whoami as cloud_whoami
 from dimos.cli.hardware_cli import app as hardware_app
 from dimos.cli.shell import shell
-from dimos.constants import CONFIG_DIR, LOG_DIR, migrate_legacy_config
+from dimos.constants import CONFIG_DIR, LOG_DIR, reject_legacy_config
 from dimos.core.daemon import daemonize, install_signal_handlers
 from dimos.core.global_config import GlobalConfig, global_config
 from dimos.core.run_registry import get_most_recent, is_pid_alive, stop_entry
@@ -85,9 +85,12 @@ SIMULATORS = ("mujoco", "dimsim")
 DEFAULT_CONFIG_PATH = CONFIG_DIR / "dimos" / "config"
 
 
-def _migrate_legacy_config() -> None:
-    if migrate_legacy_config():
-        typer.echo(f"config migrated into {CONFIG_DIR / 'dimos'}", err=True)
+def _reject_legacy_config() -> None:
+    try:
+        reject_legacy_config()
+    except RuntimeError as e:
+        typer.echo(str(e), err=True)
+        raise typer.Exit(2) from None
 
 
 def _normalize_simulation_argv(argv: list[str]) -> list[str]:
@@ -227,7 +230,7 @@ def run(
     show_help: bool = typer.Option(False, "--help"),
 ) -> None:
     """Start a robot blueprint"""
-    _migrate_legacy_config()
+    _reject_legacy_config()
     from dimos.core.coordination.blueprint_config.errors import BlueprintConfigError
     from dimos.core.coordination.blueprint_config.parser import (
         BlueprintConfigParser,

--- a/dimos/cli/dimos.py
+++ b/dimos/cli/dimos.py
@@ -98,9 +98,7 @@ def _migrate_legacy_config() -> None:
         tmp.rename(legacy / "config")
         typer.echo(f"config migrated: {legacy} -> {legacy / 'config'}", err=True)
     except OSError:
-        # ponytail: lost a migration race with a concurrent dimos run; the winner
-        # already moved it.
-        pass
+        pass  # lost a migration race; the winner already moved it
 
 
 def _normalize_simulation_argv(argv: list[str]) -> list[str]:

--- a/dimos/cli/test_cloud.py
+++ b/dimos/cli/test_cloud.py
@@ -47,7 +47,8 @@ class FakeKeyring:
 def filestore(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
     """Force the headless path: no keyring backend, credentials in a temp file."""
     monkeypatch.setattr(cloud, "_keyring", lambda: None)
-    cred = tmp_path / "dimos-credentials"
+    cred = tmp_path / "dimos" / "credentials"
+    cred.parent.mkdir()
     monkeypatch.setattr(cloud, "CREDENTIALS_PATH", cred)
     monkeypatch.setattr(global_config, "dimos_api_key", None)
     return cred

--- a/dimos/cli/test_dimos_config.py
+++ b/dimos/cli/test_dimos_config.py
@@ -16,11 +16,13 @@ from pathlib import Path
 
 import pytest
 
-from dimos.cli import dimos as cli
+from dimos import constants
+from dimos.cli import cloud, dimos as cli
 
 
 @pytest.fixture
 def config_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    monkeypatch.setattr(constants, "CONFIG_DIR", tmp_path)
     monkeypatch.setattr(cli, "CONFIG_DIR", tmp_path)
     return tmp_path
 
@@ -42,3 +44,17 @@ def test_migration_noop_without_legacy_file(config_home: Path) -> None:
     (config_home / "dimos").mkdir()  # already migrated
     cli._migrate_legacy_config()
     assert (config_home / "dimos").is_dir()
+
+
+def test_login_store_migrates_legacy_config_first(
+    config_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    legacy = config_home / "dimos"
+    legacy.write_text('{"viewer": "rerun"}')
+    monkeypatch.setattr(cloud, "_keyring", lambda: None)
+    monkeypatch.setattr(cloud, "CREDENTIALS_PATH", config_home / "dimos" / "credentials")
+
+    cloud._store("dimos_sk_x")
+
+    assert (config_home / "dimos" / "config").read_text() == '{"viewer": "rerun"}'
+    assert (config_home / "dimos" / "credentials").read_text().strip() == "dimos_sk_x"

--- a/dimos/cli/test_dimos_config.py
+++ b/dimos/cli/test_dimos_config.py
@@ -32,7 +32,7 @@ def test_legacy_flat_file_migrates_into_directory(config_home: Path) -> None:
     cli._migrate_legacy_config()
 
     assert legacy.is_dir()
-    assert (legacy / "config.json").read_text() == '{"viewer": "rerun"}'
+    assert (legacy / "config").read_text() == '{"viewer": "rerun"}'
 
 
 def test_migration_noop_without_legacy_file(config_home: Path) -> None:

--- a/dimos/cli/test_dimos_config.py
+++ b/dimos/cli/test_dimos_config.py
@@ -1,0 +1,44 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+import pytest
+
+from dimos.cli import dimos as cli
+
+
+@pytest.fixture
+def config_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    monkeypatch.setattr(cli, "CONFIG_DIR", tmp_path)
+    return tmp_path
+
+
+def test_legacy_flat_file_migrates_into_directory(config_home: Path) -> None:
+    legacy = config_home / "dimos"
+    legacy.write_text('{"viewer": "rerun"}')
+
+    cli._migrate_legacy_config()
+
+    assert legacy.is_dir()
+    assert (legacy / "config.json").read_text() == '{"viewer": "rerun"}'
+
+
+def test_migration_noop_without_legacy_file(config_home: Path) -> None:
+    cli._migrate_legacy_config()  # nothing exists
+    assert not (config_home / "dimos").exists()
+
+    (config_home / "dimos").mkdir()  # already migrated
+    cli._migrate_legacy_config()
+    assert (config_home / "dimos").is_dir()

--- a/dimos/cli/test_dimos_config.py
+++ b/dimos/cli/test_dimos_config.py
@@ -17,44 +17,36 @@ from pathlib import Path
 import pytest
 
 from dimos import constants
-from dimos.cli import cloud, dimos as cli
+from dimos.cli import cloud
 
 
 @pytest.fixture
 def config_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
     monkeypatch.setattr(constants, "CONFIG_DIR", tmp_path)
-    monkeypatch.setattr(cli, "CONFIG_DIR", tmp_path)
     return tmp_path
 
 
-def test_legacy_flat_file_migrates_into_directory(config_home: Path) -> None:
-    legacy = config_home / "dimos"
-    legacy.write_text('{"viewer": "rerun"}')
-
-    cli._migrate_legacy_config()
-
-    assert legacy.is_dir()
-    assert (legacy / "config").read_text() == '{"viewer": "rerun"}'
+def test_legacy_flat_file_is_refused_with_instructions(config_home: Path) -> None:
+    (config_home / "dimos").write_text('{"viewer": "rerun"}')
+    with pytest.raises(RuntimeError, match="mv "):
+        constants.reject_legacy_config()
 
 
-def test_migration_noop_without_legacy_file(config_home: Path) -> None:
-    cli._migrate_legacy_config()  # nothing exists
-    assert not (config_home / "dimos").exists()
+def test_no_legacy_file_passes(config_home: Path) -> None:
+    constants.reject_legacy_config()  # nothing exists
 
-    (config_home / "dimos").mkdir()  # already migrated
-    cli._migrate_legacy_config()
-    assert (config_home / "dimos").is_dir()
+    (config_home / "dimos").mkdir()  # already a directory
+    constants.reject_legacy_config()
 
 
-def test_login_store_migrates_legacy_config_first(
+def test_login_store_refuses_on_legacy_config(
     config_home: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    legacy = config_home / "dimos"
-    legacy.write_text('{"viewer": "rerun"}')
+    (config_home / "dimos").write_text('{"viewer": "rerun"}')
     monkeypatch.setattr(cloud, "_keyring", lambda: None)
     monkeypatch.setattr(cloud, "CREDENTIALS_PATH", config_home / "dimos" / "credentials")
+    monkeypatch.setattr(cloud, "reject_legacy_config", constants.reject_legacy_config)
 
-    cloud._store("dimos_sk_x")
-
-    assert (config_home / "dimos" / "config").read_text() == '{"viewer": "rerun"}'
-    assert (config_home / "dimos" / "credentials").read_text().strip() == "dimos_sk_x"
+    with pytest.raises(RuntimeError, match="old path"):
+        cloud._store("dimos_sk_x")
+    assert (config_home / "dimos").read_text() == '{"viewer": "rerun"}'  # untouched

--- a/dimos/cli/test_dimos_config.py
+++ b/dimos/cli/test_dimos_config.py
@@ -15,38 +15,29 @@
 from pathlib import Path
 
 import pytest
+import typer
 
-from dimos import constants
-from dimos.cli import cloud
+from dimos.cli import dimos as cli
 
 
 @pytest.fixture
 def config_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
-    monkeypatch.setattr(constants, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(cli, "CONFIG_DIR", tmp_path)
     return tmp_path
 
 
-def test_legacy_flat_file_is_refused_with_instructions(config_home: Path) -> None:
+def test_legacy_flat_file_is_refused_with_instructions(
+    config_home: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
     (config_home / "dimos").write_text('{"viewer": "rerun"}')
-    with pytest.raises(RuntimeError, match="mv "):
-        constants.reject_legacy_config()
+    with pytest.raises(typer.Exit):
+        cli._reject_legacy_config()
+    assert "mv " in capsys.readouterr().err
+    assert (config_home / "dimos").read_text() == '{"viewer": "rerun"}'
 
 
 def test_no_legacy_file_passes(config_home: Path) -> None:
-    constants.reject_legacy_config()  # nothing exists
+    cli._reject_legacy_config()  # nothing exists
 
     (config_home / "dimos").mkdir()  # already a directory
-    constants.reject_legacy_config()
-
-
-def test_login_store_refuses_on_legacy_config(
-    config_home: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    (config_home / "dimos").write_text('{"viewer": "rerun"}')
-    monkeypatch.setattr(cloud, "_keyring", lambda: None)
-    monkeypatch.setattr(cloud, "CREDENTIALS_PATH", config_home / "dimos" / "credentials")
-    monkeypatch.setattr(cloud, "reject_legacy_config", constants.reject_legacy_config)
-
-    with pytest.raises(RuntimeError, match="old path"):
-        cloud._store("dimos_sk_x")
-    assert (config_home / "dimos").read_text() == '{"viewer": "rerun"}'  # untouched
+    cli._reject_legacy_config()

--- a/dimos/constants.py
+++ b/dimos/constants.py
@@ -41,16 +41,6 @@ else:
 CREDENTIALS_PATH = CONFIG_DIR / "dimos" / "credentials"
 
 
-def reject_legacy_config() -> None:
-    """~/.config/dimos used to BE the config file; it is now a directory."""
-    legacy = CONFIG_DIR / "dimos"
-    if legacy.is_file():
-        raise RuntimeError(
-            f"config found at old path {legacy}, which is now a directory; move it:\n"
-            f"  mv {legacy} {legacy}.tmp && mkdir {legacy} && mv {legacy}.tmp {legacy}/config"
-        )
-
-
 """
 Constants for shared memory
 Usually, auto-detection for size would be preferred. Sadly, though, channels are made

--- a/dimos/constants.py
+++ b/dimos/constants.py
@@ -41,20 +41,14 @@ else:
 CREDENTIALS_PATH = CONFIG_DIR / "dimos" / "credentials"
 
 
-def migrate_legacy_config() -> bool:
-    """~/.config/dimos used to BE the config file; it is now a directory. Move an
-    old flat file to config inside. Returns True if a migration happened."""
+def reject_legacy_config() -> None:
+    """~/.config/dimos used to BE the config file; it is now a directory."""
     legacy = CONFIG_DIR / "dimos"
-    if not legacy.is_file():
-        return False
-    try:
-        tmp = legacy.with_name("dimos.migrating")
-        legacy.rename(tmp)
-        legacy.mkdir()
-        tmp.rename(legacy / "config")
-        return True
-    except OSError:
-        return False  # lost a migration race; the winner already moved it
+    if legacy.is_file():
+        raise RuntimeError(
+            f"config found at old path {legacy}, which is now a directory; move it:\n"
+            f"  mv {legacy} {legacy}.tmp && mkdir {legacy} && mv {legacy}.tmp {legacy}/config"
+        )
 
 
 """

--- a/dimos/constants.py
+++ b/dimos/constants.py
@@ -38,7 +38,24 @@ else:
     LOG_DIR = STATE_DIR / "logs"
     RECORDINGS_DIR = STATE_DIR / "recordings"
 
-CREDENTIALS_PATH = CONFIG_DIR / "dimos-credentials"
+CREDENTIALS_PATH = CONFIG_DIR / "dimos" / "credentials"
+
+
+def migrate_legacy_config() -> bool:
+    """~/.config/dimos used to BE the config file; it is now a directory. Move an
+    old flat file to config inside. Returns True if a migration happened."""
+    legacy = CONFIG_DIR / "dimos"
+    if not legacy.is_file():
+        return False
+    try:
+        tmp = legacy.with_name("dimos.migrating")
+        legacy.rename(tmp)
+        legacy.mkdir()
+        tmp.rename(legacy / "config")
+        return True
+    except OSError:
+        return False  # lost a migration race; the winner already moved it
+
 
 """
 Constants for shared memory

--- a/dimos/core/coordination/blueprint_config/sources.py
+++ b/dimos/core/coordination/blueprint_config/sources.py
@@ -66,7 +66,7 @@ def validate_global_values(values: Mapping[str, Any]) -> dict[str, Any]:
 def read_config_file(path: Path) -> Mapping[str, Any]:
     try:
         raw = path.read_text()
-    except FileNotFoundError:
+    except (FileNotFoundError, IsADirectoryError):
         return {}
     except OSError as error:
         raise BlueprintConfigError(f"Could not read config file {path}: {error}") from error

--- a/dimos/core/coordination/blueprint_config/test_sources.py
+++ b/dimos/core/coordination/blueprint_config/test_sources.py
@@ -18,6 +18,7 @@ import pytest
 
 from dimos.core.coordination.blueprint_config.errors import BlueprintConfigError
 from dimos.core.coordination.blueprint_config.parser import BlueprintConfigParser
+from dimos.core.coordination.blueprint_config.sources import read_config_file
 from dimos.core.global_config import global_config as process_global_config
 from dimos.core.module import Module, ModuleConfig
 
@@ -83,7 +84,4 @@ def test_config_file_errors_are_clear_but_missing_file_is_optional(tmp_path: Pat
 
 
 def test_config_path_that_is_a_directory_reads_as_absent(tmp_path: Path) -> None:
-    # ~/.config/dimos may exist as a directory (it holds the config file since the
-    # flat-file migration); pointing at a directory must mean "no config".
-    parser = BlueprintConfigParser(PrimaryModule.blueprint())
-    parser.parse(config_path=tmp_path, environ={})
+    assert read_config_file(tmp_path) == {}

--- a/dimos/core/coordination/blueprint_config/test_sources.py
+++ b/dimos/core/coordination/blueprint_config/test_sources.py
@@ -83,7 +83,7 @@ def test_config_file_errors_are_clear_but_missing_file_is_optional(tmp_path: Pat
 
 
 def test_config_path_that_is_a_directory_reads_as_absent(tmp_path: Path) -> None:
-    # ~/.config/dimos may exist as a directory (it holds config.json since the
+    # ~/.config/dimos may exist as a directory (it holds the config file since the
     # flat-file migration); pointing at a directory must mean "no config".
     parser = BlueprintConfigParser(PrimaryModule.blueprint())
     parser.parse(config_path=tmp_path, environ={})

--- a/dimos/core/coordination/blueprint_config/test_sources.py
+++ b/dimos/core/coordination/blueprint_config/test_sources.py
@@ -80,3 +80,10 @@ def test_config_file_errors_are_clear_but_missing_file_is_optional(tmp_path: Pat
     not_an_object.write_text("[]")
     with pytest.raises(BlueprintConfigError, match="must contain a JSON object"):
         parser.parse(config_path=not_an_object, environ={})
+
+
+def test_config_path_that_is_a_directory_reads_as_absent(tmp_path: Path) -> None:
+    # ~/.config/dimos may exist as a directory (it holds config.json since the
+    # flat-file migration); pointing at a directory must mean "no config".
+    parser = BlueprintConfigParser(PrimaryModule.blueprint())
+    parser.parse(config_path=tmp_path, environ={})


### PR DESCRIPTION
Final layout, per stash — the aws model:

```
~/.config/dimos/config        # human-edited JSON, extensionless
~/.config/dimos/credentials   # machine-written by dimos login, plain-text key, 0600
```

- Default `--config` is `~/.config/dimos/config`; `read_config_file` treats a directory as absent.
- **Legacy flat file at `~/.config/dimos`: `dimos run` refuses loudly** with the exact one-line `mv` recipe and exits 2 — zero filesystem mutation. The check lives only in the run command: a machine with the flat file predates `dimos login` existing, so that's the command it will hit. No migration state machine → all three Greptile P1s structurally gone.
- Verified: targeted tests + 260 across cli/blueprint_config, mypy strict clean, E2E through the installed console script (refusal prints the recipe; following it restores normal operation; credentials land 0600 inside the dir).