### PR TITLE
fix tests

### DIFF
--- a/dimos/e2e_tests/test_cockpit_browser.py
+++ b/dimos/e2e_tests/test_cockpit_browser.py
@@ -28,12 +28,15 @@ Runs in both Chromium and Firefox: their WebTransport implementations differ
 enough that one browser staying green says little about the other.
 
 Marked web_browser: excluded from the default suite (needs the
-`browser-tests` dependency group, Playwright browsers and the LFS dataset);
-the CI `web` job runs it against a freshly-built cockpit dist. Locally:
+`browser-tests` dependency group and the LFS dataset; the browser binaries
+auto-install on first run); the CI `web` job runs it against a
+freshly-built cockpit dist. Locally:
 `uv run --group browser-tests pytest -m web_browser dimos/e2e_tests/test_cockpit_browser.py`.
 """
 
 from collections.abc import Callable, Iterator
+import subprocess
+import sys
 import time
 
 import pytest
@@ -80,8 +83,15 @@ def start_go2_replay() -> Iterator[Callable[[], DimosCliCall]]:
         call.stop()
 
 
+@pytest.fixture(scope="session")
+def playwright_browsers() -> None:
+    subprocess.run(
+        [sys.executable, "-m", "playwright", "install", "chromium", "firefox"], check=True
+    )
+
+
 @pytest.fixture(params=["chromium", "firefox"])
-def page(request: pytest.FixtureRequest) -> Iterator[Page]:
+def page(request: pytest.FixtureRequest, playwright_browsers: None) -> Iterator[Page]:
     with sync_playwright() as p:
         browser = getattr(p, request.param).launch()
         try:

--- a/dimos/models/base.py
+++ b/dimos/models/base.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 from functools import cached_property
+import sys
 from typing import Annotated, Any
 
 import torch
@@ -114,6 +115,16 @@ class LocalModel(Resource, Configurable):
             torch._dynamo.reset()
         except (ImportError, AttributeError):
             pass
+
+        # torch.compile also spawns inductor compile-worker subprocesses whose
+        # reader thread outlives the model; shut them down (the next compile
+        # respawns them on demand).
+        if "torch._inductor.async_compile" in sys.modules:
+            # Imported lazily: importing async_compile itself spawns a worker
+            # pool, so only touch it when a compile already loaded it.
+            from torch._inductor.async_compile import shutdown_compile_workers
+
+            shutdown_compile_workers()
 
         gc.collect()
         if self.config.device.startswith("cuda") and torch.cuda.is_available():

--- a/web/README.md
+++ b/web/README.md
@@ -40,8 +40,8 @@ minor.
 
 The cockpit browser e2e (`dimos/e2e_tests/test_cockpit_browser.py`, marker `web_browser`) drives the
 whole stack against the go2 replay dataset in both Playwright Chromium and Firefox (their
-WebTransport stacks differ; see bug 11). The CI `web` job runs it; locally it needs
-`uv run playwright install chromium firefox` once.
+WebTransport stacks differ; see bug 11). The CI `web` job runs it; the pinned browser builds
+auto-install on first run.
 
 ## Protocol shape, and why it is odd
 


### PR DESCRIPTION
## Problem

Three broken tests:

```
ERROR dimos/e2e_tests/test_cockpit_browser.py::test_cockpit_live_data_and_reconnect[chromium] - playwright._impl._errors.Error: BrowserType.launch: Executable doesn't exist at /home/p/.cache/ms-playwright/chromium_headless_shell-1228/chrome-headless-shell-linux64/chrome-headless-shell
ERROR dimos/e2e_tests/test_cockpit_browser.py::test_cockpit_live_data_and_reconnect[firefox] - playwright._impl._errors.Error: BrowserType.launch: Executable doesn't exist at /home/p/.cache/ms-playwright/firefox-1532/firefox/firefox
ERROR dimos/models/vl/test_captioner.py::test_captioner[MoondreamVlModel] - Failed: Non-closed threads created during this test. Thread names: ['Thread-3347 (_read_thread)']. Please look at the first test that fails and fix that.
```

## Solution

Fixed.