### PR TITLE
fix(manipulation): bound Viser gizmo IK evaluation

### DIFF
--- a/dimos/manipulation/manipulation_module.py
+++ b/dimos/manipulation/manipulation_module.py
@@ -87,6 +87,7 @@ from dimos.manipulation.planning.spec.models import (
     WorldRobotID,
 )
 from dimos.manipulation.planning.spec.protocols import (
+    IKCancelCheck,
     KinematicsSpec,
     PlannerSpec,
     TrajectoryParametrizerSpec,
@@ -719,6 +720,46 @@ class ManipulationModule(Module):
         check_collision: bool = True,
     ) -> IKResult:
         """Solve planning-group pose targets without planning a joint path."""
+        return self._inverse_kinematics(
+            pose_targets,
+            auxiliary_group_ids,
+            seed,
+            check_collision,
+            max_attempts=10,
+        )
+
+    def evaluate_inverse_kinematics(
+        self,
+        pose_targets: Mapping[PlanningGroupID, PoseStamped],
+        auxiliary_group_ids: Sequence[PlanningGroupID] = (),
+        seed: JointState | None = None,
+        check_collision: bool = True,
+        *,
+        timeout_seconds: float,
+        cancel_check: IKCancelCheck,
+    ) -> IKResult:
+        """Solve one bounded IK attempt for an interactive target evaluation."""
+        return self._inverse_kinematics(
+            pose_targets,
+            auxiliary_group_ids,
+            seed,
+            check_collision,
+            max_attempts=1,
+            timeout_seconds=timeout_seconds,
+            cancel_check=cancel_check,
+        )
+
+    def _inverse_kinematics(
+        self,
+        pose_targets: Mapping[PlanningGroupID, PoseStamped],
+        auxiliary_group_ids: Sequence[PlanningGroupID],
+        seed: JointState | None,
+        check_collision: bool,
+        *,
+        max_attempts: int,
+        timeout_seconds: float | None = None,
+        cancel_check: IKCancelCheck | None = None,
+    ) -> IKResult:
         if self._kinematics is None or self._world_monitor is None:
             return IKResult(status=IKStatus.NO_SOLUTION, message="Planning not initialized")
         if not pose_targets:
@@ -754,6 +795,9 @@ class ManipulationModule(Module):
             auxiliary_groups=auxiliary_groups,
             seed=seed_state,
             check_collision=check_collision,
+            max_attempts=max_attempts,
+            timeout_seconds=timeout_seconds,
+            cancel_check=cancel_check,
         )
 
     def inverse_kinematics_single(

--- a/dimos/manipulation/planning/kinematics/drake_optimization_ik.py
+++ b/dimos/manipulation/planning/kinematics/drake_optimization_ik.py
@@ -17,19 +17,22 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
 from dimos.manipulation.planning.groups.models import PlanningGroup
 from dimos.manipulation.planning.kinematics.utils import (
     filter_result_to_group as _filter_result_to_group,
+    ik_deadline as _ik_deadline,
+    ik_interruption as _ik_interruption,
+    ik_time_remaining as _ik_time_remaining,
     resolve_single_pose_target_request as _resolve_single_pose_target_request,
     unique_pose_target_frame_for_robot as _unique_pose_target_frame_for_robot,
 )
 from dimos.manipulation.planning.spec.enums import IKStatus
 from dimos.manipulation.planning.spec.models import IKResult, WorldRobotID
-from dimos.manipulation.planning.spec.protocols import WorldSpec
+from dimos.manipulation.planning.spec.protocols import IKCancelCheck, WorldSpec
 from dimos.manipulation.planning.utils.kinematics_utils import compute_pose_error
 from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
 from dimos.msgs.geometry_msgs.Transform import Transform
@@ -44,7 +47,13 @@ try:
     from pydrake.multibody.inverse_kinematics import (
         InverseKinematics,
     )
-    from pydrake.solvers import Solve
+    from pydrake.solvers import (
+        ChooseBestSolver,
+        IpoptSolver,
+        SnoptSolver,
+        Solve,
+        SolverOptions,
+    )
 
     DRAKE_AVAILABLE = True
 except ImportError:
@@ -84,11 +93,16 @@ class DrakeOptimizationIK:
         orientation_tolerance: float = 0.01,
         check_collision: bool = True,
         max_attempts: int = 10,
+        timeout_seconds: float | None = None,
+        cancel_check: IKCancelCheck | None = None,
     ) -> IKResult:
         """Solve IK with multiple random restarts, returning the best collision-free solution."""
         error = self._validate_world(world)
         if error is not None:
             return error
+        deadline = _ik_deadline(timeout_seconds)
+        if interrupted := _ik_interruption(deadline, cancel_check):
+            return interrupted
 
         target_frame_name = _unique_pose_target_frame_for_robot(world, robot_id)
         if target_frame_name is None:
@@ -122,6 +136,8 @@ class DrakeOptimizationIK:
         best_error = float("inf")
 
         for attempt in range(max_attempts):
+            if interrupted := _ik_interruption(deadline, cancel_check):
+                return interrupted
             # Generate seed positions
             if attempt == 0:
                 current_seed = seed_positions
@@ -141,12 +157,18 @@ class DrakeOptimizationIK:
                 lower_limits=lower_limits,
                 upper_limits=upper_limits,
                 target_frame_name=target_frame_name,
+                timeout_seconds=_ik_time_remaining(deadline),
             )
+            if interrupted := _ik_interruption(deadline, cancel_check):
+                return interrupted
 
             if result.is_success() and result.joint_state is not None:
                 # Check collision if requested
                 if check_collision:
-                    if not world.check_config_collision_free(robot_id, result.joint_state):
+                    collision_free = world.check_config_collision_free(robot_id, result.joint_state)
+                    if interrupted := _ik_interruption(deadline, cancel_check):
+                        return interrupted
+                    if not collision_free:
                         continue  # Try another seed
 
                 # Check error
@@ -180,11 +202,16 @@ class DrakeOptimizationIK:
         orientation_tolerance: float = 0.01,
         check_collision: bool = True,
         max_attempts: int = 10,
+        timeout_seconds: float | None = None,
+        cancel_check: IKCancelCheck | None = None,
     ) -> IKResult:
         """Solve a planning-group-scoped pose target with Drake IK."""
         error = self._validate_world(world)
         if error is not None:
             return error
+        deadline = _ik_deadline(timeout_seconds)
+        if interrupted := _ik_interruption(deadline, cancel_check):
+            return interrupted
         request, request_error = _resolve_single_pose_target_request(
             world,
             pose_targets,
@@ -215,6 +242,8 @@ class DrakeOptimizationIK:
         best_result: IKResult | None = None
         best_error = float("inf")
         for attempt in range(max_attempts):
+            if interrupted := _ik_interruption(deadline, cancel_check):
+                return interrupted
             if attempt == 0:
                 current_seed = request.seed_positions
             else:
@@ -236,13 +265,20 @@ class DrakeOptimizationIK:
                 upper_limits=upper_limits,
                 target_frame_name=request.group.tip_link,
                 locked_joint_positions=locked_positions,
+                timeout_seconds=_ik_time_remaining(deadline),
             )
+            if interrupted := _ik_interruption(deadline, cancel_check):
+                return interrupted
             if not result.is_success() or result.joint_state is None:
                 continue
-            if check_collision and not world.check_config_collision_free(
-                request.robot_id, result.joint_state
-            ):
-                continue
+            if check_collision:
+                collision_free = world.check_config_collision_free(
+                    request.robot_id, result.joint_state
+                )
+                if interrupted := _ik_interruption(deadline, cancel_check):
+                    return interrupted
+                if not collision_free:
+                    continue
             total_error = result.position_error + result.orientation_error
             if total_error < best_error:
                 best_error = total_error
@@ -273,6 +309,7 @@ class DrakeOptimizationIK:
         upper_limits: NDArray[np.float64],
         target_frame_name: str,
         locked_joint_positions: Mapping[int, float] | None = None,
+        timeout_seconds: float | None = None,
     ) -> IKResult:
         # Get robot data from world internals (Drake-specific access)
         robot_data = world._robots[robot_id]  # type: ignore[attr-defined]
@@ -317,8 +354,10 @@ class DrakeOptimizationIK:
             full_seed[joint_idx] = seed[i]
         prog.SetInitialGuess(q, full_seed)
 
-        # Solve
-        result = Solve(prog)
+        result, unsupported = _solve_program(prog, timeout_seconds)
+        if unsupported is not None:
+            return _create_failure_result(IKStatus.UNSUPPORTED, unsupported)
+        assert result is not None
 
         if not result.is_success():
             return _create_failure_result(
@@ -351,6 +390,22 @@ class DrakeOptimizationIK:
             orientation_error=orientation_error,
             iterations=1,
         )
+
+
+def _solve_program(prog: Any, timeout_seconds: float | None) -> tuple[Any | None, str | None]:
+    """Solve a Drake program with a native wall/CPU limit when requested."""
+    if timeout_seconds is None:
+        return Solve(prog), None
+
+    solver_id = ChooseBestSolver(prog)
+    options = SolverOptions()
+    if solver_id == SnoptSolver.id():
+        options.SetOption(solver_id, "Time limit", timeout_seconds)
+    elif solver_id == IpoptSolver.id():
+        options.SetOption(solver_id, "max_wall_time", timeout_seconds)
+    else:
+        return None, f"Interactive IK timeout is unsupported by Drake solver '{solver_id.name()}'"
+    return Solve(prog, solver_options=options), None
 
 
 def _create_success_result(

--- a/dimos/manipulation/planning/kinematics/jacobian_ik.py
+++ b/dimos/manipulation/planning/kinematics/jacobian_ik.py
@@ -31,11 +31,13 @@ import numpy as np
 
 from dimos.manipulation.planning.groups.models import PlanningGroup
 from dimos.manipulation.planning.kinematics.utils import (
+    ik_deadline as _ik_deadline,
+    ik_interruption as _ik_interruption,
     resolve_single_pose_target_request as _resolve_single_pose_target_request,
 )
 from dimos.manipulation.planning.spec.enums import IKStatus
 from dimos.manipulation.planning.spec.models import IKResult, WorldRobotID
-from dimos.manipulation.planning.spec.protocols import WorldSpec
+from dimos.manipulation.planning.spec.protocols import IKCancelCheck, WorldSpec
 from dimos.manipulation.planning.utils.kinematics_utils import (
     check_singularity,
     compute_error_twist,
@@ -108,6 +110,8 @@ class JacobianIK:
         orientation_tolerance: float = 0.01,
         check_collision: bool = True,
         max_attempts: int = 10,
+        timeout_seconds: float | None = None,
+        cancel_check: IKCancelCheck | None = None,
     ) -> IKResult:
         """Solve IK with multiple random restarts.
 
@@ -140,10 +144,13 @@ class JacobianIK:
         # Extract joint names for creating random seeds
         joint_names = seed.name
 
+        deadline = _ik_deadline(timeout_seconds)
         best_result: IKResult | None = None
         best_error = float("inf")
 
         for attempt in range(max_attempts):
+            if interrupted := _ik_interruption(deadline, cancel_check):
+                return interrupted
             # Generate seed JointState
             if attempt == 0:
                 current_seed = seed
@@ -163,6 +170,8 @@ class JacobianIK:
                 max_iterations=self._max_iterations,
                 position_tolerance=position_tolerance,
                 orientation_tolerance=orientation_tolerance,
+                cancel_check=cancel_check,
+                _deadline=deadline,
             )
 
             if result.is_success() and result.joint_state is not None:
@@ -202,6 +211,8 @@ class JacobianIK:
         orientation_tolerance: float = 0.01,
         check_collision: bool = True,
         max_attempts: int = 10,
+        timeout_seconds: float | None = None,
+        cancel_check: IKCancelCheck | None = None,
     ) -> IKResult:
         """Solve a planning-group pose target using group FK/Jacobian."""
         if not world.is_finalized:
@@ -218,6 +229,9 @@ class JacobianIK:
         if request is None:
             return _create_failure_result(IKStatus.NO_SOLUTION, "Invalid pose target request")
 
+        deadline = _ik_deadline(timeout_seconds)
+        if interrupted := _ik_interruption(deadline, cancel_check):
+            return interrupted
         full_seed = JointState(
             {"name": request.joint_names, "position": request.seed_positions.tolist()}
         )
@@ -231,6 +245,8 @@ class JacobianIK:
             orientation_tolerance=orientation_tolerance,
             group=request.group,
             active_joint_indices=request.group_indices,
+            cancel_check=cancel_check,
+            _deadline=deadline,
         )
         if not result.is_success() or result.joint_state is None:
             return result
@@ -243,7 +259,12 @@ class JacobianIK:
             full_state = JointState(
                 {"name": request.joint_names, "position": full_positions.tolist()}
             )
-            if not world.check_config_collision_free(request.robot_id, full_state):
+            collision_free = world.check_config_collision_free(request.robot_id, full_state)
+            if interrupted := _ik_interruption(
+                deadline, cancel_check, iterations=result.iterations
+            ):
+                return interrupted
+            if not collision_free:
                 return _create_failure_result(IKStatus.COLLISION, "IK solution is in collision")
         return result
 
@@ -258,6 +279,9 @@ class JacobianIK:
         orientation_tolerance: float = 0.01,
         group: PlanningGroup | None = None,
         active_joint_indices: list[int] | None = None,
+        timeout_seconds: float | None = None,
+        cancel_check: IKCancelCheck | None = None,
+        _deadline: float | None = None,
     ) -> IKResult:
         """Iterative Jacobian-based IK until convergence.
 
@@ -276,6 +300,8 @@ class JacobianIK:
         Returns:
             IKResult with solution or failure status
         """
+        deadline = _ik_deadline(timeout_seconds) if _deadline is None else _deadline
+
         # Convert to internal representation
         target_matrix = Transform(
             translation=target_pose.position,
@@ -290,6 +316,8 @@ class JacobianIK:
         lower_limits, upper_limits = world.get_joint_limits(robot_id)
 
         for iteration in range(max_iterations):
+            if interrupted := _ik_interruption(deadline, cancel_check, iterations=iteration):
+                return interrupted
             with world.scratch_context() as ctx:
                 # Set current position (convert to JointState for API)
                 current_state = JointState(
@@ -304,6 +332,8 @@ class JacobianIK:
 
                 # Compute error
                 pos_error, ori_error = compute_pose_error(current_pose, target_matrix)
+                if interrupted := _ik_interruption(deadline, cancel_check, iterations=iteration):
+                    return interrupted
 
                 # Check convergence
                 if pos_error <= position_tolerance and ori_error <= orientation_tolerance:
@@ -348,6 +378,9 @@ class JacobianIK:
                 lower_limits[active_joint_indices],
                 upper_limits[active_joint_indices],
             )
+
+        if interrupted := _ik_interruption(deadline, cancel_check, iterations=max_iterations):
+            return interrupted
 
         # Compute final error
         with world.scratch_context() as ctx:

--- a/dimos/manipulation/planning/kinematics/pink_ik.py
+++ b/dimos/manipulation/planning/kinematics/pink_ik.py
@@ -28,6 +28,8 @@ from dimos.manipulation.planning.groups.models import PlanningGroup, PlanningGro
 from dimos.manipulation.planning.kinematics.config import PinkKinematicsConfig
 from dimos.manipulation.planning.kinematics.utils import (
     groups_by_robot as _groups_by_robot,
+    ik_deadline as _ik_deadline,
+    ik_interruption as _ik_interruption,
     robot_ids_by_name as _robot_ids_by_name,
     seed_positions_with_world_fallback as _seed_positions_with_world_fallback,
     unique_pose_target_frame_for_robot as _unique_pose_target_frame_for_robot,
@@ -35,7 +37,7 @@ from dimos.manipulation.planning.kinematics.utils import (
 from dimos.manipulation.planning.spec.config import RobotModelConfig
 from dimos.manipulation.planning.spec.enums import IKStatus
 from dimos.manipulation.planning.spec.models import IKResult, RobotName, WorldRobotID
-from dimos.manipulation.planning.spec.protocols import WorldSpec
+from dimos.manipulation.planning.spec.protocols import IKCancelCheck, WorldSpec
 from dimos.manipulation.planning.utils.kinematics_utils import compute_pose_error
 from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
 from dimos.msgs.sensor_msgs.JointState import JointState
@@ -116,10 +118,15 @@ class PinkIK:
         orientation_tolerance: float = 0.01,
         check_collision: bool = True,
         max_attempts: int = 10,
+        timeout_seconds: float | None = None,
+        cancel_check: IKCancelCheck | None = None,
     ) -> IKResult:
         """Solve IK with Pink, returning the standard planning ``IKResult``."""
         if not world.is_finalized:
             return _failure(IKStatus.NO_SOLUTION, "World must be finalized before IK")
+        deadline = _ik_deadline(timeout_seconds)
+        if interrupted := _ik_interruption(deadline, cancel_check):
+            return interrupted
 
         target_frame_name = _unique_pose_target_frame_for_robot(world, robot_id)
         if target_frame_name is None:
@@ -143,6 +150,8 @@ class PinkIK:
         fallback_result: IKResult | None = None
 
         for attempt in range(max_attempts):
+            if interrupted := _ik_interruption(deadline, cancel_check):
+                return interrupted
             try:
                 q0 = self._initial_q(robot_context, seed, lower_limits, upper_limits, attempt)
                 result = self._solve_single(
@@ -153,23 +162,35 @@ class PinkIK:
                     upper_limits=upper_limits,
                     position_tolerance=position_tolerance,
                     orientation_tolerance=orientation_tolerance,
+                    deadline=deadline,
+                    cancel_check=cancel_check,
                 )
             except ValueError as exc:
                 return _failure(IKStatus.NO_SOLUTION, f"Pink IK mapping failed: {exc}")
             except Exception as exc:
                 return _failure(IKStatus.NO_SOLUTION, f"Pink IK solver failed: {exc}")
 
+            if result.status == IKStatus.TIMEOUT:
+                return result
             if not result.is_success() or result.joint_state is None:
                 if fallback_result is None:
                     fallback_result = result
                 continue
 
-            if check_collision and not world.check_config_collision_free(
-                robot_id, result.joint_state
-            ):
-                fallback_result = _collision_failure(result)
-                continue
+            if check_collision:
+                collision_free = world.check_config_collision_free(robot_id, result.joint_state)
+                if interrupted := _ik_interruption(
+                    deadline, cancel_check, iterations=result.iterations
+                ):
+                    return interrupted
+                if not collision_free:
+                    fallback_result = _collision_failure(result)
+                    continue
 
+            if interrupted := _ik_interruption(
+                deadline, cancel_check, iterations=result.iterations
+            ):
+                return interrupted
             return result
 
         if fallback_result is not None:
@@ -187,10 +208,15 @@ class PinkIK:
         orientation_tolerance: float = 0.01,
         check_collision: bool = True,
         max_attempts: int = 10,
+        timeout_seconds: float | None = None,
+        cancel_check: IKCancelCheck | None = None,
     ) -> IKResult:
         """Solve planning-group-scoped pose targets with Pink IK."""
         if not world.is_finalized:
             return _failure(IKStatus.NO_SOLUTION, "World must be finalized before IK")
+        deadline = _ik_deadline(timeout_seconds)
+        if interrupted := _ik_interruption(deadline, cancel_check):
+            return interrupted
         all_groups = tuple(pose_targets.keys()) + tuple(auxiliary_groups)
         if not all_groups:
             return _failure(
@@ -215,6 +241,8 @@ class PinkIK:
 
         results_by_robot: dict[RobotName, IKResult] = {}
         for robot_name, groups in _groups_by_robot(all_groups).items():
+            if interrupted := _ik_interruption(deadline, cancel_check):
+                return interrupted
             robot_id = robot_ids_by_name[robot_name]
             config = world.get_robot_config(robot_id)
             joint_names = list(config.joint_names)
@@ -255,6 +283,8 @@ class PinkIK:
 
             fallback_result: IKResult | None = None
             for attempt in range(max_attempts):
+                if interrupted := _ik_interruption(deadline, cancel_check):
+                    return interrupted
                 current_positions = seed_positions.copy()
                 if attempt > 0:
                     current_positions[selected_indices] = np.random.uniform(
@@ -272,6 +302,8 @@ class PinkIK:
                             position_tolerance=position_tolerance,
                             orientation_tolerance=orientation_tolerance,
                             locked_joint_positions=locked_positions,
+                            deadline=deadline,
+                            cancel_check=cancel_check,
                         )
                     else:
                         result = self._solve_multi(
@@ -282,12 +314,16 @@ class PinkIK:
                             position_tolerance=position_tolerance,
                             orientation_tolerance=orientation_tolerance,
                             locked_joint_positions=locked_positions,
+                            deadline=deadline,
+                            cancel_check=cancel_check,
                         )
                 except ValueError as exc:
                     return _failure(IKStatus.NO_SOLUTION, f"Pink IK mapping failed: {exc}")
                 except Exception as exc:
                     return _failure(IKStatus.NO_SOLUTION, f"Pink IK solver failed: {exc}")
 
+                if result.status == IKStatus.TIMEOUT:
+                    return result
                 if not result.is_success() or result.joint_state is None:
                     if fallback_result is None:
                         fallback_result = result
@@ -349,12 +385,16 @@ class PinkIK:
             iterations=iterations,
             message="Pink IK solution found",
         )
-        if check_collision and not _combined_robot_results_collision_free(
-            world,
-            robot_ids_by_name,
-            results_by_robot,
-        ):
-            return _collision_failure(combined)
+        if check_collision:
+            collision_free = _combined_robot_results_collision_free(
+                world,
+                robot_ids_by_name,
+                results_by_robot,
+            )
+            if interrupted := _ik_interruption(deadline, cancel_check, iterations=iterations):
+                return interrupted
+            if not collision_free:
+                return _collision_failure(combined)
         return combined
 
     def _solve_multi(
@@ -366,6 +406,8 @@ class PinkIK:
         position_tolerance: float,
         orientation_tolerance: float,
         locked_joint_positions: Mapping[int, float] | None = None,
+        deadline: float | None = None,
+        cancel_check: IKCancelCheck | None = None,
     ) -> IKResult:
         robot_context = targets[0][0]
         pink = self._modules.pink
@@ -389,12 +431,16 @@ class PinkIK:
         final_position_error = float("inf")
         final_orientation_error = float("inf")
         for iteration in range(self.config.max_iterations):
+            if interrupted := _ik_interruption(deadline, cancel_check, iterations=iteration):
+                return interrupted
             errors = [
                 compute_pose_error(self._current_frame_matrix(ctx, configuration.q), target_model)
                 for ctx, target_model in targets
             ]
             final_position_error = max(error[0] for error in errors)
             final_orientation_error = max(error[1] for error in errors)
+            if interrupted := _ik_interruption(deadline, cancel_check, iterations=iteration):
+                return interrupted
             if (
                 final_position_error <= position_tolerance
                 and final_orientation_error <= orientation_tolerance
@@ -427,6 +473,10 @@ class PinkIK:
                     iterations=iteration + 1,
                     message="Pink IK candidate violates DimOS joint limits",
                 )
+        if interrupted := _ik_interruption(
+            deadline, cancel_check, iterations=self.config.max_iterations
+        ):
+            return interrupted
         return IKResult(
             status=IKStatus.NO_SOLUTION,
             joint_state=None,
@@ -446,6 +496,8 @@ class PinkIK:
         position_tolerance: float,
         orientation_tolerance: float,
         locked_joint_positions: Mapping[int, float] | None = None,
+        deadline: float | None = None,
+        cancel_check: IKCancelCheck | None = None,
     ) -> IKResult:
         pink = self._modules.pink
         pinocchio = self._modules.pinocchio
@@ -472,10 +524,14 @@ class PinkIK:
         final_orientation_error = float("inf")
 
         for iteration in range(self.config.max_iterations):
+            if interrupted := _ik_interruption(deadline, cancel_check, iterations=iteration):
+                return interrupted
             current_pose = self._current_frame_matrix(robot_context, configuration.q)
             final_position_error, final_orientation_error = compute_pose_error(
                 current_pose, target_model
             )
+            if interrupted := _ik_interruption(deadline, cancel_check, iterations=iteration):
+                return interrupted
             if (
                 final_position_error <= position_tolerance
                 and final_orientation_error <= orientation_tolerance
@@ -511,6 +567,10 @@ class PinkIK:
                     message="Pink IK candidate violates DimOS joint limits",
                 )
 
+        if interrupted := _ik_interruption(
+            deadline, cancel_check, iterations=self.config.max_iterations
+        ):
+            return interrupted
         return IKResult(
             status=IKStatus.NO_SOLUTION,
             joint_state=None,

--- a/dimos/manipulation/planning/kinematics/test_drake_optimization_ik_selection.py
+++ b/dimos/manipulation/planning/kinematics/test_drake_optimization_ik_selection.py
@@ -16,8 +16,10 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from pathlib import Path
+from types import SimpleNamespace
 
 import numpy as np
+import pytest
 
 from dimos.manipulation.planning.groups.models import PlanningGroup
 from dimos.manipulation.planning.kinematics import drake_optimization_ik as drake_ik
@@ -28,6 +30,14 @@ from dimos.manipulation.planning.spec.models import IKResult
 from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
 from dimos.msgs.sensor_msgs.JointState import JointState
 from dimos.robot.assets.model import RobotModel
+
+
+class FakeSolverId:
+    def __init__(self, name: str) -> None:
+        self._name = name
+
+    def name(self) -> str:
+        return self._name
 
 
 class FakeWorld:
@@ -116,6 +126,61 @@ def test_solve_pose_targets_uses_group_tip_locks_seed_fallback_and_filters(monke
     assert calls[0]["target_frame_name"] == "group_tip_link"
     np.testing.assert_allclose(calls[0]["seed"], [1.0, 22.0, 3.0, 4.0])
     assert calls[0]["locked_joint_positions"] == {0: 1.0, 2: 3.0}
+
+
+def test_solve_pose_targets_honors_cancellation_before_solver(monkeypatch) -> None:
+    monkeypatch.setattr(drake_ik, "DRAKE_AVAILABLE", True)
+    monkeypatch.setattr(DrakeOptimizationIK, "_validate_world", lambda self, world: None)
+
+    result = DrakeOptimizationIK().solve_pose_targets(
+        world=FakeWorld(),  # type: ignore[arg-type]
+        pose_targets={},
+        cancel_check=lambda: True,
+    )
+
+    assert result.status == IKStatus.TIMEOUT
+    assert "newer target" in result.message
+
+
+@pytest.mark.parametrize(
+    ("selected_solver", "option_name"),
+    (("SNOPT", "Time limit"), ("IPOPT", "max_wall_time")),
+)
+def test_bounded_drake_solve_sets_native_solver_timeout(
+    monkeypatch,
+    selected_solver: str,
+    option_name: str,
+) -> None:
+    snopt_id = FakeSolverId("SNOPT")
+    ipopt_id = FakeSolverId("IPOPT")
+    selected_id = snopt_id if selected_solver == "SNOPT" else ipopt_id
+    option_calls: list[tuple[FakeSolverId, str, float]] = []
+    solver_options = SimpleNamespace(
+        SetOption=lambda solver_id, name, value: option_calls.append((solver_id, name, value))
+    )
+    solve_calls: list[tuple[object, object]] = []
+    expected = object()
+    monkeypatch.setattr(drake_ik, "ChooseBestSolver", lambda _prog: selected_id, raising=False)
+    monkeypatch.setattr(
+        drake_ik, "SnoptSolver", SimpleNamespace(id=lambda: snopt_id), raising=False
+    )
+    monkeypatch.setattr(
+        drake_ik, "IpoptSolver", SimpleNamespace(id=lambda: ipopt_id), raising=False
+    )
+    monkeypatch.setattr(drake_ik, "SolverOptions", lambda: solver_options, raising=False)
+    monkeypatch.setattr(
+        drake_ik,
+        "Solve",
+        lambda prog, *, solver_options: (solve_calls.append((prog, solver_options)), expected)[1],
+        raising=False,
+    )
+
+    result, unsupported = drake_ik._solve_program("program", 0.1)
+
+    assert result is expected
+    assert unsupported is None
+    assert option_calls == [(selected_id, option_name, 0.1)]
+    assert solve_calls == [("program", solver_options)]
 
 
 class FakeRigidTransform:

--- a/dimos/manipulation/planning/kinematics/test_jacobian_ik_selection.py
+++ b/dimos/manipulation/planning/kinematics/test_jacobian_ik_selection.py
@@ -146,3 +146,31 @@ def test_solve_pose_targets_rejects_group_without_pose_target_frame() -> None:
 
     assert result.status == IKStatus.UNSUPPORTED
     assert "no pose target frame" in result.message
+
+
+def test_solve_pose_targets_honors_cancellation_before_iteration() -> None:
+    world = _World()
+
+    result = JacobianIK().solve_pose_targets(
+        world=world,
+        pose_targets={_group(): _pose()},
+        cancel_check=lambda: True,
+    )
+
+    assert result.status == IKStatus.TIMEOUT
+    assert "newer target" in result.message
+    assert world.group_pose_calls == 0
+
+
+def test_solve_pose_targets_honors_expired_deadline_before_iteration() -> None:
+    world = _World()
+
+    result = JacobianIK().solve_pose_targets(
+        world=world,
+        pose_targets={_group(): _pose()},
+        timeout_seconds=0.0,
+    )
+
+    assert result.status == IKStatus.TIMEOUT
+    assert result.message == "IK evaluation timed out"
+    assert world.group_pose_calls == 0

--- a/dimos/manipulation/planning/kinematics/test_pink_ik.py
+++ b/dimos/manipulation/planning/kinematics/test_pink_ik.py
@@ -608,6 +608,23 @@ def test_solve_pose_targets_rejects_group_without_tip(mocker: MockerFixture) -> 
     assert "no pose target frame" in result.message
 
 
+def test_solve_pose_targets_honors_cancellation_before_model_setup(
+    mocker: MockerFixture,
+) -> None:
+    ik = _pink_ik(mocker)
+    get_context = mocker.patch.object(ik, "_get_robot_context")
+
+    result = ik.solve_pose_targets(
+        world=cast("Any", _FakeWorld()),
+        pose_targets={},
+        cancel_check=lambda: True,
+    )
+
+    assert result.status == IKStatus.TIMEOUT
+    assert "newer target" in result.message
+    get_context.assert_not_called()
+
+
 def test_solve_pose_targets_partial_seed_reads_world_state(mocker: MockerFixture) -> None:
     ik = _pink_ik(mocker)
     mocker.patch.object(ik, "_get_robot_context", return_value=_context())

--- a/dimos/manipulation/planning/kinematics/utils.py
+++ b/dimos/manipulation/planning/kinematics/utils.py
@@ -16,6 +16,7 @@
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+import time
 
 import numpy as np
 from numpy.typing import NDArray
@@ -24,7 +25,7 @@ from dimos.manipulation.planning.groups.models import PlanningGroup, PlanningGro
 from dimos.manipulation.planning.groups.utils import filter_joint_state_to_selected_joints
 from dimos.manipulation.planning.spec.enums import IKStatus
 from dimos.manipulation.planning.spec.models import IKResult, RobotName, WorldRobotID
-from dimos.manipulation.planning.spec.protocols import WorldSpec
+from dimos.manipulation.planning.spec.protocols import IKCancelCheck, WorldSpec
 from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
 from dimos.msgs.sensor_msgs.JointState import JointState
 
@@ -37,6 +38,44 @@ class SinglePoseTargetRequest:
     joint_names: list[str]
     seed_positions: NDArray[np.float64]
     group_indices: list[int]
+
+
+def ik_deadline(timeout_seconds: float | None) -> float | None:
+    """Return a monotonic deadline for one IK request."""
+    if timeout_seconds is None:
+        return None
+    return time.monotonic() + max(0.0, timeout_seconds)
+
+
+def ik_interruption(
+    deadline: float | None,
+    cancel_check: IKCancelCheck | None,
+    *,
+    iterations: int = 0,
+) -> IKResult | None:
+    """Return a timeout result when cancellation or the deadline requests a stop."""
+    if cancel_check is not None and cancel_check():
+        return IKResult(
+            status=IKStatus.TIMEOUT,
+            joint_state=None,
+            iterations=iterations,
+            message="IK evaluation cancelled by a newer target",
+        )
+    if deadline is not None and time.monotonic() >= deadline:
+        return IKResult(
+            status=IKStatus.TIMEOUT,
+            joint_state=None,
+            iterations=iterations,
+            message="IK evaluation timed out",
+        )
+    return None
+
+
+def ik_time_remaining(deadline: float | None) -> float | None:
+    """Return non-negative seconds remaining before an IK deadline."""
+    if deadline is None:
+        return None
+    return max(0.0, deadline - time.monotonic())
 
 
 def unique_pose_target_frame_for_robot(world: WorldSpec, robot_id: WorldRobotID) -> str | None:

--- a/dimos/manipulation/planning/spec/protocols.py
+++ b/dimos/manipulation/planning/spec/protocols.py
@@ -20,8 +20,8 @@ Use factory functions from dimos.manipulation.planning.factory to create instanc
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from collections.abc import Callable, Mapping, Sequence
+from typing import TYPE_CHECKING, Any, Protocol, TypeAlias, runtime_checkable
 
 if TYPE_CHECKING:
     from contextlib import AbstractContextManager
@@ -46,6 +46,9 @@ if TYPE_CHECKING:
     from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
     from dimos.msgs.sensor_msgs.JointState import JointState
     from dimos.msgs.trajectory_msgs.JointTrajectory import JointTrajectory
+
+
+IKCancelCheck: TypeAlias = Callable[[], bool]
 
 
 @runtime_checkable
@@ -262,6 +265,8 @@ class KinematicsSpec(Protocol):
         orientation_tolerance: float = 0.01,
         check_collision: bool = True,
         max_attempts: int = 10,
+        timeout_seconds: float | None = None,
+        cancel_check: IKCancelCheck | None = None,
     ) -> IKResult:
         """Solve IK with optional collision checking."""
         ...
@@ -276,6 +281,8 @@ class KinematicsSpec(Protocol):
         orientation_tolerance: float = 0.01,
         check_collision: bool = True,
         max_attempts: int = 10,
+        timeout_seconds: float | None = None,
+        cancel_check: IKCancelCheck | None = None,
     ) -> IKResult:
         """Solve planning-group-scoped pose targets."""
         ...

--- a/dimos/manipulation/test_manipulation_unit.py
+++ b/dimos/manipulation/test_manipulation_unit.py
@@ -642,6 +642,37 @@ class TestPlanningGroupApis:
             "test_arm/joint3",
         )
 
+    def test_interactive_ik_is_one_bounded_cancellable_attempt(
+        self, robot_config, module_factory
+    ) -> None:
+        module = module_factory()
+        module._world_monitor = MagicMock()
+        module._world_monitor.world = MagicMock()
+        module._world_monitor.planning_groups = PlanningGroupRegistry([robot_config])
+        module._kinematics = MagicMock()
+        expected = IKResult(status=IKStatus.TIMEOUT, message="cancelled")
+        module._kinematics.solve_pose_targets.return_value = expected
+        seed = JointState(
+            name=[f"test_arm/{name}" for name in robot_config.joint_names],
+            position=[0.0, 0.0, 0.0],
+        )
+        cancel_check = MagicMock(return_value=False)
+
+        result = module.evaluate_inverse_kinematics(
+            {"test_arm/manipulator": PoseStamped()},
+            seed=seed,
+            timeout_seconds=0.1,
+            cancel_check=cancel_check,
+        )
+
+        assert result is expected
+        _, kwargs = module._kinematics.solve_pose_targets.call_args
+        assert kwargs["seed"] is seed
+        assert kwargs["check_collision"] is True
+        assert kwargs["max_attempts"] == 1
+        assert kwargs["timeout_seconds"] == 0.1
+        assert kwargs["cancel_check"] is cancel_check
+
     def test_plan_to_joint_targets_stores_generated_plan_and_legacy_caches(
         self, robot_config, module_factory
     ):

--- a/dimos/manipulation/visualization/operator.py
+++ b/dimos/manipulation/visualization/operator.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, cast
 from dimos.manipulation.planning.groups.models import PlanningGroup
 from dimos.manipulation.planning.planners.config import CartesianPathConfig
 from dimos.manipulation.planning.spec.models import GeneratedPlan, PlanningGroupID, RobotName
+from dimos.manipulation.planning.spec.protocols import IKCancelCheck
 from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
 from dimos.msgs.sensor_msgs.JointState import JointState
 
@@ -124,16 +125,24 @@ class ManipulationOperator:
             return self._invalid(request.group_ids, "Incomplete robot target state")
         return self._evaluate_global_target(groups, JointState(request.target), complete)
 
-    def evaluate_pose_target(self, request: PoseTargetRequest) -> TargetEvaluationResult:
+    def evaluate_pose_target(
+        self,
+        request: PoseTargetRequest,
+        *,
+        timeout_seconds: float,
+        cancel_check: IKCancelCheck,
+    ) -> TargetEvaluationResult:
         """Validate and evaluate explicit world-frame pose targets."""
         group_ids, validation = self._validate_pose_request(request)
         if validation is not None:
             return validation
-        ik = self._module.inverse_kinematics(
+        ik = self._module.evaluate_inverse_kinematics(
             pose_targets=dict(request.pose_targets),
             auxiliary_group_ids=request.auxiliary_group_ids,
             seed=JointState(request.seed) if request.seed is not None else None,
             check_collision=True,
+            timeout_seconds=timeout_seconds,
+            cancel_check=cancel_check,
         )
         if not ik.is_success() or ik.joint_state is None:
             return TargetEvaluationResult(

--- a/dimos/manipulation/visualization/test_operator.py
+++ b/dimos/manipulation/visualization/test_operator.py
@@ -14,6 +14,7 @@
 
 """Focused tests for the manipulation visualization operator facade."""
 
+from collections.abc import Callable
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -123,6 +124,8 @@ class FakeModule:
         self.clear_success = True
         self.topology_calls = 0
         self.telemetry_calls = 0
+        self.ik_timeout_seconds: float | None = None
+        self.ik_cancel_check_called = False
 
     def get_state(self) -> ManipulationSnapshot:
         return ManipulationSnapshot(
@@ -151,14 +154,19 @@ class FakeModule:
         self.telemetry_calls += 1
         return JointState(name=[f"{robot_name}/j0"], position=[0.0])
 
-    def inverse_kinematics(
+    def evaluate_inverse_kinematics(
         self,
         pose_targets: dict[PlanningGroupID, PoseStamped],
         auxiliary_group_ids: tuple[PlanningGroupID, ...] = (),
         seed: JointState | None = None,
         check_collision: bool = True,
+        *,
+        timeout_seconds: float,
+        cancel_check: Callable[[], bool],
     ) -> IKResult:
         assert check_collision is True
+        self.ik_timeout_seconds = timeout_seconds
+        self.ik_cancel_check_called = cancel_check()
         self.ik_calls.append((pose_targets, auxiliary_group_ids, seed))
         return IKResult(
             status=IKStatus.SUCCESS,
@@ -351,12 +359,18 @@ def test_pose_evaluation_accepts_world_frame_and_delegates_original_request() ->
     seed = JointState(name=["arm/j0", "arm/j1"], position=[0.0, 0.0])
     request = PoseTargetRequest({"arm/manipulator": pose}, seed=seed)
 
-    result = operator.evaluate_pose_target(request)
+    result = operator.evaluate_pose_target(
+        request,
+        timeout_seconds=0.1,
+        cancel_check=lambda: False,
+    )
 
     assert result.success is True
     assert result.target_joints is not None
     assert list(result.target_joints.name) == ["arm/j0", "arm/j1"]
     assert module.ik_calls == [({"arm/manipulator": pose}, (), seed)]
+    assert module.ik_timeout_seconds == 0.1
+    assert module.ik_cancel_check_called is False
 
 
 def test_pose_validation_rejects_frame_capability_and_seed_errors() -> None:
@@ -377,11 +391,19 @@ def test_pose_validation_rejects_frame_capability_and_seed_errors() -> None:
     ]
     operator, _, _ = _operator()
 
-    no_pose = no_pose_operator.evaluate_pose_target(PoseTargetRequest({"arm/no_pose": _pose()}))
+    no_pose = no_pose_operator.evaluate_pose_target(
+        PoseTargetRequest({"arm/no_pose": _pose()}),
+        timeout_seconds=0.1,
+        cancel_check=lambda: False,
+    )
     assert no_pose.success is False
     assert no_pose.status == "INVALID"
     for request in bad_seed_cases:
-        result = operator.evaluate_pose_target(request)
+        result = operator.evaluate_pose_target(
+            request,
+            timeout_seconds=0.1,
+            cancel_check=lambda: False,
+        )
         assert result.success is False
         assert result.status == "INVALID"
 

--- a/dimos/manipulation/visualization/viser/config.py
+++ b/dimos/manipulation/visualization/viser/config.py
@@ -50,6 +50,7 @@ class ViserVisualizationConfig(BaseModel):
         default=5.0,
         validation_alias=AliasChoices("preview_request_timeout", "viser_preview_request_timeout"),
     )
+    target_evaluation_timeout: float = Field(default=0.1, gt=0.0)
     current_match_tolerance: float = Field(
         default=0.02,
         validation_alias=AliasChoices("current_match_tolerance", "viser_current_match_tolerance"),

--- a/dimos/manipulation/visualization/viser/gui.py
+++ b/dimos/manipulation/visualization/viser/gui.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping, MutableMapping, Sequence
+from collections.abc import Callable, Mapping, MutableMapping, Sequence
 import math
 from typing import TypeAlias, cast
 
@@ -276,6 +276,7 @@ class ViserPanelGui:
         pose_targets: Mapping[PlanningGroupID, Pose],
         auxiliary_group_ids: Sequence[PlanningGroupID] = (),
         seed: JointState | None = None,
+        cancel_check: Callable[[], bool] | None = None,
     ) -> TargetEvaluationResult:
         stamped = {
             group_id: PoseStamped(
@@ -284,7 +285,9 @@ class ViserPanelGui:
             for group_id, pose in pose_targets.items()
         }
         return self.operator.evaluate_pose_target(
-            PoseTargetRequest(stamped, tuple(auxiliary_group_ids), _copy_joint_state(seed))
+            PoseTargetRequest(stamped, tuple(auxiliary_group_ids), _copy_joint_state(seed)),
+            timeout_seconds=self.config.target_evaluation_timeout,
+            cancel_check=cancel_check or (lambda: False),
         )
 
     def cancel(self) -> bool:
@@ -638,7 +641,7 @@ class ViserPanelGui:
             )
             if control is not None:
                 self._handles[f"ee_control:{group_id}"] = control
-            pose = self.state.pose_targets.get(group_id)
+            pose = self.state.candidate_pose_targets.get(group_id)
             if pose is not None:
                 self._suppress_target_callbacks = True
                 try:
@@ -771,19 +774,19 @@ class ViserPanelGui:
                     "position": [float(values[str(name)]) for name in group.local_joint_names],
                 }
             )
-            if group.has_pose_target and group_id not in self.state.pose_targets:
+            if group.has_pose_target and group_id not in self.state.candidate_pose_targets:
                 pose = self.get_group_ee_pose(group_id)
                 if pose is not None:
-                    self.state.pose_targets[group_id] = pose
+                    self.state.candidate_pose_targets[group_id] = pose
+                    self.state.accepted_pose_targets[group_id] = pose
                     self.state.group_poses[group_id] = pose
-                    if self.state.cartesian_target is None:
-                        self.state.cartesian_target = pose
         self._refresh_target_joints_from_groups()
 
     def _prune_inactive_group_state(self) -> None:
         selected = set(self.state.selected_group_ids)
         for values in (
-            self.state.pose_targets,
+            self.state.candidate_pose_targets,
+            self.state.accepted_pose_targets,
             self.state.group_joint_targets,
             self.state.group_poses,
         ):
@@ -804,11 +807,18 @@ class ViserPanelGui:
             JointState({"name": names, "position": positions}) if names else None
         )
 
-    def _active_pose_targets(self) -> dict[PlanningGroupID, Pose]:
+    def _candidate_pose_targets(self) -> dict[PlanningGroupID, Pose]:
         return {
-            group_id: self.state.pose_targets[group_id]
+            group_id: self.state.candidate_pose_targets[group_id]
             for group_id in self.state.selected_group_ids
-            if group_id in self.state.pose_targets
+            if group_id in self.state.candidate_pose_targets
+        }
+
+    def _accepted_pose_targets(self) -> dict[PlanningGroupID, Pose]:
+        return {
+            group_id: self.state.accepted_pose_targets[group_id]
+            for group_id in self.state.selected_group_ids
+            if group_id in self.state.accepted_pose_targets
         }
 
     def _preset_values_by_local_name(self, preset: str, robot_name: str) -> dict[str, float]:
@@ -941,8 +951,7 @@ class ViserPanelGui:
         pose = self._pose_from_transform_target(target)
         if pose is None:
             return
-        self.state.cartesian_target = pose
-        self.state.pose_targets[group_id] = pose
+        self.state.candidate_pose_targets[group_id] = pose
         sequence_id = self.state.next_sequence_id()
         self._worker.submit(
             TargetEvaluationRequest(
@@ -953,14 +962,14 @@ class ViserPanelGui:
                 auxiliary_group_ids=tuple(
                     selected_group_id
                     for selected_group_id in self.state.selected_group_ids
-                    if selected_group_id not in self._active_pose_targets()
+                    if selected_group_id not in self._candidate_pose_targets()
                 ),
                 joints=(
                     None
                     if self.state.target_joints is None
                     else JointState(self.state.target_joints)
                 ),
-                pose_targets=dict(self._active_pose_targets()),
+                pose_targets=dict(self._candidate_pose_targets()),
             )
         )
         self.refresh()
@@ -1050,7 +1059,10 @@ class ViserPanelGui:
             if not request.pose_targets:
                 return TargetEvaluationResult(False, "INVALID", "No pose target")
             return self.evaluate_pose_target_set(
-                request.pose_targets, request.auxiliary_group_ids, request.joints
+                request.pose_targets,
+                request.auxiliary_group_ids,
+                request.joints,
+                request.cancel_event.is_set,
             )
         if not request.joint_targets:
             return TargetEvaluationResult(False, "INVALID", "No joint target")
@@ -1075,18 +1087,21 @@ class ViserPanelGui:
             TargetStatus.FEASIBLE if success and collision_free else TargetStatus.INFEASIBLE
         )
         self.state.error = "" if success and collision_free else self.state.feasibility.message
-        if result.target_joints is not None:
+        accepted = success and collision_free
+        if accepted and result.target_joints is not None:
             self.state.target_joints = JointState(result.target_joints)
             self._split_target_joints_by_group(result.target_joints)
-        self.state.group_poses = {
-            str(group_id): pose
-            for group_id, pose in result.group_poses.items()
-            if isinstance(pose, Pose)
-        }
-        if request.source == "joints":
-            self._sync_pose_targets_from_group_poses()
-        else:
-            self._sync_controls_from_targets()
+        if accepted:
+            self.state.group_poses = {
+                str(group_id): pose
+                for group_id, pose in result.group_poses.items()
+                if isinstance(pose, Pose)
+            }
+            if request.source == "joints":
+                self._sync_pose_targets_from_group_poses()
+            else:
+                self.state.accepted_pose_targets = dict(request.pose_targets)
+                self._sync_controls_from_targets()
         self._update_target_visual_state()
         self.refresh()
 
@@ -1126,14 +1141,17 @@ class ViserPanelGui:
                 continue
             if group_id not in self.state.selected_group_ids:
                 continue
-            self.state.pose_targets[group_id] = pose
+            self.state.candidate_pose_targets[group_id] = pose
+            self.state.accepted_pose_targets[group_id] = pose
             active_group_ids.append(group_id)
         if self.scene is None:
             return
         self._suppress_target_callbacks = True
         try:
             for group_id in active_group_ids:
-                self.scene.set_target_pose(str(group_id), self.state.pose_targets[group_id])
+                self.scene.set_target_pose(
+                    str(group_id), self.state.candidate_pose_targets[group_id]
+                )
         finally:
             self._suppress_target_callbacks = False
 
@@ -1192,8 +1210,11 @@ class ViserPanelGui:
                 if (robot_id := self.robot_id_for_name(str(group.robot_name))) is not None
             )
         )
+        ghost_feasible = feasible
+        if self.state.planning_mode == PlanningMode.CARTESIAN_SPACE:
+            ghost_feasible = bool(self._accepted_pose_targets())
         for robot_id in robot_ids:
-            self.scene.set_target_robot_visual_state(robot_id, feasible)
+            self.scene.set_target_robot_visual_state(robot_id, ghost_feasible)
 
     def _can_execute(self) -> bool:
         return self.state.can_execute()
@@ -1214,7 +1235,7 @@ class ViserPanelGui:
         pose_targets: dict[PlanningGroupID, Pose] = {}
         auxiliary_group_ids: tuple[PlanningGroupID, ...] = ()
         if planning_mode == PlanningMode.CARTESIAN_SPACE:
-            pose_targets = self._active_pose_targets()
+            pose_targets = self._accepted_pose_targets()
             pose_capable_ids = {
                 group_id
                 for group_id in group_ids

--- a/dimos/manipulation/visualization/viser/state.py
+++ b/dimos/manipulation/visualization/viser/state.py
@@ -110,7 +110,8 @@ class PanelState:
     selected_group_ids: tuple[PlanningGroupID, ...] = ()
     planning_mode: PlanningMode = PlanningMode.JOINT_SPACE
     selection_epoch: int = 0
-    pose_targets: dict[PlanningGroupID, Pose] = field(default_factory=dict)
+    candidate_pose_targets: dict[PlanningGroupID, Pose] = field(default_factory=dict)
+    accepted_pose_targets: dict[PlanningGroupID, Pose] = field(default_factory=dict)
     group_joint_targets: dict[PlanningGroupID, JointState] = field(default_factory=dict)
     target_joints: JointState | None = None
     group_poses: dict[PlanningGroupID, Pose] = field(default_factory=dict)
@@ -120,7 +121,6 @@ class PanelState:
     action_status: ActionStatus = ActionStatus.IDLE
     manipulation_state: str = "DISCONNECTED"
     current_joints: list[float] | None = None
-    cartesian_target: Pose | None = None
     feasibility: FeasibilityState = field(default_factory=FeasibilityState)
     latest_sequence_id: int = 0
     plan_state: PanelPlanState = field(default_factory=PanelPlanState)
@@ -216,6 +216,11 @@ class TargetEvaluationRequest:
     auxiliary_group_ids: tuple[PlanningGroupID, ...] = ()
     pose_targets: dict[PlanningGroupID, Pose] = field(default_factory=dict)
     joint_targets: dict[PlanningGroupID, JointState] = field(default_factory=dict)
+    cancel_event: threading.Event = field(
+        default_factory=threading.Event,
+        repr=False,
+        compare=False,
+    )
 
 
 class TargetEvaluationWorker:
@@ -235,6 +240,7 @@ class TargetEvaluationWorker:
         self._apply_result = apply_result
         self._requests: queue.Queue[TargetEvaluationRequest] = queue.Queue(maxsize=1)
         self._submit_lock = threading.Lock()
+        self._active_request: TargetEvaluationRequest | None = None
         self._stop_event = threading.Event()
         self._thread: threading.Thread | None = None
 
@@ -248,6 +254,10 @@ class TargetEvaluationWorker:
 
     def stop(self, timeout: float | None = 2.0) -> None:
         self._stop_event.set()
+        with self._submit_lock:
+            if self._active_request is not None:
+                self._active_request.cancel_event.set()
+            self._cancel_queued_requests()
         if self._thread and self._thread.is_alive():
             self._thread.join(timeout=timeout)
         if self._thread is not None and not self._thread.is_alive():
@@ -255,12 +265,17 @@ class TargetEvaluationWorker:
 
     def submit(self, request: TargetEvaluationRequest) -> None:
         with self._submit_lock:
-            while True:
-                try:
-                    self._requests.get_nowait()
-                except queue.Empty:
-                    break
+            if self._active_request is not None:
+                self._active_request.cancel_event.set()
+            self._cancel_queued_requests()
             self._requests.put_nowait(request)
+
+    def _cancel_queued_requests(self) -> None:
+        while True:
+            try:
+                self._requests.get_nowait().cancel_event.set()
+            except queue.Empty:
+                return
 
     def _run(self) -> None:
         while not self._stop_event.is_set():
@@ -268,16 +283,25 @@ class TargetEvaluationWorker:
                 request = self._requests.get(timeout=0.1)
             except queue.Empty:
                 continue
-            while True:
-                try:
-                    request = self._requests.get_nowait()
-                except queue.Empty:
-                    break
+            with self._submit_lock:
+                while True:
+                    try:
+                        newer_request = self._requests.get_nowait()
+                    except queue.Empty:
+                        break
+                    request.cancel_event.set()
+                    request = newer_request
+                self._active_request = request
             try:
                 result = self._handler(request)
-                self._apply_result(request, result)
+                if not request.cancel_event.is_set():
+                    self._apply_result(request, result)
             except Exception:
                 logger.warning("Target evaluation worker caught unhandled exception", exc_info=True)
+            finally:
+                with self._submit_lock:
+                    if self._active_request is request:
+                        self._active_request = None
 
 
 class OperationWorker:

--- a/dimos/manipulation/visualization/viser/test_state.py
+++ b/dimos/manipulation/visualization/viser/test_state.py
@@ -14,10 +14,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
 import threading
 
 from dimos.manipulation.planning.spec.models import PlanningGroupID
+from dimos.manipulation.visualization.operator import TargetEvaluationResult
 from dimos.manipulation.visualization.viser.state import (
     ActionStatus,
     BackendConnectionStatus,
@@ -25,6 +25,7 @@ from dimos.manipulation.visualization.viser.state import (
     PanelRuntime,
     PanelState,
     PlanStatus,
+    TargetEvaluationRequest,
     TargetEvaluationWorker,
     TargetStatus,
 )
@@ -117,6 +118,36 @@ def test_operation_worker_uses_operation_error_callback_on_timeout() -> None:
     assert operation_errors == ["Operation timed out after 0.0s"]
 
 
-class FakeTargetEvaluationWorker(TargetEvaluationWorker):
-    def __init__(self, calls: list[Callable[[], None]]) -> None:
-        self.calls = calls
+def test_target_evaluation_worker_cancels_active_request_and_applies_latest() -> None:
+    first_started = threading.Event()
+    latest_applied = threading.Event()
+    applied: list[int] = []
+
+    def handler(request: TargetEvaluationRequest) -> TargetEvaluationResult:
+        if request.sequence_id == 1:
+            first_started.set()
+            assert request.cancel_event.wait(timeout=1.0)
+        return TargetEvaluationResult(True, "FEASIBLE", "", True)
+
+    def apply_result(
+        request: TargetEvaluationRequest,
+        _result: TargetEvaluationResult,
+    ) -> None:
+        applied.append(request.sequence_id)
+        latest_applied.set()
+
+    worker = TargetEvaluationWorker(handler, apply_result)
+    first = TargetEvaluationRequest(1, "cartesian")
+    latest = TargetEvaluationRequest(2, "cartesian")
+    worker.start()
+    try:
+        worker.submit(first)
+        assert first_started.wait(timeout=1.0)
+        worker.submit(latest)
+        assert latest_applied.wait(timeout=1.0)
+    finally:
+        worker.stop()
+
+    assert first.cancel_event.is_set()
+    assert latest.cancel_event.is_set() is False
+    assert applied == [2]

--- a/dimos/manipulation/visualization/viser/test_viser_visualization.py
+++ b/dimos/manipulation/visualization/viser/test_viser_visualization.py
@@ -351,7 +351,15 @@ class Operator:
             poses,
         )
 
-    def evaluate_pose_target(self, request: object) -> TargetEvaluationResult:
+    def evaluate_pose_target(
+        self,
+        request: object,
+        *,
+        timeout_seconds: float,
+        cancel_check: Callable[[], bool],
+    ) -> TargetEvaluationResult:
+        assert timeout_seconds > 0.0
+        assert cancel_check() is False
         group_ids = tuple(
             dict.fromkeys((*request.pose_targets.keys(), *request.auxiliary_group_ids))
         )  # type: ignore[attr-defined]
@@ -611,6 +619,10 @@ def test_cartesian_space_mode_requests_sparse_time_optimal_trajectory(
     auxiliary_group = group("arm", "gripper", ("j2",))
     gui, module, server = panel([pose_group, auxiliary_group], states("arm"))
     gui._toggle_group_selected(auxiliary_group.id)
+    accepted_pose = gui.state.accepted_pose_targets[pose_group.id]
+    gui.state.candidate_pose_targets[pose_group.id] = Pose(
+        {"position": [9.0, 9.0, 9.0], "orientation": [0.0, 0.0, 0.0, 1.0]}
+    )
     gui.state.target_status = TargetStatus.FEASIBLE
     gui._operation_worker.stop()
     monkeypatch.setattr(
@@ -628,6 +640,7 @@ def test_cartesian_space_mode_requests_sparse_time_optimal_trajectory(
     targets, config, auxiliary_ids = module.cartesian_plans[0]
     assert tuple(targets) == (pose_group.id,)
     assert targets[pose_group.id].frame_id == "world"
+    assert targets[pose_group.id].position == accepted_pose.position
     assert config.speed_mode == "time_optimal"  # type: ignore[attr-defined]
     assert config.dt == 0.05  # type: ignore[attr-defined]
     assert auxiliary_ids == (auxiliary_group.id,)
@@ -879,6 +892,9 @@ def test_theme_and_reference_scene_contract() -> None:
     assert server.gui.theme_kwargs["dark_mode"] is True
     assert server.gui.theme_kwargs["control_layout"] == "fixed"
     assert ViserVisualizationConfig().panel_enabled is True
+    assert ViserVisualizationConfig().target_evaluation_timeout == 0.1
+    with pytest.raises(ValueError):
+        ViserVisualizationConfig(target_evaluation_timeout=0.0)
 
 
 def test_preview_selection_rejects_malformed_before_visibility() -> None:
@@ -968,8 +984,9 @@ def test_initial_pose_targets_are_group_id_keyed_for_same_robot_groups() -> None
         gui.start()
         gui._toggle_group_selected(second.id)
 
-        assert list(gui.state.pose_targets[first.id].position) == [1.0, 0.0, 0.0]
-        assert list(gui.state.pose_targets[second.id].position) == [2.0, 0.0, 0.0]
+        assert list(gui.state.candidate_pose_targets[first.id].position) == [1.0, 0.0, 0.0]
+        assert list(gui.state.candidate_pose_targets[second.id].position) == [2.0, 0.0, 0.0]
+        assert gui.state.accepted_pose_targets == gui.state.candidate_pose_targets
     finally:
         gui.close()
 
@@ -1450,6 +1467,9 @@ def test_transform_control_callback_preserves_pose_through_gui_and_backend(
     submitted: list[TargetEvaluationRequest] = []
     gui._worker.submit = submitted.append  # type: ignore[method-assign]
     gui.start()
+    gui.state.planning_mode = PlanningMode.CARTESIAN_SPACE
+    accepted_before = dict(gui.state.accepted_pose_targets)
+    joints_before = JointState(gui.state.target_joints)
     control = scene._handles[f"{selected.id}:ee_control"]
     control.position = (1.0, 2.0, 3.0)
     control.wxyz = (0.4, 0.1, 0.2, 0.3)
@@ -1457,11 +1477,27 @@ def test_transform_control_callback_preserves_pose_through_gui_and_backend(
     control.callback(SimpleNamespace(target=control))
 
     request = submitted[-1]
-    assert list(gui.state.pose_targets[selected.id].position) == [1.0, 2.0, 3.0]
-    assert list(gui.state.pose_targets[selected.id].orientation) == [0.1, 0.2, 0.3, 0.4]
+    assert list(gui.state.candidate_pose_targets[selected.id].position) == [1.0, 2.0, 3.0]
+    assert list(gui.state.candidate_pose_targets[selected.id].orientation) == [0.1, 0.2, 0.3, 0.4]
     assert control.position == (1.0, 2.0, 3.0)
     assert control.wxyz == (0.4, 0.1, 0.2, 0.3)
-    assert request.pose_targets[selected.id] == gui.state.pose_targets[selected.id]
+    assert request.pose_targets[selected.id] == gui.state.candidate_pose_targets[selected.id]
+    assert gui.state.accepted_pose_targets == accepted_before
+
+    robot_visual_states: list[bool] = []
+    scene.set_target_robot_visual_state = lambda _robot_id, feasible: robot_visual_states.append(
+        feasible
+    )  # type: ignore[method-assign]
+    gui._apply_target_evaluation_result(
+        request,
+        TargetEvaluationResult(False, "TIMEOUT", "IK evaluation timed out", False),
+    )
+
+    assert gui.state.candidate_pose_targets[selected.id] == request.pose_targets[selected.id]
+    assert gui.state.accepted_pose_targets == accepted_before
+    assert gui.state.target_joints == joints_before
+    assert control.color == TARGET_CONTROL_INFEASIBLE_COLOR
+    assert robot_visual_states[-1] is True
     gui.close()
 
 


### PR DESCRIPTION
## Summary

- keep dragged Cartesian gizmos as provisional candidates until collision-free IK succeeds
- preserve the last accepted robot ghost, joint seed, and Cartesian planning target after failed or timed-out IK
- bound interactive IK to one attempt with a configurable 100 ms deadline
- cancel active and queued evaluations when a newer gizmo target arrives

## UX contract

The gizmo remains under the cursor when the target is unreachable. The UI marks that candidate infeasible and disables planning, while the robot ghost and planner retain the last accepted target. This change does not clamp the gizmo or approximate the workspace with a reachability map.

## Implementation

- split Viser pose state into candidate and accepted targets, with atomic commit after successful collision checking
- add deadline and cancellation controls to the shared kinematics protocol
- add cooperative interruption checks to Pink and Jacobian IK
- apply native time limits to Drake's SNOPT and IPOPT solvers; reject interactive evaluation for an unbounded solver
- make the target worker latest-request-wins for both queued and in-flight requests

## Testing

- 159 targeted manipulation, Viser, operator, worker, and IK tests pass
- `ruff check dimos/manipulation`
- mypy passes for all changed production modules
