### PR TITLE
fix(manip): give each convex hull its own file

### DIFF
--- a/dimos/manipulation/planning/monitor/world_obstacle_monitor.py
+++ b/dimos/manipulation/planning/monitor/world_obstacle_monitor.py
@@ -644,7 +644,9 @@ class WorldObstacleMonitor:
 
                 points, _ = obj.pointcloud.as_numpy()
                 if points is not None and points.shape[0] >= 4:
-                    mesh_path = pointcloud_to_convex_hull_obj(points)
+                    # Keyed on the object's stable unique id: rescans overwrite
+                    # in place, and no two objects share a file.
+                    mesh_path = pointcloud_to_convex_hull_obj(points, cache_key=name)
                     if mesh_path is not None:
                         return Obstacle(
                             name=name,

--- a/dimos/manipulation/planning/utils/mesh_utils.py
+++ b/dimos/manipulation/planning/utils/mesh_utils.py
@@ -26,6 +26,7 @@ from pathlib import Path
 import re
 import shutil
 from typing import TYPE_CHECKING
+import uuid
 
 from dimos.robot.assets.git_cache import DEFAULT_ROBOT_ASSET_CACHE_ROOT
 from dimos.robot.assets.model import LoadedRobotModel
@@ -149,6 +150,7 @@ def pointcloud_to_convex_hull_obj(
     points: NDArray[np.float64],
     output_path: Path | str | None = None,
     *,
+    cache_key: str | None = None,
     voxel_size: float = 0.005,
     min_points: int = 4,
 ) -> str | None:
@@ -159,7 +161,10 @@ def pointcloud_to_convex_hull_obj(
 
     Args:
         points: Nx3 numpy array of 3D points (world frame)
-        output_path: Where to save OBJ. If None, uses a temp file.
+        output_path: Where to save OBJ. If None, saves into the hull cache.
+        cache_key: Stable identity used when output_path is None. The same key
+            reuses one file, so a caller rescanning an object overwrites in
+            place; without a key each call gets its own unique file.
         voxel_size: Downsample voxel size in meters (0 to skip)
         min_points: Minimum points required for convex hull
 
@@ -198,9 +203,15 @@ def pointcloud_to_convex_hull_obj(
         return None
 
     if output_path is None:
-        hull_dir = _CACHE_DIR / "convex_hulls"
-        hull_dir.mkdir(parents=True, exist_ok=True)
-        output_path = hull_dir / f"hull_{id(points):x}.obj"
+        if cache_key is None:
+            # Not id(points): CPython recycles a freed address, so sequential
+            # callers silently overwrote each other's hulls.
+            stem = uuid.uuid4().hex
+        else:
+            # Digest so two keys that sanitize alike still get their own file.
+            safe = re.sub(r"[^A-Za-z0-9_.-]", "_", cache_key)[:64]
+            stem = f"{safe}_{hashlib.sha256(cache_key.encode()).hexdigest()[:12]}"
+        output_path = _CACHE_DIR / "convex_hulls" / f"hull_{stem}.obj"
 
     output_path = Path(output_path)
     output_path.parent.mkdir(parents=True, exist_ok=True)

--- a/dimos/manipulation/planning/utils/test_mesh_utils.py
+++ b/dimos/manipulation/planning/utils/test_mesh_utils.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import re
 from urllib.parse import unquote, urlparse
 
+import numpy as np
 import pytest
 
 from dimos.manipulation.planning.utils import mesh_utils
@@ -127,3 +128,63 @@ def test_mesh_conversion_keeps_different_same_stem_meshes_distinct(
     assert obj_paths[0] != obj_paths[1]
     assert all(path.exists() for path in obj_paths)
     assert obj_paths[0].read_text() != obj_paths[1].read_text()
+
+
+def _cube_points(scale: float) -> np.ndarray:
+    return np.array(
+        [[x, y, z] for x in (0.0, scale) for y in (0.0, scale) for z in (0.0, scale)],
+        dtype=np.float64,
+    )
+
+
+def _hull_for_scale(scale: float) -> str | None:
+    # Separate frame so the array is freed on return and CPython reuses its
+    # address, the aliasing the old id(points) name turned into shared files.
+    points = _cube_points(scale)
+    return mesh_utils.pointcloud_to_convex_hull_obj(points)
+
+
+def test_convex_hull_default_path_is_unique_per_call(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(mesh_utils, "_CACHE_DIR", tmp_path / "derived" / "drake_meshes")
+
+    paths = [_hull_for_scale(0.1 * (i + 1)) for i in range(4)]
+
+    assert all(path is not None for path in paths)
+    assert len(set(paths)) == len(paths)
+    assert len({Path(path).read_text() for path in paths}) == len(paths)
+
+
+def test_convex_hull_cache_key_reuses_one_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(mesh_utils, "_CACHE_DIR", tmp_path / "derived" / "drake_meshes")
+
+    first = mesh_utils.pointcloud_to_convex_hull_obj(_cube_points(0.1), cache_key="object_a")
+    assert first is not None
+    before = Path(first).read_text()
+
+    second = mesh_utils.pointcloud_to_convex_hull_obj(_cube_points(0.4), cache_key="object_a")
+    assert second == first
+    assert Path(first).read_text() != before
+
+    hull_dir = tmp_path / "derived" / "drake_meshes" / "convex_hulls"
+    assert len(list(hull_dir.glob("*.obj"))) == 1
+
+
+def test_convex_hull_cache_keys_that_sanitize_alike_stay_distinct(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(mesh_utils, "_CACHE_DIR", tmp_path / "derived" / "drake_meshes")
+
+    first = mesh_utils.pointcloud_to_convex_hull_obj(_cube_points(0.1), cache_key="object a/1")
+    second = mesh_utils.pointcloud_to_convex_hull_obj(_cube_points(0.4), cache_key="object_a_1")
+
+    assert first is not None
+    assert second is not None
+    assert first != second
+    assert Path(first).read_text() != Path(second).read_text()


### PR DESCRIPTION
## Contribution path

- [x] Small, safe change that does not need a tracking issue

## Problem

`pointcloud_to_convex_hull_obj()` named its output `hull_{id(points):x}.obj`. `id()` is a memory address, and CPython hands a freed address straight back to the next same-sized array, so sequential callers silently overwrote each other's hull files.

It is intermittent — it depends on allocator reuse — and it corrupts the planner's collision world, so a robot plans around the wrong geometry. This is shared planning code: it affects every robot that registers mesh obstacles (`use_mesh_obstacles=True` on `WorldObstacleMonitor`).

## Solution

Two parts, both needed:

1. **`mesh_utils`** — the default filename is now a uuid, so no caller can alias another's hull. 
2. **`world_obstacle_monitor`** — the only default-path caller now passes `cache_key=name`, where `name` is `f"object_{obj.object_id}"`. `object_id` is ObjectDB's stable per-object uuid 

The monitor passes a *key*, not a path, so it never has to reach into `mesh_utils`' private `_CACHE_DIR`.

## How to Test

```
uv run pytest dimos/manipulation/planning
```

## AI assistance

Claude Code with Opus 5. Used to locate the call sites, re-derive the fix, and write the tests. I verified and reviewed every line.

## Checklist

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
