### PR TITLE
Feat/belief layer

### DIFF
--- a/dimos/agents/annotation.py
+++ b/dimos/agents/annotation.py
@@ -66,7 +66,51 @@ def _stamp_and_log(func_name: str, result: Any, elapsed_ms: float) -> Any:
         # Not a SkillResult — we can't verify the outcome, so don't claim "OK".
         code = "UNKNOWN"
     logger.info("SKILL %s result=%s duration_ms=%.1f", func_name, code, elapsed_ms)
+    _trace_skill(func_name, result, code, elapsed_ms)
     return result
+
+
+def _trace_skill(func_name: str, result: Any, code: str, elapsed_ms: float) -> None:
+    """Record one skill outcome, if an agent trace is open.
+
+    The single point every skill passes through, which makes it the only place
+    the refusal taxonomy can be collected without touching ninety-odd call
+    sites. Silent outside a trace, so background perception at 15 Hz costs
+    nothing and does not drown the traces that matter.
+    """
+    from dimos.utils.tracing import enabled, span
+
+    if not enabled():
+        return
+    from dimos.agents.skill_result import SkillResult
+
+    attributes: dict[str, Any] = {
+        "skill_name": func_name,
+        "outcome": code,
+        "duration_ms": round(elapsed_ms, 1),
+    }
+    if isinstance(result, SkillResult):
+        reason = result.unknown_reason
+        if reason is not None:
+            # The whole point of the belief layer: why it could not answer, and
+            # what would fix it. Without these a refusal is indistinguishable
+            # from a crash on a dashboard.
+            attributes["belief_unknown_reason"] = reason.name
+            attributes["belief_suggested_capability"] = result.suggested_capability
+            attributes["belief_retryable"] = result.retryable
+            attributes["belief_needs_revisit"] = reason.needs_revisit
+        attributes["belief_evidence_count"] = len(result.evidence)
+        # `quality` is what the query layer actually attaches: row count,
+        # support, dispersion and whether the rows were deduplicated. A loop
+        # over `coverage` and `staleness_s` stood here, reading two fields that
+        # no skill has ever set.
+        quality = result.metadata.get("quality")
+        if isinstance(quality, dict):
+            for field in ("rows", "support", "dispersion_m", "deduplicated"):
+                if field in quality:
+                    attributes[f"belief_{field}"] = quality[field]
+    with span(f"skill:{func_name}", as_type="tool", **attributes):
+        pass
 
 
 def _make_skill(func: F, uses: list[str], lifecycle: SkillLifecycle) -> F:

--- a/dimos/agents/capabilities.py
+++ b/dimos/agents/capabilities.py
@@ -22,9 +22,11 @@ refuses with a plain text "Cannot start X: capability Y is held by Z" result, in
 which case the LLM decides what to do (typically: call the appropriate stop tool,
 then retry).
 
-Capabilities are plain strings. Today the only declared capability is
-`CAP_MOVEMENT`. New capabilities should be added as constants here so they are
-discoverable from one place.
+Capabilities are plain strings, declared here rather than at the use site so two
+skills contending for one resource cannot spell it two different ways. Add a
+constant when a skill is ready to declare it: a capability nothing names in
+`uses=[...]` excludes nothing, so a placeholder reads as protection that is not
+there.
 """
 
 from __future__ import annotations
@@ -35,6 +37,9 @@ import time
 from typing import NamedTuple
 
 CAP_MOVEMENT = "movement"
+#: A carried load. Declared here rather than in a demo module so it is
+#: discoverable from one place, as this file asks.
+CAP_PAYLOAD = "payload"
 
 
 class _Hold(NamedTuple):

--- a/dimos/agents/demos/demo_capabilities.py
+++ b/dimos/agents/demos/demo_capabilities.py
@@ -19,15 +19,13 @@ import time
 from typing import Any
 
 from dimos.agents.annotation import skill
-from dimos.agents.capabilities import CAP_MOVEMENT
+from dimos.agents.capabilities import CAP_MOVEMENT, CAP_PAYLOAD
 from dimos.agents.mcp.mcp_client import McpClient
 from dimos.agents.mcp.mcp_server import McpServer
 from dimos.constants import DEFAULT_THREAD_JOIN_TIMEOUT
 from dimos.core.coordination.blueprints import autoconnect
 from dimos.core.core import rpc
 from dimos.core.module import Module
-
-CAP_PAYLOAD = "payload"
 
 DEMO_CAPABILITIES_PROMPT = """
 You are controlling a simulated warehouse inspection robot.

--- a/dimos/agents/mcp/test_tool_stream.py
+++ b/dimos/agents/mcp/test_tool_stream.py
@@ -82,7 +82,9 @@ class StreamingModule(Module):
 @pytest.fixture
 def mcp_server():
     """Start a blueprint with StreamingModule + McpServer, wait for readiness."""
-    global_config.update(viewer="none")
+    # Keep the integration test hermetic: Zenoh peer discovery can block when
+    # stale peers from another local run are still finalizing.
+    global_config.update(viewer="none", transport="lcm")
     blueprint = autoconnect(StreamingModule.blueprint(), McpServer.blueprint())
     coordinator = ModuleCoordinator.build(blueprint)
 
@@ -527,7 +529,7 @@ def tool_helper_module(mocker):
     mocker.patch.object(LCMRPC, "__init__", return_value=None)
     mocker.patch.object(LCMRPC, "serve_module_rpc")
     mocker.patch.object(LCMRPC, "start")
-    module = _ToolHelperTestModule()
+    module = _ToolHelperTestModule(rpc_transport=LCMRPC)
     yield module, mock_transport
     module._close_all_tools()
 

--- a/dimos/agents/skill_result.py
+++ b/dimos/agents/skill_result.py
@@ -33,7 +33,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 import json
-from typing import Any, Generic, Literal
+from typing import TYPE_CHECKING, Any, Generic, Literal
+
+if TYPE_CHECKING:
+    from dimos.experimental.memory_belief.answer import UnknownReason
 
 # typing_extensions for PEP 696 TypeVar default support on Python < 3.13.
 from typing_extensions import TypeVar
@@ -65,9 +68,37 @@ class SkillResult(Generic[E]):
     error_code: E | None = None
     duration_ms: float = 0.0
     metadata: dict[str, Any] = field(default_factory=dict)
+    #: Raw observations this call saw or acted on, as ``(stream, id)`` pairs, so
+    #: an agent can re-read what a skill based its outcome on.
+    evidence: tuple[tuple[str, int], ...] = ()
+    #: Why the skill could not finish, when the reason is one the belief layer
+    #: already names. Carrying it rather than a bare bool is what lets
+    #: :attr:`retryable` be derived instead of guessed.
+    unknown_reason: UnknownReason | None = None
 
     def is_success(self) -> bool:
         return self.success
+
+    @property
+    def retryable(self) -> bool | None:
+        """Whether trying again could plausibly help. None when unknown.
+
+        Deliberately derived, never set by hand. Whether a retry is worth
+        anything is a property of the evidence, not of the author's mood:
+        ``occluded`` means a different vantage point may work, ``absent`` means
+        the thing is not there and calling again will say so again. Authors who
+        set this themselves get it inconsistent across a codebase.
+        """
+        if self.success:
+            return None
+        if self.unknown_reason is None:
+            return None
+        return not self.unknown_reason.is_terminal
+
+    @property
+    def suggested_capability(self) -> str | None:
+        """What would have to happen for a retry to succeed, if anything would."""
+        return self.unknown_reason.suggested_capability if self.unknown_reason else None
 
     @classmethod
     def ok(cls, message: str = "", **metadata: Any) -> SkillResult[E]:
@@ -86,6 +117,14 @@ class SkillResult(Generic[E]):
         }
         if self.metadata:
             payload["metadata"] = self.metadata
+        if self.unknown_reason is not None:
+            # Surfaced to the agent as structure, not prose: deciding what to do
+            # next should not require matching on a message string.
+            payload["unknown_reason"] = self.unknown_reason.name
+            payload["retryable"] = self.retryable
+            payload["suggested_capability"] = self.suggested_capability
+        if self.evidence:
+            payload["evidence"] = [{"stream": s, "id": i} for s, i in self.evidence]
         return [{"type": "text", "text": json.dumps(payload)}]
 
     def __str__(self) -> str:

--- a/dimos/agents/test_capabilities_declared.py
+++ b/dimos/agents/test_capabilities_declared.py
@@ -1,0 +1,93 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Capabilities must be declared centrally and actually used.
+
+The registry only prevents a conflict it has been told about. A skill that
+contends for something real but declares nothing gets dispatched anyway, and
+the failure shows up as two models fighting over a device rather than as a
+refused call.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+import dimos.agents.capabilities as caps
+
+ROOT = pathlib.Path(caps.__file__).parents[2]
+
+
+def _declared() -> set[str]:
+    return {v for k, v in vars(caps).items() if k.startswith("CAP_") and isinstance(v, str)}
+
+
+def _uses_in(path: pathlib.Path) -> set[str]:
+    """Capability names passed to @skill(uses=[...]) in one file."""
+    found: set[str] = set()
+    tree = ast.parse(path.read_text())
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", None)
+        if name != "skill":
+            continue
+        for kw in node.keywords:
+            if kw.arg == "uses" and isinstance(kw.value, ast.List):
+                found |= {e.id for e in kw.value.elts if isinstance(e, ast.Name)}
+    return found
+
+
+def _all_uses() -> set[str]:
+    found: set[str] = set()
+    for path in (ROOT / "dimos").rglob("*.py"):
+        if path.name.startswith("test_"):
+            continue
+        try:
+            found |= _uses_in(path)
+        except SyntaxError:
+            continue
+    return found
+
+
+class TestCentralRegistry:
+    def test_capability_constants_live_in_one_place(self):
+        """A locally-defined constant is invisible to anyone looking for it."""
+        stray = []
+        for path in (ROOT / "dimos").rglob("*.py"):
+            if path.samefile(pathlib.Path(caps.__file__)) or path.name.startswith("test_"):
+                continue
+            for line in path.read_text().splitlines():
+                if line.startswith("CAP_") and "=" in line and '"' in line:
+                    stray.append(f"{path.relative_to(ROOT)}: {line.strip()}")
+        assert not stray, f"declare these in agents/capabilities.py instead: {stray}"
+
+    @pytest.mark.parametrize("name", ["CAP_MOVEMENT", "CAP_PAYLOAD"])
+    def test_the_expected_capabilities_exist(self, name):
+        assert isinstance(getattr(caps, name), str)
+
+    def test_names_are_distinct(self):
+        """Two capabilities sharing a string would silently serialise each other."""
+        values = [v for k, v in vars(caps).items() if k.startswith("CAP_")]
+
+        assert len(values) == len(set(values))
+
+
+class TestContendingSkillsDeclare:
+    def test_every_referenced_capability_is_a_real_constant(self):
+        assert _all_uses() <= set(vars(caps)) | {"CAP_MOVEMENT"}

--- a/dimos/agents/test_skill_result.py
+++ b/dimos/agents/test_skill_result.py
@@ -206,3 +206,68 @@ class TestSkillDecoratorTiming:
         assert sentinel.duration_ms == 999.0  # untouched
         # Decorator overwrites with actual measured elapsed (very small).
         assert result.duration_ms != 999.0
+
+
+class TestRetryabilityIsDerived:
+    """Whether a retry helps is a property of the evidence, not the author."""
+
+    def test_an_author_cannot_set_it(self):
+        import dataclasses
+
+        names = {f.name for f in dataclasses.fields(SkillResult)}
+
+        assert "retryable" not in names
+
+    def test_a_non_terminal_reason_carries_the_capability_that_clears_it(self):
+        from dimos.experimental.memory_belief.answer import UnknownReason
+
+        result = SkillResult(success=False, unknown_reason=UnknownReason.INCOHERENT)
+
+        assert result.retryable is True
+        assert result.suggested_capability == "observe_place"
+
+    def test_a_terminal_reason_is_not_worth_retrying(self):
+        from dimos.experimental.memory_belief.answer import UnknownReason
+
+        result = SkillResult(success=False, unknown_reason=UnknownReason.NO_CAPABILITY)
+
+        assert result.retryable is False
+        assert result.suggested_capability is None
+
+    def test_success_has_no_opinion_about_retrying(self):
+        assert SkillResult(success=True).retryable is None
+
+    def test_a_failure_with_no_stated_reason_says_it_does_not_know(self):
+        """Better an admitted unknown than a fabricated True or False."""
+        assert SkillResult(success=False, error_code="EXECUTION_FAILED").retryable is None
+
+
+class TestStructuredFailureReachesTheAgent:
+    def test_the_reason_is_encoded_as_structure_not_prose(self):
+        """Deciding what to do next must not require matching a message string."""
+        import json
+
+        from dimos.experimental.memory_belief.answer import UnknownReason
+
+        result = SkillResult(success=False, unknown_reason=UnknownReason.INCOHERENT)
+        payload = json.loads(result.agent_encode()[0]["text"])
+
+        assert payload["unknown_reason"] == "INCOHERENT"
+        assert payload["retryable"] is True
+        assert payload["suggested_capability"] == "observe_place"
+
+    def test_evidence_is_encoded_when_present(self):
+        import json
+
+        result = SkillResult(success=True, evidence=(("color_image", 42),))
+        payload = json.loads(result.agent_encode()[0]["text"])
+
+        assert payload["evidence"] == [{"stream": "color_image", "id": 42}]
+
+    def test_a_plain_result_is_unchanged(self):
+        """The 60-odd skills returning bare results must not grow noise."""
+        import json
+
+        payload = json.loads(SkillResult.ok("done").agent_encode()[0]["text"])
+
+        assert set(payload) == {"success", "message", "error_code", "duration_ms"}

--- a/dimos/experimental/memory_belief/annotate.py
+++ b/dimos/experimental/memory_belief/annotate.py
@@ -1,0 +1,127 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The boxes one frame's sightings were drawn from, so the picture can show them.
+
+:class:`~dimos.experimental.memory_belief.types.BeliefObservation` carries its evidence one
+detection at a time, and a viewer given one box at a time draws one box -- a
+frame with six detections shows the sixth. Regrouping by frame is the whole of
+this module.
+
+**Placed and unplaced are drawn differently on purpose.** A detection with no
+lidar returns in its box is still a real detection; colouring it like the ones
+that survived would hide the largest source of loss between what the camera saw
+and what the store believes.
+"""
+
+from __future__ import annotations
+
+from itertools import groupby
+from typing import TYPE_CHECKING, Any
+
+from pydantic import ConfigDict
+from pydantic.dataclasses import dataclass
+
+from dimos.experimental.memory_belief.types import SCHEMA_VERSION
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator
+
+ANNOTATION_STREAM_NAME = "belief_frame_annotation"
+
+
+@dataclass(frozen=True)
+class FrameAnnotation:
+    """Every detection made on one frame, in that frame's pixel coordinates."""
+
+    __pydantic_config__ = ConfigDict(extra="forbid")
+
+    schema_version: str
+    frame_stream: str
+    frame_observation_id: int
+    ts: float
+    boxes: tuple[tuple[float, float, float, float], ...]
+    labels: tuple[str, ...]
+    confidences: tuple[float, ...]
+    placed: tuple[bool, ...]
+    """Whether each detection got a 3D position. ``False`` means the detector saw
+    it and the belief layer dropped it."""
+
+    def to_rerun(self):  # type: ignore[no-untyped-def]
+        """The frame's boxes, coloured by whether they survived into the world."""
+        import rerun as rr
+
+        if not self.boxes:
+            return rr.Clear(recursive=False)
+        return rr.Boxes2D(
+            array=[list(b) for b in self.boxes],
+            array_format=rr.Box2DFormat.XYXY,
+            colors=[(80, 220, 120) if p else (160, 160, 160) for p in self.placed],
+            labels=[
+                f"{label} {conf:.2f}" + ("" if placed else " (unplaced)")
+                for label, conf, placed in zip(
+                    self.labels, self.confidences, self.placed, strict=True
+                )
+            ],
+        )
+
+
+def annotation_stream(store: Any, *, name: str = ANNOTATION_STREAM_NAME) -> Any:
+    """Open (or create) the frame-annotation stream on ``store``."""
+    return store.stream(name, FrameAnnotation, codec="json")
+
+
+def append_annotation(stream: Any, annotation: FrameAnnotation) -> Any:
+    """Append one frame's annotations, indexed at the frame's own timestamp."""
+    return stream.append(
+        annotation,
+        ts=annotation.ts,
+        tags={
+            "frame_stream": annotation.frame_stream,
+            "frame_observation_id": annotation.frame_observation_id,
+            "detections": len(annotation.boxes),
+        },
+    )
+
+
+def fold_annotations(observations: Iterable[Any]) -> Iterator[FrameAnnotation]:
+    """Group sightings back into the frames they were drawn on.
+
+    Grouped on consecutive runs, so memory is bounded by one frame's detections
+    and the input has to arrive in timestamp order; out-of-order input degrades
+    into duplicate frame records rather than lost boxes.
+
+    Sightings without a ``bbox`` are skipped -- inventing a rectangle would put a
+    fabricated overlay on a real photograph.
+    """
+    drawn = (
+        record
+        for item in observations
+        if (record := getattr(item, "data", item)).bbox and record.evidence
+    )
+    for _, frame in groupby(
+        drawn, key=lambda r: (r.evidence[0].stream, r.evidence[0].observation_id)
+    ):
+        records = list(frame)
+        source = records[0].evidence[0]
+        yield FrameAnnotation(
+            schema_version=SCHEMA_VERSION,
+            frame_stream=source.stream,
+            frame_observation_id=source.observation_id,
+            ts=source.ts,
+            boxes=tuple(tuple(r.bbox) for r in records),
+            labels=tuple(r.label or "?" for r in records),
+            confidences=tuple(float(r.confidence.detection or 0.0) for r in records),
+            placed=tuple(r.target_pose is not None for r in records),
+        )

--- a/dimos/experimental/memory_belief/answer.py
+++ b/dimos/experimental/memory_belief/answer.py
@@ -1,0 +1,73 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Why a belief query could not be answered.
+
+The shape of an answer belongs to ``api.py``, which returns an envelope. What
+lives here is only the vocabulary of refusal, because that vocabulary is shared
+by three layers -- the query engine that emits it, the skill that hands it to
+an agent, and the resolver that turns it into a next action -- and a reason
+spelled differently in any one of them breaks the loop silently.
+
+Every member names the capability that would resolve it, or ``None`` when
+nothing the robot can do will. A capability, not a skill: which skill provides
+``sweep_place`` is a deployment question, and hardcoding one here would bind
+the query layer to a particular robot's toolset.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class UnknownReason(Enum):
+    """Why a query could not be answered, and what to do about it.
+
+    The value is the capability that would resolve it, or None when nothing the
+    robot can do will, in which case no amount of looking would help.
+    """
+
+    #: No sensor has ever swept this place and time.
+    NEVER_COVERED = "sweep_place"
+    #: Sightings that do not plausibly describe one object. Reporting their
+    #: centroid would invent a location no sensor saw, so the honest answer is
+    #: that the grouping itself is in doubt. Resolving it needs the
+    #: re-identification this layer does not yet have, which is why the remedy
+    #: is a look rather than a recompute.
+    INCOHERENT = "observe_place"
+    #: The detector was never asked about this kind of thing. Cheapest remedy in
+    #: the list: the frames are already stored, so re-running detection with a
+    #: wider vocabulary answers it without moving the robot at all.
+    OUT_OF_VOCABULARY = "redetect_with_vocabulary"
+    #: The data source cannot support this question however long it looks.
+    NO_CAPABILITY = None
+
+    @property
+    def suggested_capability(self) -> str | None:
+        value: str | None = self.value
+        return value
+
+    @property
+    def is_terminal(self) -> bool:
+        """Whether acting on the suggestion is pointless."""
+        return self.value is None
+
+    @property
+    def needs_revisit(self) -> bool:
+        """Whether the remedy requires going and looking again.
+
+        ``OUT_OF_VOCABULARY`` is the one that does not: it is answered by
+        recomputation over stored frames.
+        """
+        return self.value is not None and self is not UnknownReason.OUT_OF_VOCABULARY

--- a/dimos/experimental/memory_belief/api.py
+++ b/dimos/experimental/memory_belief/api.py
@@ -1,0 +1,510 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""One query entry point, because a round trip costs far more than a query.
+
+Splitting a question across six tool calls wraps milliseconds of work in seconds
+of inference, and gives the model six chances to go astray instead of one.
+
+The store already solved this: its filters are frozen dataclasses composed
+lazily, and because they are data rather than code the same algebra can be driven
+from JSON. So this is a front end onto the existing filter chain, not a second
+query engine. **Filters narrow; projections compute** -- that split is what lets
+a projection be added without adding a tool.
+
+Importing this module pulls in nothing heavier than the store. Reaching it
+through ``skills.py`` does pull torch, by way of ``MemoryModule``; that is the
+memory module base's dependency, not this layer's.
+
+Every answer carries how much to trust it, because the observed failure was not a
+wrong tool but a list returned with nothing to choose on.
+"""
+
+from __future__ import annotations
+
+import math
+import statistics
+from typing import TYPE_CHECKING, Any
+
+from dimos.experimental.memory_belief.entity import COHERENT
+from dimos.experimental.memory_belief.write import derived_stream
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+#: Read verbatim into the agent's tool description, so a name listed here that
+#: cannot succeed is an invitation to a failing query. One value: an entity is a
+#: thing, and a question about what is where is a question about things. Raw
+#: sightings are still stored -- they are what entities are folded from -- but
+#: answering from them would report one chair seen three hundred times as three
+#: hundred chairs.
+SELECTS = ("entities",)
+#: One projection: where the things are. Counting, timelines and distances were
+#: removed rather than left half-served -- each needed a stream this layer stopped
+#: producing, and a projection that always returns nothing is worse than an
+#: absent one, because a caller reads it as an answer.
+PROJECTIONS = ("locate",)
+
+#: How many rows one question brings back when it does not say. The bound has to
+#: live in the stream chain: capping the projection instead let a broad query
+#: read every matching row out of the store and then throw most of them away.
+DEFAULT_LIMIT = 50
+
+#: Streams backing each ``select``. Raw streams are queried directly; the rest
+#: are materialised views built by the producers in this package.
+#: Imported lazily and by path because the producers pull in numpy and scipy,
+#: and a query-only process should not pay for them to answer about a stream
+#: that may not exist.
+_STREAM_FOR = {
+    "entities": ("belief_entity", "dimos.experimental.memory_belief.entity", "Entity"),
+}
+
+
+class QueryError(ValueError):
+    """A query that cannot be built. Distinct from one that finds nothing."""
+
+
+class MissingStreamError(LookupError):
+    """The stream backing a ``select`` is not in this store.
+
+    Separate from :class:`QueryError` because the two need opposite answers: a
+    malformed query is the caller's to fix, while an absent stream is ordinary
+    ignorance and belongs in an envelope as NEVER_COVERED. A robot that just
+    booted hits this on its first question, and raising there would turn "I have
+    not seen anything yet" into a traceback.
+    """
+
+    def __init__(self, select: str, stream_name: str) -> None:
+        super().__init__(
+            f"select {select!r} needs stream {stream_name!r}, which this store has none of"
+        )
+        self.select = select
+        self.stream_name = stream_name
+
+
+def _open(store: Any, select: str) -> Any:
+    if select in _STREAM_FOR:
+        name, module_path, type_name = _STREAM_FOR[select]
+        if name not in store.list_streams():
+            raise MissingStreamError(select, name)
+        module = __import__(module_path, fromlist=[type_name])
+        return derived_stream(store, name, getattr(module, type_name))
+    # A projection passed as a select. The model confused the two, so the error
+    # says which field the value belongs in rather than only listing what was
+    # expected.
+    if select in PROJECTIONS:
+        raise QueryError(
+            f'{select!r} is a projection, not a stream: pass it as "project", '
+            f'and choose a "select" from {SELECTS}'
+        )
+    raise QueryError(f"unknown select {select!r}; expected one of {SELECTS}")
+
+
+def _before_asking_time(stream: Any, as_of: float) -> Any:
+    """Bound a stream at the asking time.
+
+    One function rather than one expression per call site: the diagnostic
+    reopened the stream and left this off, so it went on counting rows the
+    answer beside it could not see.
+    """
+    return stream.before(as_of + 1e-9)
+
+
+def _payload(observation: Any) -> Any:
+    return getattr(observation, "data", observation)
+
+
+def _check_shape(where: Any) -> None:
+    """Reject a malformed ``where`` as a fixable error, not an AttributeError.
+
+    Runs before anything reads a clause. A model that sends ``["chair"]``
+    instead of ``[{"op": "label", ...}]`` should get a message saying so and
+    retry; a traceback out of the middle of validation tells it nothing and
+    ends the turn.
+    """
+    if isinstance(where, (str, bytes)) or not isinstance(where, (list, tuple)):
+        raise QueryError(
+            f"where must be a list of clause objects, got {type(where).__name__}; "
+            'example: [{"op": "label", "value": "chair"}]'
+        )
+    for clause in where:
+        if not isinstance(clause, dict):
+            raise QueryError(
+                f"each where clause must be an object, got {type(clause).__name__}: {clause!r}"
+            )
+
+
+def _apply(stream: Any, where: Sequence[dict[str, Any]]) -> Any:
+    """Build the filter chain. Composition happens here, not across turns.
+
+    Unknown operators raise rather than being skipped: a filter silently dropped
+    widens the result set, and a caller reading the answer has no way to tell
+    that the constraint it asked for was never applied.
+    """
+    for clause in where or ():
+        op = clause.get("op")
+        if op == "label":
+            stream = stream.tags(label=clause["value"])
+        elif op == "time_range":
+            stream = stream.time_range(float(clause["t1"]), float(clause["t2"]))
+        else:
+            raise QueryError(f"unknown filter op {op!r}")
+    return stream
+
+
+def _position_of(payload: Any) -> tuple[float, float, float] | None:
+    position = getattr(payload, "position", None)
+    if position is None:
+        position = getattr(payload, "target_pose", None)
+    return tuple(position) if position is not None else None
+
+
+def _quality(rows: Sequence[Any]) -> dict[str, Any]:
+    """What a reader needs to decide whether to believe the result.
+
+    ``deduplicated`` is reported rather than assumed. It is true only when every
+    row is an entity, because a count over sightings is not a count of things,
+    and the identity layer is currently too weak for the distinction to be
+    academic.
+    """
+    payloads = [_payload(r) for r in rows]
+    supports = [n for p in payloads if (n := getattr(p, "support", None)) is not None]
+    coherences = [c for p in payloads if (c := getattr(p, "coherence", None)) is not None]
+    positions = [xyz for p in payloads if (xyz := _position_of(p)) is not None]
+    dispersion = 0.0
+    if len(positions) > 1:
+        centre = tuple(sum(p[i] for p in positions) / len(positions) for i in range(3))
+        dispersion = statistics.median(math.dist(centre, p) for p in positions)
+    return {
+        "rows": len(rows),
+        "support": sum(supports) if supports else None,
+        "dispersion_m": round(dispersion, 3),
+        "coherence": round(statistics.median(coherences), 3) if coherences else None,
+        "deduplicated": bool(payloads) and all(hasattr(p, "entity_id") for p in payloads),
+    }
+
+
+def _limit(query: dict[str, Any]) -> int:
+    """The row bound, validated, before any row is read.
+
+    ``limit`` was previously read for truth, so ``0`` and ``-1`` both fell
+    through to "no limit" -- the opposite of what either asks for. Neither is a
+    sensible number of answers, so both are refused rather than reinterpreted.
+    """
+    if query.get("limit") is None:
+        return DEFAULT_LIMIT
+    try:
+        limit = int(query["limit"])
+    except (TypeError, ValueError) as exc:
+        raise QueryError(f"limit must be a whole number, got {query['limit']!r}") from exc
+    if limit < 1:
+        raise QueryError(f"limit must be at least 1, got {limit}")
+    return limit
+
+
+def _project(kind: str, rows: Sequence[Any]) -> dict[str, Any]:
+    payloads = [_payload(r) for r in rows]
+
+    if kind == "locate":
+        positioned = [(p, xyz) for p in payloads if (xyz := _position_of(p)) is not None]
+        if not positioned:
+            return {}
+        return {
+            "positions": [
+                {
+                    "entity_id": getattr(p, "entity_id", None),
+                    "label": getattr(p, "label", None),
+                    "position": [round(v, 3) for v in xyz],
+                    "extent": list(getattr(p, "extent", None) or ()),
+                    "support": getattr(p, "support", None),
+                    "dispersion_m": round(getattr(p, "dispersion_m", 0.0) or 0.0, 3),
+                    "place_ref": getattr(p, "place_ref", None),
+                }
+                for p, xyz in positioned
+            ]
+        }
+
+    raise QueryError(f"unknown projection {kind!r}; expected one of {PROJECTIONS}")
+
+
+#: Which tag a filter needs, for the filters that read one. A stream that does not
+#: carry the tag cannot answer the clause, and saying so is the whole point: the
+#: alternative is a filter that matches nothing and an envelope that blames the
+#: robot's coverage for the caller's mistake.
+_TAG_FOR_OP = {"label": "label", "in_region": "place_ref"}
+
+
+def _tags_of(store: Any, select: str) -> set[str]:
+    """The tag keys this stream's observations actually carry.
+
+    Read from the data rather than declared in a table here, so a stream that
+    gains a tag does not need this module edited to admit it.
+    """
+    try:
+        first = _open(store, select).first()
+    except (LookupError, KeyError, TypeError, QueryError):
+        return set()
+    return set(getattr(first, "tags", None) or ())
+
+
+def _place_refs(store: Any) -> set[str]:
+    """Place references that exist, for telling a typo from an unvisited place.
+
+    Read off the entities themselves rather than from a partition stream. Named
+    regions were derived geometrically and removed: the partition could split
+    space but never name a room, so every question that named one stayed
+    unanswerable while the stream implied otherwise. A place reference is a
+    lattice cell today, and the honest list of them is whatever the sightings
+    actually resolved to.
+    """
+    from dimos.experimental.memory_belief.entity import ENTITY_STREAM_NAME
+
+    if ENTITY_STREAM_NAME not in store.streams:
+        return set()
+    return {
+        ref for o in store.streams[ENTITY_STREAM_NAME] if (ref := (o.tags or {}).get("place_ref"))
+    }
+
+
+def _vocabulary(store: Any) -> set[str]:
+    """The vocabulary the detector was actually run with, from the data itself."""
+    from dimos.experimental.memory_belief.types import STREAM_NAME as BELIEF_STREAM_NAME
+
+    try:
+        first = store.streams[BELIEF_STREAM_NAME].first()
+    except (KeyError, AttributeError, LookupError):
+        return set()
+    return set(getattr(first.data, "vocabulary", None) or ())
+
+
+def describe_store(store: Any) -> dict[str, Any]:
+    """The constants a caller has to know to write a valid query.
+
+    Every argument rejection in the first traced run was a guess at one of these
+    -- a time written as ``"09:00"``, a place invented as ``"Room 3"``. They are
+    not secrets and they are not stable across recordings, so they are read from
+    the store and handed over rather than written into a prompt by hand.
+    """
+    spans = []
+    for name in ("belief_observation", "belief_entity", "odom"):
+        # A store legitimately lacks some of these -- a recording with no
+        # detections has no entity stream -- and the span of what is absent is
+        # simply not reported. An empty stream has no first record either.
+        if name not in store.streams:
+            continue
+        stream = store.streams[name]
+        first, last = stream.first(), stream.last()
+        if first is not None and last is not None:
+            spans.append((first.ts, last.ts))
+    vocab = _vocabulary(store)
+    return {
+        "time_unit": "unix epoch seconds (float). Not a clock string, not ISO 8601.",
+        "t_start": min((a for a, _ in spans), default=None),
+        "t_end": max((b for _, b in spans), default=None),
+        "place_refs": sorted(_place_refs(store)),
+        "vocabulary_size": len(vocab),
+        "labelled_streams": sorted(s for s in SELECTS if "label" in _tags_of(store, s)),
+        "streams": sorted(s for s in SELECTS if _tags_of(store, s) or s in SELECTS),
+    }
+
+
+def _validate(store: Any, select: str, where: Sequence[dict[str, Any]]) -> str | None:
+    """Reject a clause the stream cannot answer; report an unknown term as unknown.
+
+    The distinction is the point. A ``label`` clause on a stream with no labels is
+    the caller's error and is raised. A label the detector was never asked about is
+    the *world's* limit -- the frames are stored and re-running detection resolves
+    it -- so it returns ``OUT_OF_VOCABULARY`` and travels as an answer, not an
+    exception.
+    """
+    tags = _tags_of(store, select)
+    if not tags:
+        # No tags means no records, not a stream that cannot carry the clause.
+        # Rejecting here would tell a robot that has simply not written this
+        # belief yet that it asked the wrong question, sending it to rewrite a
+        # query that was correct. Absence is reported downstream as
+        # NEVER_COVERED, where it belongs.
+        return None
+    places = _place_refs(store)
+    vocab = _vocabulary(store)
+    for clause in where:
+        op = str(clause.get("op") or "")
+        needed = _TAG_FOR_OP.get(op)
+        if needed and not (set(needed) & tags if isinstance(needed, tuple) else {needed} & tags):
+            usable = sorted(
+                s
+                for s in SELECTS
+                if _tags_of(store, s) & (set(needed) if isinstance(needed, tuple) else {needed})
+            )
+            raise QueryError(
+                f"select {select!r} carries no {op!r} information, so that clause "
+                f"can only ever match nothing. Streams that do: {usable or 'none'}."
+            )
+        if op == "in_region" and places and clause.get("region") not in places:
+            raise QueryError(
+                f"no place {clause.get('region')!r}; this recording has "
+                f"{sorted(places)}. These are lattice cells, not room names."
+            )
+        if op == "label" and vocab and clause.get("value") not in vocab:
+            import difflib
+
+            near = difflib.get_close_matches(str(clause.get("value")), vocab, n=4, cutoff=0.6)
+            return (
+                f"{clause.get('value')!r} is not in the vocabulary the detector ran "
+                f"with ({len(vocab)} terms)" + (f"; nearest: {near}" if near else "")
+            )
+    return None
+
+
+def execute(store: Any, query: dict[str, Any]) -> dict[str, Any]:
+    """Run one query and return the envelope.
+
+    ``as_of`` is required rather than defaulted. The asking time determines the
+    answer -- "where is the backpack" differs at t=30 s and t=400 s -- and a
+    default would silently pick one, which is the failure the wall-clock
+    staleness bug produced in every recorded trace.
+
+    ``limit`` is defaulted, at ``DEFAULT_LIMIT``, because the alternative is
+    reading a whole recording's worth of rows to answer a question about a
+    handful of them.
+    """
+    select = query.get("select")
+    if select is None:
+        raise QueryError("select is required")
+    if "as_of" not in query:
+        raise QueryError("as_of is required: the asking time determines the answer")
+    try:
+        as_of = float(query["as_of"])
+    except (TypeError, ValueError) as exc:
+        raise QueryError(f"as_of must be a number, got {query['as_of']!r}") from exc
+    # `inf` passes every `before` comparison, so it does not merely widen the
+    # window -- it removes it, and the answer covers the whole recording while
+    # still reporting a time base. `nan` fails every comparison instead and
+    # reads as an empty world. Neither is a moment.
+    if not math.isfinite(as_of):
+        raise QueryError(f"as_of must be a finite time, got {as_of}")
+    # "locate" is the only projection, and the previous default named one that
+    # does not exist -- so a query that simply omitted `project` was rejected as
+    # if it had asked for something.
+    projection = query.get("project") or PROJECTIONS[0]
+    limit = _limit(query)
+
+    where = query.get("where") or []
+    _check_shape(where)
+    # Validated before the stream is touched: an argument the store cannot honour
+    # must not come back looking like an absence of observation.
+    out_of_vocab = _validate(store, select, where)
+    if out_of_vocab is not None:
+        return {
+            "status": "unknown",
+            "reason": "OUT_OF_VOCABULARY",
+            "result": None,
+            "quality": {"rows": 0},
+            "time_base": {"as_of": as_of, "unit": "seconds"},
+            "diagnostic": {"note": out_of_vocab, "remedy": "redetect_with_vocabulary"},
+            "query": query,
+        }
+
+    try:
+        stream = _open(store, select)
+    except MissingStreamError as exc:
+        # Not an error the caller can fix by rewriting the query: the robot has
+        # simply never written this kind of belief. A fresh store on a robot that
+        # just booted is in exactly this state, and the first question asked of
+        # it deserves an answer rather than a traceback. `QueryError` stays an
+        # exception because a malformed query *is* the caller's to fix, and the
+        # skill layer converts that one for the agent.
+        return {
+            "status": "unknown",
+            "reason": "NEVER_COVERED",
+            "result": None,
+            "quality": {"rows": 0},
+            "time_base": {"as_of": as_of, "unit": "seconds"},
+            "diagnostic": {
+                "note": str(exc),
+                "remedy": f"write the {exc.stream_name!r} stream before asking about {exc.select!r}",
+            },
+            "query": query,
+        }
+    stream = _apply(stream, where)
+    # The asking time bounds every query. Nothing after it is knowable yet, which
+    # is true of a live stream and must stay true of a replayed one.
+    stream = _before_asking_time(stream, as_of)
+    # Bounded here rather than in the projection: `to_list` below reads every row
+    # the stream still holds, and rows discarded after that were paid for.
+    stream = stream.limit(limit)
+
+    rows = stream.to_list()
+    if not rows:
+        return {
+            "status": "unknown",
+            "reason": "NEVER_COVERED",
+            "result": None,
+            "quality": {"rows": 0},
+            "time_base": {"as_of": as_of, "unit": "seconds"},
+            "diagnostic": _diagnose(store, query, as_of),
+            "query": query,
+        }
+
+    result = _project(projection, rows)
+    quality = _quality(rows)
+    status, reason = "ok", None
+    if projection == "locate" and not result:
+        status, reason = "unknown", "NO_CAPABILITY"
+    elif quality.get("coherence") is not None and quality["coherence"] < COHERENT:
+        status, reason = "unknown", "INCOHERENT"
+
+    return {
+        "status": status,
+        "reason": reason,
+        "result": result,
+        "quality": quality,
+        "time_base": {"as_of": as_of, "unit": "seconds"},
+        "query": query,
+    }
+
+
+def _diagnose(store: Any, query: dict[str, Any], as_of: float) -> dict[str, Any]:
+    """Which clause emptied the result, so a retry is informed rather than blind.
+
+    Compressing six steps into one call costs the model its chance to see
+    intermediate results. Returning an empty list without saying why would make
+    that trade a bad one, so an empty result reports what each clause cost.
+
+    Bounded at the asking time like the query it explains. A count is still an
+    answer: unbounded, "your label clause matched nothing" came back beside a
+    row count drawn from observations the query itself had refused to look at.
+
+    Counted rather than listed. These rows are never read, only tallied, and
+    ``count()`` pushes the tally into the store instead of building a list per
+    clause to take its length.
+    """
+    where = list(query.get("where") or [])
+    if not where:
+        return {"note": "stream is empty"}
+    stream = _before_asking_time(_open(store, query["select"]), as_of)
+    remaining = stream.count()
+    steps = []
+    for clause in where:
+        try:
+            stream = _apply(stream, [clause])
+            after = stream.count()
+        except QueryError as exc:  # pragma: no cover - reported, not raised
+            steps.append({"clause": clause, "error": str(exc)})
+            break
+        steps.append({"clause": clause, "rows_before": remaining, "rows_after": after})
+        remaining = after
+        if after == 0:
+            break
+    return {"per_clause": steps, "hint": "relax the clause whose rows_after is 0"}

--- a/dimos/experimental/memory_belief/detect.py
+++ b/dimos/experimental/memory_belief/detect.py
@@ -1,0 +1,171 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Turning a 2D detector's output into belief.
+
+What a flat image cannot support is encoded in the records, not left to whoever
+reads them later: no depth means ``target_pose`` and ``place_ref`` stay None and
+only ``capture_place_ref`` is filled; no association means every record is its
+own target; and a detector that does not fire is not evidence of absence, so no
+``absent`` record is written here -- that comes from
+:mod:`~dimos.experimental.memory_belief.grid`.
+
+The vocabulary travels with the record, so a later "is there a mug here" answers
+OUT_OF_VOCABULARY instead of a confident and wrong "no".
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from dimos.experimental.memory_belief.types import (
+    SCHEMA_VERSION,
+    BeliefObservation,
+    Confidence,
+    EvidenceRef,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Iterator, Sequence
+
+
+def bright_enough(observation: Any, *, min_mean: float = 40.0) -> bool:
+    """Whether a frame carries enough signal for detection to mean anything.
+
+    Running a detector on a near-black frame does not produce absence, it
+    produces silence -- and silence that gets recorded as "nothing detected" is
+    indistinguishable from a real negative later. Filtering first keeps that
+    ambiguity out of the store.
+    """
+    import cv2
+
+    array = observation.data.to_opencv()
+    grey = cv2.cvtColor(array, cv2.COLOR_RGB2GRAY) if array.ndim == 3 else array
+    return bool(float(np.mean(grey)) >= min_mean)
+
+
+def _cell_place(pose: Any, *, size_m: float) -> str | None:
+    """A coarse place identifier from a pose, with no room list anywhere.
+
+    Deliberately derived from coordinates rather than looked up in a
+    configuration of named rooms: naming a place is a claim that needs its own
+    evidence, and this producer has none.
+    """
+    if pose is None:
+        return None
+    return (
+        f"cell({int(np.floor(pose.position.x / size_m))},{int(np.floor(pose.position.y / size_m))})"
+    )
+
+
+def _cell_place_xy(position: tuple[float, float, float], *, size_m: float) -> str:
+    """Place identifier for a point in the world, using the same lattice as
+    :func:`_cell_place` so entity places and capture places are comparable."""
+    return f"cell({int(np.floor(position[0] / size_m))},{int(np.floor(position[1] / size_m))})"
+
+
+def _bbox_of(detection: Any) -> tuple[float, float, float, float] | None:
+    """A detection's box as four floats, or None when it carries no box.
+
+    Spelled out rather than built with a generator so the four-element shape is
+    a checked fact: `BeliefObservation.bbox` is consumed as x1/y1/x2/y2, and a
+    detector handing over three or five numbers should fail here rather than
+    silently produce a record nothing can crop.
+    """
+    box = getattr(detection, "bbox", None)
+    if box is None:
+        return None
+    x1, y1, x2, y2 = (float(v) for v in box)
+    return (x1, y1, x2, y2)
+
+
+def detect_to_belief(
+    observations: Iterable[Any],
+    detector: Any,
+    *,
+    stream_name: str,
+    vocabulary: tuple[str, ...] | None,
+    source: str,
+    min_confidence: float = 0.0,
+    place_size_m: float = 5.0,
+    frame_filter: Callable[[Any], bool] | None = None,
+    locate: Callable[[Any, Any], Sequence[Any]] | None = None,
+) -> Iterator[BeliefObservation]:
+    """Run ``detector`` over observations, yielding one record per detection.
+
+    ``detector`` needs only ``process_image``, so any 2D detector fits.
+
+    ``vocabulary`` is recorded verbatim on every record -- it is what lets a
+    later "is there a mug here" answer OUT_OF_VOCABULARY rather than "no" --
+    and ``source`` stays separate from it so the two limits query separately.
+
+    Detections below ``min_confidence`` are dropped rather than recorded with a
+    low score, since a record that exists at all is evidence downstream.
+    """
+    keep_frame = frame_filter or (lambda _obs: True)
+
+    for observation in observations:
+        if not keep_frame(observation):
+            continue
+        result = detector.process_image(observation.data)
+        evidence = (
+            EvidenceRef(stream=stream_name, observation_id=observation.id, ts=observation.ts),
+        )
+        capture_place = _cell_place(getattr(observation, "pose", None), size_m=place_size_m)
+        detections = tuple(getattr(result, "detections", ()))
+        # A locator that cannot place a detection returns None for it, and that
+        # None is carried through rather than smoothed over: a position inferred
+        # from nothing reads downstream as evidence, which is worse than having
+        # no position at all.
+        placements = list(locate(observation, detections)) if locate else [None] * len(detections)
+        for index, detection in enumerate(detections):
+            if detection.confidence < min_confidence:
+                continue
+            placed = placements[index] if index < len(placements) else None
+            # A tracker numbers what it is following now; that is a tentative
+            # claim about identity, not a confirmed one, and it is recorded as
+            # such so a later re-identification pass can overrule it.
+            track_id = getattr(detection, "track_id", None)
+            yield BeliefObservation(
+                schema_version=SCHEMA_VERSION,
+                # Unassociated: each sighting is its own target until something
+                # matches it across frames. `identity.py` is where that match
+                # gets asserted, revisably, without rewriting this reference.
+                target_ref=f"{stream_name}#{observation.id}:{index}",
+                label=detection.name,
+                visibility="present",
+                valid_ts=observation.ts,
+                observed_ts=observation.ts,
+                source=source,
+                capture_place_ref=capture_place,
+                # `place_ref` comes from where the *entity* is, never from where
+                # the sensor was. It stays None without a placement, which is
+                # what keeps "seen from the kitchen" out of "in the kitchen".
+                # A lattice square. Named regions were derived from the map
+                # geometrically and removed: geometry can split space but cannot
+                # name a room, which is what the questions needed.
+                place_ref=(
+                    _cell_place_xy(placed.position, size_m=place_size_m) if placed else None
+                ),
+                target_pose=placed.position if placed else None,
+                frame_id="world" if placed else None,
+                identity_status="tentative" if track_id is not None else "none",
+                identity_basis=(f"tracker:{track_id}" if track_id is not None else None),
+                vocabulary=vocabulary,
+                evidence=evidence,
+                bbox=_bbox_of(detection),
+                confidence=Confidence(detection=float(detection.confidence)),
+            )

--- a/dimos/experimental/memory_belief/detect_recording.py
+++ b/dimos/experimental/memory_belief/detect_recording.py
@@ -1,0 +1,277 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Turn a recording's camera frames into belief, in the recording itself.
+
+    python -m dimos.experimental.memory_belief.detect_recording recording.db --vocabulary lvis
+
+Writes ``belief_observation`` back into the store it read the frames from, so
+the sightings sit on the same timeline as the camera and lidar they came from.
+``python -m scripts.build_views`` then folds them into entities in that same
+file, and ``dimos mem rerun`` plays the result. One store throughout.
+
+The vocabulary is an argument, not a constant, and whatever it is gets written
+onto every record -- so a question about a term outside it answers
+OUT_OF_VOCABULARY instead of a confident "no". ``--vocabulary none`` runs
+prompt-free and records ``None``, which reads as "covers everything".
+
+Nothing here names a class, a room, or a robot.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+import time
+from typing import TYPE_CHECKING, Any
+
+from dimos.experimental.memory_belief.identity import (
+    IDENTITY_STREAM_NAME,
+    IdentityClaim,
+    append_identity,
+    claims_from_tracks,
+)
+from dimos.experimental.memory_belief.locate import (
+    PinholeFisheye,
+)
+from dimos.experimental.memory_belief.produce import DetectParams, detect_stream
+from dimos.experimental.memory_belief.vocabulary import from_file, resolve as resolve_vocabulary
+from dimos.experimental.memory_belief.write import append_belief, belief_stream, derived_stream
+from dimos.memory.store.sqlite import SqliteStore
+from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
+
+# The one robot-specific import. The camera mount belongs in the recording's
+# `tf` stream; reading it from there would make this producer platform-neutral.
+from dimos.robot.unitree.go2.connection import GO2Connection
+
+#: Read the defaults off an instance: DetectParams uses slots, so its class
+#: attributes are descriptors rather than the values.
+_D = DetectParams()
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+def build_detector(
+    model_name: str | None,
+    conf: float,
+    device: str | None,
+    vocabulary: tuple[str, ...] | None = None,
+) -> Any:
+    """YOLO-E, open-vocabulary or constrained to a named list.
+
+    Open-vocabulary keeps the model's own tag list, which on this recording
+    contained scenes and concepts alongside objects. A vocabulary removes that
+    class of noise structurally, at the cost of being unable to see what it was
+    not given -- which is why the list is recorded on every observation.
+    """
+    from dimos.perception.detection.detectors.yoloe import Yoloe2DDetector, YoloePromptMode
+
+    if vocabulary:
+        # Text prompting needs the non-"-pf" weights; the prompt-free
+        # checkpoints have the vocabulary baked in and ignore set_classes.
+        detector = Yoloe2DDetector(
+            prompt_mode=YoloePromptMode.PROMPT,
+            model_name=model_name or "yoloe-11l-seg.pt",
+            device=device,
+            conf=conf,
+            exclude_class_ids=[],
+            max_area_ratio=None,
+        )
+        detector.set_prompts(text=list(vocabulary))
+        return detector
+
+    return Yoloe2DDetector(
+        prompt_mode=YoloePromptMode.LRPC,  # LRPC == prompt-free
+        model_name=model_name,
+        device=device,
+        conf=conf,
+        # Both filters off on purpose. `exclude_class_ids` would silently drop
+        # classes the run never gets to reconsider, and `max_area_ratio` would
+        # drop the large nearby objects that matter most indoors. A detection
+        # kept with its confidence is recoverable; one never recorded is not.
+        exclude_class_ids=[],
+        max_area_ratio=None,
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("recording", type=Path, help="path to a .db recording")
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="write to a separate store instead of into the recording. Splitting "
+        "them means every later tool needs both files and a join; the default "
+        "keeps sightings beside the frames they came from",
+    )
+    parser.add_argument("--image-stream", default="color_image")
+    parser.add_argument("--lidar-stream", default="lidar")
+    parser.add_argument(
+        "--no-locate",
+        action="store_true",
+        help="skip 3D placement; records keep capture_place_ref only",
+    )
+    parser.add_argument(
+        "--min-points", type=int, default=_D.min_points, help="lidar returns needed to place"
+    )
+    parser.add_argument(
+        "--depth-band", type=float, default=_D.depth_band_m, help="depth inlier band, metres"
+    )
+    parser.add_argument(
+        "--align-tolerance", type=float, default=0.3, help="frame-to-scan pairing window, seconds"
+    )
+    parser.add_argument(
+        "--identity",
+        action="store_true",
+        help="also write tracker-derived identity claims to the belief_identity stream",
+    )
+    parser.add_argument("--stride", type=int, default=1, help="use every Nth frame")
+    parser.add_argument("--limit", type=int, default=None, help="stop after N frames")
+    parser.add_argument("--model", default=None, help="YOLO-E weights (default: prompt-free 11s)")
+    parser.add_argument("--device", default=None, help="cuda / cpu (default: auto)")
+    parser.add_argument("--conf", type=float, default=0.25, help="detector confidence threshold")
+    parser.add_argument(
+        "--min-confidence",
+        type=float,
+        default=0.0,
+        help="drop detections below this before recording; a record that exists "
+        "at all counts as evidence downstream",
+    )
+    parser.add_argument("--min-brightness", type=float, default=_D.min_brightness)
+    parser.add_argument(
+        "--place-size", type=float, default=_D.place_size_m, help="place cell size, metres"
+    )
+    parser.add_argument(
+        "--vocabulary",
+        default=None,
+        help="'lvis', a path to a one-term-per-line file, or omit for open-vocabulary. "
+        "Whatever is chosen is recorded on every observation so a later question "
+        "about an unlisted thing answers OUT_OF_VOCABULARY, not 'no'.",
+    )
+    parser.add_argument(
+        "--vocabulary-extra",
+        default=None,
+        help="additional terms appended to --vocabulary, one per line",
+    )
+    args = parser.parse_args(argv)
+
+    # In place by default: `align()` and tag pushdown work against the frames
+    # the sightings came from only when they share a file, and every downstream
+    # tool takes one store.
+    out_path = args.out or args.recording
+
+    vocab = resolve_vocabulary(args.vocabulary)
+    if vocab and args.vocabulary_extra:
+        vocab = tuple(dict.fromkeys(vocab + from_file(args.vocabulary_extra)))
+    detector = build_detector(args.model, args.conf, args.device, vocab)
+    mode = "prompt" if vocab else "lrpc"
+    source = f"yoloe-{mode}:{Path(getattr(detector, 'model_name', 'yoloe')).stem}"
+
+    store = SqliteStore(path=str(args.recording), must_exist=True)
+    out_store = store if out_path == args.recording else SqliteStore(path=str(out_path))
+    try:
+        # No payload type: recordings disagree about what their streams hold,
+        # and the store already knows what this one was created with. Consumed
+        # as an iterator and never materialised, so this same producer runs
+        # against a live robot, where the stream does not end.
+        frames: Any = store.stream(args.image_stream)
+        locator = None
+        if not args.no_locate:
+            frames = frames.align(
+                store.stream(args.lidar_stream, PointCloud2), tolerance=args.align_tolerance
+            )
+            locator = PinholeFisheye(GO2Connection.camera_info_static)
+
+        print(f"{args.recording.name}: streaming {args.image_stream!r}, stride {args.stride}")
+        vlabel = f"{len(vocab)} terms" if vocab else "open (vocabulary=None)"
+        print(f"detector: {source}  vocabulary: {vlabel}  conf>={args.conf}")
+        print(f"placement: {'off' if args.no_locate else f'on, min_points={args.min_points}'}")
+
+        out_stream = belief_stream(out_store)
+        ident_stream = (
+            derived_stream(out_store, IDENTITY_STREAM_NAME, IdentityClaim)
+            if args.identity
+            else None
+        )
+        started = time.perf_counter()
+        written = placed = 0
+        dark = [0]
+        labels: dict[str, int] = {}
+        sightings: list[tuple[str, Any, float]] = []
+
+        params = DetectParams(
+            min_confidence=args.min_confidence,
+            min_brightness=args.min_brightness,
+            min_points=args.min_points,
+            depth_band_m=args.depth_band,
+            place_size_m=args.place_size,
+        )
+        for record in detect_stream(
+            frames,
+            detector,
+            stream_name=args.image_stream,
+            vocabulary=vocab,  # None means open-vocabulary: "covers everything"
+            source=source,
+            params=params,
+            camera=locator,
+            stride=args.stride,
+            limit=args.limit,
+            on_skip=lambda: dark.__setitem__(0, dark[0] + 1),
+        ):
+            if record.target_pose is not None:
+                placed += 1
+            if ident_stream is not None and record.identity_basis:
+                sightings.append(
+                    (record.target_ref, record.identity_basis.split(":")[-1], record.valid_ts)
+                )
+            append_belief(out_stream, record)
+            written += 1
+            if record.label:
+                labels[record.label] = labels.get(record.label, 0) + 1
+            if written % 250 == 0:
+                rate = written / (time.perf_counter() - started)
+                print(f"  {written} records  ({rate:.0f}/s)", file=sys.stderr)
+
+        elapsed = time.perf_counter() - started
+        print(
+            f"\nwrote {written} belief records to {out_path} in {elapsed:.0f}s "
+            f"({dark[0]} frames skipped as too dark)"
+        )
+        pct = placed / written * 100 if written else 0.0
+        print(f"placed in 3D: {placed} / {written} records ({pct:.0f}%)")
+        if ident_stream is not None:
+            claims = 0
+            for claim in claims_from_tracks(sightings, session=f"{args.recording.stem}"):
+                append_identity(ident_stream, claim)
+                claims += 1
+            entities = len({s[1] for s in sightings})
+            print(f"identity: {claims} claims over {entities} tracker entities")
+        if vocab:
+            named = len(labels)
+            print(f"labels used: {named} of {len(vocab)} offered ({named / len(vocab) * 100:.1f}%)")
+        else:
+            print(f"discovered vocabulary: {len(labels)} distinct labels (nothing was prompted)")
+        for label, count in sorted(labels.items(), key=lambda kv: -kv[1])[:25]:
+            print(f"  {label:<28} {count}")
+    finally:
+        if out_store is not store:
+            out_store.stop()
+        store.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/dimos/experimental/memory_belief/entity.py
+++ b/dimos/experimental/memory_belief/entity.py
@@ -1,0 +1,244 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Entities as a stream, so the store's existing filters can query them.
+
+Folding sightings and identity claims in Python produces a dictionary, which
+cannot be filtered -- every "as of" would re-fold the whole history. As a stream,
+``as_of`` is a timestamp filter, and snapshots accumulate rather than overwrite.
+
+**The envelope pose is the entity's position, not the sensor's** -- the opposite
+convention from :func:`~dimos.experimental.memory_belief.write.append_belief`. Backwards, it
+would make ``near(x, y, r)`` quietly answer a different question.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+import math
+import statistics
+from typing import TYPE_CHECKING, Any
+
+from pydantic import ConfigDict
+from pydantic.dataclasses import dataclass
+
+from dimos.experimental.memory_belief.identity import resolve_identity
+from dimos.experimental.memory_belief.types import SCHEMA_VERSION
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator
+
+ENTITY_STREAM_NAME = "belief_entity"
+
+#: Below this, a set of sightings is not describing one object well enough to
+#: place it. Derived, not tuned: it is the ratio of sightings to the entities
+#: they resolve into, discounted by how far apart they sit.
+COHERENT = 0.5
+
+
+@dataclass(frozen=True)
+class Entity:
+    """What is believed about one thing, as of one moment."""
+
+    __pydantic_config__ = ConfigDict(extra="forbid")
+
+    schema_version: str
+    entity_id: str
+    label: str | None
+    """The label carried by most of this entity's sightings. Entities whose
+    label is unstable are exactly the ones a reader should distrust, so the
+    agreement ratio travels alongside it."""
+    label_agreement: float
+    support: int
+    first_seen_ts: float
+    last_seen_ts: float
+    position: tuple[float, float, float] | None = None
+    extent: tuple[float, float, float] | None = None
+    dispersion_m: float = 0.0
+    """Median distance from the sightings to their own centroid. A position with
+    large dispersion is not a location, it is an average of several things."""
+    coherence: float = 1.0
+    """Whether these sightings plausibly describe one object. Low values are the
+    honest reason to refuse a position rather than report the centroid."""
+    displacement_m: float = 0.0
+    motion: str = "unknown"
+    """``static`` / ``moving`` / ``unknown`` -- behaviour, not category. A chair
+    that never moves and a chair that does are different to a planner in a way
+    that "chair" is not, and only the sightings can say which this one is."""
+    place_ref: str | None = None
+    identity_basis: str | None = None
+
+    def to_rerun(self):  # type: ignore[no-untyped-def]
+        """A box where the thing is, labelled with how much to trust it.
+
+        Support shows as opacity and motion as colour, so a scatter of
+        one-sighting boxes does not read as a crowd. Each entity gets its own
+        path: logged to one shared path, every snapshot would overwrite the
+        last and a viewer would show one box rather than the room.
+        """
+        import rerun as rr
+
+        key = rr.escape_entity_path_part(self.entity_id)
+        if self.position is None:
+            return [(key, rr.Clear(recursive=False))]
+        half = tuple(max(v, 0.05) / 2 for v in (self.extent or (0.2, 0.2, 0.2)))
+        colour = {
+            "static": (90, 170, 255),
+            "moving": (255, 150, 60),
+        }.get(self.motion, (150, 150, 150))
+        # Saturating at ten sightings: past that the entity is well supported and
+        # the difference between 10 and 300 is not what anyone is looking for.
+        alpha = 55 + int(200 * min(self.support, 10) / 10)
+        return [
+            (
+                key,
+                rr.Boxes3D(
+                    centers=[list(self.position)],
+                    half_sizes=[list(half)],
+                    colors=[(*colour, alpha)],
+                    # The label as written. A glyph table stood here, mapping each term
+                    # to an emoji; it cost 1,979 lines of lookup data inside dimos/ to
+                    # say less than the word does, and an unmapped term read as a
+                    # placeholder rather than as itself.
+                    labels=[self.label or "?"],
+                ),
+            )
+        ]
+
+
+def append_entity(stream: Any, entity: Entity) -> Any:
+    """Append one snapshot, indexed by valid time and the entity's own position.
+
+    ``pose`` is the entity's position on purpose -- see the module docstring.
+    ``tags`` carry the fields worth filtering on so that ``TagsFilter`` covers
+    label, place and motion without any new filter type.
+    """
+    return stream.append(
+        entity,
+        # One row per entity, parked here, so an `as_of` between first and last
+        # sighting matches nothing and the query answers NEVER_COVERED -- 19.8 s
+        # of silence per entity on the reference recording, 238 s on its longest
+        # track. Parking it at `first_seen_ts` would be worse, not better: the
+        # aggregate would then answer from sightings that had not happened yet.
+        # The fix is to fold at query time bounded by `as_of`, not to move this.
+        ts=entity.last_seen_ts,
+        pose=entity.position,
+        tags={
+            "entity_id": entity.entity_id,
+            "label": entity.label,
+            "place_ref": entity.place_ref,
+            "motion": entity.motion,
+            "support": entity.support,
+        },
+    )
+
+
+class _Accumulator:
+    """Running state for one entity. Bounded by entity count, not by sightings."""
+
+    __slots__ = ("basis", "first", "labels", "last", "n", "places", "positions")
+
+    def __init__(self) -> None:
+        self.n = 0
+        self.first = math.inf
+        self.last = -math.inf
+        self.labels: Counter[str] = Counter()
+        self.places: Counter[str] = Counter()
+        self.positions: list[tuple[float, float, float]] = []
+        self.basis: str | None = None
+
+    def add(self, record: Any) -> None:
+        self.n += 1
+        self.first = min(self.first, record.valid_ts)
+        self.last = max(self.last, record.valid_ts)
+        if record.label:
+            self.labels[record.label] += 1
+        if record.place_ref:
+            self.places[record.place_ref] += 1
+        if record.target_pose is not None:
+            self.positions.append(tuple(record.target_pose))
+        self.basis = self.basis or record.identity_basis
+
+
+def _summarise(entity_id: str, acc: _Accumulator, *, static_threshold_m: float) -> Entity:
+    label, label_n = acc.labels.most_common(1)[0] if acc.labels else (None, 0)
+    place = acc.places.most_common(1)[0][0] if acc.places else None
+
+    position = extent = None
+    dispersion = displacement = 0.0
+    coherence = 1.0
+    if acc.positions:
+        xs = [p[0] for p in acc.positions]
+        ys = [p[1] for p in acc.positions]
+        zs = [p[2] for p in acc.positions]
+        centre = (sum(xs) / len(xs), sum(ys) / len(ys), sum(zs) / len(zs))
+        dispersion = statistics.median(math.dist(centre, p) for p in acc.positions)
+        displacement = max((math.dist(acc.positions[0], p) for p in acc.positions), default=0.0)
+        position = centre
+        extent = (max(xs) - min(xs), max(ys) - min(ys), max(zs) - min(zs))
+        # Sightings spread thinly over a wide area describe several things, or
+        # nothing. One metre of spread halves the score.
+        coherence = 1.0 / (1.0 + dispersion)
+
+    motion = "unknown"
+    if len(acc.positions) >= 3:
+        motion = "moving" if displacement >= static_threshold_m else "static"
+
+    return Entity(
+        schema_version=SCHEMA_VERSION,
+        entity_id=entity_id,
+        label=label,
+        label_agreement=(label_n / acc.n) if acc.n else 0.0,
+        support=acc.n,
+        first_seen_ts=acc.first,
+        last_seen_ts=acc.last,
+        position=position,
+        extent=extent,
+        dispersion_m=dispersion,
+        coherence=coherence,
+        displacement_m=displacement,
+        motion=motion,
+        place_ref=place,
+        identity_basis=acc.basis,
+    )
+
+
+def fold_entities(
+    observations: Iterable[Any],
+    identities: Iterable[Any],
+    *,
+    static_threshold_m: float = 0.5,
+) -> Iterator[Entity]:
+    """Fold sightings and identity claims into entity snapshots.
+
+    Consumes ``observations`` as an iterator and never materialises it, so this
+    runs against a live stream. One snapshot per entity, emitted at the end.
+
+    A sighting no identity claim covers is skipped rather than made its own
+    entity -- "seen once" and "followed and lost" are different, and a singleton
+    per unassociated detection would bury that under one-sighting entities.
+    """
+    mapping = resolve_identity(identities)
+    accs: dict[str, _Accumulator] = {}
+
+    for item in observations:
+        record = getattr(item, "data", item)
+        entity_id = mapping.get(record.target_ref)
+        if entity_id is None:
+            continue
+        acc = accs.setdefault(entity_id, _Accumulator())
+        acc.add(record)
+
+    for entity_id, acc in accs.items():
+        yield _summarise(entity_id, acc, static_threshold_m=static_threshold_m)

--- a/dimos/experimental/memory_belief/identity.py
+++ b/dimos/experimental/memory_belief/identity.py
@@ -1,0 +1,148 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Saying that two sightings are the same thing, and being able to take it back.
+
+``target_ref`` is fixed at write time, when nothing yet knows two detections are
+one chair. So identity is a claim, not a column: an ``entity_id`` field on the
+observation would mean every correction rewrites history. Claims live in an
+append-only stream and the mapping is the fold of it; retracting is appending.
+
+A claim naming ``retracts`` supersedes an earlier one, which is what makes a bad
+merge reversible: the wrong claim stays in the stream, and the fold stops
+honouring it. A thing that merely moved needs no retraction -- both records were
+true when written.
+
+Tracker ids are not entity ids: a tracker reuses numbers after a reset, so claims
+namespace them by session. A second retraction path, a `belief_retraction` stream
+naming individual wrong sightings, was written and removed: nothing ever wrote to
+it, and one live mechanism is easier to reason about than one live and one that
+merely looks live.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from pydantic import ConfigDict
+from pydantic.dataclasses import dataclass
+
+from dimos.experimental.memory_belief.types import SCHEMA_VERSION
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator
+
+IDENTITY_STREAM_NAME = "belief_identity"
+
+
+@dataclass(frozen=True)
+class IdentityClaim:
+    """A claim that some sightings are one entity."""
+
+    __pydantic_config__ = ConfigDict(extra="forbid")
+
+    schema_version: str
+    claim_id: str
+    entity_id: str
+    target_refs: tuple[str, ...]
+    basis: str
+    """How the claim was reached, e.g. ``tracker:botsort``, ``reid:clip``,
+    ``user``. Kept because a downstream reader weighs a tracker's word and a
+    person's confirmation very differently."""
+    confidence: float
+    valid_ts: float
+    retracts: str | None = None
+    """``claim_id`` this supersedes. The retracted claim stays in the stream --
+    it is what makes the correction auditable."""
+
+
+def append_identity(stream: Any, claim: IdentityClaim) -> Any:
+    """Append one identity claim, indexed by valid time."""
+    return stream.append(claim, ts=claim.valid_ts)
+
+
+def resolve_identity(claims: Iterable[Any]) -> dict[str, str]:
+    """Fold the identity stream into ``target_ref -> entity_id``.
+
+    Consumes an iterator and holds only the resulting mapping, so it runs
+    against a live stream as well as a stored one. Later claims win, and a claim
+    naming ``retracts`` removes the entity its predecessor asserted, which is
+    what makes a bad merge reversible rather than permanent.
+    """
+    by_claim: dict[str, IdentityClaim] = {}
+    order: list[str] = []
+    for item in claims:
+        claim = getattr(item, "data", item)
+        if claim.retracts is not None:
+            by_claim.pop(claim.retracts, None)
+        by_claim[claim.claim_id] = claim
+        order.append(claim.claim_id)
+
+    mapping: dict[str, str] = {}
+    for claim_id in order:
+        claim = by_claim.get(claim_id)
+        if claim is None:
+            continue
+        for ref in claim.target_refs:
+            mapping[ref] = claim.entity_id
+    return mapping
+
+
+def claims_from_tracks(
+    sightings: Iterable[tuple[str, Any, float]],
+    *,
+    session: str,
+    basis: str = "tracker:botsort",
+    confidence: float = 0.6,
+    batch_size: int = 32,
+) -> Iterator[IdentityClaim]:
+    """Turn ``(target_ref, track_id, ts)`` triples into identity claims.
+
+    Yields claims incrementally rather than accumulating every sighting, so a
+    live run does not grow a dictionary for the length of its uptime. Each claim
+    covers up to ``batch_size`` sightings of one track; a reader folding the
+    stream sees them merge into one entity regardless of how they were batched.
+
+    ``track_id`` of ``None`` yields nothing: an untracked detection is exactly
+    the case this cannot speak to, and inventing a singleton entity for it would
+    make "seen once" indistinguishable from "followed and lost".
+    """
+    pending: dict[str, list[tuple[str, float]]] = {}
+    counter = 0
+
+    def _emit(track_key: str, rows: list[tuple[str, float]]) -> IdentityClaim:
+        nonlocal counter
+        counter += 1
+        return IdentityClaim(
+            schema_version=SCHEMA_VERSION,
+            claim_id=f"{session}:{track_key}:{counter}",
+            entity_id=f"{session}:{track_key}",
+            target_refs=tuple(ref for ref, _ in rows),
+            basis=basis,
+            confidence=confidence,
+            valid_ts=rows[-1][1],
+        )
+
+    for target_ref, track_id, ts in sightings:
+        if track_id is None:
+            continue
+        key = str(track_id)
+        rows = pending.setdefault(key, [])
+        rows.append((target_ref, ts))
+        if len(rows) >= batch_size:
+            yield _emit(key, rows)
+            pending[key] = []
+    for key, rows in pending.items():
+        if rows:
+            yield _emit(key, rows)

--- a/dimos/experimental/memory_belief/locate.py
+++ b/dimos/experimental/memory_belief/locate.py
@@ -1,0 +1,211 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Giving a 2D detection a place in the world, or refusing to.
+
+``world_from_camera`` is the camera's own pose, already in the world frame. A
+``camera_pose_in_world`` helper stood here that composed a robot pose with a
+static mount; every caller was passing a frame pose the recorder had *already*
+resolved through tf as ``world <- camera_optical``, so the mount went in twice
+and every detection landed as though the camera had been yawed 90 degrees.
+
+**Refusing is a result.** Too few lidar returns in the box gets ``None``, not a
+guessed depth: everything downstream treats a present position as evidence.
+
+**Extent, not a centroid.** A bottle is *on* a desk when its footprint sits above
+the desk's top surface, which a point cannot support -- so placements carry an
+axis-aligned extent and callers derive relations geometrically.
+
+Box depth is the median of the returns inside it, and returns beyond
+``depth_band_m`` are dropped first; without that a chair framed against a far
+wall measures metres deep.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+#: Where in a box's depth distribution the foreground surface sits. A box frames
+#: an object in front of its background, so the near end is the object; the
+#: median lands in the empty air between the two when they are of similar size.
+SEED_PERCENTILE = 25.0
+
+
+@dataclass(frozen=True, slots=True)
+class Placement:
+    """Where a detection is, and how well supported that claim is."""
+
+    position: tuple[float, float, float]
+    """Centroid of the inlier returns, in the frame the points arrived in."""
+
+    extent: tuple[float, float, float]
+    """Axis-aligned size of the inlier returns. Zero on a single return."""
+
+    support: int
+    """Inlier count. A placement built from three returns is not the same claim
+    as one built from three hundred, and callers that treat them alike will be
+    confidently wrong about small or distant objects."""
+
+    depth_m: float
+    """Median range from the camera, kept because it bounds the angular error:
+    a box a pixel wide is a fine position at 1 m and a poor one at 10 m."""
+
+
+class PinholeFisheye:
+    """Projection for a camera whose distortion model is ``equidistant``.
+
+    Handles the plain pinhole case too -- a zero distortion vector reduces the
+    fisheye model to it -- so callers do not branch on which camera they have.
+    """
+
+    def __init__(self, camera_info: Any) -> None:
+        k = np.asarray(camera_info.K, float).reshape(3, 3)
+        self.K = k
+        self.D = np.asarray(getattr(camera_info, "D", []) or [0.0, 0.0, 0.0, 0.0], float)[:4]
+        self.width = int(camera_info.width)
+        self.height = int(camera_info.height)
+        self.model = str(getattr(camera_info, "distortion_model", "") or "")
+
+    def project(
+        self, points_cam: NDArray[np.float64]
+    ) -> tuple[NDArray[np.float64], NDArray[np.bool_]]:
+        """Project camera-frame points to pixels.
+
+        Returns ``(uv, keep)`` where ``keep`` marks points that are in front of
+        the camera and land inside the image. Points behind the camera are
+        dropped before projection: a fisheye model will happily produce pixel
+        coordinates for them, and they land in plausible-looking places.
+        """
+        import cv2
+
+        pts = np.asarray(points_cam, np.float64).reshape(-1, 3)
+        in_front = pts[:, 2] > 0.05
+        uv = np.full((len(pts), 2), np.nan)
+        if not in_front.any():
+            return uv, np.zeros(len(pts), bool)
+
+        usable = pts[in_front].reshape(-1, 1, 3)
+        zero = np.zeros(3)
+        if self.model == "equidistant":
+            proj, _ = cv2.fisheye.projectPoints(usable, zero, zero, self.K, self.D)
+        else:
+            proj, _ = cv2.projectPoints(usable, zero, zero, self.K, np.zeros(5))
+        uv[in_front] = proj.reshape(-1, 2)
+
+        keep = in_front.copy()
+        good = ~np.isnan(uv).any(axis=1)
+        keep &= good
+        keep[good] &= (
+            (uv[good, 0] >= 0)
+            & (uv[good, 0] < self.width)
+            & (uv[good, 1] >= 0)
+            & (uv[good, 1] < self.height)
+        )
+        return uv, keep
+
+
+def locate_detections(
+    detections: Sequence[Any],
+    points_world: NDArray[np.float64],
+    *,
+    world_from_camera: Any,
+    camera: PinholeFisheye,
+    min_points: int = 8,
+    depth_band_m: float = 0.6,
+) -> list[Placement | None]:
+    """Place each detection in the world, or return ``None`` for that detection.
+
+    ``points_world`` is ``(N, 3)`` in the world frame and ``world_from_camera``
+    maps back via its ``inverse()``. Below ``min_points`` inliers a detection
+    gets no position; returns further than ``depth_band_m`` from the box's
+    median depth are dropped as background. A segmentation mask is preferred
+    when the detection carries one -- a box around a chair contains a lot of
+    floor.
+    """
+    out: list[Placement | None] = [None] * len(detections)
+    pts = np.asarray(points_world, np.float64).reshape(-1, 3)
+    if not len(pts) or not len(detections):
+        return out
+
+    cam_from_world = np.asarray(world_from_camera.inverse().to_matrix(), float)
+    homo = np.hstack([pts, np.ones((len(pts), 1))])
+    cam_pts = (cam_from_world @ homo.T).T[:, :3]
+
+    uv, keep = camera.project(cam_pts)
+    if not keep.any():
+        return out
+
+    vis_uv = uv[keep]
+    vis_world = pts[keep]
+    vis_depth = cam_pts[keep, 2]
+
+    for i, det in enumerate(detections):
+        bbox = getattr(det, "bbox", None)
+        if bbox is None:
+            continue
+        x1, y1, x2, y2 = (float(v) for v in bbox)
+        inside = (
+            (vis_uv[:, 0] >= x1)
+            & (vis_uv[:, 0] <= x2)
+            & (vis_uv[:, 1] >= y1)
+            & (vis_uv[:, 1] <= y2)
+        )
+        mask = getattr(det, "mask", None)
+        if mask is not None and np.ndim(mask) == 2 and np.any(inside):
+            m = np.asarray(mask)
+            rows = np.clip(vis_uv[:, 1].astype(int), 0, m.shape[0] - 1)
+            cols = np.clip(vis_uv[:, 0].astype(int), 0, m.shape[1] - 1)
+            on_mask = m[rows, cols] > 0
+            # Counted inside the box, not across the frame. `on_mask` covers
+            # every visible return, so a mask with enough hits elsewhere passed
+            # this guard while leaving the box nearly empty -- and the narrowed
+            # selection then fell under `min_points` and dropped a detection the
+            # box alone would have placed. That is the discard this is meant to
+            # prevent, not cause.
+            narrowed = inside & on_mask
+            if narrowed.sum() >= min_points:
+                inside = narrowed
+
+        n = int(inside.sum())
+        if n < min_points:
+            continue
+
+        depths = vis_depth[inside]
+        # Seeded at a low percentile rather than the median. A box frames an
+        # object in front of its background, so the foreground surface is the
+        # near end of the depth distribution -- and when the two are of similar
+        # size, the median lands in the empty air between them and excludes both.
+        seed = float(np.percentile(depths, SEED_PERCENTILE))
+        near = inside.copy()
+        near[inside] = np.abs(depths - seed) <= depth_band_m
+        if int(near.sum()) < min_points:
+            continue
+
+        sel = vis_world[near]
+        centre = sel.mean(axis=0)
+        size = sel.max(axis=0) - sel.min(axis=0)
+        out[i] = Placement(
+            position=(float(centre[0]), float(centre[1]), float(centre[2])),
+            extent=(float(size[0]), float(size[1]), float(size[2])),
+            support=int(near.sum()),
+            depth_m=float(np.median(vis_depth[near])),
+        )
+    return out

--- a/dimos/experimental/memory_belief/pipeline.py
+++ b/dimos/experimental/memory_belief/pipeline.py
@@ -1,0 +1,146 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The one place that says how sightings become the views questions are asked of.
+
+Three folds over one input: identity claims tie sightings together, entities are
+sightings grouped by identity, and annotations are sightings regrouped by the
+frame they were drawn on.
+
+**Why this is a module and not a script.** The same folds have to run twice: once
+offline over a finished recording, once on a robot that is still driving. If each
+caller carried its own copy of the order and the parameters, the two would drift
+-- and drift here is invisible. Nothing raises when one store grouped entities at
+a different threshold than the store it is compared against; the queries simply
+stop agreeing, and the benchmark stops reproducing, with no error to follow back.
+:class:`ViewParams` exists so that divergence has to be deliberate.
+
+Today only the offline path exists: ``detect_recording -> build_views``. The
+functions here take stores and iterators rather than paths and file handles so
+that a live producer, when there is one, calls the same code with the same
+:class:`ViewParams` instead of a second copy that drifts.
+
+A fourth fold, places, lived here until regions were removed. A place is
+entities binned by region and time, so it has no meaning without a region map --
+and a geometric partition, which can split space but cannot name a room, left
+every question that named one exactly as unanswerable as before.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from dimos.experimental.memory_belief.annotate import (
+    annotation_stream,
+    append_annotation,
+    fold_annotations,
+)
+from dimos.experimental.memory_belief.entity import (
+    ENTITY_STREAM_NAME,
+    Entity,
+    append_entity,
+    fold_entities,
+)
+from dimos.experimental.memory_belief.identity import (
+    IDENTITY_STREAM_NAME,
+    IdentityClaim,
+    append_identity,
+    claims_from_tracks,
+)
+from dimos.experimental.memory_belief.write import belief_stream, derived_stream
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+@dataclass(frozen=True, slots=True)
+class ViewParams:
+    """Everything that changes what the derived views mean.
+
+    Frozen and passed by value rather than read from module constants, because
+    the failure this guards against is two callers disagreeing silently. A
+    parameter belongs here if changing it makes two stores incomparable; a
+    parameter that only changes how long the build takes does not.
+    """
+
+    #: How far an entity may move and still count as the same static thing.
+    #: One field, because one fold survives that changes meaning. The grid and
+    #: region parameters that stood here went with the folds that read them.
+    static_threshold_m: float = 0.5
+
+
+def build_views(
+    *,
+    belief: Any,
+    out: Any,
+    session: str,
+    params: ViewParams | None = None,
+    report: Callable[[str], None] | None = None,
+) -> dict[str, int]:
+    """Write identity, entity and annotation streams into ``out``.
+
+    ``belief`` and ``out`` are separate arguments because they are two different
+    roles, not because they are two different files: a live robot passes the same
+    store for both, and an offline build passes two. Nothing here assumes they
+    differ.
+
+    Progress goes to ``report`` rather than to ``print`` so a module deployed in
+    a worker does not write to a stdout nobody is reading. Returns the counts so
+    a caller that wants to assert on them does not have to parse text.
+    """
+    params = params or ViewParams()
+    say = report or (lambda _message: None)
+    counts: dict[str, int] = {}
+
+    # Tracker claims are derived from what every sighting already stores in
+    # `identity_basis`, rather than being a flag on the detector. That keeps
+    # re-identification a rebuild of the views -- minutes -- instead of a second
+    # pass over every frame with a segmentation model.
+    identity_out = derived_stream(out, IDENTITY_STREAM_NAME, IdentityClaim)
+    sightings = [
+        (record.data.target_ref, record.data.identity_basis.split(":")[-1], record.data.valid_ts)
+        for record in belief_stream(belief)
+        if record.data.identity_basis
+    ]
+    claims = 0
+    for claim in claims_from_tracks(sightings, session=session):
+        append_identity(identity_out, claim)
+        claims += 1
+    counts["identity"] = claims
+    say(f"identity: {claims} claims over {len({s[1] for s in sightings})} tracks")
+
+    entity_out = derived_stream(out, ENTITY_STREAM_NAME, Entity)
+    entities = 0
+    for entity in fold_entities(
+        belief_stream(belief),
+        derived_stream(out, IDENTITY_STREAM_NAME, IdentityClaim),
+        static_threshold_m=params.static_threshold_m,
+    ):
+        append_entity(entity_out, entity)
+        entities += 1
+    counts["entities"] = entities
+    say(f"entities: {entities}")
+
+    annotation_out = annotation_stream(out)
+    annotations = boxes = 0
+    for annotation in fold_annotations(belief_stream(belief)):
+        append_annotation(annotation_out, annotation)
+        annotations += 1
+        boxes += len(annotation.boxes)
+    counts["annotations"] = annotations
+    counts["boxes"] = boxes
+    say(f"annotations: {annotations} frames, {boxes} boxes")
+
+    return counts

--- a/dimos/experimental/memory_belief/produce.py
+++ b/dimos/experimental/memory_belief/produce.py
@@ -1,0 +1,171 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Frames in, sightings out. The half of the pipeline a live robot needs.
+
+:mod:`~dimos.experimental.memory_belief.pipeline` folds sightings into views;
+this produces the sightings. Both take iterators and never materialise them, so
+the same call works against a recording that ends and a robot that does not --
+which is what keeps a live producer, when there is one, from being a second copy
+that drifts from this one without anything raising.
+
+The drift here is quieter than in the folds. Two runs that used different
+placement thresholds produce records that look identical -- same fields, same
+types -- and differ only in which detections got a position at all. Nothing
+downstream can tell, so :class:`DetectParams` carries every value that changes
+what a record *means*, separately from the values that only change how long a
+run takes.
+
+What is deliberately not here: opening stores, choosing an output path, printing
+progress, and building the detector. Those differ between a batch job and a
+robot, and none of them changes a record.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from dimos.experimental.memory_belief.detect import bright_enough, detect_to_belief
+from dimos.experimental.memory_belief.locate import locate_detections
+from dimos.msgs.geometry_msgs.Transform import Transform
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Iterator
+
+    from dimos.experimental.memory_belief.types import BeliefObservation
+
+
+@dataclass(frozen=True, slots=True)
+class DetectParams:
+    """Everything that changes what a sighting means.
+
+    The counterpart to :class:`~dimos.experimental.memory_belief.pipeline.ViewParams`,
+    and split from the run's own settings on the same test: a field belongs here
+    if two stores built with different values cannot be compared. ``stride`` and
+    ``limit`` are not here -- skipping frames yields fewer records, not different
+    ones.
+    """
+
+    #: Detections below this are dropped rather than stored with a low score: a
+    #: record that exists at all is evidence downstream.
+    min_confidence: float = 0.0
+    #: Mean pixel value under which a frame is treated as too dark to detect in.
+    #: A dark frame yields no records, and that absence is indistinguishable
+    #: from an empty room unless the threshold travels with the data.
+    min_brightness: float = 40.0
+    #: Lidar returns needed inside a box before it earns a position. Lower it
+    #: and more detections get placed, less reliably -- the single knob that
+    #: most changes what a store can answer.
+    min_points: int = 8
+    #: Depth inlier band, metres. Returns outside it are background seen through
+    #: or around the object.
+    depth_band_m: float = 0.6
+    #: Lattice square size for ``place_ref`` when a detection is placed.
+    place_size_m: float = 5.0
+
+
+def detect_stream(
+    frames: Iterable[Any],
+    detector: Any,
+    *,
+    stream_name: str,
+    vocabulary: tuple[str, ...] | None,
+    source: str,
+    params: DetectParams | None = None,
+    camera: Any = None,
+    stride: int = 1,
+    limit: int | None = None,
+    on_skip: Callable[[], None] | None = None,
+) -> Iterator[BeliefObservation]:
+    """Run ``detector`` over ``frames``, yielding one belief record per detection.
+
+    ``frames`` is consumed as an iterator and never materialised, so the same
+    call works against a live robot where the stream does not end. When
+    ``camera`` is given the frames are expected to be image/scan pairs, as
+    produced by aligning a camera stream against lidar; without it they are bare
+    image observations and every record is written with no position.
+
+    The pose carried by each frame is used as the camera's world pose directly,
+    not composed with a mount transform. A recorded frame's pose is resolved by
+    the recorder as ``world <- frame_id``, and the go2 stamps its images with
+    ``camera_optical`` -- so the mount is already in it. Composing again applied
+    the optical rotation and the 0.3 m offset twice, which put every detection
+    in the map as though the camera had been yawed 90 degrees.
+
+    ``vocabulary`` is recorded verbatim on every record, which is what lets a
+    later question about an unlisted term answer OUT_OF_VOCABULARY rather than
+    "no". ``on_skip`` is called once per frame dropped for darkness, because a
+    caller that cannot see that count cannot tell an unlit corridor from an
+    empty one.
+    """
+    params = params or DetectParams()
+    processed = 0
+    # One slot, not a dictionary keyed by frame: the locator runs on the frame
+    # that was just yielded and never on an older one, so nothing here grows
+    # with the length of the stream.
+    pending: dict[str, Any] = {"points": None, "pose": None}
+
+    def _selected(source_frames: Iterable[Any]) -> Iterator[Any]:
+        """Stride and limit by counting. Slicing would need a length."""
+        nonlocal processed
+        for i, item in enumerate(source_frames):
+            if i % stride:
+                continue
+            if limit is not None and processed >= limit:
+                return
+            processed += 1
+            if camera is None:
+                yield item
+                continue
+            image_obs, scan_obs = item.data
+            pending["points"] = scan_obs.data.points_f32()
+            pending["pose"] = getattr(image_obs, "pose", None)
+            yield image_obs
+
+    def _locate(_observation: Any, detections: Any) -> Any:
+        points, pose = pending["points"], pending["pose"]
+        if pose is None or points is None or not len(points):
+            return [None] * len(detections)
+        return locate_detections(
+            detections,
+            np.asarray(points).reshape(-1, 3),
+            # The frame's own pose, as a transform. Not composed with a camera
+            # mount: the recorder already resolved this pose as
+            # `world <- camera_optical`, so the mount is in it.
+            world_from_camera=Transform.from_pose("world", pose),
+            camera=camera,
+            min_points=params.min_points,
+            depth_band_m=params.depth_band_m,
+        )
+
+    def _lit(observation: Any) -> bool:
+        keep = bright_enough(observation, min_mean=params.min_brightness)
+        if not keep and on_skip is not None:
+            on_skip()
+        return keep
+
+    yield from detect_to_belief(
+        _selected(frames),
+        detector,
+        stream_name=stream_name,
+        vocabulary=vocabulary,
+        source=source,
+        min_confidence=params.min_confidence,
+        place_size_m=params.place_size_m,
+        frame_filter=_lit,
+        locate=None if camera is None else _locate,
+    )

--- a/dimos/experimental/memory_belief/remedy.py
+++ b/dimos/experimental/memory_belief/remedy.py
@@ -1,0 +1,107 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Turning "I do not know" into something to do about it.
+
+A failed query names the capability that would fix it. Mapping that name onto a
+skill is a deployment fact, not a property of the query: a legged robot resolves
+``observe_place`` by walking there, an arm by turning its wrist, a fixed camera
+not at all. Keeping the resolution here is what lets one belief layer run on all
+three.
+
+A capability with no provider is reported as such rather than silently doing
+nothing -- "nobody can fix this" and "I forgot to try" lead an agent to opposite
+next moves.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from dimos.experimental.memory_belief.answer import UnknownReason
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+
+
+@dataclass(frozen=True, slots=True)
+class Remedy:
+    """What to do about one unknown, and whether it is worth doing."""
+
+    reason: UnknownReason
+    capability: str | None
+    provider: str | None
+    #: Whether acting could plausibly change the answer. False for a terminal
+    #: reason, and for one nothing on this robot provides.
+    actionable: bool
+    #: Whether fixing it needs the robot to go and look again. False for
+    #: OUT_OF_VOCABULARY, which is answered by recomputing over stored frames.
+    needs_revisit: bool
+    note: str
+
+
+class RemedyResolver:
+    """Maps a needed capability onto whatever provides it here.
+
+    Providers are registered by capability name, not by reason, so one skill can
+    answer several reasons and a reason can be answered differently on different
+    robots.
+    """
+
+    def __init__(self, providers: Mapping[str, Callable[..., Any]] | None = None) -> None:
+        self._providers: dict[str, Callable[..., Any]] = dict(providers or {})
+
+    @property
+    def capabilities(self) -> frozenset[str]:
+        return frozenset(self._providers)
+
+    def plan_for(self, reason: UnknownReason | None) -> Remedy | None:
+        """What to do about one reason.
+
+        A reason, not an answer object. An earlier design passed the whole
+        answer and read one field off it, which coupled the remedy loop to a
+        return type the query layer stopped producing -- and left the loop
+        unreachable from the one surface an agent actually calls.
+        """
+        if reason is None:
+            return None
+        capability = reason.suggested_capability
+        if capability is None:
+            return Remedy(
+                reason=reason,
+                capability=None,
+                provider=None,
+                actionable=False,
+                needs_revisit=False,
+                note="the data source cannot answer this however long it looks",
+            )
+        provider = self._providers.get(capability)
+        if provider is None:
+            return Remedy(
+                reason=reason,
+                capability=capability,
+                provider=None,
+                actionable=False,
+                needs_revisit=reason.needs_revisit,
+                note=f"nothing here provides {capability!r}",
+            )
+        return Remedy(
+            reason=reason,
+            capability=capability,
+            provider=getattr(provider, "__name__", repr(provider)),
+            actionable=True,
+            needs_revisit=reason.needs_revisit,
+            note=f"{capability} is provided by {getattr(provider, '__name__', provider)}",
+        )

--- a/dimos/experimental/memory_belief/rerun_config.py
+++ b/dimos/experimental/memory_belief/rerun_config.py
@@ -1,0 +1,96 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""How a belief store should be drawn, for any robot that has one.
+
+``dimos mem rerun`` is deliberately robot-agnostic: it walks streams and logs
+whatever converts. That leaves two things it cannot know, and both are here
+rather than in the record types, so ``import rerun`` stays out of them.
+
+**Accumulation.** A viewer that shows only the newest record of each stream
+shows a room one object at a time. Entities log per ``entity_id`` (in
+``entity.py``) so they coexist; lidar logs per time chunk so the map builds up
+instead of replacing itself.
+
+**Where a detection belongs.** A frame's boxes go under the image they were
+drawn on, not at the world origin.
+
+Nothing here is static. Static means "true before it was seen", which is right
+for a robot's own dimensions and wrong for everything this layer records.
+Robot-shaped additions -- a camera frustum, a body box -- compose on top of
+:func:`belief_rerun_config` from the robot's own package; see
+``dimos/robot/unitree/go2/belief_rerun.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+#: Seconds of lidar per accumulated path. Every scan on its own path would
+#: accumulate too, at thousands of paths; one path per chunk keeps the entity
+#: panel usable while still revealing the map progressively as the robot drives.
+MAP_CHUNK_S = 10.0
+
+
+def map_chunk(cloud: Any) -> Any:
+    """Send each scan to a path named for its time bucket.
+
+    Keyed by the scan's own timestamp rather than a running counter, so the same
+    recording always chunks the same way and the discovery pass that converts
+    one observation to test it does not shift every boundary by one.
+    """
+    return [(f"lidar/chunk_{int(cloud.ts / MAP_CHUNK_S):05d}", cloud.to_rerun())]
+
+
+def frame_boxes(annotation: Any) -> Any:
+    """Put the frame's detection boxes under the image, where they were drawn."""
+    return [("color_image/detections", annotation.to_rerun())]
+
+
+def split_blueprint() -> Any:
+    """Camera left, world right -- the split a robot's own viewer uses."""
+    import rerun as rr
+    import rerun.blueprint as rrb
+
+    return rrb.Blueprint(
+        rrb.Horizontal(
+            rrb.Spatial2DView(origin="color_image", name="Camera + detections"),
+            rrb.Spatial3DView(
+                origin="/",
+                name="World",
+                background=rrb.Background(kind="SolidColor", color=[0, 0, 0]),
+                line_grid=rrb.LineGrid3D(plane=rr.components.Plane3D.XY.with_distance(0.0)),
+            ),
+            column_shares=[1, 2],
+        ),
+        rrb.SelectionPanel(state="hidden"),
+    )
+
+
+def belief_rerun_config(*, static: dict[str, Any] | None = None) -> dict[str, Any]:
+    """The robot-agnostic half, with room for a robot to add its own statics.
+
+    Returns a fresh dict each call rather than a module-level constant: callers
+    merge their own entries into it, and a shared dict would carry one robot's
+    frustum into the next one's view.
+    """
+    return {
+        "blueprint": split_blueprint,
+        "tf_axes": 0.3,
+        "visual_override": {
+            "lidar": map_chunk,
+            "belief_frame_annotation": frame_boxes,
+        },
+        "static": dict(static or {}),
+    }

--- a/dimos/experimental/memory_belief/skills.py
+++ b/dimos/experimental/memory_belief/skills.py
@@ -1,0 +1,185 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Belief queries an agent can call.
+
+The default agentic blueprint ships no way to consult the past, so an agent can
+look at the current frame, move and talk, and nothing else. This is the read half
+of that gap.
+
+A failure carries an :class:`~dimos.experimental.memory_belief.answer.UnknownReason` and the
+capability that would fix it, so an agent that gets "unknown" back can act rather
+than parse prose. Read-only by construction: the skill declares no capabilities.
+"""
+
+from __future__ import annotations
+
+import math
+import time
+from typing import TYPE_CHECKING, Any
+
+from dimos.agents.annotation import skill
+from dimos.agents.skill_result import SkillResult
+from dimos.core.core import rpc
+from dimos.experimental.memory_belief.answer import UnknownReason
+from dimos.experimental.memory_belief.api import QueryError, execute
+from dimos.experimental.memory_belief.remedy import RemedyResolver
+from dimos.memory.module import MemoryModule, MemoryModuleConfig
+from dimos.utils.logging_config import setup_logger
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+
+logger = setup_logger()
+
+
+class BeliefQueryConfig(MemoryModuleConfig):
+    """Thresholds a caller may need to tune per deployment."""
+
+    belief_stream_name: str = "belief_observation"
+    #: Recording start, so ``as_of`` can default to a time base the data shares.
+    #: Left None on a live robot, where wall clock and stream clock agree.
+    time_origin_ts: float | None = None
+
+
+class BeliefQuerySkills(MemoryModule):
+    """Read-only access to what the robot believes.
+
+    A :class:`~dimos.memory.module.MemoryModule` so a blueprint can point it at
+    the same ``db_path`` a recorder is writing, rather than at a second copy of
+    the belief.
+
+    **Absence here means "no record", not "looked and saw nothing".** A query
+    answers NEVER_COVERED when nothing matched, which is honest but weak: no
+    ray-marched visibility backs it. A coverage grid that did give the stronger
+    answer was written and removed -- nothing joined it to a query, so it stated
+    a capability the layer could not actually reach.
+    """
+
+    config: BeliefQueryConfig
+
+    def __init__(
+        self,
+        store: Any = None,
+        remedies: Mapping[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        if store is not None:  # tests and scripts hand one in directly
+            self._store = store
+        # No providers registered here: which skill supplies `sweep_place` is a
+        # deployment fact, not a property of the query. An empty resolver still
+        # reports a capability as unprovided, which is the honest answer on a
+        # robot that cannot act on it.
+        self._remedies = RemedyResolver(remedies)
+
+    @rpc
+    def start(self) -> None:
+        super().start()
+
+    def _now(self) -> float:
+        """The asking time, in the same base as the records.
+
+        Wall clock is only correct when the stream is live. Against a replayed
+        recording it produced staleness values of several days, which is how a
+        fresh observation came back marked stale in every recorded trace.
+        """
+        if self.config.time_origin_ts is not None:
+            return self.config.time_origin_ts
+        if self.config.belief_stream_name not in self.store.streams:
+            return time.time()
+        last: list[Any] = (
+            self.store.stream(self.config.belief_stream_name)
+            .order_by("ts", desc=True)
+            .limit(1)
+            .to_list()
+        )
+        return last[0].ts if last else time.time()
+
+    @skill
+    def query(self, query: dict[str, Any]) -> SkillResult:
+        """Ask the belief store one composed question.
+
+        Filters compose inside one call, so ask the whole question at once
+        rather than splitting it across several calls.
+
+        Args:
+            query: ``{"select": ..., "as_of": ..., "where": [...], "project": ...}``.
+                ``select``: ``entities`` -- the only one. A thing, not a
+                sighting of one.
+                ``where``: a list of clauses, ANDed. Two operators:
+                ``{"op": "label", "value": "chair"}`` and
+                ``{"op": "time_range", "t1": 0, "t2": 200}``.
+                ``project``: ``locate`` -- the only one. Position, label,
+                support and dispersion per thing.
+                ``as_of``: defaults to the latest record.
+                ``limit``: how many rows to read, 50 by default.
+        """
+        payload = dict(query or {})
+        # Clamped, not defaulted. Asking about an earlier moment is a real
+        # question -- "where was it a minute ago" -- but a model that picks a
+        # later one answers from observations that have not happened, and the
+        # answer reads exactly as well as a correct one.
+        now = self._now()
+        try:
+            asked = float(payload.get("as_of", now))
+        except (TypeError, ValueError):
+            asked = now
+        payload["as_of"] = min(asked, now) if math.isfinite(asked) else now
+        try:
+            envelope = execute(self.store, payload)
+        except QueryError as exc:
+            return SkillResult(success=False, error_code="INVALID_ARGUMENT", message=str(exc))
+        if envelope["status"] == "ok":
+            return SkillResult(
+                success=True,
+                message=str(envelope["result"]),
+                metadata={k: envelope[k] for k in ("result", "quality", "time_base")},
+            )
+        # An unknown is not a failure to be retried blindly: the diagnostic says
+        # which clause emptied the result, so the next attempt can be informed.
+        #
+        # ``unknown_reason`` is set on the result rather than left in metadata
+        # because that is the field the agent framework reads to derive
+        # ``retryable`` and the suggested capability. Reporting the reason only
+        # inside ``metadata`` makes an honest "I have not looked there" arrive
+        # as an unadorned failure, and a model that cannot see the difference
+        # answers through it -- which is the one behaviour this layer exists to
+        # prevent.
+        reason = envelope.get("reason")
+        unknown = UnknownReason[reason] if reason else None
+        # The remedy loop's whole point is that an agent can act on a refusal.
+        # Resolving it here, against the providers this deployment registered,
+        # is what separates "go and look, something can" from "nobody here can
+        # fix this" -- and those lead to opposite next moves.
+        remedy = self._remedies.plan_for(unknown)
+        return SkillResult(
+            success=False,
+            error_code="INVALID_STATE",
+            message=f"{envelope['status']}: {reason}",
+            unknown_reason=unknown,
+            metadata={
+                **{k: envelope.get(k) for k in ("reason", "quality", "time_base", "diagnostic")},
+                "remedy": None
+                if remedy is None
+                else {
+                    "capability": remedy.capability,
+                    "provider": remedy.provider,
+                    "actionable": remedy.actionable,
+                    "needs_revisit": remedy.needs_revisit,
+                    "note": remedy.note,
+                },
+            },
+        )

--- a/dimos/experimental/memory_belief/test_api.py
+++ b/dimos/experimental/memory_belief/test_api.py
@@ -1,0 +1,308 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import pytest
+
+from dimos.experimental.memory_belief.api import DEFAULT_LIMIT, QueryError, execute
+from dimos.experimental.memory_belief.entity import (
+    COHERENT,
+    ENTITY_STREAM_NAME,
+    Entity,
+    append_entity,
+)
+from dimos.experimental.memory_belief.types import (
+    SCHEMA_VERSION,
+    BeliefObservation,
+    Confidence,
+    EvidenceRef,
+)
+from dimos.experimental.memory_belief.write import append_belief, belief_stream, derived_stream
+from dimos.memory.store.sqlite import SqliteStore
+
+T0 = 1000.0
+
+
+def entity(eid, label, ts, *, position=(1.0, 1.0, 0.0), support=10, place="cell(0,0)", coh=1.0):
+    return Entity(
+        schema_version="1",
+        entity_id=eid,
+        label=label,
+        label_agreement=1.0,
+        support=support,
+        first_seen_ts=ts,
+        last_seen_ts=ts,
+        position=position,
+        extent=(0.4, 0.4, 0.4),
+        dispersion_m=0.1,
+        coherence=coh,
+        displacement_m=0.0,
+        motion="static",
+        place_ref=place,
+    )
+
+
+@pytest.fixture
+def store(tmp_path):
+    s = SqliteStore(path=str(tmp_path / "views.db"))
+    es = derived_stream(s, ENTITY_STREAM_NAME, Entity)
+    append_entity(es, entity("e1", "chair", T0 + 10))
+    append_entity(es, entity("e2", "chair", T0 + 20, position=(5.0, 5.0, 0.0)))
+    append_entity(es, entity("e3", "desk", T0 + 30, support=2, coh=0.05))
+    append_entity(es, entity("e4", "person", T0 + 40, place="cell(0,1)"))
+    # Two sightings of one chair. Folded they are one entity; raw they are two,
+    # which is what `deduplicated` exists to keep a caller from confusing.
+    bs = belief_stream(s)
+    for oid, ts in ((1, T0 + 10), (2, T0 + 11)):
+        append_belief(
+            bs,
+            BeliefObservation(
+                schema_version=SCHEMA_VERSION,
+                target_ref=f"color_image#{oid}:0",
+                label="chair",
+                visibility="present",
+                valid_ts=ts,
+                observed_ts=ts,
+                source="test",
+                evidence=(EvidenceRef(stream="color_image", observation_id=oid, ts=ts),),
+                confidence=Confidence(detection=0.9),
+            ),
+        )
+    yield s
+    s.stop()
+
+
+class TestTheAskingTimeIsRequired:
+    def test_as_of_is_not_defaulted(self, store):
+        with pytest.raises(QueryError, match="as_of"):
+            execute(store, {"select": "entities"})
+
+    def test_a_non_finite_as_of_is_refused(self, store):
+        """`inf` does not widen the window, it removes it.
+
+        Every `before` comparison passes, so the answer covers the whole
+        recording while still reporting a time base -- the one failure this
+        layer exists to prevent, wearing the shape of a valid answer.
+        """
+        for value in (float("inf"), float("-inf"), float("nan"), "Infinity"):
+            with pytest.raises(QueryError, match="finite"):
+                execute(store, {"select": "entities", "as_of": value})
+
+    def test_a_non_numeric_as_of_says_so(self, store):
+        with pytest.raises(QueryError, match="as_of must be a number"):
+            execute(store, {"select": "entities", "as_of": "lunchtime"})
+
+    def test_select_is_not_defaulted(self, store):
+        with pytest.raises(QueryError, match="select"):
+            execute(store, {"as_of": T0})
+
+    def test_nothing_after_the_asking_time_is_visible(self, store):
+        early = execute(store, {"select": "entities", "as_of": T0 + 15, "project": "locate"})
+        late = execute(store, {"select": "entities", "as_of": T0 + 100, "project": "locate"})
+        assert len(early["result"]["positions"]) == 1
+        assert len(late["result"]["positions"]) == 4
+
+
+class TestFiltersComposeInOneCall:
+    def test_two_clauses_narrow_further_than_one(self, store):
+        one = execute(
+            store,
+            {
+                "select": "entities",
+                "as_of": T0 + 100,
+                "where": [{"op": "label", "value": "chair"}],
+                "project": "locate",
+            },
+        )
+        two = execute(
+            store,
+            {
+                "select": "entities",
+                "as_of": T0 + 100,
+                "where": [
+                    {"op": "label", "value": "chair"},
+                    {"op": "time_range", "t1": T0, "t2": T0 + 15},
+                ],
+                "project": "locate",
+            },
+        )
+        assert len(one["result"]["positions"]) == 2
+        assert len(two["result"]["positions"]) == 1
+
+    def test_a_malformed_clause_is_a_fixable_error_not_a_traceback(self, store):
+        """A model that sends ["chair"] has to be told, not crashed on.
+
+        Validation read `clause.get` before anything checked the clause was an
+        object, so a wrong shape raised AttributeError out of the middle of the
+        query -- which ends the turn instead of prompting a retry.
+        """
+        with pytest.raises(QueryError, match="each where clause must be an object"):
+            execute(store, {"select": "entities", "as_of": T0, "where": ["chair"]})
+
+    def test_an_unknown_operator_raises_rather_than_being_skipped(self, store):
+        with pytest.raises(QueryError, match="bogus"):
+            execute(
+                store,
+                {"select": "entities", "as_of": T0, "where": [{"op": "bogus"}]},
+            )
+
+
+class TestEmptyResultsExplainThemselves:
+    def test_the_diagnostic_cannot_see_past_the_asking_time(self, store):
+        """The explanation is bound by the same moment as the answer.
+
+        `_diagnose` reopened the stream and left the boundary off, so a refusal
+        that correctly said "nothing then" arrived beside a row count drawn
+        from observations after the asking time -- the answer withheld and its
+        own metadata handed over.
+        """
+        es = derived_stream(store, ENTITY_STREAM_NAME, Entity)
+        append_entity(es, entity("later", "unicorn", T0 + 500))
+
+        out = execute(
+            store,
+            {
+                "select": "entities",
+                "as_of": T0 + 100,
+                "where": [{"op": "label", "value": "unicorn"}],
+            },
+        )
+
+        assert out["status"] == "unknown"
+        (step,) = out["diagnostic"]["per_clause"]
+        assert step["rows_before"] == 4, "counted rows the query itself refused to look at"
+        assert step["rows_after"] == 0
+
+    def test_no_match_reports_which_clause_emptied_it(self, store):
+        out = execute(
+            store,
+            {
+                "select": "entities",
+                "as_of": T0 + 100,
+                "where": [{"op": "label", "value": "unicorn"}],
+                "project": "locate",
+            },
+        )
+        assert out["status"] == "unknown"
+        steps = out["diagnostic"]["per_clause"]
+        assert steps[-1]["rows_after"] == 0
+        assert steps[-1]["rows_before"] > 0
+
+    def test_the_surviving_clause_count_is_reported(self, store):
+        out = execute(
+            store,
+            {
+                "select": "entities",
+                "as_of": T0 + 100,
+                "where": [
+                    {"op": "label", "value": "chair"},
+                    {"op": "time_range", "t1": T0 + 90, "t2": T0 + 99},
+                ],
+            },
+        )
+        steps = out["diagnostic"]["per_clause"]
+        assert steps[0]["rows_after"] == 2
+        assert steps[1]["rows_after"] == 0
+
+
+class TestTheAnswerCarriesItsOwnTrustworthiness:
+    def test_answers_say_they_are_about_things_not_sightings(self, store):
+        out = execute(store, {"select": "entities", "as_of": T0 + 100, "project": "locate"})
+
+        # The only select is entities, so this is always true -- and asserted
+        # anyway, because the field is what stops a caller reading a result as a
+        # count of sightings if raw observations are ever queryable again.
+        assert out["quality"]["deduplicated"] is True
+
+    def test_the_threshold_is_the_one_the_fold_defines(self, store):
+        """One definition of "coherent enough", not two that disagree.
+
+        `entity.COHERENT` says 0.5 and the status check here said 0.2, so a
+        grouping the fold called incoherent was reported as a usable answer.
+        """
+        es = derived_stream(store, ENTITY_STREAM_NAME, Entity)
+        append_entity(es, entity("e9", "lamp", T0 + 50, coh=(COHERENT + 0.2) / 2))
+        out = execute(
+            store,
+            {
+                "select": "entities",
+                "as_of": T0 + 100,
+                "where": [{"op": "label", "value": "lamp"}],
+                "project": "locate",
+            },
+        )
+
+        assert out["status"] == "unknown"
+        assert out["reason"] == "INCOHERENT"
+
+    def test_low_coherence_downgrades_the_status(self, store):
+        out = execute(
+            store,
+            {
+                "select": "entities",
+                "as_of": T0 + 100,
+                "where": [{"op": "label", "value": "desk"}],
+                "project": "locate",
+            },
+        )
+        # One sighting cluster too scattered to be one object: answering with
+        # its centroid would be a position invented from nothing.
+        assert out["status"] == "unknown"
+        assert out["reason"] == "INCOHERENT"
+
+
+class TestTheRowBoundIsAppliedBeforeTheRowsAreRead:
+    @pytest.fixture
+    def crowded(self, tmp_path):
+        s = SqliteStore(path=str(tmp_path / "crowded.db"))
+        es = derived_stream(s, ENTITY_STREAM_NAME, Entity)
+        for i in range(DEFAULT_LIMIT + 25):
+            append_entity(es, entity(f"e{i}", "chair", T0 + i))
+        yield s
+        s.stop()
+
+    def test_an_unbounded_query_still_reads_a_bounded_number_of_rows(self, crowded):
+        """The bound belongs to the query, not to the projection.
+
+        Capping the positions after the fact left the store reading every
+        matching row to build an answer that never used them, and reporting the
+        discarded ones in ``rows`` as though they were part of it.
+        """
+        out = execute(crowded, {"select": "entities", "as_of": T0 + 1000})
+
+        assert out["quality"]["rows"] == DEFAULT_LIMIT
+        assert len(out["result"]["positions"]) == DEFAULT_LIMIT
+
+    def test_an_explicit_limit_is_honoured(self, crowded):
+        out = execute(crowded, {"select": "entities", "as_of": T0 + 1000, "limit": 7})
+
+        assert out["quality"]["rows"] == 7
+        assert len(out["result"]["positions"]) == 7
+
+    def test_a_limit_of_zero_or_less_is_refused_rather_than_ignored(self, crowded):
+        # Both used to read as "no limit" through a truthiness test, which is
+        # the opposite of what either asks for.
+        for value in (0, -1):
+            with pytest.raises(QueryError, match="at least 1"):
+                execute(crowded, {"select": "entities", "as_of": T0 + 1000, "limit": value})
+
+    def test_a_non_numeric_limit_says_so(self, crowded):
+        with pytest.raises(QueryError, match="limit must be a whole number"):
+            execute(crowded, {"select": "entities", "as_of": T0 + 1000, "limit": "lots"})
+
+    def test_omitting_the_projection_answers_with_the_only_one(self, store):
+        # The default named a projection that does not exist, so a query that
+        # left `project` out was rejected as if it had asked for something.
+        assert execute(store, {"select": "entities", "as_of": T0 + 100})["status"] == "ok"

--- a/dimos/experimental/memory_belief/test_detect.py
+++ b/dimos/experimental/memory_belief/test_detect.py
@@ -1,0 +1,206 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Contract tests for the 2D detection producer.
+
+Mostly about what it refuses to claim. A flat image supports far less than it
+appears to, and each of those limits has to survive into the record rather than
+living in someone's memory of how the data was made.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pytest
+
+from dimos.experimental.memory_belief.detect import bright_enough, detect_to_belief
+from dimos.experimental.memory_belief.types import BeliefObservation
+from dimos.memory.type.observation import Observation
+from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
+from dimos.msgs.sensor_msgs.Image import Image, ImageFormat
+
+NOW = 1000.0
+
+
+@dataclass
+class FakeDetection:
+    name: str
+    confidence: float
+
+
+@dataclass
+class FakeResult:
+    detections: list[FakeDetection]
+
+
+class FakeDetector:
+    """Returns a scripted result, and records what it was shown."""
+
+    def __init__(self, detections: list[FakeDetection] | None = None) -> None:
+        self.detections = detections if detections is not None else [FakeDetection("chair", 0.9)]
+        self.seen = 0
+
+    def process_image(self, image):
+        self.seen += 1
+        return FakeResult(list(self.detections))
+
+
+def frame(oid: int = 1, ts: float = NOW, *, mean: int = 200, pose=True) -> Observation[Image]:
+    array = np.full((16, 16, 3), mean, np.uint8)
+    return Observation(
+        id=oid,
+        ts=ts,
+        pose=PoseStamped(position=(2.0, 7.0, 0.0)) if pose else None,
+        _data=Image(data=array, format=ImageFormat.RGB, frame_id="cam", ts=ts),
+    )
+
+
+def produce(frames, detector=None, **overrides) -> list[BeliefObservation]:
+    kwargs = {
+        "stream_name": "color_image",
+        "vocabulary": ("chair", "person"),
+        "source": "fake",
+        **overrides,
+    }
+    return list(detect_to_belief(frames, detector or FakeDetector(), **kwargs))
+
+
+class TestNoDepthMeansNoPosition:
+    """A bounding box says a thing was in frame, not where it is."""
+
+    def test_target_pose_is_never_filled(self):
+        assert all(r.target_pose is None for r in produce([frame()]))
+
+    def test_entity_place_is_never_filled(self):
+        assert all(r.place_ref is None for r in produce([frame()]))
+
+    def test_capture_place_is_filled_from_the_pose(self):
+        (record,) = produce([frame()])
+
+        assert record.capture_place_ref == "cell(0,1)"  # (2.0, 7.0) at 5m cells
+
+    def test_a_frame_without_a_pose_records_no_place_at_all(self):
+        assert produce([frame(pose=False)])[0].capture_place_ref is None
+
+
+class TestNoAssociationMeansNoIdentity:
+    def test_identity_status_is_none(self):
+        assert all(r.identity_status == "none" for r in produce([frame()]))
+
+    def test_the_same_object_in_two_frames_gets_two_targets(self):
+        """Honest until a re-identification step exists."""
+        records = produce([frame(oid=1), frame(oid=2)])
+
+        assert len({r.target_ref for r in records}) == 2
+
+    def test_target_refs_point_back_at_their_frame(self):
+        (record,) = produce([frame(oid=42)])
+
+        assert record.target_ref.startswith("color_image#42")
+
+
+class TestOnlyPresenceIsClaimed:
+    def test_every_record_is_present(self):
+        assert all(r.visibility == "present" for r in produce([frame()]))
+
+    def test_a_frame_with_no_detections_writes_nothing(self):
+        """Silence from a detector is not evidence of absence."""
+        records = produce([frame()], FakeDetector(detections=[]))
+
+        assert records == []
+
+
+class TestVocabularyTravelsWithTheRecord:
+    def test_a_prompted_run_records_what_it_was_asked(self):
+        (record,) = produce([frame()], vocabulary=("chair", "person"))
+
+        assert record.vocabulary == ("chair", "person")
+
+    def test_an_unprompted_run_records_none(self):
+        (record,) = produce([frame()], vocabulary=None)
+
+        assert record.vocabulary is None
+
+
+class TestConfidence:
+    def test_detection_confidence_is_kept_separate(self):
+        (record,) = produce([frame()], FakeDetector([FakeDetection("chair", 0.77)]))
+
+        assert record.confidence.detection == pytest.approx(0.77)
+        assert record.confidence.association is None
+
+    def test_low_confidence_detections_are_dropped_not_recorded(self):
+        """Anything that exists at all is treated as evidence downstream."""
+        detector = FakeDetector([FakeDetection("chair", 0.2), FakeDetection("door", 0.9)])
+
+        records = produce([frame()], detector, min_confidence=0.5)
+
+        assert [r.label for r in records] == ["door"]
+
+
+class TestFrameSelection:
+    def test_dark_frames_can_be_filtered_out(self):
+        detector = FakeDetector()
+
+        produce([frame(mean=5), frame(mean=200)], detector, frame_filter=bright_enough)
+
+        assert detector.seen == 1
+
+    def test_bright_enough_thresholds_on_mean_luminance(self):
+        assert not bright_enough(frame(mean=5))
+        assert bright_enough(frame(mean=200))
+
+    def test_no_filter_means_every_frame_is_processed(self):
+        detector = FakeDetector()
+
+        produce([frame(mean=5), frame(mean=200)], detector)
+
+        assert detector.seen == 2
+
+
+class TestTimeAxes:
+    def test_valid_time_comes_from_the_frame(self):
+        (record,) = produce([frame(ts=123.0)])
+
+        assert record.valid_ts == 123.0
+
+    def test_observed_time_defaults_to_valid_time(self):
+        (record,) = produce([frame(ts=123.0)])
+
+        assert record.observed_ts == record.valid_ts
+
+
+class TestEvidence:
+    def test_each_record_points_back_at_its_frame(self):
+        (record,) = produce([frame(oid=7, ts=5.0)])
+        (ref,) = record.evidence
+
+        assert (ref.stream, ref.observation_id, ref.ts) == ("color_image", 7, 5.0)
+
+    def test_two_detections_in_one_frame_share_its_evidence(self):
+        detector = FakeDetector([FakeDetection("chair", 0.9), FakeDetection("door", 0.9)])
+
+        records = produce([frame(oid=3)], detector)
+
+        assert {r.evidence[0].observation_id for r in records} == {3}
+
+
+class TestPlaceResolution:
+    def test_place_is_derived_from_coordinates_not_a_room_list(self):
+        """Naming a place is a claim that needs its own evidence."""
+        (record,) = produce([frame()], place_size_m=1.0)
+
+        assert record.capture_place_ref == "cell(2,7)"

--- a/dimos/experimental/memory_belief/test_entity.py
+++ b/dimos/experimental/memory_belief/test_entity.py
@@ -1,0 +1,89 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from dimos.experimental.memory_belief.entity import fold_entities
+from dimos.experimental.memory_belief.identity import IdentityClaim
+from dimos.experimental.memory_belief.types import SCHEMA_VERSION, BeliefObservation, EvidenceRef
+
+
+def sighting(ref: str, **overrides) -> BeliefObservation:
+    return BeliefObservation(
+        **{
+            "schema_version": SCHEMA_VERSION,
+            "target_ref": ref,
+            "label": "bottle",
+            "visibility": "present",
+            "valid_ts": 10.0,
+            "observed_ts": 10.0,
+            "source": "test",
+            "evidence": (EvidenceRef(stream="color_image", observation_id=1, ts=10.0),),
+            **overrides,
+        }
+    )
+
+
+def claim(*refs: str) -> IdentityClaim:
+    return IdentityClaim(
+        schema_version=SCHEMA_VERSION,
+        claim_id="c1",
+        entity_id="e1",
+        target_refs=refs,
+        basis="tracker:test",
+        confidence=0.6,
+        valid_ts=10.0,
+    )
+
+
+class TestWhereTheSensorWasIsNotWhereTheThingIs:
+    """The one confusion this layer exists to refuse.
+
+    A sighting knows where the camera stood, never where the object stands.
+    Letting ``capture_place_ref`` stand in for a missing ``place_ref`` turns
+    "the robot was in the kitchen when it saw a bottle" into "there is a bottle
+    in the kitchen". The two fields are one line apart in the record, so nothing
+    but a test keeps them apart.
+
+    This used to be asserted at the query layer, where an ``in_region`` clause
+    on raw sightings was rejected outright. That query no longer exists -- the
+    only select is entities -- so the guarantee now has to hold in the fold.
+    """
+
+    def test_a_capture_place_never_becomes_an_entity_place(self):
+        sightings = [sighting("s1", capture_place_ref="kitchen", place_ref=None)]
+
+        (entity,) = fold_entities(sightings, [claim("s1")])
+
+        assert entity.place_ref is None
+
+    def test_an_entity_place_is_carried_when_one_exists(self):
+        sightings = [sighting("s1", capture_place_ref="kitchen", place_ref="cell(3,4)")]
+
+        (entity,) = fold_entities(sightings, [claim("s1")])
+
+        assert entity.place_ref == "cell(3,4)"
+
+
+class TestFoldingIsByIdentityNotByLabel:
+    def test_a_sighting_no_claim_covers_is_skipped(self):
+        """ "Seen once" and "followed and lost" are different states.
+
+        A singleton entity per unassociated detection would bury the second
+        under a crowd of the first.
+        """
+        folded = list(fold_entities([sighting("s1"), sighting("s2")], [claim("s1")]))
+
+        assert len(folded) == 1
+        assert folded[0].support == 1

--- a/dimos/experimental/memory_belief/test_identity.py
+++ b/dimos/experimental/memory_belief/test_identity.py
@@ -1,0 +1,101 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from dimos.experimental.memory_belief.identity import (
+    IdentityClaim,
+    claims_from_tracks,
+    resolve_identity,
+)
+from dimos.experimental.memory_belief.types import SCHEMA_VERSION
+
+
+def claim(claim_id: str, entity: str, refs: tuple[str, ...], retracts: str | None = None):
+    return IdentityClaim(
+        schema_version=SCHEMA_VERSION,
+        claim_id=claim_id,
+        entity_id=entity,
+        target_refs=refs,
+        basis="test",
+        confidence=0.9,
+        valid_ts=1.0,
+        retracts=retracts,
+    )
+
+
+class TestIdentityIsAFoldNotAColumn:
+    def test_sightings_collapse_to_one_entity(self):
+        mapping = resolve_identity([claim("c1", "chair-a", ("s#1:0", "s#2:0", "s#3:1"))])
+        assert set(mapping) == {"s#1:0", "s#2:0", "s#3:1"}
+        assert set(mapping.values()) == {"chair-a"}
+
+    def test_a_later_claim_wins(self):
+        mapping = resolve_identity(
+            [claim("c1", "chair-a", ("s#1:0",)), claim("c2", "chair-b", ("s#1:0",))]
+        )
+        assert mapping["s#1:0"] == "chair-b"
+
+    def test_batches_of_one_track_merge_into_one_entity(self):
+        mapping = resolve_identity(
+            [claim("c1", "chair-a", ("s#1:0",)), claim("c2", "chair-a", ("s#2:0",))]
+        )
+        assert mapping == {"s#1:0": "chair-a", "s#2:0": "chair-a"}
+
+
+class TestAMergeCanBeTakenBack:
+    def test_retracting_removes_the_association(self):
+        # Two things were merged, then the merge was found to be wrong.
+        mapping = resolve_identity(
+            [
+                claim("c1", "one-thing", ("s#1:0", "s#2:0")),
+                claim("c2", "just-the-first", ("s#1:0",), retracts="c1"),
+            ]
+        )
+        assert mapping["s#1:0"] == "just-the-first"
+        # The sighting that only the retracted claim spoke for is unassociated
+        # again, rather than silently keeping an entity nothing still asserts.
+        assert "s#2:0" not in mapping
+
+    def test_the_retracted_claim_is_still_in_the_stream(self):
+        history = [
+            claim("c1", "one-thing", ("s#1:0", "s#2:0")),
+            claim("c2", "just-the-first", ("s#1:0",), retracts="c1"),
+        ]
+        # Auditability: folding is what drops it, not deletion.
+        assert any(c.claim_id == "c1" for c in history)
+
+
+class TestTrackerIdsAreNotEntityIds:
+    def test_tracks_are_namespaced_by_session(self):
+        a = list(claims_from_tracks([("s#1:0", 7, 1.0)], session="run-a"))
+        b = list(claims_from_tracks([("s#9:0", 7, 9.0)], session="run-b"))
+        # The same tracker number in two sessions must not merge two objects.
+        assert a[0].entity_id != b[0].entity_id
+
+    def test_untracked_detections_produce_no_claim(self):
+        assert list(claims_from_tracks([("s#1:0", None, 1.0)], session="r")) == []
+
+    def test_batching_does_not_change_the_resolved_entity(self):
+        sightings = [(f"s#{i}:0", 3, float(i)) for i in range(10)]
+        small = resolve_identity(claims_from_tracks(sightings, session="r", batch_size=2))
+        large = resolve_identity(claims_from_tracks(sightings, session="r", batch_size=100))
+        assert set(small.values()) == set(large.values())
+        assert set(small) == set(large)
+
+    def test_claims_are_emitted_incrementally(self):
+        sightings = [(f"s#{i}:0", 1, float(i)) for i in range(9)]
+        claims = list(claims_from_tracks(sightings, session="r", batch_size=4))
+        # A live run must not accumulate every sighting before emitting anything.
+        assert len(claims) == 3

--- a/dimos/experimental/memory_belief/test_locate.py
+++ b/dimos/experimental/memory_belief/test_locate.py
@@ -1,0 +1,162 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pytest
+
+from dimos.experimental.memory_belief.locate import PinholeFisheye, locate_detections
+from dimos.msgs.geometry_msgs.Quaternion import Quaternion
+from dimos.msgs.geometry_msgs.Transform import Transform
+from dimos.msgs.geometry_msgs.Vector3 import Vector3
+
+
+@dataclass
+class FakeCameraInfo:
+    K: tuple[float, ...] = (400.0, 0.0, 320.0, 0.0, 400.0, 240.0, 0.0, 0.0, 1.0)
+    D: tuple[float, ...] = (0.0, 0.0, 0.0, 0.0)
+    width: int = 640
+    height: int = 480
+    distortion_model: str = "plumb_bob"
+
+
+@dataclass
+class FakeDetection:
+    bbox: tuple[float, float, float, float]
+    mask: np.ndarray | None = None
+
+
+@pytest.fixture
+def camera() -> PinholeFisheye:
+    return PinholeFisheye(FakeCameraInfo())
+
+
+@pytest.fixture
+def identity_pose() -> Transform:
+    """Camera at the world origin, looking down +z."""
+    return Transform(
+        translation=Vector3(0.0, 0.0, 0.0),
+        rotation=Quaternion(0.0, 0.0, 0.0, 1.0),
+        frame_id="world",
+        child_frame_id="camera_optical",
+    )
+
+
+def _cube(centre: tuple[float, float, float], half: float, n: int = 6) -> np.ndarray:
+    axis = np.linspace(-half, half, n)
+    grid = np.stack(np.meshgrid(axis, axis, axis), -1).reshape(-1, 3)
+    return grid + np.asarray(centre)
+
+
+class TestRefusingIsAResult:
+    def test_no_points_yields_no_placement(self, camera, identity_pose):
+        det = FakeDetection(bbox=(300, 220, 340, 260))
+        out = locate_detections(
+            [det], np.zeros((0, 3)), world_from_camera=identity_pose, camera=camera
+        )
+        assert out == [None]
+
+    def test_too_few_points_yields_no_placement(self, camera, identity_pose):
+        # Three returns inside the box, but min_points is eight.
+        points = _cube((0.0, 0.0, 3.0), 0.02, n=2)[:3]
+        det = FakeDetection(bbox=(0, 0, 640, 480))
+        out = locate_detections(
+            [det], points, world_from_camera=identity_pose, camera=camera, min_points=8
+        )
+        assert out == [None]
+
+    def test_points_behind_the_camera_do_not_place(self, camera, identity_pose):
+        behind = _cube((0.0, 0.0, -3.0), 0.3)
+        det = FakeDetection(bbox=(0, 0, 640, 480))
+        out = locate_detections([det], behind, world_from_camera=identity_pose, camera=camera)
+        assert out == [None]
+
+
+class TestPlacementIsMeasured:
+    def test_position_matches_the_cube_it_was_built_from(self, camera, identity_pose):
+        points = _cube((0.0, 0.0, 3.0), 0.25)
+        det = FakeDetection(bbox=(0, 0, 640, 480))
+        (placed,) = locate_detections([det], points, world_from_camera=identity_pose, camera=camera)
+        assert placed is not None
+        assert placed.position == pytest.approx((0.0, 0.0, 3.0), abs=0.05)
+        assert placed.depth_m == pytest.approx(3.0, abs=0.05)
+
+    def test_extent_is_reported_not_just_a_point(self, camera, identity_pose):
+        points = _cube((0.0, 0.0, 3.0), 0.25)
+        det = FakeDetection(bbox=(0, 0, 640, 480))
+        (placed,) = locate_detections([det], points, world_from_camera=identity_pose, camera=camera)
+        assert placed is not None
+        # A 0.5 m cube, so every side should measure about half a metre. Without
+        # extent, "the bottle is on the desk" cannot be derived at query time.
+        assert placed.extent == pytest.approx((0.5, 0.5, 0.5), abs=0.05)
+
+    def test_support_counts_the_inliers(self, camera, identity_pose):
+        points = _cube((0.0, 0.0, 3.0), 0.25, n=5)
+        det = FakeDetection(bbox=(0, 0, 640, 480))
+        (placed,) = locate_detections([det], points, world_from_camera=identity_pose, camera=camera)
+        assert placed is not None
+        assert placed.support == len(points)
+
+
+class TestBackgroundIsNotTheObject:
+    def test_a_far_wall_inside_the_box_is_excluded(self, camera, identity_pose):
+        near = _cube((0.0, 0.0, 2.0), 0.2)
+        far = _cube((0.0, 0.0, 9.0), 0.2)
+        det = FakeDetection(bbox=(0, 0, 640, 480))
+        (placed,) = locate_detections(
+            [det],
+            np.vstack([near, far]),
+            world_from_camera=identity_pose,
+            camera=camera,
+            depth_band_m=0.6,
+        )
+        assert placed is not None
+        # Depth must land on one surface, not average the two into empty air.
+        assert placed.depth_m < 3.0
+        assert placed.extent[2] < 1.0
+
+
+class TestBoxIsNotTheOnlyEvidence:
+    def test_a_mask_narrows_the_selection(self, camera, identity_pose):
+        left = _cube((-1.0, 0.0, 3.0), 0.15)
+        right = _cube((1.0, 0.0, 3.0), 0.15)
+        points = np.vstack([left, right])
+        mask = np.zeros((480, 640), np.uint8)
+        mask[:, :320] = 1  # only the left half of the image
+        det = FakeDetection(bbox=(0, 0, 640, 480), mask=mask)
+        (placed,) = locate_detections([det], points, world_from_camera=identity_pose, camera=camera)
+        assert placed is not None
+        assert placed.position[0] < 0.0
+
+    def test_a_mask_that_misses_the_box_falls_back_to_it(self, camera, identity_pose):
+        """The fallback has to measure the overlap it is named for.
+
+        The guard counted mask hits across the whole frame, so a mask covering
+        a different object passed it while leaving this box nearly empty. The
+        narrowed selection then fell under `min_points` and the detection was
+        dropped -- the box alone would have placed it.
+        """
+        subject = _cube((0.0, 0.0, 3.0), 0.15)
+        elsewhere = _cube((2.0, 0.0, 3.0), 0.15)
+        points = np.vstack([subject, elsewhere])
+        # Covers only where `elsewhere` projects, far to the right of the box.
+        mask = np.zeros((480, 640), np.uint8)
+        mask[:, 560:] = 1
+        box = FakeDetection(bbox=(280, 200, 360, 280), mask=mask)
+        (placed,) = locate_detections([box], points, world_from_camera=identity_pose, camera=camera)
+        assert placed is not None, "a mask covering another object dropped this detection"
+        assert placed.position[0] == pytest.approx(0.0, abs=0.2)

--- a/dimos/experimental/memory_belief/test_produce.py
+++ b/dimos/experimental/memory_belief/test_produce.py
@@ -1,0 +1,153 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Frame selection and darkness skipping, which lived in a CLI until now.
+
+Both decide how many records a run produces and neither had a test: they were
+closures over ``argparse`` results inside ``detect_recording.main``. A stride
+off by one, or a brightness filter that counted the wrong frames, would have
+shown up as "the robot saw less than expected" with nothing to point at.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from dimos.experimental.memory_belief.produce import DetectParams, detect_stream
+from dimos.memory.type.observation import Observation
+from dimos.msgs.sensor_msgs.Image import Image, ImageFormat
+
+
+class FakeDetection:
+    def __init__(self) -> None:
+        self.name = "chair"
+        self.confidence = 0.9
+        self.box = (0.0, 0.0, 10.0, 10.0)
+        self.track_id = None
+
+
+class FakeResult:
+    def __init__(self, detections: list[FakeDetection]) -> None:
+        self.detections = detections
+
+
+class FakeDetector:
+    """Yields one detection per frame, and records how many frames it saw."""
+
+    def __init__(self) -> None:
+        self.seen = 0
+
+    def process_image(self, image):  # type: ignore[no-untyped-def]
+        self.seen += 1
+        return FakeResult([FakeDetection()])
+
+
+def frame(oid: int, ts: float, *, mean: int = 200) -> Observation[Image]:
+    array = np.full((16, 16, 3), mean, np.uint8)
+    return Observation(
+        id=oid, ts=ts, _data=Image(data=array, format=ImageFormat.RGB, frame_id="cam", ts=ts)
+    )
+
+
+class TestFrameSelection:
+    def test_stride_keeps_every_nth_frame(self):
+        detector = FakeDetector()
+
+        list(
+            detect_stream(
+                [frame(i, float(i)) for i in range(10)],
+                detector,
+                stream_name="color_image",
+                vocabulary=None,
+                source="test",
+                stride=3,
+            )
+        )
+
+        # 0, 3, 6, 9 -- counted from the first frame, not from the first kept
+        # one, so two runs over the same recording select the same frames.
+        assert detector.seen == 4
+
+    def test_limit_counts_selected_frames_not_offered_ones(self):
+        detector = FakeDetector()
+
+        list(
+            detect_stream(
+                [frame(i, float(i)) for i in range(20)],
+                detector,
+                stream_name="color_image",
+                vocabulary=None,
+                source="test",
+                stride=2,
+                limit=3,
+            )
+        )
+
+        assert detector.seen == 3
+
+
+class TestDarknessIsReportedNotHidden:
+    """A dark frame yields nothing, which reads exactly like an empty room."""
+
+    def test_dark_frames_are_skipped_and_counted(self):
+        skipped: list[int] = []
+        detector = FakeDetector()
+
+        records = list(
+            detect_stream(
+                [frame(1, 1.0, mean=5), frame(2, 2.0, mean=200), frame(3, 3.0, mean=5)],
+                detector,
+                stream_name="color_image",
+                vocabulary=None,
+                source="test",
+                params=DetectParams(min_brightness=40.0),
+                on_skip=lambda: skipped.append(1),
+            )
+        )
+
+        assert len(records) == 1
+        assert len(skipped) == 2
+
+    def test_no_callback_is_not_an_error(self):
+        records = list(
+            detect_stream(
+                [frame(1, 1.0, mean=5)],
+                FakeDetector(),
+                stream_name="color_image",
+                vocabulary=None,
+                source="test",
+            )
+        )
+
+        assert records == []
+
+
+class TestWithoutACameraNothingIsPlaced:
+    def test_records_carry_no_position(self):
+        records = list(
+            detect_stream(
+                [frame(1, 1.0)],
+                FakeDetector(),
+                stream_name="color_image",
+                vocabulary=None,
+                source="test",
+            )
+        )
+
+        # A box says a thing was in frame, never where it is. Without a camera
+        # to project through there is no depth, and inventing one is the failure
+        # this layer exists to refuse.
+        assert records
+        assert all(r.target_pose is None for r in records)
+        assert all(r.place_ref is None for r in records)

--- a/dimos/experimental/memory_belief/test_remedy.py
+++ b/dimos/experimental/memory_belief/test_remedy.py
@@ -1,0 +1,144 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Contract tests for turning an unknown into an action.
+
+The loop only closes if a failed query names something runnable. These check
+that it does, that nothing hardcodes which skill provides what, and that a
+capability with no provider is reported rather than quietly skipped.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dimos.experimental.memory_belief.answer import UnknownReason
+from dimos.experimental.memory_belief.remedy import RemedyResolver
+
+#: What a resolver is handed when the query succeeded: no reason to remedy.
+ANSWERED = None
+
+
+class TestTheLoopCloses:
+    def test_the_plan_says_which_provider_would_run(self):
+        def sweep(**kwargs):
+            return None
+
+        remedy = RemedyResolver({"sweep_place": sweep}).plan_for(UnknownReason.NEVER_COVERED)
+
+        assert remedy.actionable
+        assert remedy.provider == "sweep"
+
+    def test_an_answered_query_has_nothing_to_remedy(self):
+        assert RemedyResolver().plan_for(ANSWERED) is None
+
+
+class TestNothingHardcodesASkill:
+    def test_the_same_reason_resolves_differently_per_robot(self):
+        """A legged robot walks there; an arm turns its wrist."""
+
+        def walk(**kwargs):
+            return None
+
+        def turn_wrist(**kwargs):
+            return None
+
+        incoherent = UnknownReason.INCOHERENT
+
+        assert RemedyResolver({"observe_place": walk}).plan_for(incoherent).provider == "walk"
+        assert (
+            RemedyResolver({"observe_place": turn_wrist}).plan_for(incoherent).provider
+            == "turn_wrist"
+        )
+
+
+class TestMissingProvidersAreReported:
+    def test_an_unprovided_capability_is_not_actionable(self):
+        remedy = RemedyResolver().plan_for(UnknownReason.NEVER_COVERED)
+
+        assert not remedy.actionable
+        assert "sweep_place" in remedy.note
+
+
+class TestTerminalReasons:
+    def test_no_capability_is_never_actionable(self):
+        remedy = RemedyResolver().plan_for(UnknownReason.NO_CAPABILITY)
+
+        assert not remedy.actionable
+        assert remedy.capability is None
+
+    def test_it_stays_unactionable_even_if_everything_is_registered(self):
+        every = {
+            r.suggested_capability: (lambda **kw: None)
+            for r in UnknownReason
+            if r.suggested_capability
+        }
+
+        assert not RemedyResolver(every).plan_for(UnknownReason.NO_CAPABILITY).actionable
+
+
+class TestRevisitIsDistinguished:
+    def test_a_vocabulary_gap_needs_no_second_trip(self):
+        """The frames are stored; re-running detection answers it in place."""
+        resolver = RemedyResolver({"redetect_with_vocabulary": lambda **kw: None})
+
+        remedy = resolver.plan_for(UnknownReason.OUT_OF_VOCABULARY)
+
+        assert remedy.actionable
+        assert not remedy.needs_revisit
+
+    @pytest.mark.parametrize("reason", [UnknownReason.INCOHERENT, UnknownReason.NEVER_COVERED])
+    def test_the_others_do(self, reason):
+        every = {
+            r.suggested_capability: (lambda **kw: None)
+            for r in UnknownReason
+            if r.suggested_capability
+        }
+
+        assert RemedyResolver(every).plan_for(reason).needs_revisit
+
+
+class TestRegistration:
+    def test_registered_capabilities_are_listable(self):
+        resolver = RemedyResolver({"sweep_place": lambda **kw: None})
+
+        assert resolver.capabilities == frozenset({"sweep_place"})
+
+
+class TestEveryReasonTheEngineEmitsCanBeResolved:
+    """The gap this closes cost a KeyError at the skill boundary.
+
+    ``api.py`` returned ``reason="INCOHERENT"`` while ``UnknownReason`` had no
+    such member, so ``skills.py`` raised ``KeyError`` instead of refusing --
+    turning the layer's most characteristic answer, "these sightings may not be
+    one thing", into a crash. Reading the reasons back out of the source keeps
+    the two from drifting apart again.
+    """
+
+    def test_the_enum_holds_every_reason_api_returns(self):
+        import pathlib as _pathlib
+        import re
+
+        from dimos.experimental.memory_belief import api
+
+        source = _pathlib.Path(api.__file__).read_text()
+        emitted = set(re.findall(r'"reason":\s*"([A-Z_]+)"', source))
+        emitted |= set(re.findall(r'reason\s*=\s*"unknown",\s*"([A-Z_]+)"', source))
+
+        assert emitted, "no reasons found in api.py; this test has stopped testing anything"
+        assert emitted <= {r.name for r in UnknownReason}
+
+    def test_every_enum_member_is_reachable_from_a_skill_result(self):
+        for reason in UnknownReason:
+            assert UnknownReason[reason.name] is reason

--- a/dimos/experimental/memory_belief/test_skills.py
+++ b/dimos/experimental/memory_belief/test_skills.py
@@ -1,0 +1,162 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Contract tests for the agent-facing belief skills.
+
+The property that matters is that a failure survives the trip to the agent as
+structure: reason, whether retrying helps, and what would fix it. If any of
+that degrades to prose on the way out, the agent is back to guessing.
+"""
+
+from __future__ import annotations
+
+import math
+import time
+
+import pytest
+
+from dimos.experimental.memory_belief import skills as skills_module
+from dimos.experimental.memory_belief.answer import UnknownReason
+from dimos.experimental.memory_belief.skills import BeliefQuerySkills
+from dimos.experimental.memory_belief.types import SCHEMA_VERSION, BeliefObservation, EvidenceRef
+from dimos.experimental.memory_belief.write import append_belief, belief_stream
+from dimos.memory.store.sqlite import SqliteStore
+
+
+def record(**overrides) -> BeliefObservation:
+    fields = {
+        "schema_version": SCHEMA_VERSION,
+        "target_ref": "chair-17",
+        "label": "chair",
+        "visibility": "present",
+        "valid_ts": 0.0,
+        "observed_ts": 0.0,
+        "source": "fake",
+        "place_ref": "kitchen",
+        "evidence": (EvidenceRef(stream="color_image", observation_id=7, ts=0.0),),
+        **overrides,
+    }
+    return BeliefObservation(**fields)
+
+
+@pytest.fixture
+def skills(tmp_path):
+    """A module wired to a store holding one fresh sighting."""
+
+    store = SqliteStore(path=str(tmp_path / "b.db"))
+    stream = belief_stream(store)
+    append_belief(stream, record(valid_ts=time.time(), observed_ts=time.time()))
+
+    module = BeliefQuerySkills(store=store)
+    try:
+        yield module
+    finally:
+        module.dispose()
+        store.stop()
+
+
+class TestTheSkillCannotContradictTheEvidence:
+    def test_retryable_follows_the_reason_rather_than_the_skill(self, skills):
+        """``retryable`` is derived from the unknown reason, so a caller that
+        retries is acting on what the data says, not on what a skill claimed.
+
+        NEVER_COVERED is retryable because going and looking would change it;
+        the two must not be settable apart.
+        """
+        result = skills.query(
+            {"select": "entities", "where": [{"op": "label", "value": "no-such-thing"}]}
+        )
+
+        assert result.unknown_reason is UnknownReason.NEVER_COVERED
+        assert result.retryable is not UnknownReason.NEVER_COVERED.is_terminal
+
+
+class TestTheAgentCannotAskAboutTheFuture:
+    """The asking time is the robot's, not the model's.
+
+    ``as_of`` used to be a `setdefault`, so a model could name any moment it
+    liked. Combined with a query engine that accepted `inf`, a runtime agent
+    could answer a question about now from observations not yet made.
+    """
+
+    @staticmethod
+    def _as_of_reaching_the_engine(skills, monkeypatch, asked):
+        """The value `execute` is actually called with, not the one asked for."""
+        seen = {}
+
+        def spy(store, payload):
+            seen["as_of"] = payload["as_of"]
+            return {"status": "unknown", "reason": "NEVER_COVERED", "quality": {}}
+
+        monkeypatch.setattr(skills_module, "execute", spy)
+        skills.query({"select": "entities", "as_of": asked, "project": "locate"})
+        return seen["as_of"]
+
+    def test_a_later_as_of_is_clamped_to_now(self, skills, monkeypatch):
+        asked = time.time() + 86_400
+        assert self._as_of_reaching_the_engine(skills, monkeypatch, asked) < asked
+
+    def test_an_earlier_as_of_is_honoured(self, skills, monkeypatch):
+        """Looking back is a real question and must keep working."""
+        asked = time.time() - 3600
+        got = self._as_of_reaching_the_engine(skills, monkeypatch, asked)
+        assert got == pytest.approx(asked)
+
+    def test_a_non_finite_as_of_falls_back_to_now(self, skills, monkeypatch):
+        got = self._as_of_reaching_the_engine(skills, monkeypatch, float("inf"))
+        assert math.isfinite(got)
+
+
+class TestReadOnly:
+    def test_the_query_skill_holds_no_capabilities(self):
+        """Nothing here moves the robot or writes belief, so a query can never
+        be refused for conflicting with something that does."""
+        assert BeliefQuerySkills.query.__skill_uses__ == []
+
+
+class TestARefusalCarriesWhatWouldFixIt:
+    """A refusal an agent cannot act on is barely better than a wrong answer.
+
+    The two cases below differ only in whether this deployment registered a
+    provider, and they warrant opposite next moves: go and look, versus give up
+    and say so. Both are the resolver's, not the query's -- what a robot can do
+    is not a property of what the data says.
+    """
+
+    def _refusal(self, module):
+        result = module.query(
+            {"select": "entities", "where": [{"op": "label", "value": "no-such-thing"}]}
+        )
+        assert not result.success
+        return result.metadata["remedy"]
+
+    def test_an_unprovided_capability_is_named_but_not_actionable(self, skills):
+        remedy = self._refusal(skills)
+
+        assert remedy["capability"] == "sweep_place"
+        assert remedy["actionable"] is False
+        assert "sweep_place" in remedy["note"]
+
+    def test_a_provided_capability_becomes_actionable(self, tmp_path):
+        store = SqliteStore(path=str(tmp_path / "r.db"))
+        append_belief(belief_stream(store), record(valid_ts=time.time()))
+        module = BeliefQuerySkills(store=store, remedies={"sweep_place": lambda: None})
+        try:
+            remedy = self._refusal(module)
+        finally:
+            module.dispose()
+            store.stop()
+
+        assert remedy["actionable"] is True
+        assert remedy["needs_revisit"] is True

--- a/dimos/experimental/memory_belief/test_types.py
+++ b/dimos/experimental/memory_belief/test_types.py
@@ -1,0 +1,272 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Contract tests for belief records.
+
+These lock the distinctions that make a negative answer trustworthy: evidence
+that can be re-read, ignorance that cannot pass as absence, and a target's
+position that cannot be confused with the vantage point it was seen from.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from pathlib import Path
+import sqlite3
+import tempfile
+
+import pytest
+
+from dimos.experimental.memory_belief.types import (
+    SCHEMA_VERSION,
+    BeliefObservation,
+    Confidence,
+    EvidenceRef,
+    belief_tags,
+)
+from dimos.experimental.memory_belief.write import append_belief, belief_stream
+from dimos.experimental.world_belief.absence import (
+    ABSENT,
+    OCCLUDED,
+    OUT_OF_VIEW,
+    PRESENT,
+)
+from dimos.memory.codecs.json import JsonCodec
+from dimos.memory.store.sqlite import SqliteStore
+from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
+
+EV = (EvidenceRef(stream="color_image", observation_id=42, ts=100.0),)
+
+
+def rec(**overrides) -> BeliefObservation:
+    kwargs = {
+        "schema_version": SCHEMA_VERSION,
+        "target_ref": "chair-17",
+        "visibility": "present",
+        "valid_ts": 100.0,
+        "observed_ts": 100.0,
+        "source": "yoloe+depth",
+        "evidence": EV,
+        **overrides,
+    }
+    return BeliefObservation(**kwargs)
+
+
+@pytest.fixture
+def store():
+    with tempfile.TemporaryDirectory() as tmp:
+        s = SqliteStore(path=str(Path(tmp) / "belief.db"))
+        try:
+            yield s
+        finally:
+            s.stop()
+
+
+class TestEvidenceIsMandatory:
+    def test_a_record_without_evidence_is_rejected(self):
+        """An untraceable claim is an assertion, not a belief."""
+        with pytest.raises(ValueError, match="evidence"):
+            rec(evidence=())
+
+    def test_evidence_points_at_a_re_readable_observation(self, store):
+        stream = belief_stream(store)
+        append_belief(stream, rec())
+
+        ref = stream.to_list()[0].data.evidence[0]
+
+        assert (ref.stream, ref.observation_id) == ("color_image", 42)
+
+
+class TestVisibilitySemantics:
+    """absent is a claim; occluded and out_of_view are admissions."""
+
+    def test_the_four_verdicts_stay_in_step_with_the_geometry(self):
+        """These strings must equal the ones classify_visibility() emits.
+
+        The two definitions are deliberately separate -- memory must not depend
+        on an experimental perception module -- so this test is what catches
+        drift between them.
+        """
+
+        for verdict in (PRESENT, ABSENT, OCCLUDED, OUT_OF_VIEW):
+            rec(visibility=verdict)  # must not raise
+
+
+class TestVantagePointIsNotLocation:
+    def test_target_pose_requires_a_declared_frame(self):
+        """Coordinates with no frame cannot be compared with anything."""
+        with pytest.raises(ValueError, match="frame"):
+            rec(target_pose=(1.0, 2.0, 3.0))
+
+    def test_frame_without_a_pose_is_also_rejected(self):
+        with pytest.raises(ValueError, match="frame"):
+            rec(frame_id="map")
+
+    def test_capture_pose_lives_on_the_envelope_not_the_payload(self, store):
+        """Structural separation: the payload has no field to put it in."""
+
+        stream = belief_stream(store)
+        append_belief(
+            stream,
+            rec(target_pose=(5.0, 6.0, 7.0), frame_id="map"),
+            capture_pose=PoseStamped(position=(1.0, 2.0, 3.0)),
+        )
+
+        obs = stream.to_list()[0]
+
+        assert obs.pose.position.x == pytest.approx(1.0)  # where the robot looked from
+        assert obs.data.target_pose == (5.0, 6.0, 7.0)  # where the thing is
+        assert not hasattr(obs.data, "capture_pose")
+
+    def test_a_record_may_carry_no_position_at_all(self):
+        """No depth means no target position -- that is a valid, honest record."""
+        assert rec().target_pose is None
+
+
+class TestVocabularyAndSource:
+    def test_source_is_mandatory(self):
+        with pytest.raises(ValueError, match="source"):
+            rec(source="")
+
+    def test_closed_vocabulary_is_recorded_with_the_record(self, store):
+        """A detector only asked about chairs cannot support "there is no mug"."""
+        stream = belief_stream(store)
+        append_belief(stream, rec(vocabulary=("chair", "person")))
+
+        assert stream.to_list()[0].data.vocabulary == ("chair", "person")
+
+    def test_open_vocabulary_records_none(self):
+        assert rec(source="vlm").vocabulary is None
+
+
+class TestConfidenceStaysSeparate:
+    def test_the_three_confidences_are_independent(self):
+        c = rec(confidence=Confidence(detection=0.9, association=0.4)).confidence
+
+        assert (c.detection, c.association, c.attribute) == (0.9, 0.4, None)
+
+    def test_confidence_defaults_to_all_unknown(self):
+        c = rec().confidence
+
+        assert (c.detection, c.association, c.attribute) == (None, None, None)
+
+
+class TestTwoTimeAxes:
+    def test_valid_and_observed_time_can_differ(self):
+        """Replay and late correction: learned at 5pm what happened at 2pm."""
+        r = rec(valid_ts=100.0, observed_ts=10_000.0)
+
+        assert r.valid_ts != r.observed_ts
+
+    def test_the_envelope_is_indexed_by_valid_time(self, store):
+        """ "What was here at 2pm" is the query that has to push down."""
+        stream = belief_stream(store)
+        append_belief(stream, rec(valid_ts=100.0, observed_ts=10_000.0))
+
+        obs = stream.to_list()[0]
+
+        assert obs.ts == pytest.approx(100.0)
+        assert obs.data.observed_ts == pytest.approx(10_000.0)
+
+    def test_time_range_query_uses_valid_time(self, store):
+        stream = belief_stream(store)
+        append_belief(stream, rec(target_ref="a", valid_ts=100.0, observed_ts=9_000.0))
+        append_belief(stream, rec(target_ref="b", valid_ts=500.0, observed_ts=9_000.0))
+
+        found = stream.time_range(0.0, 200.0).to_list()
+
+        assert [o.data.target_ref for o in found] == ["a"]
+
+
+class TestTagProjection:
+    def test_tags_are_derived_not_supplied(self, store):
+        """No parameter exists to pass tags, so they cannot disagree."""
+
+        assert "tags" not in inspect.signature(append_belief).parameters
+
+    def test_tags_mirror_the_payload(self):
+        r = rec(place_ref="kitchen", label="chair", identity_status="confirmed")
+        tags = belief_tags(r)
+
+        assert tags["target_ref"] == r.target_ref
+        assert tags["visibility"] == r.visibility
+        assert tags["source"] == r.source
+        assert tags["place_ref"] == r.place_ref
+        assert tags["identity_status"] == r.identity_status
+
+    def test_absent_optional_fields_are_omitted_not_null(self):
+        """A null tag would index as a value and match "place_ref is null" oddly."""
+        assert "place_ref" not in belief_tags(rec())
+
+    @pytest.mark.parametrize("tag", ["target_ref", "visibility", "source", "place_ref"])
+    def test_tags_push_down_as_queries(self, store, tag):
+        kept = rec(
+            target_ref="chair-17", visibility="present", place_ref="kitchen", source="yoloe+depth"
+        )
+        other = rec(
+            target_ref="mug-3",
+            visibility="absent",
+            place_ref="pantry",
+            source="vlm",
+            valid_ts=101.0,
+        )
+        stream = belief_stream(store)
+        append_belief(stream, kept)
+        append_belief(stream, other)
+
+        wanted = belief_tags(kept)[tag]
+        found = stream.tags(**{tag: wanted}).to_list()
+
+        assert [o.data.target_ref for o in found] == ["chair-17"]
+
+
+class TestPersistence:
+    def test_records_survive_reopening_the_store(self, tmp_path):
+        """The whole point of JSON over pickle -- and of not opening a fifth store."""
+        path = str(tmp_path / "belief.db")
+        s1 = SqliteStore(path=path)
+        append_belief(belief_stream(s1), rec(vocabulary=("chair",)))
+        s1.stop()
+
+        s2 = SqliteStore(path=path, must_exist=True)
+        try:
+            reread = belief_stream(s2).to_list()[0].data
+        finally:
+            s2.stop()
+
+        assert reread == rec(vocabulary=("chair",))
+
+    def test_stored_bytes_are_readable_json(self, tmp_path):
+        path = str(tmp_path / "belief.db")
+        s = SqliteStore(path=path)
+        append_belief(belief_stream(s), rec())
+        s.stop()
+
+        con = sqlite3.connect(path)
+        try:
+            row = con.execute('SELECT data FROM "belief_observation_blob" LIMIT 1').fetchone()
+        finally:
+            con.close()
+
+        assert json.loads(bytes(row[0]))["target_ref"] == "chair-17"
+
+    def test_unknown_field_from_a_newer_writer_is_reported(self, tmp_path):
+        """A field this build does not know must surface, not vanish."""
+
+        codec = JsonCodec(BeliefObservation)
+        payload = codec.encode(rec()).replace(b"{", b'{"from_the_future":1,', 1)
+
+        with pytest.raises(Exception, match="from_the_future"):
+            codec.decode(payload)

--- a/dimos/experimental/memory_belief/types.py
+++ b/dimos/experimental/memory_belief/types.py
@@ -1,0 +1,172 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""One grounded judgement about one target at one moment.
+
+``visibility`` is three-way on purpose: ``absent`` is negative evidence -- the
+sensor looked through the spot -- while ``occluded`` and ``out_of_view`` are no
+evidence at all. Collapsing them turns "I did not see it" into "it is not there".
+
+Capture pose is not ``target_pose``: the first lives on the enclosing
+Observation, the second is None without geometric evidence. Keeping them apart
+is what stops "the robot was in the kitchen" becoming "X is in the kitchen".
+
+``valid_ts`` is when the fact held, ``observed_ts`` when the system worked it
+out. Detection, association and attribute ``confidence`` fail independently and
+cannot be one blended score.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from pydantic import ConfigDict
+
+SCHEMA_VERSION = "1"
+STREAM_NAME = "belief_observation"
+
+Visibility = Literal["present", "absent", "occluded", "out_of_view"]
+IdentityStatus = Literal["none", "tentative", "confirmed"]
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceRef:
+    """A pointer back to one raw observation.
+
+    ``stream`` plus ``observation_id`` is the only durable way to re-read the
+    frame; ``ts`` is carried so a reader can order evidence without opening the
+    store.
+    """
+
+    __pydantic_config__ = ConfigDict(extra="forbid")
+
+    stream: str
+    observation_id: int
+    ts: float
+
+
+@dataclass(frozen=True, slots=True)
+class Confidence:
+    """Separate confidences for separately-failing steps. None means N/A."""
+
+    __pydantic_config__ = ConfigDict(extra="forbid")
+
+    detection: float | None = None
+    association: float | None = None
+    attribute: float | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class BeliefObservation:
+    """What one look established about one target."""
+
+    __pydantic_config__ = ConfigDict(extra="forbid")
+
+    schema_version: str
+    target_ref: str
+    visibility: Visibility
+    valid_ts: float
+    observed_ts: float
+    source: str
+    evidence: tuple[EvidenceRef, ...]
+    label: str | None = None
+    #: Where the *target* is. Requires positional evidence -- depth, a fixed
+    #: camera's known footprint, a presence sensor. A plain 2D detection cannot
+    #: fill this in, and must not.
+    place_ref: str | None = None
+    #: Where the *sensor* was. Always knowable from odometry, and never a claim
+    #: about the target: "the robot was in the kitchen when it saw a bottle" is
+    #: not "there is a bottle in the kitchen".
+    capture_place_ref: str | None = None
+    target_pose: tuple[float, float, float] | None = None
+    frame_id: str | None = None
+    bbox: tuple[float, float, float, float] | None = None
+    """Pixel box ``(x1, y1, x2, y2)`` in the frame ``evidence`` points at.
+
+    Without it ``evidence`` names the frame a sighting came from but not where in
+    the frame, which is enough to re-open the image and not enough to show anyone
+    what was seen. Every claim this layer makes about the world traces back to a
+    rectangle some detector drew; keeping the rectangle is what lets a person
+    check the claim instead of trusting it."""
+    identity_status: IdentityStatus | None = None
+    identity_basis: str | None = None
+    vocabulary: tuple[str, ...] | None = None
+    confidence: Confidence = field(default_factory=Confidence)
+
+    def to_rerun(self):  # type: ignore[no-untyped-def]
+        """One sighting as a point, or nothing when it has no position.
+
+        Replayed on a timeline these accumulate into the trail an object left
+        behind. A sighting the locator refused shows as nothing rather than as a
+        point at the sensor: drawing it at the camera would put every unplaced
+        detection on the robot's own path, which is the exact conflation
+        ``capture_place_ref`` exists to avoid.
+        """
+        import rerun as rr
+
+        if self.target_pose is None:
+            return rr.Clear(recursive=False)
+        conf = float(self.confidence.detection or 0.0)
+        # Faint at low confidence so a dense trail of weak detections reads as
+        # weak rather than as a confident track.
+        shade = int(60 + 195 * min(max(conf, 0.0), 1.0))
+        return rr.Points3D(
+            positions=[list(self.target_pose)],
+            colors=[(shade, shade // 2, 255 - shade)],
+            radii=[0.04],
+            labels=[self.label or "?"],
+        )
+
+    def __post_init__(self) -> None:
+        if not self.target_ref:
+            raise ValueError("target_ref must be non-empty: a belief is about something")
+        if not self.source:
+            raise ValueError("source must be non-empty: oracle grade must stay attached")
+        if not self.evidence:
+            raise ValueError(
+                f"{self.target_ref}: belief needs evidence. A record that cannot be traced "
+                "back to a raw observation is an assertion, not a belief."
+            )
+        if (self.target_pose is None) != (self.frame_id is None):
+            raise ValueError(
+                f"{self.target_ref}: target_pose and frame_id go together. Coordinates "
+                "without a declared frame cannot be compared with anything."
+            )
+
+
+def belief_tags(record: BeliefObservation) -> dict[str, Any]:
+    """The indexed projection of a record.
+
+    SQLite indexes every tag key it sees, so these are the fields worth pushing
+    a query down on. The payload stays authoritative -- tags are a redundant
+    copy, which is why callers never supply them by hand (see
+    :func:`~dimos.experimental.memory_belief.write.append_belief`): a tag that disagreed with
+    its payload would be undetectable at query time.
+    """
+    tags: dict[str, Any] = {
+        "schema_version": record.schema_version,
+        "target_ref": record.target_ref,
+        "visibility": record.visibility,
+        "source": record.source,
+    }
+    if record.place_ref is not None:
+        tags["place_ref"] = record.place_ref
+    if record.capture_place_ref is not None:
+        tags["capture_place_ref"] = record.capture_place_ref
+    if record.label is not None:
+        tags["label"] = record.label
+    if record.identity_status is not None:
+        tags["identity_status"] = record.identity_status
+    return tags

--- a/dimos/experimental/memory_belief/vocabulary.py
+++ b/dimos/experimental/memory_belief/vocabulary.py
@@ -1,0 +1,94 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Naming what the detector was asked about, so a "no" differs from a "never asked".
+
+A closed list cannot see what it was not given. That cost is only acceptable
+because the list travels with the record --
+:attr:`~dimos.experimental.memory_belief.types.BeliefObservation.vocabulary` -- so a later
+"is there a humidifier here" answers OUT_OF_VOCABULARY rather than a confident
+and wrong "no".
+
+LVIS is used rather than a hand-written list because it is a published object
+vocabulary with a long tail of household and office items, and a hand-maintained
+list drifts.
+"""
+
+from __future__ import annotations
+
+import re
+
+
+def _clean(name: str) -> str:
+    """LVIS names carry parenthetical disambiguators and slash-separated
+    synonyms: ``monitor_(computer_equipment)/television_monitor``. The first
+    synonym, de-underscored and stripped of the parenthetical, is what a person
+    would say and what the text encoder handles best."""
+    primary = str(name).split("/")[0]
+    primary = re.sub(r"_?\(.*?\)", "", primary)
+    return primary.replace("_", " ").strip()
+
+
+def lvis_names() -> tuple[str, ...]:
+    """The 1,203 LVIS categories as readable primary names.
+
+    Returned in the dataset's own order so an index means the same thing across
+    runs. Duplicates after cleaning are dropped, keeping first occurrence.
+    """
+    import importlib.util
+
+    import yaml
+
+    spec = importlib.util.find_spec("ultralytics")
+    if spec is None or not spec.submodule_search_locations:
+        raise RuntimeError("ultralytics is not installed; LVIS names unavailable")
+    root = spec.submodule_search_locations[0]
+    path = f"{root}/cfg/datasets/lvis.yaml"
+
+    with open(path) as handle:
+        names = yaml.safe_load(handle)["names"]
+
+    seen: set[str] = set()
+    out: list[str] = []
+    for key in sorted(names, key=int):
+        cleaned = _clean(names[key])
+        if cleaned and cleaned not in seen:
+            seen.add(cleaned)
+            out.append(cleaned)
+    return tuple(out)
+
+
+def from_file(path: str) -> tuple[str, ...]:
+    """One term per line. Blank lines and ``#`` comments ignored.
+
+    Exists so a deployment can narrow or extend the list without editing code;
+    whatever it returns is what gets recorded on every observation, so the file
+    is part of the evidence rather than a setting.
+    """
+    with open(path) as handle:
+        lines = [line.split("#")[0].strip() for line in handle]
+    return tuple(dict.fromkeys(line for line in lines if line))
+
+
+def resolve(spec: str | None) -> tuple[str, ...] | None:
+    """Turn a CLI value into a vocabulary, or ``None`` for open-vocabulary.
+
+    ``None`` is not "no vocabulary chosen" -- it is the claim that the run
+    covered everything, and it is recorded as such.
+    """
+    if spec is None or spec.lower() in {"none", "open", "prompt-free"}:
+        return None
+    if spec.lower() == "lvis":
+        return lvis_names()
+    return from_file(spec)

--- a/dimos/experimental/memory_belief/write.py
+++ b/dimos/experimental/memory_belief/write.py
@@ -1,0 +1,77 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Opening and writing the belief stream.
+
+A plain derived stream in the existing store -- no second database -- which buys
+timestamps, capture pose, tag pushdown, replay and ``align()`` for free.
+
+Two invariants hold by construction rather than by review: ``append_belief``
+derives tags from the payload and takes no parameter to override them, and the
+envelope timestamp is valid time, because "what was in the kitchen at 2pm" is the
+query that has to be fast.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from dimos.experimental.memory_belief.types import STREAM_NAME, BeliefObservation, belief_tags
+
+if TYPE_CHECKING:
+    from dimos.memory.store.base import Store
+    from dimos.memory.stream import Stream
+    from dimos.memory.type.observation import Observation
+
+T = TypeVar("T")
+
+
+def derived_stream(store: Store, name: str, payload_type: type[T]) -> Stream[T]:
+    """Open (or create) a derived belief stream on ``store``.
+
+    Every derived record type is stored the same way, and the codec is the part
+    worth keeping in one place: these streams are read by tools outside this
+    package, so a payload that stopped being readable JSON would break them
+    silently.
+    """
+    return store.stream(name, payload_type, codec="json")
+
+
+def belief_stream(store: Store, *, name: str = STREAM_NAME) -> Stream[BeliefObservation]:
+    """Open (or create) the belief stream on ``store``.
+
+    Stored as JSON rather than pickle: these records outlive the release that
+    wrote them and other tools have to read them.
+    """
+    return store.stream(name, BeliefObservation, codec="json")
+
+
+def append_belief(
+    stream: Stream[BeliefObservation],
+    record: BeliefObservation,
+    *,
+    capture_pose: Any | None = None,
+) -> Observation[BeliefObservation]:
+    """Append one record, indexing it by valid time and capture pose.
+
+    ``capture_pose`` is the vantage point, deliberately separate from
+    ``record.target_pose``: conflating them turns "seen from the kitchen" into
+    "in the kitchen".
+    """
+    return stream.append(
+        record,
+        ts=record.valid_ts,
+        pose=capture_pose,
+        tags=belief_tags(record),
+    )

--- a/dimos/memory/cli/app.py
+++ b/dimos/memory/cli/app.py
@@ -33,9 +33,35 @@ def rerun(
     root: str = typer.Option(
         None, "--root", help="Nest every stream under this entity path (<root>/<name>)"
     ),
+    view: str = typer.Option(
+        None,
+        "--view",
+        help="module:function returning a rerun_config, e.g. "
+        "dimos.robot.unitree.go2.belief_rerun:go2_belief_rerun_config",
+    ),
 ) -> None:
     """Render a memory store into rerun (writes a .rrd, then opens the viewer)."""
     from dimos.memory.cli.dataset import open_dataset
     from dimos.memory.cli.render import render_store
 
-    render_store(open_dataset(path), out=out, seconds=seconds, no_gui=no_gui, root=root)
+    # `module:function`, the same form `all_blueprints` uses, so a robot's view
+    # lives with the robot instead of needing a registry here or a script of its
+    # own. Called rather than passed as a value: a config carries closures and a
+    # shared dict would leak one robot's statics into the next one's view.
+    rerun_config = None
+    if view:
+        import importlib
+
+        module_path, _, attr = view.partition(":")
+        if not attr:
+            raise typer.BadParameter("expected module:function", param_hint="--view")
+        rerun_config = getattr(importlib.import_module(module_path), attr)()
+
+    render_store(
+        open_dataset(path),
+        out=out,
+        seconds=seconds,
+        no_gui=no_gui,
+        root=root,
+        rerun_config=rerun_config,
+    )

--- a/dimos/memory/cli/render.py
+++ b/dimos/memory/cli/render.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Render any memory store into rerun.
 
 Generic: walks the store's streams and logs every observation whose payload
@@ -19,6 +18,12 @@ implements ``to_rerun()`` (the :class:`RerunConvertible` convention). Streams
 whose payload has no ``to_rerun`` are skipped. Each stream becomes an entity
 path; observations share one ``time`` timeline (relative to the store's earliest
 observation, so streams stay aligned). Writes a ``.rrd`` and opens the viewer.
+
+``rerun_config`` takes the same shape the live viewer's
+:class:`~dimos.visualization.rerun.bridge.RerunBridgeModule` already accepts, so
+a recording renders the way the robot looked while it was being made rather than
+through a second, separately-invented set of conventions. Omitting it leaves the
+behaviour here exactly as it was.
 """
 
 from __future__ import annotations
@@ -26,7 +31,7 @@ from __future__ import annotations
 from pathlib import Path
 import shutil
 import subprocess
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from dimos.memory.store.base import Store
@@ -48,6 +53,7 @@ def render_store(
     seconds: float | None = None,
     no_gui: bool = False,
     root: str | None = None,
+    rerun_config: dict[str, Any] | None = None,
 ) -> str:
     """Render ``store`` to a ``.rrd`` and (unless ``no_gui``) open the rerun viewer.
 
@@ -55,11 +61,46 @@ def render_store(
     the start. ``root`` nests every stream under that entity path
     (``<root>/<name>``) — except a stream whose name matches ``root``'s last
     segment, which stays at ``<root>`` itself. Returns the ``.rrd`` path.
+
+    Args:
+        rerun_config: Optional, and keyed by entity path exactly as the live
+            bridge's config is, so a robot's existing viewer config renders its
+            own recordings unchanged. Recognised keys:
+
+            ``visual_override``
+                ``{entity_path: fn(payload)}``, replacing that stream's own
+                ``to_rerun``. This is how a camera gets a frustum: the intrinsics
+                convert to an ``rr.Pinhole`` logged at the *image's* path.
+            ``static``
+                ``{entity_path: fn(rr)}``, logged once with ``static=True`` so it
+                is present at every instant. For fixed geometry only -- a robot
+                body, a floor plan. Anything the robot had to observe does not
+                belong here, because static means visible before it was seen.
+            ``blueprint``
+                ``fn() -> BlueprintLike``, saved as the recording's default
+                layout.
+            ``tf_axes``
+                Axis length; any value above zero nests the tf frames into their
+                real tree and attaches each stream carrying a ``frame_id`` to its
+                frame. Left at zero the entity paths stay flat, which is what
+                every caller before this argument existed got.
     """
     import rerun as rr
 
     from dimos.memory.utils.progress import progress
     from dimos.visualization.rerun.init import rerun_init
+
+    config = rerun_config or {}
+    overrides: dict[str, Any] = config.get("visual_override") or {}
+    statics: dict[str, Any] = config.get("static") or {}
+    blueprint = config.get("blueprint")
+    tf_axes = float(config.get("tf_axes") or 0.0)
+
+    tf_tree = None
+    if tf_axes > 0:
+        from dimos.msgs.tf2_msgs.TFMessage import TfFrameTree
+
+        tf_tree = TfFrameTree(axis_length=tf_axes)
 
     if out is None:
         src = getattr(store.config, "path", None) or "store"
@@ -73,6 +114,19 @@ def render_store(
             return name
         return base if name == base.rsplit("/", 1)[-1] else f"{base}/{name}"
 
+    def convert(path: str, payload: Any) -> tuple[Any, bool]:
+        """Convert one payload, and say whether it named absolute entity paths.
+
+        An override is written against entity paths, the way the live bridge's
+        config is, so the paths it returns are final. A payload's own
+        ``to_rerun`` cannot know where its stream was mounted, so the parts it
+        names are nested under it.
+        """
+        fn = overrides.get(path)
+        if fn is not None:
+            return fn(payload), True
+        return payload.to_rerun(), False
+
     # Discover renderable streams (payload has a working to_rerun) + shared anchor.
     renderable = []
     t0: float | None = None
@@ -83,11 +137,12 @@ def render_store(
         except LookupError:
             continue
         data = first.data
-        if not hasattr(data, "to_rerun"):
+        path = entity(name)
+        if path not in overrides and not hasattr(data, "to_rerun"):
             print(f"  skip {name}: {type(data).__name__} has no to_rerun()")
             continue
         try:
-            data.to_rerun()
+            convert(path, data)
         except Exception as e:
             print(f"  skip {name}: to_rerun() failed ({e})")
             continue
@@ -99,9 +154,20 @@ def render_store(
         return out
 
     rerun_init("dimos mem rerun")
-    rr.save(out)
+    rr.save(out, default_blueprint=blueprint() if blueprint else None)
 
+    for path, factory in statics.items():
+        archetypes = factory(rr)
+        for archetype in archetypes if isinstance(archetypes, list) else [archetypes]:
+            # A factory may name its own path, as the bridge's statics do.
+            if isinstance(archetype, tuple):
+                rr.log(archetype[0], archetype[1], static=True)
+            else:
+                rr.log(path, archetype, static=True)
+
+    attached: dict[str, str] = {}
     for name, stream in renderable:
+        path = entity(name)
         with progress(stream.count(), label=name) as report:
             for obs in stream:
                 if seconds is not None and obs.ts - t0 > seconds:
@@ -110,13 +176,30 @@ def render_store(
                     report(obs)
                     continue
                 rr.set_time("time", duration=obs.ts - t0)
-                data = obs.data.to_rerun()
-                path = entity(name)
+                if tf_tree is not None and hasattr(obs.data, "transforms"):
+                    data, absolute = obs.data.to_rerun(tf_tree), False  # nest frames under parents
+                else:
+                    data, absolute = convert(path, obs.data)
                 if isinstance(data, list):  # RerunMulti: [(subpath, archetype), ...]
                     for sub, arch in data:
-                        rr.log(f"{path}/{sub}", arch)
+                        rr.log(sub if absolute else f"{path}/{sub}", arch)
                 else:
                     rr.log(path, data)
+                    # Carrying a frame_id means the payload is expressed in that
+                    # frame; attaching it once puts the image inside the camera's
+                    # frustum instead of at the world origin.
+                    # A static factory that positions its own entity owns that
+                    # path's parenting; attaching it again by frame_id would give
+                    # the frame two parents, which rerun rejects outright.
+                    if (
+                        tf_tree is not None
+                        and not isinstance(data, rr.Transform3D)
+                        and path not in statics
+                    ):
+                        frame_id = getattr(obs.data, "frame_id", None)
+                        if frame_id and attached.get(path) != frame_id:
+                            rr.log(path, rr.Transform3D(parent_frame=f"tf#/{frame_id}"))
+                            attached[path] = frame_id
                 report(obs)
 
     rr.rerun_shutdown()  # flush + close the .rrd before opening it

--- a/dimos/memory/codecs/README.md
+++ b/dimos/memory/codecs/README.md
@@ -17,6 +17,37 @@ class Codec(Protocol[T]):
 | `PickleCodec` | Any Python object | Fallback. Uses `HIGHEST_PROTOCOL`. |
 | `JpegCodec` | `Image` | Lossy compression via TurboJPEG. ~10-20x smaller. Preserves `frame_id` in header. |
 | `LcmCodec` | `DimosMsg` subclasses | Uses `lcm_encode()`/`lcm_decode()`. Zero-copy for LCM message types. |
+| `JsonCodec` | Pydantic models, dataclasses | **Opt-in** — never auto-selected. For derived records that must stay readable across releases and from other tools. |
+
+### JsonCodec
+
+A pickle is only readable by the exact Python classes that wrote it. Derived
+records that outlive a release — belief, audit trails, anything another tool has
+to read — should be stored as JSON instead:
+
+```python
+store.stream("belief_observation", BeliefObservation, codec="json")
+```
+
+The payload type must declare two things, checked when the codec is constructed
+so an unreadable stream fails at open time rather than at decode time:
+
+```python
+@dataclass(frozen=True)
+class BeliefObservation:
+    __pydantic_config__ = ConfigDict(extra="forbid")   # 1. reject unknown fields
+    schema_version: str                                 # 2. carry a version
+    ...
+```
+
+`extra="forbid"` has to live on the type: `TypeAdapter` refuses a `config`
+override for models and dataclasses, and silently dropping a field a newer
+writer added would turn a schema mismatch into quiet data loss. Pass
+`version_field=None` to waive the second requirement.
+
+`codec="lz4+json"` works too, and `codec_for()` never picks `JsonCodec`
+automatically — auto-selection would change the on-disk format of existing
+streams.
 
 ## Auto-selection
 

--- a/dimos/memory/codecs/base.py
+++ b/dimos/memory/codecs/base.py
@@ -105,6 +105,10 @@ def _make_one(name: str, payload_module: str, inner: Codec[Any] | None = None) -
         from dimos.memory.codecs.lcm import LcmCodec
 
         return LcmCodec(resolve_payload_type(payload_module))
+    if name == "json":
+        from dimos.memory.codecs.json import JsonCodec
+
+        return JsonCodec(resolve_payload_type(payload_module))
     if name == "pickle":
         from dimos.memory.codecs.pickle import PickleCodec
 

--- a/dimos/memory/codecs/json.py
+++ b/dimos/memory/codecs/json.py
@@ -1,0 +1,105 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Portable JSON codec for derived records.
+
+``PickleCodec`` is the default for plain Python payloads, but a pickle is only
+readable by the exact Python classes that wrote it. Derived records that outlive
+a release -- belief, audit trails, anything another tool or language has to read
+-- need a wire format that survives refactors.
+
+Two contracts are enforced when the codec is constructed, so a stream that would
+be unreadable later fails at open time rather than at decode time:
+
+1. **The payload type must reject unknown fields.** Silently dropping a field a
+   newer writer added turns a schema mismatch into quiet data loss. Pydantic
+   cannot be told this from the outside -- ``TypeAdapter`` refuses a ``config``
+   override for models and dataclasses -- so the *type* declares it and this
+   codec checks that it did.
+
+2. **The payload type must carry a version field.** Portability without a
+   version is only the appearance of portability: the bytes parse, but nothing
+   can tell which shape they are.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
+
+from pydantic import BaseModel, TypeAdapter
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+T = TypeVar("T")
+
+DEFAULT_VERSION_FIELD = "schema_version"
+
+
+def _declared_extra(payload_type: type[Any]) -> str | None:
+    """The ``extra`` policy the type declares, or None if it declares none."""
+    config: Any
+    if isinstance(payload_type, type) and issubclass(payload_type, BaseModel):
+        config = payload_type.model_config
+    else:
+        config = getattr(payload_type, "__pydantic_config__", None)
+    if not config:
+        return None
+    extra = config.get("extra")
+    return str(extra) if extra is not None else None
+
+
+def _field_names(payload_type: type[Any]) -> Iterable[str]:
+    if isinstance(payload_type, type) and issubclass(payload_type, BaseModel):
+        return payload_type.model_fields.keys()
+    if dataclasses.is_dataclass(payload_type):
+        return (f.name for f in dataclasses.fields(payload_type))
+    return ()
+
+
+class JsonCodec(Generic[T]):
+    """Encode a Pydantic model or dataclass as JSON.
+
+    Nested models, dataclasses, tuples and enums are handled by Pydantic's
+    ``TypeAdapter``; this class only adds the two construction-time contracts.
+    """
+
+    def __init__(
+        self,
+        payload_type: type[T],
+        *,
+        version_field: str | None = DEFAULT_VERSION_FIELD,
+    ) -> None:
+        if _declared_extra(payload_type) != "forbid":
+            raise TypeError(
+                f"{payload_type.__name__} must declare extra='forbid' to be stored as JSON. "
+                "Add model_config = ConfigDict(extra='forbid') to the model, or "
+                "__pydantic_config__ = ConfigDict(extra='forbid') to the dataclass. "
+                "Without it an unknown field is dropped instead of reported."
+            )
+        if version_field is not None and version_field not in set(_field_names(payload_type)):
+            raise TypeError(
+                f"{payload_type.__name__} must declare a {version_field!r} field to be stored "
+                "as JSON, so a later reader can tell which shape the bytes are. "
+                "Pass version_field=None to opt out."
+            )
+        self._payload_type = payload_type
+        self._adapter: TypeAdapter[T] = TypeAdapter(payload_type)
+
+    def encode(self, value: T) -> bytes:
+        return self._adapter.dump_json(value)
+
+    def decode(self, data: bytes) -> T:
+        return self._adapter.validate_json(data)

--- a/dimos/memory/codecs/test_codecs.py
+++ b/dimos/memory/codecs/test_codecs.py
@@ -22,9 +22,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from pydantic import BaseModel, ConfigDict
 import pytest
 
-from dimos.memory.codecs.base import Codec, codec_for
+from dimos.memory.codecs.base import Codec, codec_for, codec_from_id, codec_id
 from dimos.memory.codecs.jpeg import JpegCodec
 from dimos.memory.codecs.lcm import LcmCodec
 from dimos.memory.codecs.pickle import PickleCodec
@@ -156,15 +157,71 @@ def _jpeg_case() -> Case | None:
     )
 
 
+@dataclass(frozen=True)
+class _JsonInner:
+    __pydantic_config__ = ConfigDict(extra="forbid")
+
+    label: str
+    weight: float
+
+
+@dataclass(frozen=True)
+class _JsonRecord:
+    """Stand-in for a derived record: versioned, nested, strict."""
+
+    __pydantic_config__ = ConfigDict(extra="forbid")
+
+    schema_version: str
+    name: str
+    count: int
+    parts: tuple[_JsonInner, ...] = ()
+    note: str | None = None
+
+
+class _JsonModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: str
+    value: int
+
+
+def _json_values() -> list[_JsonRecord]:
+    return [
+        _JsonRecord(schema_version="1", name="empty", count=0),
+        _JsonRecord(
+            schema_version="1",
+            name="nested",
+            count=2,
+            parts=(_JsonInner(label="a", weight=1.5), _JsonInner(label="b", weight=-0.25)),
+            note="with a note",
+        ),
+    ]
+
+
+def _json_case() -> Case:
+    from dimos.memory.codecs.json import JsonCodec
+
+    return Case(name="json", codec=JsonCodec(_JsonRecord), values=_json_values())
+
+
+def _lz4_json_case() -> Case:
+    from dimos.memory.codecs.json import JsonCodec
+    from dimos.memory.codecs.lz4 import Lz4Codec
+
+    return Case(name="lz4+json", codec=Lz4Codec(JsonCodec(_JsonRecord)), values=_json_values())
+
+
 _case_factories = {
     "pickle": _pickle_case,
     "lcm": _lcm_case,
     "lz4+pickle": _lz4_pickle_case,
     "lz4+lcm": _lz4_lcm_case,
     "jpeg": _jpeg_case,
+    "json": _json_case,
+    "lz4+json": _lz4_json_case,
 }
 
-case_params: list[Any] = ["pickle", "lcm", "lz4+pickle", "lz4+lcm"]
+case_params: list[Any] = ["pickle", "lcm", "lz4+pickle", "lz4+lcm", "json", "lz4+json"]
 if _turbojpeg_available():
     case_params.append("jpeg")
 
@@ -216,3 +273,101 @@ class TestCodecFor:
         from dimos.memory.codecs.jpeg import JpegCodec
 
         assert isinstance(codec_for(Image), JpegCodec)
+
+    def test_json_is_never_auto_selected(self) -> None:
+        """Opt-in only: auto-selecting it would silently change existing streams."""
+        from dimos.memory.codecs.json import JsonCodec
+
+        assert not isinstance(codec_for(_JsonRecord), JsonCodec)
+
+
+class TestJsonCodecContracts:
+    """The two construction-time contracts, and why each exists."""
+
+    def test_rejects_type_that_allows_unknown_fields(self) -> None:
+        from dimos.memory.codecs.json import JsonCodec
+
+        @dataclass(frozen=True)
+        class Lax:
+            schema_version: str
+
+        with pytest.raises(TypeError, match="extra='forbid'"):
+            JsonCodec(Lax)
+
+    def test_rejects_type_without_a_version_field(self) -> None:
+        from dimos.memory.codecs.json import JsonCodec
+
+        @dataclass(frozen=True)
+        class Unversioned:
+            __pydantic_config__ = ConfigDict(extra="forbid")
+
+            name: str
+
+        with pytest.raises(TypeError, match="schema_version"):
+            JsonCodec(Unversioned)
+
+    def test_version_requirement_can_be_waived(self) -> None:
+        from dimos.memory.codecs.json import JsonCodec
+
+        @dataclass(frozen=True)
+        class Unversioned:
+            __pydantic_config__ = ConfigDict(extra="forbid")
+
+            name: str
+
+        codec = JsonCodec(Unversioned, version_field=None)
+        assert codec.decode(codec.encode(Unversioned(name="x"))) == Unversioned(name="x")
+
+    def test_unknown_field_on_decode_raises(self) -> None:
+        """A field a newer writer added must surface, not vanish."""
+        from dimos.memory.codecs.json import JsonCodec
+
+        codec = JsonCodec(_JsonRecord)
+        payload = b'{"schema_version":"1","name":"x","count":1,"parts":[],"from_the_future":7}'
+        with pytest.raises(Exception, match="from_the_future"):
+            codec.decode(payload)
+
+    def test_missing_required_field_on_decode_raises(self) -> None:
+        from dimos.memory.codecs.json import JsonCodec
+
+        codec = JsonCodec(_JsonRecord)
+        with pytest.raises(Exception, match="count"):
+            codec.decode(b'{"schema_version":"1","name":"x"}')
+
+    def test_pydantic_model_is_supported(self) -> None:
+        from dimos.memory.codecs.json import JsonCodec
+
+        codec = JsonCodec(_JsonModel)
+        value = _JsonModel(schema_version="1", value=7)
+        assert codec.decode(codec.encode(value)) == value
+
+    def test_output_is_human_readable_json(self) -> None:
+        """The whole point over pickle: another tool can read it."""
+        import json as json_module
+
+        from dimos.memory.codecs.json import JsonCodec
+
+        encoded = JsonCodec(_JsonRecord).encode(_json_values()[1])
+        assert json_module.loads(encoded)["parts"][0]["label"] == "a"
+
+
+class TestJsonCodecRegistry:
+    """A stream stored as json must be reopenable from its recorded codec id."""
+
+    def test_codec_id_is_json(self) -> None:
+        from dimos.memory.codecs.json import JsonCodec
+
+        assert codec_id(JsonCodec(_JsonRecord)) == "json"
+
+    def test_lz4_wrapper_id_roundtrips(self) -> None:
+        from dimos.memory.codecs.json import JsonCodec
+        from dimos.memory.codecs.lz4 import Lz4Codec
+
+        assert codec_id(Lz4Codec(JsonCodec(_JsonRecord))) == "lz4+json"
+
+    @pytest.mark.parametrize("cid", ["json", "lz4+json"])
+    def test_rebuilt_from_id_still_roundtrips(self, cid: str) -> None:
+        module = f"{_JsonRecord.__module__}.{_JsonRecord.__qualname__}"
+        codec = codec_from_id(cid, module)
+        value = _json_values()[1]
+        assert codec.decode(codec.encode(value)) == value

--- a/dimos/robot/all_blueprints.py
+++ b/dimos/robot/all_blueprints.py
@@ -170,6 +170,7 @@ all_modules = {
     "b-box-navigation-module": "dimos.navigation.bbox_navigation.BBoxNavigationModule",
     "b1-connection-module": "dimos.robot.unitree.b1.connection.B1ConnectionModule",
     "basic-path-follower": "dimos.navigation.basic_path_follower.module.BasicPathFollower",
+    "belief-query-skills": "dimos.experimental.memory_belief.skills.BeliefQuerySkills",
     "benchmarker": "dimos.control.benchmarking.benchmark.Benchmarker",
     "camera-module": "dimos.hardware.sensors.camera.module.CameraModule",
     "camera-mux-module": "dimos.teleop.hosted.camera_mux.CameraMuxModule",

--- a/dimos/robot/unitree/go2/belief_rerun.py
+++ b/dimos/robot/unitree/go2/belief_rerun.py
@@ -1,0 +1,76 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The go2's own body and camera, drawn around a replayed belief store.
+
+A camera frustum and a robot-shaped box come from this machine's intrinsics and
+this machine's dimensions, so they live with the robot rather than in
+``dimos/experimental/memory_belief``. What they compose onto is
+:func:`~dimos.experimental.memory_belief.rerun_config.belief_rerun_config`, which
+carries everything true of any robot with a belief store.
+
+Both entries are ``static``: they are facts about the hardware, not
+observations. That is exactly why nothing derived from what the robot *saw* is
+static -- a sighting that appears before the robot drove past it is a lie the
+viewer tells for free.
+
+The result has the same shape the live bridge's ``rerun_config`` does, so
+replaying a recording looks like watching it being made.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from dimos.experimental.memory_belief.rerun_config import belief_rerun_config
+
+
+def camera_frustum(rr: Any) -> Any:
+    """The camera's intrinsics, drawn as a frustum around the live image.
+
+    Logged at the image's own path rather than a path of its own: rerun draws
+    the frustum wherever the ``Pinhole`` is and hangs that path's image on its
+    plane, so splitting them puts the picture at the world origin.
+
+    ``parent_frame`` belongs on the pinhole rather than being left to the
+    image's own ``frame_id``: a pinhole implicitly parents its path to the view
+    root, so letting both act gives the frame two parents and rerun drops one.
+    Declaring it here is also what the live go2 config does.
+    """
+    from dimos.robot.unitree.go2.connection import GO2Connection
+
+    info = GO2Connection.camera_info_static
+    return [
+        rr.Pinhole(
+            focal_length=[info.K[0], info.K[4]],
+            principal_point=[info.K[2], info.K[5]],
+            width=info.width,
+            height=info.height,
+            image_plane_distance=0.6,
+            parent_frame="tf#/camera_optical",
+        )
+    ]
+
+
+def robot_body(rr: Any) -> list[Any]:
+    """A go2-shaped box on base_link, so the trajectory has something driving it."""
+    return [
+        rr.Boxes3D(half_sizes=[0.35, 0.155, 0.2], colors=[(0, 255, 127)]),
+        rr.Transform3D(parent_frame="tf#/base_link"),
+    ]
+
+
+def go2_belief_rerun_config() -> dict[str, Any]:
+    """The belief view, with the go2's body and camera added."""
+    return belief_rerun_config(static={"color_image": camera_frustum, "robot_body": robot_body})

--- a/dimos/utils/test_tracing.py
+++ b/dimos/utils/test_tracing.py
@@ -1,0 +1,160 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Contract tests for tracing.
+
+Observability must not be able to break or slow a run. These check the three
+ways it could: by raising when absent, by firing on the 15 Hz perception path,
+and by carrying a secret off the machine.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dimos.utils import tracing
+
+
+@pytest.fixture(autouse=True)
+def _reset_client(monkeypatch):
+    """Each test decides for itself whether a client exists."""
+    monkeypatch.setattr(tracing, "_CLIENT", None)
+    monkeypatch.setattr(tracing, "_CLIENT_TRIED", True)
+    monkeypatch.setattr(tracing._ACTIVE, "on", False, raising=False)
+
+
+class TestAbsenceIsHarmless:
+    def test_span_without_a_client_is_a_no_op(self):
+        with tracing.span("anything", x=1) as handle:
+            handle.set(y=2)  # must not raise
+
+    def test_trace_without_a_client_still_runs_the_body(self):
+        ran = []
+        with tracing.agent_trace("task"):
+            ran.append(True)
+
+        assert ran == [True]
+
+    def test_trace_never_swallows_a_body_exception(self, monkeypatch):
+        monkeypatch.setattr(tracing, "_CLIENT", _FakeClient([]))
+
+        with pytest.raises(RuntimeError, match="product failure"):
+            with tracing.agent_trace("task"):
+                raise RuntimeError("product failure")
+
+    def test_span_never_swallows_a_body_exception(self, monkeypatch):
+        monkeypatch.setattr(tracing, "_CLIENT", _FakeClient([]))
+
+        with pytest.raises(RuntimeError, match="product failure"):
+            with tracing.agent_trace("task"), tracing.span("skill:test"):
+                raise RuntimeError("product failure")
+
+    def test_enabled_is_false_without_a_client(self):
+        assert not tracing.enabled()
+
+    def test_an_import_failure_is_swallowed(self, monkeypatch):
+        """A dev-only dependency must not take the robot down."""
+        import builtins
+
+        monkeypatch.setattr(tracing, "_CLIENT_TRIED", False)
+        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk")
+        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk")
+        real_import = builtins.__import__
+
+        def explode(name, *args, **kwargs):
+            if name.startswith("langfuse"):
+                raise ImportError("simulated: langfuse not installed")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", explode)
+
+        assert tracing._client() is None  # swallowed, not raised
+
+    def test_missing_credentials_skip_the_client_entirely(self, monkeypatch):
+        """No keys means no client, and no attempt to build one."""
+        monkeypatch.setattr(tracing, "_CLIENT_TRIED", False)
+        monkeypatch.delenv("LANGFUSE_PUBLIC_KEY", raising=False)
+        monkeypatch.delenv("LANGFUSE_SECRET_KEY", raising=False)
+
+        assert tracing._client() is None
+
+
+class TestNothingLeaksOutsideATrace:
+    """Background perception runs the same wrapped code an agent does."""
+
+    def test_a_skill_outside_a_trace_records_nothing(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(tracing, "_CLIENT", _FakeClient(calls))
+
+        assert not tracing.enabled()
+        with tracing.span("skill:perception_tick"):
+            pass
+
+        assert calls == []
+
+    def test_inside_a_trace_it_records(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(tracing, "_CLIENT", _FakeClient(calls))
+
+        with tracing.agent_trace("task"), tracing.span("skill:where_is_it"):
+            pass
+
+        assert "skill:where_is_it" in calls
+
+    def test_the_gate_is_restored_after_the_trace(self, monkeypatch):
+        monkeypatch.setattr(tracing, "_CLIENT", _FakeClient([]))
+
+        with tracing.agent_trace("task"):
+            assert tracing.enabled()
+
+        assert not tracing.enabled()
+
+
+class TestSecretsAndPixelsAreDropped:
+    @pytest.mark.parametrize(
+        "field", ["api_key", "OPENAI_API_KEY", "auth_token", "secret", "password", "authorization"]
+    )
+    def test_credential_shaped_fields_never_leave(self, field):
+        assert tracing._clean({field: "sk-real-value", "safe": 1}) == {"safe": 1}
+
+    def test_raw_bytes_are_dropped(self):
+        """An image belongs in the store, not in a trace."""
+        assert tracing._clean({"frame": b"\x89PNG...", "id": 7}) == {"id": 7}
+
+    def test_empty_values_are_dropped(self):
+        assert tracing._clean({"a": None, "b": "", "c": 0}) == {"c": 0}
+
+
+class _FakeClient:
+    def __init__(self, calls: list[str]) -> None:
+        self._calls = calls
+
+    def start_as_current_observation(self, *, name: str, as_type: str = "span"):
+        import contextlib
+
+        self._calls.append(name)
+
+        @contextlib.contextmanager
+        def _cm():
+            yield _FakeHandle()
+
+        return _cm()
+
+    def flush(self) -> None:
+        return
+
+
+class _FakeHandle:
+    def update(self, **kwargs) -> None:
+        return

--- a/dimos/utils/tracing.py
+++ b/dimos/utils/tracing.py
@@ -1,0 +1,217 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Optional tracing, off unless someone is watching.
+
+Wraps Langfuse behind an interface that costs nothing when it is absent. Three
+constraints shape this, and each one has bitten a robot codebase before:
+
+**A missing dependency must never break a run.** Tracing is a development
+convenience. ``@skill`` sits in the hot path of every skill including
+perception at 15 Hz, and an ImportError there would take the robot down for the
+sake of a dashboard.
+
+**Nothing is emitted unless a trace is open.** Background perception calls the
+same wrapped code as an agent does. Emitting on every one of them would drown
+the useful traces and bill for the privilege, so spans are recorded only inside
+an :func:`agent_trace` block -- which only an agent-initiated task opens.
+
+**No pixels, no keys.** Evidence travels as ``(stream, observation_id)``
+references. An image belongs in the store, not in a trace, and a trace is a
+place secrets leak to.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import sys
+import threading
+from typing import TYPE_CHECKING, Any
+
+from dimos.utils.logging_config import setup_logger
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator, Mapping
+
+logger = setup_logger()
+
+#: Set when a trace is open on this thread. Read by :func:`span` to decide
+#: whether anything is worth emitting.
+_ACTIVE = threading.local()
+
+_CLIENT: Any = None
+_CLIENT_TRIED = False
+
+
+def _client() -> Any:
+    """The Langfuse client, or None. Constructed once, never raises."""
+    global _CLIENT, _CLIENT_TRIED
+    if _CLIENT_TRIED:
+        return _CLIENT
+    _CLIENT_TRIED = True
+    if not (os.getenv("LANGFUSE_PUBLIC_KEY") and os.getenv("LANGFUSE_SECRET_KEY")):
+        return None
+    # The rest of dimos names this endpoint LANGFUSE_BASE_URL -- it is what
+    # `.env` and `default.env` carry -- while the Langfuse SDK reads
+    # LANGFUSE_HOST. Without this bridge a process started from `.env` gets a
+    # working client pointed at the SDK's default host, so traces are not lost
+    # loudly but silently written somewhere else.
+    if os.getenv("LANGFUSE_BASE_URL") and not os.getenv("LANGFUSE_HOST"):
+        os.environ["LANGFUSE_HOST"] = os.environ["LANGFUSE_BASE_URL"]
+    try:
+        from langfuse import get_client
+
+        _CLIENT = get_client()
+        logger.info("tracing enabled host=%s", os.getenv("LANGFUSE_HOST", "default"))
+    except Exception as exc:
+        logger.warning("tracing unavailable (%s); continuing untraced", exc)
+        _CLIENT = None
+    return _CLIENT
+
+
+def enabled() -> bool:
+    """Whether anything would be recorded right now."""
+    return bool(getattr(_ACTIVE, "on", False) and _client() is not None)
+
+
+@contextlib.contextmanager
+def agent_trace(name: str, **metadata: Any) -> Iterator[Any]:
+    """Open a trace around one agent-initiated task.
+
+    Outside this block nothing is emitted, which is what keeps 15 Hz perception
+    out of the dashboard.
+    """
+    client = _client()
+    if client is None:
+        yield None
+        return
+
+    previous = getattr(_ACTIVE, "on", False)
+    _ACTIVE.on = True
+    manager: Any = None
+    root: Any = None
+    try:
+        try:
+            manager = client.start_as_current_observation(name=name, as_type="agent")
+            root = manager.__enter__()
+        except Exception as exc:
+            logger.warning("tracing failed to start (%s); the run itself is unaffected", exc)
+            yield None
+            return
+
+        with contextlib.suppress(Exception):
+            root.update(metadata=_clean(metadata))
+        try:
+            yield root
+        finally:
+            # Never let tracing teardown mask a business exception -- an
+            # exception from the caller's body has to reach the eval runner, or
+            # an infrastructure failure scores as a valid refusal -- and never
+            # suppress it by returning the manager's boolean.
+            with contextlib.suppress(Exception):
+                manager.__exit__(*sys.exc_info())
+    finally:
+        _ACTIVE.on = previous
+        with contextlib.suppress(Exception):
+            client.flush()
+
+
+@contextlib.contextmanager
+def span(name: str, *, as_type: str = "span", **attributes: Any) -> Iterator[Any]:
+    """Record one span, if a trace is open. A no-op otherwise.
+
+    Attributes may be supplied late via the yielded handle's ``set`` -- most
+    of what is worth recording about a skill is only known once it has run.
+
+    ``as_type="tool"`` renders a skill call as a tool in the UI rather than a
+    generic span, which is what it is.
+    """
+    if not enabled():
+        yield _Recorder()
+        return
+    client = _client()
+    manager: Any = None
+    try:
+        manager = client.start_as_current_observation(name=name, as_type=as_type)
+        handle = manager.__enter__()
+    except Exception as exc:
+        logger.debug("span %s failed (%s)", name, exc)
+        yield _Recorder()
+        return
+
+    recorder = _Recorder(handle)
+    recorder.set(**attributes)
+    try:
+        yield recorder
+    finally:
+        # The observation manager must see the body exception for accurate
+        # tracing, but its return value or teardown failure must never suppress
+        # or replace that business exception.
+        with contextlib.suppress(Exception):
+            manager.__exit__(*sys.exc_info())
+
+
+class _Recorder:
+    """Attaches attributes to a span, or to nothing when none is open.
+
+    A null handle rather than a second class, so callers need no branches.
+    """
+
+    def __init__(self, handle: Any = None) -> None:
+        self._handle = handle
+
+    def set(self, **attributes: Any) -> None:
+        cleaned = _clean(attributes)
+        if self._handle is None or not cleaned:
+            return
+        with contextlib.suppress(Exception):
+            self._handle.update(metadata=cleaned)
+
+
+def _clean(attributes: Mapping[str, Any]) -> dict[str, Any]:
+    """Drop empties, and refuse anything that looks like a secret or an image.
+
+    A denylist is weaker than a schema, but the alternative here is trusting
+    every future call site to remember -- and the cost of one leaked key is
+    much higher than the cost of an over-eager filter.
+    """
+    out: dict[str, Any] = {}
+    for key, value in attributes.items():
+        if value is None or value == "":
+            continue
+        lowered = key.lower()
+        if any(word in lowered for word in ("key", "token", "secret", "password", "authorization")):
+            continue
+        if isinstance(value, (bytes, bytearray, memoryview)):
+            continue
+        out[key] = value
+    return out
+
+
+def langchain_handler() -> Any:
+    """A LangChain callback that reports to the same trace, or None.
+
+    Prompts, completions, token counts and cost come free from this; only the
+    belief-specific attributes have to be added by hand.
+    """
+    if _client() is None:
+        return None
+    try:
+        from langfuse.langchain import CallbackHandler
+
+        return CallbackHandler()
+    except Exception as exc:
+        logger.debug("langchain tracing unavailable (%s)", exc)
+        return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -235,6 +235,10 @@ agents = [
     "langchain-ollama>=1,<2",
     "ollama>=0.6.0",
     "openevals>=0.1",  # eval scorers (LLM-as-judge etc.) — dimos/evals
+    # Agent tracing (dimos/utils/tracing.py). Optional at runtime: without it
+    # _client() returns None and everything continues untraced, which is why its
+    # absence had gone unnoticed.
+    "langfuse>=3",
 
     # Audio
     "openai",

--- a/scripts/ask.py
+++ b/scripts/ask.py
@@ -1,0 +1,193 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Ask the agent about a recording, as of one moment in it.
+
+    python -m scripts.ask recording.db "where is the backpack" --at 61
+
+Pause the viewer, read the number off its timeline, ask here. ``--at`` is
+required for the same reason ``as_of`` is: the asking time decides the answer,
+so nothing picks it for you.
+
+Prints and exits. The store is opened read-only and nothing is logged anywhere:
+a question is about the recording, not part of it.
+
+**The asking time is the harness's, not the model's.** The tool overwrites
+whatever ``as_of`` the model puts in its query. A model free to choose it can
+answer a question about 1:00 from what the robot saw at 7:00, and the answer
+reads exactly as well.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+import textwrap
+import warnings
+
+from dotenv import load_dotenv
+
+from dimos.constants import DIMOS_PROJECT_ROOT
+from dimos.experimental.memory_belief.api import (
+    PROJECTIONS,
+    SELECTS,
+    QueryError,
+    describe_store,
+    execute,
+)
+from dimos.memory.store.sqlite import SqliteStore
+
+# The model key lives in the project's .env, which nothing has loaded by the
+# time a script runs.
+load_dotenv(DIMOS_PROJECT_ROOT / ".env")
+
+SYSTEM = (
+    "You answer questions about what a robot saw, using belief_query. "
+    "Compose the whole question into ONE call when you can. "
+    "You are answering as of a fixed moment: the store will not show you anything "
+    "later, and that is correct, not a fault to work around. "
+    "Call the tool before saying anything is absent or out of vocabulary: the "
+    "store decides that, not your guess about what a robot would detect. "
+    "If status is unknown, say what is unknown and why -- do not guess. "
+    "Report positions as coordinates in metres; this store holds no room names. "
+    "Results carry no timestamps. Asked when something was seen, say the store "
+    "cannot tell you -- do not answer where instead. "
+    "High dispersion_m means the sightings are too scattered to be one object. "
+    "Answer in one or two sentences."
+)
+
+
+def parse_at(value: str, t_start: float) -> float:
+    """Turn what the viewer shows into an absolute asking time.
+
+    The renderer logs a ``time`` timeline of seconds since the recording began,
+    so the number on a paused playhead is an offset -- ``61`` or ``1:01``.
+    """
+    text = value.strip()
+    if ":" in text:
+        minutes, seconds = text.split(":", 1)
+        return t_start + int(minutes) * 60 + float(seconds)
+    return t_start + float(text)
+
+
+def build_tool(store, as_of, seen):  # type: ignore[no-untyped-def]
+    from langchain_core.tools import StructuredTool
+
+    facts = describe_store(store)
+
+    def belief_query(query: dict) -> str:
+        q = dict(query or {})
+        # Overwritten, never defaulted. The moment is the caller's.
+        q["as_of"] = as_of
+        seen["calls"] += 1
+        try:
+            envelope = execute(store, q)
+        except QueryError as exc:
+            return json.dumps({"status": "error", "message": str(exc)})
+        for row in (envelope.get("result") or {}).get("positions", []):
+            if row.get("entity_id"):
+                seen["cited"].add(row["entity_id"])
+        return json.dumps(envelope, default=str)[:4000]
+
+    return StructuredTool.from_function(
+        func=belief_query,
+        name="belief_query",
+        description=f"""Ask where things are, as of a fixed moment.
+
+  time: {facts["time_unit"]}
+        answering as of {as_of:.0f}; nothing after it is visible
+  vocabulary: {facts["vocabulary_size"]} terms; a term outside it returns
+        OUT_OF_VOCABULARY with nearer terms, which are worth retrying
+
+select: one of {list(SELECTS)}
+where: clauses, ANDed. {{"op":"label","value":"chair"}} and
+       {{"op":"time_range","t1":..,"t2":..}}
+project: one of {list(PROJECTIONS)}
+
+Returns status(ok|unknown|error), reason, result, and quality(rows, support,
+dispersion_m, coherence, deduplicated). status=error means the query was
+malformed; fix it and call again rather than reporting an absence.""",
+    )
+
+
+WIDTH = 76
+
+
+def wrapped(text: str, tag: str) -> str:
+    """One tagged block: the tag on the first line, the rest hanging under it."""
+    lines = [
+        wrap
+        for para in text.strip().splitlines()
+        for wrap in (textwrap.wrap(para, WIDTH - 3) or [""])
+    ]
+    return "\n".join(f"{tag if i == 0 else '':<3}{line}" for i, line in enumerate(lines))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("store", type=Path)
+    parser.add_argument("question")
+    parser.add_argument(
+        "--at", required=True, help="asking time as the viewer's timeline reads it: 61, or 1:01"
+    )
+    parser.add_argument("--model", default="gpt-4o")
+    args = parser.parse_args(argv)
+
+    # langchain_core's import installs a filter that unmutes its own pending
+    # deprecations, so ours has to be registered after it to win. The one this
+    # silences is about a default this script never sets, and it would land
+    # above the answer.
+    import langchain_core  # noqa: F401
+
+    warnings.filterwarnings("ignore", category=PendingDeprecationWarning)
+
+    from langchain.agents import create_agent
+    from langchain_core.messages import HumanMessage, SystemMessage
+    from langchain_openai import ChatOpenAI
+
+    store = SqliteStore(path=str(args.store), must_exist=True)
+    try:
+        facts = describe_store(store)
+        if facts["t_start"] is None:
+            print(f"{args.store} holds no belief; run detect_recording first", file=sys.stderr)
+            return 1
+
+        as_of = parse_at(args.at, facts["t_start"])
+        print(
+            f"\n{args.store.name}   t+{as_of - facts['t_start']:.0f}s "
+            f"of {facts['t_end'] - facts['t_start']:.0f}s\n"
+        )
+        print(wrapped(args.question, "Q"), end="\n\n")
+
+        seen: dict = {"calls": 0, "cited": set()}
+        agent = create_agent(
+            model=ChatOpenAI(model=args.model, temperature=0),
+            tools=[build_tool(store, as_of, seen)],
+            system_prompt=SYSTEM,
+        )
+        result = agent.invoke({"messages": [SystemMessage(SYSTEM), HumanMessage(args.question)]})
+    finally:
+        store.stop()
+
+    print(wrapped(result["messages"][-1].content, "A"), end="\n\n")
+    # Zero tool calls means it answered from the question alone, which is the
+    # one failure a plausible sentence hides.
+    print(f"{'':<3}{seen['calls']} tool call(s) · {len(seen['cited'])} entities cited\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/bench_belief_suite.py
+++ b/scripts/bench_belief_suite.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Run the reachable benchmark through the belief agent, one Langfuse trace per task.
+
+    python -m scripts.bench_belief_suite --store moshi_8min.db --suite suite.json
+
+Every task opens its own trace named ``bench/<id>`` and carries the audit's own
+verdict as metadata, so the report afterwards is assembled from what Langfuse
+recorded rather than from what this script believed at the time. The distinction
+matters: a run that scores itself can only report the failures it anticipated.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import sys
+import time
+import uuid
+
+from dotenv import load_dotenv
+
+from dimos.constants import DIMOS_PROJECT_ROOT
+
+load_dotenv(DIMOS_PROJECT_ROOT / ".env", override=True)
+# The repo's .env names the endpoint LANGFUSE_BASE_URL; the SDK reads LANGFUSE_HOST.
+if os.environ.get("LANGFUSE_BASE_URL") and not os.environ.get("LANGFUSE_HOST"):
+    os.environ["LANGFUSE_HOST"] = os.environ["LANGFUSE_BASE_URL"]
+
+from langchain.agents import create_agent
+from langchain_core.messages import HumanMessage, SystemMessage
+from langchain_core.tools import StructuredTool
+from langchain_openai import ChatOpenAI
+
+from dimos.experimental.memory_belief.api import (
+    QueryError,
+    describe_store,
+    execute,
+)
+from dimos.memory.store.sqlite import SqliteStore
+from dimos.utils.tracing import agent_trace, langchain_handler
+
+SYS = (
+    "You answer questions about what a robot saw, using belief_query. "
+    "Compose the whole question into ONE call when you can. "
+    "Read the quality block: high dispersion_m means the sightings are too scattered to "
+    "be one object, so the position is an average of several. If status is unknown, say "
+    "what is unknown and why -- do not guess. "
+    "A status of 'error' means your query was malformed, not that the robot saw nothing: "
+    "the message says what is wrong, so fix the query and call again before answering. "
+    "Same for OUT_OF_VOCABULARY when it offers nearer terms -- try one. "
+    "Positions are metres in the map frame, not room names -- report them as coordinates. "
+    "If the store cannot answer at all, say so plainly. Answer in one or two sentences."
+)
+
+
+#: Characters of tool output the model sees. The first traced run cut the JSON at
+#: this length with a slice, which severed it mid-array and dropped the `quality`
+#: block the prompt tells the model to trust -- every successful query in that run
+#: arrived unparseable. Shrinking the result list instead keeps the envelope whole.
+BUDGET = 4000
+
+
+def _fit(envelope: dict, budget: int = BUDGET) -> str:
+    """Serialise the envelope, shrinking long result lists rather than the JSON.
+
+    Reports what it dropped. Silently keeping the first twenty of two hundred
+    positions is how "where are the chairs" becomes "where are the first twenty
+    chairs found", with nothing in the answer to say so.
+    """
+
+    def dump(env: dict) -> str:
+        return json.dumps(env, ensure_ascii=False, default=str)
+
+    text = dump(envelope)
+    if len(text) <= budget:
+        return text
+
+    result = envelope.get("result")
+    lists = (
+        [(k, v) for k, v in result.items() if isinstance(v, list)]
+        if isinstance(result, dict)
+        else ([("result", result)] if isinstance(result, list) else [])
+    )
+    if not lists:
+        # Nothing list-shaped to shrink: drop the result entirely rather than
+        # return a broken envelope, and say that is what happened.
+        trimmed = {
+            **envelope,
+            "result": None,
+            "truncated": {"result": "omitted, too large to send"},
+        }
+        return dump(trimmed)
+
+    for keep in (200, 100, 50, 25, 12, 6, 3, 1):
+        shrunk = dict(result) if isinstance(result, dict) else None
+        note = {}
+        for key, value in lists:
+            if len(value) > keep:
+                note[key] = f"showing {keep} of {len(value)}"
+                if shrunk is not None:
+                    shrunk[key] = value[:keep]
+        payload = shrunk if shrunk is not None else lists[0][1][:keep]
+        if not note:
+            continue
+        trimmed = {**envelope, "result": payload, "truncated": note}
+        text = dump(trimmed)
+        if len(text) <= budget:
+            return text
+    return dump({**envelope, "result": None, "truncated": {"result": "omitted, too large to send"}})
+
+
+def build_tool(store, as_of, counter):  # type: ignore[no-untyped-def]
+    def belief_query(query: dict) -> str:
+        counter["calls"] += 1
+        q = dict(query or {})
+        # Forced, not defaulted. `setdefault` let the model supply its own
+        # asking time, and a model that asks about a moment after the one it
+        # was asked at answers from observations that had not happened.
+        q["as_of"] = as_of
+        try:
+            envelope = execute(store, q)
+        except QueryError as exc:
+            counter["errors"] += 1
+            return json.dumps({"status": "error", "message": str(exc)}, ensure_ascii=False)
+        counter["status"].append(envelope.get("status"))
+        return _fit(envelope)
+
+    facts = describe_store(store)
+    return StructuredTool.from_function(
+        func=belief_query,
+        name="belief_query",
+        description=f"""Ask where things are. ONE call carries the whole question.
+
+THIS RECORDING'S CONSTANTS -- read from the store, not assumed:
+  time: {facts["time_unit"]}
+        this recording spans {facts["t_start"]:.0f} .. {facts["t_end"]:.0f}
+  vocabulary: {facts["vocabulary_size"]} terms; a term outside it returns
+        OUT_OF_VOCABULARY with the nearest terms, which are worth retrying
+
+select: "entities" -- the only one. A thing, not one sighting of it.
+where: a list of clauses, ANDed. Two operators:
+  {{"op":"label","value":"chair"}}
+  {{"op":"time_range","t1":{facts["t_start"]:.0f},"t2":{facts["t_end"]:.0f}}}
+project: "locate" -- the only one. Position, label, support, dispersion per thing.
+
+Returns an envelope: status(ok|unknown|error), reason, result, quality(rows,
+support, dispersion_m, coherence, deduplicated), `truncated` when a long result
+list was shortened, and on an empty result a diagnostic naming the clause that
+emptied it. status=error means the query was malformed and the message says how
+to fix it -- fix it and retry rather than reporting it as an absence.
+
+This store answers where things are and when they were seen. It holds no room
+names, no people's identities, no schedule and no event log; a question needing
+one of those cannot be answered from here, and saying so is the right answer.""",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--store", required=True, type=Path)
+    parser.add_argument("--suite", required=True, type=Path)
+    parser.add_argument("--as-of", type=float, default=1787859665.0)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--model", default="gpt-4o")
+    args = parser.parse_args(argv)
+
+    suite = json.loads(args.suite.read_text())[: args.limit]
+    run_id = uuid.uuid4().hex[:8]
+    store = SqliteStore(path=str(args.store), must_exist=True)
+    model = ChatOpenAI(model=args.model, temperature=0)
+    handler = langchain_handler()
+    print(f"run {run_id}: {len(suite)} tasks, tracing={'on' if handler else 'OFF'}", flush=True)
+
+    results = []
+    for i, task in enumerate(suite, 1):
+        counter = {"calls": 0, "errors": 0, "status": []}
+        tool = build_tool(store, args.as_of, counter)
+        agent = create_agent(model=model, tools=[tool], system_prompt=SYS)
+        started = time.perf_counter()
+        answer = error = None
+        try:
+            with agent_trace(
+                f"bench/{task['id']}",
+                run_id=run_id,
+                task_id=task["id"],
+                audit_verdict=task["audit_verdict"],
+                now_built=",".join(task.get("now_built") or []),
+                still_missing=",".join(task.get("still_missing") or []) or "none",
+            ):
+                out = agent.invoke(
+                    {"messages": [SystemMessage(SYS), HumanMessage(task["task"])]},
+                    config={"callbacks": [handler]} if handler else None,
+                )
+                answer = out["messages"][-1].content
+        except Exception as exc:
+            error = f"{type(exc).__name__}: {exc}"
+        row = {
+            **task,
+            "run_id": run_id,
+            "trace_name": f"bench/{task['id']}",
+            "answer": answer,
+            "error": error,
+            "tool_calls": counter["calls"],
+            "tool_errors": counter["errors"],
+            "tool_status": counter["status"],
+            "seconds": round(time.perf_counter() - started, 2),
+        }
+        results.append(row)
+        mark = "!" if error else ("." if counter["calls"] else "0")
+        print(
+            f"  [{i:3d}/{len(suite)}] {task['id']} {mark} {counter['calls']}call {row['seconds']}s",
+            flush=True,
+        )
+        args.out.write_text(
+            json.dumps({"run_id": run_id, "results": results}, ensure_ascii=False, indent=1)
+        )
+
+    store.stop()
+    # Flush before exiting: traces are batched, and a process that ends first
+    # leaves the last few tasks missing from the very report they are the point of.
+    try:
+        from dimos.utils.tracing import _client
+
+        client = _client()
+        if client is not None:
+            client.flush()
+            print("langfuse flushed")
+    except Exception as exc:
+        print(f"langfuse flush failed: {exc}")
+    print(f"\nrun_id {run_id} -> {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/build_views.py
+++ b/scripts/build_views.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fold a store's sightings into the views questions are asked against.
+
+    python -m scripts.build_views recording.db
+
+Reads ``belief_observation`` from the store and writes ``belief_identity``,
+``belief_entity`` and ``belief_frame_annotation`` back into the same file, next
+to the camera, lidar and odometry they were derived from. One file goes in, the
+same file comes out fuller.
+
+**Why in place.** Every tool downstream takes one store: ``dimos mem rerun``
+renders one, a belief query reads one, and putting streams on a shared timeline
+requires them to share a file. Deriving into a second file and merging it back
+was a step that existed only to undo the split it had just made.
+
+Re-running replaces the derived streams rather than appending to them, so the
+same command twice gives the same store rather than doubled entities.
+
+The folds themselves live in ``dimos.experimental.memory_belief.pipeline``,
+because a robot deriving the same views while it drives has to run identical
+code. Anything worth tuning is a field on ``ViewParams``, not a constant here.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+import time
+
+from dimos.experimental.memory_belief.annotate import ANNOTATION_STREAM_NAME
+from dimos.experimental.memory_belief.entity import ENTITY_STREAM_NAME
+from dimos.experimental.memory_belief.identity import IDENTITY_STREAM_NAME
+from dimos.experimental.memory_belief.pipeline import ViewParams, build_views
+from dimos.experimental.memory_belief.types import STREAM_NAME as BELIEF_STREAM_NAME
+from dimos.memory.store.sqlite import SqliteStore
+
+#: Read the defaults off an instance, not off the class: ViewParams uses slots,
+#: so its class attributes are descriptors rather than the values.
+DEFAULTS = ViewParams()
+
+#: Written by this script, and therefore safe to replace on a re-run. The raw
+#: streams are not in this list and are never touched.
+DERIVED = (IDENTITY_STREAM_NAME, ENTITY_STREAM_NAME, ANNOTATION_STREAM_NAME)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("store", type=Path, help="a recording holding belief_observation")
+    parser.add_argument(
+        "--static-threshold",
+        type=float,
+        default=DEFAULTS.static_threshold_m,
+        help="metres an entity may move and still count as static",
+    )
+    args = parser.parse_args(argv)
+
+    params = ViewParams(static_threshold_m=args.static_threshold)
+    started = time.perf_counter()
+    store = SqliteStore(path=str(args.store), must_exist=True)
+    try:
+        if BELIEF_STREAM_NAME not in store.list_streams():
+            print(
+                f"{args.store} holds no {BELIEF_STREAM_NAME!r}; run detect_recording first",
+                file=sys.stderr,
+            )
+            return 1
+
+        for name in DERIVED:
+            if name in store.list_streams():
+                store.delete_stream(name)
+                print(f"replacing {name}")
+
+        build_views(
+            belief=store,
+            out=store,
+            session=args.store.stem,
+            params=params,
+            report=print,
+        )
+    finally:
+        store.stop()
+
+    print(f"wrote views into {args.store} in {time.perf_counter() - started:.0f}s")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -3,25 +3,25 @@ revision = 3
 requires-python = ">=3.10, <3.13"
 resolution-markers = [
     "python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
-    "python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
     "python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'win32'",
     "python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "(python_full_version >= '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'win32'",
-    "python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "(python_full_version < '3.11' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'darwin'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'win32'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
     "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'darwin'",
     "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'win32'",
@@ -429,6 +429,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backoff"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
+]
+
+[[package]]
 name = "backports-tarfile"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -707,8 +716,8 @@ name = "can-motor-control"
 version = "0.0.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'linux')" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'win32') or (python_full_version >= '3.11' and sys_platform == 'linux')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/92/86/9dddbf67f49a86f0500da426fb56bcb18756db6448075bc56a086c5a60ee/can_motor_control-0.0.7.tar.gz", hash = "sha256:d0eb9ef5f47af050ac8bb5ea71834910c3e9fce972b3e86917f4a9d00d70c538", size = 145480, upload-time = "2026-08-19T03:58:07.569Z" }
 wheels = [
@@ -868,12 +877,12 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "absl-py", marker = "python_full_version < '3.11'" },
-    { name = "jax", version = "0.6.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "jaxlib", version = "0.6.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "toolz", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "absl-py" },
+    { name = "jax", version = "0.6.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "jaxlib", version = "0.6.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "toolz" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/77/70/53c7d404ce9e2a94009aea7f77ef6e392f6740e071c62683a506647c520f/chex-0.1.90.tar.gz", hash = "sha256:d3c375aeb6154b08f1cccd2bee4ed83659ee2198a6acf1160d2fe2e4a6c87b5c", size = 92363, upload-time = "2025-07-23T19:50:47.945Z" }
 wheels = [
@@ -886,29 +895,29 @@ version = "0.1.91"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
     "python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'win32'",
     "python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "(python_full_version >= '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'darwin'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'win32'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "absl-py", marker = "python_full_version >= '3.11'" },
-    { name = "jax", version = "0.9.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "jaxlib", version = "0.9.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "toolz", marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.11'" },
+    { name = "absl-py" },
+    { name = "jax", version = "0.9.0.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "jaxlib", version = "0.9.0.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" } },
+    { name = "toolz" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5b/7d/812f01e7b2ddf28a0caa8dde56bd951a2c8f691c9bbfce38d469458d1502/chex-0.1.91.tar.gz", hash = "sha256:65367a521415ada905b8c0222b0a41a68337fcadf79a1fb6fc992dbd95dd9f76", size = 90302, upload-time = "2025-09-01T21:49:32.834Z" }
 wheels = [
@@ -1243,7 +1252,7 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -1291,24 +1300,24 @@ version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
     "python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'win32'",
     "python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "(python_full_version >= '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'darwin'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'win32'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -1484,9 +1493,9 @@ name = "cupy-cuda12x"
 version = "13.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "fastrlock", marker = "platform_machine != 'aarch64'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and platform_machine != 'aarch64'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and platform_machine != 'aarch64'" },
+    { name = "fastrlock" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/53/2b/8064d94a6ab6b5c4e643d8535ab6af6cabe5455765540931f0ef60a0bc3b/cupy_cuda12x-13.6.0-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:e78409ea72f5ac7d6b6f3d33d99426a94005254fa57e10617f430f9fd7c3a0a1", size = 112238589, upload-time = "2025-08-18T08:24:15.541Z" },
@@ -1602,8 +1611,8 @@ name = "dataclasses-json"
 version = "0.6.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "marshmallow", marker = "python_full_version >= '3.11'" },
-    { name = "typing-inspect", marker = "python_full_version >= '3.11'" },
+    { name = "marshmallow" },
+    { name = "typing-inspect" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/64/a4/f71d9cf3a5ac257c993b5ca3f93df5f7fb395c725e7f1e6479d2514173c3/dataclasses_json-0.6.7.tar.gz", hash = "sha256:b6b3e528266ea45b9535223bc53ca645f5208833c29229e847b3f26a1cc55fc0", size = 32227, upload-time = "2024-06-09T16:20:19.103Z" }
 wheels = [
@@ -1768,6 +1777,7 @@ agents = [
     { name = "langchain-huggingface" },
     { name = "langchain-ollama" },
     { name = "langchain-openai" },
+    { name = "langfuse" },
     { name = "ollama" },
     { name = "openai" },
     { name = "openevals" },
@@ -1801,6 +1811,7 @@ all = [
     { name = "langchain-huggingface" },
     { name = "langchain-ollama" },
     { name = "langchain-openai" },
+    { name = "langfuse" },
     { name = "lap" },
     { name = "manifold3d" },
     { name = "matplotlib" },
@@ -1864,6 +1875,7 @@ base = [
     { name = "langchain-huggingface" },
     { name = "langchain-ollama" },
     { name = "langchain-openai" },
+    { name = "langfuse" },
     { name = "lap" },
     { name = "moondream" },
     { name = "ollama" },
@@ -1986,6 +1998,7 @@ unitree = [
     { name = "langchain-huggingface" },
     { name = "langchain-ollama" },
     { name = "langchain-openai" },
+    { name = "langfuse" },
     { name = "lap" },
     { name = "moondream" },
     { name = "ollama" },
@@ -2021,6 +2034,7 @@ unitree-dds = [
     { name = "langchain-huggingface" },
     { name = "langchain-ollama" },
     { name = "langchain-openai" },
+    { name = "langfuse" },
     { name = "lap" },
     { name = "mcap" },
     { name = "moondream" },
@@ -2307,6 +2321,7 @@ requires-dist = [
     { name = "langchain-huggingface", marker = "extra == 'agents'", specifier = ">=1,<2" },
     { name = "langchain-ollama", marker = "extra == 'agents'", specifier = ">=1,<2" },
     { name = "langchain-openai", marker = "extra == 'agents'", specifier = ">=1,<2" },
+    { name = "langfuse", marker = "extra == 'agents'", specifier = ">=3" },
     { name = "lap", marker = "extra == 'perception'", specifier = ">=0.5.12" },
     { name = "lazy-loader" },
     { name = "llvmlite", specifier = ">=0.42.0" },
@@ -2741,12 +2756,12 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "matplotlib", marker = "platform_machine != 'aarch64' and sys_platform == 'darwin'" },
-    { name = "mosek", version = "11.0.24", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and sys_platform == 'darwin'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'darwin'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and platform_machine != 'aarch64' and sys_platform == 'darwin'" },
-    { name = "pydot", marker = "platform_machine != 'aarch64' and sys_platform == 'darwin'" },
-    { name = "pyyaml", marker = "platform_machine != 'aarch64' and sys_platform == 'darwin'" },
+    { name = "matplotlib" },
+    { name = "mosek", version = "11.0.24", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pydot" },
+    { name = "pyyaml" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/31/aa4f1f5523381539e1028354cc535d5a3307d28fd33872f2b403454d8391/drake-1.45.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:b0d9bd6196dc6d3b0e660fc6351fcf236727a45ef6a7123f8dc96f85b8662ac3", size = 57314509, upload-time = "2025-09-16T19:02:10.195Z" },
@@ -2768,12 +2783,12 @@ resolution-markers = [
     "(python_full_version < '3.11' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "matplotlib", marker = "platform_machine != 'aarch64' and sys_platform != 'darwin'" },
-    { name = "mosek", version = "11.1.2", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and sys_platform != 'darwin'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform != 'darwin'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and platform_machine != 'aarch64' and sys_platform != 'darwin'" },
-    { name = "pydot", marker = "platform_machine != 'aarch64' and sys_platform != 'darwin'" },
-    { name = "pyyaml", marker = "platform_machine != 'aarch64' and sys_platform != 'darwin'" },
+    { name = "matplotlib" },
+    { name = "mosek", version = "11.1.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pydot" },
+    { name = "pyyaml" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/26/2ce3a9caf431f24e39f8b1fc7b3ebba4faafef1d61c849db3194e8d2e21d/drake-1.49.0-cp310-cp310-manylinux_2_34_x86_64.whl", hash = "sha256:6c73dbd061fcb442e82b7b5a94dadcfbf4c44949035d03394df29412114647b2", size = 41482505, upload-time = "2026-01-15T19:44:08.313Z" },
@@ -2885,7 +2900,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -3143,16 +3158,16 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "jax", version = "0.6.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "msgpack", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "optax", marker = "python_full_version < '3.11'" },
-    { name = "orbax-checkpoint", marker = "python_full_version < '3.11'" },
-    { name = "pyyaml", marker = "python_full_version < '3.11'" },
-    { name = "rich", marker = "python_full_version < '3.11'" },
-    { name = "tensorstore", version = "0.1.78", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "treescope", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "jax", version = "0.6.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "msgpack" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "optax" },
+    { name = "orbax-checkpoint" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "tensorstore", version = "0.1.78", source = { registry = "https://pypi.org/simple" } },
+    { name = "treescope" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e6/76/4ea55a60a47e98fcff591238ee26ed4624cb4fdc4893aa3ebf78d0d021f4/flax-0.10.7.tar.gz", hash = "sha256:2930d6671e23076f6db3b96afacf45c5060898f5c189ecab6dda7e05d26c2085", size = 5136099, upload-time = "2025-07-02T06:10:07.819Z" }
 wheels = [
@@ -3165,34 +3180,34 @@ version = "0.12.4"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
     "python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'win32'",
     "python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "(python_full_version >= '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'darwin'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'win32'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "jax", version = "0.9.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "msgpack", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "optax", marker = "python_full_version >= '3.11'" },
-    { name = "orbax-checkpoint", marker = "python_full_version >= '3.11'" },
-    { name = "orbax-export", marker = "python_full_version >= '3.11'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.11'" },
-    { name = "rich", marker = "python_full_version >= '3.11'" },
-    { name = "tensorstore", version = "0.1.81", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "treescope", marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.11'" },
+    { name = "jax", version = "0.9.0.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "msgpack" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" } },
+    { name = "optax" },
+    { name = "orbax-checkpoint" },
+    { name = "orbax-export" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "tensorstore", version = "0.1.81", source = { registry = "https://pypi.org/simple" } },
+    { name = "treescope" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/48/81/802fd686d3f47d7560a83f73b23efff03de7e3a0342e4f0fc41680136709/flax-0.12.4.tar.gz", hash = "sha256:5e924734a0595ddfa06a824568617e5440c7948e744772cbe6101b7ae06d66a9", size = 5070824, upload-time = "2026-02-12T19:10:17.048Z" }
 wheels = [
@@ -3825,7 +3840,7 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/de/bf/81c848ffe2b42fc141b6db3e4e8e650183b7aab8c4535498ebff25740a3b/imagecodecs-2025.3.30.tar.gz", hash = "sha256:29256f44a7fcfb8f235a3e9b3bae72b06ea2112e63bcc892267a8c01b7097f90", size = 9506573, upload-time = "2025-03-30T04:44:50.368Z" }
 wheels = [
@@ -3864,7 +3879,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3b/8d/dc18623e5e926ad53c626e128c8baaf4ec42e41029cf0a07381cfef79289/imagecodecs-2026.3.6.tar.gz", hash = "sha256:471b8a4d1b3843cbf7179b45f7d7261f0c0b28809efc1ca6c47822477b143b85", size = 9565259, upload-time = "2026-03-07T01:26:41.183Z" }
 wheels = [
@@ -3892,7 +3907,7 @@ resolution-markers = [
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/9f/b436418349779e1c18cc27575360cad03dd492bc574ae9e297832bc48cab/imagecodecs-2026.6.26.tar.gz", hash = "sha256:da95b145f6b4f746acc9e0b8707b164eefc6a36ade3b6e70f74d102e9affad8c", size = 9669990, upload-time = "2026-06-28T18:27:01.957Z" }
 wheels = [
@@ -4000,17 +4015,17 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.11'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "jedi", marker = "python_full_version < '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
-    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "stack-data", marker = "python_full_version < '3.11'" },
-    { name = "traitlets", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "exceptiongroup" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e5/61/1810830e8b93c72dcd3c0f150c80a00c3deb229562d9423807ec92c3a539/ipython-8.38.0.tar.gz", hash = "sha256:9cfea8c903ce0867cc2f23199ed8545eb741f3a69420bfcf3743ad1cec856d39", size = 5513996, upload-time = "2026-01-05T10:59:06.901Z" }
 wheels = [
@@ -4023,34 +4038,34 @@ version = "9.10.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
     "python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'win32'",
     "python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "(python_full_version >= '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'darwin'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'win32'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.11'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
-    { name = "jedi", marker = "python_full_version >= '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
-    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
-    { name = "stack-data", marker = "python_full_version >= '3.11'" },
-    { name = "traitlets", marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a6/60/2111715ea11f39b1535bed6024b7dec7918b71e5e5d30855a5b503056b50/ipython-9.10.0.tar.gz", hash = "sha256:cd9e656be97618a0676d058134cd44e6dc7012c0e5cb36a9ce96a8c904adaf77", size = 4426526, upload-time = "2026-02-02T10:00:33.594Z" }
 wheels = [
@@ -4062,7 +4077,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -4138,11 +4153,11 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "jaxlib", version = "0.6.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "ml-dtypes", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "opt-einsum", marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "jaxlib", version = "0.6.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "ml-dtypes" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "opt-einsum" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cf/1e/267f59c8fb7f143c3f778c76cb7ef1389db3fd7e4540f04b9f42ca90764d/jax-0.6.2.tar.gz", hash = "sha256:a437d29038cbc8300334119692744704ca7941490867b9665406b7f90665cd96", size = 2334091, upload-time = "2025-06-17T23:10:27.186Z" }
 wheels = [
@@ -4155,28 +4170,28 @@ version = "0.9.0.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
     "python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'win32'",
     "python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "(python_full_version >= '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'darwin'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'win32'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "jaxlib", version = "0.9.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "ml-dtypes", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "opt-einsum", marker = "python_full_version >= '3.11'" },
-    { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "jaxlib", version = "0.9.0.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "ml-dtypes" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" } },
+    { name = "opt-einsum" },
+    { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/52/40/f85d1feadd8f793fc1bfab726272523ef34b27302b55861ea872ec774019/jax-0.9.0.1.tar.gz", hash = "sha256:e395253449d74354fa813ff9e245acb6e42287431d8a01ff33d92e9ee57d36bd", size = 2534795, upload-time = "2026-02-05T18:47:33.088Z" }
 wheels = [
@@ -4198,9 +4213,9 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "ml-dtypes", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "ml-dtypes" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/15/c5/41598634c99cbebba46e6777286fb76abc449d33d50aeae5d36128ca8803/jaxlib-0.6.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:da4601b2b5dc8c23d6afb293eacfb9aec4e1d1871cb2f29c5a151d103e73b0f8", size = 54298019, upload-time = "2025-06-17T23:10:36.916Z" },
@@ -4223,26 +4238,26 @@ version = "0.9.0.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
     "python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'win32'",
     "python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "(python_full_version >= '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'darwin'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'win32'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "ml-dtypes", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "ml-dtypes" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" } },
+    { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/fd/040321b0f4303ec7b558d69488c6130b1697c33d88dab0a0d2ccd2e0817c/jaxlib-0.9.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5ff2c550dab210278ed3a3b96454b19108a02e0795625be56dca5a181c9833c9", size = 56092920, upload-time = "2026-02-05T18:46:20.873Z" },
@@ -4279,7 +4294,7 @@ name = "jaxtyping"
 version = "0.3.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "wadler-lindig", marker = "python_full_version >= '3.11'" },
+    { name = "wadler-lindig" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/40/a2ea3ce0e3e5f540eb970de7792c90fa58fef1b27d34c83f9fa94fea4729/jaxtyping-0.3.7.tar.gz", hash = "sha256:3bd7d9beb7d3cb01a89f93f90581c6f4fff3e5c5dc3c9307e8f8687a040d10c4", size = 45721, upload-time = "2026-01-30T14:18:47.409Z" }
 wheels = [
@@ -4383,6 +4398,12 @@ wheels = [
 ]
 
 [[package]]
+name = "jsmin"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/73/e01e4c5e11ad0494f4407a3f623ad4d87714909f50b17a06ed121034ff6e/jsmin-3.0.1.tar.gz", hash = "sha256:c0959a121ef94542e807a674142606f7e90214a2b3d1eb17300244bbb5cc2bfc", size = 13925, upload-time = "2022-01-16T20:35:59.13Z" }
+
+[[package]]
 name = "jsonlines"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4393,12 +4414,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/35/87/bcda8e46c88d0e34c
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/62/d9ba6323b9202dd2fe166beab8a86d29465c41a0288cbe229fac60c1ab8d/jsonlines-4.0.0-py3-none-any.whl", hash = "sha256:185b334ff2ca5a91362993f42e83588a360cf95ce4b71a73548502bda52a7c55", size = 8701, upload-time = "2023-09-01T12:34:42.563Z" },
 ]
-
-[[package]]
-name = "jsmin"
-version = "3.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5e/73/e01e4c5e11ad0494f4407a3f623ad4d87714909f50b17a06ed121034ff6e/jsmin-3.0.1.tar.gz", hash = "sha256:c0959a121ef94542e807a674142606f7e90214a2b3d1eb17300244bbb5cc2bfc", size = 13925, upload-time = "2022-01-16T20:35:59.13Z" }
 
 [[package]]
 name = "jsonpatch"
@@ -4687,6 +4702,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4f/24/9777489d6fbbee64af0c8f96d4f840239c408cf694f3394672807dafc490/langchain_protocol-0.0.15.tar.gz", hash = "sha256:9ab2d11ee73944754f10e037e717098d3a6796f0e58afa9cadda6154e7655ade", size = 5862, upload-time = "2026-05-01T22:30:04.748Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1d/7a/9c97a7b9cbe4c5dc6a44cdb1545450c28f0c8ce89b9c1f0ee7fbad896263/langchain_protocol-0.0.15-py3-none-any.whl", hash = "sha256:461eb794358f83d5e42635a5797799ffec7b4702314e34edf73ac21e75d3ef79", size = 6982, upload-time = "2026-05-01T22:30:03.877Z" },
+]
+
+[[package]]
+name = "langfuse"
+version = "4.14.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backoff" },
+    { name = "httpx" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/3f/d3387db1f472d2fd4b5de40eb6abedc2f59c9da2224e9d0a79d054a90b81/langfuse-4.14.4.tar.gz", hash = "sha256:48c4bdefc290f61a42881b8048a904ab6b81d37e02496473166836e71ee0ab3a", size = 389680, upload-time = "2026-08-11T17:03:20.472Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/1b/a198adc52aa4ffd0886ca0d4e9bb97d45f4f326db206d2395bac67677f5d/langfuse-4.14.4-py3-none-any.whl", hash = "sha256:78692a1d4785a8c255bf6ea967e673e1ee30ce078d646e7b5f7ff44549d45cce", size = 688351, upload-time = "2026-08-11T17:03:21.881Z" },
 ]
 
 [[package]]
@@ -5174,7 +5208,7 @@ name = "marshmallow"
 version = "3.26.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "packaging", marker = "python_full_version >= '3.11'" },
+    { name = "packaging" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/55/79/de6c16cc902f4fc372236926b0ce2ab7845268dcc30fb2fbb7f71b418631/marshmallow-3.26.2.tar.gz", hash = "sha256:bbe2adb5a03e6e3571b573f42527c6fe926e17467833660bebd11593ab8dfd57", size = 222095, upload-time = "2025-12-22T06:53:53.309Z" }
 wheels = [
@@ -5594,8 +5628,8 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'darwin'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and platform_machine != 'aarch64' and sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/37/e7/d04ea5c587fd8b491fbe9377fafa5feb063bb28a3a6949fb393a62230d9d/mosek-11.0.24-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:7f2ab70ad3357f9187c96237d0c49187f82f5885250a5e211b6aa20cb0a7207f", size = 8345311, upload-time = "2025-06-25T10:51:51.777Z" },
@@ -5617,8 +5651,8 @@ resolution-markers = [
     "(python_full_version < '3.11' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform != 'darwin'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and platform_machine != 'aarch64' and sys_platform != 'darwin'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c3/e9/253e759e6e00b9cfbb4e95e7fe079b0e971b3c81c75f059bf2c2be3216e9/mosek-11.1.2-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:5c3566d2a603d94a1773bcd27097c8390dba1d9a1543534f3527deb56f1d0a55", size = 15359313, upload-time = "2026-01-07T08:22:00.805Z" },
@@ -5929,17 +5963,17 @@ version = "3.6.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
     "python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'win32'",
     "python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "(python_full_version >= '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'darwin'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'win32'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'win32'",
@@ -6042,17 +6076,17 @@ version = "2.3.5"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
     "python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'win32'",
     "python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "(python_full_version >= '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'darwin'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'win32'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'win32'",
@@ -6128,7 +6162,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.7.1.26"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cublas-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/25/dc/dc825c4b1c83b538e207e34f48f86063c88deaa35d46c651c7c181364ba2/nvidia_cudnn_cu12-9.7.1.26-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:6d011159a158f3cfc47bf851aea79e31bcff60d530b70ef70474c84cac484d07", size = 726851421, upload-time = "2025-02-06T22:18:29.812Z" },
@@ -6139,7 +6173,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.41"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/26/b53c493c38dccb1f1a42e1a21dc12cba2a77fbe36c652f7726d9ec4aba28/nvidia_cufft_cu12-11.3.3.41-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:da650080ab79fcdf7a4b06aa1b460e99860646b176a43f6208099bdc17836b6a", size = 193118795, upload-time = "2025-01-23T17:56:30.536Z" },
@@ -6166,9 +6200,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.2.55"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cusparse-cu12" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/08/953675873a136d96bb12f93b49ba045d1107bc94d2551c52b12fa6c7dec3/nvidia_cusolver_cu12-11.7.2.55-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4d1354102f1e922cee9db51920dba9e2559877cf6ff5ad03a00d853adafb191b", size = 260373342, upload-time = "2025-01-23T17:58:56.406Z" },
@@ -6179,7 +6213,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.7.53"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/ab/31e8149c66213b846c082a3b41b1365b831f41191f9f40c6ddbc8a7d550e/nvidia_cusparse_cu12-12.5.7.53-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3c1b61eb8c85257ea07e9354606b26397612627fdcd327bfd91ccf6155e7c86d", size = 292064180, upload-time = "2025-01-23T18:00:23.233Z" },
@@ -6281,13 +6315,13 @@ name = "onnxruntime-gpu"
 version = "1.24.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "flatbuffers", marker = "platform_machine != 'aarch64'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and platform_machine != 'aarch64'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and platform_machine != 'aarch64'" },
-    { name = "packaging", marker = "platform_machine != 'aarch64'" },
-    { name = "protobuf", marker = "platform_machine != 'aarch64'" },
-    { name = "sympy", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and sys_platform != 'linux' and sys_platform != 'win32')" },
-    { name = "sympy", version = "1.14.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and sys_platform == 'win32')" },
+    { name = "flatbuffers" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "sympy", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "sympy", version = "1.14.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ca/c7/07d06175f1124fc89e8b7da30d70eb8e0e1400d90961ae1cbea9da69e69b/onnxruntime_gpu-1.24.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ac4bfc90c376516b13d709764ab257e4e3d78639bf6a2ccfc826e9db4a5c7ddf", size = 252616647, upload-time = "2026-02-05T17:24:02.993Z" },
@@ -6322,23 +6356,23 @@ name = "open3d"
 version = "0.19.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "addict", marker = "platform_machine != 'aarch64' or sys_platform != 'linux'" },
-    { name = "configargparse", marker = "platform_machine != 'aarch64' or sys_platform != 'linux'" },
-    { name = "dash", marker = "platform_machine != 'aarch64' or sys_platform != 'linux'" },
-    { name = "flask", marker = "platform_machine != 'aarch64' or sys_platform != 'linux'" },
-    { name = "matplotlib", marker = "platform_machine != 'aarch64' or sys_platform != 'linux'" },
-    { name = "nbformat", marker = "platform_machine != 'aarch64' or sys_platform != 'linux'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine != 'aarch64') or (python_full_version < '3.11' and sys_platform != 'linux')" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine != 'aarch64') or (python_full_version >= '3.11' and sys_platform != 'linux')" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine != 'aarch64') or (python_full_version < '3.11' and sys_platform != 'linux')" },
-    { name = "pandas", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine != 'aarch64') or (python_full_version >= '3.11' and sys_platform != 'linux')" },
-    { name = "pillow", marker = "platform_machine != 'aarch64' or sys_platform != 'linux'" },
-    { name = "pyquaternion", marker = "platform_machine != 'aarch64' or sys_platform != 'linux'" },
-    { name = "pyyaml", marker = "platform_machine != 'aarch64' or sys_platform != 'linux'" },
-    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine != 'aarch64') or (python_full_version < '3.11' and sys_platform != 'linux')" },
-    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine != 'aarch64') or (python_full_version >= '3.11' and sys_platform != 'linux')" },
-    { name = "tqdm", marker = "platform_machine != 'aarch64' or sys_platform != 'linux'" },
-    { name = "werkzeug", marker = "platform_machine != 'aarch64' or sys_platform != 'linux'" },
+    { name = "addict" },
+    { name = "configargparse" },
+    { name = "dash" },
+    { name = "flask" },
+    { name = "matplotlib" },
+    { name = "nbformat" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "pandas", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pillow" },
+    { name = "pyquaternion" },
+    { name = "pyyaml" },
+    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "tqdm" },
+    { name = "werkzeug" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/4b/91e8a4100adf0ccd2f7ad21dd24c2e3d8f12925396528d0462cfb1735e5a/open3d-0.19.0-cp310-cp310-macosx_10_15_universal2.whl", hash = "sha256:f7128ded206e07987cc29d0917195fb64033dea31e0d60dead3629b33d3c175f", size = 103086005, upload-time = "2025-01-08T07:25:56.755Z" },
@@ -6357,13 +6391,13 @@ name = "open3d-unofficial-arm"
 version = "0.19.0.post9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "configargparse", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "dash", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "flask", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "nbformat", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "werkzeug", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "configargparse" },
+    { name = "dash" },
+    { name = "flask" },
+    { name = "nbformat" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "werkzeug" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ec/f9/edcfaa213800ea278804402baa65693840bc7a323b3de8a31c54ce4e42c8/open3d_unofficial_arm-0.19.0.post9.tar.gz", hash = "sha256:ee300bd557f04750db6e47ccb6c6867c6dd6cfc04169dddeb92505da9ea739ef", size = 5327, upload-time = "2026-04-16T21:21:11.152Z" }
 wheels = [
@@ -6436,8 +6470,8 @@ name = "opencv-python"
 version = "4.13.0.92"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 
 [[package]]
@@ -6495,6 +6529,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/87/87/ca7fc790dfdbcf4f9e9aab14a39ef1b7508ead13707e283de0b3131478d2/opentelemetry_exporter_otlp_proto_grpc-1.42.1.tar.gz", hash = "sha256:975c4461f167dd8ed8857d68d3b6b25f3d272eab896f6a9470d0f5b90e2faf15", size = 27140, upload-time = "2026-05-21T16:32:56.162Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/89/2b/28ba5b128f47fe8c3bab541000d6feb4b5a9bd26623ca013406f01c0fb60/opentelemetry_exporter_otlp_proto_grpc-1.42.1-py3-none-any.whl", hash = "sha256:0ae1177e2038b18a929b3098215243631ef91136cba26b7e2b12790ceb7e87cc", size = 19617, upload-time = "2026-05-21T16:32:34.278Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.42.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/32/826bfa1d80ecea24f47808de03cd4a0d13c17ecc07712f45123f0f61e4ac/opentelemetry_exporter_otlp_proto_http-1.42.1.tar.gz", hash = "sha256:bf142a21035d7571ac3a09cb2e5639f49886f243972883cfe777ed3bf02b734d", size = 25406, upload-time = "2026-05-21T16:32:56.807Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/96/82cb223a1502f0787d4bbff12907f5f8d870a50731febcd5818d93ef9555/opentelemetry_exporter_otlp_proto_http-1.42.1-py3-none-any.whl", hash = "sha256:00a16da1b312a1d6c7233d600d557c91df71125af73020f3b9a7765bd699d59d", size = 21793, upload-time = "2026-05-21T16:32:35.277Z" },
 ]
 
 [[package]]
@@ -6598,15 +6650,15 @@ name = "orbax-export"
 version = "0.0.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "absl-py", marker = "python_full_version >= '3.11'" },
-    { name = "dataclasses-json", marker = "python_full_version >= '3.11'" },
-    { name = "etils", marker = "python_full_version >= '3.11'" },
-    { name = "jax", version = "0.9.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "jaxlib", version = "0.9.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "jaxtyping", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "orbax-checkpoint", marker = "python_full_version >= '3.11'" },
-    { name = "protobuf", marker = "python_full_version >= '3.11'" },
+    { name = "absl-py" },
+    { name = "dataclasses-json" },
+    { name = "etils" },
+    { name = "jax", version = "0.9.0.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "jaxlib", version = "0.9.0.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "jaxtyping" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" } },
+    { name = "orbax-checkpoint" },
+    { name = "protobuf" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/c8/ed7ac3c3c687bf129d7469b016c2b3d8777379f4ea453474e50ee41ce5cb/orbax_export-0.0.8.tar.gz", hash = "sha256:544eef564e2a6f17cd11b1167febe348b7b7cf56d9575de994a33d5613dd568a", size = 124980, upload-time = "2025-09-17T15:41:14.264Z" }
 wheels = [
@@ -6740,10 +6792,10 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
-    { name = "pytz", marker = "python_full_version < '3.11'" },
-    { name = "tzdata", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -6776,26 +6828,26 @@ version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
     "python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'win32'",
     "python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "(python_full_version >= '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'darwin'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'win32'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
-    { name = "tzdata", marker = "(python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" } },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/de/da/b1dc0481ab8d55d0f46e343cfe67d4551a0e14fcee52bd38ca1bd73258d8/pandas-3.0.0.tar.gz", hash = "sha256:0facf7e87d38f721f0af46fe70d97373a37701b1c09f7ed7aeeb292ade5c050f", size = 4633005, upload-time = "2026-01-21T15:52:04.726Z" }
 wheels = [
@@ -6854,7 +6906,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'win32'" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -7662,7 +7714,7 @@ name = "pydot"
 version = "4.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyparsing", marker = "platform_machine != 'aarch64'" },
+    { name = "pyparsing" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/35/b17cb89ff865484c6a20ef46bf9d95a5f07328292578de0b295f4a6beec2/pydot-4.0.1.tar.gz", hash = "sha256:c2148f681c4a33e08bf0e26a9e5f8e4099a82e0e2a068098f32ce86577364ad5", size = 162594, upload-time = "2025-06-17T20:09:56.454Z" }
 wheels = [
@@ -7904,7 +7956,7 @@ name = "pyobjc-framework-cocoa"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-core" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/02/a3/16ca9a15e77c061a9250afbae2eae26f2e1579eb8ca9462ae2d2c71e1169/pyobjc_framework_cocoa-12.1.tar.gz", hash = "sha256:5556c87db95711b985d5efdaaf01c917ddd41d148b1e52a0c66b1a2e2c5c1640", size = 2772191, upload-time = "2025-11-14T10:13:02.069Z" }
 wheels = [
@@ -7918,8 +7970,8 @@ name = "pyobjc-framework-corebluetooth"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4b/25/d21d6cb3fd249c2c2aa96ee54279f40876a0c93e7161b3304bf21cbd0bfe/pyobjc_framework_corebluetooth-12.1.tar.gz", hash = "sha256:8060c1466d90bbb9100741a1091bb79975d9ba43911c9841599879fc45c2bbe0", size = 33157, upload-time = "2025-11-14T10:13:28.064Z" }
 wheels = [
@@ -7933,8 +7985,8 @@ name = "pyobjc-framework-libdispatch"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/26/e8/75b6b9b3c88b37723c237e5a7600384ea2d84874548671139db02e76652b/pyobjc_framework_libdispatch-12.1.tar.gz", hash = "sha256:4035535b4fae1b5e976f3e0e38b6e3442ffea1b8aa178d0ca89faa9b8ecdea41", size = 38277, upload-time = "2025-11-14T10:16:46.235Z" }
 wheels = [
@@ -8000,8 +8052,8 @@ name = "pyquaternion"
 version = "0.9.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine != 'aarch64') or (python_full_version < '3.11' and sys_platform != 'linux')" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine != 'aarch64') or (python_full_version >= '3.11' and sys_platform != 'linux')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/3d092aa20efaedacb89c3221a92c6491be5b28f618a2c36b52b53e7446c2/pyquaternion-0.9.9.tar.gz", hash = "sha256:b1f61af219cb2fe966b5fb79a192124f2e63a3f7a777ac3cadf2957b1a81bea8", size = 15530, upload-time = "2020-10-05T01:31:30.327Z" }
 wheels = [
@@ -8966,10 +9018,10 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "joblib", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "threadpoolctl", marker = "python_full_version < '3.11'" },
+    { name = "joblib" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "threadpoolctl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/c2/a7855e41c9d285dfe86dc50b250978105dce513d6e459ea66a6aeb0e1e0c/scikit_learn-1.7.2.tar.gz", hash = "sha256:20e9e49ecd130598f1ca38a1d85090e1a600147b9c02fa6f15d69cb53d968fda", size = 7193136, upload-time = "2025-09-09T08:21:29.075Z" }
 wheels = [
@@ -8996,27 +9048,27 @@ version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
     "python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'win32'",
     "python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "(python_full_version >= '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'darwin'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'win32'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "joblib", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "threadpoolctl", marker = "python_full_version >= '3.11'" },
+    { name = "joblib" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" } },
+    { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "threadpoolctl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/40988bf3b8e34feec1d0e6a051446b1f66225f8529b9309becaeef62b6c4/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd", size = 7335585, upload-time = "2025-12-10T07:08:53.618Z" }
 wheels = [
@@ -9049,7 +9101,7 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -9088,24 +9140,24 @@ version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
     "python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'win32'",
     "python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "(python_full_version >= '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'darwin'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'win32'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/56/3e/9cca699f3486ce6bc12ff46dc2031f1ec8eb9ccc9a320fdaf925f1417426/scipy-1.17.0.tar.gz", hash = "sha256:2591060c8e648d8b96439e111ac41fd8342fdeff1876be2e19dea3fe8930454e", size = 30396830, upload-time = "2026-01-10T21:34:23.009Z" }
 wheels = [
@@ -9136,8 +9188,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "(platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'win32') or sys_platform == 'linux'" },
-    { name = "jeepney", marker = "(platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'win32') or sys_platform == 'linux'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -9523,23 +9575,23 @@ version = "1.13.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
-    "python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
     "(python_full_version >= '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "(python_full_version < '3.11' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'darwin'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
     "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'darwin'",
     "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "mpmath", marker = "(platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and sys_platform != 'win32')" },
+    { name = "mpmath" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ca/99/5a5b6f19ff9f083671ddf7b9632028436167cd3d33e11015754e41b249a4/sympy-1.13.1.tar.gz", hash = "sha256:9cebf7e04ff162015ce31c9c6c9144daa34a93bd082f54fd8f12deca4f47515f", size = 7533040, upload-time = "2024-07-19T09:26:51.238Z" }
 wheels = [
@@ -9553,16 +9605,16 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'win32'",
     "python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'win32'",
     "python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'win32'",
     "python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'win32'",
     "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "mpmath", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'win32'" },
+    { name = "mpmath" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
@@ -9669,8 +9721,8 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "ml-dtypes", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "ml-dtypes" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9f/ee/05eb424437f4db63331c90e4605025eedc0f71da3faff97161d5d7b405af/tensorstore-0.1.78.tar.gz", hash = "sha256:e26074ffe462394cf54197eb76d6569b500f347573cd74da3f4dd5f510a4ad7c", size = 6913502, upload-time = "2025-10-06T17:44:29.649Z" }
 wheels = [
@@ -9697,25 +9749,25 @@ version = "0.1.81"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
     "python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'win32'",
     "python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "(python_full_version >= '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'darwin'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'win32'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "ml-dtypes", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "ml-dtypes" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/43/f6/e2403fc05b97ba74ad408a98a42c288e6e1b8eacc23780c153b0e5166179/tensorstore-0.1.81.tar.gz", hash = "sha256:687546192ea6f6c8ae28d18f13103336f68017d928b9f5a00325e9b0548d9c25", size = 7120819, upload-time = "2026-02-06T18:56:12.535Z" }
 wheels = [
@@ -9907,30 +9959,30 @@ version = "2.6.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
-    "python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
     "(python_full_version >= '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "(python_full_version < '3.11' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'darwin'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
     "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'darwin'",
     "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "filelock", marker = "(platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and sys_platform != 'win32')" },
-    { name = "fsspec", marker = "(platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and sys_platform != 'win32')" },
-    { name = "jinja2", marker = "(platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and sys_platform != 'win32')" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'linux' and sys_platform != 'win32')" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform != 'linux' and sys_platform != 'win32')" },
-    { name = "setuptools", marker = "(python_full_version >= '3.12' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform != 'linux' and sys_platform != 'win32')" },
-    { name = "sympy", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and sys_platform != 'win32')" },
-    { name = "typing-extensions", marker = "(platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and sys_platform != 'win32')" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "setuptools", marker = "python_full_version >= '3.12'" },
+    { name = "sympy", version = "1.13.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/37/81/aa9ab58ec10264c1abe62c8b73f5086c3c558885d6beecebf699f0dbeaeb/torch-2.6.0-cp310-cp310-manylinux1_x86_64.whl", hash = "sha256:6860df13d9911ac158f4c44031609700e1eba07916fff62e21e6ffa0a9e01961", size = 766685561, upload-time = "2025-01-29T16:19:12.12Z" },
@@ -9951,38 +10003,38 @@ source = { registry = "https://download.pytorch.org/whl/cu128" }
 resolution-markers = [
     "python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'win32'",
     "python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'win32'",
     "python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'win32'",
     "python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'win32'",
     "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "filelock", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'win32'" },
-    { name = "fsspec", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'win32'" },
-    { name = "jinja2", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'win32'" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32')" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
-    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufile-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparselt-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "setuptools", marker = "(python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')" },
-    { name = "sympy", version = "1.14.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'win32'" },
-    { name = "triton", version = "3.3.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'win32'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cudnn-cu12", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cufft-cu12", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cufile-cu12", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-curand-cu12", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cusolver-cu12", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cusparselt-cu12", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nccl-cu12", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nvtx-cu12", marker = "sys_platform != 'win32'" },
+    { name = "setuptools", marker = "python_full_version >= '3.12'" },
+    { name = "sympy", version = "1.14.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "triton", version = "3.3.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'win32'" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.7.1%2Bcu128-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:d6c3cba198dc93f93422a8545f48a6697890366e4b9701f54351fc27e2304bd3", upload-time = "2025-06-03T18:30:47Z" },
@@ -10026,26 +10078,26 @@ version = "0.21.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
-    "python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
     "(python_full_version >= '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "(python_full_version < '3.11' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'darwin'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
     "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'darwin'",
     "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'linux' and sys_platform != 'win32')" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform != 'linux' and sys_platform != 'win32')" },
-    { name = "pillow", marker = "(platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and sys_platform != 'win32')" },
-    { name = "torch", version = "2.6.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and sys_platform != 'win32')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pillow" },
+    { name = "torch", version = "2.6.0", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/20/72eb0b5b08fa293f20fc41c374e37cf899f0033076f0144d2cdc48f9faee/torchvision-0.21.0-1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:5568c5a1ff1b2ec33127b629403adb530fab81378d9018ca4ed6508293f76e2b", size = 2327643, upload-time = "2025-03-18T17:25:51.165Z" },
@@ -10069,19 +10121,19 @@ source = { registry = "https://download.pytorch.org/whl/cu128" }
 resolution-markers = [
     "python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'win32'",
     "python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'win32'",
     "python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'win32'",
     "python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'win32'",
     "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32')" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
-    { name = "pillow", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'win32'" },
-    { name = "torch", version = "2.7.1+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'win32'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pillow" },
+    { name = "torch", version = "2.7.1+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" } },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.22.1%2Bcu128-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:538f4db667286d939b4eee0a66d31ed21b51186668006b0e0ffe20338ecc7e00", upload-time = "2025-06-03T18:37:28Z" },
@@ -10232,7 +10284,7 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'",
 ]
 dependencies = [
-    { name = "setuptools", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "setuptools" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8d/a9/549e51e9b1b2c9b854fd761a1d23df0ba2fbc60bd0c13b489ffa518cfcb7/triton-3.3.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b74db445b1c562844d3cfad6e9679c72e93fdfb1a90a24052b03bb5c49d1242e", size = 155600257, upload-time = "2025-05-29T23:39:36.085Z" },
@@ -10250,7 +10302,7 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "importlib-metadata", marker = "platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "importlib-metadata" },
 ]
 
 [[package]]
@@ -10330,8 +10382,8 @@ name = "typing-inspect"
 version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mypy-extensions", marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.11'" },
+    { name = "mypy-extensions" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/dc/74/1789779d91f1961fa9438e9a8710cdae6bd138c80d7303996933d117264a/typing_inspect-0.9.0.tar.gz", hash = "sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78", size = 13825, upload-time = "2023-05-24T20:25:47.612Z" }
 wheels = [
@@ -10917,7 +10969,7 @@ name = "winrt-runtime"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "sys_platform == 'win32'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/16/dd/acdd527c1d890c8f852cc2af644aa6c160974e66631289420aa871b05e65/winrt_runtime-3.2.1.tar.gz", hash = "sha256:c8dca19e12b234ae6c3dadf1a4d0761b51e708457492c13beb666556958801ea", size = 21721, upload-time = "2025-06-06T14:40:27.593Z" }
 wheels = [
@@ -10937,7 +10989,7 @@ name = "winrt-windows-devices-bluetooth"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "winrt-runtime", marker = "sys_platform == 'win32'" },
+    { name = "winrt-runtime" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b2/a0/1c8a0c469abba7112265c6cb52f0090d08a67c103639aee71fc690e614b8/winrt_windows_devices_bluetooth-3.2.1.tar.gz", hash = "sha256:db496d2d92742006d5a052468fc355bf7bb49e795341d695c374746113d74505", size = 23732, upload-time = "2025-06-06T14:41:20.489Z" }
 wheels = [
@@ -10957,7 +11009,7 @@ name = "winrt-windows-devices-bluetooth-advertisement"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "winrt-runtime", marker = "sys_platform == 'win32'" },
+    { name = "winrt-runtime" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/06/fc/7ffe66ca4109b9e994b27c00f3d2d506e6e549e268791f755287ad9106d8/winrt_windows_devices_bluetooth_advertisement-3.2.1.tar.gz", hash = "sha256:0223852a7b7fa5c8dea3c6a93473bd783df4439b1ed938d9871f947933e574cc", size = 16906, upload-time = "2025-06-06T14:41:21.448Z" }
 wheels = [
@@ -10977,7 +11029,7 @@ name = "winrt-windows-devices-bluetooth-genericattributeprofile"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "winrt-runtime", marker = "sys_platform == 'win32'" },
+    { name = "winrt-runtime" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/44/21/aeeddc0eccdfbd25e543360b5cc093233e2eab3cdfb53ad3cabae1b5d04d/winrt_windows_devices_bluetooth_genericattributeprofile-3.2.1.tar.gz", hash = "sha256:cdf6ddc375e9150d040aca67f5a17c41ceaf13a63f3668f96608bc1d045dde71", size = 38896, upload-time = "2025-06-06T14:41:22.687Z" }
 wheels = [
@@ -10997,7 +11049,7 @@ name = "winrt-windows-devices-enumeration"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "winrt-runtime", marker = "sys_platform == 'win32'" },
+    { name = "winrt-runtime" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9e/dd/75835bfbd063dffa152109727dedbd80f6e92ea284855f7855d48cdf31c9/winrt_windows_devices_enumeration-3.2.1.tar.gz", hash = "sha256:df316899e39bfc0ffc1f3cb0f5ee54d04e1d167fbbcc1484d2d5121449a935cf", size = 23538, upload-time = "2025-06-06T14:41:26.787Z" }
 wheels = [
@@ -11017,7 +11069,7 @@ name = "winrt-windows-devices-radios"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "winrt-runtime", marker = "sys_platform == 'win32'" },
+    { name = "winrt-runtime" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/02/9704ea359ad8b0d6faa1011f98fb477e8fb6eac5201f39d19e73c2407e7b/winrt_windows_devices_radios-3.2.1.tar.gz", hash = "sha256:4dc9b9d1501846049eb79428d64ec698d6476c27a357999b78a8331072e18a0b", size = 5908, upload-time = "2025-06-06T14:41:44.868Z" }
 wheels = [
@@ -11037,7 +11089,7 @@ name = "winrt-windows-foundation"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "winrt-runtime", marker = "sys_platform == 'win32'" },
+    { name = "winrt-runtime" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0c/55/098ce7ea0679efcc1298b269c48768f010b6c68f90c588f654ec874c8a74/winrt_windows_foundation-3.2.1.tar.gz", hash = "sha256:ad2f1fcaa6c34672df45527d7c533731fdf65b67c4638c2b4aca949f6eec0656", size = 30485, upload-time = "2025-06-06T14:41:53.344Z" }
 wheels = [
@@ -11057,7 +11109,7 @@ name = "winrt-windows-foundation-collections"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "winrt-runtime", marker = "sys_platform == 'win32'" },
+    { name = "winrt-runtime" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/62/d21e3f1eeb8d47077887bbf0c3882c49277a84d8f98f7c12bda64d498a07/winrt_windows_foundation_collections-3.2.1.tar.gz", hash = "sha256:0eff1ad0d8d763ad17e9e7bbd0c26a62b27215016393c05b09b046d6503ae6d5", size = 16043, upload-time = "2025-06-06T14:41:53.983Z" }
 wheels = [
@@ -11077,7 +11129,7 @@ name = "winrt-windows-storage-streams"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "winrt-runtime", marker = "sys_platform == 'win32'" },
+    { name = "winrt-runtime" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/00/50/f4488b07281566e3850fcae1021f0285c9653992f60a915e15567047db63/winrt_windows_storage_streams-3.2.1.tar.gz", hash = "sha256:476f522722751eb0b571bc7802d85a82a3cae8b1cce66061e6e758f525e7b80f", size = 34335, upload-time = "2025-06-06T14:43:23.905Z" }
 wheels = [


### PR DESCRIPTION
## Contribution path

- Linked issue or discussion: DIM-XXX <!-- TODO: fill in -->

## Problem

An agent on this stack can look at the current frame, move, and talk. It cannot
consult the past. Ask "where is the backpack" and there is nothing to ask — the
recording holds camera, lidar and odometry, and no layer that turns those into
"a thing, at a place, at a time".

The two failures that shape this PR both come from the same gap:

- **Wall-clock staleness.** Without an asking time, an answer about t=30 s gets
  built from what the robot saw at t=400 s. It reads exactly as well as a
  correct one.
- **An answer with nothing to judge it by.** A bare list gives the model no way
  to tell "I never looked there" from "I looked and it was gone", so it
  confabulates over both.

## Solution

A belief layer under `dimos/experimental/memory_belief/`: sightings are written
into the same store they were derived from, folded into entities, and queried
as of one moment.

**Write path** — `detect_recording` runs the detector over a recording's frames
and writes `belief_observation` back into that store; `build_views` folds those
into `belief_identity` / `belief_entity` / `belief_frame_annotation` in place.
One file goes in, the same file comes out fuller, so every stream stays on one
timeline and `dimos mem rerun` can play the result.

**Read path** — one `execute(store, query)` entry point onto the store's
existing lazy filter chain, not a second query engine. Filters narrow,
projections compute; JSON drives the same frozen-dataclass algebra the store
already had. One call instead of six, because a round trip costs milliseconds of
work wrapped in seconds of inference.

Key decisions:

- **`as_of` is required, never defaulted.** The asking time decides the answer,
  so nothing picks it for the caller. In the skill it is clamped to now rather
  than trusted: a model free to choose it can answer about 1:00 from what the
  robot saw at 7:00.
- **Every answer carries how much to trust it.** `quality` (rows, support,
  dispersion, coherence, deduplicated) plus a named `UnknownReason` —
  `NEVER_COVERED`, `OUT_OF_VOCABULARY`, `INCOHERENT`, `NO_CAPABILITY` — and the
  capability that would fix it. `SkillResult.retryable` is derived from that
  reason rather than set by hand, so it stays consistent across authors.
- **`visibility` is three-way.** `absent` is negative evidence; `occluded` and
  `out_of_view` are no evidence at all. Collapsing them turns "I did not see it"
  into "it is not there".
- **The vocabulary is recorded on every sighting**, so a question about a term
  the detector never ran with answers `OUT_OF_VOCABULARY` instead of a confident
  "no".
- **The folds live in `pipeline.py`, not in the scripts.** The same folds have to
  run offline and, later, on a robot that is still driving. Divergence there is
  invisible — nothing raises, the queries just stop agreeing — so `ViewParams`
  makes it deliberate.
- **JSON codec for derived streams.** A pickle is readable only by the exact
  classes that wrote it; the codec refuses payload types that accept unknown
  fields or carry no version, at open time rather than at decode time.
- **Tracing is optional and silent.** Missing Langfuse must never take a robot
  down for the sake of a dashboard, and spans are emitted only inside an
  `agent_trace` block, so 15 Hz perception does not drown the useful ones.

Also here because the layer needed them: `mem rerun --view module:function` so a
robot's view lives with the robot, and `SkillResult.evidence` as `(stream, id)`
pairs so an agent can re-read what a skill acted on.

Scoped to `experimental/`: the identity fold is still weak, and only the
`locate` projection ships — counting, timelines and distances were removed
rather than left half-served, because a projection that always returns nothing
reads as an answer.

## How to Test

```
python -m scripts.ask recording.db "where is the backpack" --at 61
```

Building that store from a raw recording, and watching it back:

```
python -m dimos.experimental.memory_belief.detect_recording recording.db --vocabulary lvis
python -m scripts.build_views recording.db
dimos mem rerun recording.db --view dimos.robot.unitree.go2.belief_rerun:go2_belief_rerun_config
```

Unit tests:

```
pytest dimos/experimental/memory_belief dimos/agents/test_skill_result.py dimos/utils/test_tracing.py dimos/memory/codecs/test_codecs.py
```

## AI assistance

Claude Code with Opus 5, used to implement. The architecture, the design
methodology, and every decision written up above are mine -- the model wrote code
against them. I have read every line and I am accountable for it.

## Checklist

- [ ] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
