### PR TITLE
feat(manip): draw the ranked grasp proposals in viser

### DIFF
--- a/dimos/manipulation/manipulation_module.py
+++ b/dimos/manipulation/manipulation_module.py
@@ -94,6 +94,7 @@ from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
 from dimos.msgs.geometry_msgs.Quaternion import Quaternion
 from dimos.msgs.geometry_msgs.Transform import Transform
 from dimos.msgs.geometry_msgs.Vector3 import Vector3
+from dimos.msgs.manipulation_msgs.GraspCandidateArray import GraspCandidateArray
 from dimos.msgs.sensor_msgs.JointState import JointState
 from dimos.msgs.sensor_msgs.PointCloud2 import PointCloud2
 from dimos.msgs.tf2_msgs.TFMessage import TFMessage
@@ -447,6 +448,12 @@ class ManipulationModule(Module):
             result = ExecutionResult(ExecutionStatus.ABORTED, "Planning cancelled")
         self._apply_execution_result(result)
         return result
+
+    @rpc
+    def show_grasp_proposals(self, candidates: GraspCandidateArray) -> None:
+        """Display the ranked proposals. The grasp module owns no visualizer."""
+        if self._world_monitor is not None:
+            self._world_monitor.show_grasp_proposals(candidates)
 
     @rpc
     def reset(self) -> CommandResult:

--- a/dimos/manipulation/manipulation_spec.py
+++ b/dimos/manipulation/manipulation_spec.py
@@ -24,6 +24,7 @@ from typing import Protocol
 from dimos.control.tasks.trajectory_task.trajectory_task import TrajectoryExecutionResult
 from dimos.manipulation.planning.spec.models import GeneratedPlan, PlanningGroupID
 from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
+from dimos.msgs.manipulation_msgs.GraspCandidateArray import GraspCandidateArray
 from dimos.msgs.sensor_msgs.JointState import JointState
 from dimos.msgs.trajectory_msgs.TrajectoryStatus import TrajectoryStatus
 from dimos.spec.utils import Spec
@@ -262,6 +263,8 @@ class ManipulationSpec(Spec, Protocol):
         blocking: bool = True,
         timeout: float | None = None,
     ) -> MoveResult: ...
+
+    def show_grasp_proposals(self, candidates: GraspCandidateArray) -> None: ...
 
     def reset(self) -> CommandResult: ...
 

--- a/dimos/manipulation/pick_and_place_module.py
+++ b/dimos/manipulation/pick_and_place_module.py
@@ -132,6 +132,7 @@ class PickAndPlaceModule(Module):
         except (RuntimeError, ValueError) as exc:
             return SkillResult.fail("GRASP_GENERATION_FAILED", str(exc))
         self._grasp_candidates = candidates
+        self._manipulation.show_grasp_proposals(candidates)
         if candidates.header.frame_id != self.config.planning_frame:
             return SkillResult.fail(
                 "GRASP_FRAME_MISMATCH",
@@ -231,6 +232,7 @@ class PickAndPlaceModule(Module):
 
     def _clear_selection(self) -> None:
         self._grasp_candidates = GraspCandidateArray()
+        self._manipulation.show_grasp_proposals(GraspCandidateArray())
         self._selected_object_id = None
         self._selected_grasp = None
 

--- a/dimos/manipulation/planning/monitor/test_world_monitor.py
+++ b/dimos/manipulation/planning/monitor/test_world_monitor.py
@@ -202,6 +202,9 @@ class FakeViz:
     def clear_vis_obstacles(self) -> None:
         self.calls.append(("clear_vis_obstacles",))
 
+    def show_grasp_proposals(self, candidates):
+        self.calls.append(("show_grasp_proposals", candidates))
+
 
 def _robot_config() -> RobotModelConfig:
     model_path = Path("/tmp/dimos_world_monitor_test_arm.urdf")

--- a/dimos/manipulation/planning/monitor/world_monitor.py
+++ b/dimos/manipulation/planning/monitor/world_monitor.py
@@ -35,6 +35,7 @@ from dimos.manipulation.planning.spec.protocols import VisualizationSpec, WorldS
 from dimos.manipulation.planning.spec.validation import PreparedRobotModel, prepare_robot_model
 from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
 from dimos.msgs.geometry_msgs.Quaternion import Quaternion
+from dimos.msgs.manipulation_msgs.GraspCandidateArray import GraspCandidateArray
 from dimos.msgs.sensor_msgs.JointState import JointState
 from dimos.msgs.trajectory_msgs.JointTrajectory import JointTrajectory
 from dimos.utils.logging_config import setup_logger
@@ -179,6 +180,21 @@ class WorldMonitor:
                     self._visualization.clear_vis_obstacles()
                 except Exception:
                     logger.exception("Obstacle visualization clear failed")
+
+    def show_grasp_proposals(self, candidates: GraspCandidateArray) -> None:
+        """Forward display-only grasp proposals to the visualization backend.
+
+        Proposals are not planning geometry, so nothing reaches the world; the
+        lock is still taken because the backend is shared with obstacle and
+        preview rendering.
+        """
+        with self._lock:
+            if self._visualization is None:
+                return
+            try:
+                self._visualization.show_grasp_proposals(candidates)
+            except Exception:
+                logger.exception("Grasp proposal visualization failed")
 
     # Monitor Control
 

--- a/dimos/manipulation/planning/spec/protocols.py
+++ b/dimos/manipulation/planning/spec/protocols.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
     )
     from dimos.manipulation.planning.spec.validation import PreparedRobotModel
     from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
+    from dimos.msgs.manipulation_msgs.GraspCandidateArray import GraspCandidateArray
     from dimos.msgs.sensor_msgs.JointState import JointState
     from dimos.msgs.trajectory_msgs.JointTrajectory import JointTrajectory
 
@@ -209,6 +210,14 @@ class VisualizationSpec(Protocol):
 
     def clear_vis_obstacles(self) -> None:
         """Clear obstacle representations from the visualization."""
+        ...
+
+    def show_grasp_proposals(self, candidates: GraspCandidateArray) -> None:
+        """Display the ranked grasp proposals a generator produced.
+
+        Display only: these are candidates, not planning geometry. An empty
+        array clears whatever is drawn.
+        """
         ...
 
     def get_visualization_url(self) -> str | None:

--- a/dimos/manipulation/planning/world/drake_world.py
+++ b/dimos/manipulation/planning/world/drake_world.py
@@ -49,6 +49,7 @@ if TYPE_CHECKING:
 
 from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
 from dimos.msgs.geometry_msgs.Transform import Transform
+from dimos.msgs.manipulation_msgs.GraspCandidateArray import GraspCandidateArray
 from dimos.msgs.sensor_msgs.JointState import JointState
 from dimos.msgs.trajectory_msgs.JointTrajectory import JointTrajectory
 
@@ -1104,6 +1105,10 @@ class DrakeWorld(WorldSpec, VisualizationSpec):
 
     def clear_vis_obstacles(self) -> None:
         """Embedded Meshcat observes native WorldSpec obstacle mutations."""
+        return None
+
+    def show_grasp_proposals(self, candidates: GraspCandidateArray) -> None:
+        """Meshcat draws the planning world only; grasp proposals are viser's."""
         return None
 
     def get_visualization_url(self) -> str | None:

--- a/dimos/manipulation/test_pick_and_place_unit.py
+++ b/dimos/manipulation/test_pick_and_place_unit.py
@@ -187,6 +187,18 @@ def test_pick_reports_no_reachable_candidate_when_every_attempt_fails(
     assert not module._holding_object
 
 
+def test_proposals_reach_the_viewer_as_they_are_generated(module: PickAndPlaceModule) -> None:
+    """get_grasp_candidates only answers after the fact, which is no help live."""
+    manipulation: Any = module._manipulation
+    shown: list[GraspCandidateArray] = []
+    manipulation.show_grasp_proposals.side_effect = lambda array: shown.append(array)
+
+    assert module.pick_object("cup-1").success
+
+    # The stale overlay is cleared first, then the fresh proposals go out.
+    assert [[c.score for c in array.candidates] for array in shown] == [[], [1.0]]
+
+
 def test_pick_object_rejects_empty_candidates(module: PickAndPlaceModule) -> None:
     module._grasp_generator.propose_grasps.return_value = GraspCandidateArray(
         Header(1.0, "world"), []

--- a/dimos/manipulation/visualization/test_factory.py
+++ b/dimos/manipulation/visualization/test_factory.py
@@ -44,6 +44,7 @@ from dimos.manipulation.visualization.config import (
 from dimos.manipulation.visualization.factory import create_manipulation_visualization
 from dimos.manipulation.visualization.viser.config import ViserVisualizationConfig
 from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
+from dimos.msgs.manipulation_msgs.GraspCandidateArray import GraspCandidateArray
 from dimos.msgs.sensor_msgs.JointState import JointState
 from dimos.msgs.trajectory_msgs.JointTrajectory import JointTrajectory
 from dimos.robot.assets.model import LoadedRobotModel, RobotModel
@@ -83,6 +84,9 @@ class FakeVisualization:
         return None
 
     def clear_vis_obstacles(self) -> None:
+        return None
+
+    def show_grasp_proposals(self, candidates):
         return None
 
 
@@ -243,6 +247,9 @@ class FakeMeshcatWorld(FakeWorld):
     def clear_vis_obstacles(self) -> None:
         self.visualization_calls.append(("clear_vis_obstacles",))
 
+    def show_grasp_proposals(self, candidates):
+        self.visualization_calls.append(("show_grasp_proposals", candidates))
+
 
 def test_config_defaults_to_no_visualization() -> None:
     config = ManipulationModuleConfig(model=FakeWorld().get_model_config())
@@ -332,6 +339,8 @@ def test_create_visualization_meshcat_accepts_structural_world() -> None:
     visualization.add_vis_obstacle("box", obstacle)
     visualization.remove_vis_obstacle("box")
     visualization.clear_vis_obstacles()
+    proposals = GraspCandidateArray()
+    visualization.show_grasp_proposals(proposals)
     assert fake_world.visualization_calls == [
         ("initialize", session),
         ("get_visualization_url",),
@@ -342,6 +351,7 @@ def test_create_visualization_meshcat_accepts_structural_world() -> None:
         ("add_vis_obstacle", "box", obstacle),
         ("remove_vis_obstacle", "box"),
         ("clear_vis_obstacles",),
+        ("show_grasp_proposals", proposals),
     ]
     assert fake_world.native_calls == []
 
@@ -390,6 +400,7 @@ def test_drake_meshcat_visualization_lifecycle_is_noop_without_meshcat() -> None
     world.add_vis_obstacle("box", obstacle)
     world.remove_vis_obstacle("box")
     world.clear_vis_obstacles()
+    world.show_grasp_proposals(GraspCandidateArray())
     world.cancel_preview_animation()
     world.close()
 

--- a/dimos/manipulation/visualization/viser/scene.py
+++ b/dimos/manipulation/visualization/viser/scene.py
@@ -26,6 +26,7 @@ from typing import Any, Protocol, TypeAlias, cast
 import xml.etree.ElementTree as ET
 
 import numpy as np
+from numpy.typing import NDArray
 import trimesh
 from yourdfpy import URDF  # type: ignore[import-untyped]
 
@@ -44,6 +45,8 @@ from dimos.manipulation.visualization.viser.runtime import (
 )
 from dimos.msgs.geometry_msgs.Pose import Pose
 from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
+from dimos.msgs.manipulation_msgs.GraspCandidate import GraspCandidate
+from dimos.msgs.manipulation_msgs.GraspCandidateArray import GraspCandidateArray
 from dimos.msgs.sensor_msgs.JointState import JointState
 from dimos.robot.assets.model import LoadedRobotModel
 from dimos.utils.logging_config import setup_logger
@@ -98,6 +101,22 @@ OBSTACLE_DEFAULT_RGBA = DEFAULT_OBSTACLE_RGBA
 OBSTACLE_FALLBACK_COLOR = (55, 190, 210)
 OBSTACLE_FALLBACK_OPACITY = 0.55
 OBSTACLE_PROXY_COLOR = (255, 45, 25)
+GRASP_PROPOSAL_NAMESPACE = "/manipulation/grasp-proposals"
+# Best rank green through worst orange, so the ordering reads at a glance.
+GRASP_PROPOSAL_BEST_COLOR = (60, 220, 60)
+GRASP_PROPOSAL_WORST_COLOR = (255, 160, 60)
+# Drawing every proposal of a hundred buries the ranking; the leaders are what
+# matters when you are deciding whether the generator is pointing anywhere sane.
+GRASP_PROPOSAL_DRAW_LIMIT = 20
+# The leaders are drawn thicker and labelled with their score.
+GRASP_PROPOSAL_EMPHASIS_COUNT = 3
+# Glyph geometry, in metres. Deliberately not the gripper: this marks where a
+# grasp points, and a jaw-shaped drawing sized by anything but the configured
+# sweep volume would be a claim about the hardware that nothing checks.
+GRASP_PROPOSAL_APPROACH_LENGTH = 0.05
+GRASP_PROPOSAL_CLOSING_HALF_WIDTH = 0.02
+GRASP_PROPOSAL_WIDTH = 1.5
+GRASP_PROPOSAL_EMPHASIS_WIDTH = 3.5
 
 
 class RobotDisplayMode(str, Enum):  # TODO(PY311): switch to enum.StrEnum
@@ -142,6 +161,8 @@ class ViserManipulationScene:
         self._obstacles_visible = True
         self._obstacle_gui_handles: list[object] = []
         self._obstacle_warning_handle: Any | None = None
+        self._grasp_proposal_handles: list[Any] = []
+        self._grasp_proposals_visible = True
         self._closed = False
         self._ensure_obstacle_control()
         self._ensure_reference_grid()
@@ -289,6 +310,111 @@ class ViserManipulationScene:
             for obstacle_id in list(self._obstacle_handles):
                 self.remove_vis_obstacle(obstacle_id)
 
+    def set_grasp_proposals_visible(self, visible: bool) -> None:
+        """Toggle the proposal markers without discarding their scene handles."""
+        with self._scene_lock:
+            if self._closed:
+                return
+            self._grasp_proposals_visible = bool(visible)
+            for handle in self._grasp_proposal_handles:
+                self._set_handle_visibility(handle, self._grasp_proposals_visible)
+
+    def show_grasp_proposals(self, candidates: GraspCandidateArray) -> None:
+        """Draw the ranked proposals as pose glyphs, best first.
+
+        One line-segment node carries every glyph, plus a label per emphasised
+        leader. Scores are only meaningful against each other, so rank drives
+        the colour rather than the absolute value. An empty array clears.
+        """
+        with self._scene_lock:
+            if self._closed:
+                return
+            self.clear_grasp_proposals()
+            drawn = list(candidates.candidates[:GRASP_PROPOSAL_DRAW_LIMIT])
+            if not drawn:
+                return
+            emphasis = min(GRASP_PROPOSAL_EMPHASIS_COUNT, len(drawn))
+            handles: list[Any] = []
+            for start, stop, width in (
+                (emphasis, len(drawn), GRASP_PROPOSAL_WIDTH),
+                (0, emphasis, GRASP_PROPOSAL_EMPHASIS_WIDTH),
+            ):
+                if start >= stop:
+                    continue
+                segments, colors = self._grasp_proposal_segments(drawn, start, stop, len(drawn))
+                handles.append(
+                    self.server.scene.add_line_segments(
+                        f"{GRASP_PROPOSAL_NAMESPACE}/rank-{start}",
+                        points=segments,
+                        colors=colors,
+                        line_width=width,
+                        visible=self._grasp_proposals_visible,
+                    )
+                )
+            for rank in range(emphasis):
+                pose = drawn[rank].pose
+                handles.append(
+                    self.server.scene.add_label(
+                        f"{GRASP_PROPOSAL_NAMESPACE}/label-{rank}",
+                        f"#{rank} {drawn[rank].score:.3f}",
+                        position=(
+                            float(pose.position.x),
+                            float(pose.position.y),
+                            float(pose.position.z),
+                        ),
+                        visible=self._grasp_proposals_visible,
+                    )
+                )
+            self._grasp_proposal_handles = handles
+
+    def clear_grasp_proposals(self) -> None:
+        """Remove every proposal marker while retaining the viewer's toggle."""
+        with self._scene_lock:
+            for handle in self._grasp_proposal_handles:
+                self._remove_scene_handle(handle)
+            self._grasp_proposal_handles = []
+
+    @staticmethod
+    def _grasp_proposal_segments(
+        candidates: Sequence[GraspCandidate], start: int, stop: int, total: int
+    ) -> tuple[NDArray[np.float32], NDArray[np.uint8]]:
+        """Two segments per grasp: the approach axis, and the closing axis across it.
+
+        Both arrays are shaped the way ``add_line_segments`` requires: (N, 2, 3)
+        for the endpoints, and one colour per endpoint rather than per segment.
+        """
+        segments: list[NDArray[np.float32]] = []
+        colors: list[tuple[tuple[int, int, int], tuple[int, int, int]]] = []
+        local = np.array(
+            [
+                [0.0, 0.0, -GRASP_PROPOSAL_APPROACH_LENGTH],
+                [0.0, 0.0, 0.0],
+                [0.0, -GRASP_PROPOSAL_CLOSING_HALF_WIDTH, 0.0],
+                [0.0, GRASP_PROPOSAL_CLOSING_HALF_WIDTH, 0.0],
+            ],
+            dtype=np.float32,
+        )
+        for rank in range(start, stop):
+            pose = candidates[rank].pose
+            rotation = np.asarray(pose.orientation.to_rotation_matrix(), dtype=np.float32)
+            origin = np.asarray(
+                [pose.position.x, pose.position.y, pose.position.z], dtype=np.float32
+            )
+            points = local @ rotation.T + origin
+            segments.append(points.reshape(2, 2, 3))
+            color = ViserManipulationScene._grasp_rank_color(rank, total)
+            colors.extend([(color, color)] * 2)
+        return (
+            np.concatenate(segments).astype(np.float32),
+            np.asarray(colors, dtype=np.uint8),
+        )
+
+    @staticmethod
+    def _grasp_rank_color(rank: int, total: int) -> tuple[int, int, int]:
+        t = 0.0 if total <= 1 else rank / (total - 1)
+        best, worst = GRASP_PROPOSAL_BEST_COLOR, GRASP_PROPOSAL_WORST_COLOR
+        return tuple(round(b + (w - b) * t) for b, w in zip(best, worst, strict=True))  # type: ignore[return-value]
+
     def show_obstacle_warning(self, message: str) -> None:
         """Expose a persistent renderer warning in the frontend when available."""
         with self._scene_lock:
@@ -307,8 +433,12 @@ class ViserManipulationScene:
             self._obstacle_gui_handles.append(folder)
             with folder:
                 handle = self.server.gui.add_checkbox("manipulation.obstacles", initial_value=True)
+                proposals = self.server.gui.add_checkbox(
+                    "manipulation.grasp-proposals", initial_value=True
+                )
             handle.on_update(lambda event: self.set_obstacles_visible(event.target.value))
-            self._obstacle_gui_handles.append(handle)
+            proposals.on_update(lambda event: self.set_grasp_proposals_visible(event.target.value))
+            self._obstacle_gui_handles.extend((handle, proposals))
         except (AttributeError, TypeError):
             self._obstacle_gui_handles.clear()
 

--- a/dimos/manipulation/visualization/viser/test_scene_grasp_proposals.py
+++ b/dimos/manipulation/visualization/viser/test_scene_grasp_proposals.py
@@ -1,0 +1,132 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Ranked grasp-proposal markers, without a running Viser server."""
+
+import inspect
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+pytest.importorskip("viser", reason="Viser optional dependency is not installed")
+
+from dimos.manipulation.visualization.viser.scene import (
+    GRASP_PROPOSAL_DRAW_LIMIT,
+    GRASP_PROPOSAL_EMPHASIS_COUNT,
+    ViserManipulationScene,
+)
+from dimos.msgs.geometry_msgs.Pose import Pose
+from dimos.msgs.geometry_msgs.Quaternion import Quaternion
+from dimos.msgs.geometry_msgs.Vector3 import Vector3
+from dimos.msgs.manipulation_msgs.GraspCandidate import GraspCandidate
+from dimos.msgs.manipulation_msgs.GraspCandidateArray import GraspCandidateArray
+from dimos.msgs.std_msgs.Header import Header
+
+
+def _scene() -> ViserManipulationScene:
+    return ViserManipulationScene(MagicMock(), MagicMock())
+
+
+def _proposals(count: int) -> GraspCandidateArray:
+    return GraspCandidateArray(
+        Header(1.0, "world"),
+        [
+            GraspCandidate(
+                Pose(Vector3(0.1 * index, 0.0, 0.2), Quaternion(0.0, 0.0, 0.0, 1.0)),
+                1.0 - 0.01 * index,
+            )
+            for index in range(count)
+        ],
+    )
+
+
+def test_proposals_draw_leaders_and_the_rest_as_separate_groups() -> None:
+    """The leaders are drawn thicker, so they are their own line-segment node."""
+    scene = _scene()
+
+    scene.show_grasp_proposals(_proposals(10))
+
+    calls = scene.server.scene.add_line_segments.call_args_list
+    assert len(calls) == 2
+    drawn = sum(len(call.kwargs["points"]) for call in calls)
+    assert drawn == 20  # two segments per grasp: approach, and the closing axis
+    assert scene.server.scene.add_label.call_count == GRASP_PROPOSAL_EMPHASIS_COUNT
+
+
+def test_the_drawn_arrays_match_what_viser_accepts() -> None:
+    """A mocked server takes any shape; the real one silently raises behind a log."""
+    from viser import SceneApi
+
+    scene = _scene()
+
+    scene.show_grasp_proposals(_proposals(6))
+
+    signature = inspect.signature(SceneApi.add_line_segments)
+    for call in scene.server.scene.add_line_segments.call_args_list:
+        signature.bind(scene.server.scene, *call.args, **call.kwargs)
+        points = np.asarray(call.kwargs["points"])
+        colors = np.asarray(call.kwargs["colors"])
+        # add_line_segments wants (N, 2, 3) endpoints and one colour per endpoint.
+        assert points.shape[1:] == (2, 3)
+        assert colors.shape == points.shape
+    label_signature = inspect.signature(SceneApi.add_label)
+    for call in scene.server.scene.add_label.call_args_list:
+        label_signature.bind(scene.server.scene, *call.args, **call.kwargs)
+
+
+def test_ranking_reads_as_a_colour_gradient() -> None:
+    """Scores only mean anything against each other, so rank drives the colour."""
+    scene = _scene()
+
+    scene.show_grasp_proposals(_proposals(10))
+
+    trailing, leaders = scene.server.scene.add_line_segments.call_args_list
+    best = np.asarray(leaders.kwargs["colors"])[0][0]
+    worst = np.asarray(trailing.kwargs["colors"])[-1][0]
+    assert best[1] > worst[1]  # green fades out towards the worst rank
+    assert best[0] < worst[0]  # red comes up
+
+
+def test_a_hundred_proposals_do_not_all_get_drawn() -> None:
+    """Drawing every candidate buries the ranking it is there to show."""
+    scene = _scene()
+
+    scene.show_grasp_proposals(_proposals(100))
+
+    drawn = sum(
+        len(call.kwargs["points"]) for call in scene.server.scene.add_line_segments.call_args_list
+    )
+    assert drawn == 2 * GRASP_PROPOSAL_DRAW_LIMIT
+
+
+def test_an_empty_array_clears_the_markers() -> None:
+    scene = _scene()
+    scene.show_grasp_proposals(_proposals(4))
+
+    scene.show_grasp_proposals(GraspCandidateArray())
+
+    assert scene._grasp_proposal_handles == []
+
+
+def test_redrawing_removes_the_previous_proposals() -> None:
+    """A stale overlay beside a fresh one is worse than no overlay."""
+    scene = _scene()
+    scene.show_grasp_proposals(_proposals(4))
+    handle = scene.server.scene.add_line_segments.return_value
+    handle.remove.assert_not_called()
+
+    scene.show_grasp_proposals(_proposals(2))
+
+    assert handle.remove.called

--- a/dimos/manipulation/visualization/viser/visualizer.py
+++ b/dimos/manipulation/visualization/viser/visualizer.py
@@ -30,6 +30,7 @@ from dimos.manipulation.visualization.viser.runtime import (
 )
 from dimos.manipulation.visualization.viser.scene import ViserManipulationScene
 from dimos.manipulation.visualization.viser.theme import apply_dimos_theme
+from dimos.msgs.manipulation_msgs.GraspCandidateArray import GraspCandidateArray
 from dimos.msgs.sensor_msgs.JointState import JointState
 from dimos.msgs.trajectory_msgs.JointTrajectory import JointTrajectory
 from dimos.utils.logging_config import setup_logger
@@ -215,6 +216,14 @@ class ViserManipulationVisualizer:
         self._ensure_started()
         if self._scene is not None:
             self._scene.clear_vis_obstacles()
+
+    def show_grasp_proposals(self, candidates: GraspCandidateArray) -> None:
+        """Draw the ranked grasp proposals; an empty array clears them."""
+        if self._closed:
+            return
+        self._ensure_started()
+        if self._scene is not None:
+            self._scene.show_grasp_proposals(candidates)
 
     def update_state(self, frame: VisualizationStateFrame) -> None:
         """Update current robot render state from a pushed state frame."""

--- a/docs/capabilities/manipulation/xarm-grasp.md
+++ b/docs/capabilities/manipulation/xarm-grasp.md
@@ -66,6 +66,19 @@ into it can only ever be rejected. The pregrasp-to-grasp leg and the retreat are
 therefore straight-line `move_linear` servos with collision checking off; only
 the approach to the pregrasp pose is a checked plan.
 
+## Seeing the proposals
+
+The viser scene draws the ranked proposals as pose glyphs: an approach axis with
+the closing axis across it, coloured best-green through worst-orange so the
+ordering reads at a glance, with the top three drawn thicker and labelled with
+their score. Only the leading twenty are drawn, because a hundred glyphs bury
+the ranking they exist to show. `manipulation.grasp-proposals` in the Scene panel
+toggles them.
+
+The markers are pose indicators, not a gripper: what they promise is where a
+grasp points and in what order the generator ranked it. To see what the arm will
+actually do with one, watch the plan preview.
+
 ## The scene
 
 The scene is an enclosed 2.6 m by 3.0 m room. The xArm is bolted to the world


### PR DESCRIPTION
`PickAndPlaceModule` publishes its proposals on a stream as it makes them. `ManipulationModule` subscribes and hands them to the viewer through the world monitor, the same path obstacles and previews already take.

`VisualizationSpec` grows one hook for it; meshcat implements it as a no-op, because it draws the planning world and these are not planning geometry.

One test binds the drawn arrays against the real `viser.SceneApi` signature and asserts their shapes, because a mocked server accepts any array and the first version of this shipped colours as (N, 3) where viser wants (N, 2, 3) — which surfaced only as a swallowed `Grasp proposal visualization failed` in a live run.

Verified in the grasp sim: proposals reach the scene and render with no errors in the log, and the panel checkbox toggles them.

Last of nine in the xArm grasping re-landing stack.