### PR TITLE
feat(eval): add Evo manipulation Agent Harness

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -45,8 +45,36 @@ The callable produced during exploration and replayed without an agent during ev
 _Avoid_: Agent, exploration transcript, execution mode
 
 **Policy Artifact**:
-The serialized callable and human-readable source captured when `submit_policy(policy)` is called. One artifact is produced per benchmark task and reused across fresh evaluation episodes or seeds of that task. REPL outputs and the agent transcript are separate exploration evidence.
-_Avoid_: Exploration transcript, policy source
+The one Policy Candidate explicitly frozen at the end of exploration, including its serialized callable and human-readable source. It is reused across fresh evaluation episodes or seeds of that task; REPL outputs and the agent transcript are separate exploration evidence.
+_Avoid_: Policy Candidate, exploration transcript, policy source
+
+**Policy Candidate**:
+An immutable submitted policy paired with its Debug Trial and Trial Evidence, eligible to be selected as the task's Policy Artifact. Later submissions do not replace or mutate earlier candidates.
+_Avoid_: Policy Artifact, latest submission, experiment branch
+
+**Research Artifact**:
+The versioned Manipulation Agent Harness revised and measured by autoresearch to improve how later Policy Artifacts are produced across tasks. It excludes task instructions, robot primitives, benchmark cases, and native scoring.
+_Avoid_: Policy Artifact, skillbook, task policy
+
+**Manipulation Agent Harness**:
+The deterministic, task-independent exploration machinery that structures observation access, execution evidence, failure feedback, and policy-candidate lifecycle for an Agent producing a manipulation Policy Artifact. It aligns behavior through executable affordances and feedback rather than task-specific instructions, manipulation algorithms, or secondary verifier and diagnoser models.
+_Avoid_: System prompt, manipulation primitive, evaluator, skillbook
+
+**Trial Evidence**:
+The structured, non-privileged account of a completed Debug Trial presented by the Manipulation Agent Harness as a compact summary with on-demand drilldown into timelines, logs, frames, policy output, Memory2, and complete raw artifacts. It is indexed deterministically without model interpretation, prescribed diagnoses, or hidden evidence.
+_Avoid_: Evaluation Oracle, model critique, raw trial directory
+
+**Autoresearch Experiment**:
+One Evo-managed attempt to improve a Research Artifact from a selected parent, producing an immutable benchmark outcome, task-level traces, and experiment lineage. Experiments may branch from different parents and run concurrently.
+_Avoid_: Evaluation Run, linear iteration, debug trial
+
+**Research Frontier**:
+The Evo-managed set of non-dominated Autoresearch Experiments eligible to parent later experiments. For manipulation research, task-level native scores preserve specialists that an aggregate score would hide.
+_Avoid_: Champion, current best, single branch
+
+**Research Panel**:
+A configurable collection of Evaluation Cases measured by an autoresearch run, with one task-level score per case and a combined score across cases. Its composition may change between runs but is content-hashed and immutable within a run.
+_Avoid_: Benchmark suite, fixed four-case panel, seed list
 
 **Exploration Stage**:
 The unscored training stage in which an agent receives the selected benchmark task's exact instruction, uses a persistent Python REPL, and calls `submit_policy(policy)` to run complete debug trials of that task in fresh environments and blueprints. It is part of the evaluated code-as-policy system, while model latency remains outside the evaluation horizon.

--- a/dimos/agents/code_policy_core.py
+++ b/dimos/agents/code_policy_core.py
@@ -20,22 +20,34 @@ import base64
 from dataclasses import dataclass
 import inspect
 import os
+from pathlib import Path
 import queue
 import re
 import threading
 import time
-from typing import TYPE_CHECKING, Any, Literal, get_type_hints
+from typing import Any, Literal, get_type_hints
 
+import cloudpickle  # type: ignore[import-untyped]
 from pydantic import BaseModel, ConfigDict, Field
+import requests
 
+from dimos.benchmark.evaluation.protocol import (
+    PolicyCandidate,
+    PolicySnapshot,
+    TrialEvidence,
+    TrialOutcome,
+    TrialRun,
+)
 from dimos.core.global_config import global_config
+from dimos.porcelain.dimos import Dimos
 
-if TYPE_CHECKING:
-    from dimos.benchmark.evaluation.protocol import TrialRun
-
-MAX_EXECUTION_TIMEOUT_S = 600.0
+# The MCP transport abandons a request after roughly 300 seconds. Interrupt the
+# kernel with enough headroom for the timeout response to reach the agent; otherwise
+# the abandoned execution keeps the serial session lock and every later call is busy.
+MAX_EXECUTION_TIMEOUT_S = 240.0
 DEFAULT_OUTPUT_LIMIT = 32_000
 _SUBMISSION_URL_ENV = "DIMOS_CODE_POLICY_SUBMISSION_URL"
+_FREEZE_URL_ENV = "DIMOS_CODE_POLICY_FREEZE_URL"
 _SUBMISSION_TOKEN_ENV = "DIMOS_CODE_POLICY_SUBMISSION_TOKEN"
 _RECORDING_PATH_ENV = "DIMOS_CODE_POLICY_RECORDING_PATH"
 _ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
@@ -50,6 +62,7 @@ class SubmissionEnvironment(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
     kind: Literal["submission"] = "submission"
     submission_url: str = Field(min_length=1)
+    freeze_url: str = Field(min_length=1)
     submission_token: str = Field(min_length=1)
 
 
@@ -137,7 +150,7 @@ def _load_kernel_manager() -> type[Any]:
 def _bootstrap_source(environment: SubmissionEnvironment | LiveDimosEnvironment) -> str:
     if isinstance(environment, SubmissionEnvironment):
         return """
-from dimos.agents.code_policy_core import submit_policy
+from dimos.agents.code_policy_core import freeze_policy, submit_policy
 from dimos.porcelain.dimos import Dimos
 """
     return f"""
@@ -159,13 +172,14 @@ def _kernel_environment(config: CodePolicySessionConfig) -> dict[str, str]:
     result["DIMOS_TRANSPORT"] = global_config.transport
     if isinstance(config.environment, SubmissionEnvironment):
         result[_SUBMISSION_URL_ENV] = config.environment.submission_url
+        result[_FREEZE_URL_ENV] = config.environment.freeze_url
         result[_SUBMISSION_TOKEN_ENV] = config.environment.submission_token
     else:
         result[_RECORDING_PATH_ENV] = config.environment.recording_path
     return result
 
 
-def submit_policy(policy: Any) -> TrialRun:
+def submit_policy(policy: Any) -> PolicyCandidate:
     """Submit a typed callable from the exploration kernel for one fresh trial."""
     validate_policy_callable(policy)
     try:
@@ -173,13 +187,9 @@ def submit_policy(policy: Any) -> TrialRun:
     except (OSError, TypeError) as exc:
         raise TypeError("policy source is unavailable; define it in the exploration REPL") from exc
     try:
-        import cloudpickle  # type: ignore[import-untyped]
-
         serialized = cloudpickle.dumps(policy)
     except Exception as exc:
         raise TypeError(f"policy is not serializable: {type(exc).__name__}: {exc}") from exc
-
-    import requests
 
     response = requests.post(
         os.environ[_SUBMISSION_URL_ENV],
@@ -190,24 +200,50 @@ def submit_policy(policy: Any) -> TrialRun:
     if response.status_code != 200:
         detail = response.json().get("error", response.text)
         raise RuntimeError(f"policy submission failed: {detail}")
-    from pathlib import Path
-
-    from dimos.benchmark.evaluation.protocol import TrialOutcome, TrialRun
-
     payload = response.json()
-    return TrialRun(
+    trial = TrialRun(
         run_id=payload["run_id"],
         outcome=TrialOutcome(**payload["outcome"]),
         artifacts=Path(payload["artifacts"]),
         log_path=Path(payload["log_path"]),
         memory_path=Path(payload["memory_path"]),
+        policy_output=payload["policy_output"],
     )
+    policy_payload = payload["policy"]
+    candidate_id = payload["candidate_id"]
+    return PolicyCandidate(
+        id=candidate_id,
+        policy=PolicySnapshot(
+            source=policy_payload["source"],
+            sha256=policy_payload["sha256"],
+        ),
+        evidence=TrialEvidence(
+            candidate_id=candidate_id,
+            trial=trial,
+            remaining_submissions=payload["remaining_submissions"],
+        ),
+    )
+
+
+def freeze_policy(candidate: PolicyCandidate) -> None:
+    """Irreversibly select a candidate from the current exploration."""
+    if not isinstance(candidate, PolicyCandidate):
+        raise TypeError("freeze_policy requires a PolicyCandidate returned by submit_policy")
+    import requests
+
+    response = requests.post(
+        os.environ[_FREEZE_URL_ENV],
+        headers={"Authorization": f"Bearer {os.environ[_SUBMISSION_TOKEN_ENV]}"},
+        json={"candidate_id": candidate.id},
+        timeout=None,
+    )
+    if response.status_code != 200:
+        detail = response.json().get("error", response.text)
+        raise RuntimeError(f"policy freeze failed: {detail}")
 
 
 def validate_policy_callable(policy: Any) -> None:
     """Enforce the one canonical callable contract before a trial is launched."""
-    from dimos.porcelain.dimos import Dimos
-
     if not inspect.isfunction(policy) or inspect.iscoroutinefunction(policy):
         raise TypeError("policy must be a synchronous Python function")
     if policy.__name__ != "policy":

--- a/dimos/agents/code_policy_server.py
+++ b/dimos/agents/code_policy_server.py
@@ -18,7 +18,9 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import binascii
 from collections.abc import Callable
+import json
 import logging
 import secrets
 import socket
@@ -39,7 +41,7 @@ from dimos.agents.code_policy_core import (
     LiveDimosEnvironment,
     SubmissionEnvironment,
 )
-from dimos.benchmark.evaluation.protocol import TrialRun
+from dimos.benchmark.evaluation.protocol import PolicyCandidate, PolicyRequestError
 
 SUBMISSION_PYTHON_EXEC_DESCRIPTION = """Execute Python in a persistent trusted, unsandboxed session.
 
@@ -53,7 +55,8 @@ Imports, functions, and variables persist between calls. The session provides
 `app` for DimOS RPCs and `memory` for read-only public observations.
 """
 
-SubmissionHandler = Callable[[str, bytes], TrialRun]
+SubmissionHandler = Callable[[str, bytes], PolicyCandidate]
+FreezeHandler = Callable[[str], PolicyCandidate]
 
 _NOISY_MCP_TRANSPORT_LOGGERS = (
     "mcp.server.streamable_http",
@@ -68,14 +71,18 @@ class CodePolicyMcpServer:
         self,
         submission_handler: SubmissionHandler | None = None,
         *,
+        freeze_handler: FreezeHandler | None = None,
         live_recording_path: str | None = None,
         host: str = "127.0.0.1",
     ) -> None:
         if (submission_handler is None) == (live_recording_path is None):
             raise ValueError("configure exactly one submission or live DimOS environment")
+        if (submission_handler is None) != (freeze_handler is None):
+            raise ValueError("submission and freeze handlers must be configured together")
         self.host = host
         self.port = 0
         self.submission_handler = submission_handler
+        self.freeze_handler = freeze_handler
         self.live_recording_path = live_recording_path
         self.submission_token = secrets.token_urlsafe(32)
         self.session: CodePolicySession | None = None
@@ -115,6 +122,7 @@ class CodePolicyMcpServer:
             host=host,
         )
         self.app.routes.append(Route("/submit-policy", self._submit_policy, methods=["POST"]))
+        self.app.routes.append(Route("/freeze-policy", self._freeze_policy, methods=["POST"]))
         self._server: uvicorn.Server | None = None
         self._thread: threading.Thread | None = None
         self._socket: socket.socket | None = None
@@ -128,33 +136,62 @@ class CodePolicyMcpServer:
     async def _submit_policy(self, request: Request) -> JSONResponse:
         if request.headers.get("authorization") != f"Bearer {self.submission_token}":
             return JSONResponse({"error": "unauthorized"}, status_code=401)
+        if self.submission_handler is None:
+            return JSONResponse({"error": "policy submission is disabled"}, status_code=404)
         try:
-            if self.submission_handler is None:
-                return JSONResponse({"error": "policy submission is disabled"}, status_code=404)
             body = await request.json()
             source = str(body["source"])
             serialized = base64.b64decode(str(body["serialized"]), validate=True)
-            trial = await asyncio.to_thread(self.submission_handler, source, serialized)
-        except Exception as exc:
+        except (binascii.Error, json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
             return JSONResponse(
                 {"error": f"{type(exc).__name__}: {exc}"},
                 status_code=400,
             )
+        try:
+            candidate = await asyncio.to_thread(self.submission_handler, source, serialized)
+        except PolicyRequestError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=400)
         return JSONResponse(
             {
-                "run_id": trial.run_id,
-                "outcome": {
-                    "success": trial.outcome.success,
-                    "reward": trial.outcome.reward,
-                    "status": trial.outcome.status,
-                    "error": trial.outcome.error,
-                    "duration_seconds": trial.outcome.duration_seconds,
+                "candidate_id": candidate.id,
+                "policy": {
+                    "source": candidate.policy.source,
+                    "sha256": candidate.policy.sha256,
                 },
-                "artifacts": str(trial.artifacts),
-                "log_path": str(trial.log_path),
-                "memory_path": str(trial.memory_path),
+                "remaining_submissions": candidate.evidence.remaining_submissions,
+                "run_id": candidate.trial.run_id,
+                "outcome": {
+                    "success": candidate.trial.outcome.success,
+                    "reward": candidate.trial.outcome.reward,
+                    "status": candidate.trial.outcome.status,
+                    "error": candidate.trial.outcome.error,
+                    "duration_seconds": candidate.trial.outcome.duration_seconds,
+                },
+                "artifacts": str(candidate.trial.artifacts),
+                "log_path": str(candidate.trial.log_path),
+                "memory_path": str(candidate.trial.memory_path),
+                "policy_output": candidate.trial.policy_output,
             }
         )
+
+    async def _freeze_policy(self, request: Request) -> JSONResponse:
+        if request.headers.get("authorization") != f"Bearer {self.submission_token}":
+            return JSONResponse({"error": "unauthorized"}, status_code=401)
+        if self.freeze_handler is None:
+            return JSONResponse({"error": "policy freezing is disabled"}, status_code=404)
+        try:
+            body = await request.json()
+            candidate_id = str(body["candidate_id"])
+        except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+            return JSONResponse(
+                {"error": f"{type(exc).__name__}: {exc}"},
+                status_code=400,
+            )
+        try:
+            candidate = await asyncio.to_thread(self.freeze_handler, candidate_id)
+        except PolicyRequestError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=400)
+        return JSONResponse({"candidate_id": candidate.id, "frozen": True})
 
     def start(self) -> None:
         if self._thread is not None:
@@ -172,6 +209,7 @@ class CodePolicyMcpServer:
                 environment=(
                     SubmissionEnvironment(
                         submission_url=f"http://{self.host}:{self.port}/submit-policy",
+                        freeze_url=f"http://{self.host}:{self.port}/freeze-policy",
                         submission_token=self.submission_token,
                     )
                     if self.submission_handler is not None

--- a/dimos/agents/test_code_policy_core.py
+++ b/dimos/agents/test_code_policy_core.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
 
@@ -33,7 +34,15 @@ from dimos.agents.code_policy_core import (
     validate_policy_callable,
 )
 from dimos.agents.code_policy_server import CodePolicyMcpServer
-from dimos.benchmark.evaluation.protocol import TrialOutcome, TrialRun
+from dimos.benchmark.evaluation.protocol import (
+    PolicyArtifact,
+    PolicyCandidate,
+    PolicyRequestError,
+    PolicySnapshot,
+    TrialEvidence,
+    TrialOutcome,
+    TrialRun,
+)
 from dimos.memory2.store.sqlite import SqliteStore
 from dimos.porcelain.dimos import Dimos
 
@@ -58,7 +67,7 @@ def test_validate_policy_callable_rejects_noncanonical_functions(candidate, mess
         validate_policy_callable(candidate)
 
 
-def test_exploration_repl_submits_callable_and_receives_trial(tmp_path: Path) -> None:
+def test_exploration_repl_submits_candidate_and_freezes_it(tmp_path: Path) -> None:
     artifacts = tmp_path / "trial"
     artifacts.mkdir()
     log_path = artifacts / "main.jsonl"
@@ -68,10 +77,17 @@ def test_exploration_repl_submits_callable_and_receives_trial(tmp_path: Path) ->
         memory.stream("events", str).append("attempted")
     submitted: list[object] = []
 
-    def handle(source: str, serialized: bytes) -> TrialRun:
+    policy_artifact = PolicyArtifact(
+        source="def policy(app: Dimos) -> None: ...\n",
+        serialized=cloudpickle.dumps(policy),
+        sha256="digest",
+    )
+    handled_candidates: list[PolicyCandidate] = []
+
+    def handle(source: str, serialized: bytes) -> PolicyCandidate:
         submitted.append(cloudpickle.loads(serialized))
         assert "def policy" in source
-        return TrialRun(
+        trial = TrialRun(
             run_id="debug-1",
             outcome=TrialOutcome(
                 success=False,
@@ -83,19 +99,70 @@ def test_exploration_repl_submits_callable_and_receives_trial(tmp_path: Path) ->
             artifacts=artifacts,
             log_path=log_path,
             memory_path=memory_path,
+            policy_output="planner diagnostic",
         )
+        candidate = PolicyCandidate(
+            id="candidate-0001-digest",
+            policy=PolicySnapshot(
+                source=policy_artifact.source,
+                sha256=policy_artifact.sha256,
+            ),
+            evidence=TrialEvidence("candidate-0001-digest", trial, 4),
+        )
+        handled_candidates.append(candidate)
+        return candidate
 
-    with CodePolicyMcpServer(handle) as server:
+    frozen: list[str] = []
+
+    def freeze(candidate_id: str) -> PolicyCandidate:
+        frozen.append(candidate_id)
+        return handled_candidates[0]
+
+    with CodePolicyMcpServer(handle, freeze_handler=freeze) as server:
         assert server.session is not None
         result = server.session.python_exec(
             "def policy(app: Dimos) -> None:\n"
             "    app.list_modules()\n\n"
-            "trial = submit_policy(policy)\n"
-            "(trial.run_id, trial.outcome.success)"
+            "candidate = submit_policy(policy)\n"
+            "freeze_policy(candidate)\n"
+            "(candidate.id, candidate.trial.run_id, candidate.evidence.policy_output)"
         )
 
-    assert "('debug-1', False)" in result.text
+    assert "('candidate-0001-digest', 'debug-1', 'planner diagnostic')" in result.text
     assert len(submitted) == 1
+    assert frozen == ["candidate-0001-digest"]
+
+
+def test_submission_endpoint_maps_contract_errors_to_bad_request(mocker: MockerFixture) -> None:
+    def reject(_source: str, _serialized: bytes) -> PolicyCandidate:
+        raise PolicyRequestError("submission budget exhausted")
+
+    server = CodePolicyMcpServer(reject, freeze_handler=lambda _candidate_id: None)  # type: ignore[arg-type]
+    request = mocker.Mock()
+    request.headers = {"authorization": f"Bearer {server.submission_token}"}
+    request.json = mocker.AsyncMock(
+        return_value={"source": "def policy(app): ...", "serialized": "eA=="}
+    )
+
+    response = asyncio.run(server._submit_policy(request))
+
+    assert response.status_code == 400
+    assert json.loads(response.body) == {"error": "submission budget exhausted"}
+
+
+def test_submission_endpoint_does_not_mask_server_bugs(mocker: MockerFixture) -> None:
+    def crash(_source: str, _serialized: bytes) -> PolicyCandidate:
+        raise AssertionError("server bug")
+
+    server = CodePolicyMcpServer(crash, freeze_handler=lambda _candidate_id: None)  # type: ignore[arg-type]
+    request = mocker.Mock()
+    request.headers = {"authorization": f"Bearer {server.submission_token}"}
+    request.json = mocker.AsyncMock(
+        return_value={"source": "def policy(app): ...", "serialized": "eA=="}
+    )
+
+    with pytest.raises(AssertionError, match="server bug"):
+        asyncio.run(server._submit_policy(request))
 
 
 def test_live_repl_bootstraps_public_runtime_without_credentials(
@@ -145,6 +212,7 @@ def test_python_exec_returns_displayed_image() -> None:
         CodePolicySessionConfig(
             environment=SubmissionEnvironment(
                 submission_url="http://127.0.0.1:1",
+                freeze_url="http://127.0.0.1:1",
                 submission_token="unused",
             )
         )
@@ -163,3 +231,22 @@ def test_python_exec_returns_displayed_image() -> None:
     assert len(result.images) == 1
     assert result.images[0].mime_type in {"image/png", "image/jpeg"}
     assert result.images[0].data
+
+
+def test_python_exec_rejects_timeout_longer_than_transport_request() -> None:
+    session = CodePolicySession(
+        CodePolicySessionConfig(
+            environment=SubmissionEnvironment(
+                submission_url="http://127.0.0.1:1",
+                freeze_url="http://127.0.0.1:1",
+                submission_token="unused",
+            )
+        )
+    )
+    session.start()
+    try:
+        result = session.python_exec("1 + 1", timeout_s=300.0)
+    finally:
+        session.stop()
+
+    assert result.text == "timeout_s must be in (0, 240]"

--- a/dimos/benchmark/evaluation/protocol.py
+++ b/dimos/benchmark/evaluation/protocol.py
@@ -17,10 +17,11 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from enum import StrEnum
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
 
 from pydantic import BaseModel
 
@@ -33,14 +34,27 @@ from dimos.benchmark.evaluation.progress import ProgressSink
 
 if TYPE_CHECKING:
     from dimos.memory2.store.base import Store
+    from dimos.memory2.stream import Stream
+
+
+class PolicyRequestError(RuntimeError):
+    """A submitted policy or lifecycle request violates the harness contract."""
 
 
 @dataclass(frozen=True)
 class PolicyArtifact:
-    """A task-level callable captured during exploration."""
+    """An immutable task-level callable captured during exploration."""
 
-    source_path: Path
-    serialized_path: Path
+    source: str
+    serialized: bytes = field(repr=False)
+    sha256: str
+
+
+@dataclass(frozen=True)
+class PolicySnapshot:
+    """Agent-visible identity of an immutable submitted policy."""
+
+    source: str
     sha256: str
 
 
@@ -48,7 +62,8 @@ class PolicyArtifact:
 class PolicyExecution:
     status: Literal["completed", "policy_error", "stopped", "infrastructure_error"]
     duration_seconds: float
-    error: str | None = None
+    error: str | None
+    output: str
 
 
 @dataclass(frozen=True)
@@ -69,6 +84,7 @@ class TrialRun:
     artifacts: Path
     log_path: Path
     memory_path: Path
+    policy_output: str
 
     def read_logs(
         self,
@@ -76,6 +92,7 @@ class TrialRun:
         module: str | None = None,
         tail: int | None = None,
     ) -> tuple[dict[str, object], ...]:
+        # Load log parsing only when an agent drills into recorded evidence.
         from dimos.core.log_viewer import read_log
 
         records = [json.loads(line) for line in read_log(self.log_path, count=None)]
@@ -89,9 +106,152 @@ class TrialRun:
 
     def open_memory(self) -> Store:
         """Open the completed trial's Memory2 recording read-only."""
+        # Load the storage backend only when an agent opens the recording.
         from dimos.memory2.store.sqlite import SqliteStore
 
         return SqliteStore(path=str(self.memory_path), must_exist=True, read_only=True)
+
+
+class EvidenceCategory(StrEnum):
+    """Recorded evidence classes available for deterministic drilldown."""
+
+    OUTCOME = "outcome"
+    TIMELINE = "timeline"
+    LOGS = "logs"
+    POLICY_OUTPUT = "policy_output"
+    MEMORY = "memory"
+    FRAMES = "frames"
+    ARTIFACTS = "artifacts"
+
+
+@dataclass(frozen=True)
+class EvidenceFrame:
+    """A stable pointer to a recorded visual observation."""
+
+    stream: str
+    position: Literal["initial", "terminal"]
+    timestamp: float
+
+
+@dataclass(frozen=True)
+class TrialEvidenceSummary:
+    """Small non-diagnostic view returned automatically to the Agent."""
+
+    candidate_id: str
+    success: bool
+    status: str
+    duration_seconds: float
+    remaining_submissions: int
+    categories: tuple[EvidenceCategory, ...]
+    frames: tuple[EvidenceFrame, ...]
+
+
+@dataclass(frozen=True)
+class TrialEvidence:
+    """Progressively disclosed, read-only evidence for one Debug Trial."""
+
+    candidate_id: str
+    trial: TrialRun
+    remaining_submissions: int
+
+    @property
+    def summary(self) -> TrialEvidenceSummary:
+        categories = [
+            EvidenceCategory.OUTCOME,
+            EvidenceCategory.TIMELINE,
+            EvidenceCategory.LOGS,
+            EvidenceCategory.POLICY_OUTPUT,
+            EvidenceCategory.MEMORY,
+            EvidenceCategory.ARTIFACTS,
+        ]
+        frames = self.frame_index()
+        if frames:
+            categories.append(EvidenceCategory.FRAMES)
+        return TrialEvidenceSummary(
+            candidate_id=self.candidate_id,
+            success=self.trial.outcome.success,
+            status=self.trial.outcome.status,
+            duration_seconds=self.trial.outcome.duration_seconds,
+            remaining_submissions=self.remaining_submissions,
+            categories=tuple(categories),
+            frames=frames,
+        )
+
+    def timeline(self, *, tail: int | None = None) -> tuple[dict[str, object], ...]:
+        """Return recorded log events in their persisted order."""
+        return self.trial.read_logs(tail=tail)
+
+    def logs(
+        self, *, module: str | None = None, tail: int | None = None
+    ) -> tuple[dict[str, object], ...]:
+        """Return all logs, or deterministically filter them by module."""
+        return self.trial.read_logs(module=module, tail=tail)
+
+    @property
+    def policy_output(self) -> str:
+        return self.trial.policy_output
+
+    @property
+    def artifacts(self) -> Path:
+        return self.trial.artifacts
+
+    def open_memory(self) -> Store:
+        return self.trial.open_memory()
+
+    def frame_index(self) -> tuple[EvidenceFrame, ...]:
+        """Index initial and terminal frames from recorded color streams."""
+        if not self.trial.memory_path.is_file():
+            return ()
+        frames: list[EvidenceFrame] = []
+        with self.open_memory() as memory:
+            for name in sorted(memory.list_streams()):
+                if not name.endswith("color_image"):
+                    continue
+                stream: Stream[Any] = memory.stream(name)
+                if not stream.exists() or stream.count() == 0:
+                    continue
+                initial = stream.first()
+                terminal = stream.last()
+                frames.append(EvidenceFrame(name, "initial", initial.ts))
+                frames.append(EvidenceFrame(name, "terminal", terminal.ts))
+        return tuple(frames)
+
+    def frame(self, stream: str, position: Literal["initial", "terminal"] = "terminal") -> object:
+        """Load one selected visual observation, or report it unavailable."""
+        with self.open_memory() as memory:
+            if stream not in memory.list_streams() or not stream.endswith("color_image"):
+                raise LookupError(f"visual evidence unavailable for stream {stream!r}")
+            recorded: Stream[Any] = memory.stream(stream)
+            if not recorded.exists() or recorded.count() == 0:
+                raise LookupError(f"visual evidence unavailable for stream {stream!r}")
+            return recorded.first() if position == "initial" else recorded.last()
+
+    def __repr__(self) -> str:
+        summary = self.summary
+        return (
+            "TrialEvidence("
+            f"candidate_id={summary.candidate_id!r}, success={summary.success!r}, "
+            f"status={summary.status!r}, duration_seconds={summary.duration_seconds:.3f}, "
+            f"remaining_submissions={summary.remaining_submissions}, "
+            f"categories={tuple(category.value for category in summary.categories)!r}, "
+            f"frames={summary.frames!r})"
+        )
+
+
+@dataclass(frozen=True)
+class PolicyCandidate:
+    """An immutable submitted policy and its Debug Trial evidence."""
+
+    id: str
+    policy: PolicySnapshot
+    evidence: TrialEvidence
+
+    @property
+    def trial(self) -> TrialRun:
+        return self.evidence.trial
+
+    def __repr__(self) -> str:
+        return f"PolicyCandidate(id={self.id!r}, evidence={self.evidence!r})"
 
 
 DebugTrialSubmitter = Callable[[PolicyArtifact, int, Path], TrialRun]

--- a/dimos/benchmark/evaluation/runtime.py
+++ b/dimos/benchmark/evaluation/runtime.py
@@ -16,14 +16,20 @@
 
 from __future__ import annotations
 
+from contextlib import redirect_stderr, redirect_stdout
 import hashlib
+import io
 import json
 import multiprocessing
 from pathlib import Path
+import pickle
 import shutil
 import time
-from typing import Any, Literal
+from typing import Any, Literal, TextIO
 
+import cloudpickle  # type: ignore[import-untyped]
+
+from dimos.agents.code_policy_core import validate_policy_callable
 from dimos.agents.code_policy_server import CodePolicyMcpServer
 from dimos.benchmark.evaluation.models import ArtifactReference, RuntimeCondition, RuntimeIdentity
 from dimos.benchmark.evaluation.pi_process import PI_VERSION, PiCliRunner, PiRunError
@@ -32,26 +38,34 @@ from dimos.benchmark.evaluation.protocol import (
     DebugTrialSubmitter,
     ExplorationOutcome,
     PolicyArtifact,
+    PolicyCandidate,
     PolicyExecution,
     PolicyExecutionHandle,
+    PolicyRequestError,
+    PolicySnapshot,
+    TrialEvidence,
     TrialRun,
 )
 
 CODE_POLICY_PROFILE: Literal["code-policy-v1"] = "code-policy-v1"
 TURN_TIMEOUT_SECONDS = 600.0
 DEFAULT_MAX_SUBMISSIONS = 5
+MAX_POLICY_OUTPUT = 32_000
 
 SYSTEM_INSTRUCTIONS = """You are a CodePolicy exploration agent.
 
 Use the single `python_exec` tool to solve the supplied robotics task. Python
 executes in a persistent trusted environment. Define a synchronous function
 with the exact signature `def policy(app: Dimos) -> None`, then call
-`submit_policy(policy)` to test it. Every accepted submission starts a fresh
+`submit_policy(policy)` to test it. Every accepted submission returns an immutable
+PolicyCandidate and starts a fresh
 debug environment and a fresh policy-only DimOS blueprint. Inspect the returned
-TrialRun's outcome, logs, Memory2 recording, and artifacts to diagnose failures.
-You may submit at most five trials. The last accepted submission becomes the
-task-level policy evaluated later without an agent. Do not connect to DimOS
-directly from the exploration REPL.
+candidate's bounded evidence summary, then drill into its timeline, filtered logs,
+frames, policy output, read-only Memory2 recording, or raw artifacts as needed.
+You may submit at most five trials. Before finishing, call
+`freeze_policy(candidate)` exactly once to select the task-level policy evaluated
+later without an agent. Freezing is irreversible and closes submissions. Do not
+connect to DimOS directly from the exploration REPL.
 """
 
 
@@ -118,7 +132,7 @@ class CodePolicyRuntimeFactory:
             max_submissions=max_submissions,
             record_artifact=self._runtime_artifacts.append,
         )
-        server = CodePolicyMcpServer(manager.submit)
+        server = CodePolicyMcpServer(manager.submit, freeze_handler=manager.freeze)
         server.start()
         try:
             user_message = _assemble_user_message(evaluation_protocol, task_input)
@@ -161,8 +175,8 @@ class CodePolicyRuntimeFactory:
             )
             if result.stderr:
                 self._record_text(path, relative, "stderr.log", result.stderr, "Pi stderr")
-            policy = manager.last_policy
-            error = None if policy is not None else "Pi did not submit a valid policy"
+            policy = manager.frozen_policy
+            error = None if policy is not None else "Pi did not freeze a policy candidate"
             outcome = ExplorationOutcome(
                 status="valid" if policy is not None else "invalid",
                 policy=policy,
@@ -177,6 +191,11 @@ class CodePolicyRuntimeFactory:
                 json.dumps(
                     {
                         "status": outcome.status,
+                        "frozen_candidate_id": (
+                            manager.frozen_candidate.id
+                            if manager.frozen_candidate is not None
+                            else None
+                        ),
                         "policy_sha256": policy.sha256 if policy is not None else None,
                         "submission_count": manager.accepted_count,
                         "error": error,
@@ -209,7 +228,13 @@ class CodePolicyRuntimeFactory:
         start_event = context.Event()
         process = context.Process(
             target=_execute_policy_worker,
-            args=(str(policy.serialized_path), str(memory_path), worker_messages, start_event),
+            args=(
+                policy.serialized,
+                str(memory_path),
+                str(memory_path.parent / "policy-output.log"),
+                worker_messages,
+                start_event,
+            ),
             daemon=True,
         )
         try:
@@ -223,7 +248,12 @@ class CodePolicyRuntimeFactory:
                 _stop_process(process)
                 messages.close()
                 raise RuntimeError(error or "policy worker failed before readiness")
-            return _PolicyExecutionProcess(process, messages, start_event)
+            return _PolicyExecutionProcess(
+                process,
+                messages,
+                start_event,
+                memory_path.parent / "policy-output.log",
+            )
         except BaseException:
             if process.is_alive():
                 _stop_process(process)
@@ -351,19 +381,31 @@ class _SubmissionManager:
         self.submit_debug_trial = submit_debug_trial
         self.max_submissions = max_submissions
         self.record_artifact = record_artifact
-        self.last_policy: PolicyArtifact | None = None
-        self.trials: list[TrialRun] = []
+        self.candidates: list[PolicyCandidate] = []
+        self._policies: dict[str, PolicyArtifact] = {}
+        self.frozen_candidate: PolicyCandidate | None = None
         self.accepted_count = 0
 
-    def submit(self, source: str, serialized: bytes) -> TrialRun:
+    @property
+    def trials(self) -> list[TrialRun]:
+        return [candidate.trial for candidate in self.candidates]
+
+    @property
+    def frozen_policy(self) -> PolicyArtifact | None:
+        if self.frozen_candidate is None:
+            return None
+        return self._policies[self.frozen_candidate.id]
+
+    def submit(self, source: str, serialized: bytes) -> PolicyCandidate:
+        if self.frozen_candidate is not None:
+            raise PolicyRequestError("submissions are closed after policy freezing")
         if self.accepted_count >= self.max_submissions:
-            raise RuntimeError(f"submission budget exhausted ({self.max_submissions})")
-        import cloudpickle  # type: ignore[import-untyped]
-
-        from dimos.agents.code_policy_core import validate_policy_callable
-
-        policy_callable = cloudpickle.loads(serialized)
-        validate_policy_callable(policy_callable)
+            raise PolicyRequestError(f"submission budget exhausted ({self.max_submissions})")
+        try:
+            policy_callable = cloudpickle.loads(serialized)
+            validate_policy_callable(policy_callable)
+        except (EOFError, TypeError, ValueError, pickle.UnpicklingError) as exc:
+            raise PolicyRequestError(str(exc)) from exc
         self.accepted_count += 1
         submission_number = self.accepted_count
         relative = self.relative_path / f"submission-{submission_number:04d}"
@@ -374,11 +416,10 @@ class _SubmissionManager:
         source_path.write_text(source.rstrip() + "\n", encoding="utf-8")
         serialized_path.write_bytes(serialized)
         policy = PolicyArtifact(
-            source_path=source_path,
-            serialized_path=serialized_path,
+            source=source.rstrip() + "\n",
+            serialized=serialized,
             sha256=hashlib.sha256(serialized).hexdigest(),
         )
-        self.last_policy = policy
         self.record_artifact(_artifact(relative / "policy.py", "Policy source", "text/x-python"))
         self.record_artifact(
             _artifact(relative / "policy.pkl", "Serialized policy", "application/octet-stream")
@@ -386,60 +427,93 @@ class _SubmissionManager:
         trial_path = submission_path / "trial"
         trial_path.mkdir()
         trial = self.submit_debug_trial(policy, submission_number, trial_path)
-        self.trials.append(trial)
-        return trial
+        candidate_id = f"candidate-{submission_number:04d}-{policy.sha256[:12]}"
+        candidate = PolicyCandidate(
+            id=candidate_id,
+            policy=PolicySnapshot(source=policy.source, sha256=policy.sha256),
+            evidence=TrialEvidence(
+                candidate_id=candidate_id,
+                trial=trial,
+                remaining_submissions=self.max_submissions - self.accepted_count,
+            ),
+        )
+        self._policies[candidate_id] = policy
+        self.candidates.append(candidate)
+        return candidate
+
+    def freeze(self, candidate_id: str) -> PolicyCandidate:
+        if self.frozen_candidate is not None:
+            raise PolicyRequestError("policy candidate is already frozen")
+        candidate = next(
+            (candidate for candidate in self.candidates if candidate.id == candidate_id), None
+        )
+        if candidate is None:
+            raise PolicyRequestError("candidate does not belong to this exploration")
+        self.frozen_candidate = candidate
+        return candidate
 
 
 def _execute_policy_worker(
-    serialized_path: str,
+    serialized: bytes,
     memory_path: str,
+    output_path: str,
     messages: Any,
     start_event: Any,
 ) -> None:
-    try:
+    with _BoundedPolicyWriter(Path(output_path)) as output:
         try:
-            import cloudpickle
+            try:
+                policy = cloudpickle.loads(serialized)
+            except Exception as exc:
+                messages.send(
+                    ("infrastructure_error", f"policy load failed: {type(exc).__name__}: {exc}")
+                )
+                return
+            try:
+                # Keep process-heavy runtime imports inside the spawned worker.
+                from dimos.memory2.store.sqlite import SqliteStore
+                from dimos.porcelain.dimos import Dimos
 
-            with Path(serialized_path).open("rb") as handle:
-                policy = cloudpickle.load(handle)
-        except Exception as exc:
-            messages.send(
-                ("infrastructure_error", f"policy load failed: {type(exc).__name__}: {exc}")
-            )
-            return
-        try:
-            from dimos.memory2.store.sqlite import SqliteStore
-            from dimos.porcelain.dimos import Dimos
-
-            memory = SqliteStore(path=memory_path, must_exist=True, read_only=True)
-            memory.start()
-            app = Dimos.connect(memory=memory)
-        except Exception as exc:
-            messages.send(
-                ("infrastructure_error", f"DimOS connection failed: {type(exc).__name__}: {exc}")
-            )
-            return
-        messages.send(("ready", None))
-        start_event.wait()
-        try:
-            result = policy(app)
-            if result is not None:
-                raise TypeError("policy(app) must return None")
-        except Exception as exc:
-            messages.send(("policy_error", f"{type(exc).__name__}: {exc}"))
-        else:
-            messages.send(("completed", None))
+                memory = SqliteStore(path=memory_path, must_exist=True, read_only=True)
+                memory.start()
+                app = Dimos.connect(memory=memory)
+            except Exception as exc:
+                messages.send(
+                    (
+                        "infrastructure_error",
+                        f"DimOS connection failed: {type(exc).__name__}: {exc}",
+                    )
+                )
+                return
+            messages.send(("ready", None))
+            start_event.wait()
+            try:
+                with redirect_stdout(output), redirect_stderr(output):
+                    result = policy(app)
+                if result is not None:
+                    raise TypeError("policy(app) must return None")
+            except Exception as exc:
+                messages.send(("policy_error", f"{type(exc).__name__}: {exc}"))
+            else:
+                messages.send(("completed", None))
+            finally:
+                app.stop()
         finally:
-            app.stop()
-    finally:
-        messages.close()
+            messages.close()
 
 
 class _PolicyExecutionProcess:
-    def __init__(self, process: Any, messages: Any, start_event: Any) -> None:
+    def __init__(
+        self,
+        process: Any,
+        messages: Any,
+        start_event: Any,
+        output_path: Path,
+    ) -> None:
         self._process = process
         self._messages = messages
         self._start_event = start_event
+        self._output_path = output_path
         self._started_at: float | None = None
         self._finished: PolicyExecution | None = None
 
@@ -475,12 +549,56 @@ class _PolicyExecutionProcess:
                 status = "infrastructure_error"
                 error = f"policy worker exited with code {self._process.exitcode} without a result"
         self._messages.close()
+        output = self._output_path.read_text(encoding="utf-8")
         self._finished = PolicyExecution(
             status=status,
             duration_seconds=time.monotonic() - self._started_at,
             error=error,
+            output=output,
         )
         return self._finished
+
+
+class _BoundedPolicyWriter(io.TextIOBase):
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._handle: TextIO | None = None
+        self._remaining = MAX_POLICY_OUTPUT
+        self._truncated = False
+
+    def __enter__(self) -> _BoundedPolicyWriter:
+        self._handle = self._path.open("w", encoding="utf-8")
+        return self
+
+    def __exit__(
+        self,
+        *_args: object,
+    ) -> None:
+        if self._handle is not None:
+            self._handle.close()
+
+    def write(self, value: str) -> int:
+        if self._handle is None:
+            raise RuntimeError("policy output is not open")
+        if self._remaining <= 0:
+            if not self._truncated:
+                self._handle.write("\n... [policy output truncated]")
+                self._handle.flush()
+                self._truncated = True
+            return len(value)
+        if len(value) <= self._remaining:
+            written = value
+        else:
+            written = value[: self._remaining] + "\n... [policy output truncated]"
+            self._truncated = True
+        self._handle.write(written)
+        self._handle.flush()
+        self._remaining -= len(written)
+        return len(value)
+
+    def flush(self) -> None:
+        if self._handle is not None:
+            self._handle.flush()
 
 
 def _stop_process(process: Any) -> None:

--- a/dimos/benchmark/evaluation/test_policy_runtime.py
+++ b/dimos/benchmark/evaluation/test_policy_runtime.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import multiprocessing
 from pathlib import Path
@@ -24,7 +25,13 @@ import pytest
 
 from dimos.benchmark.evaluation.models import RuntimeCondition
 from dimos.benchmark.evaluation.pi_process import PiRunError, PiRunResult
-from dimos.benchmark.evaluation.protocol import PolicyArtifact, TrialOutcome, TrialRun
+from dimos.benchmark.evaluation.protocol import (
+    EvidenceCategory,
+    PolicyArtifact,
+    TrialEvidence,
+    TrialOutcome,
+    TrialRun,
+)
 import dimos.benchmark.evaluation.runtime as runtime_module
 from dimos.benchmark.evaluation.runtime import (
     CodePolicyRuntimeFactory,
@@ -38,14 +45,16 @@ from dimos.porcelain.dimos import Dimos
 
 def policy(app: Dimos) -> None:
     del app
+    print("policy inspection")
 
 
 class _FakeCodePolicyServer:
     current = None
     mcp_url = "http://127.0.0.1:1/mcp"
 
-    def __init__(self, submission_handler) -> None:
+    def __init__(self, submission_handler, *, freeze_handler) -> None:
         self.submission_handler = submission_handler
+        self.freeze_handler = freeze_handler
         _FakeCodePolicyServer.current = self
 
     def start(self) -> None:
@@ -55,8 +64,9 @@ class _FakeCodePolicyServer:
         pass
 
 
-def _send_large_policy_error(messages, start_event, result_sending) -> None:
+def _send_large_policy_error(messages, start_event, result_sending, output_path: str) -> None:
     start_event.wait()
+    Path(output_path).write_text("diagnostic")
     result_sending.set()
     messages.send(("policy_error", "x" * 1_000_000))
     messages.close()
@@ -69,6 +79,8 @@ def _trial(path: Path, number: int) -> TrialRun:
     memory_path = path / "recording.db"
     with SqliteStore(path=str(memory_path)) as memory:
         memory.stream("events", int).append(number)
+        memory.stream("agentview_color_image", int).append(number, ts=float(number))
+        memory.stream("agentview_color_image", int).append(number + 1, ts=float(number + 1))
     return TrialRun(
         run_id=f"debug-{number}",
         outcome=TrialOutcome(
@@ -81,10 +93,13 @@ def _trial(path: Path, number: int) -> TrialRun:
         artifacts=path,
         log_path=log_path,
         memory_path=memory_path,
+        policy_output=f"attempt {number}",
     )
 
 
-def test_submission_manager_caps_trials_and_selects_last_policy(tmp_path: Path) -> None:
+def test_submission_manager_preserves_candidates_and_freezes_earlier_policy(
+    tmp_path: Path,
+) -> None:
     artifacts = []
     manager = _SubmissionManager(
         workspace=tmp_path,
@@ -97,13 +112,41 @@ def test_submission_manager_caps_trials_and_selects_last_policy(tmp_path: Path) 
     manager.path.mkdir()
     serialized = cloudpickle.dumps(policy)
 
-    trials = [manager.submit("def policy(app: Dimos) -> None: ...", serialized) for _ in range(5)]
+    candidates = [
+        manager.submit("def policy(app: Dimos) -> None: ...", serialized) for _ in range(5)
+    ]
 
-    assert [trial.run_id for trial in trials] == [f"debug-{number}" for number in range(1, 6)]
-    assert manager.last_policy is not None
-    assert manager.last_policy.serialized_path.parent.name == "submission-0005"
+    assert [candidate.trial.run_id for candidate in candidates] == [
+        f"debug-{number}" for number in range(1, 6)
+    ]
+    assert len({candidate.id for candidate in candidates}) == 5
     with pytest.raises(RuntimeError, match="budget exhausted"):
         manager.submit("def policy(app: Dimos) -> None: ...", serialized)
+    (tmp_path / "exploration" / "submission-0002" / "policy.pkl").write_bytes(b"mutated")
+    frozen = manager.freeze(candidates[1].id)
+    assert frozen is candidates[1]
+    assert manager.frozen_policy is not None
+    assert manager.frozen_policy.serialized == serialized
+    assert not hasattr(candidates[1].policy, "serialized")
+    with pytest.raises(RuntimeError, match="already frozen"):
+        manager.freeze(candidates[0].id)
+    with pytest.raises(RuntimeError, match="closed"):
+        manager.submit("def policy(app: Dimos) -> None: ...", serialized)
+
+
+def test_submission_manager_rejects_foreign_candidate(tmp_path: Path) -> None:
+    manager = _SubmissionManager(
+        workspace=tmp_path,
+        path=tmp_path / "exploration",
+        relative_path=Path("exploration"),
+        submit_debug_trial=lambda _policy, number, path: _trial(path, number),
+        max_submissions=5,
+        record_artifact=lambda _artifact: None,
+    )
+    manager.path.mkdir()
+
+    with pytest.raises(RuntimeError, match="does not belong"):
+        manager.freeze("candidate-from-another-exploration")
 
 
 def test_trial_run_exposes_logs_and_read_only_memory(tmp_path: Path) -> None:
@@ -116,24 +159,66 @@ def test_trial_run_exposes_logs_and_read_only_memory(tmp_path: Path) -> None:
             memory.streams.events.append(3)
 
 
+@pytest.mark.parametrize(
+    ("status", "success", "module"),
+    [
+        ("completed", True, "Evaluator"),
+        ("policy_error", False, "PolicyWorker"),
+        ("completed", False, "Planner"),
+        ("infrastructure_error", False, "Runtime"),
+    ],
+)
+def test_trial_evidence_recovers_recorded_trace_without_diagnosing(
+    tmp_path: Path, status: str, success: bool, module: str
+) -> None:
+    trial = _trial(tmp_path / status, 1)
+    trial.log_path.write_text(
+        json.dumps({"timestamp": 1.5, "module": module, "status": status}) + "\n"
+    )
+    trial = TrialRun(
+        run_id=trial.run_id,
+        outcome=TrialOutcome(
+            success=success,
+            reward=float(success),
+            status=status,
+            error="recorded failure" if not success else None,
+            duration_seconds=2.0,
+        ),
+        artifacts=trial.artifacts,
+        log_path=trial.log_path,
+        memory_path=trial.memory_path,
+        policy_output="x" * 50_000,
+    )
+    evidence = TrialEvidence("candidate-0001", trial, 4)
+
+    assert evidence.summary.status == status
+    assert evidence.logs(module=module)[0]["timestamp"] == 1.5
+    assert {frame.position for frame in evidence.summary.frames} == {"initial", "terminal"}
+    assert EvidenceCategory.FRAMES in evidence.summary.categories
+    assert "diagnosis" not in repr(evidence).lower()
+    assert len(repr(evidence)) < 1_000
+    assert evidence.policy_output == "x" * 50_000
+    assert evidence.artifacts == trial.artifacts
+    assert evidence.frame("agentview_color_image", "initial").ts == 1.0
+    with pytest.raises(LookupError, match="unavailable"):
+        evidence.frame("missing_color_image")
+
+
 def test_policy_artifact_records_serialized_callable(tmp_path: Path) -> None:
-    serialized_path = tmp_path / "policy.pkl"
-    serialized_path.write_bytes(cloudpickle.dumps(policy))
+    serialized = cloudpickle.dumps(policy)
     artifact = PolicyArtifact(
-        source_path=tmp_path / "policy.py",
-        serialized_path=serialized_path,
+        source="def policy(app: Dimos) -> None: ...\n",
+        serialized=serialized,
         sha256="digest",
     )
 
-    with artifact.serialized_path.open("rb") as handle:
-        loaded = cloudpickle.load(handle)
+    loaded = cloudpickle.loads(artifact.serialized)
 
     assert loaded.__name__ == "policy"
 
 
 def test_policy_worker_connects_and_invokes_callable(mocker, tmp_path: Path) -> None:
-    serialized_path = tmp_path / "policy.pkl"
-    serialized_path.write_bytes(cloudpickle.dumps(policy))
+    serialized = cloudpickle.dumps(policy)
     memory_path = tmp_path / "recording.db"
     with SqliteStore(path=str(memory_path)) as memory:
         memory.stream("events", int).append(1)
@@ -141,10 +226,17 @@ def test_policy_worker_connects_and_invokes_callable(mocker, tmp_path: Path) -> 
     connect = mocker.patch.object(Dimos, "connect", return_value=app)
     results, worker_results = multiprocessing.Pipe(duplex=False)
     start_event = threading.Event()
+    output_path = tmp_path / "policy-output.log"
 
     worker = threading.Thread(
         target=_execute_policy_worker,
-        args=(str(serialized_path), str(memory_path), worker_results, start_event),
+        args=(
+            serialized,
+            str(memory_path),
+            str(output_path),
+            worker_results,
+            start_event,
+        ),
     )
     worker.start()
 
@@ -159,17 +251,22 @@ def test_policy_worker_connects_and_invokes_callable(mocker, tmp_path: Path) -> 
     worker.join(timeout=1)
     assert not worker.is_alive()
     app.stop.assert_called_once_with()
+    assert output_path.read_text() == "policy inspection\n"
     results.close()
     worker_results.close()
 
 
-def test_prepared_policy_waits_for_explicit_start_and_stops_at_trial_end(mocker) -> None:
+def test_prepared_policy_waits_for_explicit_start_and_stops_at_trial_end(
+    mocker, tmp_path: Path
+) -> None:
     process = mocker.Mock()
     process.is_alive.return_value = True
     messages = mocker.Mock()
     messages.poll.return_value = False
     start_event = threading.Event()
-    execution = _PolicyExecutionProcess(process, messages, start_event)
+    output_path = tmp_path / "policy-output.log"
+    output_path.write_text("partial diagnostic")
+    execution = _PolicyExecutionProcess(process, messages, start_event, output_path)
 
     assert not start_event.is_set()
     execution.start()
@@ -178,22 +275,24 @@ def test_prepared_policy_waits_for_explicit_start_and_stops_at_trial_end(mocker)
     result = execution.finish(grace_s=0.0)
 
     assert result.status == "stopped"
+    assert result.output == "partial diagnostic"
     process.terminate.assert_called_once_with()
 
 
-def test_policy_result_larger_than_pipe_buffer_does_not_deadlock() -> None:
+def test_policy_result_larger_than_pipe_buffer_does_not_deadlock(tmp_path: Path) -> None:
     context = multiprocessing.get_context("spawn")
     messages, worker_messages = context.Pipe(duplex=False)
     start_event = context.Event()
     result_sending = context.Event()
+    output_path = tmp_path / "policy-output.log"
     process = context.Process(
         target=_send_large_policy_error,
-        args=(worker_messages, start_event, result_sending),
+        args=(worker_messages, start_event, result_sending, str(output_path)),
         daemon=True,
     )
     process.start()
     worker_messages.close()
-    execution = _PolicyExecutionProcess(process, messages, start_event)
+    execution = _PolicyExecutionProcess(process, messages, start_event, output_path)
     execution.start()
     assert result_sending.wait(timeout=2)
 
@@ -201,9 +300,10 @@ def test_policy_result_larger_than_pipe_buffer_does_not_deadlock() -> None:
 
     assert result.status == "policy_error"
     assert result.error == "x" * 1_000_000
+    assert result.output == "diagnostic"
 
 
-def test_explore_freezes_last_of_five_debug_submissions(mocker, tmp_path: Path) -> None:
+def test_explore_uses_explicitly_frozen_earlier_candidate(mocker, tmp_path: Path) -> None:
     class FakePiRunner:
         def __init__(self, **_kwargs) -> None:
             pass
@@ -211,11 +311,17 @@ def test_explore_freezes_last_of_five_debug_submissions(mocker, tmp_path: Path) 
         def run(self, **_kwargs) -> PiRunResult:
             assert _FakeCodePolicyServer.current is not None
             serialized = cloudpickle.dumps(policy)
+            candidates = []
             for _ in range(5):
-                _FakeCodePolicyServer.current.submission_handler(
-                    "def policy(app: Dimos) -> None: ...",
-                    serialized,
+                candidates.append(
+                    _FakeCodePolicyServer.current.submission_handler(
+                        "def policy(app: Dimos) -> None: ...",
+                        serialized,
+                    )
                 )
+            assert candidates[0].evidence.logs(module="Planner")
+            assert candidates[0].evidence.frame("agentview_color_image").data == 2
+            _FakeCodePolicyServer.current.freeze_handler(candidates[1].id)
             return PiRunResult("done", 5, 2.0, None, "")
 
     marker = tmp_path / "pi"
@@ -238,7 +344,7 @@ def test_explore_freezes_last_of_five_debug_submissions(mocker, tmp_path: Path) 
     assert outcome.status == "valid"
     assert len(outcome.trials) == 5
     assert outcome.policy is not None
-    assert outcome.policy.serialized_path.parent.name == "submission-0005"
+    assert outcome.policy.sha256 == hashlib.sha256(outcome.policy.serialized).hexdigest()
 
 
 def test_explore_publishes_jsonl_and_rendered_transcript(mocker, tmp_path: Path) -> None:

--- a/dimos/benchmark/libero_pro/autoresearch.py
+++ b/dimos/benchmark/libero_pro/autoresearch.py
@@ -1,0 +1,387 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Frozen multi-case measurement harness for LIBERO-PRO autoresearch."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable, Sequence
+from datetime import datetime, timezone
+import hashlib
+import json
+import os
+from pathlib import Path, PurePosixPath
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from dimos.benchmark.evaluation.models import EvaluationRun, InlineNativeResult
+from dimos.benchmark.evaluation.runner import execute_evaluation
+
+
+class ResearchModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+
+class PanelCase(ResearchModel):
+    id: str = Field(min_length=1, pattern=r"^[a-z][a-z0-9-]*$")
+    family: str = Field(min_length=1)
+    specification: str = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def specification_is_safe(self) -> PanelCase:
+        path = PurePosixPath(self.specification)
+        if path.is_absolute() or ".." in path.parts:
+            raise ValueError("case specification must be a safe relative path")
+        return self
+
+
+class ResearchPanel(ResearchModel):
+    schema_version: Literal["1.0"] = "1.0"
+    name: str = Field(min_length=1)
+    cases: tuple[PanelCase, ...]
+
+    @model_validator(mode="after")
+    def cases_are_valid(self) -> ResearchPanel:
+        if not self.cases:
+            raise ValueError("research panels require at least one case")
+        ids = [case.id for case in self.cases]
+        if len(set(ids)) != len(ids):
+            raise ValueError("research panel case ids must be unique")
+        return self
+
+
+class PanelCaseResult(ResearchModel):
+    id: str
+    family: str
+    output: str
+    status: Literal["completed", "failed", "cancelled", "preflight_error", "invalid_result"]
+    success: bool
+    native_score: float
+    error: str | None = None
+    failure_category: str | None = None
+    run_id: str | None = None
+    runtime: dict[str, str] | None = None
+    artifacts: dict[str, tuple[str, ...]]
+
+
+class PanelScore(ResearchModel):
+    schema_version: Literal["1.0"] = "1.0"
+    panel: str
+    panel_hash: str = Field(min_length=64, max_length=64)
+    started_at: str
+    ended_at: str
+    native_successes: int = Field(ge=0)
+    attempts: int = Field(gt=0)
+    macro_score: float
+    infrastructure_or_policy_failures: int = Field(ge=0)
+    cases: tuple[PanelCaseResult, ...]
+
+
+EvaluationExecutor = Callable[..., EvaluationRun]
+
+
+class InvalidMeasurementError(RuntimeError):
+    """Raised when a panel cannot produce comparable native measurements."""
+
+
+def run_panel(
+    panel_path: Path,
+    *,
+    output: Path,
+    api_key_env: str = "OPENAI_API_KEY",
+    executor: EvaluationExecutor = execute_evaluation,
+) -> PanelScore:
+    """Run every frozen case and aggregate only its native result."""
+    panel_path = panel_path.expanduser().resolve()
+    started_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    output = output.expanduser().resolve()
+    if output.exists() and (not output.is_dir() or any(output.iterdir())):
+        raise FileExistsError(f"Output must be absent or an empty directory: {output}")
+    output.mkdir(parents=True, exist_ok=True)
+    panel_bytes = panel_path.read_bytes()
+    panel = ResearchPanel.model_validate_json(panel_bytes)
+    resolved_specs = _resolve_specifications(panel, panel_path.parent)
+    panel_hash = _panel_hash(panel_bytes, resolved_specs)
+    results = tuple(
+        _run_case(
+            case,
+            specification_path=specification_path,
+            output=output,
+            api_key_env=api_key_env,
+            executor=executor,
+        )
+        for case, specification_path, _content in resolved_specs
+    )
+    successes = sum(result.success for result in results)
+    failures = sum(result.status != "completed" for result in results)
+    score = PanelScore(
+        panel=panel.name,
+        panel_hash=panel_hash,
+        started_at=started_at,
+        ended_at=datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        native_successes=successes,
+        attempts=len(results),
+        macro_score=sum(result.native_score for result in results) / len(results),
+        infrastructure_or_policy_failures=failures,
+        cases=results,
+    )
+    (output / "panel-score.json").write_text(
+        score.model_dump_json(indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return score
+
+
+def _resolve_specifications(
+    panel: ResearchPanel, panel_dir: Path
+) -> tuple[tuple[PanelCase, Path, bytes], ...]:
+    resolved: list[tuple[PanelCase, Path, bytes]] = []
+    for case in panel.cases:
+        path = (panel_dir / case.specification).resolve()
+        if not path.is_relative_to(panel_dir.resolve()):
+            raise ValueError(f"case specification escapes panel directory: {case.id}")
+        resolved.append((case, path, path.read_bytes()))
+    return tuple(resolved)
+
+
+def _panel_hash(panel_bytes: bytes, specs: tuple[tuple[PanelCase, Path, bytes], ...]) -> str:
+    digest = hashlib.sha256()
+    digest.update(b"panel\0")
+    digest.update(panel_bytes)
+    for case, _path, content in specs:
+        digest.update(b"\0case\0")
+        digest.update(case.id.encode())
+        digest.update(b"\0")
+        digest.update(content)
+    return digest.hexdigest()
+
+
+def _run_case(
+    case: PanelCase,
+    *,
+    specification_path: Path,
+    output: Path,
+    api_key_env: str,
+    executor: EvaluationExecutor,
+) -> PanelCaseResult:
+    case_output = output / case.id
+    try:
+        run = executor(
+            specification_path,
+            output=case_output,
+            api_key_env=api_key_env,
+            progress=None,
+        )
+    except Exception as exc:
+        return PanelCaseResult(
+            id=case.id,
+            family=case.family,
+            output=case_output.name,
+            status="preflight_error",
+            success=False,
+            native_score=0.0,
+            error=f"{type(exc).__name__}: {exc}",
+            failure_category="preflight_error",
+            artifacts=_artifact_index(case_output),
+        )
+    if run.status != "completed" or run.report is None:
+        return PanelCaseResult(
+            id=case.id,
+            family=case.family,
+            output=case_output.name,
+            status=run.status,
+            success=False,
+            native_score=0.0,
+            error=run.error.message if run.error is not None else None,
+            failure_category="measurement_failure",
+            run_id=run.run_id,
+            runtime=_runtime_identity(run),
+            artifacts=_artifact_index(case_output),
+        )
+    native = run.report.native_result
+    if not isinstance(native, InlineNativeResult) or not isinstance(native.value, dict):
+        return _invalid_result(case, case_output, "native result is not an inline mapping")
+    value: dict[str, Any] = native.value
+    if not isinstance(value.get("success"), bool) or not isinstance(
+        value.get("score"), (int, float)
+    ):
+        return _invalid_result(case, case_output, "native result lacks success or score")
+    return PanelCaseResult(
+        id=case.id,
+        family=case.family,
+        output=case_output.name,
+        status="completed",
+        success=value["success"],
+        native_score=float(value["score"]),
+        failure_category=None if value["success"] else "native_failure",
+        run_id=run.run_id,
+        runtime=_runtime_identity(run),
+        artifacts=_artifact_index(case_output),
+    )
+
+
+def _invalid_result(case: PanelCase, output: Path, error: str) -> PanelCaseResult:
+    return PanelCaseResult(
+        id=case.id,
+        family=case.family,
+        output=output.name,
+        status="invalid_result",
+        success=False,
+        native_score=0.0,
+        error=error,
+        failure_category="invalid_result",
+        artifacts=_artifact_index(output),
+    )
+
+
+def _runtime_identity(run: EvaluationRun) -> dict[str, str]:
+    return {
+        "profile": run.runtime.profile,
+        "driver": run.runtime.driver,
+        "driver_version": run.runtime.driver_version,
+        "model": run.runtime.model,
+        "thinking_level": run.runtime.thinking_level,
+    }
+
+
+def _artifact_index(output: Path) -> dict[str, tuple[str, ...]]:
+    patterns = {
+        "policy": ("policy.py", "policy.pkl"),
+        "logs": ("*.jsonl", "*.log"),
+        "videos": ("*.mp4",),
+        "memory": ("*.db",),
+        "results": ("*.json",),
+    }
+    if not output.exists():
+        return {category: () for category in patterns}
+    return {
+        category: tuple(
+            sorted(
+                path.resolve().as_posix()
+                for pattern in category_patterns
+                for path in output.rglob(pattern)
+            )
+        )
+        for category, category_patterns in patterns.items()
+    }
+
+
+def publish_evo_result(
+    score: PanelScore,
+    *,
+    result_path: Path | None,
+    traces_dir: Path | None,
+    experiment_id: str,
+) -> None:
+    """Publish Evo's inline result and per-task traces without importing Evo."""
+    if traces_dir is not None:
+        traces_dir.mkdir(parents=True, exist_ok=True)
+        for case in score.cases:
+            trace = {
+                "experiment_id": experiment_id,
+                "task_id": case.id,
+                "score": case.native_score,
+                "status": "passed" if case.success else "failed",
+                "ended_at": score.ended_at,
+                "native_status": case.status,
+                "success": case.success,
+                "failure_reason": case.failure_category,
+                "error": case.error,
+                "run_id": case.run_id,
+                "runtime": case.runtime,
+                "panel_hash": score.panel_hash,
+                "artifacts": case.artifacts,
+                "output": case.output,
+            }
+            (traces_dir / f"task_{case.id}.json").write_text(
+                json.dumps(trace, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+            )
+    invalid = [case for case in score.cases if case.status != "completed"]
+    if invalid:
+        ids = ", ".join(case.id for case in invalid)
+        raise InvalidMeasurementError(f"invalid panel measurement for: {ids}")
+    payload = {
+        "score": score.macro_score,
+        "tasks": {case.id: case.native_score for case in score.cases},
+        "panel_hash": score.panel_hash,
+        "started_at": score.started_at,
+        "ended_at": score.ended_at,
+    }
+    if result_path is None:
+        print(json.dumps(payload, sort_keys=True))
+    else:
+        _atomic_publish_json(result_path, payload)
+
+
+def _atomic_publish_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    descriptor = os.open(
+        temporary,
+        os.O_CREAT | os.O_EXCL | os.O_WRONLY | os.O_CLOEXEC,
+        0o644,
+    )
+    try:
+        remaining = memoryview((json.dumps(payload, sort_keys=True) + "\n").encode())
+        while remaining:
+            remaining = remaining[os.write(descriptor, remaining) :]
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+    try:
+        os.link(temporary, path)
+        directory = os.open(path.parent, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+    except FileExistsError as exc:
+        raise FileExistsError(f"Evo result already claimed: {path}") from exc
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--panel", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--api-key-env", default="OPENAI_API_KEY")
+    parser.add_argument("--json", action="store_true", dest="json_output")
+    args = parser.parse_args(argv)
+    result = run_panel(args.panel, output=args.output, api_key_env=args.api_key_env)
+    result_path = os.environ.get("EVO_RESULT_PATH")
+    traces_dir = os.environ.get("EVO_TRACES_DIR")
+    evo_environment = result_path is not None or traces_dir is not None
+    if evo_environment:
+        publish_evo_result(
+            result,
+            result_path=Path(result_path) if result_path is not None else None,
+            traces_dir=Path(traces_dir) if traces_dir is not None else None,
+            experiment_id=os.environ.get("EVO_EXPERIMENT_ID", "unknown"),
+        )
+    if evo_environment and result_path is None:
+        return
+    if args.json_output:
+        print(result.model_dump_json())
+    else:
+        print(
+            f"{result.panel}: {result.native_successes}/{result.attempts} "
+            f"(macro score {result.macro_score:g})"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/dimos/benchmark/libero_pro/cases/autoresearch/dev-goal/evaluation.json
+++ b/dimos/benchmark/libero_pro/cases/autoresearch/dev-goal/evaluation.json
@@ -1,0 +1,5 @@
+{
+  "schema_version": "2.0",
+  "runtime": {"model": "gpt-5.6-luna", "thinking_level": "medium"},
+  "evaluation": {"name": "libero-pro", "config": {"task_manifest": "task.json"}}
+}

--- a/dimos/benchmark/libero_pro/cases/autoresearch/dev-goal/task.json
+++ b/dimos/benchmark/libero_pro/cases/autoresearch/dev-goal/task.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": "1.0",
+  "case_id": "libero-pro-autoresearch-dev-goal",
+  "source": {
+    "repository": "Zxy-MLlab/LIBERO-PRO",
+    "revision": "eafdb809426b13153aa1e4c42d6601844217dfec",
+    "dataset_repository": "zhouxueyang/LIBERO-Pro",
+    "dataset_revision": "e9f3a5356efed7a23b06c28cfe880a22c3306074"
+  },
+  "task": {
+    "suite": "libero_goal_task",
+    "task_order_index": 0,
+    "task_index": 0,
+    "task_name": "open_the_middle_drawer_of_the_cabinet",
+    "instruction": "open the bottom drawer of the cabinet"
+  },
+  "assets": {
+    "bddl": {"repository_path": "bddl_files/libero_goal_task/open_the_middle_drawer_of_the_cabinet.bddl", "sha256": "79069933e60bdeb0a7ba4c414b3e2db3ac44ca02408dfc00a73607e201c3b334", "size_bytes": 2937},
+    "init_states": {"repository_path": "init_files/libero_goal_task/open_the_middle_drawer_of_the_cabinet.pruned_init", "sha256": "aca0dd09ccc97b099a6fbd3b3c0f6700e438234cc1b0272b47fb53b88290c6cf", "size_bytes": 4111}
+  },
+  "episodes": {"debug_init_state_indices": [1, 2, 3, 4, 5], "scored_init_state_index": 0},
+  "contract": {
+    "robot": "Panda", "controller": "OSC_POSE",
+    "cameras": [{"name": "agentview", "width": 128, "height": 128}, {"name": "robot0_eye_in_hand", "width": 128, "height": 128}],
+    "control_frequency_hz": 20, "settling_ticks": 5, "horizon_ticks": 300,
+    "clock": "continuous_real_time", "success": "native_bddl_goal_predicates"
+  }
+}

--- a/dimos/benchmark/libero_pro/cases/autoresearch/dev-long/evaluation.json
+++ b/dimos/benchmark/libero_pro/cases/autoresearch/dev-long/evaluation.json
@@ -1,0 +1,5 @@
+{
+  "schema_version": "2.0",
+  "runtime": {"model": "gpt-5.6-luna", "thinking_level": "medium"},
+  "evaluation": {"name": "libero-pro", "config": {"task_manifest": "task.json"}}
+}

--- a/dimos/benchmark/libero_pro/cases/autoresearch/dev-long/task.json
+++ b/dimos/benchmark/libero_pro/cases/autoresearch/dev-long/task.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "1.0",
+  "case_id": "libero-pro-autoresearch-dev-long",
+  "source": {"repository": "Zxy-MLlab/LIBERO-PRO", "revision": "eafdb809426b13153aa1e4c42d6601844217dfec", "dataset_repository": "zhouxueyang/LIBERO-Pro", "dataset_revision": "e9f3a5356efed7a23b06c28cfe880a22c3306074"},
+  "task": {"suite": "libero_10_task", "task_order_index": 0, "task_index": 0, "task_name": "LIVING_ROOM_SCENE2_put_both_the_alphabet_soup_and_the_tomato_sauce_in_the_basket", "instruction": "put both the cream cheese and the tomato sauce in the basket"},
+  "assets": {
+    "bddl": {"repository_path": "bddl_files/libero_10_task/LIVING_ROOM_SCENE2_put_both_the_alphabet_soup_and_the_tomato_sauce_in_the_basket.bddl", "sha256": "b04e67b9118b6b0a41956541ef4f66e479a341dd408c21f045c372a169fe01ef", "size_bytes": 3284},
+    "init_states": {"repository_path": "init_files/libero_10_task/LIVING_ROOM_SCENE2_put_both_the_alphabet_soup_and_the_tomato_sauce_in_the_basket.pruned_init", "sha256": "25a941904f264e6ee6f8d06d64d26f18fafb9d94e390038fcd76e048bef38c8e", "size_bytes": 7442}
+  },
+  "episodes": {"debug_init_state_indices": [1, 2, 3, 4, 5], "scored_init_state_index": 0},
+  "contract": {"robot": "Panda", "controller": "OSC_POSE", "cameras": [{"name": "agentview", "width": 128, "height": 128}, {"name": "robot0_eye_in_hand", "width": 128, "height": 128}], "control_frequency_hz": 20, "settling_ticks": 5, "horizon_ticks": 520, "clock": "continuous_real_time", "success": "native_bddl_goal_predicates"}
+}

--- a/dimos/benchmark/libero_pro/cases/autoresearch/dev-object/evaluation.json
+++ b/dimos/benchmark/libero_pro/cases/autoresearch/dev-object/evaluation.json
@@ -1,0 +1,5 @@
+{
+  "schema_version": "2.0",
+  "runtime": {"model": "gpt-5.6-luna", "thinking_level": "medium"},
+  "evaluation": {"name": "libero-pro", "config": {"task_manifest": "task.json"}}
+}

--- a/dimos/benchmark/libero_pro/cases/autoresearch/dev-object/task.json
+++ b/dimos/benchmark/libero_pro/cases/autoresearch/dev-object/task.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "1.0",
+  "case_id": "libero-pro-autoresearch-dev-object",
+  "source": {"repository": "Zxy-MLlab/LIBERO-PRO", "revision": "eafdb809426b13153aa1e4c42d6601844217dfec", "dataset_repository": "zhouxueyang/LIBERO-Pro", "dataset_revision": "e9f3a5356efed7a23b06c28cfe880a22c3306074"},
+  "task": {"suite": "libero_object_task", "task_order_index": 0, "task_index": 0, "task_name": "pick_up_the_alphabet_soup_and_place_it_in_the_basket", "instruction": "Pick the cream cheese and place it in the basket"},
+  "assets": {
+    "bddl": {"repository_path": "bddl_files/libero_object_task/pick_up_the_alphabet_soup_and_place_it_in_the_basket.bddl", "sha256": "3dcf0acdbafa28968d7b990520232eac3181b525ec1bcc96030dec172b64e2e2", "size_bytes": 2125},
+    "init_states": {"repository_path": "init_files/libero_object_task/pick_up_the_alphabet_soup_and_place_it_in_the_basket.pruned_init", "sha256": "292758a37a733e44006270bbe706e14f83c086ff16517fca432f851817932340", "size_bytes": 4144}
+  },
+  "episodes": {"debug_init_state_indices": [1, 2, 3, 4, 5], "scored_init_state_index": 0},
+  "contract": {"robot": "Panda", "controller": "OSC_POSE", "cameras": [{"name": "agentview", "width": 128, "height": 128}, {"name": "robot0_eye_in_hand", "width": 128, "height": 128}], "control_frequency_hz": 20, "settling_ticks": 5, "horizon_ticks": 280, "clock": "continuous_real_time", "success": "native_bddl_goal_predicates"}
+}

--- a/dimos/benchmark/libero_pro/cases/autoresearch/dev-panel.json
+++ b/dimos/benchmark/libero_pro/cases/autoresearch/dev-panel.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "1.0",
+  "name": "libero-pro-development",
+  "cases": [
+    {"id": "dev-goal", "family": "goal", "specification": "dev-goal/evaluation.json"},
+    {"id": "dev-spatial", "family": "spatial", "specification": "dev-spatial/evaluation.json"},
+    {"id": "dev-object", "family": "object", "specification": "dev-object/evaluation.json"},
+    {"id": "dev-long", "family": "libero_10", "specification": "dev-long/evaluation.json"}
+  ]
+}

--- a/dimos/benchmark/libero_pro/cases/autoresearch/dev-spatial/evaluation.json
+++ b/dimos/benchmark/libero_pro/cases/autoresearch/dev-spatial/evaluation.json
@@ -1,0 +1,5 @@
+{
+  "schema_version": "2.0",
+  "runtime": {"model": "gpt-5.6-luna", "thinking_level": "medium"},
+  "evaluation": {"name": "libero-pro", "config": {"task_manifest": "task.json"}}
+}

--- a/dimos/benchmark/libero_pro/cases/autoresearch/dev-spatial/task.json
+++ b/dimos/benchmark/libero_pro/cases/autoresearch/dev-spatial/task.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "1.0",
+  "case_id": "libero-pro-autoresearch-dev-spatial",
+  "source": {"repository": "Zxy-MLlab/LIBERO-PRO", "revision": "eafdb809426b13153aa1e4c42d6601844217dfec", "dataset_repository": "zhouxueyang/LIBERO-Pro", "dataset_revision": "e9f3a5356efed7a23b06c28cfe880a22c3306074"},
+  "task": {"suite": "libero_spatial_task", "task_order_index": 0, "task_index": 0, "task_name": "pick_up_the_black_bowl_between_the_plate_and_the_ramekin_and_place_it_on_the_plate", "instruction": "Pick the akita black bowl not between the plate and the ramekin and place it on the plate"},
+  "assets": {
+    "bddl": {"repository_path": "bddl_files/libero_spatial_task/pick_up_the_black_bowl_between_the_plate_and_the_ramekin_and_place_it_on_the_plate.bddl", "sha256": "61ff13656df194011d9c5fb3873098fcce18563d380d4437622d8d910a996bdc", "size_bytes": 3019},
+    "init_states": {"repository_path": "init_files/libero_spatial_task/pick_up_the_black_bowl_between_the_plate_and_the_ramekin_and_place_it_on_the_plate.pruned_init", "sha256": "2d7fa6a57dcfa1563ff61ca595753967318634a0ae19b204dd7750d02bf2be99", "size_bytes": 4872}
+  },
+  "episodes": {"debug_init_state_indices": [1, 2, 3, 4, 5], "scored_init_state_index": 0},
+  "contract": {"robot": "Panda", "controller": "OSC_POSE", "cameras": [{"name": "agentview", "width": 128, "height": 128}, {"name": "robot0_eye_in_hand", "width": 128, "height": 128}], "control_frequency_hz": 20, "settling_ticks": 5, "horizon_ticks": 220, "clock": "continuous_real_time", "success": "native_bddl_goal_predicates"}
+}

--- a/dimos/benchmark/libero_pro/cases/autoresearch/held-goal/evaluation.json
+++ b/dimos/benchmark/libero_pro/cases/autoresearch/held-goal/evaluation.json
@@ -1,0 +1,5 @@
+{
+  "schema_version": "2.0",
+  "runtime": {"model": "gpt-5.6-luna", "thinking_level": "medium"},
+  "evaluation": {"name": "libero-pro", "config": {"task_manifest": "task.json"}}
+}

--- a/dimos/benchmark/libero_pro/cases/autoresearch/held-goal/task.json
+++ b/dimos/benchmark/libero_pro/cases/autoresearch/held-goal/task.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "1.0",
+  "case_id": "libero-pro-autoresearch-held-goal",
+  "source": {"repository": "Zxy-MLlab/LIBERO-PRO", "revision": "eafdb809426b13153aa1e4c42d6601844217dfec", "dataset_repository": "zhouxueyang/LIBERO-Pro", "dataset_revision": "e9f3a5356efed7a23b06c28cfe880a22c3306074"},
+  "task": {"suite": "libero_goal_task", "task_order_index": 0, "task_index": 3, "task_name": "open_the_top_drawer_and_put_the_bowl_inside", "instruction": "Open the top layer of the drawer and put the cream cheese inside"},
+  "assets": {
+    "bddl": {"repository_path": "bddl_files/libero_goal_task/open_the_top_drawer_and_put_the_bowl_inside.bddl", "sha256": "468fc65a5aa7e63cc829efb9f7970cadbfc39bfe5695930c5e1d252f05ed5078", "size_bytes": 2988},
+    "init_states": {"repository_path": "init_files/libero_goal_task/open_the_top_drawer_and_put_the_bowl_inside.pruned_init", "sha256": "74b021b8965a24e7cda501c236683f862853ca4fe883621328156c78ad5414c0", "size_bytes": 4139}
+  },
+  "episodes": {"debug_init_state_indices": [1, 2, 3, 4, 5], "scored_init_state_index": 0},
+  "contract": {"robot": "Panda", "controller": "OSC_POSE", "cameras": [{"name": "agentview", "width": 128, "height": 128}, {"name": "robot0_eye_in_hand", "width": 128, "height": 128}], "control_frequency_hz": 20, "settling_ticks": 5, "horizon_ticks": 300, "clock": "continuous_real_time", "success": "native_bddl_goal_predicates"}
+}

--- a/dimos/benchmark/libero_pro/cases/autoresearch/held-long/evaluation.json
+++ b/dimos/benchmark/libero_pro/cases/autoresearch/held-long/evaluation.json
@@ -1,0 +1,5 @@
+{
+  "schema_version": "2.0",
+  "runtime": {"model": "gpt-5.6-luna", "thinking_level": "medium"},
+  "evaluation": {"name": "libero-pro", "config": {"task_manifest": "task.json"}}
+}

--- a/dimos/benchmark/libero_pro/cases/autoresearch/held-long/task.json
+++ b/dimos/benchmark/libero_pro/cases/autoresearch/held-long/task.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "1.0",
+  "case_id": "libero-pro-autoresearch-held-long",
+  "source": {"repository": "Zxy-MLlab/LIBERO-PRO", "revision": "eafdb809426b13153aa1e4c42d6601844217dfec", "dataset_repository": "zhouxueyang/LIBERO-Pro", "dataset_revision": "e9f3a5356efed7a23b06c28cfe880a22c3306074"},
+  "task": {"suite": "libero_10_task", "task_order_index": 0, "task_index": 3, "task_name": "KITCHEN_SCENE4_put_the_black_bowl_in_the_bottom_drawer_of_the_cabinet_and_close_it", "instruction": "put the bottle in the bottom drawer of the cabinet and close it"},
+  "assets": {
+    "bddl": {"repository_path": "bddl_files/libero_10_task/KITCHEN_SCENE4_put_the_black_bowl_in_the_bottom_drawer_of_the_cabinet_and_close_it.bddl", "sha256": "a2e337fb11319c753beb7d0b83e6f952783e982a4cede7d9bf2dbb4e81aa3ee8", "size_bytes": 2255},
+    "init_states": {"repository_path": "init_files/libero_10_task/KITCHEN_SCENE4_put_the_black_bowl_in_the_bottom_drawer_of_the_cabinet_and_close_it.pruned_init", "sha256": "bd5569f6c7325a8944ee3fa55f1b2e3c5915427692793b78cc26d84b1faeef36", "size_bytes": 2736}
+  },
+  "episodes": {"debug_init_state_indices": [1, 2, 3, 4, 5], "scored_init_state_index": 0},
+  "contract": {"robot": "Panda", "controller": "OSC_POSE", "cameras": [{"name": "agentview", "width": 128, "height": 128}, {"name": "robot0_eye_in_hand", "width": 128, "height": 128}], "control_frequency_hz": 20, "settling_ticks": 5, "horizon_ticks": 520, "clock": "continuous_real_time", "success": "native_bddl_goal_predicates"}
+}

--- a/dimos/benchmark/libero_pro/cases/autoresearch/held-object/evaluation.json
+++ b/dimos/benchmark/libero_pro/cases/autoresearch/held-object/evaluation.json
@@ -1,0 +1,5 @@
+{
+  "schema_version": "2.0",
+  "runtime": {"model": "gpt-5.6-luna", "thinking_level": "medium"},
+  "evaluation": {"name": "libero-pro", "config": {"task_manifest": "task.json"}}
+}

--- a/dimos/benchmark/libero_pro/cases/autoresearch/held-object/task.json
+++ b/dimos/benchmark/libero_pro/cases/autoresearch/held-object/task.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "1.0",
+  "case_id": "libero-pro-autoresearch-held-object",
+  "source": {"repository": "Zxy-MLlab/LIBERO-PRO", "revision": "eafdb809426b13153aa1e4c42d6601844217dfec", "dataset_repository": "zhouxueyang/LIBERO-Pro", "dataset_revision": "e9f3a5356efed7a23b06c28cfe880a22c3306074"},
+  "task": {"suite": "libero_object_task", "task_order_index": 0, "task_index": 3, "task_name": "pick_up_the_bbq_sauce_and_place_it_in_the_basket", "instruction": "Pick the ketchup and place it in the basket"},
+  "assets": {
+    "bddl": {"repository_path": "bddl_files/libero_object_task/pick_up_the_bbq_sauce_and_place_it_in_the_basket.bddl", "sha256": "8c74c1db216913d2d5d321613e0c7de99398005493e3792d1d9e329a9e03e0a9", "size_bytes": 2143},
+    "init_states": {"repository_path": "init_files/libero_object_task/pick_up_the_bbq_sauce_and_place_it_in_the_basket.pruned_init", "sha256": "db5ebce3a987ff88cbe4a1b16f48615fc9a351a19fb1193b98089dc141e265f4", "size_bytes": 3389}
+  },
+  "episodes": {"debug_init_state_indices": [1, 2, 3, 4, 5], "scored_init_state_index": 0},
+  "contract": {"robot": "Panda", "controller": "OSC_POSE", "cameras": [{"name": "agentview", "width": 128, "height": 128}, {"name": "robot0_eye_in_hand", "width": 128, "height": 128}], "control_frequency_hz": 20, "settling_ticks": 5, "horizon_ticks": 280, "clock": "continuous_real_time", "success": "native_bddl_goal_predicates"}
+}

--- a/dimos/benchmark/libero_pro/cases/autoresearch/held-spatial/evaluation.json
+++ b/dimos/benchmark/libero_pro/cases/autoresearch/held-spatial/evaluation.json
@@ -1,0 +1,5 @@
+{
+  "schema_version": "2.0",
+  "runtime": {"model": "gpt-5.6-luna", "thinking_level": "medium"},
+  "evaluation": {"name": "libero-pro", "config": {"task_manifest": "task.json"}}
+}

--- a/dimos/benchmark/libero_pro/cases/autoresearch/held-spatial/task.json
+++ b/dimos/benchmark/libero_pro/cases/autoresearch/held-spatial/task.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "1.0",
+  "case_id": "libero-pro-autoresearch-held-spatial",
+  "source": {"repository": "Zxy-MLlab/LIBERO-PRO", "revision": "eafdb809426b13153aa1e4c42d6601844217dfec", "dataset_repository": "zhouxueyang/LIBERO-Pro", "dataset_revision": "e9f3a5356efed7a23b06c28cfe880a22c3306074"},
+  "task": {"suite": "libero_spatial_task", "task_order_index": 0, "task_index": 3, "task_name": "pick_up_the_black_bowl_on_the_cookie_box_and_place_it_on_the_plate", "instruction": "Pick the akita black bowl on the top of the cabinet and place it on the plate"},
+  "assets": {
+    "bddl": {"repository_path": "bddl_files/libero_spatial_task/pick_up_the_black_bowl_on_the_cookie_box_and_place_it_on_the_plate.bddl", "sha256": "ef1a87899afcf9b4553aff37a8f7bfc8fd5c433c7784c14f930e9512cb85a2e4", "size_bytes": 2974},
+    "init_states": {"repository_path": "init_files/libero_spatial_task/pick_up_the_black_bowl_on_the_cookie_box_and_place_it_on_the_plate.pruned_init", "sha256": "8552541e2609bc05c03f76996e3d68e0d9eb3fad887c2949d6e12cb45c9c9f7a", "size_bytes": 364}
+  },
+  "episodes": {"debug_init_state_indices": [1, 2, 3, 4, 5], "scored_init_state_index": 0},
+  "contract": {"robot": "Panda", "controller": "OSC_POSE", "cameras": [{"name": "agentview", "width": 128, "height": 128}, {"name": "robot0_eye_in_hand", "width": 128, "height": 128}], "control_frequency_hz": 20, "settling_ticks": 5, "horizon_ticks": 220, "clock": "continuous_real_time", "success": "native_bddl_goal_predicates"}
+}

--- a/dimos/benchmark/libero_pro/cases/autoresearch/heldout-panel.json
+++ b/dimos/benchmark/libero_pro/cases/autoresearch/heldout-panel.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "1.0",
+  "name": "libero-pro-heldout",
+  "cases": [
+    {"id": "held-goal", "family": "goal", "specification": "held-goal/evaluation.json"},
+    {"id": "held-spatial", "family": "spatial", "specification": "held-spatial/evaluation.json"},
+    {"id": "held-object", "family": "object", "specification": "held-object/evaluation.json"},
+    {"id": "held-long", "family": "libero_10", "specification": "held-long/evaluation.json"}
+  ]
+}

--- a/dimos/benchmark/libero_pro/evaluation.py
+++ b/dimos/benchmark/libero_pro/evaluation.py
@@ -33,68 +33,19 @@ from dimos.benchmark.libero_pro.podman import LiberoPodmanContainer
 from dimos.core.coordination.module_coordinator import ModuleCoordinator
 from dimos.core.coordination.process_lifecycle import DIMOS_RUN_ID_ENV
 
-EVALUATION_PROTOCOL = """Develop a task-specific real-time DimOS policy.
-Use submit_policy to test each revision. Every submission runs a fresh episode of
-the exact task below. The final submitted callable is frozen and evaluated on a
-fresh initial state. The simulator advances continuously at 20 Hz while the
-callable runs, so policies must tolerate real execution latency.
+EVALUATION_PROTOCOL = """Develop a task-specific synchronous policy for the exact task input.
 
-Inspect the actual recorded RGB images after every debug submission. `python_exec`
-supports rich image output, just as it does in the navigation benchmark:
+Define `policy(app: Dimos) -> None`. Use discoverable typed DimOS modules and
+read-only `app.memory`; no evaluator-only state is available. Call
+`submit_policy(policy)` for up to five fresh Debug Trials. It returns an immutable
+PolicyCandidate with a bounded Trial Evidence summary. Drill down only as needed via
+`candidate.evidence.timeline()`, `.logs()`, `.frame()`, `.policy_output`,
+`.open_memory()`, and `.artifacts`. Recorded facts may be unavailable; do not infer
+missing causes.
 
-    trial = submit_policy(policy)
-    from IPython.display import display
-    from PIL import Image as PILImage
-    with trial.open_memory() as memory:
-        frame = memory.stream("agentview_color_image").last().data
-        display(PILImage.fromarray(frame.to_rgb().data))
-
-Displayed images are delivered to you visually. Inspect both `agentview_color_image`
-and `eye_in_hand_color_image` when the wrist view can disambiguate contact. Do not
-substitute ASCII art, pixel statistics, database internals, or textual image
-representations for viewing the RGB frames directly.
-
-Inside policy(app), `app.memory` is the live read-only Memory2 recording and normal
-modules are available by class name. Use the calibrated RGB-D helper rather than
-guessing camera geometry:
-
-    from dimos.perception.rgbd import latest_rgbd, project_depth
-    observation = latest_rgbd(
-        app.memory,
-        color_stream="agentview_color_image",
-        depth_stream="agentview_depth_image",
-        camera_info_stream="agentview_camera_info",
-        optical_frame="agentview_optical",
-    )
-    masks = app.GroundedSegmentationModule.segment(observation.color, ["object description"])
-    objects = project_depth(masks, observation)
-
-`objects` contains world-frame point clouds and ordinary shape helpers. Request ranked
-grasps with `app.GraspGenXModule.propose_grasps(objects[0].pointcloud)`. A proposal's
-header supplies its timestamp and frame. Turn each ranked candidate into a planning
-target with `PoseStamped(ts=grasps.header.timestamp,
-frame_id=grasps.header.frame_id, position=candidate.pose.position,
-orientation=candidate.pose.orientation)`. Inspect
-`app.ManipulationModule.list_planning_groups()` and use a returned `.id` instead of
-guessing group IDs. Try targets in rank order with `plan_to_poses({group.id: target})`,
-then call `execute()` only for a successful PlanResult. Every motion, gripper command,
-and execution call returns a typed result; inspect `.succeeded` and `.message` rather
-than assuming that a command moved the robot. Re-observe after motion and keep the
-policy closed-loop. The Panda gripper positions are 0.04 m open and 0.0 m closed.
-Use collision-checked planning for the free-space approach. Once that route is clear,
-`move_to_pose(..., check_collision=False)` provides the low-latency absolute Cartesian
-updates needed for contact-rich motion; keep those updates small and verify each result.
-
-Plan with the complete hand volume, not only the TCP. Infer the grasp and motion axes
-from observed geometry. For articulated handles, compare a force-closure pinch with a
-geometric hook: approach through free space, place closed fingers behind the handle,
-engage it orthogonally, then withdraw along the articulation axis. Test equivalent
-wrist-roll candidates because the fingers can reach while the wrist or forearm still
-collides with nearby objects. If IK fails at a joint boundary, retry nearby poses a few
-millimeters away instead of abandoning the strategy. Prefer short, smooth, measured
-waypoint updates over one large target jump, but do not waste the real-time horizon on
-long sleeps. A held final setpoint continues executing after policy(app) returns, so
-finish the callable once the commanded motion is safely engaged.
+Before finishing, call `freeze_policy(candidate)` exactly once. The frozen candidate
+is evaluated in a clean policy-only process. Freezing is irreversible and later
+submissions are rejected.
 """
 
 
@@ -149,7 +100,7 @@ class LiberoProEvaluation:
             runtime=runtime,
             run_id=f"{context.run_id}-scored",
         )
-        if trial.outcome.status != "completed":
+        if trial.outcome.status in {"infrastructure_error", "timed_out"}:
             raise RuntimeError(trial.outcome.error or "scored LIBERO-PRO trial failed")
         native_value = {
             "result_type": "single_trial",
@@ -197,6 +148,7 @@ class LiberoProEvaluation:
                 _artifact("scored-trial/score.json", "Native score", "application/json"),
                 _artifact("scored-trial/trial.jsonl", "Trial log", "application/x-ndjson"),
                 _artifact("scored-trial/container.log", "Container log", "text/plain"),
+                _artifact("scored-trial/policy-output.log", "Policy output", "text/plain"),
                 _artifact("scored-trial/trial.mp4", "Rendered trial", "video/mp4"),
                 _artifact(
                     "scored-trial/recording.db", "Memory2 recording", "application/x-sqlite3"
@@ -229,12 +181,14 @@ def _run_trial(
     log_path = path / "trial.jsonl"
     memory_path = path / "recording.db"
     video_path = path / "trial.mp4"
+    policy_output_path = path / "policy-output.log"
     discovery = str(path / "panda-shm")
     container = LiberoPodmanContainer(manifest, assets, artifact_dir=path)
     control = None
     coordinator = None
     execution = None
     started = time.monotonic()
+    policy_output = ""
     native: NativeTrialResult
     previous_run_id = os.environ.get(DIMOS_RUN_ID_ENV)
     try:
@@ -262,7 +216,8 @@ def _run_trial(
         timeout = manifest.contract.horizon_ticks / manifest.contract.control_frequency_hz + 15.0
         terminal = control.wait_terminal(timeout)
         policy_result = execution.finish()
-        policy_execution_status = "completed" if terminal.success else policy_result.status
+        policy_output = policy_result.output
+        policy_execution_status = policy_result.status
         native = {
             "success": bool(terminal.success),
             "score": float(terminal.score),
@@ -274,17 +229,17 @@ def _run_trial(
         }
         _log(log_path, "trial_terminal", **native)
         status: Literal["completed", "policy_error", "infrastructure_error"]
-        if terminal.terminal_reason == "failure" or policy_result.status == "infrastructure_error":
+        if policy_result.status == "infrastructure_error":
             status = "infrastructure_error"
         elif policy_execution_status == "policy_error":
             status = "policy_error"
         else:
             status = "completed"
-        error = terminal.error or ("" if terminal.success else policy_result.error)
+        error = policy_result.error or terminal.error or None
     except BaseException as exc:
         if execution is not None:
             try:
-                execution.finish()
+                policy_output = execution.finish().output
             except Exception:
                 pass
         if control is not None:
@@ -307,6 +262,7 @@ def _run_trial(
         if isinstance(exc, KeyboardInterrupt):
             raise
     finally:
+        policy_output_path.write_text(policy_output, encoding="utf-8")
         if coordinator is not None:
             coordinator.stop()
         if control is not None:
@@ -316,7 +272,9 @@ def _run_trial(
             os.environ.pop(DIMOS_RUN_ID_ENV, None)
         else:
             os.environ[DIMOS_RUN_ID_ENV] = previous_run_id
-    if status == "completed" and (not video_path.is_file() or video_path.stat().st_size == 0):
+    if status != "infrastructure_error" and (
+        not video_path.is_file() or video_path.stat().st_size == 0
+    ):
         status = "infrastructure_error"
         error = "LIBERO trial did not produce a rendered video artifact"
     outcome = TrialOutcome(
@@ -333,6 +291,7 @@ def _run_trial(
             artifacts=path,
             log_path=log_path,
             memory_path=memory_path,
+            policy_output=policy_output,
         ),
         native,
     )

--- a/dimos/benchmark/libero_pro/test_autoresearch.py
+++ b/dimos/benchmark/libero_pro/test_autoresearch.py
@@ -1,0 +1,300 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from typing import Literal
+
+import pytest
+
+from dimos.benchmark.evaluation.models import (
+    EvaluationIdentity,
+    EvaluationReport,
+    EvaluationRun,
+    EvaluationRunError,
+    EvaluationRunSpecification,
+    InlineNativeResult,
+    RuntimeCondition,
+    RuntimeIdentity,
+)
+import dimos.benchmark.libero_pro.autoresearch as autoresearch
+from dimos.benchmark.libero_pro.autoresearch import (
+    InvalidMeasurementError,
+    PanelCase,
+    ResearchPanel,
+    publish_evo_result,
+    run_panel,
+)
+from dimos.benchmark.libero_pro.models import LiberoTaskManifest
+
+CASES = Path(__file__).parent / "cases" / "autoresearch"
+
+
+def _panel(tmp_path: Path) -> Path:
+    for name in ("goal", "spatial", "object", "long"):
+        (tmp_path / f"{name}.json").write_text(json.dumps({"case": name}) + "\n")
+    path = tmp_path / "panel.json"
+    path.write_text(
+        """{
+  "schema_version": "1.0",
+  "name": "test-panel",
+  "cases": [
+    {"id": "goal", "family": "goal", "specification": "goal.json"},
+    {"id": "spatial", "family": "spatial", "specification": "spatial.json"},
+    {"id": "object", "family": "object", "specification": "object.json"},
+    {"id": "long", "family": "libero_10", "specification": "long.json"}
+  ]
+}
+"""
+    )
+    return path
+
+
+def _run(
+    *,
+    success: bool = False,
+    score: float | None = None,
+    status: Literal["completed", "failed"] = "completed",
+) -> EvaluationRun:
+    now = datetime.now(timezone.utc)
+    specification = EvaluationRunSpecification(
+        runtime=RuntimeCondition(model="model", thinking_level="medium"),
+        evaluation={"name": "libero-pro", "config": {}},
+    )
+    common = {
+        "run_id": "run",
+        "specification": specification,
+        "evaluation": EvaluationIdentity(name="libero-pro", provider="dimos", version="1"),
+        "runtime": RuntimeIdentity(
+            profile="code-policy-v1",
+            driver="pi",
+            driver_version="1",
+            model="model",
+            thinking_level="medium",
+        ),
+        "started_at": now,
+        "finished_at": now,
+        "duration_seconds": 0.0,
+    }
+    if status == "completed":
+        return EvaluationRun(
+            **common,
+            status="completed",
+            report=EvaluationReport(
+                native_result=InlineNativeResult(
+                    value={"success": success, "score": float(success) if score is None else score}
+                )
+            ),
+        )
+    return EvaluationRun(
+        **common,
+        status="failed",
+        error=EvaluationRunError(stage="evaluation", error_type="Failure", message="failed"),
+    )
+
+
+def test_panel_counts_only_native_successes_and_continues_failures(tmp_path: Path) -> None:
+    calls = 0
+
+    def execute(*args: object, **kwargs: object) -> EvaluationRun:
+        nonlocal calls
+        del args, kwargs
+        calls += 1
+        if calls == 1:
+            return _run(success=True)
+        if calls == 2:
+            return _run(status="failed")
+        if calls == 3:
+            raise RuntimeError("preflight")
+        return _run(success=False)
+
+    output = tmp_path / "output"
+    result = run_panel(_panel(tmp_path), output=output, executor=execute)
+
+    assert result.native_successes == 1
+    assert result.attempts == 4
+    assert result.macro_score == 0.25
+    assert result.infrastructure_or_policy_failures == 2
+    assert [case.status for case in result.cases] == [
+        "completed",
+        "failed",
+        "preflight_error",
+        "completed",
+    ]
+    assert (output / "panel-score.json").is_file()
+
+
+def test_panel_allows_configurable_size_and_families(tmp_path: Path) -> None:
+    payload = ResearchPanel.model_validate_json(_panel(tmp_path).read_bytes()).model_dump()
+    payload["cases"] = payload["cases"][:1]
+    payload["cases"][0]["family"] = "custom-suite"
+
+    panel = ResearchPanel.model_validate(payload)
+
+    assert len(panel.cases) == 1
+    assert panel.cases[0].family == "custom-suite"
+
+
+def test_panel_score_is_macro_average_of_native_scores(tmp_path: Path) -> None:
+    scores = iter((0.25, 0.5, 0.75, 1.0))
+
+    result = run_panel(
+        _panel(tmp_path),
+        output=tmp_path / "output",
+        executor=lambda *_args, **_kwargs: _run(score=next(scores)),
+    )
+
+    assert result.macro_score == 0.625
+
+
+def test_panel_rejects_empty_duplicate_and_unsafe_cases() -> None:
+    with pytest.raises(ValueError, match="at least one"):
+        ResearchPanel(name="empty", cases=())
+    duplicate = PanelCase(id="same", family="a", specification="a.json")
+    with pytest.raises(ValueError, match="unique"):
+        ResearchPanel(name="duplicate", cases=(duplicate, duplicate))
+    with pytest.raises(ValueError, match="safe relative"):
+        PanelCase(id="unsafe", family="a", specification="../a.json")
+
+
+def test_panel_hash_changes_with_resolved_specification(tmp_path: Path) -> None:
+    panel = _panel(tmp_path)
+    first = run_panel(panel, output=tmp_path / "first", executor=lambda *_args, **_kwargs: _run())
+    (tmp_path / "goal.json").write_text('{"case": "changed"}\n')
+    second = run_panel(panel, output=tmp_path / "second", executor=lambda *_args, **_kwargs: _run())
+
+    assert first.panel_hash != second.panel_hash
+
+
+def test_evo_publishes_atomic_score_tasks_and_traces(tmp_path: Path) -> None:
+    outcomes = iter((True, False, True, False))
+
+    def execute(*_args: object, **kwargs: object) -> EvaluationRun:
+        case_output = Path(str(kwargs["output"]))
+        trial = case_output / "runtime" / "trial"
+        trial.mkdir(parents=True)
+        for name in ("policy.py", "main.jsonl", "trial.mp4", "recording.db", "score.json"):
+            (trial / name).write_text(name)
+        return _run(success=next(outcomes))
+
+    score = run_panel(
+        _panel(tmp_path),
+        output=tmp_path / "panel-output",
+        executor=execute,
+    )
+    result_path = tmp_path / "evo" / "result.json"
+    traces = tmp_path / "evo" / "traces"
+
+    publish_evo_result(
+        score,
+        result_path=result_path,
+        traces_dir=traces,
+        experiment_id="experiment-1",
+    )
+
+    result = json.loads(result_path.read_text())
+    assert result["score"] == 0.5
+    assert result["tasks"] == {"goal": 1.0, "spatial": 0.0, "object": 1.0, "long": 0.0}
+    assert result["panel_hash"] == score.panel_hash
+    assert {path.stem for path in traces.glob("*.json")} == {
+        "task_goal",
+        "task_spatial",
+        "task_object",
+        "task_long",
+    }
+    trace = json.loads((traces / "task_spatial.json").read_text())
+    assert trace["failure_reason"] == "native_failure"
+    assert trace["score"] == 0.0
+    assert trace["status"] == "failed"
+    assert trace["runtime"]["profile"] == "code-policy-v1"
+    assert Path(trace["artifacts"]["policy"][0]).is_absolute()
+    assert Path(trace["artifacts"]["videos"][0]).name == "trial.mp4"
+    with pytest.raises(FileExistsError, match="already claimed"):
+        publish_evo_result(
+            score,
+            result_path=result_path,
+            traces_dir=traces,
+            experiment_id="experiment-2",
+        )
+
+
+def test_evo_rejects_invalid_measurement_but_preserves_trace(tmp_path: Path) -> None:
+    score = run_panel(
+        _panel(tmp_path),
+        output=tmp_path / "panel-output",
+        executor=lambda *_args, **_kwargs: _run(status="failed"),
+    )
+    result_path = tmp_path / "result.json"
+    traces = tmp_path / "traces"
+
+    with pytest.raises(InvalidMeasurementError, match="invalid panel measurement"):
+        publish_evo_result(
+            score,
+            result_path=result_path,
+            traces_dir=traces,
+            experiment_id="unknown",
+        )
+
+    assert not result_path.exists()
+    assert json.loads((traces / "task_goal.json").read_text())["failure_reason"] == (
+        "measurement_failure"
+    )
+
+
+def test_atomic_publication_failure_does_not_claim_final_path(mocker, tmp_path: Path) -> None:
+    result_path = tmp_path / "result.json"
+    mocker.patch.object(autoresearch.os, "link", side_effect=OSError("link failed"))
+
+    with pytest.raises(OSError, match="link failed"):
+        autoresearch._atomic_publish_json(result_path, {"score": 1.0})
+
+    assert not result_path.exists()
+    assert not tuple(tmp_path.glob(".*.tmp"))
+
+
+@pytest.mark.parametrize(
+    ("panel_name", "expected_horizons"),
+    [
+        ("dev-panel.json", {"goal": 300, "spatial": 220, "object": 280, "libero_10": 520}),
+        (
+            "heldout-panel.json",
+            {"goal": 300, "spatial": 220, "object": 280, "libero_10": 520},
+        ),
+    ],
+)
+def test_checked_in_panel_freezes_representative_contracts(
+    panel_name: str,
+    expected_horizons: dict[str, int],
+) -> None:
+    panel = ResearchPanel.model_validate_json((CASES / panel_name).read_bytes())
+
+    for case in panel.cases:
+        specification_path = CASES / case.specification
+        specification = EvaluationRunSpecification.model_validate_json(
+            specification_path.read_bytes()
+        )
+        manifest_path = specification_path.parent / specification.evaluation.config["task_manifest"]
+        manifest = LiberoTaskManifest.model_validate_json(manifest_path.read_bytes())
+
+        assert specification.runtime == RuntimeCondition(
+            model="gpt-5.6-luna", thinking_level="medium"
+        )
+        expected_suite = (
+            "libero_10_task" if case.family == "libero_10" else f"libero_{case.family}_task"
+        )
+        assert manifest.task.suite == expected_suite
+        assert manifest.contract.horizon_ticks == expected_horizons[case.family]
+        assert manifest.episodes.debug_init_state_indices == (1, 2, 3, 4, 5)
+        assert manifest.episodes.scored_init_state_index == 0

--- a/dimos/benchmark/libero_pro/test_evaluation.py
+++ b/dimos/benchmark/libero_pro/test_evaluation.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 from types import SimpleNamespace
 
+import cloudpickle
 from pytest_mock import MockerFixture
 
 from dimos.benchmark.evaluation.protocol import PolicyArtifact, PolicyExecution
@@ -14,15 +15,28 @@ from dimos.benchmark.libero_pro.podman import ContainerEndpoints
 CASE = Path(__file__).parent / "cases" / "goal-task-0-single-trial" / "task.json"
 
 
-def test_evaluation_protocol_requires_rich_visual_inspection_of_debug_trials() -> None:
+def test_evaluation_protocol_exposes_only_minimal_harness_contract() -> None:
     protocol = evaluation.EVALUATION_PROTOCOL
 
-    assert "trial.open_memory()" in protocol
-    assert "from IPython.display import display" in protocol
-    assert 'memory.stream("agentview_color_image").last().data' in protocol
-    assert "display(PILImage.fromarray(frame.to_rgb().data))" in protocol
-    assert "ASCII art" in protocol
-    assert "pixel statistics" in protocol
+    assert "policy(app: Dimos) -> None" in protocol
+    assert "submit_policy(policy)" in protocol
+    assert "PolicyCandidate" in protocol
+    assert "candidate.evidence.timeline()" in protocol
+    assert "freeze_policy(candidate)" in protocol
+    assert "exact task input" in protocol
+
+    forbidden = (
+        "segment_best",
+        "GraspExecutionModule",
+        "planning_group",
+        "collision-checked",
+        "skillbook",
+        "verifier",
+        "diagnoser",
+        "privileged",
+        "ASCII art",
+    )
+    assert all(term not in protocol for term in forbidden)
 
 
 def test_trial_starts_clock_and_prepared_policy_only_after_blueprint_is_ready(
@@ -32,7 +46,7 @@ def test_trial_starts_clock_and_prepared_policy_only_after_blueprint_is_ready(
     events: list[str] = []
     manifest = LiberoTaskManifest.model_validate_json(CASE.read_bytes())
     assets = PreparedAssets(tmp_path / "task.bddl", tmp_path / "states.pt")
-    policy = PolicyArtifact(tmp_path / "policy.py", tmp_path / "policy.pkl", "digest")
+    policy = PolicyArtifact("def policy(app): ...\n", cloudpickle.dumps(lambda: None), "digest")
 
     class FakeContainer:
         def __init__(self, *_args: object, **_kwargs: object) -> None:
@@ -84,7 +98,12 @@ def test_trial_starts_clock_and_prepared_policy_only_after_blueprint_is_ready(
         def finish(self, *, grace_s: float = 1.0) -> PolicyExecution:
             del grace_s
             events.append("policy.finish")
-            return PolicyExecution("policy_error", 10.5, "RPC closed after native success")
+            return PolicyExecution(
+                "policy_error",
+                10.5,
+                "RPC closed after native success",
+                "gripper result: succeeded",
+            )
 
     class FakeRuntime:
         def prepare(
@@ -128,9 +147,11 @@ def test_trial_starts_clock_and_prepared_policy_only_after_blueprint_is_ready(
         run_id="scored",
     )
 
-    assert trial.outcome.status == "completed"
+    assert trial.outcome.status == "policy_error"
+    assert trial.policy_output == "gripper result: succeeded"
+    assert (tmp_path / "trial" / "policy-output.log").read_text() == trial.policy_output
     assert native["score"] == 1.0
-    assert native["policy_execution_status"] == "completed"
+    assert native["policy_execution_status"] == "policy_error"
     assert events == [
         "container.start",
         "control.ready",

--- a/docs/adr/0019-use-evo-for-branching-autoresearch.md
+++ b/docs/adr/0019-use-evo-for-branching-autoresearch.md
@@ -1,0 +1,3 @@
+# Use Evo for branching autoresearch
+
+Evo owns manipulation autoresearch experiment worktrees, branching lineage, shared traces, frontier selection, and concurrent agent orchestration, while DimOS owns the Research Artifact and native benchmark measurement. We use unmodified upstream Evo through its public CLI, plugin, target, benchmark, gate, and trace contracts; DimOS does not fork, patch, vendor, subclass, or reproduce Evo orchestration. We use Evo's built-in GEPA-inspired per-task Pareto frontier instead of building a linear champion-challenger loop in DimOS, because aggregate-only hill climbing would discard task specialists and duplicate orchestration that Evo already provides.

--- a/docs/adr/0020-evolve-the-manipulation-agent-harness.md
+++ b/docs/adr/0020-evolve-the-manipulation-agent-harness.md
@@ -1,0 +1,3 @@
+# Evolve the manipulation agent harness
+
+Manipulation autoresearch evolves the task-independent code-policy exploration harness while task instructions remain minimal and perception, grasping, motion-planning primitives, benchmark cases, and native scoring remain fixed. We reject an editable textual skillbook because accumulating behavioral instructions obscures whether improvements come from reusable execution structure or prompt-specific coaching; the harness instead aligns the agent through structured observations, primitive-level evidence, failure feedback, and policy-candidate lifecycle.

--- a/docs/adr/0021-keep-the-manipulation-agent-harness-deterministic.md
+++ b/docs/adr/0021-keep-the-manipulation-agent-harness-deterministic.md
@@ -1,0 +1,3 @@
+# Keep the manipulation agent harness deterministic
+
+The initial Manipulation Agent Harness uses deterministic typed APIs, state transitions, trace extraction, evidence packaging, and policy-candidate lifecycle, with the task Agent as the only model interpreting Trial Evidence. We reject automatic verifier or diagnoser model calls because they would move behavioral prompting into hidden middleware, make benchmark gains harder to attribute, and introduce another stochastic research subject before the basic harness is proven.

--- a/docs/adr/0022-require-explicit-policy-freezing.md
+++ b/docs/adr/0022-require-explicit-policy-freezing.md
@@ -1,0 +1,3 @@
+# Require explicit policy freezing
+
+Every debug submission becomes an immutable Policy Candidate, and the Agent must explicitly freeze one candidate as the task's Policy Artifact before exploration ends. We reject last-submission-wins and automatic debug-score selection because diagnostic or narrowly successful later attempts can replace a more robust earlier policy, while a deterministic harness cannot infer strategic quality from sparse native outcomes alone.

--- a/docs/capabilities/agents/evaluation.md
+++ b/docs/capabilities/agents/evaluation.md
@@ -10,9 +10,9 @@ Evaluations select the runtime that matches the benchmark condition.
 Pi + Python REPL                           native Evaluation
       │                                           │
       ├── submit_policy(policy) ── fresh debug trial
-      │                         ◀── outcome, logs, Memory2, artifacts
+      │                         ◀── immutable candidate + Trial Evidence
       │
-      └── last submitted policy ── held-out trials without Pi
+      └── freeze_policy(candidate) ── held-out trials without Pi
                                                   │
                                       privileged native scorer
 ```
@@ -48,7 +48,7 @@ policy process, trial logs, or Memory2 recording.
 
 The `code-policy-v1` profile runs the model and thinking level pinned by the run
 specification with one tool: `python_exec`. The persistent Python REPL contains
-`Dimos` and `submit_policy`.
+`Dimos`, `submit_policy`, and `freeze_policy`.
 
 ```python
 def policy(app: Dimos) -> None:
@@ -56,22 +56,25 @@ def policy(app: Dimos) -> None:
     app.skills.move_to(target.position)
 
 
-trial = submit_policy(policy)
-trial.outcome
-trial.read_logs(module="MotionPlanner", tail=100)
-memory = trial.open_memory()
+candidate = submit_policy(policy)
+candidate.evidence.summary
+candidate.evidence.logs(module="MotionPlanner", tail=100)
+memory = candidate.evidence.open_memory()
 list(memory.streams)
-list(trial.artifacts.iterdir())
+list(candidate.evidence.artifacts.iterdir())
+freeze_policy(candidate)
 ```
 
 The callable must have the exact synchronous signature shown above. Each
 accepted submission starts a fresh debug environment and a fresh policy-only
 blueprint. The Evaluation chooses the debug-case sequence. Pi may submit five
-trials; its last accepted callable becomes the task-level policy artifact.
+candidates and must explicitly freeze one. Freezing is irreversible, closes
+submissions, and is the only way to produce the task-level policy artifact.
 
-`TrialRun` describes a stopped run. It exposes debug success and reward, policy
-errors, DimOS logs, a read-only Memory2 store, primitive traces, and recorded
-artifacts. It does not expose simulator state or scorer internals.
+`TrialEvidence` gives a bounded summary before exposing the underlying stopped
+`TrialRun`, filtered DimOS logs, selected frames, policy output, a read-only
+Memory2 store, and raw artifacts on demand. Missing evidence remains unavailable;
+the harness does not diagnose from incomplete facts or expose scorer internals.
 
 ## Held-out execution
 

--- a/docs/capabilities/agents/manipulation-autoresearch.md
+++ b/docs/capabilities/agents/manipulation-autoresearch.md
@@ -1,0 +1,69 @@
+---
+title: "Manipulation autoresearch with Evo"
+---
+
+# Manipulation autoresearch with Evo
+
+DimOS exposes the task-independent manipulation Agent Harness as a research target
+and the LIBERO-PRO panel as an inline Evo benchmark. Evo remains an unmodified,
+external development tool: this repository does not fork, patch, vendor, subclass,
+or import Evo. Evo owns experiment branches and search; DimOS owns native execution,
+scoring, and artifacts.
+
+## Install and initialize
+
+Install the upstream CLI and its Codex plugin, recording the installed version with
+the run artifacts:
+
+```bash
+uv tool install evo-hq-cli
+evo install codex
+evo --version
+evo init
+```
+
+During `evo init` (the CLI equivalent of discovery), configure:
+
+- target: `dimos/benchmark/evaluation/`
+- benchmark command:
+
+  ```bash
+  uv run python -m dimos.benchmark.libero_pro.autoresearch \
+    --panel dimos/benchmark/libero_pro/cases/autoresearch/dev-panel.json \
+    --output "/tmp/dimos-evo-$EVO_EXPERIMENT_ID" --json
+  ```
+
+- metric: maximize `score`
+- instrumentation: inline
+- resource profile: one concurrent experiment when the simulator/GPU services are
+  singleton
+
+The command reads `EVO_RESULT_PATH`, `EVO_TRACES_DIR`, and `EVO_EXPERIMENT_ID`
+directly. Its atomic result contains the macro score and one task dimension per panel
+case. Each trace points back to policy, logs, video, Memory2, and native result files.
+No Evo Python package is needed inside DimOS.
+
+Select Evo's built-in `pareto_per_task` frontier in the dashboard, then start the
+standard loop from Codex:
+
+```text
+$evo optimize subagents=1
+```
+
+The per-task frontier retains branches that improve different manipulation cases even
+when their macro scores tie. Use one subagent initially because local LIBERO services
+share GPU, ports, and caches; increase concurrency only after isolating those resources.
+
+## Panel identity and interpretation
+
+The development panel currently contains goal, spatial, object, and long-horizon
+cases. The runner resolves it once and hashes the panel plus case specifications. The
+hash is written to the normal DimOS result, Evo result, and every trace; changing a case
+starts a different baseline.
+
+These four binary outcomes are integration evidence for the autoresearch system. They
+are not a statistically robust benchmark result and must not be reported as
+publication-grade manipulation performance. Multi-seed measurement is a later layer.
+
+Outside Evo, omit the Evo environment variables. The same command still writes
+`panel-score.json` and prints normal JSON, which is useful for local contract checks.

--- a/openspec/changes/add-evo-manipulation-autoresearch/.openspec.yaml
+++ b/openspec/changes/add-evo-manipulation-autoresearch/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-20

--- a/openspec/changes/add-evo-manipulation-autoresearch/design.md
+++ b/openspec/changes/add-evo-manipulation-autoresearch/design.md
@@ -1,0 +1,96 @@
+## Context
+
+The code-policy runtime currently gives one Pi agent a persistent Python workspace, `submit_policy(policy)`, five fresh debug trials, and raw `TrialRun` handles. `_SubmissionManager.last_policy` silently selects the last accepted submission for evaluation. LIBERO-PRO compensates with a long protocol containing API facts and manipulation strategy, while the existing autoresearch panel runs four representative cases and writes a DimOS-specific aggregate.
+
+The desired research subject is not a prompt or skillbook. It is the task-independent exploration harness that shapes how the agent submits candidates, receives execution evidence, and selects a final policy. Evo already provides experiment worktrees, branching lineage, shared traces, concurrency, gates, and a GEPA-inspired per-task Pareto frontier, so DimOS only needs a research target and a standard benchmark adapter.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Align manipulation-agent behavior through a deterministic executable harness rather than a growing behavioral prompt.
+- Preserve every submitted policy as an immutable candidate with navigable evidence.
+- Require intentional, auditable final-policy selection.
+- Give the agent concise evidence first and deterministic access to complete raw artifacts on demand.
+- Run the current four-case LIBERO-PRO panel through unmodified Evo and expose both combined and per-case native scores.
+- Keep panel definitions data-driven and immutable within an Evo run.
+
+**Non-Goals:**
+
+- Adding verifier, diagnoser, or judge model calls.
+- Evolving task instructions, perception, grasp generation, planning, robot control, benchmark assets, or native scoring.
+- Forking, patching, vendoring, subclassing, or reproducing Evo.
+- Claiming statistically robust benchmark improvement from the four-case integration pilot.
+- Adding multi-seed task scoring in the first pilot; that is the next measurement layer after the integration is proven.
+
+## Decisions
+
+### Isolate the Manipulation Agent Harness as Evo's research target
+
+The harness will live in a focused evaluation module, separate from LIBERO task manifests, the native evaluator, and robot primitives. Runtime and kernel code will transport harness operations but will not contain manipulation strategy. Evo will be initialized with this harness module as its target and will execute the normal DimOS panel command in each experiment worktree.
+
+Alternatives rejected:
+
+- An editable skillbook or prompt: improvements would be prompt coaching rather than reusable execution structure.
+- Arbitrary repository optimization: the pilot would not isolate whether the agent harness improved.
+- A DimOS-native search controller: it would duplicate Evo's experiment tree, scheduling, and observability.
+
+### Replace last-submission-wins with immutable candidates and explicit freezing
+
+`submit_policy()` will return a `PolicyCandidate` containing a stable candidate ID, its immutable policy source/serialization, Debug Trial, compact evidence summary, and drilldown handle. The harness will keep all candidates for the exploration. `freeze_policy(candidate)` will select exactly one candidate, close further submissions, and make that candidate the `ExplorationOutcome.policy`. Exploration that ends without a frozen candidate is invalid.
+
+There is no compatibility fallback to the last submission and no automatic score-based selection. Sparse debug success cannot deterministically identify the most robust policy, and diagnostic submissions must not overwrite earlier candidates.
+
+### Present Trial Evidence through progressive disclosure
+
+The candidate returned to the Python workspace will expose a compact, bounded summary: candidate ID, native debug outcome, execution status, duration, remaining budget, initial and terminal visual evidence when available, and an index of evidence categories. On-demand methods will provide timelines, filtered logs, selected frames, policy output, read-only Memory2, and raw artifact paths.
+
+Evidence selection will use timestamps, typed statuses, module identity, and artifact metadata only. Missing structured evidence is represented as unknown or unavailable; the harness does not infer physical causes. Full raw artifacts remain accessible.
+
+Alternatives rejected:
+
+- Returning every artifact automatically: it overwhelms the agent context and obscures salient failures.
+- Model-written diagnoses: they introduce hidden behavioral prompts and another stochastic research subject.
+
+### Keep task instructions minimal and keep capability contracts out of strategy prose
+
+The runtime system instruction will state the callable contract, submission budget, evidence workflow, and explicit freeze requirement. LIBERO supplies the exact task instruction and non-privileged capability surface. The existing long manipulation recipes will be removed rather than moved to another prompt. Typed APIs, docstrings, harness summaries, and Trial Evidence provide the operational guidance.
+
+### Use Evo's inline benchmark contract without an Evo library dependency
+
+The panel command will honor `EVO_RESULT_PATH`, `EVO_TRACES_DIR`, and `EVO_EXPERIMENT_ID` directly. It will atomically publish one result with a numeric macro score and a task map keyed by Evaluation Case ID. It will write one trace per case containing the native outcome, failure category, runtime identity, panel hash, and paths to the DimOS artifacts needed for diagnosis.
+
+The current four cases remain the pilot panel. Each case is one Evo task; individual debug or scored seeds are trace details, not frontier dimensions. Evo's standard `pareto_per_task` strategy can therefore retain branches that specialize on different manipulation cases while the top-level macro score ranks overall performance.
+
+### Make panel composition configurable between runs and immutable within a run
+
+`ResearchPanel` will require a non-empty set of unique case IDs and safe relative specification paths, without enforcing exactly four cases or one hard-coded family each. The runner will hash the resolved panel and case specifications and stamp the hash into the result and traces. One invocation resolves the panel once; an Evo run is initialized against that fixed panel path and hash.
+
+Changing panel membership creates a new research baseline. Outcomes with different panel hashes are not comparable.
+
+### Distinguish low policy score from invalid measurement
+
+A completed policy attempt with native failure is a valid task score of zero. Policy exceptions are recorded as task failures when the Evaluation produces a valid native result. Preflight, infrastructure, missing-result, or malformed-result conditions make the Evo benchmark command fail non-zero rather than publishing a misleading aggregate.
+
+## Risks / Trade-offs
+
+- **Existing logs may not expose a reliable primitive timeline** → Begin implementation with a trace-quality spike over recorded failed trials. Add narrow typed event recording at the policy-capability boundary only where timestamps and statuses cannot be reconstructed.
+- **The four-case pilot is noisy and coarse** → Label it as integration evidence, retain per-case traces, and add one-policy/multi-seed measurement only after Evo demonstrates useful search behavior.
+- **Minimal instructions may initially regress performance** → Preserve API contracts and typed discovery, compare against the current baseline, and let failures identify missing harness affordances rather than restoring strategy prose.
+- **Evo agents can explore changes outside the nominal target** → Use Evo's normal target, experiment diffs, gates, and review workflow; do not modify Evo to enforce a custom sandbox in the pilot.
+- **Parallel LIBERO cases may contend for local ports, GPU services, or caches** → Let Evo size concurrency from the benchmark resource profile and start conservatively when the environment exposes singleton resources.
+- **Evo version drift can change experiment semantics** → Record the installed Evo version and generated workspace configuration with each research run; verify the public contract when upgrading.
+
+## Migration Plan
+
+1. Add the deterministic candidate/evidence models and trace-quality tests without changing final selection.
+2. Add the freeze endpoint and kernel helper, switch `ExplorationOutcome.policy` to the frozen candidate, and remove `last_policy` fallback in the same change.
+3. Replace the LIBERO coaching protocol with the minimal harness/task contract and update prompt-evidence assertions.
+4. Generalize the panel schema and add Evo inline output alongside the existing human-readable panel result.
+5. Document and execute a four-case baseline using an unmodified Evo installation and the built-in per-task Pareto frontier.
+
+Rollback is a normal source revert before adoption. There is no runtime data migration and no backward-compatible last-submission mode.
+
+## Open Questions
+
+- Do existing module logs and Memory2 timestamps provide enough typed events to locate failure-adjacent visual evidence, or is a small policy-capability event recorder required? Resolve with the first implementation spike before finalizing the evidence index.

--- a/openspec/changes/add-evo-manipulation-autoresearch/proposal.md
+++ b/openspec/changes/add-evo-manipulation-autoresearch/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+DimOS can run isolated code-policy trials and aggregate a small LIBERO-PRO panel, but the exploration agent receives a large behavioral recipe, raw trial artifacts, and a last-submission-wins policy lifecycle. We need a measurable, task-independent manipulation harness that aligns the agent through deterministic affordances and evidence, and we need to expose that harness to unmodified Evo so its built-in branching autoresearch can improve it across manipulation tasks.
+
+## What Changes
+
+- Add a deterministic Manipulation Agent Harness that manages immutable policy candidates, compact Trial Evidence, on-demand artifact drilldown, submission budget, and explicit final-policy freezing.
+- Replace the long manipulation coaching protocol with a minimal task instruction and harness contract; keep perception, grasping, planning, robot control, benchmark cases, and native scoring fixed.
+- **BREAKING**: replace last-accepted-submission selection with an explicit `freeze_policy(candidate)` requirement; exploration without a frozen candidate is invalid.
+- Adapt the existing configurable LIBERO-PRO research panel to emit Evo's standard numeric score, per-case task scores, and per-task traces while preserving native DimOS artifacts.
+- Use unmodified upstream Evo through its public CLI/plugin and inline benchmark contract, including its built-in GEPA-inspired `pareto_per_task` frontier; do not fork, patch, vendor, or reproduce Evo orchestration in DimOS.
+- Start with the current four-case panel as an integration pilot. Treat its four binary results as pilot evidence rather than a statistically robust benchmark claim.
+
+## Capabilities
+
+### New Capabilities
+
+- `manipulation-agent-harness`: Deterministic code-policy exploration, Trial Evidence navigation, immutable policy candidates, and explicit policy freezing.
+- `evo-manipulation-autoresearch`: Evo-compatible manipulation panel measurement, task-level traces, configurable frozen panel composition, and unmodified Evo orchestration.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Affects the code-policy runtime and submission API in `dimos/benchmark/evaluation/`, the exploration kernel in `dimos/agents/code_policy_core.py`, and LIBERO-PRO evaluation prompts and tests.
+- Extends the existing `dimos/benchmark/libero_pro/autoresearch.py` panel runner and its checked-in cases with Evo-compatible output.
+- Adds a focused harness research target and documentation for initializing an Evo workspace; Evo remains an external development tool rather than a DimOS runtime dependency.
+- Existing callers that rely on the final submitted policy being selected implicitly must use explicit freezing.

--- a/openspec/changes/add-evo-manipulation-autoresearch/specs/evo-manipulation-autoresearch/spec.md
+++ b/openspec/changes/add-evo-manipulation-autoresearch/specs/evo-manipulation-autoresearch/spec.md
@@ -1,0 +1,54 @@
+## ADDED Requirements
+
+### Requirement: Unmodified Evo orchestration
+Manipulation autoresearch SHALL use an upstream Evo installation through its documented CLI, plugin, target, benchmark, gate, worktree, trace, and frontier contracts. DimOS SHALL NOT fork, patch, vendor, subclass, or reimplement Evo orchestration.
+
+#### Scenario: Research workspace is initialized
+- **WHEN** a user initializes manipulation autoresearch
+- **THEN** the documented workflow configures the harness target and DimOS benchmark command using standard Evo commands and the built-in per-task Pareto frontier
+
+### Requirement: Evo-compatible result publication
+The manipulation panel runner SHALL implement Evo's inline result contract without requiring an Evo runtime library. It SHALL publish one atomic result containing a numeric combined score and a `tasks` mapping from Evaluation Case ID to native case score.
+
+#### Scenario: Four-case pilot completes
+- **WHEN** all four pilot Evaluation Cases produce valid native results
+- **THEN** the runner publishes their macro-average as `score` and publishes each case's score under its unique case ID
+
+#### Scenario: Evo environment variables are absent
+- **WHEN** the panel runner is invoked outside Evo
+- **THEN** it still writes the normal DimOS panel result and can print its JSON result without requiring an Evo package
+
+### Requirement: Per-case diagnostic traces
+The panel runner SHALL write one Evo trace per Evaluation Case with stable task ID, native score and status, failure category when applicable, runtime identity, panel hash, and references to the corresponding DimOS policy, logs, videos, Memory2, and result artifacts.
+
+#### Scenario: A policy receives native failure
+- **WHEN** an Evaluation Case completes correctly with native success false
+- **THEN** its trace records a valid score of zero and references the evidence needed to investigate the failure
+
+### Requirement: Invalid measurements fail the experiment
+The panel runner SHALL distinguish valid native task failure from measurement failure. Preflight errors, infrastructure errors, missing native results, or malformed native results MUST cause a non-zero benchmark exit and MUST NOT publish a misleading combined Evo score.
+
+#### Scenario: One case has an infrastructure failure
+- **WHEN** a panel case cannot start its container or produce a valid native result
+- **THEN** the Evo benchmark invocation fails and preserves diagnostic output without committing a numeric aggregate as a valid experiment outcome
+
+### Requirement: Configurable research panels
+A Research Panel SHALL contain at least one Evaluation Case with a unique ID and a safe relative specification path. The panel schema SHALL NOT require exactly four cases or one case from each hard-coded suite family.
+
+#### Scenario: User creates a different development panel
+- **WHEN** a panel lists a valid non-empty collection of unique Evaluation Cases
+- **THEN** the runner evaluates those cases without code changes to Evo or the panel runner
+
+### Requirement: Frozen panel identity
+The panel runner SHALL resolve panel composition once per invocation and SHALL include a deterministic content hash of the panel and resolved case specifications in the combined result and every per-case trace. Results with different panel hashes SHALL be treated as different research baselines.
+
+#### Scenario: Panel membership changes between runs
+- **WHEN** a case is added, removed, or changed before a new Evo run
+- **THEN** the new baseline receives a different panel hash and is not compared as a continuation of the previous panel
+
+### Requirement: Four-case integration pilot
+The initial documented Evo workflow SHALL use the existing goal, spatial, object, and long-horizon development cases as an integration pilot and SHALL label its four binary outcomes as pilot evidence rather than a statistically robust benchmark claim.
+
+#### Scenario: Pilot results are reported
+- **WHEN** the first Evo search reports improvement on the four-case panel
+- **THEN** the documentation identifies the result as an integration finding and does not claim publication-grade manipulation performance

--- a/openspec/changes/add-evo-manipulation-autoresearch/specs/manipulation-agent-harness/spec.md
+++ b/openspec/changes/add-evo-manipulation-autoresearch/specs/manipulation-agent-harness/spec.md
@@ -1,0 +1,58 @@
+## ADDED Requirements
+
+### Requirement: Minimal manipulation exploration contract
+The system SHALL provide the manipulation Agent only the exact task instruction, the callable and harness workflow contract, and discoverable non-privileged capabilities. It SHALL NOT provide task-solving recipes, an editable skillbook, or secondary verifier and diagnoser model output.
+
+#### Scenario: Exploration starts for a LIBERO task
+- **WHEN** the code-policy runtime assembles the manipulation exploration prompt
+- **THEN** the prompt identifies the task, submission budget, evidence access, and explicit freeze operation without prescribing perception, grasping, or motion strategies
+
+### Requirement: Immutable policy candidates
+The Manipulation Agent Harness SHALL turn every accepted submission into a uniquely identified immutable Policy Candidate containing the submitted policy, its Debug Trial, and its Trial Evidence. A later submission SHALL NOT replace or mutate an earlier candidate.
+
+#### Scenario: Agent submits multiple policies
+- **WHEN** the Agent submits two valid policy callables within its budget
+- **THEN** the harness returns two distinct candidates and preserves both policies and both trial records for later inspection and selection
+
+### Requirement: Explicit policy freezing
+The Agent MUST explicitly freeze one submitted Policy Candidate before exploration ends. Freezing SHALL select that candidate as the Policy Artifact, prevent further submissions, and be irreversible for that exploration. The runtime SHALL NOT select the latest candidate or automatically select by debug score.
+
+#### Scenario: Agent freezes an earlier candidate
+- **WHEN** the Agent submits a diagnostic candidate after a working candidate and then freezes the earlier candidate
+- **THEN** the earlier candidate becomes the Policy Artifact evaluated on the scored case
+
+#### Scenario: Agent does not freeze a candidate
+- **WHEN** the Agent session ends after one or more submissions without calling the freeze operation
+- **THEN** exploration is invalid and no Policy Artifact is evaluated
+
+#### Scenario: Agent submits after freezing
+- **WHEN** the Agent attempts another submission after freezing a candidate
+- **THEN** the harness rejects the submission without changing the frozen Policy Artifact
+
+### Requirement: Deterministic Trial Evidence summary
+Each Policy Candidate SHALL expose a bounded Trial Evidence summary produced only from non-privileged recorded facts. The summary SHALL identify the candidate, native debug outcome, execution status, duration, remaining budget, available evidence categories, and initial or terminal visual evidence when recorded. Unknown facts SHALL remain unknown rather than being inferred.
+
+#### Scenario: Failed trial has incomplete structured events
+- **WHEN** a Debug Trial fails but its raw artifacts do not identify a physical root cause
+- **THEN** the summary reports the recorded failure status and available evidence without inventing a diagnosis or repair
+
+### Requirement: On-demand evidence drilldown
+Trial Evidence SHALL provide deterministic on-demand access to event timelines, filtered module logs, selected visual frames, policy output, read-only Memory2, and complete raw artifact references. Automatic summaries SHALL NOT make the underlying evidence inaccessible.
+
+#### Scenario: Agent investigates a planning failure
+- **WHEN** the Agent requests planning-related logs and frames from a Policy Candidate
+- **THEN** the harness returns the matching recorded evidence or explicitly reports that the requested category is unavailable
+
+### Requirement: Fixed submission budget
+The Manipulation Agent Harness SHALL enforce the evaluation-owned submission budget across all Policy Candidates and SHALL report the remaining budget after each accepted submission.
+
+#### Scenario: Submission budget is exhausted
+- **WHEN** the Agent attempts to submit more candidates than the Evaluation permits
+- **THEN** the harness rejects the excess submission and preserves all previously accepted candidates and any frozen selection
+
+### Requirement: Frozen policy execution isolation
+The Evaluation Stage SHALL execute only the explicitly frozen Policy Artifact in the existing clean policy process and SHALL exclude the exploration Agent and harness mutation state from measured execution.
+
+#### Scenario: Frozen candidate enters evaluation
+- **WHEN** exploration completes with a frozen candidate
+- **THEN** the evaluator loads that candidate's serialized callable behind the existing start gate and does not load the exploration Agent

--- a/openspec/changes/add-evo-manipulation-autoresearch/tasks.md
+++ b/openspec/changes/add-evo-manipulation-autoresearch/tasks.md
@@ -1,0 +1,39 @@
+## 1. Validate the Evidence Boundary
+
+- [x] 1.1 Build a fixture-based trace-quality test from representative successful, policy-error, planning-failure, and infrastructure-failure Debug Trials and inventory which timelines, statuses, and visual timestamps are recoverable from current logs and Memory2.
+- [x] 1.2 Implement the smallest typed policy-capability event recording needed for evidence fields that the trace-quality test proves cannot be reconstructed, without recording privileged evaluator state. (The spike proved no additional event recording is needed.)
+
+## 2. Implement the Deterministic Harness Model
+
+- [x] 2.1 Add focused `PolicyCandidate`, `TrialEvidence`, evidence-summary, and evidence-category models with immutable IDs and bounded agent encodings.
+- [x] 2.2 Implement deterministic Trial Evidence indexing for outcomes, event timelines, filtered module logs, policy output, artifact references, read-only Memory2, and available initial, terminal, or failure-adjacent frames.
+- [x] 2.3 Add unit tests proving progressive disclosure, bounded summaries, unavailable-evidence behavior, non-privileged content, and access to complete raw artifacts.
+
+## 3. Replace Submission Selection with Explicit Freezing
+
+- [x] 3.1 Refactor the submission manager to preserve every accepted policy as an immutable candidate, enforce the existing submission budget, and remove `last_policy` selection.
+- [x] 3.2 Add the authenticated freeze operation to the code-policy server and exploration kernel, accepting only a candidate from the current exploration.
+- [x] 3.3 Make freezing irreversible, reject submissions after freezing, and resolve `ExplorationOutcome.policy` exclusively from the frozen candidate.
+- [x] 3.4 Add lifecycle tests for multiple candidates, freezing an earlier candidate, missing freeze, invalid candidate IDs, repeated freeze, post-freeze submission, exhausted budget, and clean frozen-policy execution.
+
+## 4. Minimize Manipulation Instructions
+
+- [x] 4.1 Replace the LIBERO-PRO strategy-heavy evaluation protocol with the exact task input, callable contract, submission/evidence workflow, non-privileged capability discovery, and explicit freeze requirement.
+- [x] 4.2 Update prompt-evidence recording and tests to prove manipulation recipes, skillbook content, privileged state, and secondary verifier or diagnoser instructions are absent.
+- [x] 4.3 Add an end-to-end mocked exploration test in which the Agent submits candidates, drills into Trial Evidence, freezes one candidate, and produces the expected Policy Artifact.
+
+## 5. Add the Evo-Compatible Research Panel
+
+- [x] 5.1 Generalize `ResearchPanel` to any non-empty collection of unique case IDs with safe relative specifications, removing the exact-four-cases and hard-coded-family requirements.
+- [x] 5.2 Resolve and hash the panel plus case specifications once per invocation, and record the panel hash in the normal panel result.
+- [x] 5.3 Add an inline Evo result publisher that honors `EVO_RESULT_PATH`, `EVO_TRACES_DIR`, and `EVO_EXPERIMENT_ID`, atomically publishes the macro score and per-case task map, and requires no Evo Python dependency.
+- [x] 5.4 Emit one diagnostic Evo trace per Evaluation Case with native outcome, stable failure category, runtime identity, panel hash, and references to DimOS policy, log, video, Memory2, and result artifacts.
+- [x] 5.5 Separate valid native or policy failure from invalid measurement so preflight, infrastructure, missing-result, and malformed-result conditions exit non-zero without publishing a valid aggregate.
+- [x] 5.6 Add tests for configurable panels, hash changes, four-case score publication, atomic duplicate-writer rejection, non-Evo invocation, per-case traces, valid zero scores, and invalid measurement exits.
+
+## 6. Document and Verify the Bare-Bones Evo Pilot
+
+- [x] 6.1 Document installation and standard `evo init`/optimize commands using the harness target, existing four-case development panel, inline instrumentation, recorded Evo version, and built-in `pareto_per_task` frontier.
+- [x] 6.2 State explicitly that Evo is an unmodified external development tool and that the four binary case outcomes are integration evidence rather than a statistically robust benchmark result.
+- [x] 6.3 Run the focused code-policy and LIBERO autoresearch unit tests, the Evo contract check with a fake local evaluator, and repository formatting/type checks for all touched files.
+- [x] 6.4 Run one upstream Evo four-case baseline and verify the dashboard receives the combined score, per-case Pareto dimensions, diagnostic traces, experiment diff, and harness artifact references. (The valid activated baseline recorded a 0.0 macro score and four 0.0 native task scores with the built-in `pareto_per_task` frontier.)


### PR DESCRIPTION
Part of the linear LIBERO stack: #3439 → #3581 → #3582 → #3583.

## Summary

- add immutable policy candidates, progressive trial evidence, and explicit freezing
- minimize task-independent manipulation instructions while retaining native evaluation
- add configurable development and held-out autoresearch panels
- publish atomic Evo macro scores, per-task dimensions, diagnostic traces, and panel identity
- classify policy failures with valid native results as scored task failures rather than invalid infrastructure

## Baseline

The verified activated four-case development baseline is 0.0 macro score with four 0.0 native task scores. Evo uses its built-in `pareto_per_task` frontier. This PR makes no performance-improvement claim.

## Verification

- 37 focused Agent Harness and autoresearch tests pass
- the upstream Evo result/dashboard contract was exercised with the fixed four-case panel

Depends on #3581.