### PR TITLE
feat(agents): opt-in capture of raw LLM request/response bodies

### DIFF
--- a/dimos/agents/llm_trace.py
+++ b/dimos/agents/llm_trace.py
@@ -19,10 +19,6 @@ the literal bytes sent to and received from the provider as
 ``<seq>-request.json`` / ``<seq>-response.json`` (auth header dropped). Give
 it to any OpenAI-backed chat model as ``http_client=``; every call becomes
 one pair of files, whole, not reconstructed from normalized messages.
-
-``write_normalized(dir, messages, result)`` is the fallback for providers
-that offer no HTTP hook: the same file pair built from LangChain's view of
-the call, marked ``"normalized": true`` so a reader knows it is not wire-exact.
 """
 
 from __future__ import annotations
@@ -118,29 +114,3 @@ def tracing_http_client(trace_dir: Path, **kwargs: Any) -> httpx.Client:
         "response": [*hooks.get("response", []), on_response],
     }
     return httpx.Client(event_hooks=hooks, **kwargs)
-
-
-def write_normalized(trace_dir: Path, messages: list[Any], result: Any) -> tuple[int, Path, Path]:
-    """Record a call from LangChain's normalized view (no HTTP hook available)."""
-    trace_dir.mkdir(parents=True, exist_ok=True)
-    seq = _next_seq(trace_dir)
-    req, resp = request_path(trace_dir, seq), response_path(trace_dir, seq)
-    _write(req, {"normalized": True, "messages": [m.model_dump() for m in messages]})
-    _write(resp, {"normalized": True, "result": result.model_dump()})
-    return seq, req, resp
-
-
-def latest_pair(trace_dir: Path, after: int) -> tuple[int, Path, Path] | None:
-    """The newest complete request/response pair with seq >= *after*, if any.
-    A retried call leaves several pairs; the newest is the one that answered."""
-    if not trace_dir.is_dir():
-        return None
-    seqs = sorted(
-        int(p.name[: -len(REQUEST_SUFFIX)])
-        for p in trace_dir.glob(f"*{REQUEST_SUFFIX}")
-        if p.name[: -len(REQUEST_SUFFIX)].isdigit()
-    )
-    seqs = [s for s in seqs if s >= after and response_path(trace_dir, s).exists()]
-    if not seqs:
-        return None
-    return seqs[-1], request_path(trace_dir, seqs[-1]), response_path(trace_dir, seqs[-1])

--- a/dimos/agents/llm_trace.py
+++ b/dimos/agents/llm_trace.py
@@ -1,0 +1,146 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Wire-exact capture of every LLM request and response.
+
+``tracing_http_client(dir)`` is an ``httpx.Client`` whose event hooks write
+the literal bytes sent to and received from the provider as
+``<seq>-request.json`` / ``<seq>-response.json`` (auth header dropped). Give
+it to any OpenAI-backed chat model as ``http_client=``; every call becomes
+one pair of files, whole, not reconstructed from normalized messages.
+
+``write_normalized(dir, messages, result)`` is the fallback for providers
+that offer no HTTP hook: the same file pair built from LangChain's view of
+the call, marked ``"normalized": true`` so a reader knows it is not wire-exact.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import threading
+import time
+from typing import Any
+
+import httpx
+
+from dimos.utils.logging_config import setup_logger
+
+logger = setup_logger()
+
+REQUEST_SUFFIX = "-request.json"
+RESPONSE_SUFFIX = "-response.json"
+_DROPPED_HEADERS = {"authorization", "x-api-key", "openai-organization", "cookie"}
+
+
+def _next_seq(trace_dir: Path) -> int:
+    return len(list(trace_dir.glob(f"*{REQUEST_SUFFIX}")))
+
+
+def _write(path: Path, record: dict[str, Any]) -> None:
+    path.write_text(json.dumps(record, indent=2, default=str))
+
+
+def _headers(headers: httpx.Headers) -> dict[str, str]:
+    return {k: v for k, v in headers.items() if k.lower() not in _DROPPED_HEADERS}
+
+
+def _body(content: bytes) -> Any:
+    try:
+        return json.loads(content)
+    except ValueError:
+        return content.decode("utf-8", errors="replace")
+
+
+def request_path(trace_dir: Path, seq: int) -> Path:
+    return trace_dir / f"{seq:03d}{REQUEST_SUFFIX}"
+
+
+def response_path(trace_dir: Path, seq: int) -> Path:
+    return trace_dir / f"{seq:03d}{RESPONSE_SUFFIX}"
+
+
+def tracing_http_client(trace_dir: Path, **kwargs: Any) -> httpx.Client:
+    """An httpx client that records each request/response pair under *trace_dir*."""
+    trace_dir.mkdir(parents=True, exist_ok=True)
+    lock = threading.Lock()
+
+    def on_request(request: httpx.Request) -> None:
+        # A hook that raises is retried by the SDK like a connection failure
+        # and the gap is silent, so never let one out.
+        try:
+            with lock:
+                seq = _next_seq(trace_dir)
+                request.extensions["llm_trace"] = (seq, time.monotonic())
+                _write(
+                    request_path(trace_dir, seq),
+                    {
+                        "method": request.method,
+                        "url": str(request.url),
+                        "headers": _headers(request.headers),
+                        "body": _body(request.content),
+                    },
+                )
+        except Exception:
+            logger.exception("llm trace: request not recorded", dir=str(trace_dir))
+
+    def on_response(response: httpx.Response) -> None:
+        try:
+            response.read()  # buffers the body; fine for the non-streaming calls this serves
+            seq, t0 = response.request.extensions.get("llm_trace", (_next_seq(trace_dir) - 1, 0.0))
+            with lock:
+                _write(
+                    response_path(trace_dir, seq),
+                    {
+                        "status": response.status_code,
+                        "latency_s": time.monotonic() - t0 if t0 else None,
+                        "headers": _headers(response.headers),
+                        "body": _body(response.content),
+                    },
+                )
+        except Exception:
+            logger.exception("llm trace: response not recorded", dir=str(trace_dir))
+
+    hooks = kwargs.pop("event_hooks", {})
+    hooks = {
+        "request": [*hooks.get("request", []), on_request],
+        "response": [*hooks.get("response", []), on_response],
+    }
+    return httpx.Client(event_hooks=hooks, **kwargs)
+
+
+def write_normalized(trace_dir: Path, messages: list[Any], result: Any) -> tuple[int, Path, Path]:
+    """Record a call from LangChain's normalized view (no HTTP hook available)."""
+    trace_dir.mkdir(parents=True, exist_ok=True)
+    seq = _next_seq(trace_dir)
+    req, resp = request_path(trace_dir, seq), response_path(trace_dir, seq)
+    _write(req, {"normalized": True, "messages": [m.model_dump() for m in messages]})
+    _write(resp, {"normalized": True, "result": result.model_dump()})
+    return seq, req, resp
+
+
+def latest_pair(trace_dir: Path, after: int) -> tuple[int, Path, Path] | None:
+    """The newest complete request/response pair with seq >= *after*, if any.
+    A retried call leaves several pairs; the newest is the one that answered."""
+    if not trace_dir.is_dir():
+        return None
+    seqs = sorted(
+        int(p.name[: -len(REQUEST_SUFFIX)])
+        for p in trace_dir.glob(f"*{REQUEST_SUFFIX}")
+        if p.name[: -len(REQUEST_SUFFIX)].isdigit()
+    )
+    seqs = [s for s in seqs if s >= after and response_path(trace_dir, s).exists()]
+    if not seqs:
+        return None
+    return seqs[-1], request_path(trace_dir, seqs[-1]), response_path(trace_dir, seqs[-1])

--- a/dimos/agents/mcp/mcp_client.py
+++ b/dimos/agents/mcp/mcp_client.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 from collections.abc import Callable
+import os
+from pathlib import Path
 from queue import Empty, Queue
 from threading import Event, RLock, Thread
 import time
@@ -29,6 +31,7 @@ warnings.filterwarnings("ignore", category=LangChainPendingDeprecationWarning)
 
 from langchain.agents import create_agent
 from langchain.chat_models import init_chat_model
+from langchain.chat_models.base import _attempt_infer_model_provider
 from langchain_core.messages import HumanMessage
 from langchain_core.messages.base import BaseMessage
 from langchain_core.tools import StructuredTool
@@ -37,6 +40,7 @@ from langgraph.graph.state import CompiledStateGraph
 from reactivex.disposable import Disposable
 import requests
 
+from dimos.agents.llm_trace import tracing_http_client
 from dimos.agents.mcp import tool_stream
 from dimos.agents.system_prompt import SYSTEM_PROMPT
 from dimos.agents.utils import pretty_print_langchain_message
@@ -45,7 +49,7 @@ from dimos.core.core import rpc
 from dimos.core.module import Module, ModuleConfig
 from dimos.core.rpc_client import RPCClient
 from dimos.core.stream import In, Out
-from dimos.utils.logging_config import setup_logger
+from dimos.utils.logging_config import get_run_log_dir, setup_logger
 from dimos.utils.sequential_ids import SequentialIds
 
 logger = setup_logger()
@@ -53,16 +57,34 @@ logger = setup_logger()
 _RESPONSES_REASONING_MODEL_PREFIXES = ("gpt-5", "o1", "o3", "o4")
 
 
-def _init_model(model_name: str) -> Any:
-    """Initialize a model while preserving LangChain provider resolution."""
+def _init_model(model_name: str, trace_dir: Path | None = None) -> Any:
+    """Initialize a model while preserving LangChain provider resolution.
+
+    With *trace_dir*, every request/response body goes to disk whole
+    (:mod:`dimos.agents.llm_trace`). Only OpenAI-backed models take the
+    ``http_client``; other providers keep working, untraced at the wire.
+    """
+    client = None if trace_dir is None else tracing_http_client(trace_dir)
     if ":" in model_name or not model_name.startswith(_RESPONSES_REASONING_MODEL_PREFIXES):
+        provider = _attempt_infer_model_provider(model_name.split(":", 1)[-1])
+        if ":" in model_name:
+            provider = model_name.split(":", 1)[0]
+        if client is not None and provider == "openai":
+            return init_chat_model(model=model_name, http_client=client)
         return init_chat_model(model=model_name)
 
     return ChatOpenAI(
         model=model_name,
         use_responses_api=True,
         reasoning={"effort": "medium", "summary": "auto"},
+        http_client=client,
     )
+
+
+def _default_trace_dir() -> Path | None:
+    """``<run log dir>/llm`` inside a ``dimos run``; nowhere outside one."""
+    log_dir = get_run_log_dir() or os.environ.get("DIMOS_RUN_LOG_DIR")
+    return Path(log_dir) / "llm" if log_dir else None
 
 
 class McpClientConfig(ModuleConfig):
@@ -70,6 +92,8 @@ class McpClientConfig(ModuleConfig):
     model: str = "gpt-5.6-luna"
     model_fixture: str | None = None
     mcp_server_url: str = "http://localhost:9990/mcp"
+    # Where raw LLM request/response bodies go. None -> <run log dir>/llm.
+    trace_dir: Path | None = None
 
 
 class McpClient(Module):
@@ -241,7 +265,7 @@ class McpClient(Module):
 
             model = MockModel(json_path=self.config.model_fixture)
         else:
-            model = _init_model(self.config.model)
+            model = _init_model(self.config.model, trace_dir=self.trace_dir())
 
         with self._lock:
             self._state_graph = create_agent(
@@ -264,6 +288,11 @@ class McpClient(Module):
             self._thread.join(timeout=DEFAULT_THREAD_JOIN_TIMEOUT)
         self._http_client.close()
         super().stop()
+
+    @rpc
+    def trace_dir(self) -> Path | None:
+        """Where this agent's raw LLM request/response bodies are written."""
+        return self.config.trace_dir or _default_trace_dir()
 
     @rpc
     def add_message(self, message: BaseMessage) -> None:

--- a/dimos/agents/mcp/mcp_client.py
+++ b/dimos/agents/mcp/mcp_client.py
@@ -30,7 +30,6 @@ warnings.filterwarnings("ignore", category=LangChainPendingDeprecationWarning)
 
 from langchain.agents import create_agent
 from langchain.chat_models import init_chat_model
-from langchain.chat_models.base import _attempt_infer_model_provider
 from langchain_core.messages import HumanMessage
 from langchain_core.messages.base import BaseMessage
 from langchain_core.tools import StructuredTool
@@ -65,12 +64,10 @@ def _init_model(model_name: str, trace_dir: Path | None = None) -> Any:
     """
     client = None if trace_dir is None else tracing_http_client(trace_dir)
     if ":" in model_name or not model_name.startswith(_RESPONSES_REASONING_MODEL_PREFIXES):
-        provider = _attempt_infer_model_provider(model_name.split(":", 1)[-1])
-        if ":" in model_name:
-            provider = model_name.split(":", 1)[0]
-        if client is not None and provider == "openai":
+        model = init_chat_model(model=model_name)
+        if client is not None and isinstance(model, ChatOpenAI):
             return init_chat_model(model=model_name, http_client=client)
-        return init_chat_model(model=model_name)
+        return model
 
     return ChatOpenAI(
         model=model_name,

--- a/dimos/agents/mcp/mcp_client.py
+++ b/dimos/agents/mcp/mcp_client.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from collections.abc import Callable
-import os
 from pathlib import Path
 from queue import Empty, Queue
 from threading import Event, RLock, Thread
@@ -49,7 +48,7 @@ from dimos.core.core import rpc
 from dimos.core.module import Module, ModuleConfig
 from dimos.core.rpc_client import RPCClient
 from dimos.core.stream import In, Out
-from dimos.utils.logging_config import get_run_log_dir, setup_logger
+from dimos.utils.logging_config import setup_logger
 from dimos.utils.sequential_ids import SequentialIds
 
 logger = setup_logger()
@@ -81,18 +80,11 @@ def _init_model(model_name: str, trace_dir: Path | None = None) -> Any:
     )
 
 
-def _default_trace_dir() -> Path | None:
-    """``<run log dir>/llm`` inside a ``dimos run``; nowhere outside one."""
-    log_dir = get_run_log_dir() or os.environ.get("DIMOS_RUN_LOG_DIR")
-    return Path(log_dir) / "llm" if log_dir else None
-
-
 class McpClientConfig(ModuleConfig):
     system_prompt: str | None = SYSTEM_PROMPT
     model: str = "gpt-5.6-luna"
     model_fixture: str | None = None
     mcp_server_url: str = "http://localhost:9990/mcp"
-    # Where raw LLM request/response bodies go. None -> <run log dir>/llm.
     trace_dir: Path | None = None
 
 
@@ -291,8 +283,8 @@ class McpClient(Module):
 
     @rpc
     def trace_dir(self) -> Path | None:
-        """Where this agent's raw LLM request/response bodies are written."""
-        return self.config.trace_dir or _default_trace_dir()
+        """Where raw LLM request/response bodies go; ``None`` when tracing is off."""
+        return self.config.trace_dir
 
     @rpc
     def add_message(self, message: BaseMessage) -> None:

--- a/dimos/agents/test_llm_trace.py
+++ b/dimos/agents/test_llm_trace.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import Callable
 import json
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 import httpx
 

--- a/dimos/agents/test_llm_trace.py
+++ b/dimos/agents/test_llm_trace.py
@@ -1,0 +1,73 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from pathlib import Path
+from typing import Any, Callable
+
+import httpx
+
+from dimos.agents.llm_trace import request_path, response_path, tracing_http_client
+
+
+def _client(trace_dir: Path, handler: Callable[[httpx.Request], httpx.Response]) -> httpx.Client:
+    return tracing_http_client(trace_dir, transport=httpx.MockTransport(handler))
+
+
+def _read(path: Path) -> dict[str, Any]:
+    record: dict[str, Any] = json.loads(path.read_text())
+    return record
+
+
+def test_records_request_response_pair(tmp_path: Path) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"pong": 1}, headers={"x-model": "gpt"})
+
+    _client(tmp_path, handler).post(
+        "https://api.test/v1/chat/completions",
+        json={"ping": 1},
+        headers={"authorization": "Bearer secret", "x-run": "7"},
+    )
+
+    request = _read(request_path(tmp_path, 0))
+    assert request["method"] == "POST"
+    assert request["url"] == "https://api.test/v1/chat/completions"
+    assert request["body"] == {"ping": 1}
+    assert "authorization" not in request["headers"]
+    assert request["headers"]["x-run"] == "7"
+
+    response = _read(response_path(tmp_path, 0))
+    assert response["status"] == 200
+    assert response["body"] == {"pong": 1}
+    assert response["headers"]["x-model"] == "gpt"
+    assert response["latency_s"] >= 0
+
+
+def test_non_json_bodies_fall_back_to_text(tmp_path: Path) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(502, text="bad gateway")
+
+    _client(tmp_path, handler).post("https://api.test/v1/chat/completions", content=b"raw bytes")
+
+    assert _read(request_path(tmp_path, 0))["body"] == "raw bytes"
+    assert _read(response_path(tmp_path, 0))["body"] == "bad gateway"
+
+
+def test_successive_calls_get_increasing_seq(tmp_path: Path) -> None:
+    client = _client(tmp_path, lambda request: httpx.Response(200, json={}))
+    client.post("https://api.test/a", json={})
+    client.post("https://api.test/b", json={})
+
+    assert _read(request_path(tmp_path, 1))["url"] == "https://api.test/b"
+    assert _read(response_path(tmp_path, 1))["status"] == 200


### PR DESCRIPTION
## Contribution path

- Small, safe change that does not need a tracking issue

## Problem

We need to save agent trajectories of our MCP client but it at present has no way of saving that information.

## Solution

An **opt-in** process that instruments the httpx client for OpenAI requests. The default behavior does not affect any existing hot paths. The first consumer will be the eval framework: #3774 

Auth headers are not saved.

Langchain does not have a provider-agnostic hook for capturing raw requests/responses, so it would require more tinkering for other providers. Because we just use OpenAI, I kept it simple. Maybe we'll be off Langchain by the time we need universal coverage :)

## How to Test

```sh
uv run python - <<'EOF'
from pathlib import Path
from dimos.agents.llm_trace import tracing_http_client

tracing_http_client(Path("/tmp/llm-trace")).post(
    "https://api.openai.com/v1/chat/completions", json={"ping": 1})
print(sorted(p.name for p in Path("/tmp/llm-trace").iterdir()))
EOF # -> Prints `['000-request.json', '000-response.json']`
```

## AI assistance

Fable 5 wrote 99.9% of this. I reviewed every line.

## Checklist

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
