### PR TITLE
add observation skill container

### DIFF
--- a/dimos/agents/demo_agent.py
+++ b/dimos/agents/demo_agent.py
@@ -14,6 +14,7 @@
 
 from dimos.agents.mcp.mcp_client import McpClient
 from dimos.agents.mcp.mcp_server import McpServer
+from dimos.agents.skills.observe_skill import ObserveSkill
 from dimos.core.coordination.blueprints import autoconnect
 from dimos.hardware.sensors.camera.module import CameraModule
 from dimos.hardware.sensors.camera.webcam import Webcam
@@ -33,6 +34,7 @@ def _create_webcam() -> Webcam:
 demo_agent_camera = autoconnect(
     McpServer.blueprint(),
     McpClient.blueprint(),
+    ObserveSkill.blueprint(),
     CameraModule.blueprint(
         hardware=_create_webcam,
     ),

--- a/dimos/agents/skills/observe_skill.py
+++ b/dimos/agents/skills/observe_skill.py
@@ -1,0 +1,42 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dimos.agents.annotation import skill
+from dimos.agents.skill_result import SkillResult
+from dimos.core.module import Module
+from dimos.core.stream import In
+from dimos.msgs.sensor_msgs.Image import Image
+
+
+class ObserveSkill(Module):
+    """Gives any robot agent the ability to observe the current camera image."""
+
+    color_image: In[Image]
+
+    _frame_timeout: float = 5.0
+
+    @skill
+    def observe(self) -> Image | SkillResult:
+        """Returns the current video frame from the robot camera. Use this skill for any visual world queries.
+
+        This skill provides the current camera view for perception tasks.
+        """
+        try:
+            return self.color_image.get_next(timeout=self._frame_timeout)
+        except Exception:
+            return SkillResult.fail(
+                "EXECUTION_TIMEOUT",
+                f"No camera frame received within {self._frame_timeout} seconds; "
+                "the camera may not be running.",
+            )

--- a/dimos/agents/skills/test_observe_skill.py
+++ b/dimos/agents/skills/test_observe_skill.py
@@ -1,0 +1,72 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import Iterator
+import threading
+import time
+
+import numpy as np
+import pytest
+from reactivex.scheduler import ThreadPoolScheduler
+
+from dimos.agents.skill_result import SkillResult
+from dimos.agents.skills.observe_skill import ObserveSkill
+from dimos.core.transport import LCMTransport
+from dimos.msgs.sensor_msgs.Image import Image, ImageFormat
+
+
+@pytest.fixture
+def module(monkeypatch: pytest.MonkeyPatch) -> Iterator[ObserveSkill]:
+    # get_next routes through backpressure(), whose shared pool threads live for
+    # the whole process; use a dedicated scheduler so the thread-leak detector
+    # stays clean (same pattern as dimos/utils/test_reactive.py).
+    scheduler = ThreadPoolScheduler(max_workers=2)
+    monkeypatch.setattr("dimos.utils.reactive.get_scheduler", lambda: scheduler)
+    m = ObserveSkill()
+    m.color_image.transport = LCMTransport("/test_observe/color_image", Image)
+    yield m
+    m.stop()
+    scheduler.executor.shutdown(wait=True)
+
+
+def test_observe_returns_published_frame(module: ObserveSkill) -> None:
+    frame = Image.from_numpy(np.zeros((8, 8, 3), dtype=np.uint8), format=ImageFormat.RGB, ts=1.0)
+    stop = threading.Event()
+
+    # get_next subscribes lazily, so keep publishing until observe picks a frame up.
+    def pump() -> None:
+        while not stop.is_set():
+            module.color_image.transport.publish(frame)
+            time.sleep(0.05)
+
+    thread = threading.Thread(target=pump, daemon=True)
+    thread.start()
+    try:
+        result = module.observe()
+    finally:
+        stop.set()
+        thread.join()
+
+    assert isinstance(result, Image)
+    assert result.data.shape[:2] == (8, 8)
+
+
+def test_observe_without_frames_fails(
+    module: ObserveSkill, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(ObserveSkill, "_frame_timeout", 0.2)
+    result = module.observe()
+    assert isinstance(result, SkillResult)
+    assert not result.success
+    assert result.error_code == "EXECUTION_TIMEOUT"

--- a/dimos/hardware/sensors/camera/module.py
+++ b/dimos/hardware/sensors/camera/module.py
@@ -18,7 +18,6 @@ import time
 from pydantic import Field
 import reactivex as rx
 
-from dimos.agents.annotation import skill
 from dimos.core.coordination.blueprints import autoconnect
 from dimos.core.core import rpc
 from dimos.core.global_config import global_config
@@ -59,7 +58,6 @@ class CameraModule(Module, perception.Camera):
     tf: Out[TFMessage]
 
     hardware: CameraHardware
-    _latest_image: Image | None = None
 
     @rpc
     def start(self) -> None:
@@ -75,12 +73,8 @@ class CameraModule(Module, perception.Camera):
         if self.config.frequency > 0:
             stream = stream.pipe(sharpness_barrier(self.config.frequency))
 
-        def on_image(image: Image) -> None:
-            self.color_image.publish(image)
-            self._latest_image = image
-
         self.register_disposable(
-            stream.subscribe(on_image),
+            stream.subscribe(self.color_image.publish),
         )
 
         self.register_disposable(
@@ -106,13 +100,6 @@ class CameraModule(Module, perception.Camera):
         )
 
         self.tf.publish(TFMessage(camera_link, camera_optical))
-
-    @skill
-    def take_a_picture(self) -> Image:
-        """Grabs and returns the latest image from the camera."""
-        if self._latest_image is None:
-            raise RuntimeError("No image received from camera yet.")
-        return self._latest_image
 
     @rpc
     def stop(self) -> None:

--- a/dimos/robot/all_blueprints.py
+++ b/dimos/robot/all_blueprints.py
@@ -248,6 +248,7 @@ all_modules = {
     "object-tracker2-d": "dimos.perception.experimental.object_tracker_2d.ObjectTracker2D",
     "object-tracker3-d": "dimos.perception.experimental.object_tracker_3d.ObjectTracker3D",
     "object-tracking": "dimos.perception.experimental.object_tracker.ObjectTracking",
+    "observe-skill": "dimos.agents.skills.observe_skill.ObserveSkill",
     "open-arm-teleop-coordinator": "dimos.robot.manipulators.openarm.blueprints.teleop.OpenArmTeleopCoordinator",
     "osm-skill": "dimos.agents.skills.osm.OsmSkill",
     "path-following-coordinator": "dimos.control.path_following_coordinator.PathFollowingCoordinator",

--- a/dimos/robot/drone/README.md
+++ b/dimos/robot/drone/README.md
@@ -211,7 +211,7 @@ Parameters: `(Kp, Ki, Kd, (min_output, max_output), integral_limit, deadband_pix
 
 ## Available Skills
 
-All skills are exposed to the LLM agent via the `@skill` decorator on `DroneConnectionModule`:
+All skills are exposed to the LLM agent via the `@skill` decorator on `DroneConnectionModule`, except `observe()`, which comes from the shared `ObserveSkill` container (`dimos/agents/skills/observe_skill.py`, remapped to the drone's `video` stream in `drone_agentic`):
 
 ### Movement & Control
 - `move(x, y, z, duration)` — Move with velocity (m/s)

--- a/dimos/robot/drone/blueprints/agentic/drone_agentic.py
+++ b/dimos/robot/drone/blueprints/agentic/drone_agentic.py
@@ -23,6 +23,7 @@ tracking, mapping skills, and an LLM agent.
 from dimos.agents.mcp.mcp_client import McpClient
 from dimos.agents.mcp.mcp_server import McpServer
 from dimos.agents.skills.google_maps_skill_container import GoogleMapsSkillContainer
+from dimos.agents.skills.observe_skill import ObserveSkill
 from dimos.agents.skills.osm import OsmSkill
 from dimos.agents.web_human_input import WebInput
 from dimos.core.coordination.blueprints import autoconnect
@@ -44,6 +45,7 @@ drone_agentic = autoconnect(
     drone_basic,
     DroneTrackingModule.blueprint(outdoor=False),
     GoogleMapsSkillContainer.blueprint(),
+    ObserveSkill.blueprint(),
     OsmSkill.blueprint(),
     McpServer.blueprint(),
     McpClient.blueprint(system_prompt=DRONE_SYSTEM_PROMPT, model="gpt-4o"),
@@ -52,5 +54,6 @@ drone_agentic = autoconnect(
     [
         (DroneTrackingModule, "video_input", "video"),
         (DroneTrackingModule, "cmd_vel", "movecmd_twist"),
+        (ObserveSkill, "color_image", "video"),
     ]
 )

--- a/dimos/robot/drone/connection_module.py
+++ b/dimos/robot/drone/connection_module.py
@@ -75,7 +75,6 @@ class DroneConnectionModule(Module):
     # Internal state
     _odom: PoseStamped | None = None
     _status: dict[str, Any] = {}
-    _latest_video_frame: Image | None = None
     _latest_telemetry: dict[str, Any] | None = None
     _latest_status: dict[str, Any] | None = None
     _latest_status_lock: threading.RLock
@@ -91,7 +90,6 @@ class DroneConnectionModule(Module):
         super().__init__(**kwargs)
         self.connection: MavlinkConnection | None = None
         self.video_stream: DJIDroneVideoStream | None = None
-        self._latest_video_frame = None
         self._latest_telemetry = None
         self._latest_status = None
         self._latest_status_lock = threading.RLock()
@@ -123,9 +121,9 @@ class DroneConnectionModule(Module):
         # Start video stream (already created above)
         if self.video_stream.start():
             logger.info("Video stream started")
-            # Subscribe to video, store latest frame and publish it
+            # Subscribe to video and publish it
             self.register_disposable(
-                self.video_stream.get_stream().subscribe(self._store_and_publish_frame),
+                self.video_stream.get_stream().subscribe(self.video.publish),
             )
             # # TEMPORARY - DELETE AFTER RECORDING
             # from dimos.utils.testing import TimedSensorStorage
@@ -166,11 +164,6 @@ class DroneConnectionModule(Module):
 
         logger.info("Drone connection module started")
         return
-
-    def _store_and_publish_frame(self, frame: Image) -> None:
-        """Store the latest video frame and publish it."""
-        self._latest_video_frame = frame
-        self.video.publish(frame)
 
     def _publish_tf(self, msg: PoseStamped) -> None:
         """Publish odometry and TF transforms."""
@@ -465,12 +458,3 @@ class DroneConnectionModule(Module):
 
         # Call parent stop to clean up Module infrastructure (event loop, LCM, disposables, etc.)
         super().stop()
-
-    @skill
-    def observe(self) -> Image | None:
-        """Returns the latest video frame from the drone camera. Use this skill for any visual world queries.
-
-        This skill provides the current camera view for perception tasks.
-        Returns None if no frame has been captured yet.
-        """
-        return self._latest_video_frame

--- a/dimos/robot/unitree/g1/blueprints/agentic/_agentic_skills.py
+++ b/dimos/robot/unitree/g1/blueprints/agentic/_agentic_skills.py
@@ -18,6 +18,7 @@
 from dimos.agents.mcp.mcp_client import McpClient
 from dimos.agents.mcp.mcp_server import McpServer
 from dimos.agents.skills.navigation import NavigationSkillContainer
+from dimos.agents.skills.observe_skill import ObserveSkill
 from dimos.agents.skills.speak_skill import SpeakSkill
 from dimos.core.coordination.blueprints import autoconnect
 from dimos.robot.unitree.g1.skill_container import UnitreeG1SkillContainer
@@ -27,6 +28,7 @@ _agentic_skills = autoconnect(
     McpServer.blueprint(),
     McpClient.blueprint(system_prompt=G1_SYSTEM_PROMPT),
     NavigationSkillContainer.blueprint(),
+    ObserveSkill.blueprint(),
     SpeakSkill.blueprint(),
     UnitreeG1SkillContainer.blueprint(),
 )

--- a/dimos/robot/unitree/go2/blueprints/agentic/_common_agentic.py
+++ b/dimos/robot/unitree/go2/blueprints/agentic/_common_agentic.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from dimos.agents.skills.navigation import NavigationSkillContainer
+from dimos.agents.skills.observe_skill import ObserveSkill
 from dimos.agents.skills.person_follow import PersonFollowSkillContainer
 from dimos.agents.skills.speak_skill import SpeakSkill
 from dimos.agents.web_human_input import WebInput
@@ -23,6 +24,7 @@ from dimos.robot.unitree.unitree_skill_container import UnitreeSkillContainer
 
 _common_agentic = autoconnect(
     NavigationSkillContainer.blueprint(),
+    ObserveSkill.blueprint(),
     PersonFollowSkillContainer.blueprint(camera_info=GO2Connection.camera_info_static),
     UnitreeSkillContainer.blueprint(),
     WebInput.blueprint(),

--- a/dimos/robot/unitree/go2/connection.py
+++ b/dimos/robot/unitree/go2/connection.py
@@ -281,7 +281,6 @@ class GO2Connection(Module, Camera, Pointcloud):
     connection: Go2ConnectionProtocol
     camera_info_static: CameraInfo = _camera_info_static()
     _camera_info_thread: Thread | None = None
-    _latest_video_frame: Image | None = None
     _latest_lowstate: LowStateMsg | None = None
 
     @classmethod
@@ -325,7 +324,6 @@ class GO2Connection(Module, Camera, Pointcloud):
         def onimage(image: Image) -> None:
             image.frame_id = _prefixed(self.config.frame_id_prefix, image.frame_id)
             self.color_image.publish(image)
-            self._latest_video_frame = image
 
         if self.config.lidar:
             self.register_disposable(self.connection.lidar_stream().subscribe(self.lidar.publish))
@@ -498,12 +496,3 @@ class GO2Connection(Module, Camera, Pointcloud):
             The result of the publish request
         """
         return self.connection.publish_request(topic, data)
-
-    @skill
-    def observe(self) -> Image | None:
-        """Returns the latest video frame from the robot camera. Use this skill for any visual world queries.
-
-        This skill provides the current camera view for perception tasks.
-        Returns None if no frame has been captured yet.
-        """
-        return self._latest_video_frame

--- a/docs/capabilities/agents/index.md
+++ b/docs/capabilities/agents/index.md
@@ -74,7 +74,7 @@ class MySkillContainer(Module):
 | `relative_move(forward, left, degrees)` | `UnitreeSkillContainer` | Move robot relative to current position |
 | `execute_sport_command(command_name)` | `UnitreeSkillContainer` | Unitree sport commands (sit, stand, flip, etc.) |
 | `wait(seconds)` | `UnitreeSkillContainer` | Pause execution |
-| `observe()` | `GO2Connection` | Capture and return current camera frame |
+| `observe()` | `ObserveSkill` | Capture and return current camera frame |
 | `navigate_with_text(query)` | `NavigationSkillContainer` | Navigate to a location by description |
 | `tag_location(location_name)` | `NavigationSkillContainer` | Tag current position for later recall |
 | `stop_navigation()` | `NavigationSkillContainer` | Cancel current navigation goal |

--- a/docs/usage/modules.md
+++ b/docs/usage/modules.md
@@ -57,7 +57,6 @@ print(CameraModule.io())
  ├─ RPC set_transport(stream_name: str, transport: Transport) -> bool
  ├─ RPC start() -> None
  ├─ RPC stop() -> None
- ├─ RPC take_a_picture() -> Image
 ```
 
 We can see that the camera module outputs two streams:
@@ -67,7 +66,7 @@ We can see that the camera module outputs two streams:
 
 It offers two RPC calls: `start()` and `stop()` (lifecycle methods).
 
-It also exposes an agentic [skill](/docs/usage/blueprints.md#defining-skills) called `take_a_picture` (more on skills in the Blueprints guide).
+Camera observation as an agentic [skill](/docs/usage/blueprints.md#defining-skills) is provided separately by the reusable `ObserveSkill` container (`dimos/agents/skills/observe_skill.py`), which subscribes to `color_image` and can be added to any blueprint (more on skills in the Blueprints guide).
 
 We can start this module and explore the output of its streams in real time (this will use your webcam).
 


### PR DESCRIPTION
Closes DIM-1505

## Problem

* Observation skill is broken when running dimsim simulator
* We have too many independent observation skills.

## Solution

* Unify all observation skills into one.
* This way, it no longer goes through each sim, just listen to `/color_image`