### PR TITLE
fix(data): initialize Git LFS before on-demand pulls

### DIFF
--- a/dimos/utils/data.py
+++ b/dimos/utils/data.py
@@ -154,22 +154,7 @@ def _get_lfs_dir() -> Path:
     return get_data_dir() / ".lfs"
 
 
-def _git_lfs_error_detail(error: subprocess.CalledProcessError) -> str:
-    output: list[str] = []
-    for stream in (error.stdout, error.stderr):
-        if isinstance(stream, bytes):
-            stream = stream.decode(errors="replace")
-        if stream:
-            output.append(stream.strip())
-    return "\n".join(output) or str(error)
-
-
-def _is_git_config_lock_error(error: subprocess.CalledProcessError) -> bool:
-    detail = _git_lfs_error_detail(error)
-    return "could not lock config file" in detail and "File exists" in detail
-
-
-def _initialize_git_lfs(repo_root: Path, *, retries: int = 2) -> None:
+def _initialize_git_lfs(repo_root: Path) -> None:
     missing: list[str] = []
 
     # Check if git is available
@@ -190,23 +175,13 @@ def _initialize_git_lfs(repo_root: Path, *, retries: int = 2) -> None:
             "Git LFS installation instructions: https://git-lfs.github.io/"
         )
 
-    for attempt in range(1, retries + 2):
-        try:
-            subprocess.run(
-                ["git", "lfs", "install", "--local", "--skip-repo"],
-                cwd=repo_root,
-                capture_output=True,
-                check=True,
-                text=True,
-            )
-            return
-        except subprocess.CalledProcessError as e:
-            if _is_git_config_lock_error(e) and attempt <= retries:
-                time.sleep(attempt)
-                continue
-
-            detail = _git_lfs_error_detail(e)
-            raise RuntimeError(f"Failed to initialize Git LFS: {detail}") from e
+    subprocess.run(
+        ["git", "lfs", "install", "--local", "--skip-repo"],
+        cwd=repo_root,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
 
 
 def _is_lfs_pointer_file(file_path: Path) -> bool:

--- a/dimos/utils/data.py
+++ b/dimos/utils/data.py
@@ -154,8 +154,8 @@ def _get_lfs_dir() -> Path:
     return get_data_dir() / ".lfs"
 
 
-def _check_git_lfs_available() -> bool:
-    missing = []
+def _initialize_git_lfs(repo_root: Path) -> None:
+    missing: list[str] = []
 
     # Check if git is available
     try:
@@ -175,7 +175,17 @@ def _check_git_lfs_available() -> bool:
             "Git LFS installation instructions: https://git-lfs.github.io/"
         )
 
-    return True
+    try:
+        subprocess.run(
+            ["git", "lfs", "install", "--local", "--skip-repo"],
+            cwd=repo_root,
+            capture_output=True,
+            check=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as e:
+        detail = e.stderr.strip() if e.stderr else str(e)
+        raise RuntimeError(f"Failed to initialize Git LFS: {detail}") from e
 
 
 def _is_lfs_pointer_file(file_path: Path) -> bool:
@@ -229,9 +239,6 @@ def _decompress_archive(filename: str | Path) -> Path:
 
 
 def _pull_lfs_archive(filename: str | Path) -> Path:
-    # Check Git LFS availability first
-    _check_git_lfs_available()
-
     # Find repository root
     repo_root = get_project_root()
 
@@ -247,6 +254,7 @@ def _pull_lfs_archive(filename: str | Path) -> Path:
 
     # If it's an LFS pointer file, ensure LFS is set up and pull the file
     if _is_lfs_pointer_file(file_path):
+        _initialize_git_lfs(repo_root)
         _lfs_pull(file_path, repo_root)
 
         # Verify the file was actually downloaded

--- a/dimos/utils/data.py
+++ b/dimos/utils/data.py
@@ -154,7 +154,22 @@ def _get_lfs_dir() -> Path:
     return get_data_dir() / ".lfs"
 
 
-def _initialize_git_lfs(repo_root: Path) -> None:
+def _git_lfs_error_detail(error: subprocess.CalledProcessError) -> str:
+    output: list[str] = []
+    for stream in (error.stdout, error.stderr):
+        if isinstance(stream, bytes):
+            stream = stream.decode(errors="replace")
+        if stream:
+            output.append(stream.strip())
+    return "\n".join(output) or str(error)
+
+
+def _is_git_config_lock_error(error: subprocess.CalledProcessError) -> bool:
+    detail = _git_lfs_error_detail(error)
+    return "could not lock config file" in detail and "File exists" in detail
+
+
+def _initialize_git_lfs(repo_root: Path, *, retries: int = 2) -> None:
     missing: list[str] = []
 
     # Check if git is available
@@ -175,17 +190,23 @@ def _initialize_git_lfs(repo_root: Path) -> None:
             "Git LFS installation instructions: https://git-lfs.github.io/"
         )
 
-    try:
-        subprocess.run(
-            ["git", "lfs", "install", "--local", "--skip-repo"],
-            cwd=repo_root,
-            capture_output=True,
-            check=True,
-            text=True,
-        )
-    except subprocess.CalledProcessError as e:
-        detail = e.stderr.strip() if e.stderr else str(e)
-        raise RuntimeError(f"Failed to initialize Git LFS: {detail}") from e
+    for attempt in range(1, retries + 2):
+        try:
+            subprocess.run(
+                ["git", "lfs", "install", "--local", "--skip-repo"],
+                cwd=repo_root,
+                capture_output=True,
+                check=True,
+                text=True,
+            )
+            return
+        except subprocess.CalledProcessError as e:
+            if _is_git_config_lock_error(e) and attempt <= retries:
+                time.sleep(attempt)
+                continue
+
+            detail = _git_lfs_error_detail(e)
+            raise RuntimeError(f"Failed to initialize Git LFS: {detail}") from e
 
 
 def _is_lfs_pointer_file(file_path: Path) -> bool:

--- a/dimos/utils/test_data.py
+++ b/dimos/utils/test_data.py
@@ -58,10 +58,56 @@ def test_initialize_git_lfs_reports_configuration_error(
         ["git", "lfs", "install", "--local", "--skip-repo"],
         stderr="unable to write repository config",
     )
-    mocker.patch.object(data.subprocess, "run", side_effect=[None, None, install_error])
+    run = mocker.patch.object(data.subprocess, "run", side_effect=[None, None, install_error])
+    sleep = mocker.patch.object(data.time, "sleep")
 
     with pytest.raises(RuntimeError, match="unable to write repository config"):
         data._initialize_git_lfs(tmp_path)
+
+    assert run.call_count == 3
+    sleep.assert_not_called()
+
+
+def test_initialize_git_lfs_retries_config_lock_contention(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    lock_error = subprocess.CalledProcessError(
+        2,
+        ["git", "lfs", "install", "--local", "--skip-repo"],
+        output=(
+            "error: could not lock config file .git/config: File exists\n"
+            "Run `git lfs install --force` to reset Git configuration."
+        ),
+    )
+    run = mocker.patch.object(data.subprocess, "run", side_effect=[None, None, lock_error, None])
+    sleep = mocker.patch.object(data.time, "sleep")
+
+    data._initialize_git_lfs(tmp_path)
+
+    assert run.call_count == 4
+    sleep.assert_called_once_with(1)
+
+
+def test_initialize_git_lfs_reports_persistent_config_lock_contention(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    lock_error = subprocess.CalledProcessError(
+        2,
+        ["git", "lfs", "install", "--local", "--skip-repo"],
+        output="error: could not lock config file .git/config: File exists",
+    )
+    run = mocker.patch.object(
+        data.subprocess,
+        "run",
+        side_effect=[None, None, lock_error, lock_error, lock_error],
+    )
+    sleep = mocker.patch.object(data.time, "sleep")
+
+    with pytest.raises(RuntimeError, match="could not lock config file"):
+        data._initialize_git_lfs(tmp_path)
+
+    assert run.call_count == 5
+    assert sleep.call_args_list == [call(1), call(2)]
 
 
 def test_pull_lfs_archive_initializes_lfs_before_pull(

--- a/dimos/utils/test_data.py
+++ b/dimos/utils/test_data.py
@@ -44,70 +44,25 @@ def test_initialize_git_lfs_configures_only_repository(
             ["git", "lfs", "install", "--local", "--skip-repo"],
             cwd=tmp_path,
             capture_output=True,
-            check=True,
+            check=False,
             text=True,
         ),
     ]
 
 
-def test_initialize_git_lfs_reports_configuration_error(
+def test_initialize_git_lfs_ignores_configuration_error(
     mocker: MockerFixture, tmp_path: Path
 ) -> None:
-    install_error = subprocess.CalledProcessError(
-        1,
+    install_result = subprocess.CompletedProcess(
         ["git", "lfs", "install", "--local", "--skip-repo"],
+        2,
         stderr="unable to write repository config",
     )
-    run = mocker.patch.object(data.subprocess, "run", side_effect=[None, None, install_error])
-    sleep = mocker.patch.object(data.time, "sleep")
-
-    with pytest.raises(RuntimeError, match="unable to write repository config"):
-        data._initialize_git_lfs(tmp_path)
-
-    assert run.call_count == 3
-    sleep.assert_not_called()
-
-
-def test_initialize_git_lfs_retries_config_lock_contention(
-    mocker: MockerFixture, tmp_path: Path
-) -> None:
-    lock_error = subprocess.CalledProcessError(
-        2,
-        ["git", "lfs", "install", "--local", "--skip-repo"],
-        output=(
-            "error: could not lock config file .git/config: File exists\n"
-            "Run `git lfs install --force` to reset Git configuration."
-        ),
-    )
-    run = mocker.patch.object(data.subprocess, "run", side_effect=[None, None, lock_error, None])
-    sleep = mocker.patch.object(data.time, "sleep")
+    run = mocker.patch.object(data.subprocess, "run", side_effect=[None, None, install_result])
 
     data._initialize_git_lfs(tmp_path)
 
-    assert run.call_count == 4
-    sleep.assert_called_once_with(1)
-
-
-def test_initialize_git_lfs_reports_persistent_config_lock_contention(
-    mocker: MockerFixture, tmp_path: Path
-) -> None:
-    lock_error = subprocess.CalledProcessError(
-        2,
-        ["git", "lfs", "install", "--local", "--skip-repo"],
-        output="error: could not lock config file .git/config: File exists",
-    )
-    run = mocker.patch.object(
-        data.subprocess,
-        "run",
-        side_effect=[None, None, lock_error, lock_error, lock_error],
-    )
-    sleep = mocker.patch.object(data.time, "sleep")
-
-    with pytest.raises(RuntimeError, match="could not lock config file"):
-        data._initialize_git_lfs(tmp_path)
-
-    assert run.call_count == 5
-    assert sleep.call_args_list == [call(1), call(2)]
+    assert run.call_count == 3
 
 
 def test_pull_lfs_archive_initializes_lfs_before_pull(

--- a/dimos/utils/test_data.py
+++ b/dimos/utils/test_data.py
@@ -16,8 +16,10 @@ import hashlib
 import os
 from pathlib import Path
 import subprocess
+from unittest.mock import call
 
 import pytest
+from pytest_mock import MockerFixture
 
 from dimos.utils import data
 from dimos.utils.data import LfsPath, backup_file
@@ -26,6 +28,68 @@ from dimos.utils.data import LfsPath, backup_file
 def _make_backups(dir_path: Path, stem: str, suffix: str, timestamps: list[str]) -> None:
     for ts in timestamps:
         (dir_path / f"{stem}.{ts}{suffix}").write_text(ts)
+
+
+def test_initialize_git_lfs_configures_only_repository(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    run = mocker.patch.object(data.subprocess, "run")
+
+    data._initialize_git_lfs(tmp_path)
+
+    assert run.call_args_list == [
+        call(["git", "--version"], capture_output=True, check=True, text=True),
+        call(["git-lfs", "version"], capture_output=True, check=True, text=True),
+        call(
+            ["git", "lfs", "install", "--local", "--skip-repo"],
+            cwd=tmp_path,
+            capture_output=True,
+            check=True,
+            text=True,
+        ),
+    ]
+
+
+def test_initialize_git_lfs_reports_configuration_error(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    install_error = subprocess.CalledProcessError(
+        1,
+        ["git", "lfs", "install", "--local", "--skip-repo"],
+        stderr="unable to write repository config",
+    )
+    mocker.patch.object(data.subprocess, "run", side_effect=[None, None, install_error])
+
+    with pytest.raises(RuntimeError, match="unable to write repository config"):
+        data._initialize_git_lfs(tmp_path)
+
+
+def test_pull_lfs_archive_initializes_lfs_before_pull(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    lfs_dir = tmp_path / "data" / ".lfs"
+    lfs_dir.mkdir(parents=True)
+    archive = lfs_dir / "sample.tar.gz"
+    archive.write_text("version https://git-lfs.github.com/spec/v1\n")
+    mocker.patch.object(data, "get_project_root", return_value=tmp_path)
+    mocker.patch.object(data, "_get_lfs_dir", return_value=lfs_dir)
+    initialize = mocker.patch.object(data, "_initialize_git_lfs")
+    pull = mocker.patch.object(
+        data,
+        "_lfs_pull",
+        side_effect=lambda *_: archive.write_bytes(b"downloaded archive"),
+    )
+    steps = mocker.Mock()
+    steps.attach_mock(initialize, "initialize")
+    steps.attach_mock(pull, "pull")
+
+    result = data._pull_lfs_archive("sample")
+
+    assert result == archive
+    assert steps.mock_calls == [
+        call.initialize(tmp_path),
+        call.pull(archive, tmp_path),
+    ]
 
 
 def test_backup_file_missing_is_noop(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- initialize Git LFS before pulling an on-demand data archive
- scope LFS filters to the DimOS data repository
- treat initialization as best effort so concurrent callers do not fail on Git's config lock

## Why

`get_data()` checked that Git and Git LFS were installed, but it did not initialize the LFS filters. Without those filters, `git lfs pull` can download an object, skip checkout, and exit successfully, leaving the pointer file in place.

This is not macOS-specific. Package managers differ in whether they initialize Git LFS after installing the binary.

The loader now runs:

```text
git lfs install --local --skip-repo
```

`--local` limits the configuration to the data repository. `--skip-repo` prevents hook installation. This avoids changing the user's global Git configuration and works for both source checkouts and PyPI installs, where DimOS creates a writable data clone outside the installed package code.

Concurrent callers can race on `.git/config.lock`. Initialization is therefore best effort: DimOS attempts it once and does not fail on a nonzero exit. The following `git lfs pull` and pointer-file verification remain authoritative and report an error if the requested file was not fetched.

Fixes #3656.

## Testing

- `dimos/utils/test_data.py`: 15 passed
- best-effort initialization unit coverage
- Ruff format and lint
- mypy on `dimos/utils/data.py`
- clean Linux container concurrency verification
- isolated non-editable wheel install with a fresh home and a real LFS download
- verified repository-local filters were written and no global Git config was created
