### PR TITLE
Improve mujoco import error handling

### DIFF
--- a/dimos/robot/unitree/mujoco_connection.py
+++ b/dimos/robot/unitree/mujoco_connection.py
@@ -71,16 +71,18 @@ class MujocoConnection:
     def __init__(self, global_config: GlobalConfig) -> None:
         try:
             import mujoco  # noqa: F401
-        except ImportError:
-            raise ImportError("'mujoco' is not installed. Use `pip install -e .[sim]`")
+            from mujoco_playground._src import mjx_env
+        except ImportError as exc:
+            raise ImportError(
+            "Simulation dependencies are not installed. "
+            "Run `uv sync --extra sim --inexact` to install them."
+            ) from exc
 
         # Pre-download the mujoco_sim data.
         get_data("mujoco_sim")
 
         # Trigger the download of the mujoco_menagerie package. This is so it
         # doesn't trigger in the mujoco process where it can time out.
-        from mujoco_playground._src import mjx_env
-
         mjx_env.ensure_menagerie_exists()
 
         self.global_config = global_config

--- a/dimos/robot/unitree/mujoco_connection.py
+++ b/dimos/robot/unitree/mujoco_connection.py
@@ -74,8 +74,8 @@ class MujocoConnection:
             from mujoco_playground._src import mjx_env
         except ImportError as exc:
             raise ImportError(
-            "Simulation dependencies are not installed. "
-            "Run `uv sync --extra sim --inexact` to install them."
+                "Simulation dependencies are not installed. "
+                "Run `uv sync --extra sim --inexact` to install them."
             ) from exc
 
         # Pre-download the mujoco_sim data.


### PR DESCRIPTION
Updated error handling for MuJoCo simulation dependencies to provide clearer, actionable installation instructions.

## Contribution path

* Linked issue: #3647

## Problem

`MujocoConnection` currently guards the `mujoco` import and provides an installation hint when it is missing. However, `mujoco_playground` is imported separately outside of that guard, so a missing `mujoco_playground` dependency results in a raw `ModuleNotFoundError`.

## Solution

Gate both `mujoco` and `mujoco_playground` imports under the same error handling and provide a consistent installation instruction:

`uv sync --extra sim --inexact`

This keeps simulation dependencies optional while providing a clearer and actionable failure mode when simulation functionality is invoked.

Closes #3647.

## How to Test

Run a MuJoCo-based simulation without the `sim` dependencies installed and verify that the error directs the user to run:

`uv sync --extra sim --inexact`

## Checklist

* [x] I have read and approved the [[CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md)](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).