### PR TITLE
fix(shm): wait for segment readiness instead of racing the creator

### DIFF
--- a/dimos/protocol/pubsub/shm/ipc_factory.py
+++ b/dimos/protocol/pubsub/shm/ipc_factory.py
@@ -15,7 +15,6 @@
 # frame_ipc.py
 # Python 3.9+
 from abc import ABC, abstractmethod
-from multiprocessing import resource_tracker
 from multiprocessing.shared_memory import SharedMemory
 import os
 import threading
@@ -26,39 +25,11 @@ import numpy as np
 from numpy.typing import DTypeLike, NDArray
 
 from dimos.utils.logging_config import setup_logger
+from dimos.utils.shm import ShmNotReadyError, attach_shm, create_or_attach_shm
 
 _UNLINK_ON_GC = os.getenv("DIMOS_IPC_UNLINK_ON_GC", "0").lower() not in ("0", "false", "no")
 
 logger = setup_logger()
-
-
-def _unregister(shm: SharedMemory) -> SharedMemory:
-    """Remove a SharedMemory segment from the resource tracker.
-
-    We manage lifecycle explicitly via close()/unlink(), so the resource
-    tracker must not attempt cleanup on process exit — that causes KeyError
-    spam when multiple processes share the same named segment.
-    """
-    try:
-        resource_tracker.unregister(shm._name, "shared_memory")  # type: ignore[attr-defined]
-    except Exception:
-        pass
-    return shm
-
-
-def _open_shm_with_retry(name: str) -> SharedMemory:
-    tries = int(os.getenv("DIMOS_IPC_ATTACH_RETRIES", "40"))  # ~40 tries
-    base_ms = float(os.getenv("DIMOS_IPC_ATTACH_BACKOFF_MS", "5"))  # 5 ms
-    cap_ms = float(os.getenv("DIMOS_IPC_ATTACH_BACKOFF_CAP_MS", "200"))  # 200 ms
-    last = None
-    for i in range(tries):
-        try:
-            return _unregister(SharedMemory(name=name))
-        except FileNotFoundError as e:
-            last = e
-            # exponential backoff, capped
-            time.sleep(min((base_ms * (2**i)), cap_ms) / 1000.0)
-    raise FileNotFoundError(f"SHM not found after {tries} retries: {name}") from last
 
 
 class FrameChannel(ABC):
@@ -144,16 +115,7 @@ def _safe_unlink(name: str) -> None:
 
 def _create_or_open(name: str, size: int) -> tuple[SharedMemory, bool]:
     """Create a named SHM segment (owner) or attach to an existing one (reader)."""
-    try:
-        # Owner: leave registered because unlink() will unregister, and
-        # the tracker serves as safety net if the process crashes.
-        shm = SharedMemory(create=True, size=size, name=name)
-        owner = True
-    except FileExistsError:
-        # Reader: unregister because we only close(), never unlink().
-        shm = _unregister(SharedMemory(name=name))
-        owner = False
-    return shm, owner
+    return create_or_attach_shm(name, size)
 
 
 class CpuShmChannel(FrameChannel):
@@ -272,12 +234,12 @@ class CpuShmChannel(FrameChannel):
         data_name = desc["data_name"]  # type: ignore[index]
         ctrl_name = desc["ctrl_name"]  # type: ignore[index]
         try:
-            obj._shm_data = _open_shm_with_retry(data_name)
-            obj._shm_ctrl = _open_shm_with_retry(ctrl_name)
-        except FileNotFoundError as e:
-            raise FileNotFoundError(
-                f"CPU IPC attach failed: control/data SHM not found "
-                f"(ctrl='{ctrl_name}', data='{data_name}'). "
+            obj._shm_data = attach_shm(data_name)
+            obj._shm_ctrl = attach_shm(ctrl_name)
+        except ShmNotReadyError as e:
+            raise ShmNotReadyError(
+                f"CPU IPC attach failed: control/data SHM never became ready "
+                f"(ctrl='{ctrl_name}', data='{data_name}'): {e}. "
                 f"Ensure the writer is running on the same host and the channel is alive."
             ) from e
         obj._ctrl = np.ndarray((3,), dtype=np.int64, buffer=obj._shm_ctrl.buf)
@@ -519,12 +481,12 @@ class CpuShmQueue(FrameChannel):
         data_name = desc["data_name"]
         ctrl_name = desc["ctrl_name"]
         try:
-            obj._shm_data = _open_shm_with_retry(data_name)
-            obj._shm_ctrl = _open_shm_with_retry(ctrl_name)
-        except FileNotFoundError as e:
-            raise FileNotFoundError(
-                f"CPU IPC queue attach failed: control/data SHM not found "
-                f"(ctrl='{ctrl_name}', data='{data_name}'). "
+            obj._shm_data = attach_shm(data_name)
+            obj._shm_ctrl = attach_shm(ctrl_name)
+        except ShmNotReadyError as e:
+            raise ShmNotReadyError(
+                f"CPU IPC queue attach failed: control/data SHM never became ready "
+                f"(ctrl='{ctrl_name}', data='{data_name}'): {e}. "
                 f"Ensure the writer is running on the same host and the channel is alive."
             ) from e
         obj._ctrl = np.ndarray((cls._CTRL_SLOTS,), dtype=np.int64, buffer=obj._shm_ctrl.buf)

--- a/dimos/protocol/pubsub/shm/test_ipc_factory.py
+++ b/dimos/protocol/pubsub/shm/test_ipc_factory.py
@@ -14,13 +14,16 @@
 
 """Unit tests for the ring-buffer SHM channel (``CpuShmQueue``)."""
 
+import os
 import threading
+import time
 import uuid
 
 import numpy as np
 import pytest
 
 from dimos.protocol.pubsub.shm.ipc_factory import CpuShmQueue
+from dimos.utils.shm import ShmNotReadyError
 
 CAP = 64
 
@@ -184,3 +187,76 @@ def test_layout_mismatch_rejected() -> None:
             CpuShmQueue((CAP,), np.uint8, data_name=data_name, ctrl_name=ctrl_name, slots=256)
     finally:
         owner.close()
+
+
+@pytest.fixture
+def slow_ftruncate(monkeypatch):
+    """Widen the creator's shm_open->ftruncate window so the race is deterministic."""
+    real = os.ftruncate
+
+    def delayed(fd: int, length: int) -> None:
+        time.sleep(0.15)
+        return real(fd, length)
+
+    monkeypatch.setattr(os, "ftruncate", delayed)
+
+
+def test_concurrent_open_survives_the_creation_window(slow_ftruncate) -> None:
+    """Two peers opening the same segment at once: one creates, one waits it out.
+
+    Before the readiness wait, the peer that lost the create raced into the
+    creator's unsized segment and died with "cannot mmap an empty file".
+    """
+    tag = uuid.uuid4().hex[:12]
+    data_name, ctrl_name = f"tq_{tag}_data", f"tq_{tag}_ctrl"
+    channels: list[CpuShmQueue] = []
+    errors: list[BaseException] = []
+    lock = threading.Lock()
+    barrier = threading.Barrier(2)
+
+    def open_peer() -> None:
+        barrier.wait()
+        try:
+            ch = CpuShmQueue((CAP,), np.uint8, data_name=data_name, ctrl_name=ctrl_name, slots=4)
+        except BaseException as exc:
+            with lock:
+                errors.append(exc)
+            return
+        with lock:
+            channels.append(ch)
+
+    threads = [threading.Thread(target=open_peer, daemon=True) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=15)
+
+    try:
+        assert not errors, f"concurrent open failed: {errors!r}"
+        assert len(channels) == 2
+        writer, reader = channels
+        _publish(writer, b"hello")
+        got, _ = _drain(reader)
+        assert [payload for _, payload in got] == [b"hello"]
+    finally:
+        for ch in channels:
+            ch.close()
+
+
+def test_attach_reports_a_bounded_timeout_not_a_hang() -> None:
+    """A descriptor pointing at a segment nobody creates fails with a clear error."""
+    tag = uuid.uuid4().hex[:12]
+    desc = {
+        "kind": "cpu_queue",
+        "shape": (CAP,),
+        "dtype": "|u1",
+        "frame_nbytes": CAP,
+        "slots": 4,
+        "data_name": f"tq_missing_{tag}_data",
+        "ctrl_name": f"tq_missing_{tag}_ctrl",
+    }
+    started = time.monotonic()
+    with pytest.raises(ShmNotReadyError, match="never became ready"):
+        CpuShmQueue.attach(desc)
+    assert time.monotonic() - started < 30.0
+    assert issubclass(ShmNotReadyError, FileNotFoundError)

--- a/dimos/simulation/engines/mujoco_shm.py
+++ b/dimos/simulation/engines/mujoco_shm.py
@@ -37,6 +37,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from dimos.utils.logging_config import setup_logger
+from dimos.utils.shm import attach_shm
 
 logger = setup_logger()
 
@@ -121,6 +122,9 @@ def shm_key_from_path(config_path: Path | str) -> str:
     return hashlib.md5(resolved.encode("utf-8")).hexdigest()[:12]
 
 
+_ATTACH_WINDOW_S = 0.5
+
+
 def _buffer_name(key: str, buffer: str) -> str:
     return f"{_NAME_PREFIX}_{key}_{buffer}"
 
@@ -187,7 +191,7 @@ class ManipShmSet:
         buffers: dict[str, SharedMemory] = {}
         for buffer_name in _shm_sizes:
             name = _buffer_name(key, buffer_name)
-            buffers[buffer_name] = _unregister(SharedMemory(name=name))
+            buffers[buffer_name] = attach_shm(name, timeout=_ATTACH_WINDOW_S)
         return cls(**buffers)
 
     def as_list(self) -> list[SharedMemory]:

--- a/dimos/utils/shm.py
+++ b/dimos/utils/shm.py
@@ -1,0 +1,92 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Race-free creation and attachment of named POSIX shared-memory segments.
+
+``SharedMemory(create=True, size=N)`` runs ``shm_open`` and *then* ``ftruncate``.
+Between the two the segment exists at size 0, so a concurrent attacher mmaps an
+empty file and dies with ``ValueError: cannot mmap an empty file``.
+
+Readiness here is "the segment exists and maps at a non-zero size". ``ftruncate``
+moves the segment from 0 to its full size in one step and the creator never shrinks
+it, so a segment that maps at all is a segment the creator has finished sizing.
+Attachers poll that predicate against a deadline and raise :class:`ShmNotReadyError`
+when it is not met, rather than retrying blindly and hoping the next mmap lands.
+
+Readiness deliberately stops at "sized": a segment that maps at the *wrong* size was
+built by a peer with a different layout, which is a permanent error its caller must
+raise, not a race to wait out.
+"""
+
+from multiprocessing import resource_tracker
+from multiprocessing.shared_memory import SharedMemory
+import os
+import time
+
+DEFAULT_ATTACH_TIMEOUT_S = float(os.getenv("DIMOS_SHM_ATTACH_TIMEOUT_S", "10"))
+_POLL_S = float(os.getenv("DIMOS_SHM_ATTACH_POLL_S", "0.0005"))
+
+
+class ShmNotReadyError(TimeoutError, FileNotFoundError):
+    """A segment did not become mappable at its layout size before the deadline.
+
+    Subclasses ``FileNotFoundError`` so callers written against the pre-readiness
+    attach path keep working across a rolling deploy.
+    """
+
+
+def unregister(shm: SharedMemory) -> SharedMemory:
+    """Drop ``shm`` from the resource tracker; lifecycle is managed explicitly."""
+    try:
+        resource_tracker.unregister(shm._name, "shared_memory")  # type: ignore[attr-defined]
+    except Exception:
+        pass
+    return shm
+
+
+def attach_shm(name: str, *, timeout: float | None = None) -> SharedMemory:
+    """Attach to ``name`` once its creator has finished sizing it."""
+    limit = DEFAULT_ATTACH_TIMEOUT_S if timeout is None else timeout
+    deadline = time.monotonic() + limit
+    while True:
+        shm, reason = _try_attach(name)
+        if shm is not None:
+            return shm
+        if time.monotonic() >= deadline:
+            raise ShmNotReadyError(f"SHM {name!r} not ready after {limit:g}s: {reason}")
+        time.sleep(_POLL_S)
+
+
+def create_or_attach_shm(
+    name: str, size: int, *, timeout: float | None = None
+) -> tuple[SharedMemory, bool]:
+    """Create ``name`` at ``size`` (owner) or wait out its creator and attach.
+
+    Returns ``(segment, is_owner)``. Owners stay registered with the resource
+    tracker so a crash still cleans up; attachers do not, since they only close.
+    """
+    try:
+        return SharedMemory(create=True, size=size, name=name), True
+    except FileExistsError:
+        return attach_shm(name, timeout=timeout), False
+
+
+def _try_attach(name: str) -> tuple[SharedMemory | None, str]:
+    try:
+        return unregister(SharedMemory(name=name)), ""
+    except FileNotFoundError:
+        return None, "segment does not exist"
+    except ValueError:
+        # shm_open has landed but ftruncate has not: the creation window.
+        return None, "creator has not sized the segment yet"

--- a/dimos/utils/test_shm.py
+++ b/dimos/utils/test_shm.py
@@ -1,0 +1,148 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for the SHM creation race (shm_open before ftruncate)."""
+
+from multiprocessing.shared_memory import SharedMemory
+import os
+import threading
+import time
+import uuid
+
+import pytest
+
+from dimos.utils.shm import ShmNotReadyError, attach_shm, create_or_attach_shm
+
+SIZE = 1 << 16
+
+
+@pytest.fixture
+def name() -> str:
+    n = f"dimos_test_{uuid.uuid4().hex[:12]}"
+    yield n
+    try:
+        SharedMemory(name=n).unlink()
+    except (FileNotFoundError, ValueError):
+        pass
+
+
+@pytest.fixture
+def slow_ftruncate(monkeypatch):
+    """Widen the shm_open->ftruncate window so the race is deterministic."""
+    real = os.ftruncate
+
+    def delayed(fd: int, length: int) -> None:
+        time.sleep(0.2)
+        return real(fd, length)
+
+    monkeypatch.setattr(os, "ftruncate", delayed)
+    return delayed
+
+
+def test_bare_attach_hits_the_race(name, slow_ftruncate):
+    """Without the fix, attaching inside the window raises the reported error."""
+    seen: list[BaseException] = []
+
+    def hammer() -> None:
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline and not seen:
+            try:
+                SharedMemory(name=name).close()
+                return
+            except FileNotFoundError:
+                continue
+            except ValueError as exc:
+                seen.append(exc)
+
+    t = threading.Thread(target=hammer, daemon=True)
+    t.start()
+    time.sleep(0.01)
+    owner = SharedMemory(create=True, size=SIZE, name=name)
+    t.join(timeout=3)
+    owner.close()
+
+    assert seen, "expected the creation window to be observable"
+    assert "cannot mmap an empty file" in str(seen[0])
+
+
+def test_attach_shm_waits_out_the_race(name, slow_ftruncate):
+    """attach_shm blocks through the window and returns a fully sized segment."""
+    result: list[object] = []
+
+    def attacher() -> None:
+        try:
+            shm = attach_shm(name, timeout=5.0)
+            result.append(shm.size)
+            shm.close()
+        except BaseException as exc:
+            result.append(exc)
+
+    t = threading.Thread(target=attacher, daemon=True)
+    t.start()
+    time.sleep(0.01)
+    owner = SharedMemory(create=True, size=SIZE, name=name)
+    t.join(timeout=6)
+    owner.close()
+
+    assert result == [SIZE], f"attacher did not survive the window: {result}"
+
+
+def test_attach_shm_times_out_instead_of_hanging(name):
+    started = time.monotonic()
+    with pytest.raises(ShmNotReadyError) as excinfo:
+        attach_shm(name, timeout=0.3)
+    elapsed = time.monotonic() - started
+    assert 0.3 <= elapsed < 3.0
+    assert "does not exist" in str(excinfo.value)
+
+
+def test_timeout_error_is_still_a_file_not_found_error(name):
+    """Callers written against the old attach path keep working mid-deploy."""
+    with pytest.raises(FileNotFoundError):
+        attach_shm(name, timeout=0.05)
+
+
+def test_a_wrongly_sized_segment_attaches_immediately(name):
+    """A layout mismatch is a permanent error for the caller to raise, not a race."""
+    owner = SharedMemory(create=True, size=SIZE, name=name)
+    try:
+        shm = attach_shm(name, timeout=0.2)
+        assert shm.size == SIZE
+        shm.close()
+    finally:
+        owner.close()
+
+
+def test_create_or_attach_splits_owner_and_reader(name, slow_ftruncate):
+    """Concurrent symmetric callers: exactly one owns, the other waits and attaches."""
+    out: list[tuple[bool, int]] = []
+    lock = threading.Lock()
+    barrier = threading.Barrier(2)
+
+    def racer() -> None:
+        barrier.wait()
+        shm, owner = create_or_attach_shm(name, SIZE, timeout=5.0)
+        with lock:
+            out.append((owner, shm.size))
+        shm.close()
+
+    threads = [threading.Thread(target=racer, daemon=True) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=8)
+
+    assert len(out) == 2, f"a racer did not finish: {out}"
+    assert sorted(owner for owner, _ in out) == [False, True]
+    assert {size for _, size in out} == {SIZE}


### PR DESCRIPTION
## Contribution path

- Linked issue: #3671

## Problem

Consumers crash attaching to a shared-memory segment with `ValueError: cannot mmap an empty file`. 

`SharedMemory(create=True, size=N)` is two syscalls: `shm_open`, then `ftruncate`. Between them the segment exists at size 0. Anyone attaching in that window maps an empty file and dies.

`_open_shm_with_retry` looked like the mitigation but only ever caught `FileNotFoundError`, so it never covered this race at all.

## Solution

Readers wait on an explicit predicate — the segment maps at a non-zero size — against a bounded deadline, and raise `ShmNotReadyError` if it never does. `ftruncate` takes the segment from 0 to full size in one step and the creator never shrinks it, so a segment that maps at all is one the creator has finished sizing.

## Breaking Changes

None. `ShmNotReadyError` subclasses `FileNotFoundError`, so callers written against the old attach path keep working. No segment layout changed, so a half-upgraded fleet is fine mid-deploy.

## How to Test

```
pytest dimos/utils/test_shm.py dimos/protocol/pubsub/shm dimos/protocol/rpc
```
## Open question for review

`DEFAULT_ATTACH_TIMEOUT_S` is 10s. Is this okay?

## AI assistance

Claude Code with Opus 5. Used to pin the race, write the helper and tests, and audit the other shared-memory call sites. I reviewed every line.

## Checklist

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
