### PR TITLE
feat(manipulation): add heuristic grasp provider

### DIFF
--- a/dimos/manipulation/grasping/heuristic_grasp.py
+++ b/dimos/manipulation/grasping/heuristic_grasp.py
@@ -1,0 +1,71 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Deterministic grasp proposals for segmented object point clouds."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+from numpy.typing import NDArray
+
+from dimos.core.core import rpc
+from dimos.core.module import Module
+from dimos.manipulation.grasping.grasp_gen_spec import GraspGenSpec
+from dimos.msgs.geometry_msgs.Pose import Pose
+from dimos.msgs.geometry_msgs.Quaternion import Quaternion
+from dimos.msgs.geometry_msgs.Vector3 import Vector3
+from dimos.msgs.manipulation_msgs.GraspCandidate import GraspCandidate
+from dimos.msgs.manipulation_msgs.GraspCandidateArray import GraspCandidateArray
+from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
+from dimos.msgs.std_msgs.Header import Header
+
+
+class HeuristicGraspModule(Module, GraspGenSpec):
+    """Generate one top-down parallel-jaw grasp."""
+
+    @rpc
+    def propose_grasps(self, object_pointcloud: PointCloud2) -> GraspCandidateArray:
+        if object_pointcloud.ts is None:
+            raise ValueError("object pointcloud must have a timestamp")
+        if not object_pointcloud.frame_id:
+            raise ValueError("object pointcloud frame_id must not be empty")
+        points = object_pointcloud.points_f32()
+        if points.ndim != 2 or points.shape[1] != 3 or len(points) < 3:
+            raise ValueError("object pointcloud must contain at least three XYZ points")
+        if not np.all(np.isfinite(points)):
+            raise ValueError("object pointcloud XYZ values must be finite floats in metres")
+
+        xy = points[:, :2]
+        center_xy = np.median(xy, axis=0)
+        low_z, high_z = np.quantile(points[:, 2], [0.05, 0.95])
+        pose = Pose(
+            Vector3(float(center_xy[0]), float(center_xy[1]), float((low_z + high_z) / 2.0)),
+            Quaternion.from_euler(Vector3(-math.pi, 0.0, self._narrow_axis_yaw(xy))),
+        )
+        return GraspCandidateArray(
+            Header(float(object_pointcloud.ts), object_pointcloud.frame_id),
+            [GraspCandidate(pose, score=1.0)],
+        )
+
+    @staticmethod
+    def _narrow_axis_yaw(xy: NDArray[np.float32]) -> float:
+        centered = xy - np.mean(xy, axis=0)
+        covariance = centered.T @ centered
+        values, vectors = np.linalg.eigh(covariance)
+        if values[1] <= 0.0 or np.isclose(values[0], values[1], rtol=0.05):
+            return 0.0
+        narrow_axis = vectors[:, 0]
+        return math.atan2(float(narrow_axis[1]), float(narrow_axis[0])) - math.pi / 2.0

--- a/dimos/manipulation/grasping/heuristic_grasp.py
+++ b/dimos/manipulation/grasping/heuristic_grasp.py
@@ -34,12 +34,15 @@ from dimos.msgs.std_msgs.Header import Header
 
 
 class HeuristicGraspModule(Module, GraspGenSpec):
-    """Generate one top-down parallel-jaw grasp."""
+    """Generate one top-down parallel-jaw grasp from a gravity-aligned point cloud.
+
+    The input frame's XY plane must be horizontal and its -Z axis must point down.
+    """
 
     @rpc
     def propose_grasps(self, object_pointcloud: PointCloud2) -> GraspCandidateArray:
-        if object_pointcloud.ts is None:
-            raise ValueError("object pointcloud must have a timestamp")
+        if object_pointcloud.ts is None or not math.isfinite(float(object_pointcloud.ts)):
+            raise ValueError("object pointcloud must have a finite timestamp")
         if not object_pointcloud.frame_id:
             raise ValueError("object pointcloud frame_id must not be empty")
         points = object_pointcloud.points_f32()
@@ -68,4 +71,6 @@ class HeuristicGraspModule(Module, GraspGenSpec):
         if values[1] <= 0.0 or np.isclose(values[0], values[1], rtol=0.05):
             return 0.0
         narrow_axis = vectors[:, 0]
-        return math.atan2(float(narrow_axis[1]), float(narrow_axis[0])) - math.pi / 2.0
+        yaw = math.atan2(float(narrow_axis[1]), float(narrow_axis[0])) - math.pi / 2.0
+        # A parallel-jaw grasp is unchanged by a 180-degree wrist rotation.
+        return (yaw + math.pi / 2.0) % math.pi - math.pi / 2.0

--- a/dimos/manipulation/grasping/test_heuristic_grasp.py
+++ b/dimos/manipulation/grasping/test_heuristic_grasp.py
@@ -1,0 +1,80 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import Iterator
+import math
+
+import numpy as np
+import pytest
+
+from dimos.manipulation.grasping.grasp_gen_spec import GraspGenSpec
+from dimos.manipulation.grasping.heuristic_grasp import HeuristicGraspModule
+from dimos.msgs.geometry_msgs.Vector3 import Vector3
+from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
+from dimos.spec.utils import spec_annotation_compliance
+
+
+def _cloud(points: np.ndarray) -> PointCloud2:
+    return PointCloud2.from_numpy(points.astype(np.float32), frame_id="world", timestamp=1.0)
+
+
+@pytest.fixture
+def module() -> Iterator[HeuristicGraspModule]:
+    instance = HeuristicGraspModule()
+    yield instance
+    instance.stop()
+
+
+def test_heuristic_grasp_implements_grasp_provider_spec(module: HeuristicGraspModule) -> None:
+    assert spec_annotation_compliance(module, GraspGenSpec)
+
+
+def test_heuristic_grasp_proposes_centered_top_down_pose(module: HeuristicGraspModule) -> None:
+    proposals = module.propose_grasps(
+        _cloud(
+            np.asarray(
+                [
+                    [-0.10, -0.02, 0.10],
+                    [-0.10, 0.02, 0.10],
+                    [0.10, -0.02, 0.20],
+                    [0.10, 0.02, 0.20],
+                ]
+            )
+        )
+    )
+
+    assert len(proposals.candidates) == 1
+    assert proposals.header.frame_id == "world"
+    assert proposals.header.timestamp == pytest.approx(1.0)
+    pose = proposals.candidates[0].pose
+    assert pose.position.x == pytest.approx(0.0)
+    assert pose.position.y == pytest.approx(0.0)
+    assert pose.position.z == pytest.approx(0.15)
+    approach = pose.orientation.rotate_vector(Vector3(0.0, 0.0, 1.0))
+    assert approach.z == pytest.approx(-1.0)
+    assert proposals.candidates[0].score == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize(
+    "points, error",
+    [
+        (np.asarray([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]]), "at least three"),
+        (np.asarray([[0.0, 0.0, math.nan]] * 3), "finite"),
+    ],
+)
+def test_heuristic_grasp_rejects_invalid_pointclouds(
+    module: HeuristicGraspModule, points: np.ndarray, error: str
+) -> None:
+    with pytest.raises(ValueError, match=error):
+        module.propose_grasps(_cloud(points))

--- a/dimos/manipulation/grasping/test_heuristic_grasp.py
+++ b/dimos/manipulation/grasping/test_heuristic_grasp.py
@@ -68,7 +68,7 @@ def test_heuristic_grasp_proposes_centered_top_down_pose(module: HeuristicGraspM
     assert proposals.candidates[0].score == pytest.approx(1.0)
 
 
-def test_heuristic_grasp_aligns_yaw_with_narrow_axis(module: HeuristicGraspModule) -> None:
+def test_heuristic_grasp_aligns_jaw_axis_with_narrow_axis(module: HeuristicGraspModule) -> None:
     proposals = module.propose_grasps(
         _cloud(
             np.asarray(
@@ -82,8 +82,10 @@ def test_heuristic_grasp_aligns_yaw_with_narrow_axis(module: HeuristicGraspModul
         )
     )
 
-    yaw = proposals.candidates[0].pose.orientation.to_euler().z
-    assert abs(math.sin(yaw)) == pytest.approx(1.0)
+    jaw_axis = proposals.candidates[0].pose.orientation.rotate_vector(Vector3(0.0, 1.0, 0.0))
+    assert abs(jaw_axis.x) == pytest.approx(1.0)
+    assert jaw_axis.y == pytest.approx(0.0, abs=1e-6)
+    assert jaw_axis.z == pytest.approx(0.0, abs=1e-6)
 
 
 @pytest.mark.parametrize(

--- a/dimos/manipulation/grasping/test_heuristic_grasp.py
+++ b/dimos/manipulation/grasping/test_heuristic_grasp.py
@@ -88,6 +88,21 @@ def test_heuristic_grasp_aligns_jaw_axis_with_narrow_axis(module: HeuristicGrasp
     assert jaw_axis.z == pytest.approx(0.0, abs=1e-6)
 
 
+def test_heuristic_grasp_canonicalizes_pca_eigenvector_sign(
+    module: HeuristicGraspModule, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    values = np.asarray([1.0, 4.0])
+    same_axis = np.asarray([[1.0, 0.0], [0.0, 1.0]])
+    opposite_axis = np.asarray([[-1.0, 0.0], [0.0, 1.0]])
+
+    monkeypatch.setattr(np.linalg, "eigh", lambda _: (values, same_axis))
+    positive_yaw = module._narrow_axis_yaw(np.zeros((3, 2), dtype=np.float32))
+    monkeypatch.setattr(np.linalg, "eigh", lambda _: (values, opposite_axis))
+    negative_yaw = module._narrow_axis_yaw(np.zeros((3, 2), dtype=np.float32))
+
+    assert negative_yaw == pytest.approx(positive_yaw)
+
+
 @pytest.mark.parametrize(
     "points, frame_id, timestamp, error",
     [
@@ -100,6 +115,8 @@ def test_heuristic_grasp_aligns_jaw_axis_with_narrow_axis(module: HeuristicGrasp
         (np.asarray([[0.0, 0.0, math.nan]] * 3), "world", 1.0, "finite"),
         (np.zeros((3, 3)), "", 1.0, "frame_id"),
         (np.zeros((3, 3)), "world", None, "timestamp"),
+        (np.zeros((3, 3)), "world", math.nan, "finite timestamp"),
+        (np.zeros((3, 3)), "world", math.inf, "finite timestamp"),
     ],
 )
 def test_heuristic_grasp_rejects_invalid_pointclouds(

--- a/dimos/manipulation/grasping/test_heuristic_grasp.py
+++ b/dimos/manipulation/grasping/test_heuristic_grasp.py
@@ -25,8 +25,10 @@ from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
 from dimos.spec.utils import spec_annotation_compliance
 
 
-def _cloud(points: np.ndarray) -> PointCloud2:
-    return PointCloud2.from_numpy(points.astype(np.float32), frame_id="world", timestamp=1.0)
+def _cloud(
+    points: np.ndarray, *, frame_id: str = "world", timestamp: float | None = 1.0
+) -> PointCloud2:
+    return PointCloud2.from_numpy(points.astype(np.float32), frame_id=frame_id, timestamp=timestamp)
 
 
 @pytest.fixture
@@ -66,15 +68,44 @@ def test_heuristic_grasp_proposes_centered_top_down_pose(module: HeuristicGraspM
     assert proposals.candidates[0].score == pytest.approx(1.0)
 
 
+def test_heuristic_grasp_aligns_yaw_with_narrow_axis(module: HeuristicGraspModule) -> None:
+    proposals = module.propose_grasps(
+        _cloud(
+            np.asarray(
+                [
+                    [-0.02, -0.10, 0.10],
+                    [0.02, -0.10, 0.10],
+                    [-0.02, 0.10, 0.20],
+                    [0.02, 0.10, 0.20],
+                ]
+            )
+        )
+    )
+
+    yaw = proposals.candidates[0].pose.orientation.to_euler().z
+    assert abs(math.sin(yaw)) == pytest.approx(1.0)
+
+
 @pytest.mark.parametrize(
-    "points, error",
+    "points, frame_id, timestamp, error",
     [
-        (np.asarray([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]]), "at least three"),
-        (np.asarray([[0.0, 0.0, math.nan]] * 3), "finite"),
+        (
+            np.asarray([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]]),
+            "world",
+            1.0,
+            "at least three",
+        ),
+        (np.asarray([[0.0, 0.0, math.nan]] * 3), "world", 1.0, "finite"),
+        (np.zeros((3, 3)), "", 1.0, "frame_id"),
+        (np.zeros((3, 3)), "world", None, "timestamp"),
     ],
 )
 def test_heuristic_grasp_rejects_invalid_pointclouds(
-    module: HeuristicGraspModule, points: np.ndarray, error: str
+    module: HeuristicGraspModule,
+    points: np.ndarray,
+    frame_id: str,
+    timestamp: float | None,
+    error: str,
 ) -> None:
     with pytest.raises(ValueError, match=error):
-        module.propose_grasps(_cloud(points))
+        module.propose_grasps(_cloud(points, frame_id=frame_id, timestamp=timestamp))

--- a/dimos/robot/all_blueprints.py
+++ b/dimos/robot/all_blueprints.py
@@ -218,6 +218,7 @@ all_modules = {
     "grasping-module": "dimos.manipulation.grasping.grasping.GraspingModule",
     "gstreamer-camera-module": "dimos.hardware.sensors.camera.gstreamer.gstreamer_camera.GstreamerCameraModule",
     "hand-teleop-module": "dimos.teleop.quest.quest_extensions.HandTeleopModule",
+    "heuristic-grasp-module": "dimos.manipulation.grasping.heuristic_grasp.HeuristicGraspModule",
     "hosted-stats-module": "dimos.teleop.hosted.hosted_stats.HostedStatsModule",
     "joint-trajectory-controller": "dimos.manipulation.control.trajectory_controller.joint_trajectory_controller.JointTrajectoryController",
     "joystick-module": "dimos.robot.unitree.b1.joystick_module.JoystickModule",


### PR DESCRIPTION
## Contribution path

- Small, focused change extracted from the pick-and-place exploration work.

## Problem

Pick-and-place needs a lightweight grasp provider that does not require the optional GraspGenX runtime.

## Solution

- Add `HeuristicGraspModule`, implementing the existing `GraspGenSpec`.
- Produce one deterministic top-down parallel-jaw proposal from a segmented object point cloud.
- Validate point-cloud metadata and geometry.
- Register the module and add focused unit coverage.

## How to Test

can test from PRs above this.

## AI assistance

OpenCode with gpt-5.6-terra assisted with implementation and validation. The author will review the public method descriptions before they are added.

## Checklist

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).