### PR TITLE
fix(tf): add forward_tolerance to the TFLookup protocol

### DIFF
--- a/dimos/protocol/tf/tf.py
+++ b/dimos/protocol/tf/tf.py
@@ -48,6 +48,8 @@ class TFLookup(Protocol):
         child_frame: str,
         time_point: float | None = None,
         time_tolerance: float | None = None,
+        *,
+        forward_tolerance: float = 0.0,
     ) -> Transform | None: ...
 
 


### PR DESCRIPTION
MultiTBuffer.get and StreamTF.get both take forward_tolerance already, the protocol just never declared it, so anything holding a TFLookup had to narrow to a concrete buffer to wait for a transform that has not arrived yet.

Dropped the warning throttle that was in here before, per review — warn=False already covers the case where misses are expected, and forward_tolerance covers the case where the transform is merely late.
