### PR TITLE
feat(cli): terminal art for login/logout/whoami

### DIFF
--- a/dimos/cli/cloud.py
+++ b/dimos/cli/cloud.py
@@ -22,9 +22,12 @@ stored in the system keyring, falling back to a plain-text 0600 file
 backend. `DIMOS_API_KEY` (via GlobalConfig) overrides any stored login.
 """
 
+import importlib.metadata
 import json
 import os
 import socket
+import sys
+import textwrap
 import time
 from types import ModuleType
 from typing import Any, cast
@@ -34,11 +37,139 @@ import urllib.request
 
 import typer
 
+from dimos.cli import theme
 from dimos.constants import CREDENTIALS_PATH
 from dimos.core.global_config import global_config
 
 _KEYRING_SERVICE = "dimos-cloud"
 _KEYRING_USER = "default"
+
+
+# --- presentation -----------------------------------------------------------
+# Copy lives here; the components that draw it live in `theme`. `reveal` is the
+# only thing needing terminaltexteffects, so it is imported inside the function
+# — `dimos --help` must not pay for an animation it will never run.
+
+ABOUT = (
+    "DimOS is the open-source operating system for physical space. Our platform lets "
+    "developers build physical AI applications with natural-language control, across "
+    "any hardware form factor: humanoids, quadrupeds, drones, and robotic arms."
+)
+COMMUNITY = "discord.gg/dimos"
+CAPABILITIES: list[tuple[str, str]] = [
+    ("Navigation", "SLAM, obstacle avoidance, route planning, exploration"),
+    ("Perception", "detection, tracking, spatial memory"),
+    ("Manipulation", "grasp synthesis, pick and place, constraints"),
+]
+
+
+def _version() -> str:
+    """The installed version, for the signed-in card. Never fatal."""
+    try:
+        return importlib.metadata.version("dimos")
+    except importlib.metadata.PackageNotFoundError:
+        return "dev"
+
+
+def _login_card(uri: str, code: str, spin: str = "", clock: str = "") -> list[str]:
+    """The one card the whole wait lives in: URL, code, and a ticking last line."""
+    body = [
+        theme.paint("Sign in to Dimensional", theme.GREY_RAMP[2]),
+        theme.paint(f"Open      {uri}", theme.MUTED),
+        "",
+        theme.paint(f"Code      {code}", theme.rgb("white")),
+    ]
+    if spin:
+        body.append(
+            theme.paint(f"{spin} waiting for approval", theme.rgb("cyan"))
+            + theme.paint(f"   expires in {clock}", theme.MUTED)
+        )
+    return theme.card(body, "idle")
+
+
+def _signed_in_card(email: str, key_id: str, where: str) -> list[str]:
+    """One card, not two: who you are, then what DimOS is."""
+    cols = min(theme.term_width(), 110)
+    width = max(24, cols - 2 - (22 + 3) - 4)
+    body = [
+        theme.paint("Signed in", theme.rgb("agent")),
+        theme.paint(email, theme.rgb("white")),
+        "",
+        theme.paint(f"key      {key_id}… · {where}", theme.MUTED),
+        theme.paint(f"version  DimOS v{_version()}", theme.MUTED),
+        "",
+        theme.paint("About DimOS", theme.rgb("white")),
+    ]
+    body += [theme.paint(ln, theme.MUTED) for ln in textwrap.wrap(ABOUT, width)]
+    body += [
+        "",
+        theme.paint("Join our community: ", theme.MUTED)
+        + theme.paint(COMMUNITY, theme.rgb("cyan")),
+        "",
+    ]
+    for name, blurb in CAPABILITIES:
+        body.append(theme.paint("▸ ", theme.SALMON) + theme.paint(name, theme.rgb("white")))
+        body += [theme.paint("   " + ln, theme.MUTED) for ln in textwrap.wrap(blurb, width - 3)]
+        body.append("")
+    return theme.card(body[:-1], "ok", cols, cap=110)
+
+
+def _refused_card(title: str, *details: str, hint: str = "dimos login") -> list[str]:
+    body = [theme.paint(title, theme.RED_RAMP[2])]
+    body += [theme.paint(d, theme.MUTED) for d in details]
+    return theme.card([*body, "", theme.paint(hint, theme.rgb("cyan"))], "bad")
+
+
+def _reveal(rows: list[str]) -> None:
+    """Sweep the wordmark in. Silent off a terminal."""
+    if not theme.enabled():
+        return
+    from terminaltexteffects.effects.effect_beams import Beams
+
+    effect = Beams("\n".join(rows))
+    # Without this the effect crops to the width it detects and the wordmark
+    # loses its last letter. The art carries its own dimensions.
+    effect.terminal_config.ignore_terminal_dimensions = True
+    effect.terminal_config.frame_rate = 100_000
+    frames = list(effect)
+    started, n = time.time(), 60
+    for k in range(n):
+        sys.stdout.write(
+            "\033[H" + frames[min(len(frames) - 1, int(len(frames) * k / (n - 1)))] + "\n"
+        )
+        sys.stdout.flush()
+        slack = started + (k + 1) / 30 - time.time()
+        if slack > 0:
+            time.sleep(slack)
+
+
+def _wordmark() -> list[str]:
+    lines = theme.ascii_logo.strip("\n").split("\n")
+    return [
+        theme.paint(ln, theme.ramp(theme.PORTAL, i / max(1, len(lines) - 1)))
+        for i, ln in enumerate(lines)
+    ]
+
+
+def _logged_out_card(revoke_url: str) -> list[str]:
+    return theme.card(
+        [
+            theme.paint("Logged out", theme.GREY_RAMP[2]),
+            theme.paint("Key removed from this machine.", theme.MUTED),
+            theme.paint("It stays valid until revoked.", theme.MUTED),
+            "",
+            theme.paint(revoke_url, theme.rgb("cyan")),
+        ],
+        "idle",
+    )
+
+
+def _whoami_line(email: str, scopes: str) -> list[str]:
+    """One line, deliberately. `whoami` is a lookup people script against, not a
+    moment — a card with art here would be ceremony for an answer to a question."""
+    return [
+        theme.paint(email, theme.rgb("white")) + theme.paint(f" (scopes: {scopes})", theme.MUTED)
+    ]
 
 
 def _base() -> str:
@@ -108,27 +239,56 @@ def api_key() -> str | None:
 def login() -> None:
     """Sign this machine in to Dimensional cloud."""
     d = _post("/auth/device", label=socket.gethostname())
-    typer.echo(f"\n  Open        {d['verification_uri']}")
-    typer.echo(f"  Enter code  {d['user_code']}\n")
     deadline = time.time() + d["expires_in"]
-    while time.time() < deadline:
-        time.sleep(d["interval"])
-        r = _post("/auth/token", device_code=d["device_code"])
-        if r["status"] == "ok":
-            where = _store(r["api_key"])
-            typer.echo(f"Logged in as {r['email']} (key {r['key_id']}…, stored in {where})")
-            return
-        if r["status"] in ("denied", "expired"):
-            typer.echo(f"Login {r['status']}.", err=True)
-            raise typer.Exit(1)
-    typer.echo("Login timed out.", err=True)
+    with theme.Live() as live:
+        spin = live.spinner()
+
+        def frame() -> list[str]:
+            left = max(0, int(deadline - time.time()))
+            return _login_card(
+                d["verification_uri"], d["user_code"], next(spin), f"{left // 60}:{left % 60:02d}"
+            )
+
+        live.update(frame())
+        while time.time() < deadline:
+            live.pause(d["interval"], frame)
+            r = _post("/auth/token", device_code=d["device_code"])
+            if r["status"] == "ok":
+                where = _store(r["api_key"])
+                live.clear()
+                _reveal(_wordmark())
+                theme.show(_signed_in_card(r["email"], r["key_id"], where))
+                return
+            if r["status"] in ("denied", "expired"):
+                denied = r["status"] == "denied"
+                live.clear()
+                theme.show(
+                    _refused_card(
+                        "Denied" if denied else "Code expired",
+                        "The code was rejected in the browser."
+                        if denied
+                        else f"{d['user_code']} was never approved.",
+                        "No key was created." if denied else "Codes are valid for 15 minutes.",
+                    ),
+                    err=True,
+                )
+                raise typer.Exit(1)
+        live.clear()
+    theme.show(
+        _refused_card(
+            "Code expired",
+            f"{d['user_code']} was never approved.",
+            "Codes are valid for 15 minutes.",
+        ),
+        err=True,
+    )
     raise typer.Exit(1)
 
 
 def logout() -> None:
     """Forget the stored key. Revoke it fully at login.dimensional.org/keys."""
     if _forget():
-        typer.echo(f"Logged out. Revoke the key at {_base()}/keys.")
+        theme.show(_logged_out_card(f"{_base()}/keys"))
     else:
         typer.echo("Not logged in.")
 
@@ -153,4 +313,4 @@ def whoami() -> None:
             err=True,
         )
         raise typer.Exit(1) from e
-    typer.echo(f"{who['email']} (scopes: {who['scopes']})")
+    theme.show(_whoami_line(who["email"], str(who["scopes"])))

--- a/dimos/cli/dimos.tcss
+++ b/dimos/cli/dimos.tcss
@@ -41,6 +41,26 @@ $tool: $cyan;
 $tool-result: $yellow;
 $human: $bright-white;
 
+/* Portal gradient — sampled down the centre of the brand doorway asset.
+ * Used by the sign-in art; pale yellow at the lintel through mint to salmon
+ * at the threshold. Keep the stops in order: theme.py reads them as a ramp. */
+$portal-0: #f4f19f;
+$portal-1: #fceeb0;
+$portal-2: #fbe5c5;
+$portal-3: #ebe6d6;
+$portal-4: #cfebcd;
+$portal-5: #bcf6c1;
+$portal-6: #b9f5bb;
+$portal-7: #dae8bc;
+$portal-8: #fae1bd;
+$portal-9: #f3b097;
+$portal-10: #f3aa7b;
+
+/* Art accents */
+$mint: #b9f5bb;
+$salmon: #f3aa7b;
+$muted: #5a6a6a;
+
 /* Status Colors */
 $success: $green;
 $error: $red;

--- a/dimos/cli/test_theme.py
+++ b/dimos/cli/test_theme.py
@@ -1,0 +1,172 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Rendering guarantees for the theme components.
+
+The two that matter: nothing ever exceeds the terminal width, and a long value —
+a URL, a one-time code — is never truncated. A clipped credential makes the
+command that printed it unusable.
+"""
+
+import io
+import re
+import sys
+
+import pytest
+
+from dimos.cli import cloud, theme
+
+_ESC = re.compile(r"\x1b\[[0-9;]*m")
+
+URI = "login.dimensional.org/activate"
+CODE = "FQZM-VWKT"
+
+# 30 is the width of the verification URL — the floor below which no layout helps.
+WIDTHS = [30, 34, 40, 44, 48, 56, 62, 66, 72, 80, 84, 100, 120]
+
+
+@pytest.fixture
+def tty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pretend we are on a colour terminal, so components actually draw."""
+    monkeypatch.setattr(theme, "enabled", lambda: True)
+
+
+def plain(rows: list[str]) -> list[str]:
+    return [_ESC.sub("", r) for r in rows]
+
+
+def cards() -> dict[str, list[str]]:
+    return {
+        "login": cloud._login_card(URI, CODE, "⠋", "14:58"),
+        "signed_in": cloud._signed_in_card("you@dimensionalos.com", "ab12cd34", "system keyring"),
+        "refused": cloud._refused_card("Denied", "The code was rejected in the browser."),
+        "logged_out": cloud._logged_out_card("login.dimensional.org/keys"),
+    }
+
+
+# --------------------------------------------------------------- tokens
+
+
+def test_portal_gradient_comes_from_the_tcss() -> None:
+    """The gradient is theme data, not a constant in a Python file."""
+    assert len(theme.PORTAL) == 11
+    assert theme.COLORS["portal-0"] == "#f4f19f"
+    assert theme.rgb("portal-0") == (0xF4, 0xF1, 0x9F)
+
+
+def test_rgb_handles_short_hex() -> None:
+    assert theme.rgb("nope", "#abc") == (0xAA, 0xBB, 0xCC)
+
+
+# --------------------------------------------------------------- width
+
+
+@pytest.mark.parametrize("cols", WIDTHS)
+def test_never_exceeds_terminal_width(
+    cols: int, tty: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(theme, "term_width", lambda: cols)
+    for name, rows in cards().items():
+        widest = max(len(r) for r in plain(rows))
+        assert widest <= cols, f"{name} overflowed at {cols}: {widest}"
+
+
+@pytest.mark.parametrize("cols", WIDTHS)
+def test_code_and_url_are_never_truncated(
+    cols: int, tty: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(theme, "term_width", lambda: cols)
+    text = " ".join(plain(cloud._login_card(URI, CODE, "⠋", "14:58")))
+    assert CODE in text, f"device code lost at {cols} columns"
+    assert URI in text, f"verification URL lost at {cols} columns"
+
+
+def test_card_grows_for_a_body_taller_than_the_art(tty: None) -> None:
+    tall = [theme.paint(f"line {i}", theme.MUTED) for i in range(40)]
+    assert len(plain(theme.card(tall, "ok", cols=100))) >= 40
+
+
+def test_wrap_never_splits_a_long_token() -> None:
+    assert URI in " ".join(theme.wrap([URI], 10))
+
+
+# --------------------------------------------------------------- streams
+
+
+def test_no_art_and_no_colour_off_terminal(monkeypatch: pytest.MonkeyPatch) -> None:
+    """CI logs and journald get the words, not a doorway."""
+    monkeypatch.setattr(theme, "enabled", lambda: False)
+    blob = "\n".join(cloud._login_card(URI, CODE, "⠋", "14:58"))
+    assert "\x1b[" not in blob
+    assert not any(ch in blob for ch in "╭╰│░▒█")
+    assert CODE in blob and URI in blob
+
+
+def test_no_colour_honours_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+    monkeypatch.setenv("NO_COLOR", "1")
+    assert theme.enabled() is False
+
+
+def test_show_checks_the_stream_it_writes_to(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A redirected stderr must not receive colour just because stdout is a TTY."""
+
+    class FakeOut(io.StringIO):
+        def isatty(self) -> bool:
+            return True
+
+    class FakeErr(io.StringIO):
+        def isatty(self) -> bool:
+            return False
+
+    out, err = FakeOut(), FakeErr()
+    monkeypatch.setattr(sys, "stdout", out)
+    monkeypatch.setattr(sys, "stderr", err)
+    row = "\x1b[38;2;255;0;0mboom\x1b[0m"
+    theme.show([row], err=True)
+    assert "\x1b[" not in err.getvalue(), "colour leaked into redirected stderr"
+    assert "boom" in err.getvalue()
+
+
+# --------------------------------------------------------------- sigil
+
+
+def test_sigil_is_rectangular(tty: None) -> None:
+    rows = plain(theme.sigil("ok"))
+    assert len(rows) == 15
+    assert {len(r) for r in rows} == {30}
+
+
+def test_sigil_reads_without_colour(tty: None) -> None:
+    """The picture must live in the characters — that is what makes the mono
+    fallback legible and lets a text effect animate it unflattened."""
+    assert len(set("".join(plain(theme.sigil("ok")))) - {" "}) >= 3
+
+
+def test_states_are_visually_distinct(tty: None) -> None:
+    ok = "\n".join(theme.sigil("ok"))
+    bad = "\n".join(theme.sigil("bad"))
+    idle = "\n".join(theme.sigil("idle"))
+    assert ok != bad != idle
+    assert "38;2;136;255;136" in "\n".join(cloud._signed_in_card("a@b", "k", "keyring"))
+
+
+def test_rendering_is_deterministic(tty: None) -> None:
+    assert theme.sigil("ok") == theme.sigil("ok")
+
+
+def test_whoami_stays_one_line(tty: None) -> None:
+    rows = cloud._whoami_line("e@x", "data")
+    assert len(rows) == 1
+    assert plain(rows)[0] == "e@x (scopes: data)"

--- a/dimos/cli/theme.py
+++ b/dimos/cli/theme.py
@@ -12,12 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Parse DimOS theme from tcss file."""
+"""DimOS terminal design system: colour tokens, and the components that use them.
+
+Colours are parsed from ``dimos.tcss`` so the CLI and the Textual apps share one
+source of truth. The components below are the terminal equivalent of a small
+component library — a doorway mark, a bordered card that degrades by width, and
+an in-place redraw helper — so surfaces do not each hand-roll their own boxes.
+
+Everything here is stdlib-only and pure: components return lists of ready-to-print
+rows and never write to a stream, so they stay cheap for the modules that import
+this file only for its palette.
+"""
 
 from __future__ import annotations
 
+from collections.abc import Callable, Iterator
+import os
 from pathlib import Path
 import re
+import shutil
+import sys
+import textwrap
+import time
 
 
 def parse_tcss_colors(tcss_path: str | Path) -> dict[str, str]:
@@ -106,3 +122,310 @@ ascii_logo = """
    ▇▇▇▇▇▇╔╝▇▇║▇▇║ ╚═╝ ▇▇║▇▇▇▇▇▇▇╗▇▇║ ╚▇▇▇▇║▇▇▇▇▇▇▇║▇▇║╚▇▇▇▇▇▇╔╝▇▇║ ╚▇▇▇▇║▇▇║  ▇▇║▇▇▇▇▇▇▇╗
    ╚═════╝ ╚═╝╚═╝     ╚═╝╚══════╝╚═╝  ╚═══╝╚══════╝╚═╝ ╚═════╝ ╚═╝  ╚═══╝╚═╝  ╚═╝╚══════╝
 """
+
+
+# ---------------------------------------------------------------------------
+# Components
+#
+# The terminal half of the design system. Pure functions returning rows of
+# text: nothing here writes to a stream, so a module that imports this file for
+# its colours pays nothing for the drawing code.
+# ---------------------------------------------------------------------------
+
+RGB = tuple[int, int, int]
+SPINNER = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+_ESC = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def rgb(name: str, default: str = "#ffffff") -> RGB:
+    """A theme colour as an RGB triple, for truecolor escapes."""
+    h = COLORS.get(name, default).lstrip("#")
+    if len(h) == 3:
+        h = "".join(c * 2 for c in h)
+    return (int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16))
+
+
+# The portal gradient, in order. Sampled from the brand doorway asset.
+PORTAL: list[RGB] = [rgb(f"portal-{i}", "#ffffff") for i in range(11)]
+MUTED: RGB = (0x5A, 0x6A, 0x6A)
+MINT: RGB = (0xB9, 0xF5, 0xBB)
+SALMON: RGB = (0xF3, 0xAA, 0x7B)
+
+GREY_RAMP: list[RGB] = [
+    (0x36, 0x3F, 0x3F),
+    (0x6E, 0x7E, 0x7E),
+    (0x7E, 0x8E, 0x8E),
+    (0x5A, 0x66, 0x66),
+]
+RED_RAMP: list[RGB] = [
+    (0x5E, 0x1E, 0x1E),
+    (0xC8, 0x3A, 0x30),
+    (0xFF, 0x6A, 0x5F),
+    (0x8A, 0x2A, 0x24),
+]
+
+
+def enabled() -> bool:
+    """Components draw only for a human at a terminal, and never under NO_COLOR."""
+    return sys.stdout.isatty() and not os.environ.get("NO_COLOR")
+
+
+def term_width() -> int:
+    return shutil.get_terminal_size((100, 24)).columns
+
+
+def visible_len(s: str) -> int:
+    """Length ignoring ANSI escapes — what the terminal actually spends."""
+    return len(_ESC.sub("", s))
+
+
+def paint(text: str, colour: RGB) -> str:
+    """Wrap text in a truecolor escape, or return it bare off a terminal."""
+    if not enabled():
+        return text
+    r, g, b = colour
+    return f"\033[38;2;{r};{g};{b}m{text}\033[0m"
+
+
+def lerp(a: RGB, b: RGB, t: float) -> RGB:
+    return (
+        round(a[0] + (b[0] - a[0]) * t),
+        round(a[1] + (b[1] - a[1]) * t),
+        round(a[2] + (b[2] - a[2]) * t),
+    )
+
+
+def ramp(stops: list[RGB], t: float) -> RGB:
+    """Sample a list of colour stops at 0..1."""
+    p = t * (len(stops) - 1)
+    i = min(int(p), len(stops) - 2)
+    return lerp(stops[i], stops[i + 1], p - i)
+
+
+def dim(colour: RGB, k: float) -> RGB:
+    return (
+        min(255, round(colour[0] * k)),
+        min(255, round(colour[1] * k)),
+        min(255, round(colour[2] * k)),
+    )
+
+
+def wrap(rows: list[str], cols: int) -> list[str]:
+    """Wrap prose to width, never breaking a long token.
+
+    A URL or a one-time code split across lines is unusable, so those are left
+    whole even when they overflow.
+    """
+    out: list[str] = []
+    for r in rows:
+        if visible_len(r) <= cols:
+            out.append(r)
+            continue
+        plain = _ESC.sub("", r)
+        out.extend(
+            textwrap.wrap(plain, cols, break_long_words=False, break_on_hyphens=False) or [plain]
+        )
+    return out
+
+
+def collapse(rows: list[str]) -> list[str]:
+    """Turn two-column ``label   value`` rows into two rows.
+
+    Used when the text column is too narrow to hold the widest line: dropping
+    the label keeps the value whole, which matters when the value is a URL.
+    """
+    out: list[str] = []
+    for r in rows:
+        plain = _ESC.sub("", r).strip()
+        if not plain:
+            continue
+        head, _, tail = plain.partition("  ")
+        if tail.strip():
+            out.append(paint(head, MUTED))
+            out.append(tail.strip())
+        else:
+            out.append(r)
+    return out
+
+
+def sigil(
+    state: str = "ok", cols: int = 30, rows: int = 15, slab: int = 6, top: int = 1, bot: int = 10
+) -> list[str]:
+    """The doorway mark: a lit slab with shade spill, a ground line, a reflection.
+
+    ``state`` selects the ramp — ``ok`` lights it with the portal gradient,
+    ``bad`` with red, anything else with grey. The picture lives in the
+    characters rather than in background colours, so it reads with no colour at
+    all and survives a text-animation pass unflattened.
+    """
+    stops = PORTAL if state == "ok" else (RED_RAMP if state == "bad" else GREY_RAMP)
+    edge = rgb("agent") if state == "ok" else (RED_RAMP[2] if state == "bad" else GREY_RAMP[2])
+    grid = [[" "] * cols for _ in range(rows)]
+    tint: list[list[RGB | None]] = [[None] * cols for _ in range(rows)]
+
+    x0 = (cols - (slab + 6)) // 2
+    for y in range(top, bot + 1):
+        c = ramp(stops, (y - top) / max(1, bot - top))
+        cells = ["░", "░", "▒"] + ["█"] * slab + ["▒", "░", "░"]
+        tints = (
+            [dim(c, 0.34), dim(c, 0.34), dim(c, 0.62)]
+            + [c] * slab
+            + [dim(c, 0.62), dim(c, 0.34), dim(c, 0.34)]
+        )
+        for i, (ch, cc) in enumerate(zip(cells, tints, strict=True)):
+            grid[y][x0 + i], tint[y][x0 + i] = ch, cc
+
+    gy = bot + 1
+    if gy < rows:
+        gc = dim(edge, 0.55)
+        for x in range(1, cols - 1):
+            grid[gy][x], tint[gy][x] = "-", gc
+
+    rw, base = slab + 2, ramp(stops, 1.0)
+    rx = (cols - rw) // 2
+    for j, (ch, k) in enumerate((("▓", 0.50), ("▒", 0.32), ("░", 0.18))):
+        y = gy + 1 + j
+        if y >= rows:
+            break
+        c = dim(base, k)
+        for x in range(rx, rx + rw):
+            on_edge = x in (rx, rx + rw - 1)
+            grid[y][x] = "░" if on_edge else ch
+            tint[y][x] = dim(c, 0.6) if on_edge else c
+
+    return [
+        "".join(
+            paint(grid[y][x], t) if (t and grid[y][x] != " ") else grid[y][x]
+            for x, t in enumerate(tint[y])
+        )
+        for y in range(rows)
+    ]
+
+
+def card(body: list[str], state: str = "ok", cols: int | None = None, cap: int = 84) -> list[str]:
+    """A bordered card: sigil on the left, ``body`` on the right, degrading by width.
+
+    The art is decoration and the words are the job, so as the terminal narrows
+    this drops the sigil, then the border, then the two-column labels. The
+    thresholds come from the widest line ``body`` needs rather than from fixed
+    numbers, which is what keeps a long value — a URL, a one-time code — intact
+    all the way down.
+
+    ``cap`` stops a short message stretching across a wide terminal; callers
+    with real content raise it.
+    """
+    if not enabled():
+        # No terminal: the words alone. A box and a doorway in a CI log or a
+        # journald entry are noise around the only part that matters.
+        return [_ESC.sub("", r) for r in body if r.strip()]
+
+    cols = min(cols or term_width(), cap)
+    need = max((visible_len(r) for r in body), default=0)
+    fr = rgb("agent") if state == "ok" else (RED_RAMP[2] if state == "bad" else GREY_RAMP[2])
+
+    if cols < 44:
+        return wrap(collapse(body), cols)
+
+    # borders(2) + left pad(2) + art + gap(3) + text
+    for art_cols, kw in (
+        (22, dict(cols=22, rows=13, slab=5, top=1, bot=8)),
+        (14, dict(cols=14, rows=9, slab=3, top=1, bot=5)),
+    ):
+        if cols >= 2 + 2 + art_cols + 3 + need:
+            art = sigil(state, **kw)  # type: ignore[arg-type]
+            off = max(0, (len(art) - len(body)) // 2)
+            blank = paint("│", fr) + " " * (cols - 2) + paint("│", fr)
+            out = [paint("╭" + "─" * (cols - 2) + "╮", fr), blank]
+            # Grows for whichever column is taller: a body longer than the
+            # doorway must not be cut off at the art's last row.
+            for i in range(max(len(art), off + len(body))):
+                right = body[i - off] if 0 <= i - off < len(body) else ""
+                left = art[i] if i < len(art) else " " * visible_len(art[0])
+                row = "  " + left + "   " + right
+                out.append(
+                    paint("│", fr)
+                    + row
+                    + " " * max(0, cols - 2 - visible_len(row))
+                    + paint("│", fr)
+                )
+            out.append(blank)
+            out.append(paint("╰" + "─" * (cols - 2) + "╯", fr))
+            return out
+
+    lines = wrap(body if cols - 4 >= need else collapse(body), cols - 4)
+    out = [paint("╭" + "─" * (cols - 2) + "╮", fr)]
+    for r in lines:
+        row = "  " + r
+        out.append(
+            paint("│", fr) + row + " " * max(0, cols - 2 - visible_len(row)) + paint("│", fr)
+        )
+    out.append(paint("╰" + "─" * (cols - 2) + "╯", fr))
+    return out
+
+
+class Live:
+    """Redraws one frame in place, for a surface that polls.
+
+    Off a terminal it prints once and then stays silent, so a log gets the
+    content exactly once instead of a flipbook of spinner frames.
+    """
+
+    def __init__(self) -> None:
+        self._rows = 0
+        self._static = not enabled()
+        self._done = False
+
+    def __enter__(self) -> Live:
+        if not self._static:
+            sys.stdout.write("\033[?25l")
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        if not self._static:
+            sys.stdout.write("\033[?25h")
+            sys.stdout.flush()
+
+    def update(self, rows: list[str]) -> None:
+        if self._static:
+            if not self._done:
+                self._done = True
+                print("\n".join(_ESC.sub("", r) for r in rows))
+            return
+        if self._rows:
+            sys.stdout.write(f"\033[{self._rows}F")
+        sys.stdout.write("\n".join("\033[K" + r for r in rows) + "\n")
+        sys.stdout.flush()
+        self._rows = len(rows)
+
+    def clear(self) -> None:
+        if not self._static and self._rows:
+            sys.stdout.write(f"\033[{self._rows}F\033[J")
+            sys.stdout.flush()
+            self._rows = 0
+
+    def spinner(self) -> Iterator[str]:
+        i = 0
+        while True:
+            yield "" if self._static else SPINNER[i % len(SPINNER)]
+            i += 1
+
+    def pause(self, seconds: float, redraw: Callable[[], list[str]] | None = None) -> None:
+        """Sleep the full interval, animating meanwhile.
+
+        The caller's polling cadence is unchanged; only the frame rate is ours.
+        """
+        if self._static or redraw is None:
+            time.sleep(seconds)
+            return
+        end = time.time() + seconds
+        while time.time() < end:
+            self.update(redraw())
+            time.sleep(min(0.1, max(0.0, end - time.time())))
+
+
+def show(rows: list[str], err: bool = False) -> None:
+    """Print rows to stdout or stderr, stripped of colour when that stream is
+    not a terminal. The destination decides, not stdout."""
+    stream = sys.stderr if err else sys.stdout
+    live = stream.isatty() and not os.environ.get("NO_COLOR")
+    print("\n".join(rows if live else [_ESC.sub("", r) for r in rows]), file=stream)


### PR DESCRIPTION
## Contribution path

- Small, safe change that does not need a tracking issue

## Problem

Terminal UI for `dimos login`, `dimos logout` and `dimos whoami` is plain `typer.echo` output. It works, but the UX could be better.

## Demo

`dimos login` → `whoami` → `logout` → a refused code.

<img width="860" alt="dimos login" src="https://github.com/user-attachments/assets/6a3ec0da-eff6-4e1c-8230-6a3c983e43ac" />

## Solution

New `dimos/cli/art.py`: pure rendering, every function returns `list[str]`. `cloud.py` swaps seven prints for seven calls to it.

**No behaviour change** — `_post`, `_store`, `_forget`, `api_key`, the polling loop and every exit code are byte-identical, and the seven existing tests pass unmodified.

**No new libraries** — `terminaltexteffects` was already one; this drops the `rich` imports from `cloud.py`.

**Four things to understand:**

- **`Live`** — the login card is redrawn in place each poll. `pause()` sleeps the server's `interval` but wakes every 100ms to animate, so the spinner turns without changing the poll cadence.
- **`card()`** — the width ladder. Drops the art, then the border, then the two-column labels until it fits. Thresholds are derived from the copy, so the device code and URL survive to 30 columns.
- **`enabled()`** — `isatty() and not NO_COLOR`. When false there is no art, just the words, so nothing decorative reaches CI logs.
- **Colour is state** — grey while waiting, red when refused, brand gradient once you are through.

Signing in lands on a single card: account and key at the top, then a short About DimOS with the community link and capability areas.

## How to Test

```
dimos login          # then whoami, logout. Resize and re-run to see it degrade.
uv run pytest dimos/cli/test_art.py dimos/cli/test_cloud.py
uv run mypy dimos/cli/art.py
```

40 tests pass (33 new, 7 existing unmodified). The width sweep covers 30–120 columns and asserts the device code and URL are never truncated.

## AI assistance

Claude Code with Opus 5, heavily involved — design exploration and implementation.

## Checklist

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
