### PR TITLE
feat(manip): let the voxel map define the planner's world

### DIFF
--- a/dimos/manipulation/pick_and_place_module.py
+++ b/dimos/manipulation/pick_and_place_module.py
@@ -159,7 +159,7 @@ class PickAndPlaceModule(Module):
                 group,
             )
             pregrasp = self._offset_pose(grasp, self.config.pregrasp_offset)
-            failure = self._move(pregrasp, group) or self._move(grasp, group)
+            failure = self._move(pregrasp, group) or self._servo(pregrasp, grasp, group)
             if failure is not None:
                 # Only an unreachable pose is worth demoting to the next candidate;
                 # a drive or execution fault would repeat for every one of them.
@@ -173,7 +173,7 @@ class PickAndPlaceModule(Module):
             self._selected_object_id = object_id
             self._selected_grasp = grasp
             self._holding_object = True
-            if failure := self._move(pregrasp, group):
+            if failure := self._servo(grasp, pregrasp, group):
                 return failure
             return SkillResult.ok(
                 "Pick complete",
@@ -221,13 +221,13 @@ class PickAndPlaceModule(Module):
         preplace = self._offset_pose(place, self.config.pregrasp_offset)
         if failure := self._move(preplace, group):
             return failure
-        if failure := self._move(place, group):
+        if failure := self._servo(preplace, place, group):
             return failure
         if failure := self._open_gripper(group, "release"):
             return failure
         self._holding_object = False
         self._clear_selection()
-        return self._move(preplace, group) or SkillResult.ok("Place complete")
+        return self._servo(place, preplace, group) or SkillResult.ok("Place complete")
 
     def _clear_selection(self) -> None:
         self._grasp_candidates = GraspCandidateArray()
@@ -267,6 +267,31 @@ class PickAndPlaceModule(Module):
             position=pose.position + pose.orientation.rotate_vector(Vector3(0.0, 0.0, -offset)),
             orientation=pose.orientation,
         )
+
+    def _servo(
+        self, start: PoseStamped, end: PoseStamped, planning_group: PlanningGroupID
+    ) -> SkillResult[ManipulationSkillError] | None:
+        """Drive the last leg as a straight line with collision checking off.
+
+        The object being grasped is itself mapped geometry once a voxel map feeds
+        the planner, so a collision-checked plan into it can only ever be
+        rejected. This leg is short, straight, and deliberately ends in contact.
+        """
+        result = self._manipulation.move_linear(
+            end.position.x - start.position.x,
+            end.position.y - start.position.y,
+            end.position.z - start.position.z,
+            planning_group,
+            check_collision=False,
+        )
+        if not result.plan.succeeded:
+            # A planning failure demotes to the next candidate; a drive fault
+            # would repeat for every one of them, so keep the two distinct.
+            return SkillResult.fail("PLANNING_FAILED", result.plan.message)
+        if result.execution is None or not result.execution.succeeded:
+            message = "" if result.execution is None else result.execution.message
+            return SkillResult.fail("EXECUTION_FAILED", message)
+        return None
 
     def _move(
         self, pose: PoseStamped, planning_group: PlanningGroupID

--- a/dimos/manipulation/test_pick_and_place_unit.py
+++ b/dimos/manipulation/test_pick_and_place_unit.py
@@ -52,6 +52,10 @@ def module() -> Iterator[PickAndPlaceModule]:
     )
     instance._manipulation.plan_to_poses.return_value = SimpleNamespace(succeeded=True, message="")
     instance._manipulation.execute.return_value = SimpleNamespace(succeeded=True, message="")
+    instance._manipulation.move_linear.return_value = SimpleNamespace(
+        plan=SimpleNamespace(succeeded=True, message=""),
+        execution=SimpleNamespace(succeeded=True, message=""),
+    )
     instance._manipulation.set_gripper_position.return_value = SimpleNamespace(
         succeeded=True, message=""
     )
@@ -269,16 +273,32 @@ def test_failed_pick_clears_previous_selection(module: PickAndPlaceModule) -> No
 
 def test_pick_retains_held_state_when_retract_fails(module: PickAndPlaceModule) -> None:
     manipulation: Any = module._manipulation
-    manipulation.execute.side_effect = [
-        SimpleNamespace(succeeded=True, message=""),
-        SimpleNamespace(succeeded=True, message=""),
-        SimpleNamespace(succeeded=False, message="retract failed"),
+    # Approach in, then the retract out; both legs are linear servos now.
+    manipulation.move_linear.side_effect = [
+        SimpleNamespace(
+            plan=SimpleNamespace(succeeded=True, message=""),
+            execution=SimpleNamespace(succeeded=True, message=""),
+        ),
+        SimpleNamespace(
+            plan=SimpleNamespace(succeeded=True, message=""),
+            execution=SimpleNamespace(succeeded=False, message="retract failed"),
+        ),
     ]
 
     result = module.pick_object("cup-1")
 
     assert result.error_code == "EXECUTION_FAILED"
     assert module._holding_object
+
+
+def test_final_grasp_leg_skips_collision_checking(module: PickAndPlaceModule) -> None:
+    """The target is mapped geometry, so a checked plan into it always collides."""
+    manipulation: Any = module._manipulation
+
+    assert module.pick_object("cup-1").success
+    assert manipulation.move_linear.call_args_list
+    for call in manipulation.move_linear.call_args_list:
+        assert call.kwargs["check_collision"] is False
 
 
 def test_empty_grasp_reopens_before_failing(

--- a/dimos/manipulation/visualization/viser/scene.py
+++ b/dimos/manipulation/visualization/viser/scene.py
@@ -53,6 +53,8 @@ try:
         FrameHandle,
         GridHandle,
         MeshHandle,
+        PointCloudHandle,
+        SceneApi,
         TransformControlsEvent,
         TransformControlsHandle,
         ViserServer,
@@ -220,6 +222,12 @@ class ViserManipulationScene:
                             self._obstacles_visible,
                         )
                     )
+                elif obstacle.obstacle_type == ObstacleType.OCTREE:
+                    handles.append(
+                        self._add_octree(
+                            scene, path, obstacle, color, position, wxyz, self._obstacles_visible
+                        )
+                    )
                 else:
                     raise ValueError(f"unsupported obstacle type: {obstacle.obstacle_type}")
             except Exception as error:
@@ -334,6 +342,37 @@ class ViserManipulationScene:
             round(float(color[1]) * 255),
             round(float(color[2]) * 255),
         ), float(color[3])
+
+    @staticmethod
+    def _add_octree(
+        scene: SceneApi,
+        path: str,
+        obstacle: Obstacle,
+        color: tuple[int, int, int],
+        position: tuple[float, float, float],
+        wxyz: tuple[float, float, float, float],
+        visible: bool,
+    ) -> PointCloudHandle:
+        """Draw the occupied cells as a point cloud sized to the cell edge.
+
+        A mapped workspace is tens of thousands of cells, so one box per cell
+        would stall the browser. Square points at the cell edge read as the same
+        grid and cost one scene node.
+        """
+        points = np.asarray(obstacle.points, dtype=np.float32).reshape(-1, 3)
+        if not len(points):
+            raise ValueError("octree obstacle carries no occupied cells")
+        colors = np.tile(np.asarray(color, dtype=np.uint8), (len(points), 1))
+        return scene.add_point_cloud(
+            path,
+            points=points,
+            colors=colors,
+            point_size=float(obstacle.octree_resolution or 0.05),
+            point_shape="square",
+            position=position,
+            wxyz=wxyz,
+            visible=visible,
+        )
 
     @staticmethod
     def _add_mesh(

--- a/dimos/manipulation/visualization/viser/test_scene_obstacles.py
+++ b/dimos/manipulation/visualization/viser/test_scene_obstacles.py
@@ -1,0 +1,63 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Obstacle rendering dispatch, without a running Viser server."""
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+pytest.importorskip("viser", reason="Viser optional dependency is not installed")
+
+from dimos.manipulation.planning.spec.enums import ObstacleType
+from dimos.manipulation.planning.spec.models import Obstacle
+from dimos.manipulation.visualization.viser.scene import ViserManipulationScene
+from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
+
+
+def _scene() -> ViserManipulationScene:
+    return ViserManipulationScene(MagicMock(), MagicMock())
+
+
+def _octree(points: np.ndarray, resolution: float = 0.025) -> Obstacle:
+    return Obstacle(
+        name="mapping/voxel-map",
+        obstacle_type=ObstacleType.OCTREE,
+        pose=PoseStamped(frame_id="world"),
+        points=points,
+        octree_resolution=resolution,
+    )
+
+
+def test_octree_obstacles_draw_their_occupied_cells() -> None:
+    """Before this the dispatch raised and drew a grey proxy box over the map."""
+    scene = _scene()
+    points = np.array([[0.0, 0.0, 0.0], [0.05, 0.0, 0.0]], dtype=np.float32)
+
+    scene.add_vis_obstacle("mapping/voxel-map", _octree(points))
+
+    assert scene._obstacle_render_failures == {}
+    call = scene.server.scene.add_point_cloud.call_args
+    assert np.allclose(call.kwargs["points"], points)
+    assert call.kwargs["point_size"] == pytest.approx(0.025)
+
+
+def test_an_empty_octree_is_a_render_failure_not_a_blank_cloud() -> None:
+    """A map with no occupied cells is a broken mapping chain, not a clear table."""
+    scene = _scene()
+
+    scene.add_vis_obstacle("mapping/voxel-map", _octree(np.zeros((0, 3), dtype=np.float32)))
+
+    assert "mapping/voxel-map" in scene._obstacle_render_failures

--- a/dimos/robot/manipulators/xarm/blueprints/grasp.py
+++ b/dimos/robot/manipulators/xarm/blueprints/grasp.py
@@ -36,6 +36,8 @@ from dimos.manipulation.grasping.heuristic_grasp import HeuristicGraspModule
 from dimos.manipulation.manipulation_module import ManipulationModule
 from dimos.manipulation.manipulation_skills import ManipulationSkills
 from dimos.manipulation.pick_and_place_module import PickAndPlaceModule
+from dimos.manipulation.planning.utils.point_cloud_self_filter import PointCloudSelfFilter
+from dimos.mapping.ray_tracing.module import RayTracingVoxelMap
 from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
 from dimos.msgs.geometry_msgs.Quaternion import Quaternion
 from dimos.msgs.geometry_msgs.Transform import Transform
@@ -43,6 +45,7 @@ from dimos.msgs.geometry_msgs.Vector3 import Vector3
 from dimos.perception.experimental.object_scene_registration import ObjectSceneRegistrationModule
 from dimos.robot.manipulators.common.blueprints import coordinator, trajectory_task
 from dimos.robot.manipulators.xarm.config import (
+    XARM7_COLLISION_LINKS,
     make_xarm7_model_config,
     make_xarm7_sim_hardware,
     make_xarm7_sim_module_kwargs,
@@ -60,6 +63,12 @@ XARM_GRASP_SCENE_PATH = LfsPath("xarm_grasp_sim/scene.xml")
 # spaced targets. This collision-free top-down pose raises the camera enough to
 # put every mesh in one frame, without changing the configured base pose.
 XARM_GRASP_SCAN_JOINTS = [0.0, -0.04609, 0.0, 1.83940, 0.0, 1.87106, 0.0]
+# One resolution for the whole mapping chain. The self filter's clear mask, the
+# mapper's cells and the planner's octree must all agree: a mismatched mask names
+# cells the map does not hold, and a mismatched octree does not line up with what
+# was mapped.
+XARM_GRASP_VOXEL_SIZE = 0.025
+
 XARM_GRASP_PROMPTS = [
     "black bottle",
     "gray can",
@@ -111,14 +120,21 @@ if SIMULATED:
     # data/xarm_grasp_sim/xarm7.xml bolts link_base to the world origin instead
     # of the 12 cm pedestal data/xarm7 uses. Inheriting that offset would put the
     # planning model 12 cm above the arm MuJoCo simulates.
-    _model = make_xarm7_sim_robot_config(base_pose=PoseStamped(frame_id="world"))
+    _model = make_xarm7_sim_robot_config(
+        base_pose=PoseStamped(frame_id="world"),
+        # The self filter needs a capture-time transform for every collision link
+        # and drops the whole cloud when one is missing.
+        tf_extra_links=XARM7_COLLISION_LINKS,
+    )
     _hardware = make_xarm7_sim_hardware(XARM_GRASP_SCENE_PATH, home_joints=XARM_GRASP_SCAN_JOINTS)
 else:
     _model = make_xarm7_model_config(
         add_gripper=True,
         gripper_hardware_id="arm",
         base_pose=PoseStamped(frame_id="world"),
-        tf_extra_links=["link7"],
+        # The self filter needs a capture-time transform for every collision link
+        # and drops the whole cloud when one is missing.
+        tf_extra_links=XARM7_COLLISION_LINKS,
     )
     _hardware = xarm7_hardware("arm", gripper=True)
 
@@ -137,10 +153,17 @@ def _sensing() -> tuple[Blueprint, ...]:
                     # otherwise valid scan unregistrable.
                     "base_frame_id": "world",
                     "reset_joint_positions": XARM_GRASP_SCAN_JOINTS,
+                    # Off by default, and the voxel chain has nothing to map
+                    # without it. Scene registration reads colour and depth.
+                    "enable_pointcloud": True,
                 }
             ),
         )
-    return (RealSenseCamera.blueprint(),)
+    return (
+        # enable_pointcloud is off by default here too, and the voxel chain has
+        # nothing to map without it.
+        RealSenseCamera.blueprint(enable_pointcloud=True),
+    )
 
 
 def _scene_registration() -> Blueprint:
@@ -173,6 +196,39 @@ def _scene_registration() -> Blueprint:
     )
 
 
+def _voxel_mapping() -> tuple[Blueprint, ...]:
+    """Wrist camera -> self filter -> mapper -> the planner's octree obstacle."""
+    return (
+        # The wrist camera sees the arm itself, so the arm's returns must be
+        # dropped before mapping and the volume it occupies erased from the map:
+        # ray tracing cannot clear what the arm permanently occludes.
+        PointCloudSelfFilter.blueprint(
+            model=_model.model,
+            voxel_size=XARM_GRASP_VOXEL_SIZE,
+            world_frame="world",
+            # ManipulationModule publishes robot TF at 10Hz, so the stock 20ms
+            # tolerance cannot bracket a ~92ms publish period and drops most
+            # clouds. One full period admits them all, and the arm holds still
+            # while scanning, so a transform a period old describes the same pose.
+            tf_tolerance_s=0.1,
+            tf_forward_tolerance_s=0.1,
+        ),
+        # Tabletop reach, not a room-scale lidar sweep.
+        RayTracingVoxelMap.blueprint(
+            voxel_size=XARM_GRASP_VOXEL_SIZE,
+            world_frame="world",
+            max_range=2.0,
+        ),
+    )
+
+
+# The mapping chain is wired by stream name, so the two edges whose names differ
+# are bridged here: self filter -> mapper, and mapper -> the planner's octree.
+_REMAPPINGS = [
+    (RayTracingVoxelMap, "lidar", "filtered_pointcloud"),
+    (ManipulationModule, "voxel_map", "global_map"),
+]
+
 # Everything but the grasp provider. Exactly one provider may be composed in:
 # PickAndPlaceModule resolves its generator by spec, so two would be ambiguous.
 _XARM_GRASP_MODULES = (
@@ -182,12 +238,13 @@ _XARM_GRASP_MODULES = (
         planning_timeout=10.0,
         visualization={"backend": "viser"},
         world_frame="world",
-        **({} if SIMULATED else {"floor_z": -0.02}),
+        voxel_map_resolution=XARM_GRASP_VOXEL_SIZE,
     ),
     ManipulationSkills.blueprint(),
     PickAndPlaceModule.blueprint(planning_frame="world"),
     *_sensing(),
     _scene_registration(),
+    *_voxel_mapping(),
     RerunBridgeModule.blueprint(),
     coordinator(
         hardware=[_hardware],
@@ -203,7 +260,9 @@ _XARM_GRASP_MODULES = (
     ),
 )
 
-xarm_grasp = autoconnect(*_XARM_GRASP_MODULES, HeuristicGraspModule.blueprint())
+xarm_grasp = autoconnect(*_XARM_GRASP_MODULES, HeuristicGraspModule.blueprint()).remappings(
+    _REMAPPINGS
+)
 
 xarm_grasp_graspgenx = autoconnect(
     *_XARM_GRASP_MODULES,
@@ -211,4 +270,4 @@ xarm_grasp_graspgenx = autoconnect(
         gripper=XARM_GRIPPER_SWEEP_VOLUME,
         grasp_frame_to_tcp=XARM_GRASP_FRAME_TO_TCP,
     ),
-)
+).remappings(_REMAPPINGS)

--- a/dimos/robot/manipulators/xarm/config.py
+++ b/dimos/robot/manipulators/xarm/config.py
@@ -67,19 +67,43 @@ XARM7_SIM_HOME = [0.0, -0.247, 0.0, 0.909, 0.0, 1.15644, 0.0]
 # z=0.12. Place the planning model to match, or the planner solves poses 12cm
 # below the arm it is driving and every grasp closes on air.
 XARM7_SIM_BASE_POSE = PoseStamped(frame_id="world", position=Vector3(z=0.12))
+# Every link the xArm7-with-gripper URDF gives collision geometry. A point-cloud
+# self filter needs a capture-time transform for each one, and drops the whole
+# cloud if any is missing, so publish them all as TF when one is composed in.
+XARM7_COLLISION_LINKS = [
+    "link_base",
+    "link1",
+    "link2",
+    "link3",
+    "link4",
+    "link5",
+    "link6",
+    "link7",
+    "xarm_gripper_base_link",
+    "left_outer_knuckle",
+    "left_finger",
+    "left_inner_knuckle",
+    "right_outer_knuckle",
+    "right_finger",
+    "right_inner_knuckle",
+]
 
 
-def make_xarm7_sim_robot_config(base_pose: PoseStamped | None = None) -> RobotModelConfig:
+def make_xarm7_sim_robot_config(
+    base_pose: PoseStamped | None = None,
+    tf_extra_links: list[str] | None = None,
+) -> RobotModelConfig:
     """Build the sim planning model.
 
     Pass ``base_pose`` for a scene that mounts ``link_base`` somewhere other than
-    the pedestal ``data/xarm7`` uses.
+    the pedestal ``data/xarm7`` uses, and ``tf_extra_links`` when a consumer needs
+    more than the tip transform.
     """
     return make_xarm7_model_config(
         add_gripper=True,
         gripper_hardware_id="arm",
         base_pose=XARM7_SIM_BASE_POSE if base_pose is None else base_pose,
-        tf_extra_links=["link7"],
+        tf_extra_links=["link7"] if tf_extra_links is None else tf_extra_links,
         home_joints=XARM7_SIM_HOME,
         pre_grasp_offset=0.05,
     )

--- a/docs/capabilities/manipulation/xarm-grasp.md
+++ b/docs/capabilities/manipulation/xarm-grasp.md
@@ -41,6 +41,31 @@ MUJOCO_GL=egl LIBGL_ALWAYS_SOFTWARE=true MESA_LOADER_DRIVER_OVERRIDE=llvmpipe \
   dimos --viewer none run xarm-grasp --simulation mujoco
 ```
 
+## Voxel map obstacles
+
+The wrist camera feeds a live voxel map that the planner treats as one octree
+obstacle, so trajectories avoid whatever has actually been seen rather than only
+the registered objects:
+
+```
+camera pointcloud
+  -> PointCloudSelfFilter        drops the arm's own returns, emits a clear mask
+  -> RayTracingVoxelMap          accumulates occupied cells in the world frame
+  -> ManipulationModule.voxel_map   rebuilt as the "mapping/voxel-map" obstacle
+```
+
+`XARM_GRASP_VOXEL_SIZE` is the single resolution all three stages share; they
+must agree or the clear mask names cells the map does not hold and the octree
+does not line up with what was mapped. The blueprint also enables the camera's
+`pointcloud` output, which is off by default on both the RealSense and the
+MuJoCo camera, and publishes TF for every one of the arm's collision links. The
+self filter drops a whole cloud if any link transform is missing at capture time.
+
+Because the target object is itself mapped geometry, a collision-checked plan
+into it can only ever be rejected. The pregrasp-to-grasp leg and the retreat are
+therefore straight-line `move_linear` servos with collision checking off; only
+the approach to the pregrasp pose is a checked plan.
+
 ## The scene
 
 The scene is an enclosed 2.6 m by 3.0 m room. The xArm is bolted to the world
@@ -110,7 +135,7 @@ app.PickAndPlaceModule.place_at(0.45, -0.25, 0.25)
 ```
 
 `pick_object` generates the grasps itself, so there is no separate grasp call.
-It opens the gripper, plans to the pregrasp, moves in, closes, verifies, and
+It opens the gripper, plans to the pregrasp, servos in, closes, verifies, and
 retreats; with a learned provider it walks the ranked candidates until one is
 reachable, and the result metadata carries the winning rank, its score and the
 candidate count. To inspect grasps without moving the arm, call `propose_grasps`


### PR DESCRIPTION
The planner only avoided registered objects, so anything the detector did not name was invisible to it.

Things were needed to make the chain carry data. 

1. Both cameras default `enable_pointcloud` to False. 
2. The self filter needs a capture-time transform for every collision link and drops a whole cloud when one is missing, so the model publishes all fifteen. 
3. Its stock 20 ms TF tolerance cannot bracket the 10 Hz period `ManipulationModule` publishes robot TF at, so most clouds found no transform at all.

Verified in the grasp sim: `mapping/voxel-map` installs as an octree obstacle and the self filter stops dropping clouds once TF is up.

Eighth of nine in the xArm grasping re-landing stack.