### PR TITLE
fix(manip): place convex-hull obstacles at their build centroid

### DIFF
--- a/dimos/manipulation/planning/monitor/test_world_monitor.py
+++ b/dimos/manipulation/planning/monitor/test_world_monitor.py
@@ -25,6 +25,7 @@ from pytest_mock import MockerFixture
 from dimos.manipulation.planning import factory as planning_factory
 from dimos.manipulation.planning.groups.models import PlanningGroupDefinition
 from dimos.manipulation.planning.monitor import world_monitor as world_monitor_module
+from dimos.manipulation.planning.monitor.world_obstacle_monitor import WorldObstacleMonitor
 from dimos.manipulation.planning.spec.config import RobotModelConfig
 from dimos.manipulation.planning.spec.enums import ObstacleType
 from dimos.manipulation.planning.spec.models import (
@@ -35,11 +36,15 @@ from dimos.manipulation.planning.spec.models import (
     VisualizationStateFrame,
 )
 from dimos.manipulation.planning.spec.protocols import VisualizationSpec
+from dimos.manipulation.planning.utils import mesh_utils
 from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
 from dimos.msgs.geometry_msgs.Quaternion import Quaternion
 from dimos.msgs.geometry_msgs.Vector3 import Vector3
+from dimos.msgs.sensor_msgs.Image import Image
 from dimos.msgs.sensor_msgs.JointState import JointState
+from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
 from dimos.msgs.trajectory_msgs.JointTrajectory import JointTrajectory
+from dimos.perception.experimental.object import Object
 from dimos.robot.assets.model import RobotModel
 
 
@@ -873,3 +878,87 @@ def test_world_obstacle_monitor_detection_add_update_and_stale_cleanup(
     update.assert_called_once_with("first-id", mocker.ANY)
     remove.assert_called_once_with("first-id")
     assert obstacle_monitor.get_obstacle_count() == 0
+
+
+def _tilted_box_cloud() -> np.ndarray:
+    """Single-view cloud of a 20x8x8 cm box tilted 30 degrees off the world axes."""
+    rng = np.random.default_rng(0)
+    length, width, height = 0.20, 0.08, 0.08
+    u = rng.uniform(-0.5, 0.5, 4000)
+    v = rng.uniform(-0.5, 0.5, 4000)
+    # Two visible faces only, so the cloud mean sits off the box center.
+    front = np.column_stack([u * length, np.full(u.size, -width / 2), v * height])
+    top = np.column_stack([u * length, v * width, np.full(u.size, height / 2)])
+    angle = np.deg2rad(30.0)
+    rotation = np.array(
+        [
+            [np.cos(angle), -np.sin(angle), 0.0],
+            [np.sin(angle), np.cos(angle), 0.0],
+            [0.0, 0.0, 1.0],
+        ]
+    )
+    return np.vstack([front, top]) @ rotation.T + np.array([1.0, 0.5, 0.9])
+
+
+def test_mesh_obstacle_is_placed_at_the_hull_centroid_without_the_bbox_rotation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mocker: MockerFixture,
+) -> None:
+    monkeypatch.setattr(mesh_utils, "_CACHE_DIR", tmp_path / "derived" / "drake_meshes")
+    parent = world_monitor_module.WorldMonitor(world=FakeWorld())  # type: ignore[arg-type]
+    add_obstacle = mocker.patch.object(parent, "add_obstacle", return_value="parent-id")
+
+    points = _tilted_box_cloud()
+    cloud = PointCloud2.from_numpy(points, frame_id="world")
+    # Mirrors Object.from_detections with use_aabb=False: pose carries the
+    # oriented-box center and rotation.
+    obb = cloud.pointcloud.get_oriented_bounding_box()
+    obj = Object(
+        object_id="tilted-box",
+        name="box",
+        center=Vector3(obb.center),
+        size=Vector3(obb.extent),
+        pose=PoseStamped(
+            frame_id="world",
+            position=Vector3(obb.center),
+            orientation=Quaternion.from_rotation_matrix(np.asarray(obb.R)),
+        ),
+        pointcloud=cloud,
+        bbox=(0.0, 0.0, 1.0, 1.0),
+        track_id=0,
+        class_id=0,
+        confidence=1.0,
+        ts=0.0,
+        image=Image(),
+    )
+
+    monitor = WorldObstacleMonitor(parent=parent, use_mesh_obstacles=True)
+    monitor.start()
+    monitor.on_objects([obj])
+    monitor.refresh_obstacles()
+
+    obstacle = add_obstacle.call_args.args[0]
+    centroid = points.mean(axis=0)
+    assert obstacle.obstacle_type == ObstacleType.MESH
+    np.testing.assert_allclose(
+        [obstacle.pose.position.x, obstacle.pose.position.y, obstacle.pose.position.z],
+        centroid,
+        atol=1e-3,
+    )
+    np.testing.assert_allclose(
+        [
+            obstacle.pose.orientation.x,
+            obstacle.pose.orientation.y,
+            obstacle.pose.orientation.z,
+            obstacle.pose.orientation.w,
+        ],
+        [0.0, 0.0, 0.0, 1.0],
+        atol=1e-9,
+    )
+    assert obstacle.pose.frame_id == "world"
+
+    # Teeth: the pose the old code used is a genuinely different placement, so
+    # this cannot pass on the bug.
+    assert np.linalg.norm(np.asarray(obb.center) - centroid) > 3e-3
+    assert abs(Quaternion.from_rotation_matrix(np.asarray(obb.R)).w) < 0.999

--- a/dimos/manipulation/planning/monitor/world_obstacle_monitor.py
+++ b/dimos/manipulation/planning/monitor/world_obstacle_monitor.py
@@ -37,6 +37,8 @@ from dimos.manipulation.planning.spec.models import (
     Obstacle,
 )
 from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
+from dimos.msgs.geometry_msgs.Quaternion import Quaternion
+from dimos.msgs.geometry_msgs.Vector3 import Vector3
 from dimos.utils.logging_config import setup_logger
 
 if TYPE_CHECKING:
@@ -646,14 +648,23 @@ class WorldObstacleMonitor:
                 if points is not None and points.shape[0] >= 4:
                     # Keyed on the object's stable unique id: rescans overwrite
                     # in place, and no two objects share a file.
-                    mesh_path = pointcloud_to_convex_hull_obj(points, cache_key=name)
-                    if mesh_path is not None:
+                    hull = pointcloud_to_convex_hull_obj(points, cache_key=name)
+                    if hull is not None:
+                        # The hull is world-axis-aligned about its own centroid,
+                        # so that is the only pose that leaves it on its points.
+                        # obj.pose carries the bbox center and the oriented-box
+                        # rotation, neither of which the vertices were built from.
                         return Obstacle(
                             name=name,
                             obstacle_type=ObstacleType.MESH,
-                            pose=obj.pose,
+                            pose=PoseStamped(
+                                ts=obj.pose.ts,
+                                frame_id=obj.pose.frame_id,
+                                position=Vector3(hull.centroid),
+                                orientation=Quaternion(0.0, 0.0, 0.0, 1.0),
+                            ),
                             color=(0.2, 0.8, 0.2, 0.6),
-                            mesh_path=mesh_path,
+                            mesh_path=hull.path,
                         )
             except Exception as e:
                 logger.debug(f"Convex hull failed for {name}, falling back to box: {e}")

--- a/dimos/manipulation/planning/utils/mesh_utils.py
+++ b/dimos/manipulation/planning/utils/mesh_utils.py
@@ -21,6 +21,7 @@ Provides utilities for preparing in-memory URDF descriptions for use with Drake:
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 import hashlib
 from pathlib import Path
 import re
@@ -146,6 +147,19 @@ def _convert_meshes(urdf_content: str, output_dir: Path) -> str:
     return re.sub(pattern, convert_mesh, urdf_content)
 
 
+@dataclass(frozen=True)
+class ConvexHullMesh:
+    """A convex hull written to disk, with the point it was centered on.
+
+    Attributes:
+        path: Path to the OBJ file
+        centroid: World-frame mean of the input cloud, the mesh's local origin
+    """
+
+    path: str
+    centroid: NDArray[np.float64]
+
+
 def pointcloud_to_convex_hull_obj(
     points: NDArray[np.float64],
     output_path: Path | str | None = None,
@@ -153,11 +167,13 @@ def pointcloud_to_convex_hull_obj(
     cache_key: str | None = None,
     voxel_size: float = 0.005,
     min_points: int = 4,
-) -> str | None:
+) -> ConvexHullMesh | None:
     """Compute convex hull from point cloud and save as OBJ file.
 
-    Points are centered at origin so the mesh is in local frame.
-    The caller sets the obstacle pose to place it in the world.
+    The mesh is centered on the returned centroid and stays axis-aligned with
+    the world frame: place it at that centroid with identity orientation. Any
+    other pose (a bounding-box center, an oriented-box rotation) moves the hull
+    off the points it was built from.
 
     Args:
         points: Nx3 numpy array of 3D points (world frame)
@@ -169,7 +185,7 @@ def pointcloud_to_convex_hull_obj(
         min_points: Minimum points required for convex hull
 
     Returns:
-        Path to OBJ file, or None if hull computation fails
+        The written hull and its centroid, or None if hull computation fails
     """
     import numpy as np
 
@@ -183,8 +199,10 @@ def pointcloud_to_convex_hull_obj(
         logger.warning("open3d not installed, cannot compute convex hull")
         return None
 
-    # Center at origin so mesh is in local frame
-    centered = points - points.mean(axis=0)
+    # Mean of the raw cloud, before any downsampling: this is the point the
+    # caller must place the mesh at.
+    centroid = points.mean(axis=0)
+    centered = points - centroid
 
     pcd = o3d.geometry.PointCloud()
     pcd.points = o3d.utility.Vector3dVector(centered.astype(np.float64))
@@ -221,7 +239,7 @@ def pointcloud_to_convex_hull_obj(
         logger.debug(
             f"Convex hull: {len(hull.vertices)} verts, {len(hull.triangles)} faces -> {output_path}"
         )
-        return str(output_path)
+        return ConvexHullMesh(path=str(output_path), centroid=centroid)
     except Exception as e:
         logger.warning(f"Failed to write convex hull OBJ: {e}")
         return None

--- a/dimos/manipulation/planning/utils/test_mesh_utils.py
+++ b/dimos/manipulation/planning/utils/test_mesh_utils.py
@@ -137,11 +137,13 @@ def _cube_points(scale: float) -> np.ndarray:
     )
 
 
-def _hull_for_scale(scale: float) -> str | None:
+def _hull_for_scale(scale: float) -> str:
     # Separate frame so the array is freed on return and CPython reuses its
     # address, the aliasing the old id(points) name turned into shared files.
     points = _cube_points(scale)
-    return mesh_utils.pointcloud_to_convex_hull_obj(points)
+    hull = mesh_utils.pointcloud_to_convex_hull_obj(points)
+    assert hull is not None
+    return hull.path
 
 
 def test_convex_hull_default_path_is_unique_per_call(
@@ -152,7 +154,6 @@ def test_convex_hull_default_path_is_unique_per_call(
 
     paths = [_hull_for_scale(0.1 * (i + 1)) for i in range(4)]
 
-    assert all(path is not None for path in paths)
     assert len(set(paths)) == len(paths)
     assert len({Path(path).read_text() for path in paths}) == len(paths)
 
@@ -165,11 +166,12 @@ def test_convex_hull_cache_key_reuses_one_file(
 
     first = mesh_utils.pointcloud_to_convex_hull_obj(_cube_points(0.1), cache_key="object_a")
     assert first is not None
-    before = Path(first).read_text()
+    before = Path(first.path).read_text()
 
     second = mesh_utils.pointcloud_to_convex_hull_obj(_cube_points(0.4), cache_key="object_a")
-    assert second == first
-    assert Path(first).read_text() != before
+    assert second is not None
+    assert second.path == first.path
+    assert Path(first.path).read_text() != before
 
     hull_dir = tmp_path / "derived" / "drake_meshes" / "convex_hulls"
     assert len(list(hull_dir.glob("*.obj"))) == 1
@@ -186,5 +188,32 @@ def test_convex_hull_cache_keys_that_sanitize_alike_stay_distinct(
 
     assert first is not None
     assert second is not None
-    assert first != second
-    assert Path(first).read_text() != Path(second).read_text()
+    assert first.path != second.path
+    assert Path(first.path).read_text() != Path(second.path).read_text()
+
+
+def _obj_vertices(path: Path) -> np.ndarray:
+    lines = path.read_text().splitlines()
+    return np.array([[float(v) for v in ln.split()[1:4]] for ln in lines if ln.startswith("v ")])
+
+
+def test_convex_hull_returns_the_centroid_it_centered_on(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(mesh_utils, "_CACHE_DIR", tmp_path / "derived" / "drake_meshes")
+
+    # Lopsided and far from the origin, so the mean is neither zero nor the
+    # bounding-box center.
+    offset = np.array([1.0, 2.0, 3.0])
+    points = np.vstack([_cube_points(0.2), np.zeros((8, 3))]) + offset
+    hull = mesh_utils.pointcloud_to_convex_hull_obj(points)
+
+    assert hull is not None
+    np.testing.assert_allclose(hull.centroid, points.mean(axis=0))
+
+    # The OBJ holds local-frame vertices, so adding the centroid back reproduces
+    # the cloud's world-frame extent. That is the contract the caller places on.
+    verts = _obj_vertices(Path(hull.path))
+    np.testing.assert_allclose(verts.min(axis=0) + hull.centroid, points.min(axis=0), atol=1e-5)
+    np.testing.assert_allclose(verts.max(axis=0) + hull.centroid, points.max(axis=0), atol=1e-5)


### PR DESCRIPTION
## Contribution path

- [x] Small, safe change that does not need a tracking issue

Follows #3668 (hull file aliasing), which reported this as an unfixed finding in the same code. That PR is merged, so this lands as its own branch off `main`.

## Problem

Mesh obstacles are placed at the wrong pose.

## Solution

**The centroid becomes part of the function's contract.** `pointcloud_to_convex_hull_obj` now returns a `ConvexHullMesh` (frozen dataclass, `path` + `centroid`) instead of a bare path string. The monitor places the hull at that exact centroid with an identity quaternion.

The bounding-box obstacle path is untouched.

## How to Test

```
uv run pytest dimos/manipulation
```


## AI assistance

Claude Code with Opus 5. Used to re-derive the fix, wire the return type through, and write the tests. I verified the placement errors myself with standalone repro scripts and confirmed the new test fails on the pre-fix code before trusting it.

## Checklist

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
