### PR TITLE
feat(web): serve the SDK and custom pages from the local relay

### DIFF
--- a/.github/actions/build-cockpit/action.yml
+++ b/.github/actions/build-cockpit/action.yml
@@ -1,8 +1,9 @@
 name: build-cockpit
 description: >-
-  Canonical Cockpit build for release artifacts: install the Deno version
-  pinned in dimos/utils/deno.py, validate the frozen lockfile, and build
-  web/cockpit/dist (shipped in the sdist and copied into wheels by setup.py).
+  Canonical web build for release artifacts: install the Deno version pinned
+  in dimos/utils/deno.py, validate the frozen lockfile, and build
+  web/sdk/dist and web/cockpit/dist (shipped in the sdist and copied into
+  wheels by setup.py).
 
 runs:
   using: composite
@@ -28,6 +29,10 @@ runs:
       shell: bash
       working-directory: web
       run: deno install --frozen
+    - name: Build sdk dist
+      shell: bash
+      working-directory: web/sdk
+      run: deno task build
     - name: Build cockpit dist
       shell: bash
       working-directory: web/cockpit

--- a/.github/scripts/check_sdist.py
+++ b/.github/scripts/check_sdist.py
@@ -31,6 +31,7 @@ REQUIRED = (
     "web/deno.lock",
     "web/relay/main.ts",
     "web/sdk/deno.json",
+    "web/sdk/dist/sdk.js",
 )
 
 

--- a/.github/scripts/wheel_smoke.py
+++ b/.github/scripts/wheel_smoke.py
@@ -36,6 +36,7 @@ REQUIRED = (
     "shared/protocol.ts",
     "cockpit/dist/index.html",
     "sdk/deno.json",
+    "sdk/dist/sdk.js",
 )
 
 # First start in a fresh container downloads Deno plus the relay's jsr deps.
@@ -67,6 +68,13 @@ def main() -> None:
             index = resp.read()
         if index != (dist / "cockpit" / "dist" / "index.html").read_bytes():
             raise SystemExit("/ did not serve the packaged Cockpit index.html")
+        with urllib.request.urlopen(f"{base}/sdk.js", timeout=30) as resp:
+            sdk_js = resp.read()
+            acao = resp.headers.get("Access-Control-Allow-Origin")
+        if sdk_js != (dist / "sdk" / "dist" / "sdk.js").read_bytes():
+            raise SystemExit("/sdk.js did not serve the packaged SDK bundle")
+        if acao != "*":
+            raise SystemExit(f"/sdk.js missing the local CORS header (got {acao!r})")
     print("wheel smoke ok")
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -355,6 +355,10 @@ jobs:
         working-directory: web/cockpit
         run: deno task test
 
+      - name: SDK bundle build
+        working-directory: web/sdk
+        run: deno task build
+
       - name: Cockpit build
         working-directory: web/cockpit
         run: deno task build
@@ -378,8 +382,10 @@ jobs:
         run: uv sync --group tests --group browser-tests --frozen
       - name: Install Playwright browsers  # the e2e runs in both engines
         run: uv run playwright install --with-deps chromium firefox
-      - name: Cockpit browser e2e
-        run: uv run pytest -m web_browser dimos/e2e_tests/test_cockpit_browser.py --no-cov
+      - name: Cockpit + SDK browser e2e
+        run: >-
+          uv run pytest -m web_browser dimos/e2e_tests/test_cockpit_browser.py
+          dimos/e2e_tests/test_sdk_browser.py --no-cov
 
   tests:
     timeout-minutes: 20

--- a/.github/workflows/release-build-check.yml
+++ b/.github/workflows/release-build-check.yml
@@ -15,6 +15,7 @@ on:
       - setup.py
       - MANIFEST.in
       - web/cockpit/**
+      - web/sdk/**
       - web/shared/**
       - web/deno.json
       - web/deno.lock

--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,10 @@ target/
 dist/
 build/
 *.so
+/web/.build.lock
 /web/cockpit/.build.lock
 /web/cockpit/.dist-*
+/web/sdk/.dist-*
 
 # Nix / direnv (symlink one of the tracked .envrc.* files to .envrc)
 .direnv/

--- a/dimos/e2e_tests/conftest.py
+++ b/dimos/e2e_tests/conftest.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 from collections.abc import Callable, Generator, Iterator
+import subprocess
+import sys
 import threading
 import time
 
@@ -29,6 +31,13 @@ from dimos.msgs.geometry_msgs.Vector3 import make_vector3
 from dimos.msgs.std_msgs.Bool import Bool
 from dimos.simulation.mujoco.direct_cmd_vel_explorer import DirectCmdVelExplorer
 from dimos.simulation.mujoco.person_on_track import PersonTrackPublisher
+
+
+@pytest.fixture(scope="session")
+def playwright_browsers() -> None:
+    subprocess.run(
+        [sys.executable, "-m", "playwright", "install", "chromium", "firefox"], check=True
+    )
 
 
 def _pose(x: float, y: float, theta: float) -> PoseStamped:

--- a/dimos/e2e_tests/dimos_cli_call.py
+++ b/dimos/e2e_tests/dimos_cli_call.py
@@ -17,6 +17,24 @@ import signal
 import subprocess
 import time
 
+import requests
+
+
+def wait_for_http(call: "DimosCliCall", url: str, timeout_s: float) -> None:
+    """Poll `url` until it answers 2xx, failing fast when the process died."""
+    deadline = time.monotonic() + timeout_s
+    while True:
+        try:
+            requests.get(url, timeout=2).raise_for_status()
+            return
+        except requests.RequestException:
+            assert call.process is not None and call.process.poll() is None, (
+                f"dimos exited with {call.process and call.process.returncode} before {url} came up"
+            )
+            if time.monotonic() > deadline:
+                raise TimeoutError(f"{url} not reachable after {timeout_s} s") from None
+            time.sleep(0.5)
+
 
 class DimosCliCall:
     process: subprocess.Popen[bytes] | None

--- a/dimos/e2e_tests/test_cockpit_browser.py
+++ b/dimos/e2e_tests/test_cockpit_browser.py
@@ -35,14 +35,10 @@ freshly-built cockpit dist. Locally:
 """
 
 from collections.abc import Callable, Iterator
-import subprocess
-import sys
-import time
 
 import pytest
-import requests
 
-from dimos.e2e_tests.dimos_cli_call import DimosCliCall
+from dimos.e2e_tests.dimos_cli_call import DimosCliCall, wait_for_http
 
 # Playwright lives in the `browser-tests` dependency group, which only the CI
 # web job installs; collection elsewhere must skip, not fail.
@@ -83,13 +79,6 @@ def start_go2_replay() -> Iterator[Callable[[], DimosCliCall]]:
         call.stop()
 
 
-@pytest.fixture(scope="session")
-def playwright_browsers() -> None:
-    subprocess.run(
-        [sys.executable, "-m", "playwright", "install", "chromium", "firefox"], check=True
-    )
-
-
 @pytest.fixture(params=["chromium", "firefox"])
 def page(request: pytest.FixtureRequest, playwright_browsers: None) -> Iterator[Page]:
     with sync_playwright() as p:
@@ -101,18 +90,7 @@ def page(request: pytest.FixtureRequest, playwright_browsers: None) -> Iterator[
 
 
 def _wait_for_relay(call: DimosCliCall, timeout_s: float) -> None:
-    deadline = time.monotonic() + timeout_s
-    while True:
-        try:
-            requests.get(f"{COCKPIT_URL}api/info", timeout=2).raise_for_status()
-            return
-        except requests.RequestException:
-            assert call.process is not None and call.process.poll() is None, (
-                f"dimos exited with {call.process and call.process.returncode} before the relay came up"
-            )
-            if time.monotonic() > deadline:
-                raise TimeoutError(f"relay not reachable after {timeout_s} s") from None
-            time.sleep(0.5)
+    wait_for_http(call, f"{COCKPIT_URL}api/info", timeout_s)
 
 
 def _assert_odom_ticks(page: Page) -> None:

--- a/dimos/e2e_tests/test_sdk_browser.py
+++ b/dimos/e2e_tests/test_sdk_browser.py
@@ -1,0 +1,165 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SDK browser e2e (the W2 acceptance demos, in CI).
+
+Starts the go2 replay blueprint with `--local-relay --serve-dir
+web/examples/minimal` and drives the zero-build page with a real browser: the
+page imports the relay-served /sdk.js bundle, connects same-origin, rides the
+lone-robot auto-watch, and must render decoded odom (this also proves the
+bundle is self-contained - a bare react import would fail the module graph).
+The cross-origin case serves a page from a second loopback origin importing
+the absolute http://127.0.0.1:7780/sdk.js and passing that base to
+connect({url}) - the Vite-dev-server scenario - and the file: case loads the
+same page straight from disk; both work only because the local relay answers
+/api/info and /sdk.js with wildcard CORS.
+
+One dimos stack serves the whole module (nothing here kills it, unlike the
+cockpit e2e's restart case, so module scope is safe and saves ~2 min/start).
+
+Marked web_browser: excluded from the default suite (needs the
+`browser-tests` dependency group, Playwright browsers and the LFS dataset).
+Locally:
+`uv run --group browser-tests pytest -m web_browser dimos/e2e_tests/test_sdk_browser.py`.
+"""
+
+from collections.abc import Iterator
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+import threading
+
+import pytest
+
+from dimos.e2e_tests.dimos_cli_call import DimosCliCall, wait_for_http
+from dimos.web.relay_bridge.locate import find_web_dir
+
+# Playwright lives in the `browser-tests` dependency group, which only the CI
+# web job installs; collection elsewhere must skip, not fail.
+pytest.importorskip("playwright")
+
+from playwright.sync_api import Page, expect, sync_playwright
+
+pytestmark = pytest.mark.web_browser
+
+RELAY_URL = "http://127.0.0.1:7780/"
+
+# The first start may download Deno and, outside CI, build the web dists.
+START_TIMEOUT_S = 300
+
+# A page whose SDK and relay live on another origin (what a Vite dev server
+# or a double-clicked local file would show): both the module import and
+# connect() use absolute URLs.
+ABSOLUTE_URL_PAGE = f"""<!DOCTYPE html>
+<html>
+  <body>
+    <pre id="odom">odom: (no data)</pre>
+    <script type="module">
+      import {{ connect }} from "{RELAY_URL}sdk.js";
+      const session = connect({{ url: "{RELAY_URL}" }});
+      session.subscribe("odom", (snapshot) => {{
+        document.querySelector("#odom").textContent =
+          `odom: ${{JSON.stringify(snapshot.slot?.value ?? null)}}`;
+      }});
+    </script>
+  </body>
+</html>
+"""
+
+
+@pytest.fixture(scope="module")
+def go2_replay_serve_dir() -> Iterator[DimosCliCall]:
+    call = DimosCliCall()
+    call.simulator = None
+    # --viewer none: no rerun viewer spawn (headless CI); the replay
+    # connection means no MuJoCo and no hardware.
+    call.global_args = ["--robot-ip", "fake", "--viewer", "none"]
+    call.extra_env = {"RELAYBRIDGEMODULE__OPEN_BROWSER": "false"}
+    call.demo_args = [
+        "run",
+        "unitree-go2-basic",
+        "--local-relay",
+        "--serve-dir",
+        str(find_web_dir() / "examples" / "minimal"),
+    ]
+    call.start()
+    try:
+        wait_for_http(call, f"{RELAY_URL}api/info", START_TIMEOUT_S)
+        yield call
+    finally:
+        call.stop()
+
+
+@pytest.fixture(params=["chromium", "firefox"])
+def page(request: pytest.FixtureRequest, playwright_browsers: None) -> Iterator[Page]:
+    with sync_playwright() as p:
+        browser = getattr(p, request.param).launch()
+        try:
+            yield browser.new_page()
+        finally:
+            browser.close()
+
+
+@pytest.fixture
+def chromium_page(playwright_browsers: None) -> Iterator[Page]:
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        try:
+            yield browser.new_page()
+        finally:
+            browser.close()
+
+
+@pytest.fixture
+def second_origin(tmp_path: Path) -> Iterator[str]:
+    """A second loopback HTTP origin serving tmp_path (the Vite stand-in)."""
+    (tmp_path / "index.html").write_text(ABSOLUTE_URL_PAGE)
+    handler = partial(SimpleHTTPRequestHandler, directory=str(tmp_path))
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_address[1]}/"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def test_minimal_page_shows_decoded_odom(go2_replay_serve_dir: DimosCliCall, page: Page) -> None:
+    page.goto(RELAY_URL)
+    # A decoded pose proves the whole chain: --serve-dir served the page,
+    # /sdk.js resolved, the session connected and auto-watched, and the
+    # json decoder ran on a live frame.
+    expect(page.locator("#odom")).to_contain_text("yaw", timeout=120_000)
+    expect(page.locator("#status")).to_contain_text("connected")
+
+
+def test_cross_origin_bootstrap_from_second_origin(
+    go2_replay_serve_dir: DimosCliCall, second_origin: str, chromium_page: Page
+) -> None:
+    chromium_page.goto(second_origin)
+    expect(chromium_page.locator("#odom")).to_contain_text("yaw", timeout=120_000)
+
+
+def test_file_page_connects(
+    go2_replay_serve_dir: DimosCliCall, tmp_path: Path, chromium_page: Page
+) -> None:
+    # The zero-config extreme: a page double-clicked from disk. Both supported
+    # browsers permit the cross-origin module import, /api/info fetch, and
+    # WebTransport from a file: context (probed in Chromium and Firefox);
+    # exercised in one engine here to bound CI time.
+    (tmp_path / "index.html").write_text(ABSOLUTE_URL_PAGE)
+    chromium_page.goto(f"file://{tmp_path / 'index.html'}")
+    expect(chromium_page.locator("#odom")).to_contain_text("yaw", timeout=120_000)

--- a/dimos/web/relay_bridge/locate.py
+++ b/dimos/web/relay_bridge/locate.py
@@ -56,7 +56,7 @@ def find_web_dir() -> Path:
 
 
 def build_allowed(web_dir: Path) -> bool:
-    """True when the cockpit auto-build may run in web_dir.
+    """True when the web auto-build may run in web_dir.
 
     A tree selected via DIMOS_WEB_DIR gets its build tooling executed with
     `deno run -A`, so it is served as-is unless DIMOS_WEB_DIR_BUILD=1
@@ -74,20 +74,38 @@ def find_cockpit_dist(web_dir: Path) -> Path | None:
     return dist.resolve() if (dist / "index.html").is_file() else None
 
 
+def find_sdk_dist(web_dir: Path) -> Path | None:
+    """Built SDK bundle dir (web/sdk/dist), canonicalized, or None when not built."""
+    dist = web_dir / "sdk" / "dist"
+    return dist.resolve() if (dist / "sdk.js").is_file() else None
+
+
 def relay_run_cmd(
-    deno: str, web_dir: Path, *args: str, cockpit_dir: Path | None = None
+    deno: str,
+    web_dir: Path,
+    *args: str,
+    cockpit_dir: Path | None = None,
+    sdk_dir: Path | None = None,
+    serve_dir: Path | None = None,
 ) -> list[str]:
     """Build the argv that runs the relay with the pinned config and least permissions."""
     # Canonical paths: the relay realpath-checks served files against its
     # roots, so a symlinked --allow-read scope (macOS /tmp -> /private/tmp)
     # would deny every read.
     web_dir = web_dir.resolve()
-    if cockpit_dir is not None:
-        cockpit_dir = cockpit_dir.resolve()
+    dirs = [
+        (flag, path.resolve())
+        for flag, path in (
+            ("--cockpit-dir", cockpit_dir),
+            ("--sdk-dir", sdk_dir),
+            ("--serve-dir", serve_dir),
+        )
+        if path is not None
+    ]
     # --node-modules-dir=none: the workspace root deno.json says "auto" (for
     # the cockpit build tooling), which would make this run materialize
     # node_modules next to the config -- inside site-packages under a wheel.
-    allow_read = str(web_dir) if cockpit_dir is None else f"{web_dir},{cockpit_dir}"
+    allow_read = ",".join([str(web_dir), *(str(path) for _, path in dirs)])
     cmd = [
         deno,
         "run",
@@ -99,8 +117,8 @@ def relay_run_cmd(
         str(web_dir / "deno.json"),
         str(web_dir / "relay" / "main.ts"),
     ]
-    if cockpit_dir is not None:
-        cmd += ["--cockpit-dir", str(cockpit_dir)]
+    for flag, path in dirs:
+        cmd += [flag, str(path)]
     return [*cmd, *args]
 
 

--- a/dimos/web/relay_bridge/relay_bridge_module.py
+++ b/dimos/web/relay_bridge/relay_bridge_module.py
@@ -41,6 +41,7 @@ from dataclasses import dataclass, field
 import functools
 import json
 import math
+from pathlib import Path
 import socket
 import threading
 import time
@@ -87,7 +88,7 @@ from dimos.web.relay_bridge.protocol import (
     TeleopStop as WireTeleopStop,
     Twist as WireTwist,
 )
-from dimos.web.relay_bridge.relay_process import RelayProcess, ensure_cockpit_dist
+from dimos.web.relay_bridge.relay_process import RelayProcess, ensure_web_dist
 from dimos.web.relay_bridge.wt_client import (
     RelayClient,
     RelayRejectedError,
@@ -193,9 +194,14 @@ class RelayBridgeConfig(ModuleConfig):
     """HTTP port of the spawned local relay; 0 picks an ephemeral port (tests)."""
     open_browser: bool = True
     """Open the local relay's page once it is up (local mode only)."""
-    cockpit_build: bool = True
-    """Build the Cockpit dist before spawning the local relay when it is
-    missing or stale (checkouts only; wheels ship it pre-built)."""
+    web_build: bool = True
+    """Build the web dists (SDK bundle + Cockpit) before spawning the local
+    relay when they are missing or stale (checkouts only; wheels ship them
+    pre-built)."""
+    serve_dir: str | None = None
+    """Directory the spawned local relay serves at / instead of the Cockpit
+    (index.html for /); /api/* and /sdk.js keep precedence over it. Local
+    relay only: rejected when relay_url attaches to an existing relay."""
     robot_id: str = ""
     """Relay identity; empty falls back to g.robot_id, then the hostname."""
     robot_name: str = ""
@@ -421,6 +427,8 @@ class RelayBridgeModule(Module):
         self._build_cancel: threading.Event | None = None
         self._session: _Session | None = None
         self._url: str | None = None
+        # Resolved config.serve_dir, kept for relay-child respawns.
+        self._serve_dir: Path | None = None
         self._robot_info: RobotInfo | None = None
         self._manifest: RobotManifest | None = None
         self._channel_defs: tuple[ChannelDef, ...] = ()
@@ -524,16 +532,25 @@ class RelayBridgeModule(Module):
                     )
             self._manifest = manifest.model_dump()
             self._url = self.config.relay_url or self.config.g.relay_url
+            if self._url is not None and self.config.serve_dir is not None:
+                raise RuntimeError(
+                    "serve_dir requires the spawned local relay (--local-relay); "
+                    "an external relay (--relay-url) cannot serve local files"
+                )
             if self._url is None:
                 # Probe before the (expensive) build: a start that will lose
                 # the port must not rewrite the dist a running relay serves.
                 _probe_local_port(self.config.local_port)
-                if self.config.cockpit_build:
+                # Before the build too: fail fast on a typo'd directory.
+                self._serve_dir = self._resolve_serve_dir()
+                if self.config.web_build:
                     try:
-                        await self._build_cockpit()
+                        await self._build_web_dist()
                     except Exception:
-                        logger.exception("cockpit build failed; continuing with the relay only")
-                self._url = await _blocking_call(self._spawn_relay, self.config.open_browser)
+                        logger.exception("web build failed; continuing with the relay only")
+                self._url = await _blocking_call(
+                    self._spawn_relay, self.config.open_browser, self._serve_dir
+                )
             # The first connect fails fast: a relay that cannot be reached at
             # startup should fail the module start visibly, not retry forever.
             session = await self._connect_and_hello()
@@ -554,8 +571,20 @@ class RelayBridgeModule(Module):
                         # its port (it has no PDEATHSIG), so surface cleanup failure.
                         logger.exception("relay bridge: stopping the local relay failed")
 
-    async def _build_cockpit(self) -> None:
-        """Build the Cockpit dist (checkouts only) before spawning the relay.
+    def _resolve_serve_dir(self) -> Path | None:
+        """Validated config.serve_dir; a clean labeled error beats the
+        relay child dying with a stderr-tail dump."""
+        if self.config.serve_dir is None:
+            return None
+        path = Path(self.config.serve_dir)
+        if not path.is_dir():
+            raise RuntimeError(
+                f"serve_dir does not exist or is not a directory: {self.config.serve_dir}"
+            )
+        return path
+
+    async def _build_web_dist(self) -> None:
+        """Build the web dists (checkouts only) before spawning the relay.
 
         The blocking build runs in a thread but stays cancellable: on
         cancellation (or module close, via _close_module) the build child is
@@ -565,7 +594,7 @@ class RelayBridgeModule(Module):
         cancel = threading.Event()
         self._build_cancel = cancel
         work = asyncio.create_task(
-            asyncio.to_thread(ensure_cockpit_dist, find_web_dir(), cancel=cancel)
+            asyncio.to_thread(ensure_web_dist, find_web_dir(), cancel=cancel)
         )
         try:
             await asyncio.shield(work)
@@ -580,7 +609,7 @@ class RelayBridgeModule(Module):
 
     def _close_module(self) -> None:
         # Runs on every stop path, including a stop() racing a still-starting
-        # main(): an in-flight cockpit build must die now, not at its timeout.
+        # main(): an in-flight web build must die now, not at its timeout.
         cancel = self._build_cancel
         if cancel is not None:
             cancel.set()
@@ -606,10 +635,10 @@ class RelayBridgeModule(Module):
             quality = candidate
         return quality
 
-    def _spawn_relay(self, open_browser: bool) -> str:
+    def _spawn_relay(self, open_browser: bool, serve_dir: Path | None) -> str:
         """Start a fresh local relay child (blocking; run via to_thread)."""
         _probe_local_port(self.config.local_port)
-        self._relay = RelayProcess(port=self.config.local_port)
+        self._relay = RelayProcess(port=self.config.local_port, serve_dir=serve_dir)
         info = self._relay.start()
         logger.info(f"local relay ready: {info.open_url}")
         if open_browser:
@@ -851,7 +880,7 @@ class RelayBridgeModule(Module):
                 logger.warning("local relay child died; respawning")
                 try:
                     await _blocking_call(self._relay.stop)
-                    self._url = await _blocking_call(self._spawn_relay, False)
+                    self._url = await _blocking_call(self._spawn_relay, False, self._serve_dir)
                 except Exception:
                     logger.exception("relay respawn failed; retrying")
                     await asyncio.sleep(_RECONNECT_PAUSE_S)

--- a/dimos/web/relay_bridge/relay_process.py
+++ b/dimos/web/relay_bridge/relay_process.py
@@ -40,6 +40,7 @@ from dimos.web.relay_bridge.locate import (
     WEB_DIR_ENV_VAR,
     build_allowed,
     find_cockpit_dist,
+    find_sdk_dist,
     find_web_dir,
     relay_run_cmd,
 )
@@ -48,7 +49,8 @@ logger = setup_logger()
 
 _STDERR_TAIL_LINES = 60
 
-_COCKPIT_BUILD_TIMEOUT_S = 600.0
+# One shared deadline across both child builds (sdk + cockpit).
+_WEB_BUILD_TIMEOUT_S = 600.0
 # SIGTERM-to-SIGKILL grace when a build child is cancelled or times out.
 _BUILD_KILL_GRACE_S = 5.0
 _BUILD_POLL_S = 0.2
@@ -71,82 +73,101 @@ def _cancel_builds_at_exit() -> None:
 atexit.register(_cancel_builds_at_exit)
 
 
-def ensure_cockpit_dist(
+def ensure_web_dist(
     web_dir: Path,
-    timeout: float = _COCKPIT_BUILD_TIMEOUT_S,
+    timeout: float = _WEB_BUILD_TIMEOUT_S,
     cancel: threading.Event | None = None,
-) -> Path | None:
-    """Path to the built Cockpit app, building it first when possible.
+) -> None:
+    """Build the web distributions (SDK bundle + Cockpit app) when possible.
 
-    Wheel installs ship a pre-built dist and no sources: return it (or None on
-    a cockpit-less wheel). Checkouts rebuild when the dist's input stamp (a
-    hash over the cockpit/shared sources, workspace config, and lockfile) no
-    longer matches; the build runs under a cross-process lock, into a
-    temporary directory published atomically, so concurrent starts serialize
-    and a failed build leaves the served dist untouched (the relay still runs;
-    with no dist at all it serves only /api plus a build hint at /). Setting
-    `cancel` kills the build child within a bounded grace.
+    Wheel installs ship pre-built dists and no sources: serve them as-is.
+    Checkouts rebuild when either dist's input stamp (a hash over the
+    cockpit/shared/sdk sources, workspace config, and lockfile) no longer
+    matches; the builds run under a cross-process lock, into temporary
+    directories published by rename only after both products built, so
+    concurrent starts serialize and a failed build leaves both served dists
+    untouched (the relay still runs; without dists it serves only /api plus
+    build hints). Setting `cancel` kills the build child within a bounded
+    grace.
     """
-    dist = find_cockpit_dist(web_dir)
+    sdk = web_dir / "sdk"
     cockpit = web_dir / "cockpit"
-    if not (cockpit / "src").is_dir():
-        return dist
+    if not ((sdk / "src").is_dir() and (cockpit / "src").is_dir()):
+        return  # wheel shape: never lock or build in site-packages
     if not build_allowed(web_dir):
         logger.warning(
-            f"{WEB_DIR_ENV_VAR} is set; serving its cockpit as-is "
+            f"{WEB_DIR_ENV_VAR} is set; serving its web dists as-is "
             f"(set {WEB_DIR_BUILD_ENV_VAR}=1 to allow building that tree)"
         )
-        return dist
+        return
     if cancel is None:
         cancel = threading.Event()
     deadline = time.monotonic() + timeout
     _live_build_cancels.add(cancel)
     try:
-        with _build_lock(cockpit, deadline, cancel) as locked:
+        with _build_lock(web_dir, deadline, cancel) as locked:
             if not locked:
-                logger.warning("another cockpit build is running; serving the existing dist")
-                return find_cockpit_dist(web_dir)
+                logger.warning("another web build is running; serving the existing dists")
+                return
             stamp = _input_stamp(web_dir)
-            dist = find_cockpit_dist(web_dir)  # a previous lock holder may have rebuilt
-            if dist is not None and _read_stamp(dist) == stamp:
-                return dist
-            state = "missing" if dist is None else "stale"
-            logger.warning(f"cockpit dist is {state}; building it (takes a minute)")
-            for leftover in cockpit.glob(".dist-*"):  # crashed builds; ours is the lock
-                shutil.rmtree(leftover, ignore_errors=True)
-            out_dir = Path(tempfile.mkdtemp(prefix=".dist-new-", dir=cockpit))
-            out_dir.chmod(0o755)  # mkdtemp gives 0o700; this becomes the dist
+            if _dists_fresh(web_dir, stamp):  # a previous lock holder may have rebuilt
+                return
+            logger.warning("web dist is missing or stale; building sdk + cockpit (takes a minute)")
+            out_dirs: dict[Path, Path] = {}
             try:
-                # Fixed argv (what cockpit/deno.json's build task runs), not
-                # the tree's task definition; --outDir keeps a failed build
-                # away from the served dist.
-                cmd = [
-                    ensure_deno(),
-                    "run",
-                    "--frozen",
-                    "-A",
-                    "npm:vite",
-                    "build",
-                    "--outDir",
-                    str(out_dir),
-                ]
-                if _run_build(cmd, cockpit, deadline, cancel):
-                    (out_dir / _STAMP_NAME).write_text(stamp)
-                    _swap_dist(cockpit, out_dir)
-                    logger.info("cockpit dist built")
+                built = True
+                for package in (sdk, cockpit):  # sdk first: it fails fastest
+                    for leftover in package.glob(".dist-*"):  # crashed builds; ours is the lock
+                        shutil.rmtree(leftover, ignore_errors=True)
+                    out_dir = Path(tempfile.mkdtemp(prefix=".dist-new-", dir=package))
+                    out_dir.chmod(0o755)  # mkdtemp gives 0o700; this becomes the dist
+                    out_dirs[package] = out_dir
+                    # Fixed argv (what the package's build task runs), not the
+                    # tree's task definition; --outDir keeps a failed build
+                    # away from the served dist.
+                    cmd = [
+                        ensure_deno(),
+                        "run",
+                        "--frozen",
+                        "-A",
+                        "npm:vite",
+                        "build",
+                        "--outDir",
+                        str(out_dir),
+                    ]
+                    if not _run_build(cmd, package, deadline, cancel):
+                        built = False
+                        break
+                if built:
+                    # Swap only after both built: a failed build must not
+                    # destroy either previously valid dist, and with one shared
+                    # stamp a half-swap would leave the other side permanently
+                    # stale (rebuild on every start). The two renames are not
+                    # atomic together; a crash between them leaves the old
+                    # stamp on the un-swapped side, so the next start rebuilds.
+                    for out_dir in out_dirs.values():
+                        (out_dir / _STAMP_NAME).write_text(stamp)
+                    for package, out_dir in out_dirs.items():
+                        _swap_dist(package, out_dir)
+                    logger.info("web dist built (sdk + cockpit)")
             except Exception:
-                logger.exception("cockpit build did not run")
+                logger.exception("web build did not run")
             finally:
-                shutil.rmtree(out_dir, ignore_errors=True)
-            return find_cockpit_dist(web_dir)
+                for out_dir in out_dirs.values():
+                    shutil.rmtree(out_dir, ignore_errors=True)  # no-op once swapped
     finally:
         _live_build_cancels.discard(cancel)
 
 
+def _dists_fresh(web_dir: Path, stamp: str) -> bool:
+    dists = (find_sdk_dist(web_dir), find_cockpit_dist(web_dir))
+    return all(dist is not None and _read_stamp(dist) == stamp for dist in dists)
+
+
 @contextlib.contextmanager
-def _build_lock(cockpit: Path, deadline: float, cancel: threading.Event) -> Iterator[bool]:
+def _build_lock(web_dir: Path, deadline: float, cancel: threading.Event) -> Iterator[bool]:
     """Cross-process flock; yields False when it stays busy until the deadline."""
-    with (cockpit / ".build.lock").open("w") as lock_file:
+    with (web_dir / ".build.lock").open("w") as lock_file:
         while True:
             try:
                 fcntl.flock(lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
@@ -206,17 +227,17 @@ def _run_build(cmd: list[str], cwd: Path, deadline: float, cancel: threading.Eve
         while (code := proc.poll()) is None:
             if cancel.is_set():
                 _kill_group(proc)
-                logger.warning("cockpit build cancelled")
+                logger.warning(f"{cwd.name} build cancelled")
                 return False
             if time.monotonic() >= deadline:
                 _kill_group(proc)
-                logger.error("cockpit build timed out")
+                logger.error(f"{cwd.name} build timed out")
                 return False
             time.sleep(_BUILD_POLL_S)
         if code != 0:
             output.seek(0)
             tail = "\n".join(output.read().decode(errors="replace").strip().splitlines()[-20:])
-            logger.error(f"cockpit build failed (exit {code}); output tail:\n{tail}")
+            logger.error(f"{cwd.name} build failed (exit {code}); output tail:\n{tail}")
             return False
         return True
 
@@ -236,10 +257,10 @@ def _kill_group(proc: subprocess.Popen[bytes]) -> None:
         proc.wait()
 
 
-def _swap_dist(cockpit: Path, new_dist: Path) -> None:
+def _swap_dist(package: Path, new_dist: Path) -> None:
     """Publish atomically: renames, so readers never see a half-written dist."""
-    dist = cockpit / "dist"
-    old = cockpit / ".dist-old"
+    dist = package / "dist"
+    old = package / ".dist-old"
     if dist.exists():
         os.rename(dist, old)
     os.rename(new_dist, dist)
@@ -272,12 +293,16 @@ class RelayProcess:
         host: str = "127.0.0.1",
         web_dir: Path | None = None,
         cockpit_dir: Path | None = None,
+        sdk_dir: Path | None = None,
+        serve_dir: Path | None = None,
         timeout: float = 20.0,
     ) -> None:
         self._port = port
         self._host = host
         self._web_dir = web_dir
         self._cockpit_dir = cockpit_dir
+        self._sdk_dir = sdk_dir
+        self._serve_dir = serve_dir
         self._timeout = timeout
         self._process: subprocess.Popen[str] | None = None
         self._threads: list[threading.Thread] = []
@@ -289,11 +314,20 @@ class RelayProcess:
         deno = ensure_deno()
         web_dir = self._web_dir or find_web_dir()
         # No build here: start() must stay cheap (tests spawn many relays).
-        # The build-if-needed step is ensure_cockpit_dist(), called by the
+        # The build-if-needed step is ensure_web_dist(), called by the
         # RelayBridgeModule before spawning.
         cockpit_dir = self._cockpit_dir or find_cockpit_dist(web_dir)
+        sdk_dir = self._sdk_dir or find_sdk_dist(web_dir)
         cmd = relay_run_cmd(
-            deno, web_dir, "--port", str(self._port), "--host", self._host, cockpit_dir=cockpit_dir
+            deno,
+            web_dir,
+            "--port",
+            str(self._port),
+            "--host",
+            self._host,
+            cockpit_dir=cockpit_dir,
+            sdk_dir=sdk_dir,
+            serve_dir=self._serve_dir,
         )
         logger.info(f"starting relay: {' '.join(cmd)}")
         env = os.environ | {"NO_COLOR": "1"}

--- a/dimos/web/relay_bridge/test_relay_bridge_e2e.py
+++ b/dimos/web/relay_bridge/test_relay_bridge_e2e.py
@@ -119,10 +119,8 @@ class _Publisher:
 
 
 def _start_bridge() -> tuple[RelayBridgeModule, tuple[pLCMTransport, ...]]:
-    # cockpit_build=False: tests must never trigger the npm-downloading build.
-    module = RelayBridgeModule(
-        local_port=0, open_browser=False, cockpit_build=False, robot_id=ROBOT_ID
-    )
+    # web_build=False: tests must never trigger the npm-downloading build.
+    module = RelayBridgeModule(local_port=0, open_browser=False, web_build=False, robot_id=ROBOT_ID)
     transports = (
         pLCMTransport("/rb_e2e/odom"),
         pLCMTransport("/rb_e2e/color_image"),
@@ -187,7 +185,7 @@ def test_local_relay_port_collision_does_not_kill_listener() -> None:
         module = RelayBridgeModule(local_port=port, open_browser=False, robot_id="collision-test")
 
         with pytest.raises(RuntimeError, match=rf"port {port} is unavailable"):
-            module._spawn_relay(False)
+            module._spawn_relay(False, None)
 
         assert listener.poll() is None
     finally:
@@ -410,7 +408,7 @@ def _start_teleop_bridge() -> tuple[RelayBridgeModule, tuple[pLCMTransport, ...]
     module = RelayBridgeModule(
         local_port=0,
         open_browser=False,
-        cockpit_build=False,
+        web_build=False,
         robot_id=ROBOT_ID,
         manifest=manifest,
     )
@@ -501,7 +499,7 @@ def deadman_bridge() -> Iterator[tuple[RelayProcess, RelayBridgeModule]]:
     module = RelayBridgeModule(
         relay_url=ready.wt_url,
         open_browser=False,
-        cockpit_build=False,
+        web_build=False,
         robot_id=ROBOT_ID,
         manifest=manifest,
     )

--- a/dimos/web/relay_bridge/test_relay_bridge_module.py
+++ b/dimos/web/relay_bridge/test_relay_bridge_module.py
@@ -758,7 +758,10 @@ def test_failed_respawn_retries_until_success(bridge, monkeypatch) -> None:
     monkeypatch.setattr(relay_bridge_module, "_RECONNECT_PAUSE_S", 0.01)
     spawns: list[int] = []
 
-    def fake_spawn(open_browser: bool) -> str:
+    # No default on serve_dir: the fake must keep _spawn_relay's exact arity
+    # (a respawn-path call with the wrong arg count once turned into a silent
+    # retry loop in production; _blocking_call's *args hides it from mypy).
+    def fake_spawn(open_browser: bool, serve_dir: Path | None) -> str:
         spawns.append(1)
         if len(spawns) == 1:
             raise RuntimeError("ready-line timeout")
@@ -786,7 +789,7 @@ def test_stop_waits_for_in_flight_respawn_and_stops_spawned_child(monkeypatch) -
     stop_errors: list[BaseException] = []
     stop_returned_before_spawn: list[bool] = []
 
-    def blocking_spawn(open_browser: bool) -> str:
+    def blocking_spawn(open_browser: bool, serve_dir: Path | None) -> str:
         spawn_started.set()
         assert release_spawn.wait(timeout=5.0)
         module._relay = spawned_relay
@@ -1092,11 +1095,11 @@ def test_port_conflict_fails_before_build(monkeypatch) -> None:
     # must not touch the dist another running relay is serving.
     builds: list[int] = []
     monkeypatch.setattr(
-        relay_bridge_module, "ensure_cockpit_dist", lambda *args, **kwargs: builds.append(1)
+        relay_bridge_module, "ensure_web_dist", lambda *args, **kwargs: builds.append(1)
     )
     spawns: list[int] = []
     monkeypatch.setattr(
-        RelayBridgeModule, "_spawn_relay", lambda self, open_browser: spawns.append(1)
+        RelayBridgeModule, "_spawn_relay", lambda self, open_browser, serve_dir: spawns.append(1)
     )
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as blocker:
         blocker.bind(("127.0.0.1", 0))
@@ -1122,12 +1125,12 @@ def test_build_cancellation_is_bounded(monkeypatch) -> None:
         cancel.wait(timeout=30.0)
         finished.set()
 
-    monkeypatch.setattr(relay_bridge_module, "ensure_cockpit_dist", fake_ensure)
+    monkeypatch.setattr(relay_bridge_module, "ensure_web_dist", fake_ensure)
     monkeypatch.setattr(relay_bridge_module, "find_web_dir", lambda: Path("/nonexistent"))
     module = RelayBridgeModule(relay_url="https://127.0.0.1:1", open_browser=False)
     try:
         assert module._loop is not None
-        future = asyncio.run_coroutine_threadsafe(module._build_cockpit(), module._loop)
+        future = asyncio.run_coroutine_threadsafe(module._build_web_dist(), module._loop)
         assert started.wait(timeout=5.0)
         future.cancel()
         assert finished.wait(timeout=5.0)  # the cancel event reached the build
@@ -1146,6 +1149,37 @@ def test_close_cancels_in_flight_build() -> None:
     assert cancel.is_set()
 
 
+def test_serve_dir_rejected_with_relay_url(tmp_path: Path) -> None:
+    # serve_dir is a local-relay feature; silently ignoring it against an
+    # external relay would leave the user's page unserved.
+    module = RelayBridgeModule(
+        relay_url="https://127.0.0.1:1", serve_dir=str(tmp_path), open_browser=False
+    )
+    with pytest.raises(RuntimeError, match="serve_dir requires"):
+        module.start()
+    stop_module(module)
+
+
+def test_missing_serve_dir_fails_before_build_and_spawn(monkeypatch, tmp_path: Path) -> None:
+    # A typo'd directory must produce the labeled error, not a minute-long
+    # build followed by a relay child dying with a stderr dump.
+    builds: list[int] = []
+    monkeypatch.setattr(
+        relay_bridge_module, "ensure_web_dist", lambda *args, **kwargs: builds.append(1)
+    )
+    spawns: list[int] = []
+    monkeypatch.setattr(
+        RelayBridgeModule, "_spawn_relay", lambda self, open_browser, serve_dir: spawns.append(1)
+    )
+    module = RelayBridgeModule(
+        local_port=0, open_browser=False, serve_dir=str(tmp_path / "nope"), robot_id="unit-bot"
+    )
+    with pytest.raises(RuntimeError, match="serve_dir does not exist"):
+        module.start()
+    stop_module(module)
+    assert builds == [] and spawns == []
+
+
 def test_failed_start_stops_spawned_relay(monkeypatch) -> None:
     # First-connect failure after a successful spawn happens before main yields;
     # its unified finally must still reap the fresh child.
@@ -1153,14 +1187,14 @@ def test_failed_start_stops_spawned_relay(monkeypatch) -> None:
         raise OSError("connect refused")
 
     monkeypatch.setattr(relay_bridge_module, "connect_with_backoff", fail_connect)
-    # cockpit_build=False: the build now runs in main() before _spawn_relay,
+    # web_build=False: the build now runs in main() before _spawn_relay,
     # so the fake spawn below no longer shields this test from it.
     module = RelayBridgeModule(
-        local_port=0, open_browser=False, cockpit_build=False, robot_id="unit-bot"
+        local_port=0, open_browser=False, web_build=False, robot_id="unit-bot"
     )
     relay = FakeRelay(running=True)
 
-    def fake_spawn(open_browser: bool) -> str:
+    def fake_spawn(open_browser: bool, serve_dir: Path | None) -> str:
         module._relay = relay
         return "https://127.0.0.1:2"
 

--- a/dimos/web/relay_bridge/test_relay_process.py
+++ b/dimos/web/relay_bridge/test_relay_process.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""RelayProcess cockpit serving and the ensure_cockpit_dist build policy."""
+"""RelayProcess serving and the ensure_web_dist build policy."""
 
 import json
 import os
@@ -31,10 +31,11 @@ from dimos.web.relay_bridge.locate import (
     WEB_DIR_BUILD_ENV_VAR,
     WEB_DIR_ENV_VAR,
     find_cockpit_dist,
+    find_sdk_dist,
     relay_run_cmd,
 )
 from dimos.web.relay_bridge.protocol import PROTOCOL_VERSION
-from dimos.web.relay_bridge.relay_process import RelayProcess, ensure_cockpit_dist
+from dimos.web.relay_bridge.relay_process import RelayProcess, ensure_web_dist
 
 
 def _fetch(url: str) -> tuple[int, bytes]:
@@ -53,7 +54,14 @@ def _make_fake_dist(root: Path) -> Path:
     return dist
 
 
-def test_relay_run_cmd_cockpit_flags() -> None:
+def _make_fake_sdk_dist(root: Path) -> Path:
+    dist = root / "dist"
+    dist.mkdir(parents=True)
+    (dist / "sdk.js").write_text("// fake sdk bundle")
+    return dist
+
+
+def test_relay_run_cmd_dir_flags() -> None:
     cmd = relay_run_cmd("deno", Path("/web"), "--port", "0")
     assert "--node-modules-dir=none" in cmd
     assert "--allow-read=/web" in cmd
@@ -62,6 +70,17 @@ def test_relay_run_cmd_cockpit_flags() -> None:
     cmd = relay_run_cmd("deno", Path("/web"), "--port", "0", cockpit_dir=Path("/elsewhere/dist"))
     assert "--allow-read=/web,/elsewhere/dist" in cmd
     assert cmd[cmd.index("--cockpit-dir") + 1] == "/elsewhere/dist"
+
+    cmd = relay_run_cmd(
+        "deno",
+        Path("/web"),
+        cockpit_dir=Path("/elsewhere/dist"),
+        sdk_dir=Path("/sdk/dist"),
+        serve_dir=Path("/my/ui"),
+    )
+    assert "--allow-read=/web,/elsewhere/dist,/sdk/dist,/my/ui" in cmd
+    assert cmd[cmd.index("--sdk-dir") + 1] == "/sdk/dist"
+    assert cmd[cmd.index("--serve-dir") + 1] == "/my/ui"
 
 
 def test_relay_run_cmd_resolves_symlinked_dirs(tmp_path: Path) -> None:
@@ -94,36 +113,82 @@ def test_relay_serves_cockpit_dist(tmp_path: Path) -> None:
         assert api_info["certHash"] == info.cert_hash
 
 
+def test_relay_serves_sdk_and_serve_dir(tmp_path: Path) -> None:
+    cockpit_dist = _make_fake_dist(tmp_path / "cockpit")
+    sdk_dist = _make_fake_sdk_dist(tmp_path / "sdk")
+    user_dir = tmp_path / "my-ui"
+    user_dir.mkdir()
+    (user_dir / "index.html").write_text("<html><body>fake user index</body></html>")
+    (user_dir / "data.txt").write_text("user data")
+    (tmp_path / "outside.txt").write_text("must never be served")
+    (user_dir / "escape.txt").symlink_to(tmp_path / "outside.txt")
+
+    with RelayProcess(
+        port=0, cockpit_dir=cockpit_dist, sdk_dir=sdk_dist, serve_dir=user_dir
+    ) as info:
+        # The user directory replaces the cockpit at /.
+        status, index = _fetch(info.open_url)
+        assert status == 200 and b"fake user index" in index
+        status, data = _fetch(f"{info.open_url}data.txt")
+        assert status == 200 and data == b"user data"
+
+        # /sdk.js and /api/* keep precedence over the user root, and /sdk.js
+        # carries the local CORS wildcard plus no-cache.
+        with urllib.request.urlopen(f"{info.open_url}sdk.js") as response:
+            assert response.headers["Access-Control-Allow-Origin"] == "*"
+            assert response.headers["Cache-Control"] == "no-cache"
+            assert response.read() == b"// fake sdk bundle"
+        status, body = _fetch(f"{info.open_url}api/info")
+        assert status == 200 and json.loads(body)["v"] == PROTOCOL_VERSION
+
+        # The traversal and symlink-escape guards apply to the user root.
+        status, _ = _fetch(f"http://127.0.0.1:{info.http_port}//etc/passwd")
+        assert status == 400
+        status, body = _fetch(f"{info.open_url}escape.txt")
+        assert status == 400 and b"never be served" not in body
+
+
 def test_relay_without_cockpit_serves_build_hint(monkeypatch: pytest.MonkeyPatch) -> None:
-    # The checkout may have a built dist; force the "not built" path.
+    # The checkout may have built dists; force the "not built" path.
     monkeypatch.setattr(relay_process, "find_cockpit_dist", lambda _: None)
+    monkeypatch.setattr(relay_process, "find_sdk_dist", lambda _: None)
     with RelayProcess(port=0) as info:
         assert info.cockpit is False
         status, index = _fetch(info.open_url)
         assert status == 404 and b"cockpit dist not built" in index
+        status, sdk = _fetch(f"{info.open_url}sdk.js")
+        assert status == 404 and b"sdk bundle not built" in sdk
 
 
 class _FakeBuild:
-    """Stands in for _run_build; writes a dist into the --outDir on success."""
+    """Stands in for _run_build; writes a per-package dist into the --outDir.
 
-    def __init__(self, ok: bool = True) -> None:
-        self.ok = ok
+    `fail` names the package (by directory name) whose build fails; every
+    other package builds successfully.
+    """
+
+    def __init__(self, fail: str | None = None) -> None:
+        self.fail = fail
         self.calls: list[Path] = []
 
     def __call__(self, cmd: list[str], cwd: Path, deadline: float, cancel: threading.Event) -> bool:
         assert cmd[-2] == "--outDir"
         self.calls.append(Path(cwd))
-        if self.ok:
-            out_dir = Path(cmd[-1])
+        if cwd.name == self.fail:
+            return False
+        out_dir = Path(cmd[-1])
+        if cwd.name == "sdk":
+            (out_dir / "sdk.js").write_text("// fake sdk bundle")
+        else:
             (out_dir / "assets").mkdir()
             (out_dir / "index.html").write_text("<html><body>fake cockpit index</body></html>")
             (out_dir / "assets" / "app.js").write_text("console.log('fake');")
-        return self.ok
+        return True
 
 
 @pytest.fixture
 def fake_web(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    """A fake checkout web/ tree with cockpit sources and no build tools."""
+    """A fake checkout web/ tree with cockpit+sdk sources and no build tools."""
     (tmp_path / "deno.json").write_text("{}")
     (tmp_path / "deno.lock").write_text("lock-v1")
     (tmp_path / "cockpit" / "src").mkdir(parents=True)
@@ -139,129 +204,181 @@ def fake_web(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     return tmp_path
 
 
-def test_ensure_cockpit_dist_builds_when_missing(
+def _dists(web_dir: Path) -> tuple[Path | None, Path | None]:
+    return find_sdk_dist(web_dir), find_cockpit_dist(web_dir)
+
+
+def test_ensure_web_dist_builds_both_when_missing(
     fake_web: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     build = _FakeBuild()
     monkeypatch.setattr(relay_process, "_run_build", build)
-    dist = ensure_cockpit_dist(fake_web)
-    assert build.calls == [fake_web / "cockpit"]
-    assert dist == (fake_web / "cockpit" / "dist").resolve()
-    assert (dist / relay_process._STAMP_NAME).is_file()
-    # The temp build dir was published (renamed), not left behind.
+    ensure_web_dist(fake_web)
+    assert build.calls == [fake_web / "sdk", fake_web / "cockpit"]
+    sdk_dist, cockpit_dist = _dists(fake_web)
+    assert sdk_dist == (fake_web / "sdk" / "dist").resolve()
+    assert cockpit_dist == (fake_web / "cockpit" / "dist").resolve()
+    # One shared stamp in both dists; the temp build dirs were published
+    # (renamed), not left behind.
+    stamps = {relay_process._read_stamp(dist) for dist in (sdk_dist, cockpit_dist)}
+    assert len(stamps) == 1 and None not in stamps
+    assert list((fake_web / "sdk").glob(".dist-*")) == []
     assert list((fake_web / "cockpit").glob(".dist-*")) == []
 
 
-def test_ensure_cockpit_dist_skips_fresh_dist(
+def test_ensure_web_dist_skips_fresh_dists(fake_web: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    build = _FakeBuild()
+    monkeypatch.setattr(relay_process, "_run_build", build)
+    ensure_web_dist(fake_web)
+    ensure_web_dist(fake_web)
+    assert len(build.calls) == 2
+
+
+def test_ensure_web_dist_rebuilds_when_one_dist_missing(
     fake_web: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     build = _FakeBuild()
     monkeypatch.setattr(relay_process, "_run_build", build)
-    ensure_cockpit_dist(fake_web)
-    assert ensure_cockpit_dist(fake_web) == (fake_web / "cockpit" / "dist").resolve()
-    assert len(build.calls) == 1
+    ensure_web_dist(fake_web)
+    shutil.rmtree(fake_web / "sdk" / "dist")
+    ensure_web_dist(fake_web)
+    assert len(build.calls) == 4
+    assert None not in _dists(fake_web)
 
 
-def test_ensure_cockpit_dist_rebuilds_on_source_change(
+def test_ensure_web_dist_rebuilds_on_source_change(
     fake_web: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     build = _FakeBuild()
     monkeypatch.setattr(relay_process, "_run_build", build)
-    ensure_cockpit_dist(fake_web)
+    ensure_web_dist(fake_web)
     source = fake_web / "cockpit" / "src" / "main.tsx"
     stat = source.stat()
     source.write_text("edited")
     os.utime(source, (stat.st_atime, stat.st_mtime))  # content, not mtime, decides
-    ensure_cockpit_dist(fake_web)
-    assert len(build.calls) == 2
+    ensure_web_dist(fake_web)
+    assert len(build.calls) == 4
 
 
-def test_ensure_cockpit_dist_rebuilds_on_sdk_change(
+def test_ensure_web_dist_rebuilds_on_sdk_change(
     fake_web: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     # The cockpit bundles the SDK sources, so an sdk/ edit must invalidate
     # the stamp too.
     build = _FakeBuild()
     monkeypatch.setattr(relay_process, "_run_build", build)
-    ensure_cockpit_dist(fake_web)
+    ensure_web_dist(fake_web)
     source = fake_web / "sdk" / "src" / "index.ts"
     stat = source.stat()
     source.write_text("edited")
     os.utime(source, (stat.st_atime, stat.st_mtime))  # content, not mtime, decides
-    ensure_cockpit_dist(fake_web)
-    assert len(build.calls) == 2
+    ensure_web_dist(fake_web)
+    assert len(build.calls) == 4
 
 
-def test_ensure_cockpit_dist_rebuilds_on_source_deletion(
+def test_ensure_web_dist_rebuilds_on_source_deletion(
     fake_web: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     extra = fake_web / "cockpit" / "src" / "Extra.tsx"
     extra.write_text("code")
     build = _FakeBuild()
     monkeypatch.setattr(relay_process, "_run_build", build)
-    ensure_cockpit_dist(fake_web)
+    ensure_web_dist(fake_web)
     extra.unlink()
-    ensure_cockpit_dist(fake_web)
-    assert len(build.calls) == 2
+    ensure_web_dist(fake_web)
+    assert len(build.calls) == 4
 
 
-def test_ensure_cockpit_dist_rebuilds_on_lockfile_change(
+def test_ensure_web_dist_rebuilds_on_lockfile_change(
     fake_web: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     build = _FakeBuild()
     monkeypatch.setattr(relay_process, "_run_build", build)
-    ensure_cockpit_dist(fake_web)
+    ensure_web_dist(fake_web)
     (fake_web / "deno.lock").write_text("lock-v2")
-    ensure_cockpit_dist(fake_web)
-    assert len(build.calls) == 2
+    ensure_web_dist(fake_web)
+    assert len(build.calls) == 4
 
 
-def test_ensure_cockpit_dist_ignores_test_and_hidden_files(
+def test_ensure_web_dist_ignores_test_and_hidden_files(
     fake_web: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     build = _FakeBuild()
     monkeypatch.setattr(relay_process, "_run_build", build)
-    ensure_cockpit_dist(fake_web)
+    ensure_web_dist(fake_web)
     (fake_web / "cockpit" / "src" / "App.test.tsx").write_text("test code")
     (fake_web / "shared" / "protocol_test.ts").write_text("test code")
     (fake_web / "cockpit" / ".env.local").write_text("hidden")
-    ensure_cockpit_dist(fake_web)
-    assert len(build.calls) == 1
+    ensure_web_dist(fake_web)
+    assert len(build.calls) == 2
 
 
-def test_ensure_cockpit_dist_failed_build_keeps_served_dist(
+def test_ensure_web_dist_failed_sdk_build_keeps_both_dists(
     fake_web: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(relay_process, "_run_build", _FakeBuild())
-    dist = ensure_cockpit_dist(fake_web)
-    assert dist is not None
-    index_before = (dist / "index.html").read_bytes()
+    ensure_web_dist(fake_web)
+    sdk_dist, cockpit_dist = _dists(fake_web)
+    assert sdk_dist is not None and cockpit_dist is not None
+    sdk_before = (sdk_dist / "sdk.js").read_bytes()
+    index_before = (cockpit_dist / "index.html").read_bytes()
 
-    (fake_web / "cockpit" / "src" / "main.tsx").write_text("edited")
-    monkeypatch.setattr(relay_process, "_run_build", _FakeBuild(ok=False))
-    assert ensure_cockpit_dist(fake_web) == dist  # stale but present beats nothing
-    assert (dist / "index.html").read_bytes() == index_before  # never clobbered
+    (fake_web / "sdk" / "src" / "index.ts").write_text("edited")
+    failing = _FakeBuild(fail="sdk")
+    monkeypatch.setattr(relay_process, "_run_build", failing)
+    ensure_web_dist(fake_web)
+    # The cockpit build was not even attempted after the sdk failure, and
+    # neither previously valid dist was touched (stale but present beats
+    # nothing).
+    assert failing.calls == [fake_web / "sdk"]
+    assert (sdk_dist / "sdk.js").read_bytes() == sdk_before
+    assert (cockpit_dist / "index.html").read_bytes() == index_before
 
-    shutil.rmtree(dist)
-    assert ensure_cockpit_dist(fake_web) is None
+
+def test_ensure_web_dist_failed_cockpit_build_keeps_both_dists(
+    fake_web: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(relay_process, "_run_build", _FakeBuild())
+    ensure_web_dist(fake_web)
+    sdk_dist, cockpit_dist = _dists(fake_web)
+    assert sdk_dist is not None and cockpit_dist is not None
+    sdk_before = (sdk_dist / "sdk.js").read_bytes()
+    index_before = (cockpit_dist / "index.html").read_bytes()
+
+    (fake_web / "sdk" / "src" / "index.ts").write_text("edited")
+    monkeypatch.setattr(relay_process, "_run_build", _FakeBuild(fail="cockpit"))
+    ensure_web_dist(fake_web)
+    # The successful sdk temp build was not swapped in: both or neither.
+    assert (sdk_dist / "sdk.js").read_bytes() == sdk_before
+    assert (cockpit_dist / "index.html").read_bytes() == index_before
+    assert list((fake_web / "sdk").glob(".dist-*")) == []
+
+    shutil.rmtree(cockpit_dist)
+    ensure_web_dist(fake_web)
+    assert find_cockpit_dist(fake_web) is None  # still failing; nothing appears
 
 
-def test_ensure_cockpit_dist_wheel_shape_never_builds(
+def test_ensure_web_dist_wheel_shape_never_builds(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # A wheel ships cockpit/dist but no cockpit/src: return the dist as-is.
-    dist = _make_fake_dist(tmp_path / "cockpit")
+    # A wheel ships both dists but no src trees: serve them as-is.
+    _make_fake_dist(tmp_path / "cockpit")
+    _make_fake_sdk_dist(tmp_path / "sdk")
     build = _FakeBuild()
     monkeypatch.setattr(relay_process, "_run_build", build)
-    assert ensure_cockpit_dist(tmp_path) == dist.resolve()
+    ensure_web_dist(tmp_path)
     assert build.calls == []
     # No lock or stamp writes either: site-packages may be read-only.
-    assert not (tmp_path / "cockpit" / ".build.lock").exists()
-    # And a wheel without a cockpit at all yields None.
-    assert ensure_cockpit_dist(tmp_path / "nowhere") is None
+    assert not (tmp_path / ".build.lock").exists()
+    # A tree with only one src dir cannot build both products: also as-is.
+    (tmp_path / "sdk" / "src").mkdir()
+    ensure_web_dist(tmp_path)
+    assert build.calls == []
+    # And a wheel without any web tree is a no-op.
+    ensure_web_dist(tmp_path / "nowhere")
 
 
-def test_ensure_cockpit_dist_env_tree_requires_opt_in(
+def test_ensure_web_dist_env_tree_requires_opt_in(
     fake_web: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     # A tree picked via DIMOS_WEB_DIR is served as-is: its build tooling runs
@@ -269,14 +386,14 @@ def test_ensure_cockpit_dist_env_tree_requires_opt_in(
     build = _FakeBuild()
     monkeypatch.setattr(relay_process, "_run_build", build)
     monkeypatch.setenv(WEB_DIR_ENV_VAR, str(fake_web))
-    assert ensure_cockpit_dist(fake_web) is None
+    ensure_web_dist(fake_web)
     assert build.calls == []
     monkeypatch.setenv(WEB_DIR_BUILD_ENV_VAR, "1")
-    assert ensure_cockpit_dist(fake_web) == (fake_web / "cockpit" / "dist").resolve()
-    assert len(build.calls) == 1
+    ensure_web_dist(fake_web)
+    assert build.calls == [fake_web / "sdk", fake_web / "cockpit"]
 
 
-def test_ensure_cockpit_dist_serializes_concurrent_builds(
+def test_ensure_web_dist_serializes_concurrent_builds(
     fake_web: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     build = _FakeBuild()
@@ -297,18 +414,15 @@ def test_ensure_cockpit_dist_serializes_concurrent_builds(
                 active -= 1
 
     monkeypatch.setattr(relay_process, "_run_build", slow_build)
-    results: list[Path | None] = []
-    threads = [
-        threading.Thread(target=lambda: results.append(ensure_cockpit_dist(fake_web)))
-        for _ in range(2)
-    ]
+    threads = [threading.Thread(target=lambda: ensure_web_dist(fake_web)) for _ in range(2)]
     for thread in threads:
         thread.start()
     for thread in threads:
         thread.join(timeout=30)
     assert peak == 1  # the flock serialized the builders
-    assert build.calls == [fake_web / "cockpit"]  # the loser re-checked and found it fresh
-    assert results == [(fake_web / "cockpit" / "dist").resolve()] * 2
+    # The loser re-checked and found both dists fresh.
+    assert build.calls == [fake_web / "sdk", fake_web / "cockpit"]
+    assert None not in _dists(fake_web)
 
 
 def test_run_build_cancel_kills_child_group(tmp_path: Path) -> None:
@@ -358,6 +472,14 @@ def test_find_cockpit_dist_requires_index(tmp_path: Path) -> None:
     assert find_cockpit_dist(tmp_path) is None
     (tmp_path / "cockpit" / "dist" / "index.html").write_text("x")
     assert find_cockpit_dist(tmp_path) == (tmp_path / "cockpit" / "dist").resolve()
+
+
+def test_find_sdk_dist_requires_bundle(tmp_path: Path) -> None:
+    assert find_sdk_dist(tmp_path) is None
+    (tmp_path / "sdk" / "dist").mkdir(parents=True)
+    assert find_sdk_dist(tmp_path) is None
+    (tmp_path / "sdk" / "dist" / "sdk.js").write_text("x")
+    assert find_sdk_dist(tmp_path) == (tmp_path / "sdk" / "dist").resolve()
 
 
 def test_find_cockpit_dist_resolves_symlinks(tmp_path: Path) -> None:

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ RELAY_DIST_SOURCES = (
     "cockpit/dist",
     "sdk/deno.json",
     "sdk/package.json",
+    "sdk/dist",
 )
 RELAY_DIST_TARGET = os.path.join("dimos", "web", "relay_bridge", "_relay_dist")
 
@@ -98,23 +99,31 @@ class build_py(_build_py):
         src = Path(__file__).parent / "web"
         if not (src / "relay" / "main.ts").is_file():
             raise RuntimeError(f"relay sources missing at {src}; refusing to build the wheel")
-        if not (src / "cockpit" / "dist" / "index.html").is_file():
-            # Wheels must carry the Cockpit: there is no fallback debug page,
-            # so a dist-less wheel's relay serves no UI at all. Building a
-            # deliberate python-only wheel (e.g. where deno is unavailable)
-            # requires the explicit env-var opt-out.
+        missing = [
+            rel
+            for rel in ("cockpit/dist/index.html", "sdk/dist/sdk.js")
+            if not (src / rel).is_file()
+        ]
+        if missing:
+            # Wheels must carry the Cockpit and the SDK bundle: there is no
+            # fallback debug page, so a dist-less wheel's relay serves no UI
+            # (and /sdk.js only a build hint). Building a deliberate
+            # python-only wheel (e.g. where deno is unavailable) requires the
+            # explicit env-var opt-out, which covers both products.
             if os.environ.get("DIMOS_ALLOW_MISSING_COCKPIT") != "1":
                 raise RuntimeError(
-                    f"cockpit dist missing at {src / 'cockpit' / 'dist'}; run "
-                    "`deno task build` in web/cockpit (or `dimos run --local-relay` "
-                    "from a checkout builds it), or set DIMOS_ALLOW_MISSING_COCKPIT=1 "
-                    "to build a UI-less wheel anyway"
+                    f"web dist missing ({', '.join(missing)}); run `deno task build` "
+                    "in web/sdk and web/cockpit (or `dimos run --local-relay` from a "
+                    "checkout builds them), or set DIMOS_ALLOW_MISSING_COCKPIT=1 to "
+                    "build a UI-less wheel anyway"
                 )
-            self.warn("cockpit dist missing; this wheel's relay will have no UI")
+            self.warn(
+                f"web dist missing ({', '.join(missing)}); this wheel's relay will have no UI"
+            )
         dst = Path(self.build_lib) / RELAY_DIST_TARGET
         for name in RELAY_DIST_SOURCES:
             entry = src / name
-            if not entry.exists():  # only cockpit/dist may be absent (env-var opt-out above)
+            if not entry.exists():  # only the dists may be absent (env-var opt-out above)
                 continue
             for path in sorted(entry.rglob("*")) if entry.is_dir() else [entry]:
                 # Filter on the path below src: matching path.parts would also

--- a/web/README.md
+++ b/web/README.md
@@ -10,10 +10,18 @@ node/npm anywhere: vite, vitest, and tsc run as npm packages under Deno (`nodeMo
 and `dimos --local-relay` auto-downloads Deno via `ensure_deno()`.
 
 ```bash
-deno task dev            # relay on http://127.0.0.1:7780 (add --cockpit-dir cockpit/dist for the UI)
+deno task dev            # relay on http://127.0.0.1:7780 (add --cockpit-dir cockpit/dist for the UI,
+                         # --sdk-dir sdk/dist for /sdk.js, --serve-dir DIR for a custom page at /)
 deno task test           # relay + shared tests (unit + loopback e2e)
 deno task check          # type-check relay + shared; deno fmt + deno lint for style (all of web/)
 ```
+
+The local relay deliberately answers `/api/info`, `/api/stats`, `/sdk.js`, and served JavaScript
+modules with wildcard CORS so any local origin (a Vite dev server, a `file:` page) can bootstrap
+against it; a remotely reachable relay is a different, fail-closed mode (W10) and must not inherit
+that. For the same reason `startRelay` refuses to bind a non-loopback host unless
+`--unsafe-non-loopback` explicitly acknowledges it (only sensible behind your own TLS and access
+control).
 
 ## SDK
 
@@ -27,12 +35,29 @@ is React-free). The SDK subscribes to nothing by itself; the cockpit's panel pol
 cd sdk
 deno task test           # vitest
 deno task check          # tsc --noEmit
+deno task build          # dist/sdk.js, the zero-build ESM bundle the relay serves at /sdk.js
 deno task fixture        # demo consumer on http://localhost:5174 (run a relay first)
 ```
 
 `fixture/` is a minimal non-cockpit consumer: it lists robots, auto-watches the lone robot, and
 subscribes to `odom` by hand. Run `dimos run <bp> --local-relay` and `deno task fixture` side by
 side; like the cockpit dev server it proxies `/api` to the relay on `:7780`.
+
+### Zero-build page
+
+`examples/minimal/` is a single HTML file importing `/sdk.js` - no bundler, no npm. Serve it from
+the relay itself:
+
+```bash
+dimos run <bp> --local-relay --serve-dir web/examples/minimal
+```
+
+`--serve-dir` replaces the cockpit at `/` with the given directory (`/api/*` and `/sdk.js` keep
+precedence, and the relay's traversal/symlink guards apply); it needs the spawned local relay and is
+rejected with `--relay-url`. A page can also import the absolute `http://127.0.0.1:7780/sdk.js` and
+pass that base to `connect({url})` - from another local origin or straight from a `file:` page (both
+supported browsers permit WebTransport there; `dimos/e2e_tests/test_sdk_browser.py` pins all three
+forms).
 
 ## Cockpit
 
@@ -48,9 +73,10 @@ Dev workflow: run the relay (`deno task dev` in `web/`, or just `dimos run <bp> 
 the vite server side by side. `localhost:5173` is a secure context; vite proxies `/api` to the relay
 on `:7780` and the WebTransport connection goes straight to the advertised `wtUrl`.
 
-Without vite, `--local-relay` serves the built `cockpit/dist` at `/`, building it first when it is
-missing or older than the sources (`ensure_cockpit_dist` in `relay_process.py`). Release wheels ship
-a pre-built dist inside `_relay_dist` (built by the release workflow; see `setup.py`), so a
+Without vite, `--local-relay` serves the built `cockpit/dist` at `/` and `sdk/dist/sdk.js` at
+`/sdk.js`, building both first when either is missing or older than the sources (`ensure_web_dist`
+in `relay_process.py`; one stamp, both products swapped together). Release wheels ship both
+pre-built dists inside `_relay_dist` (built by the release workflow; see `setup.py`), so a
 pip-installed dimos never builds or downloads npm packages.
 
 After changing cockpit or sdk dependencies run `deno install` in `web/` and commit the `deno.lock`
@@ -58,10 +84,11 @@ update; CI validates it with `deno install --frozen`. If vitest ever misbehaves 
 the fallback ladder is `--no-file-parallelism`, then `--pool=threads`, then pinning a different
 vitest minor.
 
-The cockpit browser e2e (`dimos/e2e_tests/test_cockpit_browser.py`, marker `web_browser`) drives the
-whole stack against the go2 replay dataset in both Playwright Chromium and Firefox (their
-WebTransport stacks differ; see bug 11). The CI `web` job runs it; the pinned browser builds
-auto-install on first run.
+The browser e2e (`dimos/e2e_tests/test_cockpit_browser.py` for the cockpit, `test_sdk_browser.py`
+for the SDK's zero-build/cross-origin/file: pages; marker `web_browser`) drives the whole stack
+against the go2 replay dataset in both Playwright Chromium and Firefox (their WebTransport stacks
+differ; see bug 11). The CI `web` job runs them; the pinned browser builds auto-install on first
+run.
 
 ## Teleop safety chain
 

--- a/web/deno.json
+++ b/web/deno.json
@@ -22,12 +22,14 @@
     "lineWidth": 100,
     "exclude": [
       "shared/fixtures/*.json",
-      "cockpit/dist/"
+      "cockpit/dist/",
+      "sdk/dist/"
     ]
   },
   "lint": {
     "exclude": [
-      "cockpit/dist/"
+      "cockpit/dist/",
+      "sdk/dist/"
     ],
     "rules": {
       "tags": [

--- a/web/examples/minimal/index.html
+++ b/web/examples/minimal/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<!-- Zero-build @dimos/sdk page: served by the local relay itself, so the
+     import and connect() are same-origin and /sdk.js is the relay's bundle.
+     Run:  dimos run <blueprint> --local-relay --serve-dir web/examples/minimal -->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>DimOS minimal SDK page</title>
+    <style>
+      body {
+        font-family: monospace;
+        margin: 1rem;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>DimOS minimal SDK page</h1>
+    <div id="status">status: connecting</div>
+    <pre id="odom">odom: (no data)</pre>
+    <script type="module">
+      import { connect } from "/sdk.js";
+
+      const statusEl = document.querySelector("#status");
+      const odomEl = document.querySelector("#odom");
+
+      const session = connect();
+
+      session.status.subscribe(() => {
+        const status = session.status.get();
+        const robots = status.robots.map((r) => `${r.name} (${r.id})`).join(", ");
+        statusEl.textContent = `status: ${status.transport.phase}, robots: ${
+          robots || "(none)"
+        }`;
+      });
+
+      session.subscribe("odom", (snapshot) => {
+        odomEl.textContent = `odom: ${
+          JSON.stringify(snapshot.slot?.value ?? null, null, 2)
+        }`;
+      });
+    </script>
+  </body>
+</html>

--- a/web/relay/main.ts
+++ b/web/relay/main.ts
@@ -6,7 +6,10 @@ import { PROTOCOL_VERSION } from "@dimos/shared";
 import { startRelay } from "./server.ts";
 
 const args = parseArgs(Deno.args, {
-  string: ["host", "cockpit-dir"],
+  string: ["host", "cockpit-dir", "sdk-dir", "serve-dir"],
+  // Non-loopback binds need this explicit acknowledgment: the local relay
+  // trusts every origin that can reach it (see RelayOptions.unsafeNonLoopback).
+  boolean: ["unsafe-non-loopback"],
   default: { port: 7780, host: "127.0.0.1" },
 });
 
@@ -25,6 +28,9 @@ const relay = await startRelay({
   port: Number(args.port),
   host,
   cockpitDir: args["cockpit-dir"],
+  sdkDir: args["sdk-dir"],
+  serveDir: args["serve-dir"],
+  unsafeNonLoopback: args["unsafe-non-loopback"],
 });
 
 console.log(JSON.stringify({
@@ -35,10 +41,15 @@ console.log(JSON.stringify({
   v: PROTOCOL_VERSION,
 }));
 const pageHost = host === "0.0.0.0" ? "127.0.0.1" : host;
-if (args["cockpit-dir"] !== undefined) {
+if (args["serve-dir"] !== undefined) {
+  console.log(`[relay] serving ${args["serve-dir"]}: http://${pageHost}:${relay.httpPort}/`);
+} else if (args["cockpit-dir"] !== undefined) {
   console.log(`[relay] cockpit: http://${pageHost}:${relay.httpPort}/`);
 } else {
   console.log("[relay] no cockpit dist configured; serving /api only");
+}
+if (args["sdk-dir"] !== undefined) {
+  console.log(`[relay] sdk: http://${pageHost}:${relay.httpPort}/sdk.js`);
 }
 
 for (const signal of ["SIGINT", "SIGTERM"] as const) {

--- a/web/relay/server.ts
+++ b/web/relay/server.ts
@@ -24,6 +24,19 @@ export interface RelayOptions {
    * the relay has no UI (/ answers 404 with a build hint); only /api/* works.
    */
   cockpitDir?: string;
+  /** Built SDK bundle (web/sdk/dist): serves GET /sdk.js. */
+  sdkDir?: string;
+  /** User static root served at / instead of the cockpit (--serve-dir). */
+  serveDir?: string;
+  /**
+   * Explicit acknowledgment for binding a non-loopback host. This local
+   * relay trusts every origin that can reach it (wildcard CORS on the
+   * discovery endpoints, an unauthenticated WebTransport session, optional
+   * user-file serving), so startRelay refuses other hosts without this -
+   * only sensible behind the operator's own TLS and access control. A
+   * remote-capable relay is a separate, fail-closed mode (W10), not this.
+   */
+  unsafeNonLoopback?: boolean;
 }
 
 export interface RelayHandle {
@@ -37,12 +50,31 @@ export interface RelayHandle {
 
 const MIME: Record<string, string> = {
   ".html": "text/html; charset=utf-8",
+  // Browsers enforce a JavaScript MIME type for module scripts, so .js and
+  // .mjs must both resolve to it or `<script type="module">` refuses them.
   ".js": "application/javascript",
+  ".mjs": "application/javascript",
   ".css": "text/css",
   ".json": "application/json",
   ".svg": "image/svg+xml",
   ".png": "image/png",
+  ".txt": "text/plain; charset=utf-8",
+  ".ico": "image/x-icon",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".wasm": "application/wasm",
 };
+
+// Deliberate LOCAL-relay policy: this relay binds loopback (enforced in
+// startRelay unless unsafeNonLoopback overrides it) and trusts local browser
+// applications, so any local origin (e.g. a Vite dev server) may read the
+// discovery endpoints and import served JavaScript modules. A remotely
+// reachable relay (W10) is fail-closed and must NOT inherit this wildcard.
+const LOCAL_CORS = { "access-control-allow-origin": "*" };
+
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1"]);
 
 function resolveDirUrl(dir: string, label: string): URL {
   // Canonical (realPath) so serveFrom compares symlink-free paths (macOS /tmp
@@ -114,10 +146,23 @@ export function installUnhandledRejectionGuard(): void {
 export async function startRelay(options: RelayOptions = {}): Promise<RelayHandle> {
   installUnhandledRejectionGuard();
   const host = options.host ?? "127.0.0.1";
+  if (!LOOPBACK_HOSTS.has(host) && options.unsafeNonLoopback !== true) {
+    throw new Error(
+      `host ${host} is not loopback: the local relay serves wildcard CORS, an ` +
+        "unauthenticated WebTransport session, and optional --serve-dir files to every " +
+        "origin that can reach it. Bind 127.0.0.1, or pass --unsafe-non-loopback " +
+        "(RelayOptions.unsafeNonLoopback) only behind your own TLS and access control",
+    );
+  }
 
-  // Resolve the served root before binding anything so a bad path fails
+  // Resolve the served roots before binding anything so a bad path fails
   // fast, without a QUIC endpoint or timer left behind.
   const cockpitRoot = options.cockpitDir ? resolveDirUrl(options.cockpitDir, "cockpitDir") : null;
+  const sdkRoot = options.sdkDir ? resolveDirUrl(options.sdkDir, "sdkDir") : null;
+  const serveRoot = options.serveDir ? resolveDirUrl(options.serveDir, "serveDir") : null;
+  // A user directory replaces the cockpit at /; /api/* and /sdk.js keep
+  // precedence over it in handleHttp.
+  const staticRoot = serveRoot ?? cockpitRoot;
 
   const cert = await makeEphemeralCert();
 
@@ -182,12 +227,29 @@ export async function startRelay(options: RelayOptions = {}): Promise<RelayHandl
         wtUrl: `${wtUrl}/viewer`,
         certHash: cert.certHashB64,
         v: PROTOCOL_VERSION,
-      });
+      }, { headers: LOCAL_CORS });
     }
     if (url.pathname === "/api/stats") {
-      return Response.json(registry.stats());
+      return Response.json(registry.stats(), { headers: LOCAL_CORS });
     }
-    if (cockpitRoot === null) {
+    if (url.pathname === "/sdk.js") {
+      // Never falls through to a static root: a missing bundle must yield the
+      // hint, not HTML (an HTML body imported as a module is a baffling
+      // syntax error in the consumer page). The fixed name cannot traverse,
+      // so serveFrom only returns 200 or null here.
+      const found = sdkRoot === null ? null : await serveFrom(sdkRoot, "sdk.js");
+      const res = found ?? new Response(
+        "sdk bundle not built (dimos run --local-relay builds it; " +
+          "or run `deno task build` in web/sdk)",
+        { status: 404 },
+      );
+      // Also on the 404: a cross-origin page must be able to read the hint.
+      res.headers.set("access-control-allow-origin", "*");
+      // A rebuilt bundle must not be pinned by a stale browser cache.
+      res.headers.set("cache-control", "no-cache");
+      return res;
+    }
+    if (staticRoot === null) {
       return new Response(
         "cockpit dist not built (dimos run --local-relay builds it; " +
           "or run `deno task build` in web/cockpit)",
@@ -195,7 +257,15 @@ export async function startRelay(options: RelayOptions = {}): Promise<RelayHandl
       );
     }
     const name = url.pathname === "/" ? "index.html" : url.pathname.slice(1);
-    return await serveFrom(cockpitRoot, name) ?? new Response("not found", { status: 404 });
+    const res = await serveFrom(staticRoot, name);
+    if (res === null) return new Response("not found", { status: 404 });
+    if (res.headers.get("content-type") === "application/javascript") {
+      // ES modules are fetched with CORS semantics: a page on another local
+      // origin importing a module served from this root needs the header
+      // (same local trust policy as /sdk.js).
+      res.headers.set("access-control-allow-origin", "*");
+    }
+    return res;
   }
 
   const httpServer = Deno.serve(

--- a/web/relay/server_test.ts
+++ b/web/relay/server_test.ts
@@ -706,6 +706,122 @@ Deno.test({
   }
 });
 
+Deno.test({
+  name: "relay serves /sdk.js with local CORS and no-cache",
+  sanitizeOps: false,
+  sanitizeResources: false,
+}, async () => {
+  const sdkDir = fileURLToPath(new URL("./testdata/fake_sdk_dist", import.meta.url));
+  const relay = await startRelay({ port: 0, sdkDir });
+  const httpBase = `http://127.0.0.1:${relay.httpPort}`;
+  try {
+    const sdk = await fetch(`${httpBase}/sdk.js`);
+    assertEquals(sdk.status, 200);
+    assertEquals(sdk.headers.get("content-type"), "application/javascript");
+    assertEquals(sdk.headers.get("access-control-allow-origin"), "*");
+    assertEquals(sdk.headers.get("cache-control"), "no-cache");
+    assert((await sdk.text()).includes("fake sdk bundle"));
+    // The discovery endpoints carry the local wildcard too, so a page on
+    // another loopback origin (Vite dev server) can bootstrap.
+    for (const path of ["/api/info", "/api/stats"]) {
+      const res = await fetch(`${httpBase}${path}`);
+      assertEquals(res.headers.get("access-control-allow-origin"), "*", path);
+      await res.body?.cancel();
+    }
+  } finally {
+    await relay.shutdown();
+  }
+});
+
+Deno.test({
+  name: "missing sdk bundle yields a build hint, never cockpit HTML",
+  sanitizeOps: false,
+  sanitizeResources: false,
+}, async () => {
+  const cockpitDir = fileURLToPath(new URL("./testdata/fake_cockpit", import.meta.url));
+  const relay = await startRelay({ port: 0, cockpitDir });
+  const httpBase = `http://127.0.0.1:${relay.httpPort}`;
+  try {
+    const sdk = await fetch(`${httpBase}/sdk.js`);
+    assertEquals(sdk.status, 404);
+    assertEquals(sdk.headers.get("access-control-allow-origin"), "*");
+    const body = await sdk.text();
+    assert(body.includes("sdk bundle not built"));
+    // An HTML fallback imported as a module would be a baffling syntax error
+    // in the consumer page; the hint must win over the static root.
+    assert(!body.includes("fake cockpit index"));
+  } finally {
+    await relay.shutdown();
+  }
+});
+
+Deno.test({
+  name: "serve-dir replaces the cockpit root; api and sdk keep precedence",
+  sanitizeOps: false,
+  sanitizeResources: false,
+}, async () => {
+  const cockpitDir = fileURLToPath(new URL("./testdata/fake_cockpit", import.meta.url));
+  const sdkDir = fileURLToPath(new URL("./testdata/fake_sdk_dist", import.meta.url));
+  const serveDir = fileURLToPath(new URL("./testdata/fake_user_dir", import.meta.url));
+  const relay = await startRelay({ port: 0, cockpitDir, sdkDir, serveDir });
+  const httpBase = `http://127.0.0.1:${relay.httpPort}`;
+  try {
+    const index = await (await fetch(`${httpBase}/`)).text();
+    assert(index.includes("fake user index"));
+    assert(!index.includes("fake cockpit index"));
+    // JavaScript from the user root is module-importable: the strict module
+    // MIME type (also for .mjs) plus the local CORS wildcard, so a page on
+    // another local origin can import it by absolute URL.
+    for (const path of ["/page.js", "/module.mjs"]) {
+      const mod = await fetch(`${httpBase}${path}`);
+      assertEquals(mod.status, 200, path);
+      assertEquals(mod.headers.get("content-type"), "application/javascript", path);
+      assertEquals(mod.headers.get("access-control-allow-origin"), "*", path);
+      await mod.body?.cancel();
+    }
+    // Decoy files in the user dir must not shadow the relay's own routes.
+    const info = await (await fetch(`${httpBase}/api/info`)).json();
+    assert(typeof info.wtUrl === "string");
+    const sdk = await (await fetch(`${httpBase}/sdk.js`)).text();
+    assert(sdk.includes("fake sdk bundle"));
+    assert(!sdk.includes("decoy"));
+    // The traversal and symlink-escape guards apply to the user root too.
+    const traverse = await fetch(`${httpBase}//etc/passwd`);
+    await traverse.body?.cancel();
+    assertEquals(traverse.status, 400);
+    const escape = await fetch(`${httpBase}/escape.txt`);
+    await escape.body?.cancel();
+    assertEquals(escape.status, 400);
+  } finally {
+    await relay.shutdown();
+  }
+});
+
+Deno.test("startRelay refuses a non-loopback host without the unsafe override", async () => {
+  // Before binding anything: the local trust model (wildcard CORS, no auth,
+  // optional user files) must not silently reach a LAN address.
+  await assertRejects(
+    () => startRelay({ host: "0.0.0.0" }),
+    Error,
+    "host 0.0.0.0 is not loopback",
+  );
+});
+
+Deno.test({
+  name: "the unsafe override binds a non-loopback host explicitly",
+  sanitizeOps: false,
+  sanitizeResources: false,
+}, async () => {
+  const relay = await startRelay({ host: "0.0.0.0", port: 0, unsafeNonLoopback: true });
+  try {
+    const res = await fetch(`http://127.0.0.1:${relay.httpPort}/api/info`);
+    assertEquals(res.status, 200);
+    await res.body?.cancel();
+  } finally {
+    await relay.shutdown();
+  }
+});
+
 Deno.test("startRelay rejects a bad served dir with a labeled error", async () => {
   // Before binding anything, so nothing leaks: a typo'd path names the
   // offending option, and a file (realpath-able, would 404 everything) is
@@ -719,5 +835,20 @@ Deno.test("startRelay rejects a bad served dir with a labeled error", async () =
     () => startRelay({ cockpitDir: fileURLToPath(import.meta.url) }),
     Error,
     "cockpitDir is not a directory",
+  );
+  await assertRejects(
+    () => startRelay({ serveDir: "/no/such/dir" }),
+    Error,
+    "serveDir does not exist: /no/such/dir",
+  );
+  await assertRejects(
+    () => startRelay({ serveDir: fileURLToPath(import.meta.url) }),
+    Error,
+    "serveDir is not a directory",
+  );
+  await assertRejects(
+    () => startRelay({ sdkDir: "/no/such/dir" }),
+    Error,
+    "sdkDir does not exist: /no/such/dir",
   );
 });

--- a/web/relay/testdata/fake_sdk_dist/sdk.js
+++ b/web/relay/testdata/fake_sdk_dist/sdk.js
@@ -1,0 +1,2 @@
+// fake sdk bundle
+export const fake = true;

--- a/web/relay/testdata/fake_user_dir/api/info
+++ b/web/relay/testdata/fake_user_dir/api/info
@@ -1,0 +1,1 @@
+decoy info: must never shadow /api/info

--- a/web/relay/testdata/fake_user_dir/escape.txt
+++ b/web/relay/testdata/fake_user_dir/escape.txt
@@ -1,0 +1,1 @@
+../secret.txt

--- a/web/relay/testdata/fake_user_dir/index.html
+++ b/web/relay/testdata/fake_user_dir/index.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<title>fake user index</title>

--- a/web/relay/testdata/fake_user_dir/module.mjs
+++ b/web/relay/testdata/fake_user_dir/module.mjs
@@ -1,0 +1,1 @@
+export const fromUserDir = true;

--- a/web/relay/testdata/fake_user_dir/page.js
+++ b/web/relay/testdata/fake_user_dir/page.js
@@ -1,0 +1,1 @@
+console.log("fake user page");

--- a/web/relay/testdata/fake_user_dir/sdk.js
+++ b/web/relay/testdata/fake_user_dir/sdk.js
@@ -1,0 +1,1 @@
+// decoy sdk: must never shadow the real /sdk.js

--- a/web/sdk/deno.json
+++ b/web/sdk/deno.json
@@ -8,6 +8,7 @@
   "tasks": {
     "test": "deno run -A npm:vitest run",
     "check": "deno run -A npm:typescript/tsc --noEmit",
+    "build": "deno run -A npm:vite build",
     "fixture": "deno run -A npm:vite --config fixture/vite.config.ts"
   }
 }

--- a/web/sdk/fixture/vite.config.ts
+++ b/web/sdk/fixture/vite.config.ts
@@ -2,7 +2,8 @@ import { fileURLToPath } from "node:url";
 import { defineConfig } from "vite";
 
 // Same shape as the cockpit dev server: /api/info is answered by the relay
-// on :7780 through the proxy (the relay sends no CORS headers), and the
+// on :7780 through the proxy (a convenience - the local relay also answers
+// /api/* with CORS, so connect({url}) works without it), and the
 // WebTransport connection then goes straight to the advertised wtUrl.
 // Subpath aliases must come first: aliases match in order and the bare one
 // would otherwise swallow them.

--- a/web/sdk/tsconfig.json
+++ b/web/sdk/tsconfig.json
@@ -26,5 +26,5 @@
       "@dimos/shared/manifest": ["../shared/manifest.ts"]
     }
   },
-  "include": ["src", "fixture", "vitest.config.ts"]
+  "include": ["src", "fixture", "vitest.config.ts", "vite.config.ts"]
 }

--- a/web/sdk/vite.config.ts
+++ b/web/sdk/vite.config.ts
@@ -1,0 +1,38 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vite";
+
+// Build config for the zero-build browser bundle the relay serves at
+// /sdk.js (`deno task build` -> dist/sdk.js). Tests never read this file:
+// vitest resolves vitest.config.ts first.
+//
+// Root entry only: the React bindings stay on the ./react subpath and out of
+// this bundle by design. The root graph is React-free, so `external` is a
+// tripwire: an accidental react import would survive as a bare specifier and
+// fail loudly in the consuming browser instead of silently bundling the
+// devDependency. The SDK has no dynamic imports, so the build is exactly one
+// file; the relay's CORS handling relies on that (only /sdk.js gets the
+// header).
+const sharedProtocol = fileURLToPath(new URL("../shared/protocol.ts", import.meta.url));
+const sharedManifest = fileURLToPath(new URL("../shared/manifest.ts", import.meta.url));
+
+export default defineConfig({
+  resolve: {
+    // Subpath alias first: aliases match in order (same as vitest.config.ts).
+    alias: {
+      "@dimos/shared/manifest": sharedManifest,
+      "@dimos/shared": sharedProtocol,
+    },
+  },
+  build: {
+    target: "es2022",
+    lib: {
+      entry: fileURLToPath(new URL("./src/index.ts", import.meta.url)),
+      formats: ["es"],
+      // package.json has "type": "module", so the es extension is .js and
+      // this yields literally dist/sdk.js. No source maps, matching the
+      // cockpit build.
+      fileName: "sdk",
+    },
+    rollupOptions: { external: ["react", "react/jsx-runtime"] },
+  },
+});


### PR DESCRIPTION
* By default the SDK bundle is served by the relay at `/sdk.js`.
* With `--serve-dir <dir>` you can have the relay serve a custom directory instead of the cockpit.
* The SDK is only meant to be run with a local relay, so it's only available on loopback (you can choose to allow access from anywhere).