### PR TITLE
docs: point the deploy and the site at docs.dimensional.org

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -20,7 +20,7 @@
 docs/capabilities/memory/assets/** filter=lfs diff=lfs merge=lfs -text
 docs/capabilities/memory/assets/.gitattributes -filter -diff -merge text
 docs/capabilities/mapping/assets/** filter=lfs diff=lfs merge=lfs -text
-# Mintlify deploy does not fetch Git LFS; keep site branding as normal blobs.
+# The docs deploy does not fetch all of Git LFS; keep site branding as normal blobs.
 docs/assets/dimensional-logo-master-transparent.png -filter -diff -merge
 docs/assets/favicon.png -filter -diff -merge
 # DimSim scene data and agent model

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -57,12 +57,12 @@ jobs:
           app-id: ${{ vars.DOCS_BOT_APP_ID }}
           private-key: ${{ secrets.DOCS_BOT_APP_PRIVATE_KEY }}
           owner: dimensionalOS
-          repositories: dimensionalOS.github.io
+          repositories: docs
 
       - name: Check out the pages repo
         uses: actions/checkout@v7
         with:
-          repository: dimensionalOS/dimensionalOS.github.io
+          repository: dimensionalOS/docs
           path: pages
           token: ${{ steps.pages-token.outputs.token }}
 

--- a/bin/docs-deploy
+++ b/bin/docs-deploy
@@ -21,12 +21,12 @@ usage() {
   cat >&2 <<'EOF'
 Usage: bin/docs-deploy [options]
 
-  --pages-repo DIR  Checkout of dimensionalOS.github.io. Required, or set
+  --pages-repo DIR  Checkout of dimensionalOS/docs. Required, or set
                     DOCS_PAGES_REPO in your environment.
   --target DIR      Where within that repo to publish (default: ., the site root)
   --commit          Commit in the pages repo. Never pushes.
 
-Publishes to https://dimensionalos.github.io/<target>/, leaving careers/ alone.
+Publishes to https://docs.dimensional.org/<target>/, leaving careers/ alone.
 EOF
 }
 

--- a/dimos/cli/commands/docs.py
+++ b/dimos/cli/commands/docs.py
@@ -43,7 +43,7 @@ def docs(
     if root is None:
         typer.echo(
             "No mkdocs.yml found. The docs are built from a source checkout;\n"
-            "read them online at https://dimensionalos.github.io/mkdocs/",
+            "read them online at https://docs.dimensional.org/",
             err=True,
         )
         raise typer.Exit(1)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: Dimensional
 site_description: >-
   Official documentation for Dimensional (dimOS) — the modern operating system
   for generalist robotics: Python-first, agent-native, and hardware-agnostic.
-site_url: https://dimensionalos.github.io/
+site_url: https://docs.dimensional.org/
 repo_url: https://github.com/dimensionalOS/dimos
 repo_name: dimensionalOS/dimos
 edit_uri: edit/main/docs/


### PR DESCRIPTION
The pages repo was renamed `dimensionalOS.github.io` -> `dimensionalOS/docs`, and the site is now served from `docs.dimensional.org` (github pages, custom domain) instead of `dimensionalos.github.io`, which 404s — github does not redirect an org-site url once the repo becomes a project site.

**The deploy is currently broken.** A `workflow_dispatch` run confirms it: [32839523967](https://github.com/dimensionalOS/dimos/actions/runs/32839523967) fails at `Mint a token for the pages repo` with a 404. `create-github-app-token` resolves `repositories:` by name and does not follow rename redirects. Nothing has gone stale yet only because no docs have changed since `b4dadd6`; the next merge touching `docs/**` would have failed.

`site_url` is not cosmetic either — the live `sitemap.xml` still advertises `https://dimensionalos.github.io/quickstart/` and friends, every one of which now 404s, so search engines are being pointed at dead urls until this lands.

Verified locally: `mkdocs build --strict` passes and the sitemap now emits `https://docs.dimensional.org/...`.

The remaining `mintlify` mention in `misc/mkdocs/theme.css` is left alone — it accurately records where the palette came from.