### PR TITLE
feat(web): channel authoring API and web codec registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -477,7 +477,8 @@ jobs:
       - name: Cockpit + SDK browser e2e
         run: >-
           uv run pytest -m web_browser dimos/e2e_tests/test_cockpit_browser.py
-          dimos/e2e_tests/test_sdk_browser.py --no-cov
+          dimos/e2e_tests/test_sdk_browser.py
+          dimos/e2e_tests/test_custom_channel_browser.py --no-cov
 
   tests:
     if: |

--- a/dimos/e2e_tests/test_custom_channel_browser.py
+++ b/dimos/e2e_tests/test_custom_channel_browser.py
@@ -1,0 +1,139 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Custom-channel browser e2e (the W6 acceptance demo, in CI).
+
+Starts a cockpit(channels=[...]) bridge - a generated RelayBridgeModule
+subclass with a nav_path In[Path] port whose path.points.v1 encoder was
+resolved from the codec registry at blueprint definition time - serving
+web/examples/custom-path from its own local relay. The page registers the
+matching JavaScript decoder, subscribes manually (no cockpit panel anywhere in
+the chain), and must render the decoded points: Python @web_encoder -> relay
+-> browser decoder, end to end.
+
+The bridge runs in-process (like the relay_bridge e2e) on an ephemeral port,
+so it cannot clash with test_sdk_browser's stack on :7780 in the same CI job.
+
+Marked web_browser: excluded from the default suite (needs the
+`browser-tests` dependency group, Playwright browsers, and built web dists).
+Locally:
+`uv run --group browser-tests pytest -m web_browser dimos/e2e_tests/test_custom_channel_browser.py`.
+"""
+
+from collections.abc import Iterator
+import struct
+import threading
+import time
+
+import pytest
+
+from dimos.core.transport import pLCMTransport
+from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
+from dimos.msgs.nav_msgs.Path import Path
+from dimos.web.cockpit import Channel, cockpit
+from dimos.web.codecs import EncodedPayload, web_encoder
+from dimos.web.relay_bridge.e2e_support import stop_module
+from dimos.web.relay_bridge.locate import find_web_dir
+
+pytest.importorskip("playwright")
+
+from playwright.sync_api import Page, expect, sync_playwright
+
+pytestmark = pytest.mark.web_browser
+
+TOPIC = "/custom_path_e2e/nav_path"
+
+PATH_MSG = Path(
+    ts=42.5,
+    frame_id="world",
+    poses=[
+        PoseStamped(ts=42.5, position=[1.5, -2.5, 0.0], orientation=[0.0, 0.0, 0.0, 1.0]),
+        PoseStamped(ts=42.5, position=[2.0, 0.25, 0.0], orientation=[0.0, 0.0, 0.0, 1.0]),
+        PoseStamped(ts=42.5, position=[3.5, 4.0, 0.0], orientation=[0.0, 0.0, 0.0, 1.0]),
+    ],
+)
+
+
+# The codec pair documented in web/README.md: little-endian float32 (x, y)
+# pairs, meta.n = point count; web/examples/custom-path decodes it.
+@web_encoder("path.points.v1")
+def encode_path_points(msg: Path) -> EncodedPayload:
+    payload = b"".join(struct.pack("<ff", p.position.x, p.position.y) for p in msg.poses)
+    return EncodedPayload(payload, {"n": len(msg.poses)})
+
+
+@pytest.fixture(scope="module")
+def custom_path_page_url() -> Iterator[str]:
+    blueprint = cockpit(
+        channels=[Channel("nav_path", Path, encoding="path.points.v1", max_hz=20.0)]
+    )
+    (atom,) = blueprint.blueprints
+    module = atom.module(
+        local_port=0,
+        open_browser=False,
+        robot_id="custom-path-e2e",
+        serve_dir=str(find_web_dir() / "examples" / "custom-path"),
+        **atom.kwargs,
+    )
+    bridge_transport = pLCMTransport(TOPIC)
+    bridge_transport.start()
+    module.nav_path.transport = bridge_transport
+    publisher = pLCMTransport(TOPIC)
+    publisher.start()
+    stop = threading.Event()
+
+    def republish() -> None:
+        # Frames flow only once the bridge lazily subscribes, so a single
+        # publish is never enough - keep them coming like a robot would.
+        while not stop.is_set():
+            publisher.publish(PATH_MSG)
+            time.sleep(0.1)
+
+    thread = threading.Thread(target=republish, daemon=True)
+    try:
+        module.start()  # builds web dists if stale, spawns the relay, registers
+        thread.start()
+        relay = module._relay
+        assert relay is not None and relay.info is not None
+        yield relay.info.open_url
+    finally:
+        stop.set()
+        thread.join(timeout=2)
+        stop_module(module)
+        publisher.stop()
+        bridge_transport.stop()
+
+
+@pytest.fixture
+def chromium_page() -> Iterator[Page]:
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        try:
+            yield browser.new_page()
+        finally:
+            browser.close()
+
+
+def test_custom_path_page_shows_decoded_points(
+    custom_path_page_url: str, chromium_page: Page
+) -> None:
+    chromium_page.goto(custom_path_page_url)
+    # Decoded coordinates prove the whole chain: the generated bridge class
+    # started, the registry-resolved encoder ran on demand, the relay
+    # forwarded the opaque payload, and the page's registered decoder
+    # reconstructed the points - with no cockpit panel involved.
+    expect(chromium_page.locator("#count")).to_contain_text("points: 3", timeout=120_000)
+    expect(chromium_page.locator("#points")).to_contain_text("1.5")
+    expect(chromium_page.locator("#points")).to_contain_text("-2.5")
+    expect(chromium_page.locator("#status")).to_contain_text("connected")

--- a/dimos/web/cockpit.py
+++ b/dimos/web/cockpit.py
@@ -36,10 +36,18 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence, Set as AbstractSet
 from dataclasses import dataclass, field, replace
+import json
 import math
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, Self
 
-from dimos.web.relay_bridge.manifest import MANIFEST_VERSION, Dir, parse_manifest
+from dimos.web.relay_bridge.manifest import (
+    MANIFEST_VERSION,
+    MAX_MANIFEST_ID_LEN,
+    RESERVED_CHANNEL_PREFIX,
+    Delivery,
+    Dir,
+    parse_manifest,
+)
 
 if TYPE_CHECKING:
     from dimos.core.coordination.blueprints import Blueprint
@@ -57,6 +65,62 @@ def _check_rate(name: str, value: float) -> None:
         raise ValueError(f"{name} must be a positive finite number, got {value!r}")
 
 
+class _FrozenDict(dict[str, Any]):
+    """Read-only dict for Channel.params: a frozen dataclass must not leak a
+    mutable mapping whose edits would change what a later cockpit() emits.
+    A dict subclass (not mappingproxy) so it stays picklable and
+    json.dumps-able."""
+
+    def __reduce__(self) -> tuple[Any, ...]:
+        return (_FrozenDict, (dict(self),))
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        raise TypeError("Channel params are immutable")
+
+    def __delitem__(self, key: str) -> None:
+        raise TypeError("Channel params are immutable")
+
+    # dict.__ior__ mutates at the C level (bypassing update()), so it must be
+    # blocked too; deliberately breaking the in-place contract is the whole
+    # point here, which typeshed's dict overloads cannot express.
+    def __ior__(self, other: Any) -> Self:  # type: ignore[override, misc]
+        raise TypeError("Channel params are immutable")
+
+    def clear(self) -> None:
+        raise TypeError("Channel params are immutable")
+
+    def pop(self, key: str, default: Any = None) -> Any:
+        raise TypeError("Channel params are immutable")
+
+    def popitem(self) -> tuple[str, Any]:
+        raise TypeError("Channel params are immutable")
+
+    def setdefault(self, key: str, default: Any = None) -> Any:
+        raise TypeError("Channel params are immutable")
+
+    def update(self, *args: Any, **kwargs: Any) -> None:
+        raise TypeError("Channel params are immutable")
+
+
+def _freeze_params(value: Any) -> Any:
+    """Recursively immutable copy: dicts freeze, lists become tuples."""
+    if isinstance(value, Mapping):
+        return _FrozenDict({key: _freeze_params(item) for key, item in value.items()})
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze_params(item) for item in value)
+    return value
+
+
+def _thaw_params(value: Any) -> Any:
+    """Plain-JSON deep copy of frozen params (manifests and runtime specs
+    carry ordinary dicts/lists, and pinned manifests compare with ==)."""
+    if isinstance(value, Mapping):
+        return {key: _thaw_params(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_thaw_params(item) for item in value]
+    return value
+
+
 @dataclass(frozen=True)
 class ChannelRequest:
     """One stream a panel needs advertised.
@@ -71,6 +135,84 @@ class ChannelRequest:
     encoding: str
     max_hz: float
     params: Mapping[str, Any] = field(default_factory=dict)
+    delivery: Delivery = field(default="reliable", kw_only=True)
+
+
+@dataclass(frozen=True)
+class Channel:
+    """One explicitly exposed robot<->browser channel (Web SDK authoring).
+
+    Declares a stream for custom frontends without requiring a cockpit
+    panel; pass a sequence of these to cockpit(channels=[...]). A channel
+    naming a stream some panel also requests merges with it: dir, encoding,
+    delivery, and params must agree exactly, max_hz takes the max.
+
+    `encoding` names a codec: a registered @web_encoder (dimos.web.codecs)
+    whose message type must match `message_type`, or the generic "json.v1"
+    for JSON-shaped types and dataclasses. dir/publish/required_scope beyond
+    the rx defaults arrive with the publish ticket (W7).
+    """
+
+    stream: str
+    message_type: type[Any]
+    dir: Dir = field(default="rx", kw_only=True)
+    encoding: str = field(default="json.v1", kw_only=True)
+    delivery: Delivery = field(default="reliable", kw_only=True)
+    max_hz: float = field(default=10.0, kw_only=True)
+    params: Mapping[str, Any] | None = field(default=None, kw_only=True)
+    publish: Literal["none", "shared", "exclusive"] = field(default="none", kw_only=True)
+    required_scope: str | None = field(default=None, kw_only=True)
+
+    def __post_init__(self) -> None:
+        _check_stream("stream", self.stream)
+        if len(self.stream) > MAX_MANIFEST_ID_LEN:
+            raise ValueError(
+                f"stream id {self.stream!r} is longer than {MAX_MANIFEST_ID_LEN} chars"
+            )
+        if self.stream.startswith(RESERVED_CHANNEL_PREFIX):
+            raise ValueError(
+                f"stream id {self.stream!r} is invalid: ids beginning with "
+                f"{RESERVED_CHANNEL_PREFIX!r} are reserved for protocol control"
+            )
+        if not isinstance(self.message_type, type):
+            raise TypeError(f"message_type must be a class, got {self.message_type!r}")
+        if self.dir not in ("rx", "tx"):
+            raise ValueError(f"dir must be 'rx' or 'tx', got {self.dir!r}")
+        if self.dir == "tx":
+            raise ValueError(
+                'dir="tx" channels are not available yet: generic browser-to-robot '
+                "publish is enabled by the publish ticket (W7)"
+            )
+        if not isinstance(self.encoding, str) or not 1 <= len(self.encoding) <= MAX_MANIFEST_ID_LEN:
+            raise ValueError(
+                f"encoding must be 1..{MAX_MANIFEST_ID_LEN} chars, got {self.encoding!r}"
+            )
+        if self.delivery not in ("latest", "reliable"):
+            raise ValueError(f"delivery must be 'latest' or 'reliable', got {self.delivery!r}")
+        _check_rate("max_hz", self.max_hz)
+        if self.publish not in ("none", "shared", "exclusive"):
+            raise ValueError(
+                f"publish must be 'none', 'shared', or 'exclusive', got {self.publish!r}"
+            )
+        if self.publish != "none":
+            raise ValueError("rx channels must use publish='none' (generic publish is tx-only, W7)")
+        if self.required_scope is not None:
+            raise ValueError(
+                "rx channels cannot set required_scope (reserved for tx publish channels, W7)"
+            )
+        if self.params is not None and not isinstance(self.params, Mapping):
+            raise ValueError(f"params must be a mapping or None, got {self.params!r}")
+        params = {} if self.params is None else dict(self.params)
+        if any(not isinstance(key, str) for key in params):
+            raise ValueError("params keys must be strings")
+        try:
+            # Params ride the manifest verbatim; non-JSON values (bytes,
+            # arrays) and non-finite numbers must fail at authoring, not at
+            # manifest parse or on the wire.
+            json.dumps(params, allow_nan=False)
+        except (TypeError, ValueError) as e:
+            raise ValueError(f"params must be JSON-shaped: {e}") from e
+        object.__setattr__(self, "params", _freeze_params(params))
 
 
 class Panel(ABC):
@@ -110,7 +252,14 @@ class Video(Panel):
 
     def _channel_requests(self) -> tuple[ChannelRequest, ...]:
         return (
-            ChannelRequest(self.stream, "rx", "jpeg.v1", self.max_hz, {"quality": self.quality}),
+            ChannelRequest(
+                self.stream,
+                "rx",
+                "jpeg.v1",
+                self.max_hz,
+                {"quality": self.quality},
+                delivery="latest",
+            ),
         )
 
 
@@ -133,7 +282,11 @@ class Map2D(Panel):
         _check_rate("pose_hz", self.pose_hz)
 
     def _channel_requests(self) -> tuple[ChannelRequest, ...]:
-        requests = [ChannelRequest(self.costmap, "rx", "costmap.zlib.v1", self.costmap_hz)]
+        requests = [
+            ChannelRequest(
+                self.costmap, "rx", "costmap.zlib.v1", self.costmap_hz, delivery="latest"
+            )
+        ]
         if self.pose is not None:
             requests.append(ChannelRequest(self.pose, "rx", "pose.json.v1", self.pose_hz))
         return tuple(requests)
@@ -179,6 +332,7 @@ class Teleop(Panel):
                     "boost": self.boost,
                     "watchdogMs": self.watchdog_ms,
                 },
+                delivery="latest",
             ),
         )
 
@@ -231,34 +385,45 @@ def build_manifest_data(
     pages: Sequence[Panel],
     *,
     registry: Mapping[str, tuple[str, str]],
-    rx_streams: AbstractSet[str],
     tx_streams: AbstractSet[str],
     tx_registry: Mapping[str, tuple[str, str]] | None = None,
+    channels: Sequence[ChannelRequest] = (),
     extra_channels: Sequence[ChannelRequest] = (),
 ) -> dict[str, Any]:
-    """Compile a layout tree + pages into a plain manifest-v1 dict.
+    """Compile a layout tree + pages + explicit channels into a manifest-v1
+    dict.
 
     Shared by cockpit() and the bridge's availability-driven default
     manifest (default_manifest in relay_bridge_module.py). `registry` and
-    `tx_registry` map stream name -> (encoding, delivery) in advertisement
-    order (the bridge's CHANNELS/TX_CHANNELS tables); rx/tx_streams are the
-    module's typed In/Out names. Panel ids are p0..pN in tree order (layout
-    depth-first, then pages). Channels requested by several panels merge:
-    max_hz takes the max, any other disagreement raises. `extra_channels`
-    are advertised channel-only unless a panel already requested the stream.
+    `tx_registry` map built-in stream name -> (encoding, delivery) in
+    advertisement order (the bridge's BUILTIN_CHANNELS/TX_CHANNELS tables);
+    tx_streams are the module's typed Out names. Panel ids are p0..pN in
+    tree order (layout depth-first, then pages).
+
+    Panel requests and `channels` (cockpit(channels=...) declarations) run
+    through one merge: dir, encoding, delivery, and params must agree,
+    max_hz takes the max. An rx stream outside `registry` is legal only when
+    `channels` declares it (the caller resolves its codec and port type).
+    `extra_channels` are advertised channel-only unless something already
+    requested the stream.
+
+    Advertisement order: rx built-ins in registry order, then rx customs in
+    first-declaration order, then tx in tx_registry order - so manifests
+    without custom channels keep their historical channel order.
     """
     tx_registry = {} if tx_registry is None else tx_registry
-    channels: dict[str, ChannelRequest] = {}
+    merged: dict[str, ChannelRequest] = {}
     panels_out: list[dict[str, Any]] = []
 
     def merge(request: ChannelRequest) -> None:
-        previous = channels.get(request.stream)
+        previous = merged.get(request.stream)
         if previous is None:
-            channels[request.stream] = request
+            merged[request.stream] = request
             return
-        same = (previous.dir, previous.encoding, dict(previous.params)) == (
+        same = (previous.dir, previous.encoding, previous.delivery, dict(previous.params)) == (
             request.dir,
             request.encoding,
+            request.delivery,
             dict(request.params),
         )
         if not same:
@@ -267,7 +432,7 @@ def build_manifest_data(
                 f"{previous!r} vs {request!r}"
             )
         if request.max_hz > previous.max_hz:
-            channels[request.stream] = replace(previous, max_hz=request.max_hz)
+            merged[request.stream] = replace(previous, max_hz=request.max_hz)
 
     def add_panel(panel: Panel) -> str:
         panel_id = f"p{len(panels_out)}"
@@ -304,18 +469,27 @@ def build_manifest_data(
             raise ValueError(f"pages entries must be panels, got {page!r}")
         page_ids.append(add_panel(page))
 
-    for stream, request in channels.items():
+    for request in channels:
+        merge(request)
+
+    declared = {request.stream for request in channels}
+    for stream, request in merged.items():
         if request.dir == "rx":
-            if stream not in rx_streams or stream not in registry:
+            if stream in registry:
+                expected_encoding, expected_delivery = registry[stream]
+                if expected_encoding != request.encoding:
+                    raise ValueError(
+                        f"stream {stream!r} encodes {expected_encoding}, not {request.encoding} "
+                        f"(wrong panel type for this stream?)"
+                    )
+                if expected_delivery != request.delivery:
+                    raise ValueError(
+                        f"stream {stream!r} delivers {expected_delivery}, not {request.delivery}"
+                    )
+            elif stream not in declared:
                 raise ValueError(
                     f"unknown stream {stream!r}; this robot bridge supports: "
-                    f"{', '.join(sorted(registry))}"
-                )
-            expected_encoding = registry[stream][0]
-            if expected_encoding != request.encoding:
-                raise ValueError(
-                    f"stream {stream!r} encodes {expected_encoding}, not {request.encoding} "
-                    f"(wrong panel type for this stream?)"
+                    f"{', '.join(sorted(set(registry) | declared))}"
                 )
         else:
             if stream not in tx_streams:
@@ -334,19 +508,22 @@ def build_manifest_data(
                     f"stream {stream!r} encodes {expected[0]}, not {request.encoding} "
                     f"(wrong panel type for this stream?)"
                 )
+            if expected[1] != request.delivery:
+                raise ValueError(
+                    f"stream {stream!r} delivers {expected[1]}, not {request.delivery}"
+                )
 
     for request in extra_channels:
-        if request.stream not in channels:
-            channels[request.stream] = request
+        if request.stream not in merged:
+            merged[request.stream] = request
 
-    # Registry order, not first-request order: the advertisement order is the
-    # bridge's channel-table order (rx table, then tx table) however panels
-    # were nested.
-    ordered = [channels[stream] for stream in registry if stream in channels]
-    ordered += [channels[stream] for stream in tx_registry if stream in channels]
-    delivery = {
-        stream: pair[1] for table in (registry, tx_registry) for stream, pair in table.items()
-    }
+    ordered = [merged[stream] for stream in registry if stream in merged]
+    ordered += [
+        request
+        for stream, request in merged.items()
+        if request.dir == "rx" and stream not in registry
+    ]
+    ordered += [merged[stream] for stream in tx_registry if stream in merged]
     return {
         "version": MANIFEST_VERSION,
         "channels": [
@@ -354,7 +531,7 @@ def build_manifest_data(
                 "ch": request.stream,
                 "dir": request.dir,
                 "encoding": request.encoding,
-                "delivery": delivery[request.stream],
+                "delivery": request.delivery,
                 "maxHz": request.max_hz,
                 "params": dict(request.params),
             }
@@ -366,37 +543,117 @@ def build_manifest_data(
     }
 
 
-def cockpit(layout: Panel | Row | Col | None = None, pages: Sequence[Panel] = ()) -> Blueprint:
-    """Cockpit blueprint for the given layout (default: `_default_preset`).
+def cockpit(
+    layout: Panel | Row | Col | None = None,
+    pages: Sequence[Panel] = (),
+    channels: Sequence[Channel] = (),
+) -> Blueprint:
+    """Cockpit blueprint for the given layout (default: `_default_preset`)
+    plus explicitly exposed channels.
 
-    Walks the tree, compiles the manifest, validates it eagerly, and returns
-    a RelayBridgeModule blueprint carrying it; compose onto a robot with
-    `autoconnect(robot_blueprint, cockpit(...))`. Streams whose producer
-    never publishes are still advertised: their panels show "waiting for
-    data" (no runtime stream probing).
+    Walks the tree, merges panel requests with the `channels` declarations,
+    compiles the manifest, validates it eagerly, resolves every rx channel's
+    codec, and returns a relay bridge blueprint carrying it all; compose
+    onto a robot with `autoconnect(robot_blueprint, cockpit(...))`. Channels
+    whose stream is not a built-in bridge port get a generated
+    RelayBridgeModule subclass with matching typed ports (autoconnected by
+    name + message type). Streams whose producer never publishes are still
+    advertised: their panels show "waiting for data" (no runtime stream
+    probing).
+
+    The default preset layout applies only when neither a layout nor
+    channels are given; cockpit(channels=[...]) alone compiles with no
+    panels and no layout.
     """
+    declared: dict[str, Channel] = {}
+    for entry in channels:
+        if not isinstance(entry, Channel):
+            raise ValueError(f"channels entries must be Channel, got {entry!r}")
+        if entry.stream in declared:
+            raise ValueError(f"duplicate channel declaration for stream {entry.stream!r}")
+        declared[entry.stream] = entry
     try:
+        from dimos.web.relay_bridge.dynamic import DynamicPortSpec, make_relay_bridge_class
         from dimos.web.relay_bridge.relay_bridge_module import (
-            CHANNELS,
+            BUILTIN_CHANNELS,
             TX_CHANNELS,
             RelayBridgeModule,
+            RuntimeChannelSpec,
         )
     except ImportError as e:
         raise RuntimeError(
             "the cockpit blueprint needs the web extra: `uv sync --extra web --inexact`"
         ) from e
     from dimos.core.coordination.blueprints import autoconnect
+    from dimos.web.codecs import resolve_encoder
 
     atom = RelayBridgeModule.blueprint().blueprints[0]
+    port_types = {s.name: s.type for s in atom.streams}
+    builtin_by_ch = {b.ch: b for b in BUILTIN_CHANNELS}
     data = build_manifest_data(
-        _default_preset() if layout is None else layout,
+        _default_preset() if layout is None and not declared else layout,
         tuple(pages),
-        registry={cd.ch: (cd.encoding, cd.delivery) for cd in CHANNELS},
-        rx_streams={s.name for s in atom.streams if s.direction == "in"},
+        registry={b.ch: (b.encoding, b.delivery) for b in BUILTIN_CHANNELS},
         tx_streams={s.name for s in atom.streams if s.direction == "out"},
         tx_registry={ch: (encoding, delivery) for ch, encoding, delivery in TX_CHANNELS},
+        channels=tuple(
+            ChannelRequest(
+                c.stream,
+                c.dir,
+                c.encoding,
+                c.max_hz,
+                # Deep plain copy: the manifest and specs must not alias the
+                # (frozen) authoring record's nested values.
+                _thaw_params(c.params or {}),
+                delivery=c.delivery,
+            )
+            for c in declared.values()
+        ),
     )
     # The domain parser is the authority; authoring bugs must fail at
     # blueprint definition time, not at robot start.
     parse_manifest(data)
-    return autoconnect(RelayBridgeModule.blueprint(manifest=data))
+
+    specs: list[RuntimeChannelSpec] = []
+    ports: list[DynamicPortSpec] = []
+    for wire in data["channels"]:
+        if wire["dir"] != "rx":
+            continue
+        ch = wire["ch"]
+        explicit = declared.get(ch)
+        builtin = builtin_by_ch.get(ch)
+        if builtin is not None:
+            message_type = port_types[ch]
+            if explicit is not None and explicit.message_type is not message_type:
+                raise ValueError(
+                    f"channel {ch!r}: message type {explicit.message_type.__qualname__} "
+                    f"does not match the bridge port type {message_type.__qualname__}"
+                )
+        else:
+            assert explicit is not None  # build_manifest_data rejected the rest
+            message_type = explicit.message_type
+            ports.append(DynamicPortSpec(ch, message_type, "rx"))
+        try:
+            codec = resolve_encoder(wire["encoding"], message_type)
+            if codec.check_params is not None:
+                codec.check_params(wire["params"])
+        except ValueError as e:
+            raise ValueError(f"channel {ch!r}: {e}") from e
+        specs.append(
+            RuntimeChannelSpec(
+                ch=ch,
+                message_type=message_type,
+                dir="rx",
+                encoding=wire["encoding"],
+                delivery=wire["delivery"],
+                max_hz=float(wire["maxHz"]),
+                params=dict(wire["params"]),
+                encoder=codec.encode,
+                encoder_takes_params=codec.takes_params,
+                resend_on_subscribe=builtin.resend_on_subscribe if builtin is not None else False,
+            )
+        )
+    # Generated classes carry only the custom ports; the built-ins are
+    # inherited. No custom streams means the plain static class.
+    module_class = make_relay_bridge_class(ports) if ports else RelayBridgeModule
+    return autoconnect(module_class.blueprint(manifest=data, channels=tuple(specs)))

--- a/dimos/web/codecs.py
+++ b/dimos/web/codecs.py
@@ -1,0 +1,398 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Web codec registry: DimOS message <-> wire payload, keyed by encoding id.
+
+An encoder turns one DimOS message into the bytes of a relay data frame; the
+matching JavaScript decoder (web/sdk, DecoderRegistry) turns them back into a
+browser value. Decoders here run the other direction (browser publish -> DimOS
+message) and are registered now but only exercised by the publish ticket (W7).
+
+    @web_encoder("path.points.v1")
+    def encode_path(msg: Path) -> bytes: ...
+
+    @web_decoder("goal.json.v1")
+    def decode_goal(value: dict[str, Any], context: PublishContext) -> PoseStamped: ...
+
+The registry is consulted in the parent process: the cockpit() blueprint
+compiler resolves encoding ids to callables at blueprint definition time and
+ships the resolved callable inside an immutable runtime channel spec, so a
+worker never depends on the user's codec module having been imported there.
+Codec functions must therefore live at module level (standard pickle ships
+them by reference); built-ins register in
+dimos/web/relay_bridge/builtin_codecs.py.
+
+Encoders take the message (plus, optionally, the channel's params mapping) and
+return `bytes`, an `EncodedPayload` when the frame needs header meta, or None
+to skip the sample. The generic json.v1 encoder is the only codec applied
+without registration, and only to JSON-shaped message types; anything
+potentially large (DimOS/LCM messages, images, arrays, bytes) needs an
+explicit @web_encoder.
+"""
+
+from collections.abc import Callable, Mapping
+import dataclasses
+from dataclasses import dataclass
+import inspect
+import json
+import sys
+import threading
+import types
+from typing import Any, TypeVar, Union, get_args, get_origin, get_type_hints
+
+from dimos.web.relay_bridge.manifest import MAX_MANIFEST_ID_LEN, RESERVED_CHANNEL_PREFIX
+
+_F = TypeVar("_F", bound=Callable[..., Any])
+
+# Frame header meta rides the wire on every frame; keep it a small JSON object.
+MAX_ENCODED_META_BYTES = 16 * 1024
+
+# Message types the generic json.v1 encoder accepts (plus dataclasses). An
+# exact-class whitelist on purpose: a subclass may carry arbitrarily large
+# state, and a mistaken Image/PointCloud2 declaration must fail at authoring
+# time instead of serializing a pixel buffer per frame.
+_JSON_V1_TYPES = frozenset({str, int, float, bool, dict, list})
+
+
+@dataclass(frozen=True)
+class EncodedPayload:
+    """Encoder result carrying frame payload bytes plus optional header meta."""
+
+    payload: bytes
+    meta: Mapping[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.payload, (bytes, bytearray, memoryview)):
+            raise TypeError(f"payload must be bytes-like, got {type(self.payload).__name__}")
+        object.__setattr__(self, "payload", bytes(self.payload))
+        if self.meta is None:
+            return
+        if not isinstance(self.meta, Mapping):
+            raise TypeError(f"meta must be a mapping or None, got {type(self.meta).__name__}")
+        if any(not isinstance(key, str) for key in self.meta):
+            raise ValueError("meta keys must be strings")
+        try:
+            # allow_nan=False: NaN/Infinity are not JSON; the frame header
+            # would reject them later and the frame would vanish silently.
+            dumped = json.dumps(dict(self.meta), separators=(",", ":"), allow_nan=False)
+        except (TypeError, ValueError) as e:
+            raise ValueError(f"meta must be JSON-serializable: {e}") from e
+        if len(dumped.encode()) > MAX_ENCODED_META_BYTES:
+            raise ValueError(
+                f"meta is {len(dumped.encode())} B encoded (limit {MAX_ENCODED_META_BYTES}); "
+                "meta rides the frame header, put bulk data in the payload"
+            )
+        object.__setattr__(self, "meta", dict(self.meta))
+
+
+@dataclass(frozen=True)
+class PublishContext:
+    """Relay-authored provenance handed to tx decoders (publish ticket, W7)."""
+
+    robot: str
+    ch: str
+    relay_ts: float
+    principal: str | None = None
+    gen: int | None = None
+
+
+@dataclass(frozen=True)
+class EncoderDef:
+    encoding: str
+    message_type: type[Any]
+    encode: Callable[..., Any]
+    takes_params: bool
+    # Validates a channel's merged params before any frame is encoded, so a
+    # bad authored value (jpeg quality) fails at blueprint/module start.
+    check_params: Callable[[Mapping[str, Any]], None] | None = None
+
+
+@dataclass(frozen=True)
+class DecoderDef:
+    encoding: str
+    message_type: type[Any]
+    decode: Callable[..., Any]
+    takes_context: bool
+
+
+# Append-only after import time in practice; the lock serializes registration
+# (tests and user modules may register from any thread), lookups read a dict
+# that only ever gains keys.
+_registry_lock = threading.Lock()
+_encoders: dict[str, EncoderDef] = {}
+_decoders: dict[str, DecoderDef] = {}
+
+
+def _check_encoding_id(encoding: Any) -> None:
+    if not isinstance(encoding, str) or not 1 <= len(encoding) <= MAX_MANIFEST_ID_LEN:
+        raise ValueError(f"encoding id must be 1..{MAX_MANIFEST_ID_LEN} chars, got {encoding!r}")
+    if encoding.startswith(RESERVED_CHANNEL_PREFIX):
+        raise ValueError(
+            f"encoding id {encoding!r} is invalid: ids beginning with "
+            f"{RESERVED_CHANNEL_PREFIX!r} are reserved for protocol control"
+        )
+
+
+def _describe(func: Callable[..., Any]) -> str:
+    return f"{func.__module__}.{func.__qualname__}"
+
+
+def _check_registrable(func: Callable[..., Any], label: str) -> None:
+    """Decoration-time importability gate.
+
+    The full pickle-by-reference walk (`_resolves_by_reference`) cannot run
+    here: a decorator fires before the def statement binds the module
+    attribute. resolve_encoder() completes the check once the module exists.
+    """
+    if not inspect.isfunction(func):
+        raise TypeError(f"{label} must be a module-level function, got {func!r}")
+    if func.__name__ == "<lambda>":
+        raise ValueError(f"{label} cannot be a lambda; standard pickle ships codecs by reference")
+    if "<locals>" in func.__qualname__:
+        raise ValueError(
+            f"{label} {_describe(func)} is defined inside a function; move it to "
+            "module level so it can be pickled by reference"
+        )
+    if func.__module__ == "__main__":
+        raise ValueError(
+            f"{label} {func.__qualname__} is only defined in __main__; move it into "
+            "an importable module so worker processes can reconstruct it"
+        )
+
+
+def _resolves_by_reference(func: Callable[..., Any]) -> bool:
+    """Mirror pickle's save-by-reference lookup for a function."""
+    obj: Any = sys.modules.get(func.__module__)
+    for part in func.__qualname__.split("."):
+        obj = getattr(obj, part, None)
+        if obj is None:
+            return False
+    return obj is func
+
+
+def _signature_params(func: Callable[..., Any], label: str) -> list[inspect.Parameter]:
+    params = list(inspect.signature(func).parameters.values())
+    for param in params:
+        if param.kind not in (param.POSITIONAL_ONLY, param.POSITIONAL_OR_KEYWORD):
+            raise ValueError(
+                f"{label} {_describe(func)} must take 1 or 2 positional parameters "
+                f"(no *args/**kwargs/keyword-only), got {param.name!r}"
+            )
+    if len(params) not in (1, 2):
+        raise ValueError(
+            f"{label} {_describe(func)} must take 1 or 2 positional parameters, got {len(params)}"
+        )
+    return params
+
+
+def _union_members(hint: Any) -> tuple[Any, ...] | None:
+    """Members of a `X | Y` / Optional[X] annotation, None for non-unions."""
+    if get_origin(hint) in (Union, types.UnionType):
+        return get_args(hint)
+    return None
+
+
+def _check_params_annotation(hint: Any, func: Callable[..., Any]) -> None:
+    args = get_args(hint)
+    if get_origin(hint) not in (dict, Mapping) or not args or args[0] is not str:
+        raise ValueError(
+            f"web encoder {_describe(func)}: the second parameter must be annotated "
+            f"Mapping[str, Any] (the channel params), got {hint!r}"
+        )
+
+
+def _check_encoder_return(hints: Mapping[str, Any], func: Callable[..., Any]) -> None:
+    if "return" not in hints:
+        raise ValueError(
+            f"web encoder {_describe(func)}: the return annotation must be bytes, "
+            "EncodedPayload, or an optional union of them; none given"
+        )
+    hint = hints["return"]
+    members = _union_members(hint)
+    candidates = members if members is not None else (hint,)
+    produces = {bytes, EncodedPayload}
+    if not all(m in produces or m is type(None) for m in candidates) or not any(
+        m in produces for m in candidates
+    ):
+        raise ValueError(
+            f"web encoder {_describe(func)}: the return annotation must be bytes, "
+            f"EncodedPayload, or an optional union of them, got {hint!r}"
+        )
+
+
+def _is_json_annotation(hint: Any) -> bool:
+    """Whether an annotation describes a parsed-JSON value shape."""
+    if hint is Any or hint in _JSON_V1_TYPES or hint is type(None):
+        return True
+    members = _union_members(hint)
+    if members is not None:
+        return all(_is_json_annotation(m) for m in members)
+    return get_origin(hint) in (dict, list, Mapping)
+
+
+def _register_encoder(definition: EncoderDef) -> None:
+    with _registry_lock:
+        existing = _encoders.get(definition.encoding)
+        # Same module-level function re-decorated (importlib.reload of the
+        # defining module) replaces silently; a different owner is a clash.
+        if existing is not None and _describe(existing.encode) != _describe(definition.encode):
+            raise ValueError(
+                f"web encoder for encoding {definition.encoding!r} is already "
+                f"registered ({_describe(existing.encode)})"
+            )
+        _encoders[definition.encoding] = definition
+
+
+def _register_decoder(definition: DecoderDef) -> None:
+    with _registry_lock:
+        existing = _decoders.get(definition.encoding)
+        if existing is not None and _describe(existing.decode) != _describe(definition.decode):
+            raise ValueError(
+                f"web decoder for encoding {definition.encoding!r} is already "
+                f"registered ({_describe(existing.decode)})"
+            )
+        _decoders[definition.encoding] = definition
+
+
+def web_encoder(
+    encoding: str,
+    *,
+    check_params: Callable[[Mapping[str, Any]], None] | None = None,
+) -> Callable[[_F], _F]:
+    """Register a module-level function as the encoder for `encoding`.
+
+    The first parameter annotation is the supported DimOS message type; an
+    optional second parameter annotated `Mapping[str, Any]` receives the
+    channel's params. Returns bytes, EncodedPayload, or None (skip sample).
+    """
+    _check_encoding_id(encoding)
+
+    def decorate(func: _F) -> _F:
+        _check_registrable(func, "web encoder")
+        params = _signature_params(func, "web encoder")
+        hints = get_type_hints(func)
+        message_type = hints.get(params[0].name)
+        if not isinstance(message_type, type):
+            raise ValueError(
+                f"web encoder {_describe(func)}: the first parameter must be annotated "
+                f"with the supported message class, got {message_type!r}"
+            )
+        takes_params = len(params) == 2
+        if takes_params:
+            _check_params_annotation(hints.get(params[1].name), func)
+        _check_encoder_return(hints, func)
+        _register_encoder(EncoderDef(encoding, message_type, func, takes_params, check_params))
+        return func
+
+    return decorate
+
+
+def web_decoder(encoding: str) -> Callable[[_F], _F]:
+    """Register a module-level function as the decoder for `encoding`.
+
+    The return annotation is the produced DimOS message type; an optional
+    second parameter annotated `PublishContext` receives relay provenance.
+    Registered now, exercised by generic tx publish (W7).
+    """
+    _check_encoding_id(encoding)
+
+    def decorate(func: _F) -> _F:
+        _check_registrable(func, "web decoder")
+        params = _signature_params(func, "web decoder")
+        hints = get_type_hints(func)
+        value_hint = hints.get(params[0].name)
+        if value_hint is None or not _is_json_annotation(value_hint):
+            raise ValueError(
+                f"web decoder {_describe(func)}: the first parameter must be annotated "
+                f"with the JSON value shape it accepts (dict/list/scalars or a union "
+                f"of them), got {value_hint!r}"
+            )
+        message_type = hints.get("return")
+        if not isinstance(message_type, type) or message_type is type(None):
+            raise ValueError(
+                f"web decoder {_describe(func)}: the return annotation must be the "
+                f"produced message class, got {message_type!r}"
+            )
+        takes_context = len(params) == 2
+        if takes_context and hints.get(params[1].name) is not PublishContext:
+            raise ValueError(
+                f"web decoder {_describe(func)}: the second parameter must be annotated "
+                f"PublishContext, got {hints.get(params[1].name)!r}"
+            )
+        _register_decoder(DecoderDef(encoding, message_type, func, takes_context))
+        return func
+
+    return decorate
+
+
+def encoder_definition(encoding: str) -> EncoderDef | None:
+    return _encoders.get(encoding)
+
+
+def decoder_definition(encoding: str) -> DecoderDef | None:
+    return _decoders.get(encoding)
+
+
+def encode_json_v1(msg: Any) -> bytes:
+    """Generic json.v1 encoder for JSON-shaped values and dataclasses.
+
+    allow_nan=False: a non-finite number would serialize to `NaN`/`Infinity`,
+    which is not JSON and which the browser's JSON.parse rejects - better to
+    drop the sample at the codec boundary (ValueError) than ship a corrupt
+    frame.
+    """
+    value: Any = msg
+    if dataclasses.is_dataclass(msg) and not isinstance(msg, type):
+        value = dataclasses.asdict(msg)
+    return json.dumps(value, separators=(",", ":"), allow_nan=False).encode()
+
+
+def resolve_encoder(encoding: str, message_type: type[Any]) -> EncoderDef:
+    """The encoder a channel (encoding, message type) compiles to; ValueError
+    when the pair is unsupported. Runs in the parent at blueprint authoring
+    time, so this also finishes the pickle-by-reference check deferred from
+    decoration."""
+    definition = _encoders.get(encoding)
+    if definition is not None:
+        if message_type is not definition.message_type:
+            raise ValueError(
+                f"encoding {encoding!r} encodes {definition.message_type.__qualname__}, "
+                f"not {message_type.__qualname__}"
+            )
+        if not _resolves_by_reference(definition.encode):
+            raise ValueError(
+                f"encoder {_describe(definition.encode)} for {encoding!r} cannot be "
+                "pickled by reference; it must be importable under its own module "
+                "and qualified name"
+            )
+        return definition
+    if encoding == "json.v1":
+        # DimosMsg detection by attribute: the protocol has a data member, so
+        # issubclass() is unavailable, and importing dimos.msgs here would
+        # defeat this module's import-lightness. Some wire messages (Image)
+        # are dataclasses too - the marker must win.
+        is_dimos_msg = callable(getattr(message_type, "lcm_encode", None))
+        plain_dataclass = dataclasses.is_dataclass(message_type) and not is_dimos_msg
+        if message_type not in _JSON_V1_TYPES and not plain_dataclass:
+            raise ValueError(
+                f"message type {message_type.__module__}.{message_type.__qualname__} is "
+                "not supported by json.v1 (JSON scalars, lists, dicts and plain "
+                "dataclasses only; DimOS wire messages may be huge); register an "
+                "explicit codec with @web_encoder(...)"
+            )
+        return EncoderDef("json.v1", message_type, encode_json_v1, takes_params=False)
+    raise ValueError(
+        f"no encoder registered for encoding {encoding!r}; register one with "
+        f"@web_encoder({encoding!r})"
+    )

--- a/dimos/web/relay_bridge/builtin_codecs.py
+++ b/dimos/web/relay_bridge/builtin_codecs.py
@@ -1,0 +1,104 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Built-in web encoders (jpeg.v1, pose.json.v1, costmap.zlib.v1).
+
+Registered into dimos.web.codecs at import time; relay_bridge_module imports
+this module so every bridge process (parent and worker) has the built-ins.
+Wire bytes are pinned by web/shared/fixtures/costmap_frames.json and the
+relay e2e tests; the matching JS decoders live in web/sdk/src/decoders/.
+"""
+
+from collections.abc import Mapping
+import json
+from typing import Any
+import zlib
+
+import numpy as np
+
+from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
+from dimos.msgs.nav_msgs.OccupancyGrid import OccupancyGrid, block_max_reduce
+from dimos.msgs.sensor_msgs.Image import Image
+from dimos.web.codecs import EncodedPayload, web_encoder
+
+# Custom jpeg channels authored without a quality param; the built-in
+# color_image channel never reaches this (main() merges config.jpeg_quality
+# into its params).
+_DEFAULT_JPEG_QUALITY = 75
+
+
+def _check_jpeg_params(params: Mapping[str, Any]) -> None:
+    quality = params.get("quality")
+    if quality is None:
+        return
+    if isinstance(quality, bool) or not isinstance(quality, int) or not 0 <= quality <= 100:
+        raise ValueError(f"quality must be an int in 0..100, got {quality!r}")
+
+
+@web_encoder("jpeg.v1", check_params=_check_jpeg_params)
+def encode_jpeg(msg: Image, params: Mapping[str, Any]) -> EncodedPayload:
+    # TurboJPEG via the message's own encoder (handles BGR/RGB/gray inputs).
+    return EncodedPayload(
+        msg.to_jpeg_bytes(quality=params.get("quality", _DEFAULT_JPEG_QUALITY)),
+        {"w": msg.width, "h": msg.height},
+    )
+
+
+@web_encoder("pose.json.v1")
+def encode_pose(msg: PoseStamped) -> bytes:
+    pose = {
+        "x": msg.position.x,
+        "y": msg.position.y,
+        "z": msg.position.z,
+        "yaw": msg.yaw,
+        "ts": msg.ts,
+    }
+    return json.dumps(pose, separators=(",", ":")).encode()
+
+
+# The historical costmap encoder's choice (websocket_vis/optimized_costmap.py);
+# full grids compress to ~10-30 KB at <= 5 Hz, so speed over ratio is fine.
+_COSTMAP_ZLIB_LEVEL = 6
+# Render budget shared with the cockpit decoder (MAX_COSTMAP_DIM in
+# costmap.ts): larger grids are block-max downsampled before compression so
+# every frame stays within what consumers accept and render. 2048^2 raw is
+# 4 MiB, and zlib worst case adds ~0.01%, so the 8 MiB payload caps
+# (_wt_session._MAX_PAYLOAD_BYTES and the cockpit's) are unreachable.
+_COSTMAP_MAX_SIDE = 2048
+
+
+@web_encoder("costmap.zlib.v1")
+def encode_costmap(msg: OccupancyGrid) -> EncodedPayload | None:
+    grid = msg.grid
+    if grid.size == 0:
+        return None  # mapper still warming up; nothing to draw
+    res = msg.resolution
+    side = max(grid.shape)
+    if side > _COSTMAP_MAX_SIDE:
+        factor = -(-side // _COSTMAP_MAX_SIDE)
+        grid = block_max_reduce(grid, factor)
+        res *= factor
+    h, w = grid.shape
+    # Wire contract (costmap.zlib.v1): uint8 cells, ROS -1 unknown -> 255.
+    # int8 -1 is byte 0xff and 0..100 are byte-identical, so the raw buffer
+    # already is the wire payload - no mask/astype/tobytes copies.
+    cells = np.ascontiguousarray(grid)
+    origin = msg.origin
+    meta = {
+        "w": w,
+        "h": h,
+        "res": res,
+        "origin": [origin.position.x, origin.position.y, origin.yaw],
+    }
+    return EncodedPayload(zlib.compress(cells, _COSTMAP_ZLIB_LEVEL), meta)

--- a/dimos/web/relay_bridge/gen_costmap_fixtures.py
+++ b/dimos/web/relay_bridge/gen_costmap_fixtures.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 import base64
 import json
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any
 
 import numpy as np
 
@@ -37,11 +37,8 @@ from dimos.msgs.geometry_msgs.Pose import Pose
 from dimos.msgs.geometry_msgs.Quaternion import Quaternion
 from dimos.msgs.geometry_msgs.Vector3 import Vector3
 from dimos.msgs.nav_msgs.OccupancyGrid import OccupancyGrid
+from dimos.web.relay_bridge.builtin_codecs import encode_costmap
 from dimos.web.relay_bridge.locate import find_web_dir
-from dimos.web.relay_bridge.relay_bridge_module import _encode_costmap
-
-if TYPE_CHECKING:
-    from dimos.web.relay_bridge.relay_bridge_module import RelayBridgeModule
 
 
 def grid_msg(rows: list[list[int]], res: float, x: float, y: float, yaw: float) -> OccupancyGrid:
@@ -86,9 +83,9 @@ def build_vectors() -> list[dict[str, Any]]:
     vectors: list[dict[str, Any]] = []
     for name, (rows, res, x, y, yaw) in CASES.items():
         msg = grid_msg(rows, res, x, y, yaw)
-        encoded = _encode_costmap(cast("RelayBridgeModule", None), msg)  # module unused
+        encoded = encode_costmap(msg)
         assert encoded is not None
-        payload, meta = encoded
+        payload, meta = encoded.payload, encoded.meta
         cells = np.where(msg.grid == -1, 255, msg.grid).astype(np.uint8)
         vectors.append(
             {

--- a/dimos/web/relay_bridge/relay_bridge_module.py
+++ b/dimos/web/relay_bridge/relay_bridge_module.py
@@ -37,19 +37,16 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import AsyncIterator, Callable, Collection
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 import functools
-import json
 import math
 from pathlib import Path
 import socket
 import threading
 import time
-from typing import Any, TypeVar
+from typing import Any, Literal, TypeVar
 import webbrowser
-import zlib
 
-import numpy as np
 from pydantic import Field
 from reactivex.disposable import Disposable
 
@@ -59,7 +56,7 @@ from dimos.core.stream import In, Out
 from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
 from dimos.msgs.geometry_msgs.Twist import Twist
 from dimos.msgs.geometry_msgs.Vector3 import Vector3
-from dimos.msgs.nav_msgs.OccupancyGrid import OccupancyGrid, block_max_reduce
+from dimos.msgs.nav_msgs.OccupancyGrid import OccupancyGrid
 from dimos.msgs.sensor_msgs.Image import Image
 from dimos.utils.logging_config import setup_logger
 
@@ -75,8 +72,13 @@ from dimos.web.cockpit import (
     Video,
     build_manifest_data,
 )
+from dimos.web.codecs import EncodedPayload, encoder_definition
+
+# Imported for its registration side effect: the built-in encoders must be in
+# the codec registry wherever this module runs (parent and worker).
+from dimos.web.relay_bridge import builtin_codecs  # noqa: F401
 from dimos.web.relay_bridge.locate import find_web_dir
-from dimos.web.relay_bridge.manifest import parse_manifest
+from dimos.web.relay_bridge.manifest import Dir, parse_manifest
 from dimos.web.relay_bridge.protocol import (
     ChannelSpec,
     Delivery,
@@ -117,6 +119,10 @@ _BUILD_CANCEL_WAIT_S = 8.0
 # Deadman poll granularity; small against the default 300 ms watchdog window
 # so the zero lands close to the deadline.
 _TELEOP_POLL_S = 0.05
+
+# Per-channel floor between "encoder failed" logs (a broken encoder on a
+# 30 Hz stream must not flood the log).
+_ENCODE_ERROR_LOG_S = 5.0
 
 
 @dataclass(frozen=True)
@@ -187,6 +193,36 @@ async def _cancel_task(task: asyncio.Task[None] | None, name: str) -> None:
         logger.exception(f"relay bridge {name} task failed during teardown")
 
 
+@dataclass(frozen=True)
+class RuntimeChannelSpec:
+    """One channel's immutable runtime contract.
+
+    Compiled by cockpit() in the parent (encoder resolved from the codec
+    registry, ready to pickle by reference into the worker) or resolved from
+    the manifest against BUILTIN_CHANNELS at module start. The bridge's rx
+    behavior is driven entirely by these specs; publish/required_scope are
+    carried for the tx publish ticket (W7).
+    """
+
+    ch: str
+    message_type: type[Any]
+    dir: Dir
+    encoding: str
+    delivery: Delivery
+    max_hz: float
+    params: dict[str, Any]
+    publish: Literal["none", "shared", "exclusive"] = "none"
+    required_scope: str | None = None
+    # bytes | EncodedPayload | None (None skips the sample); None for tx.
+    encoder: Callable[..., Any] | None = None
+    encoder_takes_params: bool = False
+    # Keep an always-on raw-input cache (decode only, no encode) and replay
+    # the newest message when the channel goes from zero viewers to some
+    # viewer: a new session must not wait for the next publish (the producer
+    # may have gone quiet, possibly before the first viewer ever attached).
+    resend_on_subscribe: bool = False
+
+
 class RelayBridgeConfig(ModuleConfig):
     relay_url: str | None = None
     """Attach to a running relay (wtUrl). None: spawn a local one."""
@@ -223,82 +259,10 @@ class RelayBridgeConfig(ModuleConfig):
     quality (params) overriding the flat rate/quality fields above. None:
     default_manifest() builds one at start from the available inputs and
     those fields."""
-
-
-def _encode_image(module: RelayBridgeModule, msg: Image) -> tuple[bytes, dict[str, Any] | None]:
-    # TurboJPEG via the message's own encoder (handles BGR/RGB/gray inputs).
-    # Quality resolved at start from the manifest channel params (falling
-    # back to config.jpeg_quality).
-    return (
-        msg.to_jpeg_bytes(quality=module._jpeg_quality),
-        {"w": msg.width, "h": msg.height},
-    )
-
-
-def _encode_odom(
-    module: RelayBridgeModule, msg: PoseStamped
-) -> tuple[bytes, dict[str, Any] | None]:
-    pose = {
-        "x": msg.position.x,
-        "y": msg.position.y,
-        "z": msg.position.z,
-        "yaw": msg.yaw,
-        "ts": msg.ts,
-    }
-    return json.dumps(pose, separators=(",", ":")).encode(), None
-
-
-# The historical costmap encoder's choice (websocket_vis/optimized_costmap.py);
-# full grids compress to ~10-30 KB at <= 5 Hz, so speed over ratio is fine.
-_COSTMAP_ZLIB_LEVEL = 6
-# Render budget shared with the cockpit decoder (MAX_COSTMAP_DIM in
-# costmap.ts): larger grids are block-max downsampled before compression so
-# every frame stays within what consumers accept and render. 2048^2 raw is
-# 4 MiB, and zlib worst case adds ~0.01%, so the 8 MiB payload caps
-# (_wt_session._MAX_PAYLOAD_BYTES and the cockpit's) are unreachable.
-_COSTMAP_MAX_SIDE = 2048
-
-
-def _encode_costmap(
-    module: RelayBridgeModule, msg: OccupancyGrid
-) -> tuple[bytes, dict[str, Any] | None] | None:
-    grid = msg.grid
-    if grid.size == 0:
-        return None  # mapper still warming up; nothing to draw
-    res = msg.resolution
-    side = max(grid.shape)
-    if side > _COSTMAP_MAX_SIDE:
-        factor = -(-side // _COSTMAP_MAX_SIDE)
-        grid = block_max_reduce(grid, factor)
-        res *= factor
-    h, w = grid.shape
-    # Wire contract (costmap.zlib.v1): uint8 cells, ROS -1 unknown -> 255.
-    # int8 -1 is byte 0xff and 0..100 are byte-identical, so the raw buffer
-    # already is the wire payload - no mask/astype/tobytes copies.
-    cells = np.ascontiguousarray(grid)
-    origin = msg.origin
-    meta = {
-        "w": w,
-        "h": h,
-        "res": res,
-        "origin": [origin.position.x, origin.position.y, origin.yaw],
-    }
-    return zlib.compress(cells, _COSTMAP_ZLIB_LEVEL), meta
-
-
-@dataclass(frozen=True)
-class ChannelDef:
-    ch: str
-    encoding: str
-    delivery: Delivery
-    max_hz: Callable[[RelayBridgeConfig], float]
-    # Returning None skips the frame (an empty grid before mapping starts).
-    encode: Callable[[RelayBridgeModule, Any], tuple[bytes, _FrameMeta] | None]
-    # Keep an always-on raw-input cache (decode only, no encode) and replay
-    # the newest message when the channel goes from zero viewers to some
-    # viewer: a new session must not wait for the next publish (the producer
-    # may have gone quiet, possibly before the first viewer ever attached).
-    resend_on_subscribe: bool = False
+    channels: tuple[RuntimeChannelSpec, ...] | None = None
+    """Compiled rx runtime specs, set by cockpit() alongside `manifest` (they
+    are authored together and cross-checked at start). None: encoders resolve
+    from the manifest against BUILTIN_CHANNELS."""
 
 
 def _passes_rate_gate(
@@ -323,26 +287,49 @@ class _Session:
     retired: threading.Event = field(default_factory=threading.Event)
 
 
-# The stream -> encoder registry; every entry needs a matching `In` on the
-# module. What actually gets advertised (and which panels bind it) is the
-# manifest's business, not this table's.
-CHANNELS: tuple[ChannelDef, ...] = (
-    ChannelDef("color_image", "jpeg.v1", "latest", lambda c: c.image_max_hz, _encode_image),
-    ChannelDef("odom", "pose.json.v1", "reliable", lambda c: c.odom_max_hz, _encode_odom),
-    ChannelDef(
+def _no_default_params(config: RelayBridgeConfig) -> dict[str, Any]:
+    return {}
+
+
+def _jpeg_default_params(config: RelayBridgeConfig) -> dict[str, Any]:
+    return {"quality": config.jpeg_quality}
+
+
+@dataclass(frozen=True)
+class BuiltinChannel:
+    """Declaration of one static-port channel (no encoder here: codecs come
+    from the dimos.web.codecs registry, the same one custom channels use).
+    Drives the no-manifest (auto) mode and validates hand-written manifests;
+    every entry needs a matching `In` on the module."""
+
+    ch: str
+    encoding: str
+    delivery: Delivery
+    max_hz: Callable[[RelayBridgeConfig], float]
+    # Config-driven params merged under the manifest's (manifest wins), so
+    # flat config fields keep working as fallbacks in every mode.
+    default_params: Callable[[RelayBridgeConfig], dict[str, Any]] = _no_default_params
+    resend_on_subscribe: bool = False
+
+
+BUILTIN_CHANNELS: tuple[BuiltinChannel, ...] = (
+    BuiltinChannel(
+        "color_image", "jpeg.v1", "latest", lambda c: c.image_max_hz, _jpeg_default_params
+    ),
+    BuiltinChannel("odom", "pose.json.v1", "reliable", lambda c: c.odom_max_hz),
+    BuiltinChannel(
         "global_costmap",
         "costmap.zlib.v1",
         "latest",
         lambda c: c.costmap_max_hz,
-        _encode_costmap,
         resend_on_subscribe=True,
     ),
 )
 
-# The tx (viewer->robot) counterpart of CHANNELS: stream -> (encoding,
-# delivery). Every entry needs a matching `Out` on the module and a handler
-# in _supervise; it is also the delivery source for tx channels in authored
-# manifests (dimos/web/cockpit.py).
+# The tx (viewer->robot) counterpart of BUILTIN_CHANNELS: stream ->
+# (encoding, delivery). Every entry needs a matching `Out` on the module and
+# a handler in _supervise; it is also the delivery source for tx channels in
+# authored manifests (dimos/web/cockpit.py).
 TX_CHANNELS: tuple[tuple[str, str, Delivery], ...] = (("tele_cmd_vel", "twist.json.v1", "latest"),)
 
 
@@ -380,19 +367,18 @@ def default_manifest(config: RelayBridgeConfig, available: Collection[str]) -> d
         layout = Row(main, side, shares=[2, 1])
     else:
         layout = main if main is not None else side
-    registry = {cd.ch: (cd.encoding, cd.delivery) for cd in CHANNELS}
+    registry = {b.ch: (b.encoding, b.delivery) for b in BUILTIN_CHANNELS}
     tx_registry = {ch: (encoding, delivery) for ch, encoding, delivery in TX_CHANNELS}
     return build_manifest_data(
         layout,
         (),
         registry=registry,
-        rx_streams=frozenset(registry),
         tx_streams=frozenset(tx_registry),
         tx_registry=tx_registry,
         extra_channels=tuple(
-            ChannelRequest(cd.ch, "rx", cd.encoding, cd.max_hz(config))
-            for cd in CHANNELS
-            if cd.ch in present
+            ChannelRequest(b.ch, "rx", b.encoding, b.max_hz(config), delivery=b.delivery)
+            for b in BUILTIN_CHANNELS
+            if b.ch in present
         ),
     )
 
@@ -431,17 +417,18 @@ class RelayBridgeModule(Module):
         self._serve_dir: Path | None = None
         self._robot_info: RobotInfo | None = None
         self._manifest: RobotManifest | None = None
-        self._channel_defs: tuple[ChannelDef, ...] = ()
+        self._channel_specs: tuple[RuntimeChannelSpec, ...] = ()
         self._min_interval: dict[str, float] = {}
         self._last_input: dict[str, float] = {}
+        # Last "encoder failed" log time per channel: a broken encoder on a
+        # 30 Hz stream must not flood the log (rate gated like the inputs).
+        self._encode_error_logged: dict[str, float] = {}
         # Newest raw message (+ arrival wall time, the replay's frame ts) per
         # resend_on_subscribe channel; written on the transport thread, read
         # on the loop (GIL-atomic dict swap), and kept across sessions so a
         # reconnect replays too. Pins the full grid (MBs, one per channel);
         # encoding stays lazy.
         self._last_msg: dict[str, tuple[Any, float]] = {}
-        # Resolved at start from the manifest's jpeg channel params.
-        self._jpeg_quality: int = self.config.jpeg_quality
         # Teleop state, all touched on the module loop only. None params =
         # the manifest advertises no teleop channel; every teleop message is
         # then ignored. `driving` implements the release-edge rule: publish
@@ -455,13 +442,19 @@ class RelayBridgeModule(Module):
         self._teleop_gen: int | float = -math.inf
         self._teleop_last_seq = -math.inf
         self._teleop_last_rx = 0.0
-        self.encoded: dict[str, int] = {cd.ch: 0 for cd in CHANNELS}
+        # Live-path encode counters, keyed by the advertised rx channels at
+        # start (main() fills it once the manifest resolves).
+        self.encoded: dict[str, int] = {}
 
     async def main(self) -> AsyncIterator[None]:
         supervisor: asyncio.Task[None] | None = None
         try:
             self._robot_info = resolve_robot_info(self.config)
             manifest_data = self.config.manifest
+            if self.config.channels is not None and manifest_data is None:
+                raise RuntimeError(
+                    "channels runtime specs require a manifest; author both through cockpit()"
+                )
             if manifest_data is None:
                 allowed = (
                     None
@@ -469,10 +462,10 @@ class RelayBridgeModule(Module):
                     else frozenset(self.config.available_channels)
                 )
                 available = tuple(
-                    cd.ch
-                    for cd in CHANNELS
-                    if (allowed is None or cd.ch in allowed)
-                    and self.inputs[cd.ch].transport is not None
+                    b.ch
+                    for b in BUILTIN_CHANNELS
+                    if (allowed is None or b.ch in allowed)
+                    and self.inputs[b.ch].transport is not None
                 )
                 # tx side: an Out gets a transport whether or not anything
                 # consumes it, so availability comes from the composition
@@ -484,22 +477,13 @@ class RelayBridgeModule(Module):
             # The domain parser is the authority: an invalid manifest fails
             # module start instead of poisoning the relay.
             manifest = parse_manifest(manifest_data)
-            by_ch = {cd.ch: cd for cd in CHANNELS}
-            rx_specs = [spec for spec in manifest.channels if spec.dir == "rx"]
-            for spec in rx_specs:
-                encoder = by_ch.get(spec.ch)
-                if (
-                    encoder is None
-                    or encoder.encoding != spec.encoding
-                    or encoder.delivery != spec.delivery
-                ):
-                    raise RuntimeError(
-                        f"manifest channel {spec.ch!r} ({spec.encoding}/{spec.delivery}) has no "
-                        f"matching encoder; this bridge supports: {sorted(by_ch)}"
-                    )
-            self._channel_defs = tuple(by_ch[spec.ch] for spec in rx_specs)
-            self._min_interval = {spec.ch: 1.0 / spec.maxHz for spec in rx_specs}
-            self._jpeg_quality = self._resolve_jpeg_quality(rx_specs)
+            rx_wire = [spec for spec in manifest.channels if spec.dir == "rx"]
+            if self.config.channels is not None:
+                self._channel_specs = self._adopt_authored_specs(rx_wire)
+            else:
+                self._channel_specs = self._resolve_builtin_specs(rx_wire)
+            self._min_interval = {s.ch: 1.0 / s.max_hz for s in self._channel_specs}
+            self.encoded = {s.ch: 0 for s in self._channel_specs}
             by_tx = {ch: (encoding, delivery) for ch, encoding, delivery in TX_CHANNELS}
             for spec in manifest.channels:
                 if spec.dir != "tx":
@@ -514,20 +498,22 @@ class RelayBridgeModule(Module):
             # No runtime stream probing: an authored channel whose input got
             # no transport stays advertised (its panel shows "waiting for
             # data"); _reconcile just never subscribes it.
-            unwired = sorted(spec.ch for spec in rx_specs if self.inputs[spec.ch].transport is None)
+            unwired = sorted(
+                s.ch for s in self._channel_specs if self.inputs[s.ch].transport is None
+            )
             if unwired:
                 logger.info(
                     f"relay bridge: channels {unwired} advertised without a wired input; "
                     "their panels will wait for data"
                 )
-            for cd in self._channel_defs:
-                if cd.resend_on_subscribe and self.inputs[cd.ch].transport is not None:
+            for s in self._channel_specs:
+                if s.resend_on_subscribe and self.inputs[s.ch].transport is not None:
                     # Always-on raw cache: grids published before the first
                     # viewer, or while nobody watches, must still be
                     # replayable on the next 0->1 subscribe.
                     self.register_disposable(
                         Disposable(
-                            self.inputs[cd.ch].subscribe(functools.partial(self._cache_input, cd))
+                            self.inputs[s.ch].subscribe(functools.partial(self._cache_input, s))
                         )
                     )
             self._manifest = manifest.model_dump()
@@ -615,25 +601,130 @@ class RelayBridgeModule(Module):
             cancel.set()
         super()._close_module()
 
-    def _resolve_jpeg_quality(self, rx_specs: list[ChannelSpec]) -> int:
-        # A single int is honest while CHANNELS has exactly one jpeg entry;
-        # revisit if a second camera channel ever appears.
-        quality = self.config.jpeg_quality
-        for spec in rx_specs:
-            if spec.encoding != "jpeg.v1":
-                continue
-            candidate = spec.params.get("quality", quality)
+    def _adopt_authored_specs(self, rx_wire: list[ChannelSpec]) -> tuple[RuntimeChannelSpec, ...]:
+        """cockpit() compiled config.channels together with the manifest;
+        cross-check the pair and finish config-dependent params.
+
+        Every advertised field that drives runtime behavior must agree, so a
+        stale or independently overridden half fails start instead of gating
+        and encoding differently from what viewers were told. The encoder
+        callable and the internal resend flag are runtime-only and not
+        advertised, so they have no wire side to compare against.
+        """
+        assert self.config.channels is not None
+        by_ch = {s.ch: s for s in self.config.channels}
+        if {w.ch for w in rx_wire} != set(by_ch):
+            raise RuntimeError(
+                f"manifest rx channels {sorted(w.ch for w in rx_wire)} do not match the "
+                f"compiled runtime specs {sorted(by_ch)}; author both through cockpit()"
+            )
+        specs = []
+        for wire in rx_wire:
+            spec = by_ch[wire.ch]
+            advertised = (wire.dir, wire.encoding, wire.delivery, float(wire.maxHz), wire.params)
+            compiled = (spec.dir, spec.encoding, spec.delivery, spec.max_hz, spec.params)
+            if advertised != compiled:
+                raise RuntimeError(
+                    f"manifest channel {wire.ch!r} does not match its compiled runtime "
+                    "spec; author both through cockpit()"
+                )
+            if spec.publish != "none" or spec.required_scope is not None:
+                raise RuntimeError(
+                    f"runtime spec {wire.ch!r} sets publish={spec.publish!r}/"
+                    f"required_scope={spec.required_scope!r}; generic publish arrives "
+                    "with the publish ticket (W7)"
+                )
+            if wire.ch not in self.inputs:
+                raise RuntimeError(
+                    f"runtime spec {wire.ch!r} has no matching input port on {type(self).__name__}"
+                )
+            port_type = self.inputs[wire.ch].type
+            if port_type is not spec.message_type:
+                raise RuntimeError(
+                    f"runtime spec {wire.ch!r} message type "
+                    f"{spec.message_type.__qualname__} does not match the "
+                    f"{type(self).__name__} port type {port_type.__qualname__}"
+                )
+            specs.append(self._finalize_spec(spec))
+        return tuple(specs)
+
+    def _resolve_builtin_specs(self, rx_wire: list[ChannelSpec]) -> tuple[RuntimeChannelSpec, ...]:
+        """Runtime specs for a hand-written or auto (default_manifest)
+        manifest: every rx channel must be a built-in declaration, with its
+        encoder taken from the codec registry."""
+        by_ch = {b.ch: b for b in BUILTIN_CHANNELS}
+        specs = []
+        for wire in rx_wire:
+            builtin = by_ch.get(wire.ch)
             if (
-                isinstance(candidate, bool)
-                or not isinstance(candidate, int)
-                or not 0 <= candidate <= 100
+                builtin is None
+                or builtin.encoding != wire.encoding
+                or builtin.delivery != wire.delivery
             ):
                 raise RuntimeError(
-                    f"manifest channel {spec.ch!r} quality must be an int in 0..100, "
-                    f"got {candidate!r}"
+                    f"manifest channel {wire.ch!r} ({wire.encoding}/{wire.delivery}) has no "
+                    f"matching encoder; this bridge supports: {sorted(by_ch)}"
                 )
-            quality = candidate
-        return quality
+            definition = encoder_definition(wire.encoding)
+            assert definition is not None, wire.encoding  # built-ins register at import
+            specs.append(
+                self._finalize_spec(
+                    RuntimeChannelSpec(
+                        ch=wire.ch,
+                        message_type=definition.message_type,
+                        dir="rx",
+                        encoding=wire.encoding,
+                        delivery=wire.delivery,
+                        max_hz=float(wire.maxHz),
+                        params=dict(wire.params),
+                        encoder=definition.encode,
+                        encoder_takes_params=definition.takes_params,
+                        resend_on_subscribe=builtin.resend_on_subscribe,
+                    )
+                )
+            )
+        return tuple(specs)
+
+    def _finalize_spec(self, spec: RuntimeChannelSpec) -> RuntimeChannelSpec:
+        """Merge config-driven defaults under a built-in channel's params and
+        run the codec's params check, so a bad authored value (jpeg quality)
+        fails module start, not the first frame."""
+        params = dict(spec.params)
+        builtin = next((b for b in BUILTIN_CHANNELS if b.ch == spec.ch), None)
+        if builtin is not None:
+            params = {**builtin.default_params(self.config), **params}
+        definition = encoder_definition(spec.encoding)
+        if definition is not None and definition.check_params is not None:
+            try:
+                definition.check_params(params)
+            except ValueError as e:
+                raise RuntimeError(f"manifest channel {spec.ch!r} {e}") from e
+        return replace(spec, params=params)
+
+    def _run_encoder(self, spec: RuntimeChannelSpec, msg: Any) -> tuple[bytes, _FrameMeta] | None:
+        """One sample through the channel's encoder; None drops it (encoder
+        skip, failure, or a bad return type - failures are logged at most
+        once per channel per _ENCODE_ERROR_LOG_INTERVAL_S)."""
+        assert spec.encoder is not None
+        now = time.monotonic()
+        try:
+            out = spec.encoder(msg, spec.params) if spec.encoder_takes_params else spec.encoder(msg)
+        except Exception:
+            if _passes_rate_gate(self._encode_error_logged, spec.ch, now, _ENCODE_ERROR_LOG_S):
+                logger.exception(f"relay bridge: encoding {spec.ch} failed")
+            return None
+        if out is None:
+            return None
+        if isinstance(out, EncodedPayload):
+            return out.payload, dict(out.meta) if out.meta is not None else None
+        if isinstance(out, (bytes, bytearray, memoryview)):
+            return bytes(out), None
+        if _passes_rate_gate(self._encode_error_logged, spec.ch, now, _ENCODE_ERROR_LOG_S):
+            logger.error(
+                f"relay bridge: {spec.ch} encoder returned {type(out).__name__}; "
+                "expected bytes, EncodedPayload, or None"
+            )
+        return None
 
     def _spawn_relay(self, open_browser: bool, serve_dir: Path | None) -> str:
         """Start a fresh local relay child (blocking; run via to_thread)."""
@@ -661,11 +752,11 @@ class RelayBridgeModule(Module):
 
     def _build_senders(self, client: RelayClient) -> dict[str, _Sender]:
         senders: dict[str, _Sender] = {}
-        for cd in self._channel_defs:
-            if cd.delivery == "latest":
-                senders[cd.ch] = client.latest_writer(cd.ch).offer
+        for spec in self._channel_specs:
+            if spec.delivery == "latest":
+                senders[spec.ch] = client.latest_writer(spec.ch).offer
             else:
-                senders[cd.ch] = functools.partial(self._send_reliable, client, cd.ch)
+                senders[spec.ch] = functools.partial(self._send_reliable, client, spec.ch)
         return senders
 
     def _send_reliable(
@@ -896,15 +987,15 @@ class RelayBridgeModule(Module):
 
     def _reconcile(self, session: _Session, want: set[str]) -> None:
         """Subscribe/unsubscribe inputs so exactly `want` is being encoded."""
-        for cd in self._channel_defs:
-            active = cd.ch in session.unsubs
-            should = cd.ch in want
+        for spec in self._channel_specs:
+            active = spec.ch in session.unsubs
+            should = spec.ch in want
             if should and not active:
-                if self.inputs[cd.ch].transport is None:
+                if self.inputs[spec.ch].transport is None:
                     # Advertised but unwired (manifest-authored): nothing to
                     # subscribe; the panel shows "waiting for data".
                     continue
-                cached = self._last_msg.get(cd.ch)
+                cached = self._last_msg.get(spec.ch)
                 if cached is not None:
                     # Replay precedes the subscribe: this offer runs
                     # synchronously on the loop, so a live frame - possible
@@ -914,52 +1005,46 @@ class RelayBridgeModule(Module):
                     # an extra viewer on an already-active channel waits for
                     # the next publish (review issue 2, deferred).
                     msg, recv_ts = cached
-                    try:
-                        encoded = cd.encode(self, msg)
-                    except Exception:
-                        logger.exception(f"relay bridge: replaying {cd.ch} failed")
-                        encoded = None
+                    encoded = self._run_encoder(spec, msg)
                     if encoded is not None:
                         # self.encoded counts live-path encodes only; the
                         # arrival ts keeps a stale replay honest about its age.
-                        self._offer(session, session.senders[cd.ch], *encoded, recv_ts)
-                session.unsubs[cd.ch] = self.inputs[cd.ch].subscribe(
-                    functools.partial(self._on_input, session, cd, session.senders[cd.ch])
+                        self._offer(session, session.senders[spec.ch], *encoded, recv_ts)
+                session.unsubs[spec.ch] = self.inputs[spec.ch].subscribe(
+                    functools.partial(self._on_input, session, spec, session.senders[spec.ch])
                 )
-                logger.info(f"relay bridge: viewer subscribed to {cd.ch}; encoding started")
+                logger.info(f"relay bridge: viewer subscribed to {spec.ch}; encoding started")
             elif active and not should:
-                unsubscribe = session.unsubs[cd.ch]
+                unsubscribe = session.unsubs[spec.ch]
                 unsubscribe()
-                del session.unsubs[cd.ch]
-                logger.info(f"relay bridge: no viewers on {cd.ch}; encoding stopped")
-        unknown = want - {cd.ch for cd in self._channel_defs}
+                del session.unsubs[spec.ch]
+                logger.info(f"relay bridge: no viewers on {spec.ch}; encoding stopped")
+        unknown = want - {spec.ch for spec in self._channel_specs}
         if unknown:
             logger.debug(f"relay bridge: ignoring unknown channels {sorted(unknown)}")
 
-    def _on_input(self, session: _Session, cd: ChannelDef, sender: _Sender, msg: Any) -> None:
+    def _on_input(
+        self, session: _Session, spec: RuntimeChannelSpec, sender: _Sender, msg: Any
+    ) -> None:
         """Transport-thread callback: maxHz gate, encode, hand to the loop."""
         if session.retired.is_set():
             return
         now = time.monotonic()
-        if not _passes_rate_gate(self._last_input, cd.ch, now, self._min_interval[cd.ch]):
+        if not _passes_rate_gate(self._last_input, spec.ch, now, self._min_interval[spec.ch]):
             return
-        try:
-            encoded = cd.encode(self, msg)
-        except Exception:
-            logger.exception(f"relay bridge: encoding {cd.ch} failed")
-            return
+        encoded = self._run_encoder(spec, msg)
         if encoded is None:
             return
         payload, meta = encoded
-        self.encoded[cd.ch] += 1
+        self.encoded[spec.ch] += 1
         loop = self._loop
         if loop is not None and loop.is_running():
             loop.call_soon_threadsafe(self._offer, session, sender, payload, meta)
 
-    def _cache_input(self, cd: ChannelDef, msg: Any) -> None:
+    def _cache_input(self, spec: RuntimeChannelSpec, msg: Any) -> None:
         """Transport-thread callback: remember the newest raw message so a
         0->1 subscribe can replay it (its arrival time becomes the frame ts)."""
-        self._last_msg[cd.ch] = (msg, time.time())
+        self._last_msg[spec.ch] = (msg, time.time())
 
     def _offer(
         self,
@@ -1007,8 +1092,12 @@ class RelayBridgeModule(Module):
 def with_relay_bridge(blueprint: Blueprint) -> Blueprint:
     """Append a relay bridge wired to the blueprint's channel producers."""
     # An external or explicitly composed blueprint may already own a customized
-    # relay bridge. Preserve that atom rather than overriding its kwargs.
-    if any(atom.module is RelayBridgeModule for atom in blueprint.blueprints):
+    # relay bridge (possibly a generated subclass with custom channel ports).
+    # Preserve that atom rather than overriding its kwargs.
+    if any(
+        isinstance(atom.module, type) and issubclass(atom.module, RelayBridgeModule)
+        for atom in blueprint.blueprints
+    ):
         return blueprint
 
     producer_keys: set[tuple[str, type]] = set()
@@ -1033,7 +1122,7 @@ def with_relay_bridge(blueprint: Blueprint) -> Blueprint:
     }
     available_channels = tuple(
         channel.ch
-        for channel in CHANNELS
+        for channel in BUILTIN_CHANNELS
         if (channel_type := bridge_input_types.get(channel.ch)) is not None
         and (channel.ch, channel_type) in producer_keys
     ) + tuple(

--- a/dimos/web/relay_bridge/test_costmap_encoding.py
+++ b/dimos/web/relay_bridge/test_costmap_encoding.py
@@ -28,9 +28,9 @@ import pytest
 
 from dimos.msgs.geometry_msgs.Pose import Pose
 from dimos.msgs.nav_msgs.OccupancyGrid import OccupancyGrid
+from dimos.web.relay_bridge.builtin_codecs import encode_costmap
 from dimos.web.relay_bridge.gen_costmap_fixtures import grid_msg
 from dimos.web.relay_bridge.locate import find_web_dir
-from dimos.web.relay_bridge.relay_bridge_module import _encode_costmap
 
 with open(find_web_dir() / "shared" / "fixtures" / "costmap_frames.json") as f:
     VECTORS: list[dict[str, Any]] = json.load(f)["vectors"]
@@ -47,9 +47,9 @@ def test_encoder_reproduces_golden_vector(vec: dict[str, Any]) -> None:
     rows = np.where(cells == 255, -1, cells).astype(np.int8).reshape(meta["h"], meta["w"])
     ox, oy, yaw = meta["origin"]
     msg = grid_msg(rows.tolist(), meta["res"], ox, oy, yaw)
-    encoded = _encode_costmap(None, msg)  # the costmap encoder ignores the module
+    encoded = encode_costmap(msg)
     assert encoded is not None
-    payload, out_meta = encoded
+    payload, out_meta = encoded.payload, encoded.meta
     assert payload == base64.b64decode(vec["payload_b64"])
     assert zlib.decompress(payload) == cells.tobytes()
     assert (out_meta["w"], out_meta["h"], out_meta["res"]) == (meta["w"], meta["h"], meta["res"])
@@ -63,15 +63,15 @@ def test_encoder_handles_wire_decoded_grid() -> None:
     global_costmap frame failed to encode)."""
     msg = grid_msg([[0, 100], [-1, 50]], 0.05, -1.25, 2.5, 0.5)
     decoded = OccupancyGrid.lcm_decode(msg.lcm_encode())
-    encoded = _encode_costmap(None, decoded)
+    encoded = encode_costmap(decoded)
     assert encoded is not None
-    payload, meta = encoded
+    payload, meta = encoded.payload, encoded.meta
     assert meta["origin"] == pytest.approx([-1.25, 2.5, 0.5])
     assert zlib.decompress(payload) == bytes([0, 100, 255, 50])
 
 
 def test_empty_grid_encodes_to_none() -> None:
-    assert _encode_costmap(None, OccupancyGrid()) is None
+    assert encode_costmap(OccupancyGrid()) is None
 
 
 def test_oversized_grid_is_downsampled_within_budget() -> None:
@@ -79,9 +79,9 @@ def test_oversized_grid_is_downsampled_within_budget() -> None:
     rows[0, 1] = 100  # lone obstacle: the block max must keep it
     rows[2:4, 2:4] = -1  # a fully unknown block stays unknown
     msg = OccupancyGrid(grid=rows, resolution=0.05, origin=Pose(1.0, 2.0, 0.0), ts=1.0)
-    encoded = _encode_costmap(None, msg)
+    encoded = encode_costmap(msg)
     assert encoded is not None
-    payload, meta = encoded
+    payload, meta = encoded.payload, encoded.meta
     assert (meta["w"], meta["h"]) == (2048, 2048)
     assert meta["res"] == pytest.approx(0.1)
     assert meta["origin"][:2] == [1.0, 2.0]
@@ -94,9 +94,9 @@ def test_oversized_grid_is_downsampled_within_budget() -> None:
 def test_grid_at_exactly_max_side_is_not_downsampled() -> None:
     rows = np.full((4, 2048), 7, dtype=np.int8)
     msg = OccupancyGrid(grid=rows, resolution=0.05, origin=Pose(0.0, 0.0, 0.0), ts=1.0)
-    encoded = _encode_costmap(None, msg)
+    encoded = encode_costmap(msg)
     assert encoded is not None
-    payload, meta = encoded
+    payload, meta = encoded.payload, encoded.meta
     assert (meta["w"], meta["h"], meta["res"]) == (2048, 4, 0.05)
     assert zlib.decompress(payload) == rows.astype(np.uint8).tobytes()
 
@@ -104,8 +104,8 @@ def test_grid_at_exactly_max_side_is_not_downsampled() -> None:
 def test_non_square_oversized_grid_uses_ceil_factor() -> None:
     rows = np.zeros((100, 4100), dtype=np.int8)
     msg = OccupancyGrid(grid=rows, resolution=0.05, origin=Pose(0.0, 0.0, 0.0), ts=1.0)
-    encoded = _encode_costmap(None, msg)
+    encoded = encode_costmap(msg)
     assert encoded is not None
-    _, meta = encoded
+    meta = encoded.meta
     assert (meta["w"], meta["h"]) == (1366, 33)
     assert meta["res"] == pytest.approx(0.15)

--- a/dimos/web/relay_bridge/test_dynamic.py
+++ b/dimos/web/relay_bridge/test_dynamic.py
@@ -18,6 +18,7 @@
 # Module class whose annotations become strings silently loses its streams
 # (see the module-level note in test_relay_bridge_module.py).
 
+from dataclasses import dataclass
 import pickle
 import re
 import subprocess
@@ -37,6 +38,7 @@ from dimos.msgs.geometry_msgs.Twist import Twist
 from dimos.msgs.geometry_msgs.Vector3 import Vector3
 from dimos.msgs.nav_msgs.OccupancyGrid import OccupancyGrid
 from dimos.msgs.sensor_msgs.Image import Image
+from dimos.web.cockpit import Channel, cockpit
 from dimos.web.relay_bridge import dynamic
 from dimos.web.relay_bridge.dynamic import DynamicPortSpec, make_relay_bridge_class
 from dimos.web.relay_bridge.e2e_support import stop_module
@@ -376,6 +378,40 @@ def test_two_shapes_deploy_to_one_worker(worker_manager, deployed_proxies):
     # Shape A does not have shape B's port; shape B has it but unwired.
     assert isinstance(proxy_a.peek_stream("duo_feed_b", 0.1), PeekNotFound)
     assert proxy_b.peek_stream("duo_feed_b", 0.1) is None
+
+
+@dataclass(frozen=True)
+class _OpsNote:
+    text: str
+    priority: int
+
+
+@pytest.mark.skipif_macos_bug
+def test_cockpit_channels_blueprint_deploys_through_forkserver(worker_manager, deployed_proxies):
+    """W6: a cockpit(channels=)-compiled atom - generated class plus runtime
+    specs carrying by-reference encoder callables in the kwargs - must
+    survive the real forkserver deploy path (config re-validates in the
+    child)."""
+    assert worker_manager.workers[0].pid is not None
+
+    blueprint = cockpit(
+        channels=[
+            Channel("target_pose", PoseStamped, encoding="pose.json.v1", max_hz=5.0),
+            Channel("ops_note", _OpsNote),
+        ]
+    )
+    (atom,) = blueprint.blueprints
+    assert atom.module.__name__.startswith("DynamicRelayBridge_")
+    proxy = worker_manager.deploy(atom.module, global_config, atom.kwargs)
+    deployed_proxies.append(proxy)
+
+    assert isinstance(proxy.peek_stream("no_such_stream", 0.1), PeekNotFound)
+    # Both generated ports exist in the worker (unwired: None, not NotFound).
+    assert proxy.peek_stream("target_pose", 0.1) is None
+    assert proxy.peek_stream("ops_note", 0.1) is None
+    remote = proxy.target_pose
+    assert isinstance(remote, RemoteIn)
+    assert remote.type is PoseStamped
 
 
 @pytest.mark.skipif_macos_bug

--- a/dimos/web/relay_bridge/test_relay_bridge_module.py
+++ b/dimos/web/relay_bridge/test_relay_bridge_module.py
@@ -26,7 +26,9 @@ from collections.abc import AsyncIterator, Callable
 from dataclasses import replace
 import json
 from pathlib import Path
+import pickle
 import socket
+import struct
 import subprocess
 import sys
 import threading
@@ -46,9 +48,12 @@ from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
 from dimos.msgs.geometry_msgs.Twist import Twist
 from dimos.msgs.geometry_msgs.Vector3 import Vector3
 from dimos.msgs.nav_msgs.OccupancyGrid import OccupancyGrid
+from dimos.msgs.nav_msgs.Path import Path as NavPath
 from dimos.msgs.sensor_msgs.Image import Image
 from dimos.simulation.mujoco.constants import VIDEO_FPS
-from dimos.web.relay_bridge import relay_bridge_module
+from dimos.web.cockpit import Channel, Video, cockpit
+from dimos.web.codecs import EncodedPayload, web_encoder
+from dimos.web.relay_bridge import builtin_codecs, relay_bridge_module
 from dimos.web.relay_bridge.e2e_support import stop_module
 from dimos.web.relay_bridge.manifest import ManifestError, parse_manifest
 from dimos.web.relay_bridge.protocol import (
@@ -60,9 +65,9 @@ from dimos.web.relay_bridge.protocol import (
     Twist as WireTwist,
 )
 from dimos.web.relay_bridge.relay_bridge_module import (
-    CHANNELS,
     RelayBridgeConfig,
     RelayBridgeModule,
+    RuntimeChannelSpec,
     default_manifest,
     resolve_robot_info,
     with_relay_bridge,
@@ -521,7 +526,7 @@ def test_no_costmap_encode_while_unsubscribed(costmap_bridge, monkeypatch) -> No
         calls["n"] += 1
         return real(data, level)
 
-    monkeypatch.setattr(relay_bridge_module.zlib, "compress", spy)
+    monkeypatch.setattr(builtin_codecs.zlib, "compress", spy)
     costmap_transport(module).publish(COSTMAP_GRID)
     costmap_transport(module).publish(COSTMAP_GRID)
     flush_loop(module)
@@ -688,23 +693,20 @@ def test_encode_started_in_old_session_is_not_sent_to_replacement(
     encode_started = threading.Event()
     release_encode = threading.Event()
 
-    def blocking_encode(
-        module: RelayBridgeModule, msg: PoseStamped
-    ) -> tuple[bytes, dict[str, Any] | None]:
+    def blocking_encode(msg: PoseStamped) -> bytes:
         encode_started.set()
         assert release_encode.wait(timeout=5.0)
-        return b"old-session-frame", None
+        return b"old-session-frame"
 
-    odom = next(channel for channel in CHANNELS if channel.ch == "odom")
-    monkeypatch.setattr(
-        relay_bridge_module,
-        "CHANNELS",
-        tuple(
-            replace(channel, encode=blocking_encode) if channel.ch == "odom" else channel
-            for channel in CHANNELS
-        ),
-    )
     module, clients = _make_bridge(monkeypatch)
+    # Swap the resolved odom spec's encoder for the blocking one before any
+    # viewer subscribes (the runtime specs are the encoder source now).
+    module._channel_specs = tuple(
+        replace(spec, encoder=blocking_encode, encoder_takes_params=False)
+        if spec.ch == "odom"
+        else spec
+        for spec in module._channel_specs
+    )
     publisher = threading.Thread(
         target=odom_transport(module).publish,
         args=(
@@ -716,7 +718,7 @@ def test_encode_started_in_old_session_is_not_sent_to_replacement(
         ),
     )
     try:
-        push(module, clients[0], Subs(chs=[odom.ch], n=1))
+        push(module, clients[0], Subs(chs=["odom"], n=1))
         assert wait_until(lambda: len(odom_transport(module).subscribers) == 1)
 
         publisher.start()
@@ -946,7 +948,8 @@ def test_start_with_authored_manifest_rates_and_quality(monkeypatch) -> None:
         assert hello_manifest["layout"] == "p0"
         # Rate and quality come from the manifest, not the config fields.
         assert module._min_interval == {"color_image": 1.0 / 4.0}
-        assert module._jpeg_quality == 33
+        (image_spec,) = module._channel_specs
+        assert image_spec.params["quality"] == 33
         qualities: list[int] = []
         real = Image.to_jpeg_bytes
 
@@ -1610,3 +1613,276 @@ def test_composition_preserves_existing_relay() -> None:
         "local_port": 8899,
         "available_channels": ("odom",),
     }
+
+
+@web_encoder("path.rbm.v1")
+def _encode_path_points(msg: NavPath) -> EncodedPayload:
+    payload = b"".join(struct.pack("<ff", p.position.x, p.position.y) for p in msg.poses)
+    return EncodedPayload(payload, {"n": len(msg.poses)})
+
+
+@web_encoder("boom.rbm.v1")
+def _encode_boom(msg: NavPath) -> bytes:
+    raise RuntimeError("boom")
+
+
+_NAV_PATH = NavPath(
+    ts=1.0,
+    frame_id="world",
+    poses=[PoseStamped(ts=1.0, position=[1.5, -2.5, 0.0], orientation=[0.0, 0.0, 0.0, 1.0])],
+)
+_NAV_PATH_PAYLOAD = struct.pack("<ff", 1.5, -2.5)
+
+
+def _start_authored(monkeypatch, blueprint, wire: tuple[str, ...]):
+    """Start a cockpit()-compiled bridge atom (possibly a generated class)
+    against the fake relay client, mirroring _make_bridge."""
+    (atom,) = blueprint.blueprints
+    clients: list[FakeClient] = []
+
+    async def fake_connect(url: str, role: str, **kwargs: Any) -> FakeClient:
+        clients.append(FakeClient())
+        return clients[-1]
+
+    monkeypatch.setattr(relay_bridge_module, "connect_with_backoff", fake_connect)
+    module = atom.module(
+        relay_url="https://127.0.0.1:1", open_browser=False, robot_id="unit-bot", **atom.kwargs
+    )
+    for ch in wire:
+        getattr(module, ch).transport = FakeTransport()
+    module.start()
+    return module, clients
+
+
+def _transport_of(module: RelayBridgeModule, ch: str) -> FakeTransport:
+    transport = getattr(module, ch).transport
+    assert isinstance(transport, FakeTransport)
+    return transport
+
+
+def test_config_accepts_runtime_specs_by_identity_and_pickles() -> None:
+    spec = RuntimeChannelSpec(
+        ch="odom",
+        message_type=PoseStamped,
+        dir="rx",
+        encoding="pose.json.v1",
+        delivery="reliable",
+        max_hz=20.0,
+        params={"a": 1},
+        encoder=builtin_codecs.encode_pose,
+    )
+    config = RelayBridgeConfig(channels=(spec,))
+    # Pydantic must pass the frozen dataclass through untouched; a rebuilt
+    # copy would break the is-checks blueprints rely on.
+    assert config.channels is not None and config.channels[0] is spec
+    restored = pickle.loads(pickle.dumps(config))
+    assert restored.channels[0].encoder is builtin_codecs.encode_pose
+    assert restored.channels[0].params == {"a": 1}
+
+
+def test_authored_specs_drive_generated_port(monkeypatch) -> None:
+    blueprint = cockpit(
+        channels=[Channel("nav_path", NavPath, encoding="path.rbm.v1", max_hz=1000.0)]
+    )
+    module, clients = _start_authored(monkeypatch, blueprint, wire=("nav_path",))
+    try:
+        nav = _transport_of(module, "nav_path")
+        nav.publish(_NAV_PATH)
+        flush_loop(module)
+        assert clients[0].frames == []  # no viewers: no encode, no send
+        assert module.encoded == {"nav_path": 0}
+
+        push(module, clients[0], Subs(chs=["nav_path"], n=1))
+        assert wait_until(lambda: nav.subscribers)
+        nav.publish(_NAV_PATH)
+        assert wait_until(lambda: clients[0].frames)
+        ch, payload, delivery, meta = clients[0].frames[0]
+        assert (ch, delivery) == ("nav_path", "reliable")
+        assert payload == _NAV_PATH_PAYLOAD
+        assert meta == {"n": 1}
+        assert module.encoded["nav_path"] == 1
+
+        push(module, clients[0], Subs(chs=[], n=2))
+        assert wait_until(lambda: not nav.subscribers)
+    finally:
+        stop_module(module)
+
+
+def test_two_jpeg_channels_use_independent_quality(monkeypatch) -> None:
+    # The second camera the old single-int _jpeg_quality could not express.
+    blueprint = cockpit(
+        layout=Video("color_image", quality=33, max_hz=1000.0),
+        channels=[
+            Channel(
+                "rear_cam",
+                Image,
+                encoding="jpeg.v1",
+                delivery="latest",
+                max_hz=1000.0,
+                params={"quality": 90},
+            )
+        ],
+    )
+    module, clients = _start_authored(monkeypatch, blueprint, wire=("color_image", "rear_cam"))
+    try:
+        qualities: list[int] = []
+        real = Image.to_jpeg_bytes
+
+        def spy(self: Image, quality: int = 75) -> bytes:
+            qualities.append(quality)
+            return real(self, quality=quality)
+
+        monkeypatch.setattr(Image, "to_jpeg_bytes", spy)
+        push(module, clients[0], Subs(chs=["color_image", "rear_cam"], n=1))
+        front, rear = _transport_of(module, "color_image"), _transport_of(module, "rear_cam")
+        assert wait_until(lambda: front.subscribers and rear.subscribers)
+        image = Image.from_numpy(np.zeros((8, 12, 3), dtype=np.uint8))
+        front.publish(image)
+        rear.publish(image)
+        assert wait_until(lambda: sorted(qualities) == [33, 90])
+    finally:
+        stop_module(module)
+
+
+def test_resend_flag_replays_cache_on_generated_port(monkeypatch) -> None:
+    # The replay mechanism is spec-driven now; prove it on a generated input
+    # (the flag is internal - cockpit() sets it only for the built-in costmap).
+    blueprint = cockpit(
+        channels=[Channel("nav_path", NavPath, encoding="path.rbm.v1", max_hz=1000.0)]
+    )
+    (atom,) = blueprint.blueprints
+    atom.kwargs["channels"] = tuple(
+        replace(spec, resend_on_subscribe=True) for spec in atom.kwargs["channels"]
+    )
+    module, clients = _start_authored(monkeypatch, blueprint, wire=("nav_path",))
+    try:
+        nav = _transport_of(module, "nav_path")
+        assert len(nav.subscribers) == 1  # the always-on raw cache
+        nav.publish(_NAV_PATH)  # nobody watching; only the cache sees it
+        flush_loop(module)
+        assert clients[0].frames == []
+
+        push(module, clients[0], Subs(chs=["nav_path"], n=1))
+        # The cached message replays without a new publish.
+        assert wait_until(lambda: clients[0].frames)
+        assert clients[0].frames[0][1] == _NAV_PATH_PAYLOAD
+        assert module.encoded["nav_path"] == 0  # replays do not count
+    finally:
+        stop_module(module)
+
+
+def test_encoder_failure_is_isolated_and_rate_limited(monkeypatch) -> None:
+    blueprint = cockpit(
+        channels=[
+            Channel("bad_path", NavPath, encoding="boom.rbm.v1", max_hz=1000.0),
+            Channel("target_pose", PoseStamped, encoding="pose.json.v1", max_hz=1000.0),
+        ]
+    )
+    module, clients = _start_authored(monkeypatch, blueprint, wire=("bad_path", "target_pose"))
+    try:
+        exceptions: list[str] = []
+        monkeypatch.setattr(
+            relay_bridge_module.logger,
+            "exception",
+            lambda msg, *args, **kwargs: exceptions.append(msg),
+        )
+        push(module, clients[0], Subs(chs=["bad_path", "target_pose"], n=1))
+        bad, pose = _transport_of(module, "bad_path"), _transport_of(module, "target_pose")
+        assert wait_until(lambda: bad.subscribers and pose.subscribers)
+        # Drop the input rate gates so every publish reaches the encoder.
+        module._min_interval = {"bad_path": 0.0, "target_pose": 0.0}
+        for _ in range(3):
+            bad.publish(_NAV_PATH)
+        pose.publish(PoseStamped(ts=2.0, position=[1.0, 2.0, 0.0], orientation=[0, 0, 0, 1]))
+        assert wait_until(lambda: clients[0].frames)
+        # The healthy channel flows; the broken one drops every sample.
+        assert all(frame[0] == "target_pose" for frame in clients[0].frames)
+        assert module.encoded == {"bad_path": 0, "target_pose": 1}
+        # Three failures inside the log window produce one exception log.
+        assert len(exceptions) == 1
+        assert "bad_path" in exceptions[0]
+    finally:
+        stop_module(module)
+
+
+def test_channels_without_manifest_fails(monkeypatch) -> None:
+    async def fake_connect(url: str, role: str, **kwargs: Any) -> FakeClient:
+        raise AssertionError("must not reach the relay without a manifest")
+
+    monkeypatch.setattr(relay_bridge_module, "connect_with_backoff", fake_connect)
+    spec = RuntimeChannelSpec(
+        ch="odom",
+        message_type=PoseStamped,
+        dir="rx",
+        encoding="pose.json.v1",
+        delivery="reliable",
+        max_hz=20.0,
+        params={},
+        encoder=builtin_codecs.encode_pose,
+    )
+    module = RelayBridgeModule(
+        relay_url="https://127.0.0.1:1", robot_id="unit-bot", channels=(spec,)
+    )
+    with pytest.raises(RuntimeError, match="require a manifest"):
+        try:
+            module.start()
+        finally:
+            stop_module(module)
+
+
+def test_spec_manifest_mismatch_fails(monkeypatch) -> None:
+    async def fake_connect(url: str, role: str, **kwargs: Any) -> FakeClient:
+        raise AssertionError("must not reach the relay with mismatched specs")
+
+    monkeypatch.setattr(relay_bridge_module, "connect_with_backoff", fake_connect)
+    manifest = {
+        "version": 1,
+        "channels": [
+            {"ch": "odom", "encoding": "pose.json.v1", "delivery": "reliable", "maxHz": 5.0}
+        ],
+    }
+
+    def start_with(spec: RuntimeChannelSpec, match: str) -> None:
+        module = RelayBridgeModule(
+            relay_url="https://127.0.0.1:1",
+            robot_id="unit-bot",
+            manifest=manifest,
+            channels=(spec,),
+        )
+        module.odom.transport = FakeTransport()
+        with pytest.raises(RuntimeError, match=match):
+            try:
+                module.start()
+            finally:
+                stop_module(module)
+
+    good = RuntimeChannelSpec(
+        ch="odom",
+        message_type=PoseStamped,
+        dir="rx",
+        encoding="pose.json.v1",
+        delivery="reliable",
+        max_hz=5.0,
+        params={},
+        encoder=builtin_codecs.encode_pose,
+    )
+    start_with(replace(good, ch="target_pose"), "do not match the compiled runtime specs")
+    # Every advertised field that drives behavior is cross-checked: a spec
+    # gating at 500 Hz while the manifest promises 5 Hz (or drifted params,
+    # encoding, delivery, direction) must fail start.
+    start_with(replace(good, encoding="json.v1"), "does not match its compiled runtime spec")
+    start_with(replace(good, delivery="latest"), "does not match its compiled runtime spec")
+    start_with(replace(good, max_hz=500.0), "does not match its compiled runtime spec")
+    start_with(replace(good, params={"q": 1}), "does not match its compiled runtime spec")
+    start_with(replace(good, dir="tx"), "does not match its compiled runtime spec")
+    start_with(replace(good, publish="shared"), r"publish ticket \(W7\)")
+    start_with(replace(good, required_scope="goal:write"), r"publish ticket \(W7\)")
+    start_with(
+        replace(good, message_type=Twist),
+        "message type Twist does not match the RelayBridgeModule port type PoseStamped",
+    )
+
+
+def test_composition_preserves_generated_bridge() -> None:
+    blueprint = cockpit(channels=[Channel("target_pose", PoseStamped, encoding="pose.json.v1")])
+    assert with_relay_bridge(blueprint) is blueprint

--- a/dimos/web/test_cockpit.py
+++ b/dimos/web/test_cockpit.py
@@ -14,13 +14,30 @@
 
 """Authoring-API tests: cockpit()/panels/layout compile to pinned manifests."""
 
+from dataclasses import dataclass
 import pickle
+import struct
 import subprocess
 import sys
 
 import pytest
 
-from dimos.web.cockpit import ChannelRequest, Col, Map2D, Panel, Row, Teleop, Video, cockpit
+from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
+from dimos.msgs.geometry_msgs.Twist import Twist
+from dimos.msgs.nav_msgs.Path import Path
+from dimos.msgs.sensor_msgs.Image import Image
+from dimos.web.cockpit import (
+    Channel,
+    ChannelRequest,
+    Col,
+    Map2D,
+    Panel,
+    Row,
+    Teleop,
+    Video,
+    cockpit,
+)
+from dimos.web.codecs import EncodedPayload, encode_json_v1, web_encoder
 from dimos.web.relay_bridge.manifest import parse_manifest
 from dimos.web.relay_bridge.protocol import (
     MAX_CONTROL_PAYLOAD_BYTES,
@@ -241,6 +258,284 @@ def test_go2_hello_fits_the_control_payload_cap() -> None:
     )
     size = len(encode_datagram(hello))
     assert size <= MAX_CONTROL_PAYLOAD_BYTES, f"go2 hello grew to {size} B"
+
+
+@dataclass(frozen=True)
+class _OpsNote:
+    text: str
+    priority: int
+
+
+@web_encoder("path.ck.v1")
+def _encode_path_xy(msg: Path) -> EncodedPayload:
+    payload = b"".join(struct.pack("<ff", p.position.x, p.position.y) for p in msg.poses)
+    return EncodedPayload(payload, {"n": len(msg.poses)})
+
+
+def test_channel_tx_rejected_until_publish_ticket() -> None:
+    with pytest.raises(ValueError, match="publish ticket"):
+        Channel("goal", dict, dir="tx")
+
+
+def test_channel_rx_publish_policy() -> None:
+    with pytest.raises(ValueError, match="publish='none'"):
+        Channel("note", dict, publish="shared")
+    with pytest.raises(ValueError, match="publish='none'"):
+        Channel("note", dict, publish="exclusive")
+    with pytest.raises(ValueError, match="required_scope"):
+        Channel("note", dict, required_scope="chat:send")
+
+
+def test_channel_message_type_must_be_a_class() -> None:
+    with pytest.raises(TypeError, match="message_type must be a class"):
+        Channel("note", "str")
+
+
+@pytest.mark.parametrize(
+    "build",
+    [
+        lambda: Channel("", dict),
+        lambda: Channel("x" * 65, dict),
+        lambda: Channel("@note", dict),
+        lambda: Channel("note", dict, dir="sideways"),
+        lambda: Channel("note", dict, encoding=""),
+        lambda: Channel("note", dict, encoding="x" * 65),
+        lambda: Channel("note", dict, delivery="mostly"),
+        lambda: Channel("note", dict, max_hz=0),
+        lambda: Channel("note", dict, max_hz=True),
+        lambda: Channel("note", dict, publish="all"),
+        lambda: Channel("note", dict, params=[("a", 1)]),
+    ],
+    ids=[
+        "empty_stream",
+        "long_stream",
+        "reserved_stream",
+        "bad_dir",
+        "empty_encoding",
+        "long_encoding",
+        "bad_delivery",
+        "zero_rate",
+        "bool_rate",
+        "bad_publish",
+        "params_not_mapping",
+    ],
+)
+def test_channel_validation_errors(build) -> None:
+    with pytest.raises(ValueError):
+        build()
+
+
+def test_channel_params_are_copied() -> None:
+    params = {"scale": 2, "nested": {"a": [1, 2]}}
+    channel = Channel("note", dict, params=params)
+    params["scale"] = 99
+    params["nested"]["a"].append(3)
+    assert channel.params == {"scale": 2, "nested": {"a": (1, 2)}}
+
+
+def test_channel_params_are_immutable() -> None:
+    channel = Channel("note", dict, params={"scale": 2, "nested": {"a": [1, 2]}})
+    with pytest.raises(TypeError, match="immutable"):
+        channel.params["scale"] = 10
+    with pytest.raises(TypeError, match="immutable"):
+        del channel.params["scale"]
+    with pytest.raises(TypeError, match="immutable"):
+        channel.params.update({"scale": 10})
+    with pytest.raises(TypeError, match="immutable"):
+        channel.params["nested"]["a"] = []
+    # Nested sequences freeze to tuples: no append surface at all.
+    assert channel.params["nested"]["a"] == (1, 2)
+    restored = pickle.loads(pickle.dumps(channel))
+    assert restored.params == channel.params
+    with pytest.raises(TypeError, match="immutable"):
+        restored.params["scale"] = 10
+
+
+def test_channel_params_must_be_json_shaped() -> None:
+    with pytest.raises(ValueError, match="params keys must be strings"):
+        Channel("note", dict, params={1: "x"})
+    with pytest.raises(ValueError, match="JSON-shaped"):
+        Channel("note", dict, params={"blob": b"\x00"})
+    with pytest.raises(ValueError, match="JSON-shaped"):
+        Channel("note", dict, params={"n": float("nan")})
+
+
+def test_channel_nested_params_emit_plain_json_in_the_manifest() -> None:
+    blueprint = cockpit(
+        channels=[Channel("cfg", dict, params={"tags": ["a", "b"], "nested": {"n": 1}})]
+    )
+    (atom,) = blueprint.blueprints
+    manifest = atom.kwargs["manifest"]
+    (channel,) = manifest["channels"]
+    # The frozen authoring form (tuples/_FrozenDict) must not leak into the
+    # manifest: pinned manifests compare with == and json round-trips must
+    # be idempotent.
+    assert channel["params"] == {"tags": ["a", "b"], "nested": {"n": 1}}
+    assert isinstance(channel["params"]["tags"], list)
+    assert type(channel["params"]["nested"]) is dict
+    assert parse_manifest(manifest).model_dump() == manifest
+    (spec,) = atom.kwargs["channels"]
+    assert isinstance(spec.params["tags"], list)
+
+
+def test_channels_only_blueprint() -> None:
+    blueprint = cockpit(
+        channels=[
+            Channel("nav_path", Path, encoding="path.ck.v1", delivery="reliable", max_hz=20.0),
+            Channel("ops_note", _OpsNote),
+        ]
+    )
+    (atom,) = blueprint.blueprints
+    manifest = atom.kwargs["manifest"]
+    assert [c["ch"] for c in manifest["channels"]] == ["nav_path", "ops_note"]
+    assert manifest["channels"][0]["encoding"] == "path.ck.v1"
+    assert manifest["panels"] == [] and manifest["layout"] is None and manifest["pages"] == []
+    assert parse_manifest(manifest).model_dump() == manifest
+    # Custom streams ride a generated RelayBridgeModule subclass with real
+    # typed ports.
+    assert atom.module is not RelayBridgeModule
+    assert issubclass(atom.module, RelayBridgeModule)
+    assert any(
+        s.name == "nav_path" and s.type is Path and s.direction == "in" for s in atom.streams
+    )
+    specs = atom.kwargs["channels"]
+    assert [s.ch for s in specs] == ["nav_path", "ops_note"]
+    assert specs[0].encoder is _encode_path_xy and specs[0].message_type is Path
+    assert specs[0].encoder_takes_params is False
+    assert specs[1].encoder is encode_json_v1 and specs[1].message_type is _OpsNote
+    # Blueprint kwargs cross the forkserver Pipe: class identity and the
+    # by-reference encoder must survive pickling.
+    restored = pickle.loads(pickle.dumps(blueprint))
+    (ratom,) = restored.blueprints
+    assert ratom.module is atom.module
+    assert ratom.kwargs["channels"][0].encoder is _encode_path_xy
+    assert ratom.kwargs["manifest"] == manifest
+
+
+def test_default_path_channels_kwarg_matches_manifest() -> None:
+    (atom,) = cockpit().blueprints
+    assert atom.module is RelayBridgeModule
+    specs = atom.kwargs["channels"]
+    rx = [c["ch"] for c in GO2_MANIFEST["channels"] if c["dir"] == "rx"]
+    assert [s.ch for s in specs] == rx
+    assert all(s.encoder is not None for s in specs)
+    costmap = next(s for s in specs if s.ch == "global_costmap")
+    assert costmap.resend_on_subscribe
+
+
+def test_pages_only_still_gets_the_default_preset() -> None:
+    manifest = manifest_of(cockpit(pages=[Video("color_image", max_hz=12.0)]))
+    # The preset grid keeps ids p0..p2; the page panel follows as p3.
+    assert [p["id"] for p in manifest["panels"]] == ["p0", "p1", "p2", "p3"]
+    assert manifest["pages"] == ["p3"]
+
+
+def test_explicit_channel_merges_with_panel_request() -> None:
+    blueprint = cockpit(
+        layout=Video("front_cam", quality=60, max_hz=12.0),
+        channels=[
+            Channel(
+                "front_cam",
+                Image,
+                encoding="jpeg.v1",
+                delivery="latest",
+                max_hz=24.0,
+                params={"quality": 60},
+            )
+        ],
+    )
+    (atom,) = blueprint.blueprints
+    manifest = atom.kwargs["manifest"]
+    (channel,) = manifest["channels"]
+    assert channel["ch"] == "front_cam" and channel["maxHz"] == 24.0
+    assert manifest["panels"][0]["channels"] == ["front_cam"]
+    assert any(s.name == "front_cam" and s.type is Image for s in atom.streams)
+
+
+@pytest.mark.parametrize(
+    "channel",
+    [
+        Channel("front_cam", Image, encoding="jpeg.v1", delivery="latest", params={"quality": 90}),
+        Channel("front_cam", Image),
+        Channel(
+            "front_cam", Image, encoding="jpeg.v1", delivery="reliable", params={"quality": 60}
+        ),
+    ],
+    ids=["params_conflict", "encoding_conflict", "delivery_conflict"],
+)
+def test_explicit_channel_conflicts_with_panel_raise(channel: Channel) -> None:
+    with pytest.raises(ValueError, match="conflicting requirements for stream 'front_cam'"):
+        cockpit(layout=Video("front_cam", quality=60), channels=[channel])
+
+
+def test_builtin_stream_type_and_table_mismatches() -> None:
+    with pytest.raises(ValueError, match="does not match the bridge port type PoseStamped"):
+        cockpit(channels=[Channel("odom", Twist, encoding="pose.json.v1")])
+    with pytest.raises(ValueError, match="'odom' encodes pose.json.v1, not json.v1"):
+        cockpit(channels=[Channel("odom", PoseStamped)])
+    with pytest.raises(ValueError, match="'odom' delivers reliable, not latest"):
+        cockpit(channels=[Channel("odom", PoseStamped, encoding="pose.json.v1", delivery="latest")])
+
+
+def test_json_v1_requires_explicit_codec_for_large_types() -> None:
+    # A mistaken image declaration must fail at authoring, not serialize a
+    # pixel buffer per frame.
+    with pytest.raises(
+        ValueError, match=r"'snapshot'.*Image.*not supported by json\.v1.*@web_encoder"
+    ):
+        cockpit(channels=[Channel("snapshot", Image)])
+
+
+def test_unregistered_custom_encoding_names_the_decorator() -> None:
+    with pytest.raises(
+        ValueError, match=r"'blob'.*no encoder registered.*@web_encoder\('blob\.bin\.v9'\)"
+    ):
+        cockpit(channels=[Channel("blob", dict, encoding="blob.bin.v9")])
+
+
+def test_panel_on_undeclared_custom_stream_still_raises_unknown() -> None:
+    # The typo guard survives channels=: panels alone cannot mint streams,
+    # and the error lists the declared ones next to the built-ins.
+    with pytest.raises(ValueError, match="unknown stream 'lidr'.*nav_path"):
+        cockpit(
+            layout=Video("lidr"),
+            channels=[Channel("nav_path", Path, encoding="path.ck.v1", delivery="reliable")],
+        )
+
+
+def test_duplicate_channel_declaration_raises() -> None:
+    with pytest.raises(ValueError, match="duplicate channel declaration for stream 'note'"):
+        cockpit(channels=[Channel("note", dict), Channel("note", dict)])
+
+
+def test_non_channel_entry_raises() -> None:
+    with pytest.raises(ValueError, match="channels entries must be Channel"):
+        cockpit(channels=[Video("color_image")])
+
+
+@pytest.mark.parametrize("stream", ["encoded", "ref", "class"])
+def test_reserved_stream_names_rejected(stream: str) -> None:
+    with pytest.raises(ValueError):
+        cockpit(channels=[Channel(stream, dict)])
+
+
+def test_channel_ordering_builtins_then_customs() -> None:
+    blueprint = cockpit(
+        layout=GO2_LAYOUT,
+        channels=[
+            Channel("target_pose", PoseStamped, encoding="pose.json.v1", max_hz=5.0),
+            Channel("ops_note", _OpsNote),
+        ],
+    )
+    (atom,) = blueprint.blueprints
+    assert [c["ch"] for c in atom.kwargs["manifest"]["channels"]] == [
+        "color_image",
+        "odom",
+        "global_costmap",
+        "target_pose",
+        "ops_note",
+        "tele_cmd_vel",
+    ]
 
 
 def test_import_stays_light() -> None:

--- a/dimos/web/test_codecs.py
+++ b/dimos/web/test_codecs.py
@@ -1,0 +1,369 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Codec registry tests: decorators, validation, lookup, json.v1 gate."""
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+import subprocess
+import sys
+from typing import Any
+
+import numpy as np
+import pytest
+
+from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
+from dimos.msgs.nav_msgs.Path import Path
+from dimos.msgs.sensor_msgs.Image import Image
+from dimos.web.codecs import (
+    MAX_ENCODED_META_BYTES,
+    DecoderDef,
+    EncodedPayload,
+    EncoderDef,
+    PublishContext,
+    decoder_definition,
+    encode_json_v1,
+    encoder_definition,
+    resolve_encoder,
+    web_decoder,
+    web_encoder,
+)
+
+
+@dataclass(frozen=True)
+class _Point:
+    x: float
+    y: float
+
+
+# Undecorated fixtures for decoration-error tests: decorating them at module
+# level would fail the import, and defining them inside a test trips the
+# <locals> gate before the error under test.
+def _enc_ok(msg: _Point) -> bytes:
+    return encode_json_v1(msg)
+
+
+def _enc_with_params(msg: _Point, params: Mapping[str, Any]) -> bytes:
+    return encode_json_v1({"x": msg.x, "scale": params.get("scale", 1)})
+
+
+def _enc_dict_params(msg: _Point, params: dict[str, Any]) -> bytes:
+    return b""
+
+
+def _enc_zero_params() -> bytes:
+    return b""
+
+
+def _enc_three_params(msg: _Point, params: Mapping[str, Any], extra: int) -> bytes:
+    return b""
+
+
+def _enc_varargs(*msgs: Any) -> bytes:
+    return b""
+
+
+def _enc_unannotated(msg) -> bytes:
+    return b""
+
+
+def _enc_generic_first(msg: list[int]) -> bytes:
+    return b""
+
+
+def _enc_bad_second(msg: _Point, params: int) -> bytes:
+    return b""
+
+
+def _enc_bare_params(msg: _Point, params: dict) -> bytes:
+    return b""
+
+
+def _enc_int_key_params(msg: _Point, params: Mapping[int, Any]) -> bytes:
+    return b""
+
+
+def _enc_no_return(msg: _Point):
+    return b""
+
+
+def _enc_bad_return(msg: _Point) -> int:
+    return 1
+
+
+def _enc_optional_union(msg: _Point) -> bytes | EncodedPayload | None:
+    return None
+
+
+def _dec_ok(value: dict[str, Any]) -> _Point:
+    return _Point(value["x"], value["y"])
+
+
+def _dec_with_context(value: dict[str, Any], context: PublishContext) -> _Point:
+    return _Point(value["x"], value["y"])
+
+
+def _dec_no_return(value: dict[str, Any]):
+    return None
+
+
+def _dec_bad_context(value: dict[str, Any], context: int) -> _Point:
+    return _Point(0.0, 0.0)
+
+
+def _dec_bytes_input(value: bytes) -> _Point:
+    return _Point(0.0, 0.0)
+
+
+def _dec_unannotated_input(value) -> _Point:
+    return _Point(0.0, 0.0)
+
+
+def _dec_none_return(value: dict[str, Any]) -> None:
+    return None
+
+
+def _dec_union_input(value: dict[str, Any] | list[Any] | None) -> _Point:
+    return _Point(0.0, 0.0)
+
+
+def _dec_any_input(value: Any) -> _Point:
+    return _Point(0.0, 0.0)
+
+
+def test_encoder_decorator_registers_and_returns_the_function() -> None:
+    decorated = web_encoder("t.enc.reg.v1")(_enc_ok)
+    assert decorated is _enc_ok
+    definition = encoder_definition("t.enc.reg.v1")
+    assert definition == EncoderDef("t.enc.reg.v1", _Point, _enc_ok, takes_params=False)
+
+
+def test_encoder_second_param_variants() -> None:
+    web_encoder("t.enc.params.v1")(_enc_with_params)
+    web_encoder("t.enc.dictparams.v1")(_enc_dict_params)
+    assert encoder_definition("t.enc.params.v1").takes_params is True
+    assert encoder_definition("t.enc.dictparams.v1").takes_params is True
+
+
+def test_encoder_check_params_is_kept() -> None:
+    def check(params: Mapping[str, Any]) -> None:
+        pass
+
+    web_encoder("t.enc.check.v1", check_params=check)(_enc_ok)
+    assert encoder_definition("t.enc.check.v1").check_params is check
+
+
+def test_same_function_re_registration_is_idempotent() -> None:
+    web_encoder("t.enc.idem.v1")(_enc_ok)
+    web_encoder("t.enc.idem.v1")(_enc_ok)
+    assert encoder_definition("t.enc.idem.v1").encode is _enc_ok
+
+
+def test_conflicting_duplicate_registration_raises() -> None:
+    web_encoder("t.enc.dup.v1")(_enc_ok)
+    with pytest.raises(ValueError, match="already registered.*_enc_ok"):
+        web_encoder("t.enc.dup.v1")(_enc_with_params)
+
+
+@pytest.mark.parametrize("encoding", ["", "x" * 65, "@control"], ids=["empty", "long", "reserved"])
+def test_encoding_id_bounds(encoding: str) -> None:
+    with pytest.raises(ValueError):
+        web_encoder(encoding)
+
+
+@pytest.mark.parametrize(
+    ("func", "match"),
+    [
+        (_enc_zero_params, "1 or 2 positional parameters"),
+        (_enc_three_params, "1 or 2 positional parameters"),
+        (_enc_varargs, "positional parameters"),
+        (_enc_unannotated, "first parameter must be annotated"),
+        (_enc_generic_first, "first parameter must be annotated"),
+        (_enc_bad_second, "second parameter must be annotated Mapping"),
+        (_enc_bare_params, "second parameter must be annotated Mapping"),
+        (_enc_int_key_params, "second parameter must be annotated Mapping"),
+        (_enc_no_return, "return annotation must be bytes"),
+        (_enc_bad_return, "return annotation must be bytes"),
+    ],
+    ids=[
+        "zero",
+        "three",
+        "varargs",
+        "unannotated",
+        "generic_first",
+        "bad_second",
+        "bare_params",
+        "int_key_params",
+        "no_return",
+        "bad_return",
+    ],
+)
+def test_encoder_signature_rejected(func, match: str) -> None:
+    with pytest.raises(ValueError, match=match):
+        web_encoder("t.enc.badsig.v1")(func)
+
+
+def test_encoder_return_union_accepted() -> None:
+    web_encoder("t.enc.union.v1")(_enc_optional_union)
+    assert encoder_definition("t.enc.union.v1").encode is _enc_optional_union
+
+
+def test_lambda_rejected() -> None:
+    with pytest.raises(ValueError, match="lambda"):
+        web_encoder("t.enc.lambda.v1")(lambda msg: b"")
+
+
+def test_locals_function_rejected() -> None:
+    def local_encoder(msg: _Point) -> bytes:
+        return b""
+
+    with pytest.raises(ValueError, match="defined inside a function"):
+        web_encoder("t.enc.locals.v1")(local_encoder)
+
+
+def test_main_module_function_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_enc_ok, "__module__", "__main__")
+    with pytest.raises(ValueError, match="only defined in __main__"):
+        web_encoder("t.enc.main.v1")(_enc_ok)
+
+
+def test_non_function_rejected() -> None:
+    class CallableEncoder:
+        def __call__(self, msg: _Point) -> bytes:
+            return b""
+
+    with pytest.raises(TypeError, match="module-level function"):
+        web_encoder("t.enc.obj.v1")(CallableEncoder())
+
+
+def test_decoder_contracts() -> None:
+    web_decoder("t.dec.plain.v1")(_dec_ok)
+    web_decoder("t.dec.ctx.v1")(_dec_with_context)
+    web_decoder("t.dec.union.v1")(_dec_union_input)
+    web_decoder("t.dec.any.v1")(_dec_any_input)
+    plain = decoder_definition("t.dec.plain.v1")
+    assert plain == DecoderDef("t.dec.plain.v1", _Point, _dec_ok, takes_context=False)
+    assert decoder_definition("t.dec.ctx.v1").takes_context is True
+
+
+def test_decoder_signature_rejected() -> None:
+    with pytest.raises(ValueError, match="return annotation must be the produced message class"):
+        web_decoder("t.dec.noret.v1")(_dec_no_return)
+    with pytest.raises(ValueError, match="return annotation must be the produced message class"):
+        web_decoder("t.dec.noneret.v1")(_dec_none_return)
+    with pytest.raises(ValueError, match="second parameter must be annotated PublishContext"):
+        web_decoder("t.dec.badctx.v1")(_dec_bad_context)
+    with pytest.raises(ValueError, match="first parameter must be annotated with the JSON value"):
+        web_decoder("t.dec.bytesin.v1")(_dec_bytes_input)
+    with pytest.raises(ValueError, match="first parameter must be annotated with the JSON value"):
+        web_decoder("t.dec.noin.v1")(_dec_unannotated_input)
+
+
+def test_duplicate_decoder_registration_raises() -> None:
+    web_decoder("t.dec.dup.v1")(_dec_ok)
+    with pytest.raises(ValueError, match="already registered.*_dec_ok"):
+        web_decoder("t.dec.dup.v1")(_dec_with_context)
+
+
+def test_encode_json_v1_values() -> None:
+    assert encode_json_v1(_Point(1.5, -2.5)) == b'{"x":1.5,"y":-2.5}'
+    assert encode_json_v1({"a": [1, "x"], "b": None}) == b'{"a":[1,"x"],"b":null}'
+    assert encode_json_v1("hello") == b'"hello"'
+
+
+def test_encode_json_v1_rejects_non_finite_numbers() -> None:
+    # `NaN`/`Infinity` are not JSON and JSON.parse in the browser rejects
+    # them; the sample must die at the codec boundary, not ship corrupt.
+    with pytest.raises(ValueError):
+        encode_json_v1(float("nan"))
+    with pytest.raises(ValueError):
+        encode_json_v1({"x": float("inf")})
+    with pytest.raises(ValueError):
+        encode_json_v1(_Point(float("nan"), 0.0))
+
+
+def test_resolve_json_v1_whitelist_accepts() -> None:
+    for message_type in (dict, list, str, int, float, bool, _Point):
+        definition = resolve_encoder("json.v1", message_type)
+        assert definition.encode is encode_json_v1
+        assert definition.takes_params is False
+
+
+@pytest.mark.parametrize(
+    # Image is the sharp case: a dataclass AND a DimOS wire message - the
+    # DimosMsg marker must beat the dataclass whitelist.
+    "message_type",
+    [np.ndarray, bytes, PoseStamped, Path, Image],
+    ids=lambda t: t.__name__,
+)
+def test_resolve_json_v1_whitelist_rejects(message_type: type) -> None:
+    with pytest.raises(ValueError, match=r"not supported by json\.v1.*@web_encoder"):
+        resolve_encoder("json.v1", message_type)
+
+
+def test_resolve_registered_type_mismatch() -> None:
+    web_encoder("t.enc.mismatch.v1")(_enc_ok)
+    with pytest.raises(ValueError, match="encodes _Point, not dict"):
+        resolve_encoder("t.enc.mismatch.v1", dict)
+
+
+def test_resolve_unknown_encoding() -> None:
+    with pytest.raises(ValueError, match="no encoder registered for encoding 'nope.v1'"):
+        resolve_encoder("nope.v1", dict)
+
+
+def test_resolve_rechecks_pickle_by_reference(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Decoration cannot verify the module binding (the def statement has not
+    # bound the name yet); resolve does. Simulate a codec whose module-level
+    # name was deleted after registration.
+    web_encoder("t.enc.unref.v1")(_enc_ok)
+    monkeypatch.delattr(sys.modules[__name__], "_enc_ok")
+    with pytest.raises(ValueError, match="cannot be pickled by reference"):
+        resolve_encoder("t.enc.unref.v1", _Point)
+
+
+def test_encoded_payload_normalizes_bytes_like() -> None:
+    assert EncodedPayload(bytearray(b"ab")).payload == b"ab"
+    assert EncodedPayload(memoryview(b"cd"), {"n": 2}).meta == {"n": 2}
+
+
+def test_encoded_payload_rejects_bad_payload_and_meta() -> None:
+    with pytest.raises(TypeError, match="payload must be bytes-like"):
+        EncodedPayload("text")
+    with pytest.raises(TypeError, match="meta must be a mapping"):
+        EncodedPayload(b"", meta=[1, 2])
+    with pytest.raises(ValueError, match="meta keys must be strings"):
+        EncodedPayload(b"", meta={1: "x"})
+    with pytest.raises(ValueError, match="JSON-serializable"):
+        EncodedPayload(b"", meta={"blob": b"\x00"})
+    # Non-finite numbers are not JSON; the frame header would reject them
+    # later and the frame would vanish silently.
+    with pytest.raises(ValueError, match="JSON-serializable"):
+        EncodedPayload(b"", meta={"n": float("nan")})
+    with pytest.raises(ValueError, match="JSON-serializable"):
+        EncodedPayload(b"", meta={"deep": [{"n": float("inf")}]})
+    with pytest.raises(ValueError, match=str(MAX_ENCODED_META_BYTES)):
+        EncodedPayload(b"", meta={"pad": "x" * MAX_ENCODED_META_BYTES})
+
+
+def test_import_stays_light() -> None:
+    # User modules import dimos.web.codecs for the decorators; that must not
+    # drag in the bridge runtime, aioquic, or numpy.
+    code = (
+        "import sys; import dimos.web.codecs; "
+        "assert 'dimos.web.relay_bridge.relay_bridge_module' not in sys.modules; "
+        "assert 'aioquic' not in sys.modules; "
+        "assert 'numpy' not in sys.modules"
+    )
+    subprocess.run([sys.executable, "-c", code], check=True)

--- a/web/README.md
+++ b/web/README.md
@@ -43,6 +43,39 @@ deno task fixture        # demo consumer on http://localhost:5174 (run a relay f
 subscribes to `odom` by hand. Run `dimos run <bp> --local-relay` and `deno task fixture` side by
 side; like the cockpit dev server it proxies `/api` to the relay on `:7780`.
 
+### Decoders
+
+Each session owns a `DecoderRegistry` (pass one via `connect({decoders})`; the default is a fresh
+registry with the built-ins). A decoder is
+`(payload: Uint8Array, header: FrameHeader) => { value, preview? }`, looked up by the channel's
+manifest `encoding`. Built-ins: `jpeg.v1`, `costmap.zlib.v1`, `json.v1`; any other `*.json.vN`
+encoding JSON-decodes without registration. An exact registration wins over that convention, and a
+duplicate `register()` throws unless `{ replace: true }`. An encoding with no decoder is not an
+error: the channel still counts frames and renders as unsupported. A throwing decoder bumps the
+channel's `decodeErrors`/`decodeFailing` stats and keeps the last good value. Keep decoders
+synchronous and cheap - they run on the ingest path; panel-paced work (inflate, draw) belongs in the
+consumer.
+
+The Python half is `@web_encoder` (`dimos.web.codecs`) plus `Channel` (`dimos.web.cockpit`);
+`examples/custom-path/` is the end-to-end pair for this exact codec:
+
+```python skip
+import struct
+
+from dimos.msgs.nav_msgs.Path import Path
+from dimos.web.cockpit import Channel, cockpit
+from dimos.web.codecs import EncodedPayload, web_encoder
+
+
+@web_encoder("path.points.v1")
+def encode_path_points(msg: Path) -> EncodedPayload:
+    payload = b"".join(struct.pack("<ff", p.position.x, p.position.y) for p in msg.poses)
+    return EncodedPayload(payload, {"n": len(msg.poses)})
+
+
+my_ui = cockpit(channels=[Channel("nav_path", Path, encoding="path.points.v1", max_hz=20.0)])
+```
+
 ### Zero-build page
 
 `examples/minimal/` is a single HTML file importing `/sdk.js` - no bundler, no npm. Serve it from

--- a/web/examples/custom-path/index.html
+++ b/web/examples/custom-path/index.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<!-- Custom-decoder @dimos/sdk page: the browser half of the path.points.v1
+     example (Python half: @web_encoder + Channel, see the Decoders section
+     in web/README.md). Subscribes with no cockpit panel involved.
+     Run:  dimos run <blueprint> --local-relay --serve-dir web/examples/custom-path -->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>DimOS custom path decoder</title>
+    <style>
+      body {
+        font-family: monospace;
+        margin: 1rem;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>DimOS custom path decoder</h1>
+    <div id="status">status: connecting</div>
+    <div id="count">points: (no data)</div>
+    <pre id="points">(no data)</pre>
+    <script type="module">
+      import { connect, createDecoderRegistry } from "/sdk.js";
+
+      const decoders = createDecoderRegistry();
+      // path.points.v1: little-endian float32 (x, y) pairs; meta.n = count.
+      decoders.register("path.points.v1", (payload, header) => {
+        const view = new DataView(payload.buffer, payload.byteOffset, payload.byteLength);
+        const points = [];
+        for (let i = 0; i + 8 <= payload.byteLength; i += 8) {
+          points.push({ x: view.getFloat32(i, true), y: view.getFloat32(i + 4, true) });
+        }
+        return { value: { n: header.meta?.n ?? points.length, points } };
+      });
+
+      const statusEl = document.querySelector("#status");
+      const countEl = document.querySelector("#count");
+      const pointsEl = document.querySelector("#points");
+
+      const session = connect({ decoders });
+
+      session.status.subscribe(() => {
+        statusEl.textContent = `status: ${session.status.get().transport.phase}`;
+      });
+
+      session.subscribe("nav_path", (snapshot) => {
+        const value = snapshot.slot?.value;
+        if (!value) return;
+        countEl.textContent = `points: ${value.n}`;
+        pointsEl.textContent = JSON.stringify(value.points, null, 2);
+      });
+    </script>
+  </body>
+</html>

--- a/web/sdk/src/session.test.ts
+++ b/web/sdk/src/session.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { type Msg, PROTOCOL_VERSION, type RobotInfo } from "@dimos/shared";
 import type { CostmapValue } from "./decoders/costmap.ts";
+import { createDecoderRegistry } from "./decoders/index.ts";
 import { teleopHooks } from "./internal/teleopMachine.ts";
 import {
   connect,
@@ -464,6 +465,37 @@ describe("Session over a fake WebTransport", () => {
     const { stats } = handle.store.getUiSnapshot("color_image");
     expect(stats.decodeErrors).toBe(1);
     expect(stats.decodeFailing).toBe(true);
+  });
+
+  it("connect({decoders}) decodes a custom encoding into the store", async () => {
+    // The per-session registry path: no cockpit panel, no built-in decoder -
+    // the custom frontend supplies its own (the W6 Channel authoring pair).
+    const decoders = createDecoderRegistry();
+    decoders.register("path.points.v1", (payload, header) => {
+      const view = new DataView(payload.buffer, payload.byteOffset, payload.byteLength);
+      const points: { x: number; y: number }[] = [];
+      for (let i = 0; i + 8 <= payload.byteLength; i += 8) {
+        points.push({ x: view.getFloat32(i, true), y: view.getFloat32(i + 4, true) });
+      }
+      return { value: { n: header.meta?.n, points }, preview: `${points.length} points` };
+    });
+    const { relay, handle } = start({ decoders });
+    await goLive(relay, handle, ROBOT_A, [
+      spec({ ch: "nav_path", encoding: "path.points.v1", delivery: "reliable" }),
+    ]);
+    handle.subscribe("nav_path", () => {});
+    await until(() => relay.subs().includes("nav_path"), "sub");
+
+    const payload = new Uint8Array(16);
+    const view = new DataView(payload.buffer);
+    for (const [i, coord] of [1.5, -2.5, 3.5, 4.5].entries()) {
+      view.setFloat32(i * 4, coord, true);
+    }
+    relay.pushRaw(1, payload, "nav_path", { n: 2 });
+    await until(() => handle.store.get("nav_path") !== null, "frame");
+    const slot = handle.store.get("nav_path")!;
+    expect(slot.value).toEqual({ n: 2, points: [{ x: 1.5, y: -2.5 }, { x: 3.5, y: 4.5 }] });
+    expect(slot.preview).toBe("2 points");
   });
 
   it("retries the watch when the robot reappears after unknown_robot", async () => {


### PR DESCRIPTION
* You can send any dimOS message to the web by registering a converter to bytes using the `@web_encoder` / `@web_decoder` decorators.