### PR TITLE
fix(dimsim): wire observe to /color_image without republishing

### DIFF
--- a/dimos/robot/unitree/dimsim_connection.py
+++ b/dimos/robot/unitree/dimsim_connection.py
@@ -49,20 +49,34 @@ class DimSimConnection:
         frame_id="camera_optical",
     )
 
+    # DimSim already publishes JPEG frames on LCM /color_image. GO2Connection
+    # must cache them for observe() but not republish onto the same topic.
+    video_on_bus: bool = True
+
     def __init__(self, global_config: GlobalConfig) -> None:
         self._dimsim_process: DimSimProcess = DimSimProcess(global_config)
         self._odom_transport: PubSubTransport[PoseStamped] = make_transport("/odom", PoseStamped)
         self._tf_transport: PubSubTransport[TFMessage] = make_transport("/tf", TFMessage)
+        self._video_transport: PubSubTransport[Image] = make_transport("/color_image", Image)
+        self._video_subject = Subject()
         self._unsubscribe_odom: Callable[[], None] | None = None
+        self._unsubscribe_video: Callable[[], None] | None = None
 
     def start(self) -> None:
         self._dimsim_process.start()
         self._odom_transport.start()
+        self._video_transport.start()
         self._unsubscribe_odom = self._odom_transport.subscribe(self._handle_odom)
+        self._unsubscribe_video = self._video_transport.subscribe(self._video_subject.on_next)
 
     def stop(self) -> None:
         if self._unsubscribe_odom is not None:
             self._unsubscribe_odom()
+            self._unsubscribe_odom = None
+        if self._unsubscribe_video is not None:
+            self._unsubscribe_video()
+            self._unsubscribe_video = None
+        self._video_transport.stop()
         self._odom_transport.stop()
         self._dimsim_process.stop()
 
@@ -74,9 +88,8 @@ class DimSimConnection:
     def odom_stream(self) -> Observable[PoseStamped]:
         return Subject()
 
-    @functools.cache
     def video_stream(self) -> Observable[Image]:
-        return Subject()
+        return self._video_subject
 
     @functools.cache
     def lowstate_stream(self) -> Observable[Any]:

--- a/dimos/robot/unitree/go2/connection.py
+++ b/dimos/robot/unitree/go2/connection.py
@@ -322,11 +322,6 @@ class GO2Connection(Module, Camera, Pointcloud):
             return
         self.connection.start()
 
-        def onimage(image: Image) -> None:
-            image.frame_id = _prefixed(self.config.frame_id_prefix, image.frame_id)
-            self.color_image.publish(image)
-            self._latest_video_frame = image
-
         if self.config.lidar:
             self.register_disposable(self.connection.lidar_stream().subscribe(self.lidar.publish))
         self.register_disposable(self.connection.odom_stream().subscribe(self._publish_tf))
@@ -334,7 +329,7 @@ class GO2Connection(Module, Camera, Pointcloud):
         self.register_disposable(Disposable(self.cmd_vel.subscribe(self.move)))
 
         if self.config.camera:
-            self.register_disposable(self.connection.video_stream().subscribe(onimage))
+            self.register_disposable(self.connection.video_stream().subscribe(self._on_video_frame))
             self._camera_info_thread = Thread(
                 target=self.publish_camera_info,
                 daemon=True,
@@ -405,6 +400,14 @@ class GO2Connection(Module, Camera, Pointcloud):
             self.tf.publish(TFMessage(*transforms))
         if self.odom.transport:
             self.odom.publish(msg)
+
+    def _on_video_frame(self, image: Image) -> None:
+        image.frame_id = _prefixed(self.config.frame_id_prefix, image.frame_id)
+        self._latest_video_frame = image
+        # DimSim (and similar) already publish /color_image; republishing would echo.
+        if getattr(self.connection, "video_on_bus", False) is True:
+            return
+        self.color_image.publish(image)
 
     def publish_camera_info(self) -> None:
         while True:

--- a/dimos/robot/unitree/go2/test_connection.py
+++ b/dimos/robot/unitree/go2/test_connection.py
@@ -22,10 +22,12 @@ from collections.abc import Callable, Iterator
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import numpy as np
 import pytest
 
 from dimos.core.global_config import GlobalConfig
 from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
+from dimos.msgs.sensor_msgs.Image import Image, ImageFormat
 from dimos.robot.unitree.go2 import connection as go2_conn
 from dimos.robot.unitree.go2.connection import ConnectionConfig, GO2Connection
 
@@ -119,3 +121,37 @@ def test_odom_to_tf_prefixed() -> None:
         "robot0/camera_link",
         "robot0/camera_optical",
     )
+
+
+def _rgb_frame() -> Image:
+    return Image.from_numpy(
+        np.zeros((2, 2, 3), dtype=np.uint8),
+        format=ImageFormat.RGB,
+        frame_id="camera_optical",
+        ts=1.0,
+    )
+
+
+def test_observe_caches_and_republishes_video_frame(stub_webrtc: MagicMock) -> None:
+    module = GO2Connection(g=GlobalConfig(robot_ip="127.0.0.1"))
+    module.color_image = MagicMock()
+    frame = _rgb_frame()
+    try:
+        module._on_video_frame(frame)
+        assert module.observe() is frame
+        module.color_image.publish.assert_called_once_with(frame)
+    finally:
+        module.stop()
+
+
+def test_observe_skips_republish_when_video_already_on_bus(stub_webrtc: MagicMock) -> None:
+    module = GO2Connection(g=GlobalConfig(robot_ip="127.0.0.1"))
+    module.color_image = MagicMock()
+    module.connection.video_on_bus = True
+    frame = _rgb_frame()
+    try:
+        module._on_video_frame(frame)
+        assert module.observe() is frame
+        module.color_image.publish.assert_not_called()
+    finally:
+        module.stop()

--- a/dimos/robot/unitree/test_dimsim_connection.py
+++ b/dimos/robot/unitree/test_dimsim_connection.py
@@ -1,0 +1,111 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DimSimConnection forwards LCM /color_image frames onto video_stream()."""
+
+from collections.abc import Callable, Iterator
+from typing import Any
+
+import numpy as np
+import pytest
+from pytest_mock import MockerFixture
+
+from dimos.core.global_config import GlobalConfig
+from dimos.msgs.sensor_msgs.Image import Image, ImageFormat
+from dimos.robot.unitree.dimsim_connection import DimSimConnection
+from dimos.simulation.dimsim.dimsim_process import DimSimProcess
+
+
+class _Bus:
+    def __init__(self) -> None:
+        self._callback: Callable[[Any], None] | None = None
+
+    def start(self) -> None:
+        return None
+
+    def stop(self) -> None:
+        return None
+
+    def subscribe(self, callback: Callable[[Any], None]) -> Callable[[], None]:
+        self._callback = callback
+
+        def unsubscribe() -> None:
+            self._callback = None
+
+        return unsubscribe
+
+    def emit(self, msg: Any) -> None:
+        if self._callback is not None:
+            self._callback(msg)
+
+
+def _rgb_frame(frame_id: str = "camera_optical") -> Image:
+    return Image.from_numpy(
+        np.zeros((4, 4, 3), dtype=np.uint8),
+        format=ImageFormat.RGB,
+        frame_id=frame_id,
+        ts=1.0,
+    )
+
+
+@pytest.fixture
+def dimsim_connection(mocker: MockerFixture) -> Iterator[tuple[DimSimConnection, dict[str, _Bus]]]:
+    buses = {
+        "/odom": _Bus(),
+        "/tf": _Bus(),
+        "/color_image": _Bus(),
+    }
+
+    def make_transport(name: str, msg_type: type | None = None, **kwargs: object) -> _Bus:
+        return buses[name]
+
+    mocker.patch(
+        "dimos.robot.unitree.dimsim_connection.make_transport",
+        side_effect=make_transport,
+    )
+    mocker.patch.object(DimSimProcess, "start")
+    mocker.patch.object(DimSimProcess, "stop")
+    conn = DimSimConnection(GlobalConfig())
+    try:
+        yield conn, buses
+    finally:
+        conn.stop()
+
+
+def test_video_stream_forwards_color_image_from_bus(
+    dimsim_connection: tuple[DimSimConnection, dict[str, _Bus]],
+) -> None:
+    conn, buses = dimsim_connection
+    received: list[Image] = []
+    conn.start()
+    conn.video_stream().subscribe(received.append)
+
+    frame = _rgb_frame()
+    buses["/color_image"].emit(frame)
+
+    assert received == [frame]
+
+
+def test_stop_unsubscribes_from_color_image_bus(
+    dimsim_connection: tuple[DimSimConnection, dict[str, _Bus]],
+) -> None:
+    conn, buses = dimsim_connection
+    received: list[Image] = []
+    conn.start()
+    conn.video_stream().subscribe(received.append)
+    conn.stop()
+
+    buses["/color_image"].emit(_rgb_frame())
+
+    assert received == []


### PR DESCRIPTION
## Summary
- DimSim already publishes JPEG camera frames on LCM `/color_image`, but `DimSimConnection.video_stream()` was an empty subject, so `observe()` always returned `None` and the agent thought it was blind.
- Forward those bus frames into the Go2 video cache, and skip republishing onto `/color_image` (`video_on_bus`) so we do not create an echo loop.

## Test plan
- [ ] `uv run pytest dimos/robot/unitree/test_dimsim_connection.py dimos/robot/unitree/go2/test_connection.py`
- [ ] `dimos --simulation dimsim --dimsim-scene=apartment run unitree-go2-agentic`
- [ ] After the renderer is up, ask the agent what it sees and confirm `observe` returns a camera frame instead of `None`