### PR TITLE
fix(xarm): publish the wrist camera mount edge

### DIFF
--- a/dimos/manipulation/manipulation_module.py
+++ b/dimos/manipulation/manipulation_module.py
@@ -152,6 +152,11 @@ class ManipulationModuleConfig(ModuleConfig):
     # to prevent the planner from routing trajectories below this height.
     # Set to None to disable.
     floor_z: float | None = None
+    # Fixed mount edges published alongside the robot's own TF, for rigs bolted
+    # to a link the model already publishes -- an eye-in-hand camera, say. One
+    # publisher for the whole chain: a second module publishing the mount at its
+    # own rate leaves the two edges of one chain stamped up to a period apart.
+    static_transforms: list[Transform] = Field(default_factory=list)
     # Frame the voxel_map port's clouds must already be expressed in.
     world_frame: str = "world"
     # Edge length of a voxel_map cell (meters). Must match the mapper's
@@ -347,6 +352,11 @@ class ManipulationModule(Module):
                         link_tf = Transform.from_pose(link_name, link_pose)
                         link_tf.frame_id = "world"
                         transforms.append(link_tf)
+
+                now = time.time()
+                for static in self.config.static_transforms:
+                    static.ts = now
+                    transforms.append(static)
 
                 if transforms:
                     self.tf.publish(TFMessage(*transforms))

--- a/dimos/manipulation/test_manipulation_unit.py
+++ b/dimos/manipulation/test_manipulation_unit.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import pickle
+import time
 from unittest.mock import ANY, MagicMock, call
 
 import numpy as np
@@ -59,6 +60,7 @@ from dimos.manipulation.planning.trajectory_generator.simple_parametrizer import
 from dimos.msgs.geometry_msgs.Pose import Pose
 from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
 from dimos.msgs.geometry_msgs.Quaternion import Quaternion
+from dimos.msgs.geometry_msgs.Transform import Transform
 from dimos.msgs.geometry_msgs.Vector3 import Vector3
 from dimos.msgs.sensor_msgs.JointState import JointState
 from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
@@ -916,6 +918,38 @@ class TestPlanningGroupApis:
             call("right_arm"),
         ]
         publish.assert_called_once()
+
+    def test_tf_loop_publishes_mount_edges_alongside_the_robot(
+        self, module_factory, mocker: MockerFixture
+    ) -> None:
+        """One publisher for the chain, so the mount is never stamped a period stale."""
+        model = _bimanual_config()
+        module = module_factory()
+        module.config.model = model
+        module.config.static_transforms = [
+            Transform(frame_id="left/tool", child_frame_id="camera_link")
+        ]
+        module._world_monitor = MagicMock(spec=WorldMonitor)
+        module._world_monitor.planning_groups = PlanningGroupRegistry(model.planning_groups)
+        module._world_monitor.get_group_ee_pose.return_value = PoseStamped(
+            position=Vector3(0.4, 0.2, 0.3)
+        )
+        publish = mocker.patch.object(module.tf, "publish")
+
+        def stop_after_first_iteration(_period: float) -> bool:
+            module._tf_stop_event.set()
+            return True
+
+        mocker.patch.object(module._tf_stop_event, "wait", side_effect=stop_after_first_iteration)
+        module._tf_stop_event.clear()
+        before = time.time()
+
+        module._tf_publish_loop()
+
+        published = list(publish.call_args.args[0])
+        mount = next(t for t in published if t.child_frame_id == "camera_link")
+        assert mount.frame_id == "left/tool"
+        assert mount.ts >= before
 
     def test_get_ee_pose_fails_safely_without_pose_group(self, robot_config, module_factory):
         no_pose_config = RobotModelConfig(

--- a/dimos/robot/manipulators/xarm/blueprints/perception.py
+++ b/dimos/robot/manipulators/xarm/blueprints/perception.py
@@ -31,9 +31,16 @@ from dimos.msgs.geometry_msgs.Vector3 import Vector3
 from dimos.perception.experimental.object_scene_registration import ObjectSceneRegistrationModule
 from dimos.robot.manipulators.xarm.config import make_xarm7_model_config
 
+# Hand-eye calibration for the eye-in-hand RealSense. RealSenseCamera publishes
+# only its own subtree, so without this edge camera_link has no parent, nothing
+# resolves into world, and every cloud the camera produces is silently unusable.
+# link7 is a frame the model already publishes, so ManipulationModule emits the
+# whole chain from one loop at one rate.
 XARM_PERCEPTION_CAMERA_TRANSFORM = Transform(
     translation=Vector3(x=0.06693724, y=-0.0309563, z=0.00691482),
     rotation=Quaternion(0.70513398, 0.00535696, 0.70897578, -0.01052180),  # xyzw
+    frame_id="link7",
+    child_frame_id="camera_link",
 )
 
 xarm_perception = autoconnect(
@@ -47,6 +54,7 @@ xarm_perception = autoconnect(
             ),
             tf_extra_links=["link7"],
         ),
+        static_transforms=[XARM_PERCEPTION_CAMERA_TRANSFORM],
         planning_timeout=10.0,
         visualization={"backend": "viser"},
         floor_z=-0.02,
@@ -54,8 +62,6 @@ xarm_perception = autoconnect(
     ManipulationSkills.blueprint(),
     PickAndPlaceModule.blueprint(planning_frame="world"),
     HeuristicGraspModule.blueprint(),
-    # TODO: tf tree is broken here; RealSenseCamera no longer publishes its mount
-    # edge, so camera_link needs a parent (e.g. from the arm) to resolve into world.
     RealSenseCamera.blueprint(),
     ObjectSceneRegistrationModule.blueprint(
         target_frame="world",

--- a/dimos/robot/manipulators/xarm/blueprints/test_perception.py
+++ b/dimos/robot/manipulators/xarm/blueprints/test_perception.py
@@ -1,0 +1,39 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dimos.hardware.sensors.camera.realsense.camera import RealSenseCameraConfig
+from dimos.manipulation.manipulation_module import ManipulationModule
+from dimos.robot.manipulators.xarm.blueprints.perception import (
+    XARM_PERCEPTION_CAMERA_TRANSFORM,
+    xarm_perception,
+)
+
+
+def test_wrist_camera_edge_joins_the_camera_subtree_to_the_arm() -> None:
+    """RealSenseCamera publishes only below camera_link.
+
+    Without a parent for it nothing resolves into world and every cloud the
+    camera produces is silently unusable, so the mount edge has to be published
+    and its parent has to be a link the planning model actually publishes --
+    from the same loop, or the two edges of one chain are stamped a period apart.
+    """
+    manipulation = next(
+        atom.kwargs
+        for atom in xarm_perception.active_blueprints
+        if issubclass(atom.module, ManipulationModule)
+    )
+
+    assert manipulation["static_transforms"] == [XARM_PERCEPTION_CAMERA_TRANSFORM]
+    assert XARM_PERCEPTION_CAMERA_TRANSFORM.child_frame_id == RealSenseCameraConfig().frame_id
+    assert XARM_PERCEPTION_CAMERA_TRANSFORM.frame_id in manipulation["model"].tf_extra_links


### PR DESCRIPTION
`xarm_perception` carried a TODO saying its tf tree was broken. `RealSenseCamera` publishes only its own subtree, rooted at `camera_link`, so `camera_link` had no parent, nothing the camera produced resolved into `world`, and the hand-eye calibration already sitting in `XARM_PERCEPTION_CAMERA_TRANSFORM` was dead code , the constant had neither a `frame_id` nor a `child_frame_id`.
