### PR TITLE
docs: --record / --record-topics

### DIFF
--- a/docs/capabilities/navigation/relocalization.md
+++ b/docs/capabilities/navigation/relocalization.md
@@ -29,7 +29,7 @@ If `ROBOT_IP` is set in the environment or `.env`, you can omit `--robot-ip`:
 dimos run unitree-go2-memory
 ```
 
-This writes `recording_go2.db` to the repo root (`DIMOS_PROJECT_ROOT`) and records `lidar`, `odom`, and `color_image` plus the live TF tree. The recorder stamps lidar frames with the latest odom pose so `dimos map global` can reconstruct poses later- see [`Go2Memory`](/dimos/robot/unitree/go2/blueprints/smart/unitree_go2.py).
+This writes `recording_go2.db` to the repo root (`DIMOS_PROJECT_ROOT`) and records `lidar`, `odom`, and `color_image` plus the live TF tree. `dimos --record run unitree-go2` records the same streams (and every other one) to `recordings/<run-id>/memory.db` instead; see [Recording](/docs/usage/recording.md). The recorder stamps lidar frames with the latest odom pose so `dimos map global` can reconstruct poses later- see [`Go2Memory`](/dimos/robot/unitree/go2/blueprints/smart/unitree_go2.py).
 
 ### Quick validation (optional)
 

--- a/docs/platforms/quadruped/go2/index.md
+++ b/docs/platforms/quadruped/go2/index.md
@@ -14,6 +14,7 @@
 | `dimos run unitree-go2-agentic-ollama` | Agent with local Ollama models |
 | `dimos run unitree-go2-spatial` | Navigation + spatial memory |
 | `dimos run unitree-go2-detection` | Navigation + object detection |
+| `dimos --record run unitree-go2` | Navigation + record every stream to `recordings/<run-id>/memory.db` ([Recording](/docs/usage/recording.md)) |
 | `dimos run unitree-go2-memory` | Navigation + record `lidar`/`odom`/`color_image` to `.db` |
 | `dimos run unitree-go2-relocalization` | Navigation + align live scans to a saved `.pc2.lcm` premap |
 

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -17,6 +17,8 @@ dimos [GLOBAL OPTIONS] COMMAND [ARGS]
 | `--simulation` / `--no-simulation` | bool | `False` | Enable MuJoCo simulation |
 | `--replay` / `--no-replay` | bool | `False` | Use recorded replay data |
 | `--replay-db` | TEXT | `go2_bigoffice` | Replay memory SQLite database name |
+| `--record [sqlite]` | `sqlite` | off | Record every stream to `recordings/<run-id>/memory.db` ([Recording](/docs/usage/recording.md)) |
+| `--record-topics` | TEXT | `*` | Comma-separated globs on stream names to record |
 | `--new-memory` / `--no-new-memory` | bool | `False` | Clear persistent memory on start |
 | `--viewer` | `rerun\|none` | `rerun` | Visualization backend |
 | `--rerun-open` | `native\|web\|both\|none` | `native` | How to open the Rerun viewer |
@@ -91,6 +93,10 @@ dimos run unitree-go2-agentic --daemon
 
 # Replay with Rerun viewer
 dimos --replay --viewer rerun run unitree-go2
+
+# Record every stream of a run, then replay it
+dimos --record --simulation run unitree-go2
+dimos --replay --replay-db recordings/<run-id>/memory.db run unitree-go2
 
 # Replay Big Office (Zenoh is the default transport)
 dimos --transport=zenoh --dtop --replay --replay-db=go2_bigoffice run unitree-go2

--- a/docs/usage/data_streams/index.md
+++ b/docs/usage/data_streams/index.md
@@ -11,6 +11,7 @@ Dimos uses reactive streams (RxPY) to handle sensor data. This approach naturall
 | [Quality-Based Filtering](/docs/usage/data_streams/quality_filter.md) | Select highest quality frames when downsampling streams       |
 | [Temporal Alignment](/docs/usage/data_streams/temporal_alignment.md)  | Match messages from multiple sensors by timestamp             |
 | [Storage & Replay](/docs/usage/data_streams/storage_replay.md)        | Record sensor streams to disk and replay with original timing |
+| [Recording](/docs/usage/recording.md)                                 | `dimos --record`: capture every stream of a run to one memory store |
 
 ## Quick Example
 

--- a/docs/usage/recording.md
+++ b/docs/usage/recording.md
@@ -1,6 +1,6 @@
 # Recording
 
-`--record` writes every stream a blueprint publishes to one SQLite memory store, the way `rosbag record` captures a bus. Nothing to wire: each stream is tapped on the transport that carries it.
+`--record` writes every stream a blueprint publishes to one SQLite memory store. Each stream is tapped on the transport that carries it.
 
 ```bash
 dimos --record --simulation run unitree-go2
@@ -19,21 +19,48 @@ dimos --record --record-topics lidar,odom,tf run unitree-go2
 dimos --record --record-topics 'global_*' run unitree-go2
 ```
 
-No spaces, no braces. A pattern that matches no stream is an error at startup, listing the stream names the blueprint has.
+A pattern that matches no stream throws an error at startup, listing the valid stream names of the given blueprint.
 
 Streams whose type is not a dimOS message (`Any`, `dict`) are not recorded.
 
 ## Inspecting and replaying
 
+View contents of the memory by stream:
+```console
+$ dimos mem summary recordings/<run-id>/memory.db
+
+┏━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━┓
+┃ Stream         ┃  Items ┃    Hz ┃ Start (UTC)         ┃ Duration ┃       Size ┃
+┡━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━┩
+│ lidar          │     43 │   2.0 │ 2026-08-27 03:39:06 │    21.2s │   5.14 MiB │
+│ color_image    │    376 │  17.3 │ 2026-08-27 03:39:06 │    21.6s │   4.26 MiB │
+│ global_map     │      9 │   0.4 │ 2026-08-27 03:39:07 │    20.2s │   3.08 MiB │
+│ global_costmap │      9 │   0.4 │ 2026-08-27 03:39:07 │    20.2s │ 421.03 KiB │
+│ tf             │    981 │  45.2 │ 2026-08-27 03:39:06 │    21.7s │ 292.19 KiB │
+│ cmd_vel        │  1,855 │  99.7 │ 2026-08-27 03:39:07 │    18.6s │ 101.45 KiB │
+│ tele_cmd_vel   │  1,855 │  98.6 │ 2026-08-27 03:39:07 │    18.8s │ 101.45 KiB │
+│ goal           │  1,855 │  98.9 │ 2026-08-27 03:39:07 │    18.8s │  94.20 KiB │
+│ way_point      │  1,855 │  98.9 │ 2026-08-27 03:39:07 │    18.8s │  94.20 KiB │
+│ odom           │    981 │  45.2 │ 2026-08-27 03:39:06 │    21.7s │  82.39 KiB │
+│ stop_movement  │  1,855 │  98.9 │ 2026-08-27 03:39:07 │    18.7s │  16.30 KiB │
+│ camera_info    │     24 │     — │ 2026-08-27 03:38:56 │     0.0s │   8.67 KiB │
+│ nav_cmd_vel    │      3 │  32.8 │ 2026-08-27 03:39:28 │     0.1s │   168.00 B │
+│ goal_request   │      1 │     — │ 2026-08-27 03:39:28 │     0.0s │    86.00 B │
+│ path           │      2 │ 289.1 │ 2026-08-27 03:39:28 │     0.0s │    68.00 B │
+│ goal_reached   │      1 │     — │ 2026-08-27 03:39:28 │     0.0s │     9.00 B │
+├────────────────┼────────┼───────┼─────────────────────┼──────────┼────────────┤
+│ total          │ 11,705 │       │                     │          │  13.66 MiB │
+└────────────────┴────────┴───────┴─────────────────────┴──────────┴────────────┘
+```
+Replay memory from DB:
 ```bash
-dimos mem summary recordings/<run-id>/memory.db
 dimos --replay --replay-db recordings/<run-id>/memory.db run unitree-go2
 ```
 
 `--replay` swaps the robot connection for the recording; it needs `lidar`, `odom`, and `color_image`, so record all streams (the default) if you intend to replay. Poses are not stored per frame; `tf` is recorded like any other stream and `dimos map pose-fill` derives poses from it.
 
-## Behaviour
+## Behavior
 
 - Off unless `--record`; never active under `--replay`.
 - One writer thread; transport callbacks only enqueue. Queue holds 1000 messages, then drops and warns.
-- Explicit recorder modules (`unitree-go2-memory`, `unitree-go2-mid360-record`, `unitree-g1-record`) are unaffected and still record their own streams.
+- We also still have explicit recorder modules (`unitree-go2-memory`, `unitree-go2-mid360-record`, `unitree-g1-record`) that are unaffected and still record their own streams. These will be deprecated shortly. 

--- a/docs/usage/recording.md
+++ b/docs/usage/recording.md
@@ -1,0 +1,39 @@
+# Recording
+
+`--record` writes every stream a blueprint publishes to one SQLite memory store, the way `rosbag record` captures a bus. Nothing to wire: each stream is tapped on the transport that carries it.
+
+```bash
+dimos --record --simulation run unitree-go2
+dimos --record --robot-ip 192.168.123.161 run unitree-go2
+```
+
+The file lands at `recordings/<run-id>/memory.db` under the checkout (`~/.local/state/dimos/recordings/` for an installed package). `<run-id>` is the same `YYYYMMDD-HHMMSS-<blueprint>` as the `logs/` directory of that run.
+
+## Choosing streams
+
+`--record-topics` takes comma-separated globs on the stream name (the blueprint name, e.g. `lidar`, not `/lidar`). Default `*`.
+
+```bash
+dimos --record --record-topics color_image run unitree-go2
+dimos --record --record-topics lidar,odom,tf run unitree-go2
+dimos --record --record-topics 'global_*' run unitree-go2
+```
+
+No spaces, no braces. A pattern that matches no stream is an error at startup, listing the stream names the blueprint has.
+
+Streams whose type is not a dimOS message (`Any`, `dict`) are not recorded.
+
+## Inspecting and replaying
+
+```bash
+dimos mem summary recordings/<run-id>/memory.db
+dimos --replay --replay-db recordings/<run-id>/memory.db run unitree-go2
+```
+
+`--replay` swaps the robot connection for the recording; it needs `lidar`, `odom`, and `color_image`, so record all streams (the default) if you intend to replay. Poses are not stored per frame; `tf` is recorded like any other stream and `dimos map pose-fill` derives poses from it.
+
+## Behaviour
+
+- Off unless `--record`; never active under `--replay`.
+- One writer thread; transport callbacks only enqueue. Queue holds 1000 messages, then drops and warns.
+- Explicit recorder modules (`unitree-go2-memory`, `unitree-go2-mid360-record`, `unitree-g1-record`) are unaffected and still record their own streams.

--- a/docs/usage/recording.md
+++ b/docs/usage/recording.md
@@ -57,7 +57,7 @@ Replay memory from DB:
 dimos --replay --replay-db recordings/<run-id>/memory.db run unitree-go2
 ```
 
-`--replay` swaps the robot connection for the recording; it needs `lidar`, `odom`, and `color_image`, so record all streams (the default) if you intend to replay. Poses are not stored per frame; `tf` is recorded like any other stream and `dimos map pose-fill` derives poses from it.
+`--replay` swaps the robot connection for the recording; it needs `lidar`, `odom`, and `color_image`, so record all streams (the default) if you intend to replay. Poses are not stored per frame; `tf` is recorded like any other stream and `dimos map global` uses it to register clouds. `dimos map pose-fill` instead derives poses from `odom` by default.
 
 ## Behavior
 


### PR DESCRIPTION
## Summary

Docs for `--record` / `--record-topics` (#3710).

- `docs/usage/recording.md` (new): what `--record` writes and where, choosing streams with `--record-topics`, `dimos mem summary` + `--replay-db` on the result, behaviour notes.
- `docs/usage/cli.md`: the two flags in the global options table; record → replay example.
- Links from the data-streams index, the Go2 blueprint table, and the relocalization guide's record step.

## Test plan

- [x] pre-commit doclinks / em-dash hooks pass on the changed files
