### PR TITLE
fix(perception): capture transform before inference

### DIFF
--- a/dimos/perception/experimental/object_scene_registration.py
+++ b/dimos/perception/experimental/object_scene_registration.py
@@ -52,6 +52,7 @@ class ObjectSceneRegistrationConfig(ModuleConfig):
     prompt_mode: YoloePromptMode = YoloePromptMode.LRPC
     detector_backend: Literal["yoloe", "owlv2", "moondream"] = "yoloe"
     segmentation_backend: Literal["yolo", "edgetam"] = "yolo"
+    detector_confidence: float = 0.6
     detect_on_request: bool = False
     distance_threshold: float = 0.2
     min_detections_for_permanent: int = 6
@@ -92,7 +93,7 @@ class ObjectSceneRegistrationModule(Module):
         self._prompt_mode = self.config.prompt_mode
         self._detector_backend = self.config.detector_backend
         self._segmentation_backend = self.config.segmentation_backend
-        self._detector_confidence = 0.6
+        self._detector_confidence = self.config.detector_confidence
         self._detect_on_request = self.config.detect_on_request
         self._object_db = ObjectDB(
             distance_threshold=self.config.distance_threshold,

--- a/dimos/perception/experimental/object_scene_registration.py
+++ b/dimos/perception/experimental/object_scene_registration.py
@@ -390,6 +390,16 @@ class ObjectSceneRegistrationModule(Module):
             data=depth_cv, format=ImageFormat.DEPTH, frame_id=depth_msg.frame_id, ts=depth_msg.ts
         )
 
+        camera_transform = None
+        if self._target_frame != color_image.frame_id:
+            camera_transform = self.tfbuffer.get(
+                self._target_frame,
+                color_image.frame_id,
+                color_image.ts,
+                0.1,
+                forward_tolerance=0.2,
+            )
+
         if self._detector_backend == "owlv2":
             if not self._text_prompts:
                 detections_2d = ImageDetections2D(color_image, [])
@@ -422,31 +432,24 @@ class ObjectSceneRegistrationModule(Module):
         self.detections_2d.publish(detections_2d_msg)
 
         # Process 3D detections
-        return self._process_3d_detections(detections_2d, color_image, depth_image)
+        return self._process_3d_detections(
+            detections_2d, color_image, depth_image, camera_transform
+        )
 
     def _process_3d_detections(
         self,
         detections_2d: ImageDetections2D[Any],
         color_image: Image,
         depth_image: Image,
+        camera_transform: Transform | None,
     ) -> list[DetObject]:
         """Convert 2D detections to 3D and publish."""
         if self._camera_info is None:
             return []
 
-        # Look up transform from camera frame to target frame (e.g., map)
-        camera_transform = None
-        if self._target_frame != color_image.frame_id:
-            camera_transform = self.tfbuffer.get(
-                self._target_frame,
-                color_image.frame_id,
-                color_image.ts,
-                0.1,
-                forward_tolerance=0.2,
-            )
-            if camera_transform is None:
-                logger.info("Failed to lookup transform from camera frame to target frame")
-                return []
+        if self._target_frame != color_image.frame_id and camera_transform is None:
+            logger.warning("Failed to lookup transform from camera frame to target frame")
+            return []
 
         # Cache depth and transform together, only after the lookup succeeds.
         self._latest_scene_snapshot = (depth_image, camera_transform)

--- a/dimos/perception/experimental/test_object_scene_registration_temporal.py
+++ b/dimos/perception/experimental/test_object_scene_registration_temporal.py
@@ -149,7 +149,7 @@ def test_full_scene_pointcloud_uses_one_coherent_scene_snapshot(
 
 
 def test_owlv2_queries_configured_prompts(monkeypatch: Any) -> None:
-    module = ObjectSceneRegistrationModule(detector_backend="owlv2")
+    module = ObjectSceneRegistrationModule(detector_backend="owlv2", detector_confidence=0.07)
     module._camera_info = MagicMock()
     module._detector = MagicMock()
     module._text_prompts = ["mug"]
@@ -167,7 +167,7 @@ def test_owlv2_queries_configured_prompts(monkeypatch: Any) -> None:
 
     module._process_images(color, _image(4.0))
 
-    module._detector.query_detections.assert_called_once_with(color, ["mug"], threshold=0.6)
+    module._detector.query_detections.assert_called_once_with(color, ["mug"], threshold=0.07)
     process_3d.assert_called_once_with(detections, color, ANY)
     module.stop()
 

--- a/dimos/perception/experimental/test_object_scene_registration_temporal.py
+++ b/dimos/perception/experimental/test_object_scene_registration_temporal.py
@@ -61,32 +61,53 @@ def module() -> Iterator[ObjectSceneRegistrationModule]:
     module.stop()
 
 
-def test_temporal_tf_lookup_uses_bounded_image_timestamp(
+def test_transform_is_captured_before_slow_detector(
     monkeypatch: Any, module: ObjectSceneRegistrationModule
 ) -> None:
-    tf = _FakeTF(MagicMock())
-    module._tf = tf  # type: ignore[assignment]
-    monkeypatch.setattr(
-        "dimos.perception.experimental.object_scene_registration.Object.from_2d_to_list",
-        lambda **_: [],
-    )
+    now = [0.0]
+    transform = MagicMock(name="fresh_transform")
 
-    ObjectSceneRegistrationModule._process_3d_detections(
-        module,
-        MagicMock(spec=ImageDetections2D),
-        _image(12.5),
-        _image(12.5),
+    class _ExpiringTF(_FakeTF):
+        def get(self, *args: Any, **kwargs: Any) -> Any:
+            super().get(*args, **kwargs)
+            return transform if now[0] <= 10.0 else None
+
+    tf = _ExpiringTF(None)
+    module._tf = tf  # type: ignore[assignment]
+    module._detector_backend = "owlv2"
+    module._detector = MagicMock()
+    module._text_prompts = ["cup"]
+    module.detections_2d = MagicMock()
+    color = Image(
+        data=np.zeros((2, 2, 3), dtype=np.uint8),
+        format=ImageFormat.BGR,
+        frame_id="camera",
+        ts=12.5,
     )
+    detections = ImageDetections2D(color, [])
+
+    def slow_detection(*_args: Any, **_kwargs: Any) -> ImageDetections2D:
+        now[0] = 11.0
+        return detections
+
+    module._detector.query_detections.side_effect = slow_detection
+    process_3d = MagicMock()
+    monkeypatch.setattr(module, "_process_3d_detections", process_3d)
+
+    module._process_images(color, _image(12.5))
 
     assert tf.calls == [(("map", "camera", 12.5, 0.1), {"forward_tolerance": 0.2})]
+    process_3d.assert_called_once_with(detections, color, ANY, transform)
 
 
 def test_failed_lookup_does_not_retry_without_time_or_replace_coherent_cache(
     monkeypatch: Any, module: ObjectSceneRegistrationModule
 ) -> None:
     old_transform = MagicMock(name="old_transform")
-    tf = _FakeTF(old_transform)
-    module._tf = tf  # type: ignore[assignment]
+    warning = MagicMock()
+    monkeypatch.setattr(
+        "dimos.perception.experimental.object_scene_registration.logger.warning", warning
+    )
     monkeypatch.setattr(
         "dimos.perception.experimental.object_scene_registration.Object.from_2d_to_list",
         lambda **_: [],
@@ -98,19 +119,19 @@ def test_failed_lookup_does_not_retry_without_time_or_replace_coherent_cache(
         MagicMock(spec=ImageDetections2D),
         old_depth,
         old_depth,
+        old_transform,
     )
-    tf.result = None
     new_depth = _image(2.0)
     ObjectSceneRegistrationModule._process_3d_detections(
         module,
         MagicMock(spec=ImageDetections2D),
         new_depth,
         new_depth,
+        None,
     )
 
-    assert len(tf.calls) == 2
-    assert tf.calls[1] == (("map", "camera", 2.0, 0.1), {"forward_tolerance": 0.2})
     assert module._latest_scene_snapshot == (old_depth, old_transform)
+    warning.assert_called_once_with("Failed to lookup transform from camera frame to target frame")
 
 
 def test_full_scene_pointcloud_uses_one_coherent_scene_snapshot(
@@ -149,7 +170,9 @@ def test_full_scene_pointcloud_uses_one_coherent_scene_snapshot(
 
 
 def test_owlv2_queries_configured_prompts(monkeypatch: Any) -> None:
-    module = ObjectSceneRegistrationModule(detector_backend="owlv2", detector_confidence=0.07)
+    module = ObjectSceneRegistrationModule(
+        target_frame="camera", detector_backend="owlv2", detector_confidence=0.07
+    )
     module._camera_info = MagicMock()
     module._detector = MagicMock()
     module._text_prompts = ["mug"]
@@ -168,12 +191,12 @@ def test_owlv2_queries_configured_prompts(monkeypatch: Any) -> None:
     module._process_images(color, _image(4.0))
 
     module._detector.query_detections.assert_called_once_with(color, ["mug"], threshold=0.07)
-    process_3d.assert_called_once_with(detections, color, ANY)
+    process_3d.assert_called_once_with(detections, color, ANY, None)
     module.stop()
 
 
 def test_moondream_queries_each_configured_prompt(monkeypatch: Any) -> None:
-    module = ObjectSceneRegistrationModule(detector_backend="moondream")
+    module = ObjectSceneRegistrationModule(target_frame="camera", detector_backend="moondream")
     module._camera_info = MagicMock()
     module._detector = MagicMock()
     module._text_prompts = ["cup", "bottle"]
@@ -207,7 +230,7 @@ def test_moondream_queries_each_configured_prompt(monkeypatch: Any) -> None:
 
 
 def test_edgetam_refines_detector_output(monkeypatch: Any) -> None:
-    module = ObjectSceneRegistrationModule(segmentation_backend="edgetam")
+    module = ObjectSceneRegistrationModule(target_frame="camera", segmentation_backend="edgetam")
     module._camera_info = MagicMock()
     color = Image(
         data=np.zeros((2, 2, 3), dtype=np.uint8),
@@ -228,7 +251,7 @@ def test_edgetam_refines_detector_output(monkeypatch: Any) -> None:
     module._process_images(color, _image(4.0))
 
     module._segmenter.segment.assert_called_once_with(raw_detections)
-    process_3d.assert_called_once_with(segmented_detections, color, ANY)
+    process_3d.assert_called_once_with(segmented_detections, color, ANY, None)
     module.stop()
 
 
@@ -309,6 +332,7 @@ def test_scan_output_includes_pending_objects(monkeypatch: Any) -> None:
         MagicMock(spec=ImageDetections2D),
         _image(4.0),
         _image(4.0),
+        None,
     )
 
     assert observed == [pending]
@@ -320,6 +344,7 @@ def test_scan_output_includes_pending_objects(monkeypatch: Any) -> None:
         MagicMock(spec=ImageDetections2D),
         _image(5.0),
         _image(5.0),
+        None,
     )
 
     assert observed == []


### PR DESCRIPTION
ObjectSceneRegistration looked up the camera transform only after detector inference. On CPU the detector takes about 11 seconds while the TF buffer retains about 10 seconds, so valid 3D detections were dropped.

This captures the frame transform before inference and carries it into 3D registration. 