### PR TITLE
fix(sim): stamp camera output at render time and pace on the monotonic clock

### DIFF
--- a/dimos/simulation/engines/mujoco_sim_module.py
+++ b/dimos/simulation/engines/mujoco_sim_module.py
@@ -344,6 +344,12 @@ class MujocoSimModule(
         self._gripper_joint_range: tuple[float, float] = (0.0, 1.0)
         self._stop_event = threading.Event()
         self._publish_thread: threading.Thread | None = None
+        # Guards _camera_info_base and _latest_frame_ts, which the publish
+        # thread, the camera_info interval, the RPC thread, and stop() all
+        # touch. Hold it only across the field access itself: never across the
+        # publish-thread join in stop(), and never while calling a method that
+        # takes it again (it is not reentrant).
+        self._state_lock = threading.Lock()
         self._camera_info_base: CameraInfo | None = None
         self._shm_ready_signaled = False
         self._latest_frame_ts: float | None = None
@@ -380,25 +386,26 @@ class MujocoSimModule(
         return f"{self.config.camera_name}_depth_optical_frame"
 
     def _camera_info_ts(self) -> float:
-        """Latest frame's sim time; wall clock only before the first frame.
-
-        Read once: the publish thread writes this while stop() clears it, so a
-        second read could return None after the first saw a stamp.
-        """
-        ts = self._latest_frame_ts
+        """Latest frame's sim time; wall clock only before the first frame."""
+        with self._state_lock:
+            ts = self._latest_frame_ts
         return time.time() if ts is None else ts
 
     @rpc
     def get_color_camera_info(self) -> CameraInfo | None:
-        if self._camera_info_base is None:
+        with self._state_lock:
+            base = self._camera_info_base
+        if base is None:
             return None
-        return self._camera_info_base.with_ts(self._camera_info_ts())
+        return base.with_ts(self._camera_info_ts())
 
     @rpc
     def get_depth_camera_info(self) -> CameraInfo | None:
-        if self._camera_info_base is None:
+        with self._state_lock:
+            base = self._camera_info_base
+        if base is None:
             return None
-        return self._camera_info_base.with_ts(self._camera_info_ts())
+        return base.with_ts(self._camera_info_ts())
 
     @rpc
     def get_depth_scale(self) -> float:
@@ -690,8 +697,9 @@ class MujocoSimModule(
                 errors.append(("shm.cleanup", exc))
 
         self._sim_hooks = None
-        self._camera_info_base = None
-        self._latest_frame_ts = None
+        with self._state_lock:
+            self._camera_info_base = None
+            self._latest_frame_ts = None
         super().stop()
 
         if errors:
@@ -856,7 +864,7 @@ class MujocoSimModule(
         fovy_rad = math.radians(fovy_deg)
         fy = h / (2.0 * math.tan(fovy_rad / 2.0))
         fx = fy  # square pixels
-        self._camera_info_base = CameraInfo.from_intrinsics(
+        camera_info = CameraInfo.from_intrinsics(
             fx=fx,
             fy=fy,
             cx=w / 2.0,
@@ -865,6 +873,8 @@ class MujocoSimModule(
             height=h,
             frame_id=self._color_optical_frame,
         )
+        with self._state_lock:
+            self._camera_info_base = camera_info
 
     def _publish_loop(self) -> None:
         """Poll engine for rendered frames and publish at configured FPS."""
@@ -905,7 +915,8 @@ class MujocoSimModule(
                 continue
             last_timestamp = frame.timestamp
             ts = frame.timestamp
-            self._latest_frame_ts = ts
+            with self._state_lock:
+                self._latest_frame_ts = ts
 
             if self.config.enable_color:
                 color_img = Image(
@@ -941,7 +952,8 @@ class MujocoSimModule(
                 time.sleep(sleep_time)
 
     def _publish_camera_info(self) -> None:
-        base = self._camera_info_base
+        with self._state_lock:
+            base = self._camera_info_base
         if base is None:
             return
         ts = self._camera_info_ts()
@@ -1003,7 +1015,9 @@ class MujocoSimModule(
             self._generate_mujoco_lidar_pointcloud()
             return
         # Back-project the primary camera's depth image.
-        if self._camera_info_base is None:
+        with self._state_lock:
+            camera_info = self._camera_info_base
+        if camera_info is None:
             return
         frame = self._engine.read_camera(self.config.camera_name)
         if frame is None:
@@ -1024,7 +1038,7 @@ class MujocoSimModule(
             pcd = PointCloud2.from_rgbd(
                 color_image=color_img,
                 depth_image=depth_img,
-                camera_info=self._camera_info_base,
+                camera_info=camera_info,
                 depth_scale=1.0,
             )
             pcd = pcd.voxel_downsample(0.005)

--- a/dimos/simulation/engines/mujoco_sim_module.py
+++ b/dimos/simulation/engines/mujoco_sim_module.py
@@ -346,6 +346,7 @@ class MujocoSimModule(
         self._publish_thread: threading.Thread | None = None
         self._camera_info_base: CameraInfo | None = None
         self._shm_ready_signaled = False
+        self._latest_frame_ts: float | None = None
 
         # IMU sensor slices into MjData.sensordata, resolved once at start.
         # None if the MJCF has no recognized IMU sensors (e.g. arm-only sims).
@@ -378,17 +379,23 @@ class MujocoSimModule(
     def _depth_optical_frame(self) -> str:
         return f"{self.config.camera_name}_depth_optical_frame"
 
+    def _camera_info_ts(self) -> float:
+        """Latest frame's sim time; wall clock only before the first frame."""
+        if self._latest_frame_ts is None:
+            return time.time()
+        return self._latest_frame_ts
+
     @rpc
     def get_color_camera_info(self) -> CameraInfo | None:
         if self._camera_info_base is None:
             return None
-        return self._camera_info_base.with_ts(time.time())
+        return self._camera_info_base.with_ts(self._camera_info_ts())
 
     @rpc
     def get_depth_camera_info(self) -> CameraInfo | None:
         if self._camera_info_base is None:
             return None
-        return self._camera_info_base.with_ts(time.time())
+        return self._camera_info_base.with_ts(self._camera_info_ts())
 
     @rpc
     def get_depth_scale(self) -> float:
@@ -681,6 +688,7 @@ class MujocoSimModule(
 
         self._sim_hooks = None
         self._camera_info_base = None
+        self._latest_frame_ts = None
         super().stop()
 
         if errors:
@@ -877,6 +885,7 @@ class MujocoSimModule(
             return
 
         while not self._stop_event.is_set():
+            loop_start = time.monotonic()
             try:
                 frame = engine.read_camera(self.config.camera_name)
             except RuntimeError as exc:
@@ -892,7 +901,8 @@ class MujocoSimModule(
                 self._stop_event.wait(timeout=interval * 0.5)
                 continue
             last_timestamp = frame.timestamp
-            ts = time.time()
+            ts = frame.timestamp
+            self._latest_frame_ts = ts
 
             if self.config.enable_color:
                 color_img = Image(
@@ -922,7 +932,7 @@ class MujocoSimModule(
                     depth_shape=frame.depth.shape,
                 )
 
-            elapsed = time.time() - ts
+            elapsed = time.monotonic() - loop_start
             sleep_time = interval - elapsed
             if sleep_time > 0:
                 time.sleep(sleep_time)
@@ -931,7 +941,7 @@ class MujocoSimModule(
         base = self._camera_info_base
         if base is None:
             return
-        ts = time.time()
+        ts = self._camera_info_ts()
         info = CameraInfo(
             height=base.height,
             width=base.width,

--- a/dimos/simulation/engines/mujoco_sim_module.py
+++ b/dimos/simulation/engines/mujoco_sim_module.py
@@ -380,10 +380,13 @@ class MujocoSimModule(
         return f"{self.config.camera_name}_depth_optical_frame"
 
     def _camera_info_ts(self) -> float:
-        """Latest frame's sim time; wall clock only before the first frame."""
-        if self._latest_frame_ts is None:
-            return time.time()
-        return self._latest_frame_ts
+        """Latest frame's sim time; wall clock only before the first frame.
+
+        Read once: the publish thread writes this while stop() clears it, so a
+        second read could return None after the first saw a stamp.
+        """
+        ts = self._latest_frame_ts
+        return time.time() if ts is None else ts
 
     @rpc
     def get_color_camera_info(self) -> CameraInfo | None:

--- a/dimos/simulation/engines/mujoco_sim_module.py
+++ b/dimos/simulation/engines/mujoco_sim_module.py
@@ -344,11 +344,6 @@ class MujocoSimModule(
         self._gripper_joint_range: tuple[float, float] = (0.0, 1.0)
         self._stop_event = threading.Event()
         self._publish_thread: threading.Thread | None = None
-        # Guards _camera_info_base and _latest_frame_ts, which the publish
-        # thread, the camera_info interval, the RPC thread, and stop() all
-        # touch. Hold it only across the field access itself: never across the
-        # publish-thread join in stop(), and never while calling a method that
-        # takes it again (it is not reentrant).
         self._state_lock = threading.Lock()
         self._camera_info_base: CameraInfo | None = None
         self._shm_ready_signaled = False

--- a/dimos/simulation/engines/test_mujoco_sim_module.py
+++ b/dimos/simulation/engines/test_mujoco_sim_module.py
@@ -24,6 +24,7 @@ from unittest.mock import MagicMock
 import numpy as np
 import pytest
 
+from dimos.msgs.sensor_msgs.CameraInfo import CameraInfo
 from dimos.simulation.engines.mujoco_engine import CameraFrame, MujocoEngine
 from dimos.simulation.engines.mujoco_sim_module import MujocoSimModule, MujocoSimModuleConfig
 
@@ -468,3 +469,98 @@ def test_engine_request_reset_to_applies_pose_in_sim_loop(freejoint_engine: Mujo
         [0.0, 0.0, np.sin(0.15), np.cos(0.15)],
         atol=1e-8,
     )
+
+
+class _FakeCameraEngine:
+    """Serves a fixed list of frame timestamps, then stops the publish loop."""
+
+    connected = True
+
+    def __init__(self, timestamps: list[float], stop_event: threading.Event) -> None:
+        self._timestamps = list(timestamps)
+        self._stop_event = stop_event
+
+    def read_camera(self, camera_name: str) -> CameraFrame | None:
+        if not self._timestamps:
+            self._stop_event.set()
+            return None
+        return CameraFrame(
+            rgb=np.zeros((1, 1, 3), dtype=np.uint8),
+            depth=np.ones((1, 1), dtype=np.float32),
+            cam_pos=np.array([1.0, 2.0, 3.0]),
+            cam_mat=np.eye(3),
+            fovy=60.0,
+            timestamp=self._timestamps.pop(0),
+            base_pos=np.array([1.0, 2.0, 2.0]),
+            base_mat=np.eye(3),
+        )
+
+    def disconnect(self) -> None:
+        pass
+
+
+def _run_publish_loop(module: MujocoSimModule, timestamps: list[float]) -> None:
+    module._engine = _FakeCameraEngine(timestamps, module._stop_event)
+    module._publish_loop()
+
+
+def test_publish_loop_stamps_messages_with_frame_timestamp() -> None:
+    # Sim time far from wall clock, so a wall-clock stamp cannot pass by accident.
+    frame_ts = [1_000_000.0, 1_000_000.5]
+    module = MujocoSimModule()
+    try:
+        module.config = MujocoSimModuleConfig(fps=1000)
+        module._camera_info_base = CameraInfo.from_intrinsics(
+            width=1, height=1, fx=1.0, fy=1.0, cx=0.5, cy=0.5, frame_id="wrist_camera_color_frame"
+        )
+        color: list[Any] = []
+        depth: list[Any] = []
+        tf: list[Any] = []
+        info: list[Any] = []
+        module.color_image.subscribe(color.append)
+        module.depth_image.subscribe(depth.append)
+        module.tf.subscribe(tf.append)
+        module.camera_info.subscribe(info.append)
+
+        _run_publish_loop(module, frame_ts)
+        module._publish_camera_info()
+
+        assert [img.ts for img in color] == frame_ts
+        assert [img.ts for img in depth] == frame_ts
+        assert [msg.transforms[0].ts for msg in tf] == frame_ts
+        # camera_info rides the latest frame's sim clock, not wall time.
+        assert info[-1].ts == frame_ts[-1]
+        assert module.get_color_camera_info().ts == frame_ts[-1]
+        assert module.get_depth_camera_info().ts == frame_ts[-1]
+    finally:
+        module.stop()
+
+
+def test_camera_info_falls_back_to_wall_clock_before_first_frame() -> None:
+    module = MujocoSimModule()
+    try:
+        module.config = MujocoSimModuleConfig()
+        module._camera_info_base = CameraInfo.from_intrinsics(
+            width=1, height=1, fx=1.0, fy=1.0, cx=0.5, cy=0.5, frame_id="wrist_camera_color_frame"
+        )
+        assert module._latest_frame_ts is None
+        assert module._camera_info_ts() == pytest.approx(time.time(), abs=5.0)
+    finally:
+        module.stop()
+
+
+@pytest.mark.parametrize("base_ts", [0.05, 1_000_000.0])
+def test_publish_loop_pacing_is_independent_of_frame_timestamp_magnitude(base_ts: float) -> None:
+    # Pacing must come from the wall clock, not from (wall - sim), which is a huge
+    # positive number for any realistic sim clock and drops the loop to render rate.
+    fps = 100
+    frame_ts = [base_ts + i * 0.05 for i in range(5)]
+    module = MujocoSimModule()
+    try:
+        module.config = MujocoSimModuleConfig(fps=fps)
+        start = time.monotonic()
+        _run_publish_loop(module, frame_ts)
+        elapsed = time.monotonic() - start
+        assert elapsed >= (len(frame_ts) - 1) / fps
+    finally:
+        module.stop()

--- a/dimos/simulation/engines/test_mujoco_sim_module.py
+++ b/dimos/simulation/engines/test_mujoco_sim_module.py
@@ -19,7 +19,7 @@ from pathlib import Path
 import threading
 import time
 from typing import Any
-from unittest.mock import MagicMock, PropertyMock, patch
+from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
@@ -562,29 +562,5 @@ def test_publish_loop_pacing_is_independent_of_frame_timestamp_magnitude(base_ts
         _run_publish_loop(module, frame_ts)
         elapsed = time.monotonic() - start
         assert elapsed >= (len(frame_ts) - 1) / fps
-    finally:
-        module.stop()
-
-
-def test_camera_info_rpcs_snapshot_the_base_once() -> None:
-    # stop() clears _camera_info_base, so a check-then-use would call
-    # with_ts() on None.
-    module = MujocoSimModule()
-    try:
-        module.config = MujocoSimModuleConfig()
-        module._latest_frame_ts = 1000.0
-        base = CameraInfo.from_intrinsics(
-            width=1, height=1, fx=1.0, fy=1.0, cx=0.5, cy=0.5, frame_id="wrist_camera_color_frame"
-        )
-        with patch.object(
-            type(module),
-            "_camera_info_base",
-            new_callable=PropertyMock,
-            side_effect=[base, None],
-            create=True,
-        ):
-            info = module.get_color_camera_info()
-        assert info is not None
-        assert info.ts == 1000.0
     finally:
         module.stop()

--- a/dimos/simulation/engines/test_mujoco_sim_module.py
+++ b/dimos/simulation/engines/test_mujoco_sim_module.py
@@ -19,7 +19,7 @@ from pathlib import Path
 import threading
 import time
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import numpy as np
 import pytest
@@ -562,5 +562,23 @@ def test_publish_loop_pacing_is_independent_of_frame_timestamp_magnitude(base_ts
         _run_publish_loop(module, frame_ts)
         elapsed = time.monotonic() - start
         assert elapsed >= (len(frame_ts) - 1) / fps
+    finally:
+        module.stop()
+
+
+def test_camera_info_ts_reads_the_frame_stamp_only_once() -> None:
+    # stop() clears _latest_frame_ts while the publish thread writes it, so a
+    # check-then-use would hand None to CameraInfo(ts=...) during shutdown.
+    module = MujocoSimModule()
+    try:
+        module.config = MujocoSimModuleConfig()
+        with patch.object(
+            type(module),
+            "_latest_frame_ts",
+            new_callable=PropertyMock,
+            side_effect=[1000.0, None],
+            create=True,
+        ):
+            assert module._camera_info_ts() == 1000.0
     finally:
         module.stop()

--- a/dimos/simulation/engines/test_mujoco_sim_module.py
+++ b/dimos/simulation/engines/test_mujoco_sim_module.py
@@ -566,24 +566,6 @@ def test_publish_loop_pacing_is_independent_of_frame_timestamp_magnitude(base_ts
         module.stop()
 
 
-def test_camera_info_ts_reads_the_frame_stamp_only_once() -> None:
-    # stop() clears _latest_frame_ts while the publish thread writes it, so a
-    # check-then-use would hand None to CameraInfo(ts=...) during shutdown.
-    module = MujocoSimModule()
-    try:
-        module.config = MujocoSimModuleConfig()
-        with patch.object(
-            type(module),
-            "_latest_frame_ts",
-            new_callable=PropertyMock,
-            side_effect=[1000.0, None],
-            create=True,
-        ):
-            assert module._camera_info_ts() == 1000.0
-    finally:
-        module.stop()
-
-
 def test_camera_info_rpcs_snapshot_the_base_once() -> None:
     # stop() clears _camera_info_base, so a check-then-use would call
     # with_ts() on None.

--- a/dimos/simulation/engines/test_mujoco_sim_module.py
+++ b/dimos/simulation/engines/test_mujoco_sim_module.py
@@ -582,3 +582,27 @@ def test_camera_info_ts_reads_the_frame_stamp_only_once() -> None:
             assert module._camera_info_ts() == 1000.0
     finally:
         module.stop()
+
+
+def test_camera_info_rpcs_snapshot_the_base_once() -> None:
+    # stop() clears _camera_info_base, so a check-then-use would call
+    # with_ts() on None.
+    module = MujocoSimModule()
+    try:
+        module.config = MujocoSimModuleConfig()
+        module._latest_frame_ts = 1000.0
+        base = CameraInfo.from_intrinsics(
+            width=1, height=1, fx=1.0, fy=1.0, cx=0.5, cy=0.5, frame_id="wrist_camera_color_frame"
+        )
+        with patch.object(
+            type(module),
+            "_camera_info_base",
+            new_callable=PropertyMock,
+            side_effect=[base, None],
+            create=True,
+        ):
+            info = module.get_color_camera_info()
+        assert info is not None
+        assert info.ts == 1000.0
+    finally:
+        module.stop()


### PR DESCRIPTION
## What

The camera publish loop stamped images, TF, and `camera_info` with `time.time()` sampled when the frame was consumed, not with the timestamp the frame already carries from when it was rendered.

## Why it matters

Every message for a frame was skewed later than the observation it describes by the render-to-publish latency, measured live at **4.5-101.7 ms (mean 52.7 ms)**, which is the same order as the 0.1 s TF lookup tolerance and can register object poses against the wrong TF sample.


