### PR TITLE
fix(gpu_utils): detect CUDA via torch instead of phantom pycuda dep

### DIFF
--- a/dimos/utils/gpu_utils.py
+++ b/dimos/utils/gpu_utils.py
@@ -15,9 +15,9 @@
 
 def is_cuda_available():  # type: ignore[no-untyped-def]
     try:
-        import pycuda.driver as cuda
+        # Lazy: gpu_utils must stay importable in torch-less contexts.
+        import torch
 
-        cuda.init()
-        return cuda.Device.count() > 0
+        return torch.cuda.is_available()
     except Exception:
         return False

--- a/dimos/utils/test_gpu_utils.py
+++ b/dimos/utils/test_gpu_utils.py
@@ -1,0 +1,48 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import types
+
+import pytest
+
+from dimos.utils.gpu_utils import is_cuda_available
+
+
+def _fake_torch(is_available) -> types.ModuleType:
+    torch = types.ModuleType("torch")
+    torch.cuda = types.SimpleNamespace(is_available=is_available)
+    return torch
+
+
+def test_returns_false_when_torch_is_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    # None in sys.modules makes `import torch` raise ImportError.
+    monkeypatch.setitem(sys.modules, "torch", None)
+    assert is_cuda_available() is False
+
+
+@pytest.mark.parametrize("available", [True, False])
+def test_passes_through_torch_cuda_is_available(
+    monkeypatch: pytest.MonkeyPatch, available: bool
+) -> None:
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(lambda: available))
+    assert is_cuda_available() is available
+
+
+def test_returns_false_when_torch_cuda_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    def boom() -> bool:
+        raise RuntimeError("no CUDA driver")
+
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(boom))
+    assert is_cuda_available() is False


### PR DESCRIPTION
`is_cuda_available()` imported `pycuda.driver`, but pycuda is not a dimos dependency and is never installed — the import always raised, so the function always returned `False`. It now asks torch, which is what the detectors actually run on.

Impact: [yolo.py:43](dimos/perception/detection/detectors/yolo.py#L43) and [person/yolo.py:42](dimos/perception/detection/detectors/person/yolo.py#L42) silently selected `cpu` for YOLO inference on every CUDA box; on a GPU host `is_cuda_available()` went `False` → `True` with this change.