### PR TITLE
docs: serve raw markdown and llms.txt for agents

### DIFF
--- a/misc/mkdocs/hooks.py
+++ b/misc/mkdocs/hooks.py
@@ -20,11 +20,16 @@ building instead of rewriting 73 documents:
 - links are repo-root absolute (`/docs/usage/modules.md`, `/dimos/core/module.py`),
   the form `bin/doclinks` maintains and github renders natively
 - code fences carry md-babel parameters (```python skip session=rx)
+
+The site also serves the markdown it was built from, for agents: every page
+at its docs/ path, indexed by llms.txt (overrides/llms.txt).
 """
 
 from pathlib import Path
 import posixpath
 import re
+
+from mkdocs.utils import write_file
 
 THEME_CSS = Path(__file__).with_name("theme.css")
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -219,3 +224,9 @@ def on_page_markdown(markdown, page, config, files):
     markdown = _github_alerts(markdown)
     markdown = _normalize_fences(markdown)
     return _LINK.sub(lambda m: _rewrite_link(m, page.file.src_uri), markdown)
+
+
+def on_post_page(output, page, config):
+    """Serve the page's markdown beside its html: usage/modules.md next to usage/modules/."""
+    write_file(page.markdown.encode(), str(Path(config.site_dir, page.file.src_uri)))
+    return output

--- a/misc/mkdocs/overrides/llms.txt
+++ b/misc/mkdocs/overrides/llms.txt
@@ -1,0 +1,28 @@
+{#-
+  https://llmstxt.org/: the site's pages, in nav order, for agents. Each link
+  is the page's markdown, which hooks.py serves beside its html.
+-#}
+{%- macro link(page) %}
+- [{{ page.title | striptags }}]({{ config.site_url }}{{ page.file.src_uri }})
+{%- endmacro -%}
+# {{ config.site_name }}
+
+> {{ config.site_description | trim }}
+
+Every page is also served as markdown at its docs/ path: `usage/modules/` is
+`usage/modules.md`, and a section's index page is `usage/index.md`.
+{% for item in nav %}
+{%- if item.is_page %}
+{{- link(item) }}
+{%- else %}
+
+## {{ item.title }}
+{% for child in item.children recursive %}
+{%- if child.is_page %}
+{{- link(child) }}
+{%- else %}
+{{- loop(child.children) }}
+{%- endif %}
+{%- endfor %}
+{%- endif %}
+{%- endfor %}

--- a/misc/mkdocs/overrides/main.html
+++ b/misc/mkdocs/overrides/main.html
@@ -5,6 +5,12 @@
 -#}
 {% extends "base.html" %}
 
+{% block extrahead %}
+  {% if page %}
+    <link rel="alternate" type="text/markdown" href="{{ page.file.src_uri | url }}">
+  {% endif %}
+{% endblock %}
+
 {% block content %}
   {% set markdown = page.file.src_uri | url %}
   <div class="md-content__button md-icon dim-markdown">

--- a/misc/mkdocs/overrides/main.html
+++ b/misc/mkdocs/overrides/main.html
@@ -1,0 +1,44 @@
+{#-
+  Material's page template, plus a menu beside the edit button offering the
+  page as markdown. Every page is served as markdown at its docs/ path (see
+  on_post_page in hooks.py); the menu copies that, or opens it.
+-#}
+{% extends "base.html" %}
+
+{% block content %}
+  {% set markdown = page.file.src_uri | url %}
+  <div class="md-content__button md-icon dim-markdown">
+    <button class="dim-markdown__toggle" title="This page as markdown">
+      {% include ".icons/material/language-markdown.svg" %}
+      {% include ".icons/material/chevron-down.svg" %}
+    </button>
+    <div class="dim-markdown__menu">
+      <button class="dim-markdown__copy" data-href="{{ markdown }}">Copy as markdown</button>
+      <a href="{{ markdown }}">View as markdown</a>
+    </div>
+  </div>
+  {{ super() }}
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script>
+    document.addEventListener("click", (event) => {
+      const menu = document.querySelector(".dim-markdown");
+      if (event.target.closest(".dim-markdown__toggle")) {
+        menu.classList.toggle("dim-markdown--open");
+      } else {
+        menu.classList.remove("dim-markdown--open");
+      }
+      const copy = event.target.closest(".dim-markdown__copy");
+      if (copy) {
+        const text = fetch(copy.dataset.href)
+          .then((response) => response.text())
+          .then((markdown) => new Blob([markdown], { type: "text/plain" }));
+        navigator.clipboard
+          .write([new ClipboardItem({ "text/plain": text })])
+          .then(() => alert$.next("{{ lang.t('clipboard.copied') }}"));
+      }
+    });
+  </script>
+{% endblock %}

--- a/misc/mkdocs/theme.css
+++ b/misc/mkdocs/theme.css
@@ -490,6 +490,68 @@
   opacity: 1;
 }
 
+/* The page as markdown: a menu beside the edit button, for readers that
+ * would rather copy the page into an agent than read it here. The markup
+ * is overrides/main.html; the markdown it offers is written by hooks.py. */
+.dim-markdown {
+  position: relative;
+}
+
+.dim-markdown__toggle {
+  display: flex;
+  align-items: center;
+  color: inherit;
+  cursor: pointer;
+  transition: color 120ms;
+}
+
+.dim-markdown__toggle:hover,
+.dim-markdown--open .dim-markdown__toggle {
+  color: var(--md-accent-fg-color);
+}
+
+/* The chevron is a hint that this one opens, not a second icon. */
+.dim-markdown__toggle svg:last-child {
+  width: 0.8rem;
+  height: 0.8rem;
+  margin-left: -0.1rem;
+}
+
+.dim-markdown__menu {
+  display: none;
+  position: absolute;
+  top: 100%;
+  right: 0;
+  z-index: 3;
+  margin-top: 0.3rem;
+  padding: 0.25rem;
+  border: 1px solid var(--dim-hairline);
+  border-radius: var(--dim-radius);
+  background-color: var(--md-default-bg-color--light);
+}
+
+.dim-markdown--open .dim-markdown__menu {
+  display: block;
+}
+
+.dim-markdown__menu > :is(a, button) {
+  display: block;
+  width: 100%;
+  padding: 0.35rem 0.7rem;
+  border-radius: var(--dim-radius-sm);
+  color: var(--md-default-fg-color);
+  font-size: 0.68rem;
+  text-align: left;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: background-color 120ms, color 120ms;
+}
+
+.dim-markdown__menu > :is(a, button):hover {
+  background-color: color-mix(in srgb, var(--md-default-fg-color) 7%, transparent);
+  color: var(--md-accent-fg-color);
+}
+
 /* Tabs, when a site turns them on, read as pills rather than underlines. */
 .md-tabs__link {
   border-radius: var(--dim-radius-pill);

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,9 @@ watch:
 
 theme:
   name: material
+  custom_dir: misc/mkdocs/overrides
+  static_templates:
+    - llms.txt
   favicon: assets/favicon.png
   logo: assets/dimensional-logo-master-transparent.png
   font:


### PR DESCRIPTION
## Contribution path

- Small, safe change that does not need a tracking issue

## Problem

We have all these wonderful docs but agents can't view them efficiently.

## Solution

- added llms.txt
- `.md` can be appended to a docs URL and the raw md will be served
- doc pages have a dropdown to view/copy markdown

Also, some docs will reroute to the `.md` content if the request header includes `Accept: text/markdown`. It doesn't look like we can do that with our setup, so `<link rel="alternate" type="text/markdown" href="{{ page.file.src_uri | url }}"> ` is added to the head of docs pages which _might_ help out some agent harnesses and prevent them from ingesting whole HTML pages. 

## How to Test

- `uv run dimos docs`
- Navigate to `https://localhost:8000`
- append `.md` to a docs url (if home page, do localhost:8000/index.html)
- go to `https://localhost:8000/llms.txt`


https://github.com/user-attachments/assets/bf4e8a8f-b0e2-4600-aaab-641013f37fb0


## AI assistance

fable 5 wrote the bulk of the code diff

## Checklist

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
