### PR TITLE
fix(manip): retry Pink IK on seed-specific solver failures

### DIFF
--- a/dimos/manipulation/planning/kinematics/pink_ik.py
+++ b/dimos/manipulation/planning/kinematics/pink_ik.py
@@ -154,9 +154,17 @@ class PinkIK(_PinkSolverCore):
                     orientation_tolerance=orientation_tolerance,
                 )
             except ValueError as exc:
+                # Mapping failures are seed-independent: the target or seed cannot be
+                # expressed in the model frame at all, so perturbed retries cannot help.
                 return _failure(IKStatus.NO_SOLUTION, f"Pink IK mapping failed: {exc}")
             except Exception as exc:
-                return _failure(IKStatus.NO_SOLUTION, f"Pink IK solver failed: {exc}")
+                # Solver failures (notably pink's NoSolutionFound on QP infeasibility) are
+                # frequently seed-specific, so retry from the next perturbed seed.
+                if fallback_result is None:
+                    fallback_result = _failure(
+                        IKStatus.NO_SOLUTION, f"Pink IK solver failed: {exc}"
+                    )
+                continue
 
             if not result.is_success() or result.joint_state is None:
                 if fallback_result is None:
@@ -271,9 +279,15 @@ class PinkIK(_PinkSolverCore):
                         locked_joint_positions=locked_positions,
                     )
                 except ValueError as exc:
+                    # Seed-independent, as in _solve: mapping cannot succeed on a retry.
                     return _failure(IKStatus.NO_SOLUTION, f"Pink IK mapping failed: {exc}")
                 except Exception as exc:
-                    return _failure(IKStatus.NO_SOLUTION, f"Pink IK solver failed: {exc}")
+                    # Seed-specific solver failure; retry from the next perturbed seed.
+                    if fallback_result is None:
+                        fallback_result = _failure(
+                            IKStatus.NO_SOLUTION, f"Pink IK solver failed: {exc}"
+                        )
+                    continue
 
                 if not result.is_success() or result.joint_state is None:
                     if fallback_result is None:

--- a/dimos/manipulation/planning/kinematics/pink_ik.py
+++ b/dimos/manipulation/planning/kinematics/pink_ik.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import pink
+from pink.exceptions import NoSolutionFound
 import pinocchio
 
 from dimos.manipulation.planning.groups.models import PlanningGroup, PlanningGroupSelection
@@ -157,14 +158,15 @@ class PinkIK(_PinkSolverCore):
                 # Mapping failures are seed-independent: the target or seed cannot be
                 # expressed in the model frame at all, so perturbed retries cannot help.
                 return _failure(IKStatus.NO_SOLUTION, f"Pink IK mapping failed: {exc}")
-            except Exception as exc:
-                # Solver failures (notably pink's NoSolutionFound on QP infeasibility) are
-                # frequently seed-specific, so retry from the next perturbed seed.
+            except NoSolutionFound as exc:
+                # QP infeasibility can be seed-specific, so try the next perturbed seed.
                 if fallback_result is None:
                     fallback_result = _failure(
                         IKStatus.NO_SOLUTION, f"Pink IK solver failed: {exc}"
                     )
                 continue
+            except Exception as exc:
+                return _failure(IKStatus.NO_SOLUTION, f"Pink IK solver failed: {exc}")
 
             if not result.is_success() or result.joint_state is None:
                 if fallback_result is None:
@@ -281,13 +283,15 @@ class PinkIK(_PinkSolverCore):
                 except ValueError as exc:
                     # Seed-independent, as in _solve: mapping cannot succeed on a retry.
                     return _failure(IKStatus.NO_SOLUTION, f"Pink IK mapping failed: {exc}")
-                except Exception as exc:
-                    # Seed-specific solver failure; retry from the next perturbed seed.
+                except NoSolutionFound as exc:
+                    # QP infeasibility can be seed-specific, so try the next perturbed seed.
                     if fallback_result is None:
                         fallback_result = _failure(
                             IKStatus.NO_SOLUTION, f"Pink IK solver failed: {exc}"
                         )
                     continue
+                except Exception as exc:
+                    return _failure(IKStatus.NO_SOLUTION, f"Pink IK solver failed: {exc}")
 
                 if not result.is_success() or result.joint_state is None:
                     if fallback_result is None:

--- a/dimos/manipulation/planning/kinematics/test_pink_ik.py
+++ b/dimos/manipulation/planning/kinematics/test_pink_ik.py
@@ -25,6 +25,7 @@ from types import MappingProxyType, ModuleType, SimpleNamespace
 from typing import Any, cast
 
 import numpy as np
+from pink.exceptions import NoSolutionFound, PinkError
 import pytest
 from pytest_mock import MockerFixture
 
@@ -1472,3 +1473,207 @@ def test_solve_pose_targets_auxiliary_only_retains_seed_selection_order(
     assert result.joint_state.name == ["arm/joint_c", "arm/joint_a", "arm/joint_b"]
     assert result.joint_state.position == [0.3, 0.1, 0.2]
     assert world.joint_state_calls == 0
+
+
+def _solved_joint_state() -> JointState:
+    return JointState({"name": ["joint_a", "joint_b", "joint_c"], "position": [0.1, 0.2, 0.3]})
+
+
+def _qp_infeasible() -> Exception:
+    """Stand-in for pink's ``NoSolutionFound``, which is not a ``ValueError``."""
+    return Exception("QP solver did not find a solution")
+
+
+def test_pink_no_solution_found_is_not_a_value_error() -> None:
+    assert issubclass(NoSolutionFound, PinkError)
+    assert not issubclass(NoSolutionFound, ValueError)
+
+
+def test_solve_retries_after_solver_exception(mocker: MockerFixture) -> None:
+    ik = _pink_ik(mocker, converge=True)
+    ik._robot_contexts = {("robot", "tool"): _context()}
+    outcomes: list[object] = [
+        _qp_infeasible(),
+        IKResult(
+            status=IKStatus.SUCCESS,
+            joint_state=_solved_joint_state(),
+            position_error=0.0006,
+            orientation_error=0.0,
+            iterations=1,
+        ),
+    ]
+
+    def fake_solve_targets(**_: object) -> IKResult:
+        outcome = outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return cast("IKResult", outcome)
+
+    solve_targets = mocker.patch.object(ik, "_solve_targets", side_effect=fake_solve_targets)
+
+    result = ik.solve(
+        world=cast("Any", _FakeWorld(collision_free=True)),
+        robot_id="robot",
+        target_pose=PoseStamped(
+            position=Vector3(0.1, 0.0, 0.0),
+            orientation=Quaternion(0.0, 0.0, 0.0, 1.0),
+        ),
+        check_collision=True,
+        max_attempts=2,
+    )
+
+    assert solve_targets.call_count == 2
+    assert result.status == IKStatus.SUCCESS
+    assert result.joint_state is not None
+
+
+def test_solve_reports_first_solver_exception_after_all_attempts(mocker: MockerFixture) -> None:
+    ik = _pink_ik(mocker, converge=True)
+    ik._robot_contexts = {("robot", "tool"): _context()}
+    messages = ["first failure", "second failure", "third failure"]
+
+    def fake_solve_targets(**_: object) -> IKResult:
+        raise Exception(messages[solve_targets.call_count - 1])
+
+    solve_targets = mocker.patch.object(ik, "_solve_targets", side_effect=fake_solve_targets)
+
+    result = ik.solve(
+        world=cast("Any", _FakeWorld(collision_free=True)),
+        robot_id="robot",
+        target_pose=PoseStamped(
+            position=Vector3(0.1, 0.0, 0.0),
+            orientation=Quaternion(0.0, 0.0, 0.0, 1.0),
+        ),
+        check_collision=True,
+        max_attempts=3,
+    )
+
+    assert solve_targets.call_count == 3
+    assert result.status == IKStatus.NO_SOLUTION
+    assert "first failure" in result.message
+    assert "second failure" not in result.message
+    assert "third failure" not in result.message
+
+
+def test_solve_mapping_value_error_fails_without_retrying(mocker: MockerFixture) -> None:
+    ik = _pink_ik(mocker, converge=True)
+    ik._robot_contexts = {("robot", "tool"): _context()}
+    solve_targets = mocker.patch.object(
+        ik, "_solve_targets", side_effect=ValueError("joint 'joint_z' is not in the model")
+    )
+
+    result = ik.solve(
+        world=cast("Any", _FakeWorld(collision_free=True)),
+        robot_id="robot",
+        target_pose=PoseStamped(
+            position=Vector3(0.1, 0.0, 0.0),
+            orientation=Quaternion(0.0, 0.0, 0.0, 1.0),
+        ),
+        check_collision=True,
+        max_attempts=5,
+    )
+
+    assert solve_targets.call_count == 1
+    assert result.status == IKStatus.NO_SOLUTION
+    assert "Pink IK mapping failed" in result.message
+
+
+def _pose_targets_seed() -> JointState:
+    return JointState(
+        {"name": ["arm/joint_a", "arm/joint_b", "arm/joint_c"], "position": [0.0, 0.0, 0.0]}
+    )
+
+
+def test_solve_pose_targets_retries_after_solver_exception(mocker: MockerFixture) -> None:
+    ik = _pink_ik(mocker, converge=True)
+    mocker.patch.object(ik, "_get_robot_context", return_value=_context())
+    world = _FakeWorld()
+    outcomes: list[object] = [
+        _qp_infeasible(),
+        IKResult(
+            status=IKStatus.SUCCESS,
+            joint_state=_solved_joint_state(),
+            position_error=0.0006,
+            orientation_error=0.0,
+        ),
+    ]
+
+    def fake_solve_targets(**_: object) -> IKResult:
+        outcome = outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return cast("IKResult", outcome)
+
+    solve_targets = mocker.patch.object(ik, "_solve_targets", side_effect=fake_solve_targets)
+
+    result = ik.solve_pose_targets(
+        world=cast("Any", world),
+        pose_targets={
+            world.groups["arm/manipulator"]: PoseStamped(
+                position=Vector3(), orientation=Quaternion(0.0, 0.0, 0.0, 1.0)
+            )
+        },
+        seed=_pose_targets_seed(),
+        max_attempts=2,
+    )
+
+    assert solve_targets.call_count == 2
+    assert result.status == IKStatus.SUCCESS
+    assert result.joint_state is not None
+
+
+def test_solve_pose_targets_reports_first_solver_exception_after_all_attempts(
+    mocker: MockerFixture,
+) -> None:
+    ik = _pink_ik(mocker, converge=True)
+    mocker.patch.object(ik, "_get_robot_context", return_value=_context())
+    world = _FakeWorld()
+    messages = ["first failure", "second failure", "third failure"]
+
+    def fake_solve_targets(**_: object) -> IKResult:
+        raise Exception(messages[solve_targets.call_count - 1])
+
+    solve_targets = mocker.patch.object(ik, "_solve_targets", side_effect=fake_solve_targets)
+
+    result = ik.solve_pose_targets(
+        world=cast("Any", world),
+        pose_targets={
+            world.groups["arm/manipulator"]: PoseStamped(
+                position=Vector3(), orientation=Quaternion(0.0, 0.0, 0.0, 1.0)
+            )
+        },
+        seed=_pose_targets_seed(),
+        max_attempts=3,
+    )
+
+    assert solve_targets.call_count == 3
+    assert result.status == IKStatus.NO_SOLUTION
+    assert "first failure" in result.message
+    assert "second failure" not in result.message
+    assert "third failure" not in result.message
+
+
+def test_solve_pose_targets_mapping_value_error_fails_without_retrying(
+    mocker: MockerFixture,
+) -> None:
+    ik = _pink_ik(mocker, converge=True)
+    mocker.patch.object(ik, "_get_robot_context", return_value=_context())
+    world = _FakeWorld()
+    solve_targets = mocker.patch.object(
+        ik, "_solve_targets", side_effect=ValueError("joint 'joint_z' is not in the model")
+    )
+
+    result = ik.solve_pose_targets(
+        world=cast("Any", world),
+        pose_targets={
+            world.groups["arm/manipulator"]: PoseStamped(
+                position=Vector3(), orientation=Quaternion(0.0, 0.0, 0.0, 1.0)
+            )
+        },
+        seed=_pose_targets_seed(),
+        max_attempts=5,
+    )
+
+    assert solve_targets.call_count == 1
+    assert result.status == IKStatus.NO_SOLUTION
+    assert "Pink IK mapping failed" in result.message

--- a/dimos/manipulation/planning/kinematics/test_pink_ik.py
+++ b/dimos/manipulation/planning/kinematics/test_pink_ik.py
@@ -25,7 +25,7 @@ from types import MappingProxyType, ModuleType, SimpleNamespace
 from typing import Any, cast
 
 import numpy as np
-from pink.exceptions import NoSolutionFound, PinkError
+from pink.exceptions import NoSolutionFound
 import pytest
 from pytest_mock import MockerFixture
 
@@ -1479,17 +1479,14 @@ def _solved_joint_state() -> JointState:
     return JointState({"name": ["joint_a", "joint_b", "joint_c"], "position": [0.1, 0.2, 0.3]})
 
 
-def _qp_infeasible() -> Exception:
-    """Stand-in for pink's ``NoSolutionFound``, which is not a ``ValueError``."""
-    return Exception("QP solver did not find a solution")
+def _qp_infeasible() -> NoSolutionFound:
+    return NoSolutionFound(
+        problem=cast("Any", SimpleNamespace()),
+        results=cast("Any", SimpleNamespace()),
+    )
 
 
-def test_pink_no_solution_found_is_not_a_value_error() -> None:
-    assert issubclass(NoSolutionFound, PinkError)
-    assert not issubclass(NoSolutionFound, ValueError)
-
-
-def test_solve_retries_after_solver_exception(mocker: MockerFixture) -> None:
+def test_solve_retries_after_no_solution_found(mocker: MockerFixture) -> None:
     ik = _pink_ik(mocker, converge=True)
     ik._robot_contexts = {("robot", "tool"): _context()}
     outcomes: list[object] = [
@@ -1527,13 +1524,14 @@ def test_solve_retries_after_solver_exception(mocker: MockerFixture) -> None:
     assert result.joint_state is not None
 
 
-def test_solve_reports_first_solver_exception_after_all_attempts(mocker: MockerFixture) -> None:
+def test_solve_reports_first_no_solution_found_after_all_attempts(
+    mocker: MockerFixture,
+) -> None:
     ik = _pink_ik(mocker, converge=True)
     ik._robot_contexts = {("robot", "tool"): _context()}
-    messages = ["first failure", "second failure", "third failure"]
 
     def fake_solve_targets(**_: object) -> IKResult:
-        raise Exception(messages[solve_targets.call_count - 1])
+        raise _qp_infeasible()
 
     solve_targets = mocker.patch.object(ik, "_solve_targets", side_effect=fake_solve_targets)
 
@@ -1550,9 +1548,30 @@ def test_solve_reports_first_solver_exception_after_all_attempts(mocker: MockerF
 
     assert solve_targets.call_count == 3
     assert result.status == IKStatus.NO_SOLUTION
-    assert "first failure" in result.message
-    assert "second failure" not in result.message
-    assert "third failure" not in result.message
+    assert "QP solver did not find a solution" in result.message
+
+
+def test_solve_does_not_retry_unexpected_exception(mocker: MockerFixture) -> None:
+    ik = _pink_ik(mocker, converge=True)
+    ik._robot_contexts = {("robot", "tool"): _context()}
+    solve_targets = mocker.patch.object(
+        ik, "_solve_targets", side_effect=RuntimeError("unexpected solver failure")
+    )
+
+    result = ik.solve(
+        world=cast("Any", _FakeWorld(collision_free=True)),
+        robot_id="robot",
+        target_pose=PoseStamped(
+            position=Vector3(0.1, 0.0, 0.0),
+            orientation=Quaternion(0.0, 0.0, 0.0, 1.0),
+        ),
+        check_collision=True,
+        max_attempts=3,
+    )
+
+    assert solve_targets.call_count == 1
+    assert result.status == IKStatus.NO_SOLUTION
+    assert result.message == "Pink IK solver failed: unexpected solver failure"
 
 
 def test_solve_mapping_value_error_fails_without_retrying(mocker: MockerFixture) -> None:
@@ -1584,7 +1603,7 @@ def _pose_targets_seed() -> JointState:
     )
 
 
-def test_solve_pose_targets_retries_after_solver_exception(mocker: MockerFixture) -> None:
+def test_solve_pose_targets_retries_after_no_solution_found(mocker: MockerFixture) -> None:
     ik = _pink_ik(mocker, converge=True)
     mocker.patch.object(ik, "_get_robot_context", return_value=_context())
     world = _FakeWorld()
@@ -1622,16 +1641,15 @@ def test_solve_pose_targets_retries_after_solver_exception(mocker: MockerFixture
     assert result.joint_state is not None
 
 
-def test_solve_pose_targets_reports_first_solver_exception_after_all_attempts(
+def test_solve_pose_targets_reports_first_no_solution_found_after_all_attempts(
     mocker: MockerFixture,
 ) -> None:
     ik = _pink_ik(mocker, converge=True)
     mocker.patch.object(ik, "_get_robot_context", return_value=_context())
     world = _FakeWorld()
-    messages = ["first failure", "second failure", "third failure"]
 
     def fake_solve_targets(**_: object) -> IKResult:
-        raise Exception(messages[solve_targets.call_count - 1])
+        raise _qp_infeasible()
 
     solve_targets = mocker.patch.object(ik, "_solve_targets", side_effect=fake_solve_targets)
 
@@ -1648,9 +1666,33 @@ def test_solve_pose_targets_reports_first_solver_exception_after_all_attempts(
 
     assert solve_targets.call_count == 3
     assert result.status == IKStatus.NO_SOLUTION
-    assert "first failure" in result.message
-    assert "second failure" not in result.message
-    assert "third failure" not in result.message
+    assert "QP solver did not find a solution" in result.message
+
+
+def test_solve_pose_targets_does_not_retry_unexpected_exception(
+    mocker: MockerFixture,
+) -> None:
+    ik = _pink_ik(mocker, converge=True)
+    mocker.patch.object(ik, "_get_robot_context", return_value=_context())
+    world = _FakeWorld()
+    solve_targets = mocker.patch.object(
+        ik, "_solve_targets", side_effect=RuntimeError("unexpected solver failure")
+    )
+
+    result = ik.solve_pose_targets(
+        world=cast("Any", world),
+        pose_targets={
+            world.groups["arm/manipulator"]: PoseStamped(
+                position=Vector3(), orientation=Quaternion(0.0, 0.0, 0.0, 1.0)
+            )
+        },
+        seed=_pose_targets_seed(),
+        max_attempts=3,
+    )
+
+    assert solve_targets.call_count == 1
+    assert result.status == IKStatus.NO_SOLUTION
+    assert result.message == "Pink IK solver failed: unexpected solver failure"
 
 
 def test_solve_pose_targets_mapping_value_error_fails_without_retrying(


### PR DESCRIPTION
## What

Both perturbed-seed retry loops in `PinkIK` aborted the entire loop the first time the solver
raised. A single unlucky seed made a *reachable* grasp pose report `NO_SOLUTION`.


## Why a solver exception should retry

`pink.solve_ik` raises `NoSolutionFound` when the QP is infeasible:

```
pink/exceptions.py:49   class NoSolutionFound(PinkError)
pink/solve_ik.py:273    raise NoSolutionFound(problem, result)
message                 "QP solver did not find a solution to the differential IK problem"
```

QP infeasibility at a given configuration is frequently **seed-specific** — it says the
linearized step is infeasible from *this* seed, not that the pose is unreachable.
## Mapping vs solver: why only one of them retries

| branch | example | seed-dependent? | behavior |
|---|---|---|---|
| `except Exception` | `NoSolutionFound` (QP infeasible) | yes, often | record first failure, `continue` |
| `except ValueError` | joint not in model, mapping length mismatch | no | return immediately |

A `ValueError` here means the target or seed cannot be expressed in the model frame at all —
a structural mismatch that fails identically on every perturbed seed, so retrying only burns
the attempt budget. 

This split is safe because the two are **not** the same exception type. `PinkError` derives
straight from `Exception`, not from `ValueError`:

```
NoSolutionFound MRO = [NoSolutionFound, PinkError, Exception, BaseException, object]
issubclass(NoSolutionFound, ValueError) -> False
```

So QP infeasibility cannot be swallowed by the `ValueError` branch. Discriminating by exception
type is sufficient; no source-based discrimination is needed.


## Tests

Added to `test_pink_ik.py`, mocked at the `_solve_targets` boundary, mirroring the existing
`test_solve_retries_after_joint_limit_failure` pattern. The same trio for each loop:


No API change: no signature, return type, `IKStatus`, or message-format change.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
