### PR TITLE
fix(xarm): stop commanding the arm on every launch

### DIFF
--- a/dimos/hardware/manipulators/xarm/adapter.py
+++ b/dimos/hardware/manipulators/xarm/adapter.py
@@ -44,9 +44,6 @@ XARM_GRIPPER_MAX = 850.0
 MAX_CARTESIAN_SPEED_MM = 500.0  # Max cartesian speed in mm/s
 _XARM_LIFECYCLE_SPEED_DEG = 20.0
 _XARM_LIFECYCLE_ACCEL_DEG = 500.0
-_XARM6_INITIAL_JOINTS_DEG = [0.0, -40.0, -50.0, 0.0, 90.0, 0.0]
-# TODO (CC): change this once we have 7dof arm setup
-_XARM7_INITIAL_JOINTS_DEG = [0.0, 0.0, 0.0, 0.0, 0.0, math.degrees(-0.7), 0.0]
 
 # XArm mode codes
 _XARM_MODE_POSITION = 0
@@ -63,7 +60,14 @@ class XArmAdapter(ManipulatorAdapter):
     No inheritance required - just matching method signatures.
     """
 
-    def __init__(self, address: str, dof: int = 6, arm_dof: int | None = None, **_: object) -> None:
+    def __init__(
+        self,
+        address: str,
+        dof: int = 6,
+        arm_dof: int | None = None,
+        initial_positions: list[float] | None = None,
+        **_: object,
+    ) -> None:
         if not address:
             raise ValueError("address (IP) is required for XArmAdapter")
         resolved_arm_dof = dof if arm_dof is None else arm_dof
@@ -80,6 +84,15 @@ class XArmAdapter(ManipulatorAdapter):
         self._arm: XArmAPI | None = None
         self._control_mode: ControlMode = ControlMode.POSITION
         self._gripper_enabled: bool = False
+        if initial_positions is not None and len(initial_positions) != resolved_arm_dof:
+            raise ValueError(
+                f"XArmAdapter initial_positions must contain {resolved_arm_dof} entries"
+            )
+        # Joint pose (radians) to drive to on activate and deactivate. None means
+        # do not move: bringing a blueprint up should not command the arm
+        # anywhere, and ManipulationModule already adopts wherever it is as the
+        # "init" preset from the first joint state it receives.
+        self._initial_positions = None if initial_positions is None else list(initial_positions)
 
     def connect(self) -> bool:
         """Connect to XArm via TCP/IP."""
@@ -254,7 +267,7 @@ class XArmAdapter(ManipulatorAdapter):
         return ok
 
     def activate(self) -> bool:
-        """Enable motion and move the arm to its initial joint pose."""
+        """Enable motion, and move to the initial pose only if one is configured."""
         if not self._arm:
             return False
 
@@ -264,7 +277,7 @@ class XArmAdapter(ManipulatorAdapter):
         return self.set_control_mode(ControlMode.SERVO_POSITION)
 
     def deactivate(self) -> bool:
-        """Move the arm to its initial joint pose and enter stopped state."""
+        """Enter stopped state, parking at the initial pose only if one is configured."""
         if not self._arm:
             return False
 
@@ -301,11 +314,9 @@ class XArmAdapter(ManipulatorAdapter):
         return code == 0
 
     def _initial_joints_degrees(self) -> list[float] | None:
-        if self._arm_dof == 6:
-            return _XARM6_INITIAL_JOINTS_DEG
-        if self._arm_dof == 7:
-            return _XARM7_INITIAL_JOINTS_DEG
-        return None
+        if self._initial_positions is None:
+            return None
+        return [math.degrees(value) for value in self._initial_positions]
 
     def _prepare_for_position_motion(self) -> None:
         if not self._arm:

--- a/dimos/hardware/manipulators/xarm/test_adapter.py
+++ b/dimos/hardware/manipulators/xarm/test_adapter.py
@@ -127,17 +127,40 @@ def test_activate_prepares_xarm_for_safe_commanded_motion(
     arm = _FakeXArmSdk.instances[-1]
     assert arm.warn_code == 0
     assert arm.error_code == 0
-    assert arm.actions[-8:] == [
+    # Bringing a blueprint up must not command the arm anywhere.
+    assert arm.actions[-7:] == [
         ("clean_warn", None),
         ("clean_error", None),
         ("motion_enable", True),
         ("set_mode", 0),
         ("set_state", 0),
-        ("set_servo_angle", [0.0, -40.0, -50.0, 0.0, 90.0, 0.0], 20.0, 500.0, True),
         ("set_mode", 1),
         ("set_state", 0),
     ]
+    assert not any(action[0] == "set_servo_angle" for action in arm.actions)
     assert adapter.get_control_mode() == xarm_adapter_module.ControlMode.SERVO_POSITION
+
+
+def test_activate_moves_only_to_an_explicitly_configured_initial_pose(
+    xarm_adapter_module: ModuleType,
+) -> None:
+    initial = [0.0, -math.pi / 4, 0.0, 0.0, math.pi / 2, 0.0]
+    adapter = xarm_adapter_module.XArmAdapter(
+        address="192.0.2.10", dof=6, initial_positions=initial
+    )
+    assert adapter.connect()
+
+    assert adapter.activate()
+
+    arm = _FakeXArmSdk.instances[-1]
+    assert ("set_servo_angle", [0.0, -45.0, 0.0, 0.0, 90.0, 0.0], 20.0, 500.0, True) in arm.actions
+
+
+def test_initial_positions_must_match_the_arm_axis_count(
+    xarm_adapter_module: ModuleType,
+) -> None:
+    with pytest.raises(ValueError):
+        xarm_adapter_module.XArmAdapter(address="192.0.2.10", dof=6, initial_positions=[0.0])
 
 
 def test_joint_position_commands_use_degrees_for_xarm_sdk(


### PR DESCRIPTION
`XArmAdapter.activate()` unconditionally drove the arm to a hardcoded joint pose, and `deactivate()` drove it there again on the way out. The pose came from two module constants picked by axis count, `_XARM6_INITIAL_JOINTS_DEG` and `_XARM7_INITIAL_JOINTS_DEG`, the latter carrying a `TODO (CC): change this once we have 7dof arm setup`. Nothing asked for that motion: bringing a blueprint up is a connect, and the operator has no way to know the arm is about to sweep to a pose chosen inside the driver. It was redundant too, because `ManipulationModule` already adopts wherever the arm actually is as its `init` preset from the first joint state it receives.

The pose is now an explicit `initial_positions` argument, matching what the mock and a750 adapters already take, and rejected when its length does not match the arm's axis count the same way they reject it. With no argument the adapter commands nothing on either lifecycle edge. The existing activate test now asserts that no `set_servo_angle` reaches the SDK at all.

Verified on a headless launch of the hardware grasping blueprint further up this stack: every module comes up and the run stops only where it must, at the socket connect to the arm, with zero `set_servo_angle` calls in the log.

Second of nine in the xArm grasping re-landing stack.