### PR TITLE
refactor(manip): place robot models with a base pose, not axis offsets

### DIFF
--- a/dimos/robot/manipulators/_modeling.py
+++ b/dimos/robot/manipulators/_modeling.py
@@ -16,29 +16,11 @@
 
 from __future__ import annotations
 
-import math
 from typing import TypeAlias
-
-from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
-from dimos.msgs.geometry_msgs.Quaternion import Quaternion
-from dimos.msgs.geometry_msgs.Vector3 import Vector3
 
 DegreesOfFreedom: TypeAlias = int
 JointPrefix: TypeAlias = str
 UrdfJointName: TypeAlias = str
-
-
-def base_pose(
-    x: float = 0.0,
-    y: float = 0.0,
-    z: float = 0.0,
-    pitch: float = 0.0,
-) -> PoseStamped:
-    half_pitch = pitch / 2.0
-    return PoseStamped(
-        position=Vector3(x=x, y=y, z=z),
-        orientation=Quaternion([0.0, math.sin(half_pitch), 0.0, math.cos(half_pitch)]),
-    )
 
 
 def joint_names(

--- a/dimos/robot/manipulators/a1z/config.py
+++ b/dimos/robot/manipulators/a1z/config.py
@@ -32,7 +32,6 @@ from dimos.manipulation.planning.spec.config import RobotModelConfig
 from dimos.robot.assets.model import RobotModel
 from dimos.robot.assets.source import RobotDescriptionSource
 from dimos.robot.manipulators._modeling import (
-    base_pose,
     joint_names,
 )
 
@@ -123,7 +122,6 @@ def make_a1z_model_config(
         )
     return RobotModelConfig(
         model=model,
-        base_pose=base_pose(),
         joint_names=model_joint_names,
         base_link="base_link",
         planning_groups=[

--- a/dimos/robot/manipulators/a750/config.py
+++ b/dimos/robot/manipulators/a750/config.py
@@ -26,7 +26,6 @@ from dimos.manipulation.planning.groups.models import PlanningGroupDefinition
 from dimos.manipulation.planning.spec.config import RobotModelConfig
 from dimos.robot.assets.model import RobotModel
 from dimos.robot.manipulators._modeling import (
-    base_pose,
     joint_names,
 )
 from dimos.utils.data import LfsPath
@@ -111,7 +110,6 @@ def make_a750_model_config() -> RobotModelConfig:
     model_joint_names = joint_names(dof)
     return RobotModelConfig(
         model=RobotModel.from_file(A750_MODEL_PATH, package_paths=A750_PACKAGE_PATHS),
-        base_pose=base_pose(),
         joint_names=model_joint_names,
         base_link="base_link",
         planning_groups=[

--- a/dimos/robot/manipulators/openarm/config.py
+++ b/dimos/robot/manipulators/openarm/config.py
@@ -24,7 +24,6 @@ from dimos.manipulation.planning.groups.models import PlanningGroupDefinition
 from dimos.manipulation.planning.spec.config import RobotModelConfig
 from dimos.robot.assets.model import RobotModel
 from dimos.robot.assets.source import RobotDescriptionSource
-from dimos.robot.manipulators._modeling import base_pose
 
 OPENARM_DESCRIPTION_URL = "https://github.com/enactic/openarm_description"
 OPENARM_DESCRIPTION_REF = "1fba2cbc05001f05b4514120b70130b4ac06f409"
@@ -141,7 +140,6 @@ def openarm_bimanual_model_config() -> RobotModelConfig:
     canonical_joint_names = [*openarm_urdf_joints("left"), *openarm_urdf_joints("right")]
     return RobotModelConfig(
         model=OPENARM_BIMANUAL_MODEL,
-        base_pose=base_pose(),
         joint_names=canonical_joint_names,
         base_link="openarm_body_link0",
         planning_groups=[

--- a/dimos/robot/manipulators/openyam/config.py
+++ b/dimos/robot/manipulators/openyam/config.py
@@ -27,7 +27,6 @@ from dimos.manipulation.planning.groups.models import PlanningGroupDefinition
 from dimos.manipulation.planning.spec.config import RobotModelConfig
 from dimos.robot.assets.model import RobotModel
 from dimos.robot.manipulators._modeling import (
-    base_pose,
     joint_names,
 )
 from dimos.utils.data import LfsPath
@@ -81,7 +80,6 @@ def make_openyam_model_config(
     model_joint_names = joint_names(OPENYAM_DOF, prefix="yam_joint")
     return RobotModelConfig(
         model=RobotModel.from_file(OPENYAM_MODEL_PATH, package_paths=OPENYAM_PACKAGE_PATHS),
-        base_pose=base_pose(),
         joint_names=model_joint_names,
         base_link="yam_base_link",
         planning_groups=[

--- a/dimos/robot/manipulators/piper/config.py
+++ b/dimos/robot/manipulators/piper/config.py
@@ -26,7 +26,6 @@ from dimos.manipulation.planning.groups.models import PlanningGroupDefinition
 from dimos.manipulation.planning.spec.config import RobotModelConfig
 from dimos.robot.assets.model import RobotModel
 from dimos.robot.manipulators._modeling import (
-    base_pose,
     joint_names,
 )
 from dimos.utils.data import LfsPath
@@ -142,7 +141,6 @@ def make_piper_model_config(
     model_home_joints = list(home_joints) if home_joints is not None else list(PIPER_HOME_JOINTS)
     return RobotModelConfig(
         model=RobotModel.from_file(PIPER_MODEL_PATH, package_paths=PIPER_PACKAGE_PATHS),
-        base_pose=base_pose(),
         joint_names=model_joint_names,
         base_link="base_link",
         planning_groups=[

--- a/dimos/robot/manipulators/xarm/blueprints/perception.py
+++ b/dimos/robot/manipulators/xarm/blueprints/perception.py
@@ -24,6 +24,7 @@ from dimos.manipulation.grasping.heuristic_grasp import HeuristicGraspModule
 from dimos.manipulation.manipulation_module import ManipulationModule
 from dimos.manipulation.manipulation_skills import ManipulationSkills
 from dimos.manipulation.pick_and_place_module import PickAndPlaceModule
+from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
 from dimos.msgs.geometry_msgs.Quaternion import Quaternion
 from dimos.msgs.geometry_msgs.Transform import Transform
 from dimos.msgs.geometry_msgs.Vector3 import Vector3
@@ -40,7 +41,10 @@ xarm_perception = autoconnect(
         model=make_xarm7_model_config(
             add_gripper=True,
             gripper_hardware_id="arm",
-            pitch=math.radians(45),
+            base_pose=PoseStamped(
+                frame_id="world",
+                orientation=Quaternion.from_euler(Vector3(0.0, math.radians(45), 0.0)),
+            ),
             tf_extra_links=["link7"],
         ),
         planning_timeout=10.0,

--- a/dimos/robot/manipulators/xarm/config.py
+++ b/dimos/robot/manipulators/xarm/config.py
@@ -28,12 +28,11 @@ from dimos.core.global_config import global_config
 from dimos.hardware.spec import JointLimits
 from dimos.manipulation.planning.groups.models import PlanningGroupDefinition
 from dimos.manipulation.planning.spec.config import RobotModelConfig
+from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
+from dimos.msgs.geometry_msgs.Vector3 import Vector3
 from dimos.robot.assets.model import RobotModel
 from dimos.robot.assets.source import RobotDescriptionSource
-from dimos.robot.manipulators._modeling import (
-    base_pose,
-    joint_names,
-)
+from dimos.robot.manipulators._modeling import joint_names
 from dimos.utils.data import LfsPath
 
 XARM_GRIPPER_COLLISION_EXCLUSIONS: list[tuple[str, str]] = [
@@ -64,12 +63,17 @@ XARM_PACKAGE_PATHS: dict[str, Path] = {"xarm_description": _XARM_REPO / "xarm_de
 XARM6_SIM_PATH = LfsPath("xarm6/scene.xml")
 XARM7_SIM_PATH = LfsPath("xarm7/scene.xml")
 XARM7_SIM_HOME = [0.0, -0.247, 0.0, 0.909, 0.0, 1.15644, 0.0]
+# The sim scene stands the arm on a pedestal: xarm7.xml mounts link_base at
+# z=0.12. Place the planning model to match, or the planner solves poses 12cm
+# below the arm it is driving and every grasp closes on air.
+XARM7_SIM_BASE_POSE = PoseStamped(frame_id="world", position=Vector3(z=0.12))
 
 
 def make_xarm7_sim_robot_config() -> RobotModelConfig:
     return make_xarm7_model_config(
         add_gripper=True,
         gripper_hardware_id="arm",
+        base_pose=XARM7_SIM_BASE_POSE,
         tf_extra_links=["link7"],
         home_joints=XARM7_SIM_HOME,
         pre_grasp_offset=0.05,
@@ -276,10 +280,7 @@ def make_xarm_model_config(
     prefix: str = "",
     add_gripper: bool = True,
     gripper_hardware_id: str | None = None,
-    x_offset: float = 0.0,
-    y_offset: float = 0.0,
-    z_offset: float = 0.0,
-    pitch: float = 0.0,
+    base_pose: PoseStamped | None = None,
     tf_extra_links: list[str] | None = None,
     home_joints: list[float] | None = None,
     pre_grasp_offset: float = 0.10,
@@ -305,7 +306,7 @@ def make_xarm_model_config(
             package_paths=XARM_PACKAGE_PATHS,
             xacro_args=xacro_args,
         ),
-        base_pose=base_pose(x_offset, y_offset, z_offset, pitch),
+        base_pose=base_pose if base_pose is not None else PoseStamped(),
         joint_names=model_joint_names,
         base_link=f"{prefix}link_base",
         planning_groups=[

--- a/dimos/robot/manipulators/xarm/test_model_config.py
+++ b/dimos/robot/manipulators/xarm/test_model_config.py
@@ -18,9 +18,12 @@ import pytest
 
 from dimos.manipulation.planning.spec.validation import validate_robot_model_config
 from dimos.robot.manipulators.xarm.config import (
+    XARM7_SIM_BASE_POSE,
+    XARM7_SIM_PATH,
     XARM_GRIPPER_COLLISION_EXCLUSIONS,
     make_dual_xarm6_model_config,
     make_xarm6_model_config,
+    make_xarm7_sim_robot_config,
 )
 
 
@@ -80,3 +83,22 @@ def test_prefixed_xarm_model_asset_uses_coordinator_facing_names() -> None:
     model = validate_robot_model_config(config)
 
     assert [joint.name for joint in model.joints if joint.type != "fixed"] == config.joint_names
+
+
+@pytest.mark.self_hosted
+def test_sim_model_stands_on_the_same_pedestal_as_the_sim_scene() -> None:
+    """The planner and MuJoCo must agree on where the arm is bolted down.
+
+    xarm7.xml mounts link_base on a pedestal. A model placed at the origin
+    instead solves every pose that far below the arm it is driving, so grasps
+    close on air with no error anywhere to explain it.
+    """
+    import re
+
+    mjcf = (XARM7_SIM_PATH.parent / "xarm7.xml").read_text()
+    match = re.search(r'<body name="link_base" pos="([\d.\- ]+)"', mjcf)
+    assert match is not None, "xarm7.xml no longer declares link_base with a pos"
+    scene_base_z = float(match.group(1).split()[2])
+
+    assert scene_base_z == XARM7_SIM_BASE_POSE.position.z
+    assert make_xarm7_sim_robot_config().base_pose == XARM7_SIM_BASE_POSE


### PR DESCRIPTION
The robot base pose generation was hacky and used scalars for x,y,z,rpy . A better approach is to set PoseStamped transform as a proper way of setting robot base pose

Verified on the sim: planning and MuJoCo TCP agree exactly, and a pick on the cup holds at readback 0.725, inside the band #3701 calibrated.

An earlier revision widened arrival in `await_gripper_settle` so a re-open of already-open jaws could not time out. Greptile was right that it regressed the release path, and it has been withdrawn.