### PR TITLE
fix(manip): judge gripper arrival by the open band, not the stillness threshold

### DIFF
--- a/dimos/manipulation/grasp_verification.py
+++ b/dimos/manipulation/grasp_verification.py
@@ -104,6 +104,7 @@ def await_gripper_settle(
     target: float,
     config: GraspVerificationConfig,
     *,
+    arrival_tolerance: float | None = None,
     sleep: Callable[[float], None] = time.sleep,
     clock: Callable[[], float] = time.monotonic,
 ) -> GripperSettle:
@@ -113,7 +114,17 @@ def await_gripper_settle(
     either observed travel or arrival at ``target``. Without that second
     condition a poll started before the jaws react would call the pre-command
     position settled. ``sleep`` and ``clock`` are injectable for tests.
+
+    ``arrival_tolerance`` answers a different question from ``settle_tolerance``:
+    stillness is how little the jaws moved between polls, arrival is how near the
+    target they stopped. It defaults to ``settle_tolerance`` because a close is
+    meant to stop short, on the object, and only an exact arrival at
+    ``closed_position`` means empty jaws. An open is the opposite: a gripper
+    driven to its mechanical stop always halts short of the commanded extreme --
+    the xArm rests at 0.988 of a nominal 850 count -- so the open path must pass
+    the band that decides whether where the jaws stopped counts as open.
     """
+    reached = config.settle_tolerance if arrival_tolerance is None else arrival_tolerance
     start = clock()
     deadline = start + config.timeout
     first: float | None = None
@@ -133,7 +144,7 @@ def await_gripper_settle(
             if abs(position - first) > config.settle_tolerance:
                 moved = True
             last = position
-            arrived = abs(position - target) <= config.settle_tolerance
+            arrived = abs(position - target) <= reached
             if stable >= config.settle_samples and (moved or arrived):
                 return GripperSettle(True, position, moved, clock() - start)
 

--- a/dimos/manipulation/pick_and_place_module.py
+++ b/dimos/manipulation/pick_and_place_module.py
@@ -268,7 +268,10 @@ class PickAndPlaceModule(Module):
         return None
 
     def _command_and_settle(
-        self, position: float, planning_group: PlanningGroupID
+        self,
+        position: float,
+        planning_group: PlanningGroupID,
+        arrival_tolerance: float | None = None,
     ) -> GripperSettle | SkillResult[ManipulationSkillError]:
         result = self._manipulation.set_gripper_position(position, planning_group)
         if not result.succeeded:
@@ -276,14 +279,22 @@ class PickAndPlaceModule(Module):
                 "GRIPPER_FAILED", result.message or "Gripper command was rejected"
             )
         return await_gripper_settle(
-            lambda: self._gripper_position(planning_group), position, self.config.grasp_verification
+            lambda: self._gripper_position(planning_group),
+            position,
+            self.config.grasp_verification,
+            arrival_tolerance=arrival_tolerance,
         )
 
     def _open_gripper(
         self, planning_group: PlanningGroupID, step: str
     ) -> SkillResult[ManipulationSkillError] | None:
+        # Jaws resting against the open stop never move and never reach the
+        # commanded extreme; open_tolerance is the band that already decides
+        # whether where they stopped counts as open.
         settle = self._command_and_settle(
-            self.config.grasp_verification.open_position, planning_group
+            self.config.grasp_verification.open_position,
+            planning_group,
+            arrival_tolerance=self.config.grasp_verification.open_tolerance,
         )
         if isinstance(settle, SkillResult):
             return settle

--- a/dimos/manipulation/test_grasp_verification.py
+++ b/dimos/manipulation/test_grasp_verification.py
@@ -52,11 +52,16 @@ def reader(values):
     return read
 
 
-def settle(values, target=0.0, clock=None, **overrides):
+def settle(values, target=0.0, clock=None, arrival_tolerance=None, **overrides):
     config = GraspVerificationConfig(**overrides)
     clock = clock or FakeClock()
     return await_gripper_settle(
-        reader(values), target, config, sleep=clock.sleep, clock=clock
+        reader(values),
+        target,
+        config,
+        arrival_tolerance=arrival_tolerance,
+        sleep=clock.sleep,
+        clock=clock,
     ), config
 
 
@@ -98,6 +103,34 @@ def test_open_command_settles_immediately_when_already_open():
     assert result.settled
     assert not result.moved
     assert clock.now < config.timeout
+
+
+def test_open_settles_when_the_jaws_stop_short_of_the_commanded_extreme():
+    """A gripper driven to its stop never reaches 1.0 and never moves again.
+
+    The real xArm rests at 0.988 of its nominal 850 count. Judged by the
+    stillness threshold it can never arrive, so re-opening an already-open
+    gripper times out; judged by open_tolerance it settles and reads open.
+    """
+    clock = FakeClock()
+    result, config = settle(
+        [0.988] * 4,
+        target=1.0,
+        clock=clock,
+        arrival_tolerance=GraspVerificationConfig().open_tolerance,
+    )
+
+    assert result.settled
+    assert not result.moved
+    assert clock.now < config.timeout
+    assert open_failure(result, config) is None
+
+
+def test_open_short_of_the_stop_still_times_out_on_the_stillness_threshold():
+    """The old behaviour, kept explicit: settle_tolerance cannot judge arrival."""
+    result, _ = settle([0.988] * 8, target=1.0)
+
+    assert not result.settled
 
 
 def test_a_gripper_that_never_stops_moving_times_out():

--- a/dimos/manipulation/test_pick_and_place_unit.py
+++ b/dimos/manipulation/test_pick_and_place_unit.py
@@ -66,7 +66,7 @@ def module() -> Iterator[PickAndPlaceModule]:
 
 @pytest.fixture(autouse=True)
 def settled_gripper(monkeypatch: pytest.MonkeyPatch) -> None:
-    def settle(read: Any, target: float, config: Any) -> GripperSettle:
+    def settle(read: Any, target: float, config: Any, **_: Any) -> GripperSettle:
         position = 0.5 if target == config.closed_position else target
         return GripperSettle(True, position, True, 0.1)
 
@@ -231,7 +231,7 @@ def test_empty_grasp_reopens_before_failing(
 ) -> None:
     manipulation: Any = module._manipulation
 
-    def settle(read: Any, target: float, config: Any) -> GripperSettle:
+    def settle(read: Any, target: float, config: Any, **_: Any) -> GripperSettle:
         position = 0.0 if target == config.closed_position else target
         return GripperSettle(True, position, True, 0.1)
 
@@ -247,7 +247,7 @@ def test_empty_grasp_reopens_before_failing(
 def test_pick_rejects_jaws_that_never_closed(
     module: PickAndPlaceModule, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    def settle(read: Any, target: float, config: Any) -> GripperSettle:
+    def settle(read: Any, target: float, config: Any, **_: Any) -> GripperSettle:
         position = config.open_position if target == config.closed_position else target
         return GripperSettle(True, position, True, 0.1)
 
@@ -269,7 +269,7 @@ def test_empty_grasp_reports_failed_recovery(
         SimpleNamespace(succeeded=False, message="recovery open failed"),
     ]
 
-    def settle(read: Any, target: float, config: Any) -> GripperSettle:
+    def settle(read: Any, target: float, config: Any, **_: Any) -> GripperSettle:
         position = 0.0 if target == config.closed_position else target
         return GripperSettle(True, position, True, 0.1)
 
@@ -295,7 +295,7 @@ def test_pick_fails_when_gripper_command_is_rejected(module: PickAndPlaceModule)
 def test_pick_fails_when_gripper_feedback_is_unavailable(
     module: PickAndPlaceModule, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    def settle(read: Any, target: float, config: Any) -> GripperSettle:
+    def settle(read: Any, target: float, config: Any, **_: Any) -> GripperSettle:
         if target == config.closed_position:
             return GripperSettle(False, None, False, config.timeout)
         return GripperSettle(True, target, True, 0.1)
@@ -314,7 +314,7 @@ def test_place_retains_held_state_when_release_fails(
     module._selected_grasp = PoseStamped(frame_id="world")
     module._holding_object = True
 
-    def settle(read: Any, target: float, config: Any) -> GripperSettle:
+    def settle(read: Any, target: float, config: Any, **_: Any) -> GripperSettle:
         return GripperSettle(True, 0.5, True, 0.1)
 
     monkeypatch.setattr("dimos.manipulation.pick_and_place_module.await_gripper_settle", settle)


### PR DESCRIPTION
`await_gripper_settle` used `settle_tolerance` for two different questions: how little the jaws moved between polls, and how near the commanded target they stopped. A gripper driven to its mechanical stop always halts short of the extreme, the real xArm rests at 0.988 of a nominal 850 count, so opening an already-open gripper moved nothing, could never "arrive", and timed out with `gripper did not settle within 3.00s`.
.