### PR TITLE
chore(eval): containerize built-in evaluations

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,13 @@
 .git
 .gitignore
 .github/
+.evo/
+.container-eval/
+.mypy_cache/
+.pytest_cache/
+.ruff_cache/
+logs/
+recordings/
 
 # Editor and IDE files
 .vscode
@@ -82,6 +89,14 @@ node_modules/
 package-lock.json
 package.json
 bin/node_modules/
+
+# The code-policy agent is part of the locked evaluation environment.
+!packages/pi-code-policy-extension/package.json
+!packages/pi-code-policy-extension/package-lock.json
+!packages/pi-code-policy-extension/tsconfig.json
+!packages/pi-code-policy-extension/tsconfig.build.json
+!packages/pi-code-policy-extension/src/
+!packages/pi-code-policy-extension/src/**
 
 # Database files
 *.db

--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ data/*
 # Runtime output
 /logs
 /recordings
+/.container-eval/
 results/
 /assets/output/
 /assets/rgbd_data/

--- a/dimos/benchmark/evaluation/container.py
+++ b/dimos/benchmark/evaluation/container.py
@@ -1,0 +1,346 @@
+"""Build and run the locked outer environment for built-in Evaluations."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable, Mapping, Sequence
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import tempfile
+from typing import Final
+
+from dimos.constants import CACHE_DIR, DIMOS_PROJECT_ROOT
+
+_IMAGE_TAG: Final = "localhost/dimos-evaluation:build"
+_CONTAINER_ROOT: Final = Path("/opt/dimos")
+_SOCKET_TARGET: Final = Path("/run/podman/podman.sock")
+_INSIDE_ENV: Final = "DIMOS_EVALUATION_CONTAINER"
+_ENVIRONMENT_NAME: Final = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_DEFAULT_FORWARDED_ENV: Final = (
+    "OPENAI_BASE_URL",
+    "HF_TOKEN",
+    "HUGGING_FACE_HUB_TOKEN",
+)
+
+CommandFactory = Callable[[Path], Sequence[str]]
+
+
+class ContainerEvaluationError(RuntimeError):
+    """The locked evaluation container could not be built or started."""
+
+
+def inside_container(environ: Mapping[str, str] | None = None) -> bool:
+    """Return whether execution is already inside the locked evaluation image."""
+    return (os.environ if environ is None else environ).get(_INSIDE_ENV) == "1"
+
+
+def _checked_run(command: Sequence[str]) -> None:
+    try:
+        subprocess.run(command, check=True)
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise ContainerEvaluationError(f"{command[0]} command failed") from exc
+
+
+def _podman_socket(environ: Mapping[str, str]) -> Path:
+    runtime = Path(environ.get("XDG_RUNTIME_DIR", f"/run/user/{os.getuid()}"))
+    socket = runtime / "podman" / "podman.sock"
+    if not socket.is_socket():
+        raise ContainerEvaluationError(
+            f"rootless Podman socket is unavailable at {socket}; "
+            "run `systemctl --user enable --now podman.socket`"
+        )
+    return socket
+
+
+def _build_image(iid_path: Path) -> str:
+    iid_path.unlink(missing_ok=True)
+    _checked_run(
+        (
+            "podman",
+            "build",
+            "--iidfile",
+            str(iid_path),
+            "--tag",
+            _IMAGE_TAG,
+            "--file",
+            str(DIMOS_PROJECT_ROOT / "docker" / "evaluation" / "Dockerfile"),
+            str(DIMOS_PROJECT_ROOT),
+        )
+    )
+    try:
+        image_id = iid_path.read_text(encoding="utf-8").strip()
+    finally:
+        iid_path.unlink(missing_ok=True)
+    if not image_id.startswith("sha256:"):
+        raise ContainerEvaluationError(f"Podman returned an invalid image ID: {image_id!r}")
+    return image_id
+
+
+def _generate_cdi_spec(scratch: Path) -> Path:
+    cdi_directory = scratch / "cdi"
+    cdi_directory.mkdir(parents=True, exist_ok=True)
+    specification = cdi_directory / "nvidia.yaml"
+    _checked_run(("nvidia-ctk", "cdi", "generate", f"--output={specification}"))
+    if not specification.is_file():
+        raise ContainerEvaluationError("nvidia-ctk did not produce a CDI specification")
+    return cdi_directory
+
+
+def candidate_path(path: Path) -> Path:
+    """Translate a checked-in host path to the source baked into the image."""
+    resolved = path.expanduser().resolve()
+    try:
+        relative = resolved.relative_to(DIMOS_PROJECT_ROOT.resolve())
+    except ValueError as exc:
+        raise ContainerEvaluationError("candidate input must be a checked-in path") from exc
+    return _CONTAINER_ROOT / relative
+
+
+def _validate_output(output: Path) -> None:
+    if output.exists() and (not output.is_dir() or any(output.iterdir())):
+        raise FileExistsError(f"Output must be absent or an empty directory: {output}")
+
+
+def _environment_mounts(environ: Mapping[str, str]) -> tuple[Path, ...]:
+    paths: list[Path] = []
+    for name in ("EVO_RESULT_PATH", "EVO_TRACES_DIR"):
+        value = environ.get(name)
+        if value is None:
+            continue
+        path = Path(value)
+        if not path.is_absolute():
+            raise ContainerEvaluationError(f"{name} must be an absolute path")
+        paths.append(path.parent if name == "EVO_RESULT_PATH" else path)
+    return tuple(paths)
+
+
+def _mount_arguments(
+    *,
+    read_only: Sequence[Path],
+    writable: Sequence[Path],
+) -> tuple[str, ...]:
+    mounts = {path.resolve(): "ro" for path in read_only}
+    mounts.update((path.resolve(), "rw") for path in writable)
+    arguments: list[str] = []
+    for path, mode in sorted(mounts.items(), key=lambda item: (len(item[0].parts), str(item[0]))):
+        if path == Path("/"):
+            raise ContainerEvaluationError("refusing to mount the host filesystem root")
+        if mode == "ro":
+            if not path.is_dir():
+                raise ContainerEvaluationError(f"read-only input directory is unavailable: {path}")
+        else:
+            path.mkdir(parents=True, exist_ok=True)
+        arguments.extend(("--volume", f"{path}:{path}:{mode}"))
+    return tuple(arguments)
+
+
+def _container_environment() -> dict[str, str]:
+    return {
+        _INSIDE_ENV: "1",
+        "CONTAINER_HOST": f"unix://{_SOCKET_TARGET}",
+        "TMPDIR": "/runner-tmp",
+        "TMP": "/runner-tmp",
+        "TEMP": "/runner-tmp",
+        "XDG_CACHE_HOME": str(CACHE_DIR.resolve().parent),
+    }
+
+
+def _container_command(
+    *,
+    image_id: str,
+    cdi_directory: Path,
+    socket: Path,
+    scratch: Path,
+    read_only: Sequence[Path],
+    writable: Sequence[Path],
+    forwarded_environment: Sequence[str],
+    environ: Mapping[str, str],
+    inner: Sequence[str],
+) -> tuple[str, ...]:
+    command = [
+        "podman",
+        "--cdi-spec-dir",
+        str(cdi_directory),
+        "run",
+        "--rm",
+        "--network",
+        "host",
+        "--device",
+        "nvidia.com/gpu=all",
+        "--security-opt",
+        "label=disable",
+        "--volume",
+        f"{socket}:{_SOCKET_TARGET}:rw",
+        "--volume",
+        f"{scratch}:/runner-tmp:rw",
+        *_mount_arguments(read_only=read_only, writable=writable),
+    ]
+    for name in sorted(set(forwarded_environment)):
+        if _ENVIRONMENT_NAME.fullmatch(name) is None:
+            raise ContainerEvaluationError(f"invalid environment variable name: {name!r}")
+        if environ.get(name):
+            command.extend(("--env", name))
+    for name, value in sorted(_container_environment().items()):
+        command.extend(("--env", f"{name}={value}"))
+    command.extend((image_id, *inner))
+    return tuple(command)
+
+
+def run_in_container(
+    command: CommandFactory,
+    *,
+    output: Path,
+    input_directories: Sequence[Path],
+    forwarded_environment: Sequence[str],
+    environ: Mapping[str, str] | None = None,
+) -> int:
+    """Run one command in the locked image and publish its complete output."""
+    host_environment = dict(os.environ if environ is None else environ)
+    output = output.expanduser().resolve()
+    _validate_output(output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    staging = Path(tempfile.mkdtemp(prefix=f".{output.name}-container-", dir=output.parent))
+    result = staging / "result"
+    scratch = staging / "tmp"
+    scratch.mkdir()
+    try:
+        socket = _podman_socket(host_environment)
+        image_id = _build_image(staging / "image.iid")
+        cdi_directory = _generate_cdi_spec(scratch)
+        writable = (
+            staging,
+            CACHE_DIR.resolve(),
+            *_environment_mounts(host_environment),
+        )
+        invocation = _container_command(
+            image_id=image_id,
+            cdi_directory=cdi_directory,
+            socket=socket,
+            scratch=scratch,
+            read_only=input_directories,
+            writable=writable,
+            forwarded_environment=(*_DEFAULT_FORWARDED_ENV, *forwarded_environment),
+            environ=host_environment,
+            inner=tuple(command(result)),
+        )
+        try:
+            completed = subprocess.run(invocation, check=False)
+        except OSError as exc:
+            raise ContainerEvaluationError("podman command failed") from exc
+        if result.exists():
+            if not result.is_dir():
+                raise ContainerEvaluationError("evaluation output is not a directory")
+            if output.exists():
+                output.rmdir()
+            os.replace(result, output)
+        elif completed.returncode == 0:
+            raise ContainerEvaluationError("evaluation container completed without output")
+        return completed.returncode
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
+
+
+def run_evaluation(
+    specification: Path,
+    *,
+    output: Path,
+    api_key_env: str,
+    json_output: bool,
+    quiet: bool,
+) -> int:
+    """Run one public Evaluation command in the locked image."""
+    specification = specification.expanduser().resolve()
+
+    def command(result: Path) -> Sequence[str]:
+        inner = [
+            str(_CONTAINER_ROOT / ".venv" / "bin" / "dimos"),
+            "eval",
+            "_inside-run",
+            str(specification),
+            "--api-key-env",
+            api_key_env,
+            "--output",
+            str(result),
+            "--display-output",
+            str(output),
+        ]
+        if json_output:
+            inner.append("--json")
+        if quiet:
+            inner.append("--quiet")
+        return inner
+
+    return run_in_container(
+        command,
+        output=output,
+        input_directories=(specification.parent,),
+        forwarded_environment=(api_key_env,),
+    )
+
+
+def _inside_check() -> None:
+    # The full runtime is intentionally imported only inside the built image.
+    from dimos.benchmark.evaluation.runtime import _pi_paths
+
+    if DIMOS_PROJECT_ROOT.resolve() != _CONTAINER_ROOT:
+        raise ContainerEvaluationError(
+            f"candidate import resolved to {DIMOS_PROJECT_ROOT}, expected {_CONTAINER_ROOT}"
+        )
+    missing = [str(path) for path in _pi_paths() if not path.is_file()]
+    if missing:
+        raise ContainerEvaluationError(f"locked Pi build is incomplete: {', '.join(missing)}")
+    _checked_run(("podman", "info", "--format", "{{.Host.Security.Rootless}}"))
+    _checked_run(("nvidia-smi", "-L"))
+
+
+def check_environment(workspace: Path, environ: Mapping[str, str] | None = None) -> None:
+    """Build and verify the generic image without starting an Evaluation."""
+    host_environment = dict(os.environ if environ is None else environ)
+    workspace = workspace.expanduser().resolve()
+    workspace.mkdir(parents=True, exist_ok=True)
+    scratch = workspace / "tmp"
+    scratch.mkdir(exist_ok=True)
+    socket = _podman_socket(host_environment)
+    image_id = _build_image(workspace / "image.iid")
+    cdi_directory = _generate_cdi_spec(scratch)
+    command = _container_command(
+        image_id=image_id,
+        cdi_directory=cdi_directory,
+        socket=socket,
+        scratch=scratch,
+        read_only=(),
+        writable=(CACHE_DIR.resolve(),),
+        forwarded_environment=(),
+        environ=host_environment,
+        inner=(
+            str(_CONTAINER_ROOT / ".venv" / "bin" / "python"),
+            "-m",
+            "dimos.benchmark.evaluation.container",
+            "_inside-check",
+        ),
+    )
+    _checked_run(command)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="mode", required=True)
+    check = subparsers.add_parser("check", help="verify the locked evaluation environment")
+    check.add_argument("--workspace", type=Path, required=True)
+    subparsers.add_parser("_inside-check", help=argparse.SUPPRESS)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    arguments = _parser().parse_args(argv)
+    if arguments.mode == "_inside-check":
+        _inside_check()
+    else:
+        check_environment(arguments.workspace)
+
+
+if __name__ == "__main__":
+    main()

--- a/dimos/benchmark/evaluation/registry.py
+++ b/dimos/benchmark/evaluation/registry.py
@@ -12,23 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Lazy built-in and installed-package Evaluation discovery."""
+"""Lazy built-in Evaluation discovery."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 import importlib
 import importlib.metadata as importlib_metadata
-import re
 from typing import Any
 
-from packaging.utils import canonicalize_name
 from pydantic import BaseModel
 
 from dimos.benchmark.evaluation.protocol import Evaluation
 
-ENTRY_POINT_GROUP = "dimos.evaluations"
-LOCAL_NAME_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 BUILTIN_EVALUATIONS: dict[str, str] = {
     "libero-pro": "dimos.benchmark.libero_pro.evaluation:libero_pro",
     "vlnce-r2r": "dimos.benchmark.vlnce_r2r.evaluation:vlnce_r2r",
@@ -36,7 +32,7 @@ BUILTIN_EVALUATIONS: dict[str, str] = {
 
 
 class EvaluationRegistryError(ValueError):
-    """An Evaluation name or plugin could not be resolved."""
+    """A built-in Evaluation name or target could not be resolved."""
 
 
 @dataclass(frozen=True)
@@ -48,59 +44,23 @@ class ResolvedEvaluation:
 
 
 def available_evaluations() -> list[str]:
-    return sorted([*BUILTIN_EVALUATIONS, *_external_entries()])
+    return sorted(BUILTIN_EVALUATIONS)
 
 
 def resolve_evaluation(name: str) -> ResolvedEvaluation:
-    if name in BUILTIN_EVALUATIONS:
-        target = _load_target(BUILTIN_EVALUATIONS[name], name)
-        return ResolvedEvaluation(
-            name=name,
-            provider="dimos",
-            version=_distribution_version("dimos"),
-            evaluation=_validate_target(name, target),
-        )
-
-    entries = _external_entries()
-    entry = entries.get(name)
-    if entry is None:
-        available = available_evaluations()
-        suffix = f" Available evaluations: {', '.join(available)}." if available else ""
-        raise EvaluationRegistryError(f"Unknown evaluation {name!r}.{suffix}")
-    try:
-        target = entry.load()
-    except Exception as exc:
+    path = BUILTIN_EVALUATIONS.get(name)
+    if path is None:
+        available = ", ".join(available_evaluations())
         raise EvaluationRegistryError(
-            f"Failed to load evaluation {name!r} from {entry.value!r}: {type(exc).__name__}: {exc}"
-        ) from exc
-    distribution = entry.dist
-    assert distribution is not None
-    distribution_name = distribution.metadata["Name"]
+            f"Unknown evaluation {name!r}. Available evaluations: {available}."
+        )
+    target = _load_target(path, name)
     return ResolvedEvaluation(
         name=name,
-        provider=distribution_name,
-        version=distribution.version,
+        provider="dimos",
+        version=_distribution_version("dimos"),
         evaluation=_validate_target(name, target),
     )
-
-
-def _external_entries() -> dict[str, importlib_metadata.EntryPoint]:
-    result: dict[str, importlib_metadata.EntryPoint] = {}
-    for entry in importlib_metadata.entry_points(group=ENTRY_POINT_GROUP):
-        distribution = entry.dist
-        if distribution is None:
-            continue
-        distribution_name = distribution.metadata.get("Name")
-        if not distribution_name or LOCAL_NAME_PATTERN.fullmatch(entry.name) is None:
-            continue
-        namespace = str(canonicalize_name(distribution_name))
-        qualified_name = f"{namespace}.{entry.name}"
-        if qualified_name in result:
-            raise EvaluationRegistryError(
-                f"Multiple installed entry points provide evaluation {qualified_name!r}"
-            )
-        result[qualified_name] = entry
-    return result
 
 
 def _load_target(path: str, name: str) -> Any:

--- a/dimos/benchmark/evaluation/test_container.py
+++ b/dimos/benchmark/evaluation/test_container.py
@@ -1,0 +1,167 @@
+"""Tests for the shared locked Evaluation launcher."""
+
+from pathlib import Path
+import subprocess
+
+import pytest
+from pytest_mock import MockerFixture
+
+from dimos.benchmark.evaluation import container
+
+
+def test_container_command_uses_immutable_image_and_explicit_authority(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    cache = tmp_path / "cache" / "dimos"
+    monkeypatch.setattr(container, "CACHE_DIR", cache)
+    input_directory = tmp_path / "input"
+    input_directory.mkdir()
+    staging = tmp_path / "staging"
+    scratch = staging / "tmp"
+    socket = tmp_path / "podman.sock"
+    environ = {
+        "OPENAI_API_KEY": "secret",
+        "UNRELATED_SECRET": "do-not-forward",
+    }
+
+    command = container._container_command(
+        image_id="sha256:candidate",
+        cdi_directory=tmp_path / "cdi",
+        socket=socket,
+        scratch=scratch,
+        read_only=(input_directory,),
+        writable=(staging, cache),
+        forwarded_environment=("OPENAI_API_KEY",),
+        environ=environ,
+        inner=("python", "-m", "benchmark"),
+    )
+
+    rendered = " ".join(command)
+    assert "--network host" in rendered
+    assert f"--cdi-spec-dir {tmp_path / 'cdi'}" in rendered
+    assert "--device nvidia.com/gpu=all" in rendered
+    assert f"{socket}:/run/podman/podman.sock:rw" in rendered
+    assert f"{scratch}:/runner-tmp:rw" in rendered
+    assert f"{input_directory}:{input_directory}:ro" in rendered
+    assert f"{staging}:{staging}:rw" in rendered
+    assert f"{cache}:{cache}:rw" in rendered
+    assert "--env OPENAI_API_KEY" in rendered
+    assert "DIMOS_EVALUATION_CONTAINER=1" in rendered
+    assert "secret" not in rendered
+    assert "UNRELATED_SECRET" not in rendered
+    assert command[-4:] == ("sha256:candidate", "python", "-m", "benchmark")
+
+
+def test_mount_arguments_rejects_host_root(tmp_path: Path) -> None:
+    with pytest.raises(container.ContainerEvaluationError, match="filesystem root"):
+        container._mount_arguments(read_only=(Path("/"),), writable=(tmp_path,))
+
+
+def test_candidate_input_must_be_baked_into_image(tmp_path: Path) -> None:
+    with pytest.raises(container.ContainerEvaluationError, match="checked-in"):
+        container.candidate_path(tmp_path / "panel.json")
+
+
+def test_build_image_runs_by_returned_image_id(mocker: MockerFixture, tmp_path: Path) -> None:
+    def write_iid(command: tuple[str, ...]) -> None:
+        Path(command[command.index("--iidfile") + 1]).write_text("sha256:exact\n")
+
+    run = mocker.patch.object(container, "_checked_run", side_effect=write_iid)
+    iid = tmp_path / "iid"
+
+    image_id = container._build_image(iid)
+
+    assert image_id == "sha256:exact"
+    assert not iid.exists()
+    assert "docker/evaluation/Dockerfile" in " ".join(run.call_args.args[0])
+
+
+def test_generate_cdi_spec_is_scoped_to_scratch(
+    mocker: MockerFixture,
+    tmp_path: Path,
+) -> None:
+    def write_spec(command: tuple[str, ...]) -> None:
+        output = next(argument for argument in command if argument.startswith("--output="))
+        Path(output.removeprefix("--output=")).write_text("cdiVersion: 0.7.0\n")
+
+    run = mocker.patch.object(container, "_checked_run", side_effect=write_spec)
+
+    directory = container._generate_cdi_spec(tmp_path)
+
+    assert directory == tmp_path / "cdi"
+    assert (directory / "nvidia.yaml").is_file()
+    assert run.call_args.args[0][:3] == ("nvidia-ctk", "cdi", "generate")
+
+
+def test_recorded_failure_output_is_published(
+    mocker: MockerFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(container, "CACHE_DIR", tmp_path / "cache")
+    mocker.patch.object(container, "_podman_socket", return_value=tmp_path / "podman.sock")
+    mocker.patch.object(container, "_build_image", return_value="sha256:exact")
+    mocker.patch.object(container, "_generate_cdi_spec", return_value=tmp_path / "cdi")
+    mocker.patch.object(
+        container.subprocess,
+        "run",
+        return_value=subprocess.CompletedProcess(("podman",), 1),
+    )
+    output = tmp_path / "output"
+
+    def command(result: Path) -> tuple[str, ...]:
+        result.mkdir()
+        (result / "run.json").write_text('{"status":"failed"}\n')
+        return ("evaluate", str(result))
+
+    exit_code = container.run_in_container(
+        command,
+        output=output,
+        input_directories=(),
+        forwarded_environment=(),
+        environ={},
+    )
+
+    assert exit_code == 1
+    assert (output / "run.json").read_text() == '{"status":"failed"}\n'
+    assert not tuple(tmp_path.glob(".output-container-*"))
+
+
+def test_success_without_output_is_rejected(
+    mocker: MockerFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(container, "CACHE_DIR", tmp_path / "cache")
+    mocker.patch.object(container, "_podman_socket", return_value=tmp_path / "podman.sock")
+    mocker.patch.object(container, "_build_image", return_value="sha256:exact")
+    mocker.patch.object(container, "_generate_cdi_spec", return_value=tmp_path / "cdi")
+    mocker.patch.object(
+        container.subprocess,
+        "run",
+        return_value=subprocess.CompletedProcess(("podman",), 0),
+    )
+
+    with pytest.raises(container.ContainerEvaluationError, match="without output"):
+        container.run_in_container(
+            lambda _result: ("evaluate",),
+            output=tmp_path / "output",
+            input_directories=(),
+            forwarded_environment=(),
+            environ={},
+        )
+
+
+def test_command_failure_does_not_render_arguments(mocker: MockerFixture) -> None:
+    mocker.patch.object(
+        container.subprocess,
+        "run",
+        side_effect=subprocess.CalledProcessError(1, ("podman", "--env", "TOKEN=secret")),
+    )
+
+    with pytest.raises(container.ContainerEvaluationError) as error:
+        container._checked_run(("podman", "--env", "TOKEN=secret"))
+
+    assert str(error.value) == "podman command failed"
+    assert "secret" not in str(error.value)

--- a/dimos/benchmark/evaluation/test_registry.py
+++ b/dimos/benchmark/evaluation/test_registry.py
@@ -12,67 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pydantic import BaseModel
 import pytest
 
-from dimos.benchmark.evaluation.models import EvaluationReport, InlineNativeResult
-from dimos.benchmark.evaluation.protocol import EvaluationContext
 import dimos.benchmark.evaluation.registry as registry
 
 
-class Config(BaseModel):
-    value: int
-
-
-class PluginEvaluation:
-    name = "sample"
-    runtime_profile = "code-policy-v1"
-    config_model: type[BaseModel] = Config
-
-    def run(self, config: BaseModel, context: EvaluationContext) -> EvaluationReport:
-        return EvaluationReport(native_result=InlineNativeResult(value=None))
-
-
-class Distribution:
-    metadata = {"Name": "Acme_Evals"}
-    version = "2.0"
-
-
-class EntryPoint:
-    name = "sample"
-    value = "acme.evals:sample"
-    dist = Distribution()
-
-    def __init__(self, target) -> None:
-        self.target = target
-
-    def load(self):
-        return self.target
-
-
-def test_external_evaluation_uses_distribution_namespace(monkeypatch) -> None:
-    entry = EntryPoint(PluginEvaluation())
-    monkeypatch.setattr(
-        registry.importlib_metadata,
-        "entry_points",
-        lambda **_kwargs: [entry],
-    )
-
-    resolved = registry.resolve_evaluation("acme-evals.sample")
-
-    assert resolved.provider == "Acme_Evals"
-    assert resolved.version == "2.0"
-    assert resolved.evaluation is entry.target
-
-
-def test_unknown_evaluation_reports_name(monkeypatch) -> None:
-    monkeypatch.setattr(
-        registry.importlib_metadata,
-        "entry_points",
-        lambda **_kwargs: [],
-    )
-
-    with pytest.raises(registry.EvaluationRegistryError, match="Unknown evaluation 'missing'"):
+def test_unknown_evaluation_reports_available_builtins() -> None:
+    with pytest.raises(
+        registry.EvaluationRegistryError,
+        match="Available evaluations: libero-pro, vlnce-r2r",
+    ):
         registry.resolve_evaluation("missing")
 
 
@@ -88,26 +37,3 @@ def test_builtin_vlnce_r2r_evaluation_resolves_with_live_agent() -> None:
 
     assert resolved.provider == "dimos"
     assert resolved.evaluation.runtime_profile == "live-agent-v1"
-
-
-def test_external_target_must_implement_whole_evaluation(monkeypatch) -> None:
-    entry = EntryPoint(object())
-    monkeypatch.setattr(
-        registry.importlib_metadata,
-        "entry_points",
-        lambda **_kwargs: [entry],
-    )
-
-    with pytest.raises(registry.EvaluationRegistryError, match="runtime_profile"):
-        registry.resolve_evaluation("acme-evals.sample")
-
-
-def test_duplicate_external_evaluation_names_are_rejected(monkeypatch) -> None:
-    monkeypatch.setattr(
-        registry.importlib_metadata,
-        "entry_points",
-        lambda **_kwargs: [EntryPoint(PluginEvaluation()), EntryPoint(PluginEvaluation())],
-    )
-
-    with pytest.raises(registry.EvaluationRegistryError, match="Multiple installed"):
-        registry.available_evaluations()

--- a/dimos/benchmark/libero_pro/autoresearch.py
+++ b/dimos/benchmark/libero_pro/autoresearch.py
@@ -27,6 +27,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from dimos.benchmark.evaluation import container
 from dimos.benchmark.evaluation.models import EvaluationRun, InlineNativeResult
 from dimos.benchmark.evaluation.runner import execute_evaluation
 
@@ -361,6 +362,39 @@ def main(argv: Sequence[str] | None = None) -> None:
     parser.add_argument("--api-key-env", default="OPENAI_API_KEY")
     parser.add_argument("--json", action="store_true", dest="json_output")
     args = parser.parse_args(argv)
+    if not container.inside_container():
+        panel = container.candidate_path(args.panel)
+
+        def command(result_path: Path) -> Sequence[str]:
+            inner = [
+                "/opt/dimos/.venv/bin/python",
+                "-m",
+                "dimos.benchmark.libero_pro.autoresearch",
+                "--panel",
+                str(panel),
+                "--output",
+                str(result_path),
+                "--api-key-env",
+                args.api_key_env,
+            ]
+            if args.json_output:
+                inner.append("--json")
+            return inner
+
+        exit_code = container.run_in_container(
+            command,
+            output=args.output,
+            input_directories=(),
+            forwarded_environment=(
+                args.api_key_env,
+                "EVO_RESULT_PATH",
+                "EVO_TRACES_DIR",
+                "EVO_EXPERIMENT_ID",
+            ),
+        )
+        if exit_code:
+            raise SystemExit(exit_code)
+        return
     result = run_panel(args.panel, output=args.output, api_key_env=args.api_key_env)
     result_path = os.environ.get("EVO_RESULT_PATH")
     traces_dir = os.environ.get("EVO_TRACES_DIR")

--- a/dimos/benchmark/libero_pro/evaluation.py
+++ b/dimos/benchmark/libero_pro/evaluation.py
@@ -60,9 +60,7 @@ class LiberoProEvaluation:
         if not isinstance(context.runtime, CodePolicyRuntime):
             raise TypeError("libero-pro requires the code-policy-v1 runtime")
         runtime = context.runtime
-        manifest_path = Path(config.task_manifest)
-        if not manifest_path.is_absolute():
-            manifest_path = context.spec_dir / manifest_path
+        manifest_path = context.spec_dir / config.task_manifest
         manifest = LiberoTaskManifest.model_validate_json(manifest_path.read_bytes())
         emit_progress(
             context.progress,

--- a/dimos/benchmark/libero_pro/models.py
+++ b/dimos/benchmark/libero_pro/models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import PurePosixPath
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -92,3 +93,10 @@ class LiberoTaskManifest(LiberoModel):
 
 class LiberoProConfig(LiberoModel):
     task_manifest: str = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def task_manifest_is_relative(self) -> LiberoProConfig:
+        path = PurePosixPath(self.task_manifest)
+        if path.is_absolute() or not path.parts or ".." in path.parts:
+            raise ValueError("task_manifest must be a safe relative path")
+        return self

--- a/dimos/benchmark/libero_pro/test_autoresearch.py
+++ b/dimos/benchmark/libero_pro/test_autoresearch.py
@@ -298,3 +298,48 @@ def test_checked_in_panel_freezes_representative_contracts(
         assert manifest.contract.horizon_ticks == expected_horizons[case.family]
         assert manifest.episodes.debug_init_state_indices == (1, 2, 3, 4, 5)
         assert manifest.episodes.scored_init_state_index == 0
+
+
+def test_main_bootstraps_through_shared_evaluation_container(mocker, tmp_path: Path) -> None:
+    panel = CASES / "dev-panel.json"
+    baked_panel = Path("/opt/dimos/dimos/benchmark/libero_pro/cases/autoresearch/dev-panel.json")
+    output = tmp_path / "panel-output"
+    mocker.patch.object(autoresearch.container, "inside_container", return_value=False)
+    mocker.patch.object(autoresearch.container, "candidate_path", return_value=baked_panel)
+    run = mocker.patch.object(autoresearch.container, "run_in_container", return_value=0)
+
+    autoresearch.main(
+        [
+            "--panel",
+            str(panel),
+            "--output",
+            str(output),
+            "--api-key-env",
+            "TEST_API_KEY",
+            "--json",
+        ]
+    )
+
+    command = run.call_args.args[0](Path("/staging/result"))
+    assert command == [
+        "/opt/dimos/.venv/bin/python",
+        "-m",
+        "dimos.benchmark.libero_pro.autoresearch",
+        "--panel",
+        str(baked_panel),
+        "--output",
+        "/staging/result",
+        "--api-key-env",
+        "TEST_API_KEY",
+        "--json",
+    ]
+    assert run.call_args.kwargs == {
+        "output": output,
+        "input_directories": (),
+        "forwarded_environment": (
+            "TEST_API_KEY",
+            "EVO_RESULT_PATH",
+            "EVO_TRACES_DIR",
+            "EVO_EXPERIMENT_ID",
+        ),
+    }

--- a/dimos/benchmark/libero_pro/test_models.py
+++ b/dimos/benchmark/libero_pro/test_models.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from dimos.benchmark.libero_pro.models import LiberoTaskManifest
+from dimos.benchmark.libero_pro.models import LiberoProConfig, LiberoTaskManifest
 
 CASE = Path(__file__).parent / "cases" / "goal-task-0-single-trial" / "task.json"
 
@@ -22,3 +22,8 @@ def test_manifest_rejects_scored_row_used_for_debugging() -> None:
 
     with pytest.raises(ValueError, match="must not be used for debugging"):
         LiberoTaskManifest.model_validate(payload)
+
+
+def test_evaluation_config_rejects_absolute_task_manifest() -> None:
+    with pytest.raises(ValueError, match="safe relative path"):
+        LiberoProConfig(task_manifest="/tmp/task.json")

--- a/dimos/benchmark/vlnce_r2r/evaluation.py
+++ b/dimos/benchmark/vlnce_r2r/evaluation.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
 import threading
 import time
 
@@ -99,9 +98,7 @@ class VlnceR2REvaluation:
             raise TypeError("vlnce-r2r received the wrong configuration type")
         if not isinstance(context.runtime, LiveAgentRuntime):
             raise TypeError("vlnce-r2r requires the live-agent-v1 runtime")
-        manifest_path = Path(config.task_manifest)
-        if not manifest_path.is_absolute():
-            manifest_path = context.spec_dir / manifest_path
+        manifest_path = context.spec_dir / config.task_manifest
         manifest = VlnceTaskManifest.model_validate_json(manifest_path.read_bytes())
         emit_progress(context.progress, StatusProgress(channel="eval", message="VLN-CE preflight"))
         preparation = prepare_public_assets(manifest.source, manifest.task)

--- a/dimos/benchmark/vlnce_r2r/models.py
+++ b/dimos/benchmark/vlnce_r2r/models.py
@@ -153,6 +153,11 @@ class VlnceConfig(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
     task_manifest: str = Field(min_length=1)
 
+    @model_validator(mode="after")
+    def task_manifest_is_relative(self) -> VlnceConfig:
+        _validate_relative_path(self.task_manifest, "task_manifest")
+        return self
+
 
 def _validate_relative_path(value: str, label: str) -> None:
     path = PurePosixPath(value)

--- a/dimos/benchmark/vlnce_r2r/test_evaluation.py
+++ b/dimos/benchmark/vlnce_r2r/test_evaluation.py
@@ -15,6 +15,7 @@
 import json
 from pathlib import Path
 
+import pytest
 from pytest_mock import MockerFixture
 
 from dimos.benchmark.evaluation.models import RuntimeIdentity
@@ -23,6 +24,11 @@ import dimos.benchmark.vlnce_r2r.evaluation as evaluation
 from dimos.benchmark.vlnce_r2r.models import VlnceConfig, VlnceTaskManifest
 
 CASE = Path(__file__).parent / "cases/mp3d-example-episode-515/task.json"
+
+
+def test_evaluation_config_rejects_absolute_task_manifest() -> None:
+    with pytest.raises(ValueError, match="safe relative path"):
+        VlnceConfig(task_manifest="/tmp/task.json")
 
 
 def test_live_agent_starts_after_runtime_barrier_and_native_score_survives_render_failure(

--- a/dimos/cli/eval.py
+++ b/dimos/cli/eval.py
@@ -39,6 +39,20 @@ def execute_evaluation(*args: Any, **kwargs: Any) -> Any:
     return execute(*args, **kwargs)
 
 
+@app.command("check")
+def check(
+    workspace: Path = typer.Option(..., "--workspace"),
+) -> None:
+    """Build and verify the locked Evaluation environment."""
+    try:
+        from dimos.benchmark.evaluation.container import check_environment
+
+        check_environment(workspace)
+    except Exception as exc:
+        typer.echo(f"Evaluation preflight failed: {type(exc).__name__}: {exc}", err=True)
+        raise typer.Exit(2) from exc
+
+
 @app.command("run")
 def run(
     specification: Path = typer.Argument(..., exists=True, dir_okay=False, readable=True),
@@ -47,7 +61,34 @@ def run(
     json_output: bool = typer.Option(False, "--json", help="Print compact JSON"),
     quiet: bool = typer.Option(False, "--quiet", help="Suppress live evaluation progress"),
 ) -> None:
-    """Run one Evaluation Run Specification synchronously."""
+    """Run one Evaluation Run Specification in the locked environment."""
+    try:
+        from dimos.benchmark.evaluation.container import run_evaluation
+
+        exit_code = run_evaluation(
+            specification,
+            output=output,
+            api_key_env=api_key_env,
+            json_output=json_output,
+            quiet=quiet,
+        )
+    except Exception as exc:
+        typer.echo(f"Evaluation preflight failed: {type(exc).__name__}: {exc}", err=True)
+        raise typer.Exit(2) from exc
+    if exit_code:
+        raise typer.Exit(exit_code)
+
+
+@app.command("_inside-run", hidden=True)
+def inside_run(
+    specification: Path = typer.Argument(..., exists=True, dir_okay=False, readable=True),
+    api_key_env: str = typer.Option("OPENAI_API_KEY", "--api-key-env"),
+    output: Path = typer.Option(..., "--output"),
+    display_output: Path | None = typer.Option(None, "--display-output", hidden=True),
+    json_output: bool = typer.Option(False, "--json"),
+    quiet: bool = typer.Option(False, "--quiet"),
+) -> None:
+    """Execute the Python Evaluation runner inside the locked image."""
     renderer = None if quiet else ProgressRenderer()
     try:
         result = execute_evaluation(
@@ -63,7 +104,11 @@ def run(
         raise typer.Exit(2) from exc
     if renderer is not None:
         renderer.finish()
-    typer.echo(result.model_dump_json() if json_output else format_result(result, output))
+    typer.echo(
+        result.model_dump_json()
+        if json_output
+        else format_result(result, display_output if display_output is not None else output)
+    )
     if result.status == "cancelled":
         raise typer.Exit(130)
     if result.status == "failed":

--- a/dimos/cli/test_eval.py
+++ b/dimos/cli/test_eval.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 from pytest_mock import MockerFixture
 from typer.testing import CliRunner
 
+from dimos.benchmark.evaluation import container as evaluation_container
 from dimos.cli import eval as eval_cli
 from dimos.cli.dimos import main
 
@@ -20,7 +21,45 @@ CASE = (
 )
 
 
-def test_libero_pro_smoke_json_treats_zero_score_as_completed(
+def test_run_dispatches_to_locked_evaluation_container(
+    mocker: MockerFixture,
+    tmp_path: Path,
+) -> None:
+    run_container = mocker.patch.object(evaluation_container, "run_evaluation", return_value=0)
+    output = tmp_path / "output"
+
+    invocation = CliRunner().invoke(
+        main,
+        ["eval", "run", str(CASE), "--output", str(output), "--json", "--quiet"],
+    )
+
+    assert invocation.exit_code == 0
+    run_container.assert_called_once_with(
+        CASE,
+        output=output,
+        api_key_env="OPENAI_API_KEY",
+        json_output=True,
+        quiet=True,
+    )
+
+
+def test_check_dispatches_to_shared_container_preflight(
+    mocker: MockerFixture,
+    tmp_path: Path,
+) -> None:
+    check_environment = mocker.patch.object(evaluation_container, "check_environment")
+    workspace = tmp_path / "check"
+
+    invocation = CliRunner().invoke(
+        main,
+        ["eval", "check", "--workspace", str(workspace)],
+    )
+
+    assert invocation.exit_code == 0
+    check_environment.assert_called_once_with(workspace)
+
+
+def test_inside_run_treats_zero_score_as_completed(
     mocker: MockerFixture,
     tmp_path: Path,
 ) -> None:
@@ -37,7 +76,7 @@ def test_libero_pro_smoke_json_treats_zero_score_as_completed(
 
     invocation = CliRunner().invoke(
         main,
-        ["eval", "run", str(CASE), "--output", str(output), "--json", "--quiet"],
+        ["eval", "_inside-run", str(CASE), "--output", str(output), "--json", "--quiet"],
     )
 
     assert invocation.exit_code == 0

--- a/docker/evaluation/Dockerfile
+++ b/docker/evaluation/Dockerfile
@@ -1,0 +1,30 @@
+FROM docker.io/library/node@sha256:cff78eb5aa1cf27dc2b6aeea9d31366415a43e9a9ea0ddec00d780b2b66fad0f AS node
+
+FROM docker.io/library/python@sha256:72d3d75f2639ab82b34b29390ad3d6e0827c775befee94edda8e9976818f488d
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PATH=/opt/dimos/.venv/bin:/usr/local/bin:$PATH \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential git libegl1 libgl1 libglib2.0-0 libglfw3 libosmesa6 podman \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=node /usr/local/ /usr/local/
+RUN python -m pip install --no-cache-dir uv==0.11.24
+
+WORKDIR /opt/dimos
+COPY . /opt/dimos
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-default-groups \
+        --extra agents \
+        --extra misc \
+        --extra perception \
+        --extra manipulation \
+        --extra cuda \
+        --extra graspgenx \
+    && npm ci --prefix packages/pi-code-policy-extension \
+    && npm run build --prefix packages/pi-code-policy-extension
+
+ENTRYPOINT []

--- a/docs/adr/0011-keep-libero-pro-in-repo.md
+++ b/docs/adr/0011-keep-libero-pro-in-repo.md
@@ -1,3 +1,3 @@
 # Keep LIBERO-PRO integration in the DimOS repository
 
-The first LIBERO-PRO integration is in-repo DimOS work: its Evaluation, `LiberoConnection`, blueprint composition, benchmark manifests, tests, and container definition live in the main repository and use the existing built-in evaluation resolution path. We will not create a separate Python distribution, installation workflow, or external `dimos.evaluations` entry point for this change. Outside registration remains the registry's concern and is not an abstraction the LIBERO vertical slice needs to introduce.
+The first LIBERO-PRO integration is in-repo DimOS work: its Evaluation, `LiberoConnection`, blueprint composition, benchmark manifests, tests, and container definition live in the main repository and use the built-in evaluation registry. Executable Evaluations are explicit built-ins; there is no external package entry point or separate installation workflow.

--- a/docs/capabilities/agents/evaluation.md
+++ b/docs/capabilities/agents/evaluation.md
@@ -34,8 +34,7 @@ unchanged. Complete benchmarks use the `Evaluation` interface and the
 
 An `Evaluation` owns its native environment, cases, seeds, blueprint lifecycle,
 step or real-time horizon, privileged scorer, aggregation, and native result.
-Built-in evaluations resolve in-repo; external packages may use the existing
-`dimos.evaluations` entry point. Each Evaluation declares `code-policy-v1` or
+Evaluations are explicit in-repo built-ins. Each declares `code-policy-v1` or
 `live-agent-v1`. The shared runner constructs that runtime and publishes one
 immutable result directory.
 
@@ -101,12 +100,13 @@ model generation do not consume real-time or simulator-step budgets.
 
 ## CLI
 
-Install the agent dependencies and build the Pi extension:
+Start the rootless Podman service and verify the required GPU runtime:
 
 ```bash
-uv sync --extra agents
-npm --prefix packages/pi-code-policy-extension install
-npm --prefix packages/pi-code-policy-extension run build
+systemctl --user enable --now podman.socket
+nvidia-smi -L
+
+uv run dimos eval check --workspace "$PWD/.container-eval/check"
 ```
 
 Run an installed Evaluation from a strict JSON specification:
@@ -129,10 +129,17 @@ Run an installed Evaluation from a strict JSON specification:
 dimos eval run specification.json --output evaluation-run
 ```
 
+`dimos eval run` always builds the current checkout into the locked evaluation
+image and executes that immutable image ID. There is no host execution mode. The
+specification directory is mounted read-only; task-manifest references must be
+relative to it. Outputs are staged on a private host-backed mount and published
+atomically after the container exits, including valid failed or cancelled run
+records.
+
 The in-repo LIBERO-PRO smoke case runs each debug submission and the scored
-trial in a fresh rootless Podman container and a fresh DimOS blueprint. Podman
-owns the pinned simulator environment; LIBERO is never imported into the host
-DimOS Python environment.
+trial in a fresh sibling Podman container and a fresh DimOS blueprint. The same
+outer evaluation image also runs VLN-CE; each Evaluation retains ownership of its
+native simulator image and scoring.
 
 ```bash
 dimos eval run \

--- a/docs/capabilities/agents/manipulation-autoresearch.md
+++ b/docs/capabilities/agents/manipulation-autoresearch.md
@@ -67,3 +67,32 @@ publication-grade manipulation performance. Multi-seed measurement is a later la
 
 Outside Evo, omit the Evo environment variables. The same command still writes
 `panel-score.json` and prints normal JSON, which is useful for local contract checks.
+
+## Reproducible evaluation container
+
+The benchmark command automatically launches through the shared locked Evaluation
+container. It builds the current DimOS candidate from digest-pinned Python and Node
+bases plus `uv.lock` and `package-lock.json`, then executes the resulting local image
+by immutable ID. Start the rootless service and verify the generic environment first:
+
+```bash
+systemctl --user enable --now podman.socket
+nvidia-smi -L
+
+uv run dimos eval check --workspace "$PWD/.container-eval/check"
+```
+
+Then use the same panel command configured in Evo:
+
+```bash
+uv run python -m dimos.benchmark.libero_pro.autoresearch \
+  --panel dimos/benchmark/libero_pro/cases/autoresearch/dev-panel.json \
+  --output "$(dirname "$EVO_RESULT_PATH")/dimos-panel" --json
+```
+
+The shared launcher uses host networking and the mounted rootless Podman socket to
+launch simulator containers as siblings. It mounts only private output staging,
+DimOS cache, and configured Evo result/trace directories at identical absolute paths.
+Agent IPC uses a short `/runner-tmp` mount. Only named OpenAI/Hugging Face credentials
+and Evo result variables are forwarded. Each invocation uses a fresh run-scoped NVIDIA
+CDI spec and never reads or replaces system CDI configuration.

--- a/openspec/changes/containerize-libero-autoresearch/.openspec.yaml
+++ b/openspec/changes/containerize-libero-autoresearch/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-20

--- a/openspec/changes/containerize-libero-autoresearch/design.md
+++ b/openspec/changes/containerize-libero-autoresearch/design.md
@@ -1,0 +1,56 @@
+## Context
+
+The unified `dimos eval` runner owns result publication and injects either the code-policy or live-agent Pi runtime into a native Evaluation. LIBERO-PRO and VLN-CE already keep their native simulators in sibling OCI containers, but the evaluator, Pi extension, DimOS checkout, and orchestration still depend on the host Python environment. The LIBERO autoresearch wrapper demonstrated the required outer topology and also exposed why it belongs at the shared runner seam.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Build one outer image from digest-pinned bases, `uv.lock`, and the Pi package lock.
+- Make public built-in Evaluation execution container-only without changing the run specification.
+- Execute exact candidate sources by immutable image ID and reuse the host rootless Podman service for sibling simulators.
+- Preserve daemon-visible paths and atomically publish complete result directories.
+- Reuse the same launcher for the autoresearch panel and a cheap environment check.
+
+**Non-Goals:**
+
+- Changing native simulator images, task cases, native scores, runtime profiles, the Agent Harness, or Evo.
+- Publishing images to a registry or adding CI deployment.
+- Supporting external Evaluation plugins, host-mode execution, Docker-in-Docker, privileged containers, or remote multi-host Podman.
+
+## Decisions
+
+### Put the container seam above the shared runner
+
+The public CLI is a dependency-light host launcher. A hidden command invokes the existing runner only inside the built image. The launcher mounts the rootless Podman socket, sets `CONTAINER_HOST`, and uses host networking, so existing Evaluation implementations create sibling simulator containers without modification. There is no public host fallback.
+
+### Run by the image ID emitted by Podman
+
+The launcher builds locally with an IID file and runs the resulting `sha256:` identifier, not a mutable tag. The generic recipe pins Python and Node base digests, installs the frozen extras required by all built-ins, and builds Pi with `npm ci`. No project image is pulled from a registry.
+
+### Stage and publish host-visible paths explicitly
+
+The launcher creates a private staging root beside the requested output and mounts it at the identical absolute path. The inside runner writes there, sibling Podman containers can resolve its paths, and the host moves a complete result into place after exit. The specification directory is mounted read-only at the same absolute path; built-in task manifests must remain relative to it. Cache, Evo result/traces, and short IPC scratch paths are explicit mounts.
+
+### Forward an allowlist of environment variables
+
+The CLI forwards the selected API-key variable plus known Hugging Face credentials; autoresearch additionally forwards its three Evo variables. Values never appear in command arguments or raised errors. Every run receives host networking, the rootless socket, and a fresh run-scoped NVIDIA CDI specification, matching the current built-in resource contract.
+
+### Keep the executable registry built-in only
+
+Installed entry-point discovery has no in-repository adapter and cannot be reproduced by the locked local image. Remove that hypothetical seam rather than introduce plugin-specific image metadata. New executable Evaluations are added explicitly to the built-in registry and therefore enter the same image through the checked-in dependency lock.
+
+## Risks / Trade-offs
+
+- **Host Podman socket grants container-management authority** → Mount only the rootless user's socket and document that the image is locally built from the current trusted checkout.
+- **Identical absolute mounts expose selected host directories** → Mount only the input directory, private staging root, cache, and explicit Evo paths; reject filesystem root.
+- **Large locked image build** → Keep simulator dependencies in the existing separate image and rely on local layer caching.
+- **NVIDIA Container Toolkit or the Podman socket can be absent** → Fail in the cheap `check` mode with an actionable error before running the panel; keep generated CDI data scoped to run scratch.
+
+## Migration Plan
+
+Replace the existing specialized wrapper and remove plugin discovery in the container-execution PR. Verify both built-ins through the public command, then use the unchanged autoresearch benchmark command. This intentionally replaces host execution rather than preserving a compatibility path.
+
+## Open Questions
+
+None.

--- a/openspec/changes/containerize-libero-autoresearch/proposal.md
+++ b/openspec/changes/containerize-libero-autoresearch/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Complete `dimos eval` benchmarks currently run their evaluator and Pi runtime in the mutable host environment even though their native simulators are isolated. The LIBERO autoresearch wrapper proved that a locked outer image removes checkout, dependency, temporary-filesystem, and GPU-runtime drift, but keeping that wrapper benchmark-specific duplicates the execution boundary every future Evaluation would need.
+
+## What Changes
+
+- Replace the LIBERO-specific wrapper with a shared, locally built evaluation image and launcher used by every built-in `dimos eval` command.
+- Make container execution mandatory for the public CLI while keeping the existing Python runner as the private inside-container implementation.
+- Grant the outer image GPU access and the host rootless Podman socket so existing native simulator containers remain siblings.
+- Stage inputs, outputs, caches, and IPC on explicit identical absolute mounts, then atomically publish the completed run.
+- Reuse the shared launcher for LIBERO autoresearch without changing its benchmark command.
+- Remove unused external Evaluation entry-point discovery; the executable registry contains built-ins only.
+
+## Capabilities
+
+### New Capabilities
+
+- `containerized-evaluation`: Reproducible, container-only execution for built-in `dimos eval` benchmarks and the LIBERO autoresearch panel.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+This replaces the specialized launcher with a shared evaluation module, changes the public `dimos eval run` execution path, simplifies registry discovery, and updates focused tests and documentation. It does not change runtime profiles, task instructions, perception, planning, robot control, benchmark cases, or native scoring.

--- a/openspec/changes/containerize-libero-autoresearch/specs/containerized-evaluation/spec.md
+++ b/openspec/changes/containerize-libero-autoresearch/specs/containerized-evaluation/spec.md
@@ -1,0 +1,65 @@
+## ADDED Requirements
+
+### Requirement: Locked local evaluation image
+The system SHALL build the outer environment for every built-in `dimos eval` locally from digest-pinned base images, checked-in dependency locks, and the current candidate source. It SHALL execute the image by the immutable image ID returned by the build.
+
+#### Scenario: Build current candidate
+- **WHEN** a user starts a containerized check or benchmark
+- **THEN** the launcher builds the current checkout and runs the exact returned image ID without pulling a project image from a registry
+
+### Requirement: Container-only public execution
+The public `dimos eval run` command SHALL execute built-in Evaluations only inside the locked outer image and SHALL NOT expose a host execution fallback.
+
+#### Scenario: Run a built-in Evaluation
+- **WHEN** a user invokes `dimos eval run` for LIBERO-PRO or VLN-CE
+- **THEN** the dependency-light host command launches the immutable image and the existing Python runner executes only inside it
+
+### Requirement: Rootless sibling simulator topology
+The system SHALL use the host user's rootless Podman socket to launch native simulator images as sibling containers and SHALL NOT run a nested container daemon.
+
+#### Scenario: Start a native trial
+- **WHEN** an outer evaluation starts LIBERO-PRO or VLN-CE
+- **THEN** its existing simulator container is created through the mounted host socket and its endpoints remain reachable through host networking
+
+### Requirement: Daemon-visible artifacts and bounded temporary storage
+The system SHALL mount the read-only specification directory, private output staging root, Evo paths, and cache at identical absolute host and outer-container paths. It SHALL provide a short host-backed temporary mount for IPC and atomically publish a complete result directory.
+
+#### Scenario: Simulator consumes cached assets
+- **WHEN** the outer runner passes an asset or artifact path to the host Podman service
+- **THEN** that absolute path identifies the same host file for the sibling simulator
+
+#### Scenario: Agent creates a Unix socket
+- **WHEN** the evaluation creates temporary Jupyter or multiprocessing IPC
+- **THEN** it uses the short `/runner-tmp` path rather than host `/tmp` or a long worktree path
+
+#### Scenario: Evaluation exits with a recorded failure
+- **WHEN** the inside runner publishes a valid failed or cancelled `run.json`
+- **THEN** the host publishes that complete result directory and propagates the container exit status
+
+### Requirement: Explicit runtime authority
+The system SHALL pass the host network, NVIDIA CDI GPU, rootless Podman socket, and only an allowlist of required credential and Evo environment variables. It SHALL generate and use a per-run CDI specification without modifying system CDI configuration.
+
+#### Scenario: Construct runner command
+- **WHEN** the launcher constructs the outer container invocation
+- **THEN** it includes explicit GPU/socket/network access and excludes unrelated host environment variables
+
+### Requirement: Cheap preflight
+The system SHALL provide a check mode that verifies the baked candidate import, locked Pi build, GPU visibility, and connectivity to the rootless Podman service without executing the panel.
+
+#### Scenario: Missing service
+- **WHEN** a required runtime service or artifact is unavailable
+- **THEN** check mode exits non-zero with an actionable error before any benchmark case starts
+
+### Requirement: Built-in-only registry
+The executable Evaluation registry SHALL resolve only explicitly registered built-ins and SHALL NOT discover installed Python entry points.
+
+#### Scenario: Resolve an unknown Evaluation
+- **WHEN** a specification names an Evaluation outside the built-in registry
+- **THEN** preflight fails with the available built-in names without importing installed plugin code
+
+### Requirement: Shared autoresearch bootstrap
+The LIBERO autoresearch module SHALL use the same outer launcher while retaining its existing command-line interface and Evo publication contract.
+
+#### Scenario: Run the fixed Evo benchmark command
+- **WHEN** Evo invokes the autoresearch Python module from the host checkout
+- **THEN** the module launches itself in the locked image exactly once and publishes native panel results through the existing Evo paths

--- a/openspec/changes/containerize-libero-autoresearch/tasks.md
+++ b/openspec/changes/containerize-libero-autoresearch/tasks.md
@@ -1,0 +1,21 @@
+## 1. Generalize the Locked Image and Registry
+
+- [x] 1.1 Move the outer image recipe and launcher into the shared evaluation framework.
+- [x] 1.2 Remove external Evaluation entry-point discovery, tests, and documentation.
+
+## 2. Make Public Evaluation Container-Only
+
+- [x] 2.1 Route `dimos eval run` through the generic launcher and keep a hidden inside-container command for the existing runner.
+- [x] 2.2 Add read-only input, private output staging, cache, IPC, GPU/CDI, rootless socket, environment forwarding, and atomic publication behavior.
+- [x] 2.3 Require built-in task manifests to be relative to their run specification.
+
+## 3. Reuse the Launcher for Autoresearch
+
+- [x] 3.1 Bootstrap the existing LIBERO autoresearch module through the generic container without changing its benchmark command.
+- [x] 3.2 Remove the LIBERO-specific outer runner and update evaluation documentation.
+
+## 4. Verify the Replacement
+
+- [x] 4.1 Add focused registry, launcher, CLI, publication, secret-redaction, and autoresearch bootstrap tests.
+- [x] 4.2 Run formatting, lint, typing, focused unit suites, and the generic outer-container preflight.
+- [ ] 4.3 Run one checked-in case for each built-in and the four-case development panel after credential rotation.


### PR DESCRIPTION
Part of the linear evaluation stack: #3439 → #3581 → #3582 → #3583.

## Summary

- make `dimos eval run` container-only for every built-in Evaluation
- replace the LIBERO-specific wrapper with one shared, digest-pinned evaluation image and launcher used by LIBERO-PRO and VLNCE-R2R
- keep executable Evaluations explicit and built-in; remove the unused external entry-point plugin seam
- require task manifests to be relative to their run specification
- run the existing LIBERO autoresearch command through the same container automatically
- execute by immutable Podman image ID with rootless sibling containers, run-scoped NVIDIA CDI, read-only inputs, allowlisted environment names, and atomically published staged outputs

## Verification

- 56 focused tests pass across the shared framework, CLI, LIBERO-PRO, VLNCE-R2R, and autoresearch bootstrap
- Ruff check and format check pass on all changed Python files
- OpenSpec strict validation passes
- generic outer-container preflight passes: candidate import, Pi build, rootless Podman connection, and RTX 3090 visibility
- real checked-in evaluation cases remain pending until the previously exposed API credential is rotated

Depends on #3582.
