### PR TITLE
feat(mapping): add a voxel clear mask so a sensor can erase its own ghost

### DIFF
--- a/dimos/mapping/ray_tracing/module.py
+++ b/dimos/mapping/ray_tracing/module.py
@@ -80,6 +80,10 @@ class RayTracingVoxelMap(NativeModule, mapping.GlobalPointcloud):
     config: RayTracingVoxelMapConfig
 
     lidar: In[PointCloud2]
+    # World-frame points a sensor knows to be empty. Their voxels are deleted
+    # outright, reaching space ray tracing cannot clear: a wrist camera's own
+    # arm occludes the volume behind it, so no ray ever misses through it.
+    voxel_clear_mask: In[PointCloud2]
     tf: In[TFMessage]
     global_map: Out[PointCloud2]
     local_map: Out[PointCloud2]

--- a/dimos/mapping/ray_tracing/rust/Cargo.toml
+++ b/dimos/mapping/ray_tracing/rust/Cargo.toml
@@ -24,6 +24,7 @@ threads = 2
 
 [package.metadata.dimos.module.ray_tracing.inputs]
 lidar = "sensor_msgs.PointCloud2"
+voxel_clear_mask = "sensor_msgs.PointCloud2"
 tf = "tf2_msgs.TFMessage"
 
 [package.metadata.dimos.module.ray_tracing.outputs]

--- a/dimos/mapping/ray_tracing/rust/src/mapper.rs
+++ b/dimos/mapping/ray_tracing/rust/src/mapper.rs
@@ -14,12 +14,13 @@
 
 use std::sync::Arc;
 
+use ahash::AHashSet;
 use dimos_module::worker_pool;
 use nalgebra::{Quaternion, UnitQuaternion, Vector3};
 
 use crate::voxel_ray_tracer::{
-    batch_local_bounds, emit_points, emit_points_fine, global_normal_fits, update_map, Config,
-    Cylinder, FrameHits, LocalBounds, VoxelMap,
+    batch_local_bounds, coarse_of_fine, emit_points, emit_points_fine, global_normal_fits,
+    metric_voxel_keys, update_map, Config, Cylinder, FrameHits, LocalBounds, VoxelMap,
 };
 
 pub type Point = (f32, f32, f32);
@@ -197,6 +198,26 @@ impl Mapper {
             .install(|| global_normal_fits(&self.map, self.config.voxel_size))
     }
 
+    /// Delete the voxels covering `points`, world-frame metric positions the
+    /// caller knows to be free. Returns how many voxels were removed.
+    ///
+    /// This frame's live hits are dropped alongside them, so a cleared voxel
+    /// cannot come back out of the live overlay before the next frame replaces
+    /// it.
+    pub fn clear_metric(&mut self, points: impl IntoIterator<Item = Point>) -> usize {
+        let keys: Vec<_> = metric_voxel_keys(points, self.config.voxel_size).collect();
+        for key in &keys {
+            self.live.coarse.remove(key);
+        }
+        if let Some((divisor, _)) = self.config.fine_layer() {
+            let cleared: AHashSet<_> = keys.iter().copied().collect();
+            self.live
+                .fine
+                .retain(|&fine| !cleared.contains(&coarse_of_fine(fine, divisor as i32)));
+        }
+        self.map.clear_voxels(keys)
+    }
+
     /// Reset to an empty map, keeping the config.
     pub fn clear(&mut self) {
         self.map.clear();
@@ -342,6 +363,25 @@ mod tests {
             mapper.add_frame(vec![(5.5, 0.5, 0.5)], pose);
             assert_eq!((mapper.local_due(), mapper.global_due()), (false, false));
         }
+    }
+
+    /// The ghost case: a sensor deposits returns off its own body, then tells
+    /// the mapper that volume is free. Ray tracing never reaches it because the
+    /// body occludes what is behind it, so the mask is the only way out.
+    #[test]
+    fn clear_metric_erases_voxels_ray_tracing_cannot_reach() {
+        let mut mapper = Mapper::new(config());
+        let pose = Pose {
+            position: (0.0, 0.0, 0.0),
+            orientation: IDENTITY,
+        };
+        mapper.add_frame(vec![(5.5, 0.5, 0.5)], pose);
+        assert_eq!(mapper.global_points(), vec![5.5, 0.5, 0.5]);
+
+        assert_eq!(mapper.clear_metric([(5.5, 0.5, 0.5)]), 1);
+
+        assert!(mapper.global_points().is_empty());
+        assert_eq!(mapper.clear_metric([(5.5, 0.5, 0.5)]), 0);
     }
 
     #[test]

--- a/dimos/mapping/ray_tracing/rust/src/module.rs
+++ b/dimos/mapping/ray_tracing/rust/src/module.rs
@@ -28,6 +28,11 @@ pub struct RayTracingVoxelMap {
     #[input(decode = PointCloud2::decode, handler = on_lidar)]
     lidar: Input<PointCloud2>,
 
+    // World-frame points a sensor knows to be empty. Their voxels are deleted
+    // outright, reaching space ray tracing cannot clear.
+    #[input(decode = PointCloud2::decode, handler = on_voxel_clear_mask)]
+    voxel_clear_mask: Input<PointCloud2>,
+
     #[tf]
     tf: Tf,
 
@@ -50,6 +55,10 @@ pub struct RayTracingVoxelMap {
 
     // Built once at startup by init_mapper. All mapping state lives inside.
     mapper: Option<Mapper>,
+
+    // Stamp of the last applied clear mask, so a late one cannot erase voxels a
+    // newer mask already accounted for.
+    last_clear_mask_stamp: f64,
 }
 
 impl RayTracingVoxelMap {
@@ -160,6 +169,56 @@ impl RayTracingVoxelMap {
             let fine = points_to_cloud(&points, out_frame_id, stamp);
             publish_cloud(&self.local_map_fine, &fine).await;
         }
+    }
+
+    /// Delete the voxels covering a cloud of world-frame points a sensor knows
+    /// to be empty.
+    ///
+    /// Ray tracing only clears what a ray passes through, so a sensor that
+    /// occludes itself - a wrist camera staring past its own arm - can never
+    /// clear the volume its arm hides. It deposits voxels of itself there and
+    /// walls itself in. A publisher that knows those points are free says so
+    /// here.
+    async fn on_voxel_clear_mask(&mut self, msg: PointCloud2) {
+        let stamp = time_secs(&msg.header.stamp);
+        if stamp < self.last_clear_mask_stamp {
+            warn_throttled!(
+                Duration::from_secs(1),
+                stamp,
+                last_stamp = self.last_clear_mask_stamp,
+                "Out-of-order voxel clear mask dropped",
+            );
+            return;
+        }
+        // The keys are metric positions, so the cloud must already be in the
+        // world frame. Registering it would need a pose this node has no reason
+        // to trust for a mask.
+        if msg.header.frame_id != self.config.world_frame {
+            warn_throttled!(
+                Duration::from_secs(1),
+                frame = %msg.header.frame_id,
+                expected = %self.config.world_frame,
+                "Voxel clear mask is not in the world frame, dropped a mask.",
+            );
+            return;
+        }
+        let points = match extract_xyz(&msg) {
+            Ok(p) => p,
+            Err(e) => {
+                warn_throttled!(
+                    Duration::from_secs(1),
+                    error = %e,
+                    "Failed to get clear mask points, dropped a mask.",
+                );
+                return;
+            }
+        };
+        self.last_clear_mask_stamp = stamp;
+        if points.is_empty() {
+            return;
+        }
+        let mapper = self.mapper.as_mut().expect("built in setup");
+        mapper.clear_metric(points);
     }
 }
 
@@ -297,7 +356,9 @@ async fn publish_cloud(out: &Output<PointCloud2>, cloud: &PointCloud2) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::voxel_ray_tracer::{emit_points, update_map, LocalBounds, VoxelKey, VoxelMap};
+    use crate::voxel_ray_tracer::{
+        emit_points, metric_voxel_keys, update_map, LocalBounds, VoxelKey, VoxelMap,
+    };
     use ahash::AHashSet;
 
     /// Build a map whose listed voxels are healthy, through the public API.
@@ -348,6 +409,26 @@ mod tests {
             (ky as f32 + 0.5).to_bits(),
             (kz as f32 + 0.5).to_bits(),
         )
+    }
+
+    /// The clear-mask handler names voxels by decoding a cloud and quantizing
+    /// it. Both halves have to agree with how returns were quantized on the way
+    /// in, or a mask silently clears nothing.
+    #[test]
+    fn clear_mask_cloud_round_trips_to_the_voxels_it_covers() {
+        let map = map_with_healthy(&[(3, -2, 1)]);
+        let occupied: Vec<VoxelKey> = map.voxels.keys().copied().collect();
+        assert_eq!(occupied, vec![(3, -2, 1)]);
+
+        // A mask cloud naming that voxel's center, encoded and decoded exactly
+        // as the port would.
+        let cloud = points_to_cloud(&[3.5, -1.5, 1.5], "world", Time::default());
+        let Ok(points) = extract_xyz(&cloud) else {
+            panic!("clear mask cloud must decode");
+        };
+        let keys: Vec<VoxelKey> = metric_voxel_keys(points, 1.0).collect();
+
+        assert_eq!(keys, occupied);
     }
 
     #[test]

--- a/dimos/mapping/ray_tracing/rust/src/voxel_ray_tracer.rs
+++ b/dimos/mapping/ray_tracing/rust/src/voxel_ray_tracer.rs
@@ -137,6 +137,12 @@ fn split_fine_key(fine_key: VoxelKey, divisor: i32) -> (VoxelKey, usize) {
     (coarse, ((lx * divisor + ly) * divisor + lz) as usize)
 }
 
+/// The voxel a fine key belongs to.
+#[inline]
+pub fn coarse_of_fine(fine_key: VoxelKey, divisor: i32) -> VoxelKey {
+    split_fine_key(fine_key, divisor).0
+}
+
 /// Rebuild a fine key from its voxel key and flat child index.
 #[inline]
 fn join_fine_key(coarse: VoxelKey, index: usize, divisor: i32) -> VoxelKey {
@@ -303,6 +309,32 @@ impl VoxelMap {
         self.update_health_index(key, was_healthy, now_healthy);
         if was_healthy != now_healthy {
             self.propagate_neighbor_support(key, if now_healthy { 1 } else { -1 });
+        }
+        removed
+    }
+
+    /// Delete voxels outright, whatever their health, keeping the healthy-chunk
+    /// index and every neighbor's `support` count in sync. Unknown keys are
+    /// skipped. Returns how many voxels were removed.
+    ///
+    /// This is the escape hatch for space a sensor cannot ray-trace clear: a
+    /// wrist camera's own arm occludes the volume behind it, so no ray ever
+    /// fires a miss there and the arm's own returns would sit in the map
+    /// forever. A caller that knows those keys are free names them here.
+    pub fn clear_voxels(&mut self, keys: impl IntoIterator<Item = VoxelKey>) -> usize {
+        let mut removed = 0;
+        for key in keys {
+            let Some(voxel) = self.voxels.remove(&key) else {
+                continue;
+            };
+            // The fine-cell bitmask rides inside the removed voxel, so the fine
+            // layer needs no separate cleanup.
+            let was_healthy = voxel.health > 0;
+            self.update_health_index(key, was_healthy, false);
+            if was_healthy {
+                self.propagate_neighbor_support(key, -1);
+            }
+            removed += 1;
         }
         removed
     }
@@ -973,6 +1005,19 @@ fn world_to_voxel(x: f32, y: f32, z: f32, inv: f32) -> VoxelKey {
         (y * inv).floor() as i32,
         (z * inv).floor() as i32,
     )
+}
+
+/// Quantize world-frame metric points to voxel keys the same way returns are
+/// quantized, so a caller naming voxels by position lands on the ones the map
+/// actually holds.
+pub fn metric_voxel_keys(
+    points: impl IntoIterator<Item = (f32, f32, f32)>,
+    voxel_size: f32,
+) -> impl Iterator<Item = VoxelKey> {
+    let inv = 1.0 / voxel_size;
+    points
+        .into_iter()
+        .map(move |(x, y, z)| world_to_voxel(x, y, z, inv))
 }
 
 /// Fine cells of `key` crossed by the ray segment between `t0` and `t1`,

--- a/dimos/mapping/ray_tracing/rust/src/voxel_ray_tracer/tests.rs
+++ b/dimos/mapping/ray_tracing/rust/src/voxel_ray_tracer/tests.rs
@@ -1357,3 +1357,91 @@ fn fine_children_bin_exactly_to_their_parents() {
         .collect();
     assert_eq!(binned, healthy);
 }
+
+#[test]
+fn metric_voxel_keys_quantize_by_map_resolution() {
+    let keys: Vec<VoxelKey> =
+        metric_voxel_keys([(0.049, 0.05, -0.001), (0.1, -0.1, 0.0)], 0.05).collect();
+
+    assert_eq!(keys, vec![(0, 1, -1), (2, -2, 0)]);
+}
+
+/// A naive `voxels.remove` leaves the healthy-chunk index pointing at a voxel
+/// that is gone. With support_min 0, emit_points reads only the index, so the
+/// deleted voxel would come straight back out.
+#[test]
+fn clear_voxels_removes_from_the_healthy_chunk_index() {
+    let cfg = basic_config();
+    let mut map = VoxelMap::default();
+    update_map(&mut map, (0.0, 0.0, 0.0), &[(5.5, 0.5, 0.5)], &cfg);
+    let no_live = AHashSet::new();
+    assert!(!emit_points(&map, 1.0, None, 0, &no_live).is_empty());
+
+    assert_eq!(map.clear_voxels([(5, 0, 0)]), 1);
+
+    assert_eq!(map.health((5, 0, 0)), None);
+    assert!(
+        emit_points(&map, 1.0, None, 0, &no_live).is_empty(),
+        "cleared voxel must not emit from a stale chunk index"
+    );
+}
+
+/// Every one of the 26 neighbors counts a healthy voxel in its `support`.
+/// Deleting it without decrementing them leaves counts that never come back
+/// down, and support_min then keeps phantom surfaces in the local map.
+#[test]
+fn clear_voxels_decrements_neighbor_support() {
+    let mut map = VoxelMap::default();
+    map.set_health((0, 0, 0), 1);
+    map.set_health((1, 0, 0), 1);
+    map.set_health((0, 1, 0), 1);
+    assert_eq!(map.voxels[&(1, 0, 0)].support, 2);
+    assert_eq!(map.voxels[&(0, 1, 0)].support, 2);
+
+    assert_eq!(map.clear_voxels([(0, 0, 0)]), 1);
+
+    assert_eq!(map.voxels[&(1, 0, 0)].support, 1);
+    assert_eq!(map.voxels[&(0, 1, 0)].support, 1);
+}
+
+/// An unhealthy voxel was never counted in its neighbors' support, so removing
+/// it must not decrement them or the counts go stale downward.
+#[test]
+fn clear_voxels_leaves_support_alone_for_an_unhealthy_voxel() {
+    let mut map = VoxelMap::default();
+    map.set_health((1, 0, 0), 1);
+    map.set_health((0, 0, 0), 0);
+    assert_eq!(map.voxels[&(1, 0, 0)].support, 0);
+
+    assert_eq!(map.clear_voxels([(0, 0, 0)]), 1);
+
+    assert_eq!(map.voxels[&(1, 0, 0)].support, 0);
+}
+
+#[test]
+fn clear_voxels_skips_keys_the_map_does_not_hold() {
+    let mut map = VoxelMap::default();
+    map.set_health((0, 0, 0), 1);
+
+    assert_eq!(map.clear_voxels([(0, 0, 0), (9, 9, 9), (0, 0, 0)]), 1);
+
+    assert!(map.voxels.is_empty());
+}
+
+/// The fine-cell bitmask lives inside the voxel, so clearing the coarse voxel
+/// has to take its fine children with it.
+#[test]
+fn clear_voxels_takes_the_fine_layer_with_it() {
+    let cfg = Config {
+        fine_divisor: 2,
+        ..basic_config()
+    };
+    let mut map = VoxelMap::default();
+    update_map(&mut map, (0.0, 0.0, 0.0), &[(5.1, 0.1, 0.1)], &cfg);
+    let no_live = AHashSet::new();
+    assert!(!emit_points_fine(&map, 1.0, 2, None, 0, &no_live).is_empty());
+
+    assert_eq!(map.clear_voxels([(5, 0, 0)]), 1);
+
+    assert!(emit_points_fine(&map, 1.0, 2, None, 0, &no_live).is_empty());
+}


### PR DESCRIPTION
## The physics

Ray tracing clears a voxel by passing a ray *through* it to a farther return. That works when the sensor sees past the thing it is mapping.

A wrist camera does not. Its own arm sits between the lens and the space behind it, so **no ray ever reaches through the arm** and `record_miss` never fires in that volume. Meanwhile the arm's own returns land in the map as ordinary hits. The result: the arm deposits voxels of itself, and there is no mechanism that can ever erase them. Over a work session the robot slowly walls itself in with a ghost of where it has been, and a planner reading `global_map` refuses to go there.

Ray-trace clearing cannot fix this — the geometry forbids it. The information has to come from somewhere else: a publisher that knows, from URDF plus TF, that a given volume is the robot and therefore free.

## What this adds

A `voxel_clear_mask: Input<PointCloud2>` port. The cloud is world-frame metric points meaning *"these are definitely free"*; the node deletes the voxels covering them.

- **Frame-gated** against `world_frame`. The points are metric positions, so the mask must already be in the world frame 

## Tests

`cargo test --workspace --all-features --locked`: 60 passed. `cargo fmt --check` and `cargo clippy -D warnings` clean..

Files: 6.