### PR TITLE
fix(manip): restore perception obstacle wiring

### DIFF
--- a/dimos/manipulation/conftest.py
+++ b/dimos/manipulation/conftest.py
@@ -79,6 +79,7 @@ def module_factory(mocker: MockerFixture) -> Iterator[ModuleFactory]:
         # Nulling a port drops it from Module.inputs, so start() does not bind
         # handle_voxel_map and no transport is needed. Same reason as above.
         cast("Any", module).voxel_map = None
+        cast("Any", module).objects = None
         mocker.patch.object(module, "_initialize_planning")
         module.start()
         return module

--- a/dimos/manipulation/manipulation_module.py
+++ b/dimos/manipulation/manipulation_module.py
@@ -107,6 +107,7 @@ from dimos.msgs.geometry_msgs.Vector3 import Vector3
 from dimos.msgs.sensor_msgs.JointState import JointState
 from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
 from dimos.msgs.tf2_msgs.TFMessage import TFMessage
+from dimos.perception.experimental.object import Object as DetObject
 from dimos.utils.logging_config import setup_logger
 
 logger = setup_logger()
@@ -189,6 +190,7 @@ class ManipulationModule(Module):
     # Input: occupied cells of a mapped workspace, in the planning frame. Each
     # message is a complete map, so it replaces the obstacle rather than adding.
     voxel_map: In[PointCloud2]
+    objects: In[list[DetObject]]
     tf: Out[TFMessage]
 
     def __init__(self, **kwargs: Any) -> None:
@@ -291,6 +293,7 @@ class ManipulationModule(Module):
             logger.info("Floor obstacle added", z=fz)
 
         self._world_monitor.start_state_monitor()
+        self._world_monitor.start_obstacle_monitor()
 
         if self._world_monitor.visualization is not None:
             self._world_monitor.start_visualization_thread(rate_hz=10.0)
@@ -1315,6 +1318,27 @@ class ManipulationModule(Module):
     def world_monitor(self) -> WorldMonitor | None:
         """Access the world monitor for advanced obstacle/world operations."""
         return self._world_monitor
+
+    async def handle_objects(self, objects: list[DetObject]) -> None:
+        """Cache the latest perception objects for an explicit obstacle refresh."""
+        if self._world_monitor is not None:
+            self._world_monitor.on_objects(objects)
+
+    @rpc
+    def refresh_obstacles(self, min_duration: float = 0.0) -> int:
+        """Sync cached perception objects into the planning world."""
+        if self._world_monitor is None:
+            return 0
+        return len(self._world_monitor.refresh_obstacles(min_duration))
+
+    @rpc
+    def get_obstacles(self) -> dict[str, PoseStamped]:
+        """Return planning-world obstacle poses keyed by obstacle name."""
+        if self._world_monitor is None:
+            return {}
+        return {
+            obstacle.name: obstacle.pose for obstacle in self._world_monitor.world.get_obstacles()
+        }
 
     @rpc
     def add_obstacle(

--- a/dimos/manipulation/test_manipulation_unit.py
+++ b/dimos/manipulation/test_manipulation_unit.py
@@ -46,6 +46,7 @@ from dimos.manipulation.planning.spec.enums import IKStatus, ObstacleType, Plann
 from dimos.manipulation.planning.spec.models import (
     GeneratedPlan,
     IKResult,
+    Obstacle,
     PlanningResult,
 )
 from dimos.manipulation.planning.trajectory_generator.config import (
@@ -280,6 +281,23 @@ class TestVoxelMap:
 
 
 class TestObstacleUpdates:
+    async def test_perception_objects_are_refreshable_and_queryable(self, module_factory) -> None:
+        module = module_factory()
+        module._world_monitor = MagicMock(spec=WorldMonitor)
+        detected = MagicMock()
+        pose = PoseStamped(position=Vector3(0.4, 0.1, 0.2))
+        obstacle = Obstacle(name="object-1", pose=pose, obstacle_type=ObstacleType.BOX)
+        module._world_monitor.refresh_obstacles.return_value = [{"object_id": "object-1"}]
+        module._world_monitor.world.get_obstacles.return_value = [obstacle]
+
+        await module.handle_objects([detected])
+        count = module.refresh_obstacles()
+        obstacles = module.get_obstacles()
+
+        module._world_monitor.on_objects.assert_called_once_with([detected])
+        assert count == 1
+        assert obstacles == {"object-1": pose}
+
     def test_complete_update_forwards_new_obstacle_value(self, module_factory) -> None:
         module = module_factory()
         module._world_monitor = MagicMock(spec=WorldMonitor)
@@ -464,6 +482,7 @@ class TestPlanningInitialization:
         module = ManipulationModule(model=robot_config)
         module.coordinator_joint_state = None
         module.voxel_map = None
+        module.objects = None
         initialize_planning = mocker.patch.object(module, "_initialize_planning")
         initialize_execution = mocker.patch.object(module, "_initialize_execution")
 
@@ -475,6 +494,7 @@ class TestPlanningInitialization:
         module = ManipulationModule(model=robot_config)
         module.coordinator_joint_state = None
         module.voxel_map = None
+        module.objects = None
         initialize_planning = mocker.patch.object(module, "_initialize_planning")
         initialize_execution = mocker.patch.object(module, "_initialize_execution")
 
@@ -496,6 +516,7 @@ class TestPlanningInitialization:
         module._control_coordinator = _control_coordinator()
         module.coordinator_joint_state = None
         module.voxel_map = None
+        module.objects = None
         observed_status: list[ExecutionStatus] = []
 
         def observe_state() -> None:


### PR DESCRIPTION
ManipulationModule lost the only consumer of perception's objects stream during the module swap, leaving the planner collision-blind to detected objects. This restores the input, caches detections in the obstacle monitor, and adds explicit refresh/query RPCs so the expensive world sync stays off the shared transport thread.\n\nSurfaced by sim E2E verification.\n\nTest: .venv/bin/pytest dimos/manipulation/test_manipulation_unit.py -q (37 passed)