### PR TITLE
feat(viser): add scan-from-here and saved viewpoints

### DIFF
--- a/dimos/manipulation/conftest.py
+++ b/dimos/manipulation/conftest.py
@@ -80,6 +80,7 @@ def module_factory(mocker: MockerFixture) -> Iterator[ModuleFactory]:
         # handle_voxel_map and no transport is needed. Same reason as above.
         cast("Any", module).voxel_map = None
         cast("Any", module).objects = None
+        cast("Any", module).scan_results = None
         mocker.patch.object(module, "_initialize_planning")
         module.start()
         return module

--- a/dimos/manipulation/manipulation_module.py
+++ b/dimos/manipulation/manipulation_module.py
@@ -27,6 +27,7 @@ import asyncio
 from collections.abc import Mapping, Sequence
 from enum import Enum
 import math
+import queue
 import threading
 import time
 import traceback
@@ -107,6 +108,7 @@ from dimos.msgs.geometry_msgs.Vector3 import Vector3
 from dimos.msgs.sensor_msgs.JointState import JointState
 from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
 from dimos.msgs.tf2_msgs.TFMessage import TFMessage
+from dimos.msgs.vision_msgs.Detection3DArray import Detection3DArray
 from dimos.perception.experimental.object import Object as DetObject
 from dimos.utils.logging_config import setup_logger
 
@@ -191,6 +193,8 @@ class ManipulationModule(Module):
     # message is a complete map, so it replaces the obstacle rather than adding.
     voxel_map: In[PointCloud2]
     objects: In[list[DetObject]]
+    scan_results: In[Detection3DArray]
+    scan_requests: Out[list[str]]
     tf: Out[TFMessage]
 
     def __init__(self, **kwargs: Any) -> None:
@@ -211,6 +215,9 @@ class ManipulationModule(Module):
 
         # Canonical generated plan for the plan/preview/execute workflow.
         self._last_plan: GeneratedPlan | None = None
+        self._scan_lock = threading.Lock()
+        self._scan_result_queue: queue.Queue[Detection3DArray] = queue.Queue(maxsize=1)
+        self._objects_updated = threading.Condition()
 
         # Coordinator integration (initialized in start())
         self._execution_manager: PlanExecutionManager
@@ -1323,6 +1330,17 @@ class ManipulationModule(Module):
         """Cache the latest perception objects for an explicit obstacle refresh."""
         if self._world_monitor is not None:
             self._world_monitor.on_objects(objects)
+        with self._objects_updated:
+            self._objects_updated.notify_all()
+
+    async def handle_scan_results(self, result: Detection3DArray) -> None:
+        """Deliver one OSR scan response to the synchronous visualization seam."""
+        while True:
+            try:
+                self._scan_result_queue.get_nowait()
+            except queue.Empty:
+                break
+        self._scan_result_queue.put_nowait(result)
 
     @rpc
     def refresh_obstacles(self, min_duration: float = 0.0) -> int:
@@ -1330,6 +1348,49 @@ class ManipulationModule(Module):
         if self._world_monitor is None:
             return 0
         return len(self._world_monitor.refresh_obstacles(min_duration))
+
+    @rpc
+    def scan_from_here(self, prompts: list[str], timeout: float = 30.0) -> dict[str, int]:
+        """Run OSR at the current camera pose and refresh accumulated obstacles."""
+        normalized = [prompt.strip() for prompt in prompts if prompt.strip()]
+        if not normalized:
+            raise ValueError("At least one scan prompt is required")
+        if timeout <= 0.0:
+            raise ValueError("Scan timeout must be positive")
+        with self._scan_lock:
+            while True:
+                try:
+                    self._scan_result_queue.get_nowait()
+                except queue.Empty:
+                    break
+            self.scan_requests.publish(normalized)
+            try:
+                result = self._scan_result_queue.get(timeout=timeout)
+            except queue.Empty as error:
+                raise TimeoutError(f"Scan timed out after {timeout:.1f}s") from error
+            expected_ids = {str(detection.id) for detection in result.detections if detection.id}
+            self._wait_for_scan_objects(expected_ids, time.monotonic() + timeout)
+            refreshed = self.refresh_obstacles()
+            return {
+                "detected": int(result.detections_length),
+                "refreshed": refreshed,
+                "total": len(self.get_obstacles()),
+            }
+
+    def _wait_for_scan_objects(self, expected_ids: set[str], deadline: float) -> None:
+        if self._world_monitor is None or not expected_ids:
+            return
+        with self._objects_updated:
+            while True:
+                cached_ids = {
+                    str(obj.object_id) for obj in self._world_monitor.get_cached_objects()
+                }
+                if expected_ids.issubset(cached_ids):
+                    return
+                remaining = deadline - time.monotonic()
+                if remaining <= 0.0:
+                    raise TimeoutError("Timed out waiting for scanned objects to reach planning")
+                self._objects_updated.wait(timeout=remaining)
 
     @rpc
     def get_obstacles(self) -> dict[str, PoseStamped]:

--- a/dimos/manipulation/test_manipulation_unit.py
+++ b/dimos/manipulation/test_manipulation_unit.py
@@ -298,6 +298,26 @@ class TestObstacleUpdates:
         assert count == 1
         assert obstacles == {"object-1": pose}
 
+    def test_scan_from_here_waits_for_osr_then_refreshes(self, module_factory, mocker) -> None:
+        module = module_factory()
+        module._world_monitor = MagicMock(spec=WorldMonitor)
+        module._world_monitor.refresh_obstacles.return_value = [{"object_id": "one"}]
+        module._world_monitor.world.get_obstacles.return_value = [
+            Obstacle(name="one", pose=PoseStamped(), obstacle_type=ObstacleType.BOX)
+        ]
+        result_message = MagicMock(detections=[], detections_length=0)
+        publish = mocker.patch.object(
+            module.scan_requests,
+            "publish",
+            side_effect=lambda _prompts: module._scan_result_queue.put_nowait(result_message),
+        )
+
+        result = module.scan_from_here([" cup ", "bottle"], timeout=1.0)
+
+        publish.assert_called_once_with(["cup", "bottle"])
+        module._world_monitor.refresh_obstacles.assert_called_once_with(0.0)
+        assert result == {"detected": 0, "refreshed": 1, "total": 1}
+
     def test_complete_update_forwards_new_obstacle_value(self, module_factory) -> None:
         module = module_factory()
         module._world_monitor = MagicMock(spec=WorldMonitor)
@@ -483,6 +503,7 @@ class TestPlanningInitialization:
         module.coordinator_joint_state = None
         module.voxel_map = None
         module.objects = None
+        module.scan_results = None
         initialize_planning = mocker.patch.object(module, "_initialize_planning")
         initialize_execution = mocker.patch.object(module, "_initialize_execution")
 
@@ -495,6 +516,7 @@ class TestPlanningInitialization:
         module.coordinator_joint_state = None
         module.voxel_map = None
         module.objects = None
+        module.scan_results = None
         initialize_planning = mocker.patch.object(module, "_initialize_planning")
         initialize_execution = mocker.patch.object(module, "_initialize_execution")
 
@@ -517,6 +539,7 @@ class TestPlanningInitialization:
         module.coordinator_joint_state = None
         module.voxel_map = None
         module.objects = None
+        module.scan_results = None
         observed_status: list[ExecutionStatus] = []
 
         def observe_state() -> None:

--- a/dimos/manipulation/visualization/operator.py
+++ b/dimos/manipulation/visualization/operator.py
@@ -218,6 +218,10 @@ class ManipulationOperator:
     def clear_plan(self) -> bool:
         return self._module.clear_planned_path()
 
+    def scan_from_here(self, prompts: list[str], timeout: float) -> dict[str, int]:
+        """Run perception at the current arm pose and refresh planner obstacles."""
+        return self._module.scan_from_here(prompts, timeout)
+
     def _validate_joint_request(
         self, request: JointTargetRequest
     ) -> tuple[tuple[PlanningGroup, ...] | None, TargetEvaluationResult | None]:

--- a/dimos/manipulation/visualization/test_operator.py
+++ b/dimos/manipulation/visualization/test_operator.py
@@ -87,6 +87,7 @@ def _operator() -> tuple[ManipulationOperator, MagicMock, MagicMock]:
     module._execute_generated_plan.return_value = True
     module.cancel.return_value = ExecutionResult(ExecutionStatus.NO_EXECUTION)
     module.clear_planned_path.return_value = True
+    module.scan_from_here.return_value = {"detected": 3, "refreshed": 5, "total": 5}
 
     monitor = MagicMock()
     monitor.planning_groups = PlanningGroupRegistry([config])
@@ -178,3 +179,12 @@ def test_cartesian_planning_uses_current_group_pose() -> None:
     assert result is module.generate_cartesian_plan.return_value
     targets = module.generate_cartesian_plan.call_args.args[0]
     assert targets["left_arm"] == (monitor.get_group_ee_pose.return_value, target)
+
+
+def test_scan_from_here_uses_module_seam() -> None:
+    operator, module, _ = _operator()
+
+    result = operator.scan_from_here(["cup", "bottle"], 12.0)
+
+    assert result == {"detected": 3, "refreshed": 5, "total": 5}
+    module.scan_from_here.assert_called_once_with(["cup", "bottle"], 12.0)

--- a/dimos/manipulation/visualization/viser/config.py
+++ b/dimos/manipulation/visualization/viser/config.py
@@ -35,6 +35,25 @@ class ViserVisualizationConfig(BaseModel):
     panel_enabled: bool = Field(
         default=True, validation_alias=AliasChoices("panel_enabled", "viser_panel_enabled")
     )
+    scan_from_here_enabled: bool = Field(
+        default=False,
+        validation_alias=AliasChoices("scan_from_here_enabled", "viser_scan_from_here_enabled"),
+    )
+    scan_prompts: tuple[str, ...] = Field(
+        default=(), validation_alias=AliasChoices("scan_prompts", "viser_scan_prompts")
+    )
+    scan_timeout: float = Field(
+        default=30.0, gt=0.0, validation_alias=AliasChoices("scan_timeout", "viser_scan_timeout")
+    )
+    scan_debounce_seconds: float = Field(
+        default=0.75,
+        ge=0.0,
+        validation_alias=AliasChoices("scan_debounce_seconds", "viser_scan_debounce_seconds"),
+    )
+    viewpoints_enabled: bool = Field(
+        default=False,
+        validation_alias=AliasChoices("viewpoints_enabled", "viser_viewpoints_enabled"),
+    )
     poll_hz: float = Field(default=5.0, validation_alias=AliasChoices("poll_hz", "viser_poll_hz"))
     preview_duration: float = Field(
         default=3.0, validation_alias=AliasChoices("preview_duration", "viser_preview_duration")

--- a/dimos/manipulation/visualization/viser/gui.py
+++ b/dimos/manipulation/visualization/viser/gui.py
@@ -15,7 +15,9 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
 import math
+import time
 from typing import TypeAlias, cast
 
 from dimos.manipulation.planning.groups.models import PlanningGroup
@@ -65,6 +67,7 @@ try:
         GuiFolderHandle,
         GuiMarkdownHandle,
         GuiSliderHandle,
+        GuiTextHandle,
         TransformControlsHandle,
         ViserServer,
     )
@@ -80,6 +83,7 @@ PanelHandle: TypeAlias = (
     | GuiButtonHandle
     | GuiCheckboxHandle
     | GuiSliderHandle[float]
+    | GuiTextHandle
     | TransformControlsHandle
 )
 
@@ -110,6 +114,14 @@ PLANNING_MODE_LABELS = {
 PLANNING_MODES_BY_LABEL = {label: mode for mode, label in PLANNING_MODE_LABELS.items()}
 
 
+@dataclass(frozen=True)
+class CameraViewpoint:
+    position: tuple[float, float, float]
+    look_at: tuple[float, float, float]
+    up_direction: tuple[float, float, float]
+    fov: float
+
+
 class ViserPanelGui:
     """Viser operator panel for manipulation target editing and plan control."""
 
@@ -136,6 +148,10 @@ class ViserPanelGui:
         self._default_group_initialized = False
         self._handles: dict[str, PanelHandle] = {}
         self._joint_sliders: dict[tuple[PlanningGroupID, str], GuiSliderHandle[float]] = {}
+        self._viewpoints: dict[str, CameraViewpoint] = {}
+        self._viewpoint_counter = 0
+        self._scan_running = False
+        self._last_scan_started = float("-inf")
         self._worker = TargetEvaluationWorker(
             self._handle_target_evaluation_request,
             self._apply_target_evaluation_result,
@@ -343,6 +359,7 @@ class ViserPanelGui:
     def _build_panel_controls(self, gui: GuiApi) -> None:
         self._handles["status"] = gui.add_markdown("### Status\n**State:** Ready")
         self._build_scene_controls(gui)
+        self._build_interaction_controls(gui)
         self._handles["planning_groups_heading"] = gui.add_markdown(
             "### Planning Groups\nActive planning groups for pose goals, planning, and joint edits."
         )
@@ -384,6 +401,132 @@ class ViserPanelGui:
         joint_controls = gui.add_folder("Joint Control", expand_by_default=False)
         self._handles["joint_control_folder"] = joint_controls
         self._build_joint_sliders()
+
+    def _build_interaction_controls(self, gui: GuiApi) -> None:
+        if self.config.scan_from_here_enabled:
+            scan_folder = gui.add_folder("Perception", expand_by_default=True)
+            self._handles["scan_folder"] = scan_folder
+            with scan_folder:
+                scan_button = gui.add_button("Scan from here")
+                scan_button.on_click(lambda _event: self._submit_scan())
+                self._handles["scan"] = scan_button
+                self._handles["scan_status"] = gui.add_markdown("No scan yet.")
+        if self.config.viewpoints_enabled:
+            viewpoint_folder = gui.add_folder("Viewpoints", expand_by_default=False)
+            self._handles["viewpoint_folder"] = viewpoint_folder
+            with viewpoint_folder:
+                name = gui.add_text("Name", initial_value="")
+                self._handles["viewpoint_name"] = name
+                save = gui.add_button("Save current camera")
+                save.on_click(self._save_viewpoint)
+                self._handles["viewpoint_save"] = save
+                choices = gui.add_dropdown(
+                    "Saved viewpoints", options=["(none)"], initial_value="(none)"
+                )
+                self._handles["viewpoint_choices"] = choices
+                restore = gui.add_button("Jump to viewpoint")
+                restore.on_click(self._restore_viewpoint)
+                self._handles["viewpoint_restore"] = restore
+                self._handles["viewpoint_status"] = gui.add_markdown("No viewpoints saved.")
+
+    def _save_viewpoint(self, event: object) -> None:
+        client = getattr(event, "client", None)
+        if self._closed or client is None:
+            self._set_interaction_status("viewpoint_status", "Open the panel in a client first.")
+            return
+        name_handle = self._handles.get("viewpoint_name")
+        name = str(getattr(name_handle, "value", "")).strip()
+        if not name:
+            self._viewpoint_counter += 1
+            name = f"Viewpoint {self._viewpoint_counter}"
+        camera = client.camera
+        self._viewpoints[name] = CameraViewpoint(
+            position=self._camera_vector(camera.position),
+            look_at=self._camera_vector(camera.look_at),
+            up_direction=self._camera_vector(camera.up_direction),
+            fov=float(camera.fov),
+        )
+        choices = self._handles.get("viewpoint_choices")
+        self._set_optional_handle_attr(choices, "options", list(self._viewpoints))
+        self._set_optional_handle_attr(choices, "value", name)
+        self._set_optional_handle_attr(name_handle, "value", "")
+        self._set_interaction_status("viewpoint_status", f"Saved `{name}` for this session.")
+
+    def _restore_viewpoint(self, event: object) -> None:
+        client = getattr(event, "client", None)
+        choices = self._handles.get("viewpoint_choices")
+        name = str(getattr(choices, "value", ""))
+        viewpoint = self._viewpoints.get(name)
+        if self._closed or client is None or viewpoint is None:
+            self._set_interaction_status(
+                "viewpoint_status", "Select a saved viewpoint in an active client."
+            )
+            return
+        camera = client.camera
+        camera.position = viewpoint.position
+        camera.look_at = viewpoint.look_at
+        camera.up_direction = viewpoint.up_direction
+        camera.fov = viewpoint.fov
+        self._set_interaction_status("viewpoint_status", f"Restored `{name}`.")
+
+    def _submit_scan(self) -> None:
+        now = time.monotonic()
+        if (
+            self._closed
+            or not self.config.scan_from_here_enabled
+            or self._scan_running
+            or self.state.action_status != ActionStatus.IDLE
+            or now - self._last_scan_started < self.config.scan_debounce_seconds
+        ):
+            return
+        self._last_scan_started = now
+        self._scan_running = True
+        self.state.action_status = ActionStatus.RUNNING
+        self._set_interaction_status("scan_status", "Scanning from the current arm pose…")
+        operation_id = self._next_operation_id()
+        self.refresh()
+
+        def operation() -> None:
+            if not self._operation_is_current(operation_id):
+                return
+            result = self.operator.scan_from_here(
+                list(self.config.scan_prompts), self.config.scan_timeout
+            )
+            if not self._operation_is_current(operation_id):
+                return
+            self._scan_running = False
+            self.state.mark_plan_stale()
+            self._set_interaction_status(
+                "scan_status",
+                "Scan complete: "
+                f"{result['detected']} detected, {result['total']} planner objects total.",
+            )
+            self._finish_operation(
+                f"scan={result['detected']}, total={result['total']}",
+                operation_id=operation_id,
+            )
+
+        self._operation_worker.submit(
+            operation,
+            timeout_seconds=self.config.scan_timeout + 1.0,
+            on_error=lambda message: self._set_scan_error(message, operation_id),
+        )
+
+    def _set_scan_error(self, message: str, operation_id: int) -> None:
+        if not self._operation_is_current(operation_id):
+            return
+        self._scan_running = False
+        self._set_interaction_status("scan_status", f"Scan failed: {message}")
+        self._set_operation_error(message, operation_id)
+
+    def _set_interaction_status(self, key: str, content: str) -> None:
+        handle = self._handles.get(key)
+        if handle is not None:
+            self._set_optional_handle_attr(handle, "content", content)
+
+    @staticmethod
+    def _camera_vector(values: Sequence[float]) -> tuple[float, float, float]:
+        return (float(values[0]), float(values[1]), float(values[2]))
 
     def _build_motion_settings(self, gui: GuiApi) -> None:
         """Build controls that affect trajectories generated in the future."""
@@ -1059,6 +1202,9 @@ class ViserPanelGui:
         can_cancel = self.state.can_cancel()
         self._set_disabled("cancel", not can_cancel)
         self._set_visible("cancel", can_cancel)
+        self._set_disabled(
+            "scan", self._scan_running or self.state.action_status != ActionStatus.IDLE
+        )
         self._update_target_visual_state()
 
     def _update_target_visual_state(self) -> None:

--- a/dimos/manipulation/visualization/viser/test_gui.py
+++ b/dimos/manipulation/visualization/viser/test_gui.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -50,10 +51,15 @@ class EmptyServer:
 class FakeOperatorBackend:
     def __init__(self) -> None:
         self.cancel_calls = 0
+        self.scan_calls: list[tuple[list[str], float]] = []
 
     def cancel(self) -> bool:
         self.cancel_calls += 1
         return True
+
+    def scan_from_here(self, prompts: list[str], timeout: float) -> dict[str, int]:
+        self.scan_calls.append((prompts, timeout))
+        return {"detected": 2, "refreshed": 4, "total": 4}
 
 
 class FakeOperator:
@@ -71,6 +77,9 @@ class FakeOperator:
 
     def preview(self, *_args: object, **_kwargs: object) -> bool:
         return True
+
+    def scan_from_here(self, prompts: list[str], timeout: float) -> dict[str, int]:
+        return self.module.scan_from_here(prompts, timeout)
 
 
 @dataclass
@@ -283,6 +292,69 @@ def test_gui_only_preview_submits_timeout_override(monkeypatch: pytest.MonkeyPat
     gui._submit_preview()
 
     assert submissions == [{"timeout_seconds": 0.25}]
+
+
+def test_scan_is_debounced_and_reports_accumulated_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    submissions: list[Callable[[], None]] = []
+    backend = FakeOperatorBackend()
+    gui = make_gui(backend)
+    gui.config = ViserVisualizationConfig(
+        scan_from_here_enabled=True,
+        scan_prompts=("cup", "bottle"),
+        scan_timeout=12.0,
+    )
+    gui._operation_worker.stop()
+    monkeypatch.setattr(gui, "_operation_worker", FakeOperationSubmitWorker(submissions))
+    monkeypatch.setattr(gui, "refresh", lambda: None)
+    scan_status = SimpleNamespace(content="")
+    gui._handles["scan_status"] = scan_status
+    gui.state.action_status = ActionStatus.IDLE
+
+    gui._submit_scan()
+    gui._submit_scan()
+    submissions[0]()
+
+    assert backend.scan_calls == [(["cup", "bottle"], 12.0)]
+    assert scan_status.content == "Scan complete: 2 detected, 4 planner objects total."
+    assert gui.state.action_status == ActionStatus.IDLE
+    assert gui.state.last_result == "scan=2, total=4"
+
+
+def test_named_camera_viewpoint_round_trip_lives_in_panel_session() -> None:
+    gui = make_gui()
+    camera = SimpleNamespace(
+        position=(1.0, 2.0, 3.0),
+        look_at=(0.1, 0.2, 0.3),
+        up_direction=(0.0, 0.0, 1.0),
+        fov=0.8,
+    )
+    event = SimpleNamespace(client=SimpleNamespace(camera=camera))
+    name = SimpleNamespace(value="table overview")
+    choices = SimpleNamespace(options=["(none)"], value="(none)")
+    status = SimpleNamespace(content="")
+    gui._handles.update(
+        {
+            "viewpoint_name": name,
+            "viewpoint_choices": choices,
+            "viewpoint_status": status,
+        }
+    )
+
+    gui._save_viewpoint(event)
+    camera.position = (9.0, 9.0, 9.0)
+    camera.look_at = (8.0, 8.0, 8.0)
+    camera.up_direction = (0.0, 1.0, 0.0)
+    camera.fov = 1.2
+    gui._restore_viewpoint(event)
+
+    assert choices.options == ["table overview"]
+    assert camera.position == (1.0, 2.0, 3.0)
+    assert camera.look_at == (0.1, 0.2, 0.3)
+    assert camera.up_direction == (0.0, 0.0, 1.0)
+    assert camera.fov == 0.8
+    assert status.content == "Restored `table overview`."
 
 
 def test_gui_preview_enters_previewing_before_worker_runs(

--- a/dimos/perception/experimental/object_scene_registration.py
+++ b/dimos/perception/experimental/object_scene_registration.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import threading
 import time
 from typing import Any, Literal
@@ -73,11 +74,13 @@ class ObjectSceneRegistrationModule(Module):
     depth_image: In[Image]
     camera_info: In[CameraInfo]
     tf: In[TFMessage]
+    scan_requests: In[list[str]]
 
     detections_2d: Out[Detection2DArray]
     detections_3d: Out[Detection3DArray]
     objects: Out[list[DetObject]]
     pointcloud: Out[PointCloud2]
+    scan_results: Out[Detection3DArray]
 
     _detector: Any | None = None
     _segmenter: BoxPromptImageSegmenter | None = None
@@ -220,6 +223,11 @@ class ObjectSceneRegistrationModule(Module):
                 frame_id=self._target_frame,
                 ts=frames[0].ts,
             )
+
+    async def handle_scan_requests(self, prompts: list[str]) -> None:
+        """Run a panel-requested scan and publish its response."""
+        result = await asyncio.to_thread(self.scan_scene, text=prompts)
+        self.scan_results.publish(result)
 
     def _scan_scene_objects(self, frames: tuple[Image, Image] | None = None) -> list[DetObject]:
         """Process one frame and return only objects observed during this scan."""

--- a/dimos/robot/manipulators/xarm/blueprints/simulation.py
+++ b/dimos/robot/manipulators/xarm/blueprints/simulation.py
@@ -90,7 +90,12 @@ xarm_room_sim = autoconnect(
     ManipulationModule.blueprint(
         model=_xarm7_sim_model,
         planning_timeout=10.0,
-        visualization={"backend": "none"},
+        visualization={
+            "backend": "viser",
+            "scan_from_here_enabled": True,
+            "scan_prompts": XARM_ROOM_PROMPTS,
+            "viewpoints_enabled": True,
+        },
     ),
     ManipulationSkills.blueprint(),
     PickAndPlaceModule.blueprint(planning_frame="world"),


### PR DESCRIPTION
## Summary
- add per-client named Viser camera viewpoints with save and jump controls
- route debounced scan-from-here requests through `ManipulationOperator` and typed module-to-OSR request/response streams
- refresh planner obstacles after each completed scan and show detection/total counts in the panel
- enable both controls for `xarm-room-sim`
