### PR TITLE
cli: device login talks to api.dimensional.org

### DIFF
--- a/dimos/cli/cloud.py
+++ b/dimos/cli/cloud.py
@@ -14,7 +14,7 @@
 
 """Dimensional cloud auth: `dimos login` / `dimos logout` / `dimos whoami`.
 
-Device-code flow (RFC 8628 shaped) against login.dimensional.org — built for robots:
+Device-code flow (RFC 8628 shaped) against api.dimensional.org — built for robots:
 no browser or clipboard needed on this machine. The CLI prints an 8-character code,
 you approve it from any signed-in browser (laptop, phone), and the minted API key is
 stored in the system keyring, falling back to a plain-text 0600 file
@@ -126,9 +126,9 @@ def login() -> None:
 
 
 def logout() -> None:
-    """Forget the stored key. Revoke it fully at login.dimensional.org/keys."""
+    """Forget the stored key. Revoke it fully at console.dimensional.org/keys."""
     if _forget():
-        typer.echo(f"Logged out. Revoke the key at {_base()}/keys.")
+        typer.echo("Logged out. Revoke the key at https://console.dimensional.org/keys.")
     else:
         typer.echo("Not logged in.")
 

--- a/dimos/cli/cloud.py
+++ b/dimos/cli/cloud.py
@@ -126,9 +126,9 @@ def login() -> None:
 
 
 def logout() -> None:
-    """Forget the stored key. Revoke it fully at console.dimensional.org/keys."""
+    """Forget the stored key. The key itself stays valid until revoked in the console."""
     if _forget():
-        typer.echo("Logged out. Revoke the key at https://console.dimensional.org/keys.")
+        typer.echo("Logged out. The key stays valid until you revoke it in the console.")
     else:
         typer.echo("Not logged in.")
 

--- a/dimos/core/global_config.py
+++ b/dimos/core/global_config.py
@@ -121,7 +121,7 @@ class GlobalConfig(BaseSettings):
     dimsim_headless: bool = True
     local_relay: bool = False
     relay_url: str | None = None
-    dimos_cloud_url: str = "https://login.dimensional.org"
+    dimos_cloud_url: str = "https://api.dimensional.org"
     dimos_api_key: str | None = None
 
     model_config = SettingsConfigDict(

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -131,7 +131,7 @@ Config(
         dimsim_headless=True,
         local_relay=False,
         relay_url=None,
-        dimos_cloud_url='https://login.dimensional.org',
+        dimos_cloud_url='https://api.dimensional.org',
         dimos_api_key=None
     ),
     publish_interval=0,


### PR DESCRIPTION
Companion to the dimos-cloud login-domain cutover: `login.dimensional.org` becomes the Cognito Managed Login domain for the users pool (one sign-in surface for every human-facing service). The device-code endpoints are served on `api.dimensional.org/auth/*` (already live there today) and approval is `console.dimensional.org/activate` (already what the server returns as `verification_uri`).

- `dimos_cloud_url` default: `https://api.dimensional.org` (env/config override unchanged)
- logout message points at `console.dimensional.org/keys`
- docstring + configuration doc example updated

7/7 cloud CLI tests, mypy strict clean. Safe to merge before or after the cloud cutover: api.* serves `/auth/*` either way.