### PR TITLE
G1 smooth bring up for low level control

### DIFF
--- a/dimos/control/tasks/servo_task/servo_task.py
+++ b/dimos/control/tasks/servo_task/servo_task.py
@@ -183,11 +183,17 @@ class JointServoTask(BaseControlTask):
                 # our joints, track their measured positions so the hold
                 # resumes from wherever that task releases them instead of
                 # snapping back to the previously latched target.
+                # A joint missing from this snapshot stays pending: clearing
+                # it unmeasured resumes the hold on the stale pre-preemption
+                # target, and no further callback arrives once released.
+                still_pending: set[str] = set()
                 for name in self._preempted_joints:
                     position = state.joints.joint_positions.get(name)
-                    if position is not None:
-                        target[self._name_to_index[name]] = position
-                self._preempted_joints.clear()
+                    if position is None:
+                        still_pending.add(name)
+                        continue
+                    target[self._name_to_index[name]] = position
+                self._preempted_joints = still_pending
                 # Preemption defers the timeout: the joints are actively
                 # driven, and the hold must be alive when they are released.
                 self._last_update_time = state.t_now
@@ -339,7 +345,7 @@ def create_task(cfg: Any, hardware: Any) -> JointServoTask:
         kwargs["default_positions"] = params.default_positions
         # Zero timeout pairs naturally with default-hold.
         kwargs.setdefault("timeout", 0.0)
+    kwargs["hold_measured_on_start"] = params.hold_measured_on_start
     if params.hold_measured_on_start:
-        kwargs["hold_measured_on_start"] = True
         kwargs.setdefault("timeout", 0.0)
     return JointServoTask(cfg.name, JointServoTaskConfig(**kwargs))  # type: ignore[arg-type]

--- a/dimos/control/tasks/servo_task/servo_task.py
+++ b/dimos/control/tasks/servo_task/servo_task.py
@@ -55,12 +55,17 @@ class JointServoTaskConfig:
             length if provided. Useful for "hold at this pose" tasks
             (e.g. arms during whole-body locomotion). Pair with
             timeout=0.0 to hold indefinitely.
+        hold_measured_on_start: Latch the hold target from the first
+            measured state instead of a configured pose. Startup is then
+            bumpless: a configured pose would snap the joints there from
+            wherever the robot actually is, at full stiffness.
     """
 
     joint_names: list[str]
     priority: int = 10
     timeout: float = 0.5  # 500ms default timeout
     default_positions: list[float] | None = None
+    hold_measured_on_start: bool = False
 
 
 class JointServoTask(BaseControlTask):
@@ -108,6 +113,9 @@ class JointServoTask(BaseControlTask):
         self._target: list[float] | None = None
         self._last_update_time: float = 0.0
         self._active = False
+        self._name_to_index = {name: i for i, name in enumerate(self._joint_names_list)}
+        self._preempted_joints: set[str] = set()
+        self._logged_preemption: frozenset[str] = frozenset()
 
         if config.default_positions is not None:
             if len(config.default_positions) != self._num_joints:
@@ -131,7 +139,23 @@ class JointServoTask(BaseControlTask):
     def is_active(self) -> bool:
         """Check if task should run this tick."""
         with self._lock:
+            if self._active and self._config.hold_measured_on_start and self._target is None:
+                # No target yet, but compute() will latch one from measured
+                # state; stay active so it gets the chance.
+                return True
             return self._active and self._target is not None
+
+    def _latch_measured(self, state: CoordinatorState) -> bool:
+        """Adopt measured positions as the hold target. False until all arrive."""
+        measured = []
+        for name in self._joint_names_list:
+            position = state.joints.joint_positions.get(name)
+            if position is None:
+                return False
+            measured.append(float(position))
+        self._target = measured
+        logger.info(f"JointServoTask {self._name} holding measured start pose")
+        return True
 
     def compute(self, state: CoordinatorState) -> JointCommandOutput | None:
         """Output current target positions.
@@ -143,8 +167,33 @@ class JointServoTask(BaseControlTask):
             JointCommandOutput with positions, or None if inactive/timed out
         """
         with self._lock:
-            if not self._active or self._target is None:
+            if not self._active:
                 return None
+            if self._target is None:
+                # Latching from measured keeps startup bumpless: commanding a
+                # configured pose here would snap the joints there from
+                # wherever the robot actually is, at full stiffness.
+                if not self._config.hold_measured_on_start or not self._latch_measured(state):
+                    return None
+            target = self._target
+            assert target is not None  # narrowed by the latch above
+
+            if self._preempted_joints:
+                # Bumpless handoff: while a higher-priority task drives some of
+                # our joints, track their measured positions so the hold
+                # resumes from wherever that task releases them instead of
+                # snapping back to the previously latched target.
+                for name in self._preempted_joints:
+                    position = state.joints.joint_positions.get(name)
+                    if position is not None:
+                        target[self._name_to_index[name]] = position
+                self._preempted_joints.clear()
+                # Preemption defers the timeout: the joints are actively
+                # driven, and the hold must be alive when they are released.
+                self._last_update_time = state.t_now
+            elif self._logged_preemption:
+                self._logged_preemption = frozenset()
+                logger.info(f"JointServoTask {self._name} resumed hold at handed-off positions")
 
             # Check timeout
             if self._config.timeout > 0:
@@ -159,7 +208,7 @@ class JointServoTask(BaseControlTask):
 
             return JointCommandOutput(
                 joint_names=self._joint_names_list,
-                positions=list(self._target),
+                positions=list(target),
                 mode=ControlMode.SERVO_POSITION,
             )
 
@@ -170,8 +219,19 @@ class JointServoTask(BaseControlTask):
             by_task: Name of preempting task
             joints: Joints that were preempted
         """
-        if joints & self._joint_names:
-            logger.warning(f"JointServoTask {self._name} preempted by {by_task} on joints {joints}")
+        overlap = joints & self._joint_names
+        if not overlap:
+            return
+        with self._lock:
+            self._preempted_joints |= overlap
+            should_log = overlap != self._logged_preemption
+            if should_log:
+                self._logged_preemption = frozenset(overlap)
+        if should_log:
+            logger.warning(
+                f"JointServoTask {self._name} preempted by {by_task} on joints "
+                f"{sorted(overlap)}; hold target tracks measured positions until released"
+            )
 
     def set_target(self, positions: list[float], t_now: float) -> bool:
         """Set target joint positions.
@@ -215,7 +275,11 @@ class JointServoTask(BaseControlTask):
         ordered = []
         for name in self._joint_names_list:
             if name not in positions:
-                # Missing joint - don't update
+                logger.warning(
+                    f"JointServoTask {self._name}: dropping command missing '{name}' "
+                    f"(partial sets are ignored; name all {len(self._joint_names_list)} "
+                    f"claimed joints)"
+                )
                 return False
             ordered.append(positions[name])
 
@@ -260,6 +324,7 @@ class JointServoTask(BaseControlTask):
 class JointServoTaskParams(BaseConfig):
     timeout: float | None = None
     default_positions: list[float] | None = None
+    hold_measured_on_start: bool = False
 
 
 def create_task(cfg: Any, hardware: Any) -> JointServoTask:
@@ -273,5 +338,8 @@ def create_task(cfg: Any, hardware: Any) -> JointServoTask:
     if params.default_positions is not None:
         kwargs["default_positions"] = params.default_positions
         # Zero timeout pairs naturally with default-hold.
+        kwargs.setdefault("timeout", 0.0)
+    if params.hold_measured_on_start:
+        kwargs["hold_measured_on_start"] = True
         kwargs.setdefault("timeout", 0.0)
     return JointServoTask(cfg.name, JointServoTaskConfig(**kwargs))  # type: ignore[arg-type]

--- a/dimos/control/tasks/servo_task/test_servo_task.py
+++ b/dimos/control/tasks/servo_task/test_servo_task.py
@@ -43,3 +43,68 @@ def test_on_joint_command_requires_all_claimed_joints() -> None:
     task = _task()
     assert not task.on_joint_command(JointState(name=["a/j1"], position=[0.1]), 1.0)
     assert not task.is_active()
+
+
+def _state(t_now: float, positions: dict[str, float] | None = None) -> CoordinatorState:
+    return CoordinatorState(joints=JointStateSnapshot(joint_positions=positions or {}), t_now=t_now)
+
+
+def test_preempted_joints_track_measured_positions() -> None:
+    task = _task()
+    task.on_joint_command(JointState(name=["a/j1", "a/j2"], position=[0.0, 0.0]), 1.0)
+
+    task.on_preempted("traj", frozenset({"a/j2"}))
+    out = task.compute(_state(1.1, {"a/j1": 0.5, "a/j2": 0.8}))
+    assert out is not None
+    assert out.positions == [0.0, 0.8]
+
+    out = task.compute(_state(1.2, {"a/j1": 0.5, "a/j2": 0.0}))
+    assert out is not None
+    assert out.positions == [0.0, 0.8]
+
+
+def test_hold_resumes_at_handoff_position_after_release() -> None:
+    task = _task()
+    task.on_joint_command(JointState(name=["a/j1", "a/j2"], position=[0.0, 0.0]), 1.0)
+
+    for step in range(5):
+        task.on_preempted("traj", frozenset({"a/j1", "a/j2"}))
+        task.compute(_state(1.0 + 0.1 * step, {"a/j1": 0.2 * step, "a/j2": 0.1 * step}))
+
+    out = task.compute(_state(1.5, {"a/j1": 0.81, "a/j2": 0.41}))
+    assert out is not None
+    assert out.positions == [0.8, 0.4]
+
+
+def test_hold_measured_on_start_latches_the_real_pose() -> None:
+    # A configured pose would snap the joints there from wherever the robot
+    # is, at full stiffness, on the first tick — the G1 arms did exactly that.
+    task = JointServoTask(
+        "servo_arms",
+        JointServoTaskConfig(joint_names=["a", "b"], timeout=0.0, hold_measured_on_start=True),
+    )
+    task.start()
+
+    # Stays active while waiting so it gets a chance to latch.
+    assert task.is_active()
+    assert task.compute(_state(1.0)) is None, "must not command before state arrives"
+
+    out = task.compute(_state(1.1, {"a": 0.4, "b": -0.25}))
+    assert out is not None
+    assert out.positions == [0.4, -0.25]
+
+    # Once latched it holds that pose, not whatever the joints drift to.
+    held = task.compute(_state(1.2, {"a": 0.9, "b": -0.9}))
+    assert held is not None
+    assert held.positions == [0.4, -0.25]
+
+
+def test_default_positions_still_command_the_configured_pose() -> None:
+    task = JointServoTask(
+        "servo",
+        JointServoTaskConfig(joint_names=["a"], timeout=0.0, default_positions=[0.0]),
+    )
+    task.start()
+    out = task.compute(_state(1.0, {"a": 0.7}))
+    assert out is not None
+    assert out.positions == [0.0]

--- a/dimos/control/tasks/servo_task/test_servo_task.py
+++ b/dimos/control/tasks/servo_task/test_servo_task.py
@@ -108,3 +108,21 @@ def test_default_positions_still_command_the_configured_pose() -> None:
     out = task.compute(_state(1.0, {"a": 0.7}))
     assert out is not None
     assert out.positions == [0.0]
+
+
+def test_unmeasured_preempted_joint_stays_pending() -> None:
+    task = _task()
+    task.on_joint_command(JointState(name=["a/j1", "a/j2"], position=[0.0, 0.0]), 1.0)
+
+    task.on_preempted("traj", frozenset({"a/j2"}))
+    # a/j2 is missing from this snapshot, so there is nothing to hand off yet.
+    out = task.compute(_state(1.1, {"a/j1": 0.5}))
+    assert out is not None
+    assert out.positions == [0.0, 0.0]
+
+    # Arbitration released the joint, so no further preemption callback comes.
+    # The first complete snapshot must still adopt the handed-off position
+    # rather than resuming on the stale pre-preemption target.
+    out = task.compute(_state(1.2, {"a/j1": 0.5, "a/j2": 0.8}))
+    assert out is not None
+    assert out.positions == [0.0, 0.8]

--- a/dimos/robot/unitree/g1/blueprints/basic/unitree_g1_groot_wbc.py
+++ b/dimos/robot/unitree/g1/blueprints/basic/unitree_g1_groot_wbc.py
@@ -328,14 +328,17 @@ else:
     # One process per heavy module; fewer workers starve the Rerun bridge.
     _n_workers = 10
     # Real hardware needs the arms held -- kd damping alone would let
-    # them sag toward singular configurations between trajectories.
+    # them sag toward singular configurations between trajectories. The hold
+    # starts from the measured pose, not ARM_DEFAULT_POSE: the servo has no
+    # ramp, so a configured pose slams the arms there from wherever the robot
+    # actually is, at full GR00T stiffness, on the very first tick.
     _arm_holder = TaskConfig(
         name="servo_arms",
         type="servo",
         joint_names=g1_arms,
         priority=10,
         auto_start=True,
-        params={"default_positions": ARM_DEFAULT_POSE},
+        params={"hold_measured_on_start": True},
     )
     # Same nav middle as unitree-g1-nav-simple, fed by Point-LIO from the
     # MID-360, executed through the coordinator's twist_command.

--- a/dimos/robot/unitree/g1/test_wholebody_connection.py
+++ b/dimos/robot/unitree/g1/test_wholebody_connection.py
@@ -17,11 +17,15 @@ from __future__ import annotations
 from contextlib import contextmanager
 from types import SimpleNamespace
 
+from pydantic import ValidationError
+import pytest
+
 from dimos.msgs.sensor_msgs.MotorCommandArray import MotorCommandArray
 from dimos.robot.unitree.g1.wholebody_connection import (
     _NUM_MOTOR_SLOTS,
     _NUM_MOTORS,
     G1WholeBodyConnection,
+    G1WholeBodyConnectionConfig,
 )
 
 
@@ -121,3 +125,12 @@ def test_wrong_joint_count_is_dropped():
         connection._on_motor_command(MotorCommandArray(q=[0.0] * 5))
 
         assert publisher.frames == []
+
+
+@pytest.mark.parametrize("value", [float("inf"), float("-inf"), float("nan")])
+def test_non_finite_soft_start_is_rejected(value):
+    # inf satisfies a bare ge=0.0, and every finite elapsed time over inf is
+    # zero, so the scale would pin at 0 forever: full damping, no stiffness,
+    # and no way back to the commanded gains.
+    with pytest.raises(ValidationError):
+        G1WholeBodyConnectionConfig(soft_start_seconds=value)

--- a/dimos/robot/unitree/g1/test_wholebody_connection.py
+++ b/dimos/robot/unitree/g1/test_wholebody_connection.py
@@ -1,0 +1,123 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+from dimos.msgs.sensor_msgs.MotorCommandArray import MotorCommandArray
+from dimos.robot.unitree.g1.wholebody_connection import (
+    _NUM_MOTOR_SLOTS,
+    _NUM_MOTORS,
+    G1WholeBodyConnection,
+)
+
+
+@contextmanager
+def _connection():
+    connection = G1WholeBodyConnection()
+    try:
+        yield connection
+    finally:
+        connection._publisher = None  # keep stop() away from the fake DDS state
+        connection._low_cmd = None
+        connection.stop()
+
+
+class _FakePublisher:
+    def __init__(self):
+        self.frames = []
+
+    def Write(self, low_cmd):
+        self.frames.append(
+            [(m.q, m.dq, m.kp, m.kd, m.tau) for m in low_cmd.motor_cmd[:_NUM_MOTORS]]
+        )
+
+
+def _wire(connection, soft_start_seconds):
+    """Give the connection just enough fake DDS state to accept commands."""
+    connection.config.soft_start_seconds = soft_start_seconds
+    connection._publisher = _FakePublisher()
+    connection._low_cmd = SimpleNamespace(
+        mode_machine=0,
+        crc=0,
+        motor_cmd=[
+            SimpleNamespace(mode=1, q=0.0, dq=0.0, kp=0.0, kd=0.0, tau=0.0)
+            for _ in range(_NUM_MOTOR_SLOTS)
+        ],
+    )
+    connection._crc = SimpleNamespace(Crc=lambda _cmd: 0)
+    connection._mode_machine = 5
+    return connection._publisher
+
+
+def _command():
+    return MotorCommandArray(
+        q=[1.0] * _NUM_MOTORS,
+        dq=[0.0] * _NUM_MOTORS,
+        kp=[100.0] * _NUM_MOTORS,
+        kd=[5.0] * _NUM_MOTORS,
+        tau=[8.0] * _NUM_MOTORS,
+    )
+
+
+def test_soft_start_is_damping_first():
+    with _connection() as connection:
+        publisher = _wire(connection, soft_start_seconds=1000.0)
+
+        connection._on_motor_command(_command())
+
+        q, dq, kp, kd, tau = publisher.frames[0][0]
+        # First frame: target and damping pass through, stiffness and tau do not —
+        # this is what keeps taking control from slamming the robot.
+        assert q == 1.0
+        assert kd == 5.0
+        assert kp < 1.0
+        assert abs(tau) < 0.1
+
+
+def test_stiffness_ramps_to_full():
+    with _connection() as connection:
+        publisher = _wire(connection, soft_start_seconds=0.05)
+
+        connection._on_motor_command(_command())
+        # Rewind the clock instead of sleeping through the window.
+        connection._soft_start_t0 -= 1.0
+        connection._on_motor_command(_command())
+
+        _q, _dq, kp, kd, tau = publisher.frames[-1][0]
+        assert kp == 100.0
+        assert kd == 5.0
+        assert tau == 8.0
+
+
+def test_soft_start_disabled_passes_through():
+    with _connection() as connection:
+        publisher = _wire(connection, soft_start_seconds=0.0)
+
+        connection._on_motor_command(_command())
+
+        _q, _dq, kp, _kd, tau = publisher.frames[0][0]
+        assert kp == 100.0
+        assert tau == 8.0
+
+
+def test_wrong_joint_count_is_dropped():
+    with _connection() as connection:
+        publisher = _wire(connection, soft_start_seconds=0.0)
+
+        connection._on_motor_command(MotorCommandArray(q=[0.0] * 5))
+
+        assert publisher.frames == []

--- a/dimos/robot/unitree/g1/wholebody_connection.py
+++ b/dimos/robot/unitree/g1/wholebody_connection.py
@@ -93,7 +93,7 @@ class G1WholeBodyConnectionConfig(ModuleConfig):
     # mirroring the remote's damp -> lock-stand feel. Full commanded stiffness
     # in the very first frame slams the robot from wherever it hangs to the
     # commanded pose. 0 disables.
-    soft_start_seconds: float = Field(default=3.0, ge=0.0)
+    soft_start_seconds: float = Field(default=3.0, ge=0.0, allow_inf_nan=False)
 
 
 @dataclass(frozen=True)

--- a/dimos/robot/unitree/g1/wholebody_connection.py
+++ b/dimos/robot/unitree/g1/wholebody_connection.py
@@ -88,6 +88,12 @@ class G1WholeBodyConnectionConfig(ModuleConfig):
     publish_rate_hz: float = 500.0
     frame_id: str = "g1_pelvis"
     mode_machine: int = _MODE_MACHINE_G1
+    # Stiffness soft-start on taking low-level control: the first commands go
+    # out with full damping (kd) but kp and tau scaled in over this window,
+    # mirroring the remote's damp -> lock-stand feel. Full commanded stiffness
+    # in the very first frame slams the robot from wherever it hangs to the
+    # commanded pose. 0 disables.
+    soft_start_seconds: float = Field(default=3.0, ge=0.0)
 
 
 @dataclass(frozen=True)
@@ -137,6 +143,9 @@ class G1WholeBodyConnection(Module):
         self._lock = threading.Lock()
         self._stop_event = threading.Event()
         self._publish_thread: Thread | None = None
+        # Soft-start clock, armed by the first motor command after start().
+        self._soft_start_t0: float | None = None
+        self._soft_start_done = False
 
     @rpc
     def start(self) -> None:
@@ -196,6 +205,10 @@ class G1WholeBodyConnection(Module):
             logger.info("Skipping sport mode release (release_sport_mode=False)")
 
         logger.info("G1WholeBodyConnection connected", mode_machine=self._mode_machine)
+
+        # Fresh soft-start every time control is (re)acquired.
+        self._soft_start_t0 = None
+        self._soft_start_done = False
 
         self.register_disposable(Disposable(self.motor_command.subscribe(self._on_motor_command)))
 
@@ -365,6 +378,20 @@ class G1WholeBodyConnection(Module):
             else:
                 next_tick = time.perf_counter()
 
+    def _soft_start_scale(self, now: float) -> float:
+        """Stiffness scale in [0, 1] for this command frame. Caller holds the lock."""
+        duration = self.config.soft_start_seconds
+        if duration <= 0.0:
+            return 1.0
+        if self._soft_start_t0 is None:
+            self._soft_start_t0 = now
+            logger.info(f"Soft-start: full damping now, stiffness ramping in over {duration:.1f}s")
+        scale = min(1.0, (now - self._soft_start_t0) / duration)
+        if scale >= 1.0 and not self._soft_start_done:
+            self._soft_start_done = True
+            logger.info("Soft-start complete - full commanded stiffness")
+        return scale
+
     def _on_motor_command(self, msg: MotorCommandArray) -> None:
         if msg.num_joints != _NUM_MOTORS:
             logger.warning(f"Expected {_NUM_MOTORS} motor commands, got {msg.num_joints}; ignoring")
@@ -383,12 +410,17 @@ class G1WholeBodyConnection(Module):
             # G1 firmware requires mode_machine on every LowCmd frame.
             self._low_cmd.mode_machine = self._mode_machine
 
+            # Damping-first bring-up: kd applies in full from the first frame
+            # (that is Unitree's own damp mode), while kp and tau fade in so
+            # taking control never step-changes the stiffness.
+            scale = self._soft_start_scale(time.perf_counter())
+
             for i in range(_NUM_MOTORS):
                 self._low_cmd.motor_cmd[i].q = msg.q[i]
                 self._low_cmd.motor_cmd[i].dq = msg.dq[i]
-                self._low_cmd.motor_cmd[i].kp = msg.kp[i]
+                self._low_cmd.motor_cmd[i].kp = msg.kp[i] * scale
                 self._low_cmd.motor_cmd[i].kd = msg.kd[i]
-                self._low_cmd.motor_cmd[i].tau = msg.tau[i]
+                self._low_cmd.motor_cmd[i].tau = msg.tau[i] * scale
 
             self._low_cmd.crc = self._crc.Crc(self._low_cmd)
             self._publisher.Write(self._low_cmd)


### PR DESCRIPTION
## Contribution path


- Small, safe change that does not need a tracking issue

## Problem

Bringing up G1 for low level control using Unitree SDK caused sudden jump when transitioning from `damping` mode to `locked standing`

## Solution

Added a soft start with a Kd factor to have damping when getting into initial mode. This mimics the official behaviour of g1 when bringing up

## How to Test

This requires G1 hardware to test

`dimos run unitree-g1-groot_wbc`

## AI assistance

Used Claude Code 5.0. to help build

## Checklist

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
