### PR TITLE
feat(perception): re-identify tracklets a tracker lost

### DIFF
--- a/dimos/perception/detection/reid/test_tracklet_reid.py
+++ b/dimos/perception/detection/reid/test_tracklet_reid.py
@@ -1,0 +1,456 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from dimos.perception.detection.reid.tracklet_reid import (
+    Merge,
+    OnlineAssociator,
+    OnlinePolicy,
+    ReidPolicy,
+    Tracklet,
+    connected,
+    find_merges,
+    group_similarity,
+)
+
+
+def views(direction: tuple[float, float], n: int = 10, jitter: float = 0.02) -> np.ndarray:
+    """``n`` unit vectors clustered around one direction in 2-D embedding space."""
+    rng = np.random.default_rng(0)
+    base = np.asarray(direction, float)
+    raw = base + rng.normal(0.0, jitter, size=(n, 2))
+    return raw / np.linalg.norm(raw, axis=1, keepdims=True)
+
+
+def tracklet(key, t0, t1, xy=(0.0, 0.0), look=(1.0, 0.0), n=10, label="chair") -> Tracklet:
+    return Tracklet(
+        key=key,
+        t_start=t0,
+        t_end=t1,
+        positions=np.array([[xy[0], xy[1], 0.0]] * n, float),
+        embeddings=views(look, n=n),
+        label=label,
+    )
+
+
+class TestGeometryVetoesAppearance:
+    """Two chairs of one model score near-perfect, correctly. Only where and
+    when they were separates them, so no score overrides those checks."""
+
+    def test_two_things_seen_at_once_never_merge(self):
+        a = tracklet("a", 0.0, 10.0, xy=(0.0, 0.0))
+        b = tracklet("b", 5.0, 15.0, xy=(0.2, 0.0))  # identical look, overlapping time
+
+        merges, report = find_merges([a, b])
+
+        assert merges == []
+        assert report.rejected == {"time_overlap": 1}
+
+    def test_identical_things_far_apart_never_merge(self):
+        a = tracklet("a", 0.0, 10.0, xy=(0.0, 0.0))
+        b = tracklet("b", 20.0, 30.0, xy=(50.0, 0.0))
+
+        merges, report = find_merges([a, b], ReidPolicy(max_move_m=2.0))
+
+        assert merges == []
+        assert report.rejected == {"too_far": 1}
+
+    def test_the_same_thing_seen_again_nearby_merges(self):
+        a = tracklet("a", 0.0, 10.0, xy=(0.0, 0.0))
+        b = tracklet("b", 20.0, 30.0, xy=(0.5, 0.0))
+
+        merges, _ = find_merges([a, b])
+
+        assert len(merges) == 1
+        assert merges[0].keys == ("a", "b")
+        assert merges[0].gap_s == 10.0
+        assert merges[0].distance_m is not None
+
+
+class TestAThingIsAllowedToHaveMoved:
+    """A fixed radius refuses every person who walked away and came back."""
+
+    def test_a_walk_within_reach_of_the_gap_merges(self):
+        a = tracklet("a", 0.0, 10.0, xy=(0.0, 0.0), label="person")
+        b = tracklet("b", 40.0, 50.0, xy=(6.0, 0.0), label="person")
+
+        # 30 s at 1.5 m/s reaches 47 m, capped to 8 m; 6 m is inside it.
+        merges, _ = find_merges([a, b], ReidPolicy(max_move_m=2.0, max_speed_mps=1.5))
+
+        assert len(merges) == 1
+        assert merges[0].gap_s == 30.0
+
+    def test_the_allowance_stops_growing_at_the_ceiling(self):
+        """A budget that grows without limit stops being a constraint."""
+        a = tracklet("a", 0.0, 10.0, xy=(0.0, 0.0))
+        b = tracklet("b", 300.0, 310.0, xy=(30.0, 0.0))
+
+        # 290 s of walking reaches 437 m, further than any room.
+        merges, report = find_merges(
+            [a, b], ReidPolicy(max_move_m=2.0, max_speed_mps=1.5, max_reach_m=8.0)
+        )
+
+        assert merges == []
+        assert report.rejected == {"too_far": 1}
+
+    def test_a_walk_beyond_reach_of_the_gap_does_not(self):
+        a = tracklet("a", 0.0, 10.0, xy=(0.0, 0.0), label="person")
+        b = tracklet("b", 12.0, 22.0, xy=(20.0, 0.0), label="person")
+
+        # 2 s reaches 5 m. Twenty metres in two seconds is not one person.
+        merges, report = find_merges([a, b], ReidPolicy(max_move_m=2.0, max_speed_mps=1.5))
+
+        assert merges == []
+        assert report.rejected == {"too_far": 1}
+
+    def test_zero_speed_restores_a_fixed_radius(self):
+        a = tracklet("a", 0.0, 10.0, xy=(0.0, 0.0))
+        b = tracklet("b", 40.0, 50.0, xy=(20.0, 0.0))
+
+        merges, report = find_merges([a, b], ReidPolicy(max_move_m=2.0, max_speed_mps=0.0))
+
+        assert merges == []
+        assert report.rejected == {"too_far": 1}
+
+
+def walk(start: float, stop: float, n: int = 10) -> np.ndarray:
+    """A run that moves from ``start`` to ``stop`` along x, oldest row first."""
+    return np.array([[x, 0.0, 0.0] for x in np.linspace(start, stop, n)], float)
+
+
+class TestTheBudgetIsSpentOnTheGap:
+    """The allowance is what the gap permits, so it is measured across the gap:
+    where the earlier run ended, where the later one resumed. A whole-run mean
+    answers a different question and gets both directions wrong."""
+
+    def test_movement_inside_a_run_is_not_charged_to_the_gap(self):
+        a = Tracklet("a", 0.0, 10.0, positions=walk(0.0, 14.0), embeddings=views((1.0, 0.0)))
+        b = Tracklet(
+            "b",
+            12.0,
+            22.0,
+            positions=np.array([[14.0, 0.0, 0.0]] * 10),
+            embeddings=views((1.0, 0.0)),
+        )
+
+        # a ends at 14 m and b resumes at 14 m: nothing crossed the gap. The
+        # whole-run means are 7 m apart, which 2 s of budget would have refused.
+        merges, _ = find_merges([a, b], ReidPolicy(max_move_m=2.0, max_speed_mps=1.5))
+
+        assert len(merges) == 1
+        assert merges[0].distance_m == 0.0
+
+    def test_a_jump_across_the_gap_is_refused_though_the_runs_average_alike(self):
+        a = Tracklet("a", 0.0, 10.0, positions=walk(0.0, 20.0), embeddings=views((1.0, 0.0)))
+        b = Tracklet("b", 12.0, 22.0, positions=walk(0.0, 20.0), embeddings=views((1.0, 0.0)))
+
+        # Both runs average to 10 m, so their means coincide -- but a ended at
+        # 20 m and b resumed at 0 m. Twenty metres in two seconds is not one thing.
+        merges, report = find_merges([a, b], ReidPolicy(max_move_m=2.0, max_speed_mps=1.5))
+
+        assert merges == []
+        assert report.rejected == {"too_far": 1}
+
+
+class TestAppearanceStillHasToAgree:
+    def test_a_different_looking_thing_nearby_does_not_merge(self):
+        a = tracklet("a", 0.0, 10.0, xy=(0.0, 0.0), look=(1.0, 0.0))
+        b = tracklet("b", 20.0, 30.0, xy=(0.5, 0.0), look=(0.0, 1.0))
+
+        merges, report = find_merges([a, b])
+
+        assert merges == []
+        assert report.rejected == {"below_threshold": 1}
+
+
+class TestEvidenceHasToBeEnough:
+    def test_a_tracklet_with_too_few_views_is_refused_not_guessed(self):
+        a = tracklet("a", 0.0, 10.0, n=2)
+        b = tracklet("b", 20.0, 30.0, n=20)
+
+        merges, report = find_merges([a, b], ReidPolicy(min_views=5))
+
+        assert merges == []
+        assert report.rejected == {"too_few_views": 1}
+
+    def test_a_tracklet_with_no_position_is_refused_by_default(self):
+        a = Tracklet("a", 0.0, 10.0, positions=None, embeddings=views((1.0, 0.0)))
+        b = tracklet("b", 20.0, 30.0)
+
+        merges, report = find_merges([a, b])
+
+        # Nothing vetoes a sighting that could be anywhere.
+        assert merges == []
+        assert report.rejected == {"no_position": 1}
+
+    def test_positionless_merging_is_available_when_asked_for(self):
+        a = Tracklet("a", 0.0, 10.0, positions=None, embeddings=views((1.0, 0.0)))
+        b = tracklet("b", 20.0, 30.0)
+
+        merges, _ = find_merges([a, b], ReidPolicy(merge_without_position=True))
+
+        assert len(merges) == 1
+        assert merges[0].distance_m is None
+
+
+class TestTheReportSaysWhyNothingMerged:
+    """Zero merges from bad input and from good input look alike."""
+
+    def test_every_rejection_is_counted_by_reason(self):
+        far = tracklet("far", 20.0, 30.0, xy=(50.0, 0.0))
+        overlapping = tracklet("over", 5.0, 15.0)
+        base = tracklet("base", 0.0, 10.0)
+
+        _, report = find_merges([base, overlapping, far])
+
+        assert sum(report.rejected.values()) == 3
+        assert "time_overlap" in report.summary()
+
+
+class TestAGroupIsCheckedAsAWhole:
+    """Every pair in a chain can pass and the chain still be wrong: a-b and b-c
+    both in range puts a and c twice as far."""
+
+    def test_the_link_that_overruns_is_refused_not_the_whole_group(self):
+        chain = [
+            tracklet("a", 0.0, 10.0, xy=(0.0, 0.0)),
+            tracklet("b", 20.0, 30.0, xy=(1.8, 0.0)),
+            tracklet("c", 40.0, 50.0, xy=(3.6, 0.0)),
+        ]
+        merges = [Merge(("a", "b"), 0.99, 1.8, 10.0), Merge(("b", "c"), 0.90, 1.8, 10.0)]
+
+        # Unchecked, the chain closes into one group spanning 3.6 m.
+        assert list(connected(merges)) == [frozenset({"a", "b", "c"})]
+
+        # Checked, the stronger link is taken and only the one that would
+        # overrun is refused. Dropping the whole group instead cost several
+        # hundred correct merges on real data.
+        groups = sorted(connected(merges, chain, ReidPolicy(max_spread_m=2.0)), key=sorted)
+        assert groups == [frozenset({"a", "b"}), frozenset({"c"})]
+
+    def test_a_tight_chain_survives(self):
+        chain = [
+            tracklet("a", 0.0, 10.0, xy=(0.0, 0.0)),
+            tracklet("b", 20.0, 30.0, xy=(0.3, 0.0)),
+            tracklet("c", 40.0, 50.0, xy=(0.6, 0.0)),
+        ]
+        merges = [Merge(("a", "b"), 0.95, 0.3, 10.0), Merge(("b", "c"), 0.95, 0.3, 10.0)]
+
+        groups = list(connected(merges, chain, ReidPolicy(max_spread_m=2.0)))
+
+        assert groups == [frozenset({"a", "b", "c"})]
+
+
+class TestGroupingIsAWeakerClaim:
+    def test_chained_merges_close_into_one_group(self):
+        groups = list(
+            connected([Merge(("a", "b"), 0.9, 1.0, 5.0), Merge(("b", "c"), 0.9, 1.0, 5.0)])
+        )
+
+        assert groups == [frozenset({"a", "b", "c"})]
+
+    def test_unrelated_merges_stay_separate(self):
+        groups = list(
+            connected([Merge(("a", "b"), 0.9, 1.0, 5.0), Merge(("c", "d"), 0.9, 1.0, 5.0)])
+        )
+
+        assert sorted(groups, key=sorted) == [frozenset({"a", "b"}), frozenset({"c", "d"})]
+
+
+class TestSimilarityAggregation:
+    def test_the_best_fraction_ignores_the_worst_pairs(self):
+        a = np.array([[1.0, 0.0], [0.0, 1.0]])
+        b = np.array([[1.0, 0.0], [0.0, 1.0]])
+
+        # Pairs are 1, 0, 0, 1. The best half average to 1; all four average
+        # to 0.5, which would hide a real match behind unhelpful views.
+        assert group_similarity(a, b, top_frac=0.5) == 1.0
+        assert group_similarity(a, b, top_frac=1.0) == 0.5
+
+    def test_the_fraction_does_not_degenerate_on_small_tracklets(self):
+        """A count would: five views each is 25 pairs, and the best 20 is a mean."""
+        a = np.eye(5)
+        b = np.eye(5)
+
+        # Orthogonal views: every pair scores 0 except the five matching ones.
+        assert group_similarity(a, b, top_frac=0.2) == 1.0
+        assert group_similarity(a, b, top_frac=0.8) < 0.3
+
+
+class TestAGroupIsHeldToTheVetoItsPairsWere:
+    """A group asserts sameness about every pair inside it, including pairs no
+    merge ever proposed. The instant-overlap veto has no exception for those."""
+
+    def test_a_group_never_holds_two_things_seen_at_once(self):
+        chain = [
+            tracklet("a", 0.0, 10.0, xy=(0.0, 0.0)),
+            tracklet("b", 20.0, 30.0, xy=(0.3, 0.0)),
+            tracklet("c", 5.0, 15.0, xy=(0.6, 0.0)),  # overlaps a, disjoint from b
+        ]
+        # Both links are legal and the group is tight enough to pass spread.
+        merges = [Merge(("a", "b"), 0.99, 0.3, 10.0), Merge(("b", "c"), 0.90, 0.3, 10.0)]
+
+        groups = sorted(connected(merges, chain, ReidPolicy()), key=sorted)
+
+        assert groups == [frozenset({"a", "b"}), frozenset({"c"})]
+
+    def test_grouping_without_the_tracklets_it_checks_is_refused(self):
+        """Half the keys checked reads from outside exactly like all of them."""
+        merges = [Merge(("a", "b"), 0.9, 1.0, 5.0)]
+
+        with pytest.raises(ValueError, match="no tracklet given"):
+            list(connected(merges, [tracklet("a", 0.0, 10.0)]))
+
+
+class TestBadInputIsRefusedNotMerged:
+    def test_un_normalised_embeddings_are_refused_not_rescaled(self):
+        """Scale does not lower a cosine, it inflates one: orthogonal tracklets
+        scored 3.29 and merged."""
+        a = tracklet("a", 0.0, 10.0, xy=(0.0, 0.0))
+        b = Tracklet(
+            "b", 20.0, 30.0, positions=np.zeros((10, 3)), embeddings=views((0.0, 1.0)) * 10.0
+        )
+
+        with pytest.raises(ValueError, match="L2-normalised"):
+            find_merges([a, b])
+
+    def test_a_tracklet_can_be_put_in_a_set(self):
+        """Frozen promises hashable, and arrays broke both that and ``==``."""
+        a = tracklet("a", 0.0, 10.0)
+
+        assert len({a, a}) == 1
+
+
+class TestOnlineDecidesLateRatherThanTwice:
+    """Deciding on partial evidence is paid for by declining to answer, not by
+    answering and revising -- a caller cannot un-act on an identity."""
+
+    def feed(self, assoc, track, direction, n, t0, xy=(0.0, 0.0)):
+        for i, vector in enumerate(views(direction, n=n)):
+            assoc.observe(
+                track,
+                embedding=vector,
+                position=(xy[0], xy[1], 0.0),
+                ts=t0 + i * 0.1,
+            )
+
+    def test_a_thin_track_gets_no_id_rather_than_a_wrong_one(self):
+        assoc = OnlineAssociator(ReidPolicy(min_views=5))
+        self.feed(assoc, "a", (1.0, 0.0), n=2, t0=0.0)
+
+        assert assoc.resolve("a") is None
+
+    def test_an_id_once_given_does_not_change(self):
+        assoc = OnlineAssociator(ReidPolicy(min_views=5))
+        self.feed(assoc, "a", (1.0, 0.0), n=10, t0=0.0)
+        first = assoc.resolve("a")
+
+        self.feed(assoc, "a", (0.0, 1.0), n=10, t0=5.0)
+
+        assert assoc.resolve("a") == first
+
+    def test_the_same_thing_seen_again_gets_the_same_id(self):
+        assoc = OnlineAssociator(ReidPolicy(min_views=5, similarity=0.9))
+        self.feed(assoc, "a", (1.0, 0.0), n=10, t0=0.0, xy=(0.0, 0.0))
+        self.feed(assoc, "b", (1.0, 0.0), n=10, t0=30.0, xy=(0.5, 0.0))
+
+        assert assoc.resolve("a") == assoc.resolve("b")
+
+    def test_things_seen_at_once_never_share_an_id(self):
+        assoc = OnlineAssociator(ReidPolicy(min_views=5, similarity=0.9))
+        self.feed(assoc, "a", (1.0, 0.0), n=10, t0=0.0)
+        self.feed(assoc, "b", (1.0, 0.0), n=10, t0=0.0)  # identical, simultaneous
+        assoc.co_occurring(["a", "b"])
+
+        assert assoc.resolve("a") != assoc.resolve("b")
+
+    def test_a_forgotten_track_does_not_crash_the_group_it_was_in(self):
+        """Reading a dropped track's span raised KeyError once the budget was
+        reached -- so this worked until it had run long enough to matter."""
+        assoc = OnlineAssociator(
+            ReidPolicy(min_views=2, similarity=0.5), OnlinePolicy(max_tracks=2)
+        )
+        self.feed(assoc, "first", (1.0, 0.0), n=6, t0=0.0)
+        assoc.resolve("first")
+        self.feed(assoc, "second", (1.0, 0.0), n=6, t0=50.0)
+        assoc.resolve("second")
+        self.feed(assoc, "third", (1.0, 0.0), n=6, t0=100.0)
+
+        assert assoc.resolve("third") is not None
+
+    def test_a_forgotten_track_is_a_new_thing_not_a_stale_match(self):
+        """Reporting the id it used to have would be a match made from evidence
+        that is no longer there."""
+        assoc = OnlineAssociator(
+            ReidPolicy(min_views=2, similarity=0.9), OnlinePolicy(max_tracks=2)
+        )
+        self.feed(assoc, "first", (1.0, 0.0), n=6, t0=0.0)
+        original = assoc.resolve("first")
+
+        for n in range(3):  # pushes "first" out of the budget
+            self.feed(assoc, f"later{n}", (0.0, 1.0), n=6, t0=100.0 + n * 100.0)
+        self.feed(assoc, "first", (1.0, 0.0), n=6, t0=500.0)
+
+        assert assoc.resolve("first") != original
+
+    def test_an_id_does_not_absorb_a_track_declared_a_different_object(self):
+        """The exclusion is against the id, not against the one track that
+        scored: entering through a third track is the same wrong answer."""
+        assoc = OnlineAssociator(ReidPolicy(min_views=2, similarity=0.5))
+        self.feed(assoc, "a", (1.0, 0.0), n=6, t0=0.0, xy=(0.0, 0.0))
+        self.feed(assoc, "x", (1.0, 0.0), n=6, t0=0.0, xy=(0.3, 0.0))
+        assoc.co_occurring(["a", "x"])
+        self.feed(assoc, "b", (1.0, 0.0), n=6, t0=30.0, xy=(0.2, 0.0))
+
+        entity = assoc.resolve("a")
+
+        assert assoc.resolve("b") == entity  # b rejoins a, nothing forbids it
+        assert assoc.resolve("x") != entity  # x cannot enter that id through b
+
+    def test_the_track_dropped_is_the_one_least_recently_seen(self):
+        """Order of first sighting is not recency: a landmark watched all shift
+        was evicted ahead of a track that went quiet a minute in."""
+        assoc = OnlineAssociator(ReidPolicy(min_views=2), OnlinePolicy(max_tracks=2))
+        self.feed(assoc, "landmark", (1.0, 0.0), n=6, t0=0.0)
+        self.feed(assoc, "passer", (0.0, 1.0), n=6, t0=10.0)
+        self.feed(assoc, "landmark", (1.0, 0.0), n=6, t0=100.0)
+        self.feed(assoc, "newcomer", (0.0, 1.0), n=6, t0=110.0)  # forces a drop
+
+        assert assoc.resolve("landmark") is not None
+        assert assoc.resolve("passer") is None
+
+    def test_a_reused_key_is_not_barred_by_the_exclusion_it_inherited(self):
+        """Trackers reuse ids. An exclusion that outlives the track which earned
+        it refuses a match the new holder of that key never co-occurred with."""
+        assoc = OnlineAssociator(
+            ReidPolicy(min_views=2, similarity=0.5), OnlinePolicy(max_tracks=4)
+        )
+        self.feed(assoc, "reused", (1.0, 0.0), n=6, t0=0.0, xy=(5.0, 0.0))
+        self.feed(assoc, "watcher", (1.0, 0.0), n=6, t0=1.0, xy=(0.0, 0.0))
+        assoc.co_occurring(["watcher", "reused"])  # the old holder of the key
+
+        for n in range(3):  # pushes "reused" out of the budget
+            self.feed(assoc, f"filler{n}", (0.0, 1.0), n=6, t0=100.0 + n * 100.0)
+        self.feed(assoc, "watcher", (1.0, 0.0), n=6, t0=500.0, xy=(0.0, 0.0))  # still seen
+
+        # The tracker hands the freed key to a different object entirely, and it
+        # is the one holding an id by the time the excluded track asks for one.
+        self.feed(assoc, "reused", (1.0, 0.0), n=6, t0=600.0, xy=(0.5, 0.0))
+        entity = assoc.resolve("reused")
+
+        assert assoc.resolve("watcher") == entity

--- a/dimos/perception/detection/reid/tracklet_reid.py
+++ b/dimos/perception/detection/reid/tracklet_reid.py
@@ -1,0 +1,554 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Merging tracklets a tracker lost track of.
+
+Two chairs of one model are identical to a similarity model, so a threshold high
+enough to merge one chair's fragments also merges two different chairs -- and a
+wrong merge invents an object where fragments only under-report. What separates
+identical things is where and when they were, so geometry vetoes first and
+appearance only decides what survives.
+
+Pairs score 100% precision; the 99% recall figure predates the reachability veto
+moving from run centroids to the sightings either side of the gap and wants one
+rerun. Grouping is unmeasured: the numbers
+that once stood here were taken before closure applied the overlap veto to the
+group it forms, and the benchmark's negative class is that same veto, so it
+cannot referee the fix. Hence :func:`find_merges` returns pairs and
+:func:`connected` is opt-in. Measurements and method:
+``docs/capabilities/perception/tracklet_reid.md``.
+
+numpy only -- embeddings arrive already computed, positions and times as plain
+numbers -- so whoever has the crops keeps that half.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+import itertools
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator
+
+    from numpy.typing import NDArray
+
+
+@dataclass(frozen=True, slots=True, eq=False)
+class Tracklet:
+    """One run of sightings a tracker believed was a single thing.
+
+    The unit is the tracklet, not the sighting: the tracker has already done the
+    easy grouping, and thirty views decide better than thirty decisions of one.
+    """
+
+    key: str
+    t_start: float
+    t_end: float
+
+    #: One row per positioned sighting, oldest first. The order matters: the
+    #: reachability veto reads the two rows either side of the gap, not the mean.
+    #: None leaves geometry unable to veto.
+    positions: NDArray[np.float64] | None = None
+
+    #: ``(N, D)``, L2-normalised. None means this cannot be compared at all.
+    embeddings: NDArray[np.float64] | None = None
+
+    label: str | None = None
+
+    def centroid(self) -> NDArray[np.float64] | None:
+        """Where the whole run sat. For how far a group spans, not for reachability."""
+        if self.positions is None or not len(self.positions):
+            return None
+        mean: NDArray[np.float64] = np.asarray(self.positions, float).mean(axis=0)
+        return mean
+
+    def first_point(self) -> NDArray[np.float64] | None:
+        """Where this run began."""
+        if self.positions is None or not len(self.positions):
+            return None
+        point: NDArray[np.float64] = np.asarray(self.positions[0], float)
+        return point
+
+    def last_point(self) -> NDArray[np.float64] | None:
+        """Where this run ended."""
+        if self.positions is None or not len(self.positions):
+            return None
+        point: NDArray[np.float64] = np.asarray(self.positions[-1], float)
+        return point
+
+    def overlaps(self, other: Tracklet) -> bool:
+        return self.t_start <= other.t_end and other.t_start <= self.t_end
+
+
+@dataclass(frozen=True, slots=True)
+class ReidPolicy:
+    """What counts as the same thing. Every field is a claim about the world."""
+
+    #: Belongs to the embedding model and to ``top_frac``, not to this code: a
+    #: threshold read under one aggregation is wrong under another. Measured
+    #: together; picking either alone cost 15 points of recall.
+    similarity: float = 0.63
+
+    #: Placement error, not motion. The veto that keeps two identical chairs
+    #: apart.
+    max_move_m: float = 2.0
+
+    #: Travel allowed across the gap. Without it the distance check treats a
+    #: chair and a walking person alike, and 30 objects on the measured capture
+    #: could never be rejoined. Zero restores a fixed radius.
+    max_speed_mps: float = 1.5
+
+    #: Ceiling on that allowance. Unbounded it stops being a constraint: a
+    #: minute of walking reaches past every wall of the room.
+    max_reach_m: float = 8.0
+
+    #: Metres a merged group may span. Pairwise checks cannot see this -- a-b
+    #: and b-c both in range puts a and c twice as far -- and an unchecked
+    #: closure produced a "chair" spread over 4.28 m.
+    max_spread_m: float = 4.0
+
+    #: A chair's back and its front are not similar; one view either side of a
+    #: merge is not evidence.
+    min_views: int = 10
+
+    #: Fraction of pairwise similarities averaged. A fraction, not a count: a
+    #: count degenerates into the mean on small tracklets, which is what the
+    #: aggregation exists to avoid.
+    top_frac: float = 0.12
+
+    #: A sighting with no depth could be anywhere, so nothing vetoes it and
+    #: appearance decides alone. False refuses instead.
+    merge_without_position: bool = False
+
+    #: Off by default: labels flicker between synonyms far more than appearance
+    #: does.
+    require_same_label: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class Merge:
+    """A claim that two tracklets are one thing, with what supports it."""
+
+    keys: tuple[str, ...]
+    similarity: float
+    #: Across the gap: the earlier run's last sighting to the later run's first.
+    distance_m: float | None
+    #: Not disqualifying -- a long gap is the case a tracker cannot handle --
+    #: but it is what a reader needs to judge the claim.
+    gap_s: float
+
+
+@dataclass
+class Report:
+    """What a pass did, including what it refused.
+
+    Merging nothing because the constraints held and merging nothing because no
+    tracklet carried an embedding look identical from outside. Only the counts
+    tell them apart.
+    """
+
+    merges: list[Merge] = field(default_factory=list)
+    rejected: Counter[str] = field(default_factory=Counter)
+
+    def summary(self) -> str:
+        parts = ", ".join(f"{k}={v}" for k, v in sorted(self.rejected.items()))
+        return f"{len(self.merges)} merges; rejected: {parts or 'none'}"
+
+
+def group_similarity(a: NDArray[np.float64], b: NDArray[np.float64], *, top_frac: float) -> float:
+    """Mean of the best ``top_frac`` of pairwise cosines. Inputs L2-normalised."""
+    sims = np.asarray(a, float) @ np.asarray(b, float).T
+    flat = sims.ravel()
+    k = max(1, min(flat.size, round(top_frac * flat.size)))
+    return float(np.mean(np.partition(flat, -k)[-k:]))
+
+
+def any_overlap(spans: Iterable[tuple[float, float]]) -> bool:
+    """Does any pair of these windows share an instant?
+
+    Sorted by start, it is enough to compare neighbours: anything between two
+    overlapping windows starts inside the earlier one and so overlaps it too.
+    """
+    windows = sorted(spans)
+    return any(later[0] <= earlier[1] for earlier, later in itertools.pairwise(windows))
+
+
+def gap_between(a: Tracklet, b: Tracklet) -> float:
+    """Seconds between one tracklet ending and the other beginning."""
+    earlier, later = (a, b) if a.t_end <= b.t_start else (b, a)
+    return max(0.0, later.t_start - earlier.t_end)
+
+
+def _veto(a: Tracklet, b: Tracklet, policy: ReidPolicy) -> tuple[str | None, float | None]:
+    """The cheap checks, most conclusive first."""
+    if a.overlaps(b):
+        # Two tracks visible at one instant are two things, whatever they look
+        # like. No score outweighs this.
+        return "time_overlap", None
+    if policy.require_same_label and a.label != b.label:
+        return "label_mismatch", None
+
+    # The budget is what the gap allows, so measure what the gap spans: where the
+    # earlier run ended and where the later one resumed. A whole-run centroid
+    # answers a different question -- it charges a continuation for movement that
+    # happened inside its own tracklet, and forgives a jump when two runs happen to
+    # average to the same place. Non-overlapping by the check above, so the order
+    # is well defined.
+    earlier, later = (a, b) if a.t_end <= b.t_start else (b, a)
+    left, right = earlier.last_point(), later.first_point()
+    if left is None or right is None:
+        if not policy.merge_without_position:
+            return "no_position", None
+        return None, None
+
+    distance = float(np.linalg.norm(left - right))
+    reachable = min(
+        policy.max_move_m + policy.max_speed_mps * gap_between(a, b), policy.max_reach_m
+    )
+    if distance > reachable:
+        return "too_far", distance
+    return None, distance
+
+
+def find_merges(
+    tracklets: Iterable[Tracklet], policy: ReidPolicy | None = None
+) -> tuple[list[Merge], Report]:
+    """Every pair that survives the vetoes and clears the threshold.
+
+    Pairs, not clusters: "a matches b, b matches c" asserts something about a
+    and c that nothing here checked, and on identical objects it is often false.
+    """
+    policy = policy or ReidPolicy()
+    items = list(tracklets)
+    report = Report()
+
+    # The online path normalises what it is given; this one is handed arrays it
+    # cannot re-check per pair. Un-normalised vectors do not lower the score,
+    # they inflate it -- orthogonal tracklets scored 3.29 and merged -- so this
+    # fails loudly rather than merging on a cosine that is not one.
+    for t in items:
+        if t.embeddings is None or not len(t.embeddings):
+            continue
+        norms = np.linalg.norm(np.asarray(t.embeddings, float), axis=1)
+        if not np.allclose(norms, 1.0, atol=1e-3):
+            raise ValueError(
+                f"tracklet {t.key!r} carries embeddings that are not L2-normalised "
+                f"(norms {float(norms.min()):.3f}..{float(norms.max()):.3f})"
+            )
+
+    # ponytail: every pair, no spatial index -- fine for one room, revisit if a
+    # capture ever holds enough tracklets that the vetoes stop being the cheap part.
+    for a, b in itertools.combinations(items, 2):
+        reason, distance = _veto(a, b, policy)
+        if reason is not None:
+            report.rejected[reason] += 1
+            continue
+        if a.embeddings is None or b.embeddings is None:
+            report.rejected["no_embeddings"] += 1
+            continue
+        if len(a.embeddings) < policy.min_views or len(b.embeddings) < policy.min_views:
+            report.rejected["too_few_views"] += 1
+            continue
+
+        score = group_similarity(a.embeddings, b.embeddings, top_frac=policy.top_frac)
+        # NaN in, merge out: `nan < threshold` is False, so one bad row of
+        # embedding would pass the check the whole module rests on.
+        if not np.isfinite(score):
+            report.rejected["undefined_similarity"] += 1
+            continue
+        if score < policy.similarity:
+            report.rejected["below_threshold"] += 1
+            continue
+
+        report.merges.append(
+            Merge(
+                keys=(a.key, b.key),
+                similarity=score,
+                distance_m=distance,
+                gap_s=gap_between(a, b),
+            )
+        )
+    return report.merges, report
+
+
+def connected(
+    merges: Iterable[Merge],
+    tracklets: Iterable[Tracklet] | None = None,
+    policy: ReidPolicy | None = None,
+) -> Iterator[frozenset[str]]:
+    """Close pairwise merges into groups, strongest link first.
+
+    A weaker claim than the pairs it is built from, and an unmeasured one -- see
+    the module docstring. Given ``tracklets``, a link is refused if the group it
+    would create holds two tracklets seen at one instant, or overruns
+    ``max_spread_m``; refusing the link rather than the finished group keeps one
+    bad pair from costing every good merge around it. Descending similarity
+    means what gets refused is the weakest evidence.
+
+    ``tracklets`` must cover every key in ``merges``: a veto that silently
+    skipped half of them would read from outside exactly like one that held.
+    """
+    policy = policy or ReidPolicy()
+    centroids: dict[str, NDArray[np.float64] | None] = {}
+    spans: dict[str, tuple[float, float]] = {}
+    if tracklets is not None:
+        for t in tracklets:
+            centroids[t.key] = t.centroid()
+            spans[t.key] = (t.t_start, t.t_end)
+        missing = {k for m in merges for k in m.keys} - spans.keys()
+        if missing:
+            # A veto that silently covers half the keys is worse than none: it
+            # reads as checked.
+            raise ValueError(f"no tracklet given for {sorted(missing)}")
+
+    parent: dict[str, str] = {}
+    members: dict[str, set[str]] = {}
+
+    def find(x: str) -> str:
+        parent.setdefault(x, x)
+        members.setdefault(x, {x})
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    def spread(keys: set[str]) -> float:
+        points = [c for c in (centroids.get(k) for k in keys) if c is not None]
+        if len(points) < 2:
+            return 0.0
+        stacked = np.stack(points)
+        return float(np.linalg.norm(stacked.max(axis=0) - stacked.min(axis=0)))
+
+    # ponytail: greedy, strongest link first, no backtracking -- a link refused
+    # here is gone. A global objective only if grouping is ever trusted enough.
+    for merge in sorted(merges, key=lambda m: -m.similarity):
+        roots = {find(k) for k in merge.keys}
+        if len(roots) < 2:
+            continue
+        joined: set[str] = set().union(*(members[r] for r in roots))
+        # Pairwise, "seen at one instant" is the veto no score outweighs. A
+        # group asserts the same thing about every pair it contains, including
+        # the ones no merge ever proposed, so it has to clear the same bar.
+        if spans and any_overlap(spans[k] for k in joined if k in spans):
+            continue
+        if centroids and spread(joined) > policy.max_spread_m:
+            continue
+        keep = roots.pop()
+        for other in roots:
+            parent[other] = keep
+        members[keep] = joined
+
+    for root in {find(k) for k in parent}:
+        yield frozenset(members[root])
+
+
+@dataclass(frozen=True, slots=True)
+class OnlinePolicy:
+    """Bounds a batch pass does not need, because a robot runs for a shift."""
+
+    #: The comparison reads the best few anyway, so what a cap drops is the
+    #: middle of the distribution rather than its shape.
+    max_views: int = 200
+
+    #: A track last seen an hour ago is not a candidate for something visible
+    #: now -- the speed veto would refuse it regardless.
+    max_tracks: int = 500
+
+
+class OnlineAssociator:
+    """Assign long-term ids to tracks as their sightings arrive.
+
+    The same decisions as :func:`find_merges`, one observation at a time: state
+    accumulates into :class:`Tracklet` views that the same vetoes and similarity
+    run against, so the two halves cannot disagree about what counts as one
+    thing.
+
+    **Deciding late is allowed; deciding twice is not.** :meth:`resolve` returns
+    None while evidence is thin rather than inventing an id it would take back.
+
+    An id is a group, so this inherits whatever grouping is worth -- which the
+    module docstring says is not yet known. It is here because the shape suits a
+    robot, not because anything measured justifies deploying it.
+    """
+
+    def __init__(self, policy: ReidPolicy | None = None, online: OnlinePolicy | None = None):
+        self.policy = policy or ReidPolicy()
+        self.online = online or OnlinePolicy()
+        self._views: dict[str, list[NDArray[np.float64]]] = {}
+        self._points: dict[str, list[tuple[float, float, float]]] = {}
+        self._span: dict[str, tuple[float, float]] = {}
+        self._label: dict[str, str | None] = {}
+        self._assigned: dict[str, str] = {}
+        self._excluded: dict[str, set[str]] = {}
+        #: Insertion-ordered, rewritten on every sighting: least recently seen
+        #: first. Keyed by track, the value is unused.
+        self._order: dict[str, None] = {}
+        self._counter = 0
+
+    def observe(
+        self,
+        track: str,
+        *,
+        embedding: NDArray[np.float64] | None = None,
+        position: tuple[float, float, float] | None = None,
+        ts: float,
+        label: str | None = None,
+    ) -> None:
+        """Add one sighting's evidence to a track."""
+        self._order.pop(track, None)
+        self._order[track] = None
+        self._forget_old()
+        first, last = self._span.get(track, (ts, ts))
+        self._span[track] = (min(first, ts), max(last, ts))
+        if label is not None:
+            self._label.setdefault(track, label)
+        if embedding is not None:
+            vector = np.asarray(embedding, float).ravel()
+            norm = float(np.linalg.norm(vector))
+            if norm:
+                views = self._views.setdefault(track, [])
+                views.append(vector / norm)
+                if len(views) > self.online.max_views:
+                    # From the middle: the first views establish the track and
+                    # the newest reflect it now.
+                    del views[len(views) // 2]
+        if position is not None:
+            x, y, z = (float(v) for v in position)
+            self._points.setdefault(track, []).append((x, y, z))
+
+    def co_occurring(self, tracks: Iterable[str]) -> None:
+        """Record that these tracks shared a frame, so they are not one thing.
+
+        The batch path derives this from overlapping spans; live, a caller that
+        knows gets the veto before either track is long enough to compare.
+        """
+        keys = list(tracks)
+        for a in keys:
+            self._excluded.setdefault(a, set()).update(k for k in keys if k != a)
+
+    def _tracklet(self, track: str) -> Tracklet:
+        first, last = self._span[track]
+        points = self._points.get(track)
+        views = self._views.get(track)
+        return Tracklet(
+            key=track,
+            t_start=first,
+            t_end=last,
+            positions=np.asarray(points, float) if points else None,
+            embeddings=np.stack(views) if views else None,
+            label=self._label.get(track),
+        )
+
+    def resolve(self, track: str) -> str | None:
+        """The long-term id for ``track``, or None while the evidence is thin.
+
+        Once given, an id does not change: revising one a caller already acted
+        on is worse than having been slow.
+        """
+        if track in self._assigned:
+            return self._assigned[track]
+        views = self._views.get(track)
+        if views is None or len(views) < self.policy.min_views:
+            return None
+
+        query = self._tracklet(track)
+        if query.embeddings is None:
+            return None
+        best_key, best_score = None, self.policy.similarity
+        centroid = query.centroid()
+
+        entities: dict[str, list[str]] = {}
+        for other in self._order:
+            entity = self._assigned.get(other)
+            if entity is not None and other != track:
+                entities.setdefault(entity, []).append(other)
+
+        # ponytail: re-derives every member's tracklet per resolve; cache per entity
+        # if resolve ever runs hot enough to show up.
+        for entity, group in entities.items():
+            # Joining an id claims sameness with everything already under it,
+            # not just with the track that scored. So every member gets a veto,
+            # a thin one included: "seen at one instant" needs no embedding.
+            if any(m in self._excluded.get(track, ()) for m in group):
+                continue
+            if any(_veto(query, self._tracklet(m), self.policy)[0] is not None for m in group):
+                continue
+            # Without this, 388 pieces of one capture collapsed into a single
+            # id -- every link legal, the chain across the room.
+            if centroid is not None and self._spread_with(entity, centroid) > (
+                self.policy.max_spread_m
+            ):
+                continue
+            for member in group:
+                candidate = self._tracklet(member)
+                if (
+                    candidate.embeddings is None
+                    or len(candidate.embeddings) < self.policy.min_views
+                ):
+                    continue
+                score = group_similarity(
+                    query.embeddings, candidate.embeddings, top_frac=self.policy.top_frac
+                )
+                if score >= best_score:
+                    best_key, best_score = member, score
+
+        if best_key is not None:
+            assigned = self._assigned[best_key]
+        else:
+            self._counter += 1
+            assigned = f"entity-{self._counter}"
+        self._assigned[track] = assigned
+        return assigned
+
+    def _spread_with(self, entity: str, point: NDArray[np.float64]) -> float:
+        """How far a group would span with ``point`` added to it."""
+        points = [point]
+        for track, assigned in self._assigned.items():
+            if assigned != entity:
+                continue
+            centre = self._tracklet(track).centroid()
+            if centre is not None:
+                points.append(centre)
+        if len(points) < 2:
+            return 0.0
+        stacked = np.stack(points)
+        return float(np.linalg.norm(stacked.max(axis=0) - stacked.min(axis=0)))
+
+    def _forget_old(self) -> None:
+        """Drop the oldest tracks entirely, assignment included.
+
+        An id outliving its evidence is an answer nothing supports, and the
+        group it names still measured itself against a span already dropped.
+        """
+        while len(self._order) > self.online.max_tracks:
+            gone = next(iter(self._order))
+            del self._order[gone]
+            # A tracker reuses ids. Leaving the dropped key inside surviving
+            # exclusion sets would bar the next track to carry it from a match it
+            # never co-occurred with.
+            for excluded in self._excluded.values():
+                excluded.discard(gone)
+            for store in (
+                self._views,
+                self._points,
+                self._span,
+                self._label,
+                self._excluded,
+                self._assigned,
+            ):
+                store.pop(gone, None)

--- a/docs/capabilities/perception/index.md
+++ b/docs/capabilities/perception/index.md
@@ -2,6 +2,18 @@
 
 ## Detections
 
+## Re-identification
+
+A tracker associates across adjacent frames, so it breaks on every occlusion, turn
+away, or detector miss, and each break invents an object. `EmbeddingIDSystem`
+(`dimos/perception/detection/reid/`) assigns long-term ids from appearance and is what
+`ReidModule` runs.
+
+[Tracklet re-identification](tracklet_reid.md) adds position and time as vetoes ahead
+of appearance — two chairs of one model are identical to a similarity model, and only
+where and when they were separates them. That page records what was measured, what the
+numbers rule out, and which of them are withdrawn.
+
 ## Experimental WorldBelief
 
 The experimental xArm6 WorldBelief stack records RGB-D observations and processes

--- a/docs/capabilities/perception/tracklet_reid.md
+++ b/docs/capabilities/perception/tracklet_reid.md
@@ -1,0 +1,127 @@
+# Tracklet re-identification: what was measured
+
+`dimos/perception/detection/reid/tracklet_reid.py` merges tracklets a tracker lost. This records what
+it was tested against and what the results ruled out.
+
+**The grouping numbers below are withdrawn.** They were measured against a
+`connected` and an `OnlineAssociator` that applied the instant-overlap veto only
+between the two tracklets of a pair, never to the group a link would create —
+and this benchmark's negative class *is* "overlapping in time". So every wrong
+merge it counted was a pair the module's own hardest veto would have refused,
+had the grouping path asked it. The veto now runs group-wide. The rows are kept,
+struck through, because the conclusion drawn from them was published.
+
+## Ground truth without labelling
+
+Re-identification's job is "the tracker lost this; find it again", so the
+benchmark makes the tracker lose it on purpose.
+
+| | How | Why it is exact |
+|---|---|---|
+| **same-object pairs** | cut one tracklet into pieces, discard 30% between them | the tracker held it continuously, so the pieces are one object |
+| **different-object pairs** | two tracklets overlapping in time | both visible at one instant in different tracks |
+
+Neither needs a human. The discarded span is a dial, so a method can be scored
+on how far it bridges rather than only on whether it merges anything.
+
+Data: one 7.8-minute go2 capture of an SF office (`go2_SF_office_8mins_moshi`),
+6,628 frames, 36,189 sightings, 64% placed in 3D. Crops embedded once with CLIP;
+every method saw identical input, differing only in the association rule.
+
+**388 pieces from 194 tracks — 194 same-object pairs, 1,246 different-object
+pairs.**
+
+## Results
+
+| method | recall | precision | merged same | merged different |
+|---|---|---|---|---|
+| **pairs only, shipped defaults** | **99.0%** | **100.0%** | 192 | **0** |
+| upstream `EmbeddingIDSystem` rule | 99.0% | 100.0% | 192 | 0 |
+| pairs only, threshold picked separately | 83.5% | 100.0% | 162 | 0 |
+| geometry only, no appearance | 96.9% | 41.2% | 188 | 268 |
+| ~~ours, with transitive closure~~ | ~~96.4%~~ | ~~38.5%~~ | ~~187~~ | ~~299~~ |
+| ~~ours, online (ids, so groups)~~ | ~~96.9%~~ | ~~23.9%~~ | ~~188~~ | ~~597~~ |
+| appearance only @0.63 | 100.0% | 13.5% | 194 | 1,238 |
+
+**The recall column needs one rerun.** These were measured when the reachability
+veto compared whole-run centroids; it now compares the sighting either side of
+the gap, which is what the speed budget was always modelling. Precision is
+unaffected either way — this benchmark's negatives are pairs overlapping in
+time, and the overlap veto refuses those before any distance is computed, so no
+distance rule can change the zero in the "merged different" column. Recall can
+move in either direction and has not been remeasured.
+
+## What this rules out
+
+**Grouping: unmeasured, not refuted.** The pairwise half stands — 192 right,
+0 wrong, and its decision logic is unchanged. The grouping half was not what it
+claimed to be. `connected` closed links checking only group spread, and
+`OnlineAssociator` vetoed a candidate track without asking the entity that track
+already belonged to, so a group could hold two tracklets seen at one instant and
+an id could absorb a track a caller had explicitly declared a different object.
+Both now apply the veto to the whole group, and `co_occurring` binds every
+member of an id rather than one track of it.
+
+This benchmark cannot referee that change: its negative class and the new check
+are the same predicate, so rerunning it would score the check against itself and
+report something near 100% that means nothing.
+
+**So `find_merges` returns pairs and `connected` stays opt-in** — now because
+grouping is unmeasured, not because it was measured and failed. What it needs is
+a negative class that does not reduce to co-visibility: pairs of one model never
+in frame together, labelled by hand, few enough to label in an afternoon. Until
+then, whether eight fragments are one chair or three is a judgement, and looking
+at eight crops answers it.
+
+**Online.** An id *is* a group, so the online path inherits whatever grouping
+turns out to be worth, and cannot revise what it already said. It is in the
+module because the shape is right for a robot, not because anything measured
+here justifies deploying it.
+
+## What the geometry veto is worth
+
+Upstream vetoes only co-occurrence — things visible in the same frame. Adding
+position and speed refused **48 pairs upstream would have merged, all 48
+correctly**: things that look alike and were never seen together, like two
+chairs of one model at opposite ends of a room.
+
+    similarity 0.914, 5.3 m apart, reachable 5.3 m  -> different objects
+    similarity 0.890, 8.0 m apart, reachable 4.1 m  -> different objects
+
+The benchmark cannot score this. Its negatives are defined as *overlapping in
+time*, which is exactly what co-occurrence already catches, so the 48 fall
+outside the labelled set. The benchmark understates this method's advantage, and
+that limitation is the reason to keep the number here rather than in a score.
+
+## Thresholds are the model's, not the code's
+
+Measured on this capture with CLIP: same-object pairs at median 0.967,
+different-object pairs at 0.862, separating at 0.925 with 93.7% balanced
+accuracy. The repo's person-re-identification default of 0.63 would have merged
+nearly every different-object pair — under *that* aggregation.
+
+Under `top_frac`, 0.63 is right and 0.925 costs 15 points of recall. **The
+threshold and the aggregation are one setting, not two**, and changing either
+without re-measuring the other cost 15 points of recall until both were
+measured together. Re-measure by cutting tracklets in half; it takes one GPU
+pass.
+
+## Known limits of these numbers
+
+- One capture, one room, one model, one detector.
+- Every figure predates the group-wide veto and the boundary reachability veto.
+  Pairwise precision survives both (negatives are refused on time overlap before
+  either runs); pairwise recall was measured under centroid distance and needs
+  one rerun.
+- `find_merges` now requires L2-normalised embeddings rather than assuming them,
+  so a capture whose vectors were not normalised will raise where it used to
+  return inflated cosines.
+- Positives are two halves of a tracklet with 30% discarded: temporally adjacent,
+  small viewpoint change. **Easier than the real problem**, so every recall
+  figure here is optimistic. Widening the cut is the next measurement.
+- `torchreid`'s OSNet was never run — its weights need LFS credentials this
+  machine lacks — so "is a person-re-identification model better than CLIP for
+  office furniture" is open.
+- 36% of detections carry no 3D position and are refused outright. On this data
+  that was 340,000 of 673,000 refusals. The limit on re-identification here is
+  placement, not association.


### PR DESCRIPTION
## Contribution path

- Small, safe change that does not need a tracking issue

## Problem

A tracker associates across adjacent frames, so it breaks whenever continuity does:
an occlusion, a robot turning away, a detector miss. Every break makes a new object
where there was one. Nothing puts the pieces back.

## Solution

**Geometry vetoes, appearance decides.** Two chairs of one model are identical to a
similarity model, so a threshold high enough to merge one chair's fragments also
merges two different chairs — and a wrong merge is worse than fragmentation, because
fragments are honest while a merge invents an object. What separates identical things
is where and when they were, so the cheap constraints run first and the embedding
comparison only sees pairs that survive them. On a 7.8-minute office capture that
refused 673,000 pairs before a single embedding was compared.

Ground truth needs no labelling: cut a tracklet the tracker held continuously and the
pieces are one object; two tracklets overlapping in time are two objects.

**Pairwise: 100.0% precision, zero wrong merges.** The 99.0% recall that stood
beside it was measured before the reachability veto moved to the gap boundary
(below) and wants one rerun.

### The budget is spent on the gap, so it is measured across the gap

The speed allowance models how far a thing could travel while unseen, but the veto
compared whole-run centroids — charging a continuation for a walk that happened inside
its own tracklet, and forgiving a jump when two runs happened to average to the same
place. It now compares where the earlier run ended against where the later one resumed.
Precision is untouched: this benchmark's negatives are pairs overlapping in time,
refused before any distance is computed. Recall can move either way and has not been
remeasured. (Raised by Greptile.)

### What is measured and what is not

| | status |
|---|---|
| `find_merges` — pairs | measured, shipped defaults, table in the doc |
| `connected` — groups | **unmeasured**, opt-in |
| `OnlineAssociator` — ids | **unmeasured**, not for deployment |

The grouping figures this PR originally carried (38.5% closure, 23.9% online) are
**withdrawn**. They were taken against a version that applied the instant-overlap veto
only between the two tracklets of a pair, never to the group a link would create — and
this benchmark's negative class *is* "overlapping in time". So every wrong merge it
counted was a pair the module's own hardest veto would have refused, had the grouping
path asked it.

The veto now runs group-wide, and `co_occurring` binds every member of an id rather
than one track of it. The benchmark cannot referee that change: its negative class and
the new check are the same predicate, so rerunning it scores the check against itself.
`connected` stays opt-in — now because grouping is unmeasured, not because it was
measured and failed. A real number needs a negative class that does not reduce to
co-visibility: pairs of one model never in frame together, labelled by hand, few enough
to label in an afternoon. `docs/capabilities/perception/tracklet_reid.md` keeps the
withdrawn rows struck through and says the rest.

### What the geometry veto is worth

Upstream (`EmbeddingIDSystem`) vetoes only co-occurrence. Adding position and speed
refused **48 pairs upstream would have merged, all 48 correctly** — things that look
alike and were never seen together, like two chairs of one model at opposite ends of a
room. The benchmark cannot score this: its negatives are defined as overlapping in
time, which co-occurrence already catches, so the 48 fall outside the labelled set.

### Boundary

Embeddings arrive already computed by whatever model the caller picked, so the module
does not own that half — but it does own the boundary. Un-normalised vectors do not
lower a cosine, they inflate it (orthogonal tracklets scored 3.29 and merged at the
shipped threshold); a NaN row scores NaN and `nan < threshold` is False, so it merged
and was counted as nothing. Both are now refused, loudly, naming the tracklet.

numpy and the standard library, nothing else. No torch, no store, no message type, no
module system. Verified by import.

### Open for the reviewer

1. **`OnlineAssociator` overlaps `dimos/perception/detection/reid/embedding_id_system.py`**
   — same 0.63, same 500-cap, same min-10, same top-k mean, same co-occurrence
   negatives — and the doc measures the two as identical on pairs. The genuinely new
   part is the geometry veto, ~15 lines. Is the right shape to add that veto to
   `EmbeddingIDSystem` and drop the second associator? That is ~170 lines deleted.
2. **`connected` ships with no number behind it.** Keeping it as published evidence is
   one call; deleting it until there is a benchmark that can score it is another.

Placement was the third question here and is settled: the module now sits in
`dimos/perception/detection/reid/` beside `EmbeddingIDSystem`, and
`docs/capabilities/perception/index.md` links the page and says which of the two is
wired into a module. The packages above it carry no `__init__`, so the numpy-only
claim survives the move.

## How to Test

```bash
uv run pytest dimos/perception/detection/reid/test_tracklet_reid.py
```

33 tests, numpy and pytest only, no fixtures. Nine are regressions for the vetoes
above: a group never holds two tracklets seen at one instant; `connected` refuses
tracklets it was not given; an id does not absorb a track declared a different object;
movement inside a run is not charged to the gap; a jump across the gap is refused
though the runs average alike; a reused track id is not barred by the exclusion it
inherited; the track dropped is the least recently seen; un-normalised embeddings are
refused not rescaled; a `Tracklet` can go in a set. `ruff` and `mypy` clean.

There is no blueprint to run: the module is numpy in, dataclasses out, and has no
callers yet by design.

## AI assistance

Claude Code with Opus 5, used as an implementation tool.

The approach is mine. Geometry vetoes before appearance decides. A wrong merge is worse
than fragmentation, so this fragments rather than guesses. Ground truth for
re-identification can be built by cutting tracklets the tracker held continuously
instead of by labelling anything. A negative result about grouping is worth publishing
rather than tuning away. What the vetoes are, what `find_merges` returns, why
`connected` is opt-in, and the decision to withdraw the grouping numbers rather than
rerun a benchmark that cannot referee its own check — those are my calls, and they are
what this PR is actually proposing.

Claude implemented against that design, and in a later pass audited the result: it
found the group-level veto gap, the NaN and normalisation fail-opens, and the
least-recently-seen eviction bug, then wrote those fixes and six regression tests.
Every number in this description was re-run except the withdrawn ones, which is why
they are withdrawn rather than restated. I have reviewed the diff and understand the code.

## Checklist

- [ ] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
