### PR TITLE
feat(agent evals): add the Pi agent as well as pointcloud sim evals

### DIFF
--- a/dimos/evals/agents/base.py
+++ b/dimos/evals/agents/base.py
@@ -31,6 +31,10 @@ class AgentConfig(BaseConfig):
     modules: tuple[str, ...] = ()
 
 
+class ModelAgentConfig(AgentConfig):
+    model: str = "gpt-5.6-luna"
+
+
 class Agent(Configurable, ABC):
     """Run an instruction independently of the case and its grader.
 

--- a/dimos/evals/agents/lib/model_trace_proxy.py
+++ b/dimos/evals/agents/lib/model_trace_proxy.py
@@ -12,38 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Wire capture for agents that run as a subprocess and cannot take an
-``http_client``: a local endpoint that forwards to the provider and records
-every request/response pair whole."""
+"""Forward an external agent's model HTTP requests and record requests and responses."""
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-import threading
+import subprocess
+import sys
 from typing import Any
-
-import httpx
 
 from dimos.agents.llm_trace import tracing_http_client
 
 
-class RecordingProxy:
-    """``with RecordingProxy(raw_dir, upstream) as url:`` — a request to
-    ``url/<path>`` is sent to ``upstream/<path>`` through
-    :func:`~dimos.agents.llm_trace.tracing_http_client`, so each one becomes a
-    ``<seq>-request.json`` / ``-response.json`` pair under *raw_dir* (auth
-    header dropped). A reply is relayed whole once it has arrived, so a
-    streamed response reaches the caller in one piece."""
-
-    def __init__(self, raw_dir: Path, upstream: str) -> None:
-        self.raw_dir = raw_dir
-        self.upstream = upstream.rstrip("/")
-        self._server: ThreadingHTTPServer | None = None
-
-    def __enter__(self) -> str:
-        client = tracing_http_client(self.raw_dir, timeout=httpx.Timeout(600.0))
-        upstream = self.upstream
+def _serve(raw_dir: Path, upstream: str) -> None:
+    """Own forwarding threads and sockets in a process that can be stopped."""
+    with tracing_http_client(raw_dir, timeout=600.0) as client:
 
         class Forward(BaseHTTPRequestHandler):
             def do_POST(self) -> None:
@@ -71,12 +57,43 @@ class RecordingProxy:
             def log_message(self, format: str, *args: Any) -> None:
                 return None
 
-        self._server = ThreadingHTTPServer(("127.0.0.1", 0), Forward)
-        threading.Thread(target=self._server.serve_forever, name="llm-proxy", daemon=True).start()
-        return f"http://127.0.0.1:{self._server.server_port}"
+        with ThreadingHTTPServer(("127.0.0.1", 0), Forward) as server:
+            print(f"http://127.0.0.1:{server.server_port}", flush=True)
+            server.serve_forever()
 
-    def __exit__(self, *exc: object) -> None:
-        if self._server is not None:
-            self._server.shutdown()
-            self._server.server_close()
-            self._server = None
+
+@contextmanager
+def model_trace_proxy(raw_dir: Path, upstream: str) -> Iterator[str]:
+    """Yield a local provider URL; record each complete HTTP exchange in raw_dir.
+
+    Exiting stops the server process, including any requests blocked upstream.
+    A subprocess also works inside the eval module's daemon worker.
+    """
+    with subprocess.Popen(
+        [sys.executable, "-m", __name__, str(raw_dir), upstream.rstrip("/")],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        text=True,
+    ) as process:
+        assert process.stdout is not None
+        try:
+            with process.stdout:
+                url = process.stdout.readline().strip()
+                if not url:
+                    status = process.wait()
+                    raise RuntimeError(
+                        f"Model trace proxy exited before startup with status {status}"
+                    )
+            yield url
+        finally:
+            process.terminate()
+            try:
+                # Bound cleanup even if the worker fails to respond to SIGTERM.
+                process.wait(timeout=1.0)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait()
+
+
+if __name__ == "__main__":
+    _serve(Path(sys.argv[1]), sys.argv[2])

--- a/dimos/evals/agents/lib/model_trace_proxy.py
+++ b/dimos/evals/agents/lib/model_trace_proxy.py
@@ -19,21 +19,33 @@ from __future__ import annotations
 from collections.abc import Iterator
 from contextlib import contextmanager
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import json
 from pathlib import Path
 import subprocess
 import sys
+import threading
 from typing import Any
 
 from dimos.agents.llm_trace import tracing_http_client
 
 
-def _serve(raw_dir: Path, upstream: str) -> None:
+def _serve(raw_dir: Path, upstream: str, max_requests: int | None, limit_reached: Path) -> None:
     """Own forwarding threads and sockets in a process that can be stopped."""
+    requests = 0
+    budget_lock = threading.Lock()
     with tracing_http_client(raw_dir, timeout=600.0) as client:
 
         class Forward(BaseHTTPRequestHandler):
             def do_POST(self) -> None:
+                nonlocal requests
                 body = self.rfile.read(int(self.headers.get("Content-Length") or 0))
+                with budget_lock:
+                    if max_requests is not None and requests >= max_requests:
+                        limit_reached.touch()
+                        self.send_error(400, "Pi model request budget exhausted")
+                        return
+                    # Reserve before forwarding, including failures and retries.
+                    requests += 1
                 # hop-by-hop headers belong to this connection, not the upstream one
                 skip = {
                     "host",
@@ -63,14 +75,26 @@ def _serve(raw_dir: Path, upstream: str) -> None:
 
 
 @contextmanager
-def model_trace_proxy(raw_dir: Path, upstream: str) -> Iterator[str]:
+def model_trace_proxy(
+    raw_dir: Path, upstream: str, *, max_requests: int | None, limit_reached: Path
+) -> Iterator[str]:
     """Yield a local provider URL; record each complete HTTP exchange in raw_dir.
 
+    Forward at most max_requests attempts (None is unlimited). An excess request
+    is rejected locally and creates limit_reached so the adapter can report why.
     Exiting stops the server process, including any requests blocked upstream.
     A subprocess also works inside the eval module's daemon worker.
     """
     with subprocess.Popen(
-        [sys.executable, "-m", __name__, str(raw_dir), upstream.rstrip("/")],
+        [
+            sys.executable,
+            "-m",
+            __name__,
+            str(raw_dir),
+            upstream.rstrip("/"),
+            json.dumps(max_requests),
+            str(limit_reached),
+        ],
         stdin=subprocess.DEVNULL,
         stdout=subprocess.PIPE,
         text=True,
@@ -96,4 +120,4 @@ def model_trace_proxy(raw_dir: Path, upstream: str) -> Iterator[str]:
 
 
 if __name__ == "__main__":
-    _serve(Path(sys.argv[1]), sys.argv[2])
+    _serve(Path(sys.argv[1]), sys.argv[2], json.loads(sys.argv[3]), Path(sys.argv[4]))

--- a/dimos/evals/agents/lib/pi_to_atif.py
+++ b/dimos/evals/agents/lib/pi_to_atif.py
@@ -1,0 +1,94 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Translate Pi events into ATIF steps paired with recorded model requests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from dimos.agents.llm_trace import latest_pair
+from dimos.evals.agents.lib.trajectory_builder import TrajectoryBuilder
+from dimos.evals.types import Metrics, ToolCall
+
+
+def _result_text(result: Any) -> str:
+    content = result.get("content") if isinstance(result, dict) else None
+    if isinstance(content, list):
+        return "\n".join(str(c.get("text", "")) for c in content if c.get("type") == "text")
+    return str(result)
+
+
+class PiToAtif:
+    """Append assistant steps and tool results from Pi's JSON event stream."""
+
+    def __init__(self, raw_dir: Path, trajectory: TrajectoryBuilder) -> None:
+        self.raw_dir = raw_dir
+        self.trajectory = trajectory
+        self.calls = 0  # model calls seen
+        self.wants_tool = False  # the latest one asked for a tool
+        self.error = ""
+        self._next_seq = 0
+
+    def append_event(self, event: dict[str, Any]) -> None:
+        if event.get("type") == "tool_execution_end" and self.calls:
+            self.trajectory.observe(str(event["toolCallId"]), _result_text(event.get("result")))
+        elif event.get("type") == "message_end" and event["message"].get("role") == "assistant":
+            self._step(event["message"])
+
+    def _step(self, message: dict[str, Any]) -> None:
+        pair = latest_pair(self.raw_dir, self._next_seq)
+        if pair is None:
+            raise RuntimeError(
+                f"Pi made a model call that left no trace under {self.raw_dir}; "
+                "every call must go through the recording proxy"
+            )
+        self._next_seq = pair[0] + 1
+        usage = message.get("usage") or {}
+        content = message.get("content") or []
+        if message.get("stopReason") in ("error", "aborted"):
+            self.error = str(message.get("errorMessage") or message["stopReason"])
+        tool_calls = tuple(
+            ToolCall(
+                tool_call_id=str(c["id"]),
+                function_name=str(c["name"]),
+                arguments=dict(c.get("arguments") or {}),
+            )
+            for c in content
+            if c.get("type") == "toolCall"
+        )
+        # Pi's ``input`` excludes cache traffic: what was sent is the three together.
+        cached = int(usage.get("cacheRead", 0))
+        self.trajectory.step(
+            message="".join(str(c.get("text", "")) for c in content if c.get("type") == "text"),
+            reasoning="\n\n".join(
+                str(c.get("thinking", "")) for c in content if c.get("type") == "thinking"
+            ),
+            tool_calls=tool_calls,
+            metrics=Metrics(
+                prompt_tokens=int(usage.get("input", 0)) + int(usage.get("cacheWrite", 0)) + cached,
+                completion_tokens=int(usage.get("output", 0)),
+                cached_tokens=cached,
+                cost_usd=float((usage.get("cost") or {}).get("total") or 0.0),
+            ),
+            model_name=str(message.get("responseModel") or message.get("model") or ""),
+            latency_s=float(json.loads(pair[2].read_text()).get("latency_s") or 0.0),
+            reasoning_tokens=int(usage.get("reasoning", 0)),
+            request=pair[1],
+            response=pair[2],
+        )
+        self.calls += 1
+        self.wants_tool = bool(tool_calls)

--- a/dimos/evals/agents/lib/pi_to_atif.py
+++ b/dimos/evals/agents/lib/pi_to_atif.py
@@ -20,7 +20,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-from dimos.agents.llm_trace import latest_pair
+from dimos.agents.llm_trace import list_llm_trace_pairs
 from dimos.evals.agents.lib.trajectory_builder import TrajectoryBuilder
 from dimos.evals.types import Metrics, ToolCall
 
@@ -30,6 +30,24 @@ def _result_text(result: Any) -> str:
     if isinstance(content, list):
         return "\n".join(str(c.get("text", "")) for c in content if c.get("type") == "text")
     return str(result)
+
+
+def _response_id(body: Any) -> str | None:
+    """Read the provider response ID from an OpenAI Responses JSON or SSE body."""
+    if isinstance(body, dict):
+        response_id = body.get("id")
+        return str(response_id) if response_id else None
+    if isinstance(body, str):
+        for line in body.splitlines():
+            if not line.startswith("data:"):
+                continue
+            data = line.removeprefix("data:").strip()
+            if data == "[DONE]":
+                continue
+            event = json.loads(data)
+            if response_id := (event.get("response") or {}).get("id"):
+                return str(response_id)
+    return None
 
 
 class PiToAtif:
@@ -49,18 +67,41 @@ class PiToAtif:
         elif event.get("type") == "message_end" and event["message"].get("role") == "assistant":
             self._step(event["message"])
 
+    def _trace_for_response(self, response_id: str) -> tuple[Path, Path, float]:
+        """Match by provider ID: newer traces may already exist when stdout is buffered."""
+        for seq, request, response in list_llm_trace_pairs(self.raw_dir):
+            if seq < self._next_seq:
+                continue
+            try:
+                record = json.loads(response.read_text())
+                recorded_id = _response_id(record["body"])
+            except json.JSONDecodeError:
+                # An abandoned attempt may still be writing. The matching
+                # response is complete before the proxy delivers it to Pi.
+                continue
+            if recorded_id == response_id:
+                self._next_seq = seq + 1
+                return request, response, float(record.get("latency_s") or 0.0)
+        raise RuntimeError(f"No recorded HTTP response for Pi response {response_id!r}")
+
     def _step(self, message: dict[str, Any]) -> None:
-        pair = latest_pair(self.raw_dir, self._next_seq)
-        if pair is None:
-            raise RuntimeError(
-                f"Pi made a model call that left no trace under {self.raw_dir}; "
-                "every call must go through the recording proxy"
-            )
-        self._next_seq = pair[0] + 1
+        self.calls += 1
+        self.wants_tool = False
+        self.error = (
+            str(message.get("errorMessage") or message["stopReason"])
+            if message.get("stopReason") in ("error", "aborted")
+            else ""
+        )
+        response_id = message.get("responseId")
+        if not response_id:
+            if self.error:
+                # Pi reported no response ID. Keep the raw failure logs;
+                # a successful retry will clear this error and record its own step.
+                return
+            raise RuntimeError("Pi assistant message has no provider response ID")
+        request, response, latency_s = self._trace_for_response(response_id)
         usage = message.get("usage") or {}
         content = message.get("content") or []
-        if message.get("stopReason") in ("error", "aborted"):
-            self.error = str(message.get("errorMessage") or message["stopReason"])
         tool_calls = tuple(
             ToolCall(
                 tool_call_id=str(c["id"]),
@@ -85,10 +126,9 @@ class PiToAtif:
                 cost_usd=float((usage.get("cost") or {}).get("total") or 0.0),
             ),
             model_name=str(message.get("responseModel") or message.get("model") or ""),
-            latency_s=float(json.loads(pair[2].read_text()).get("latency_s") or 0.0),
+            latency_s=latency_s,
             reasoning_tokens=int(usage.get("reasoning", 0)),
-            request=pair[1],
-            response=pair[2],
+            request=request,
+            response=response,
         )
-        self.calls += 1
         self.wants_tool = bool(tool_calls)

--- a/dimos/evals/agents/lib/proxy.py
+++ b/dimos/evals/agents/lib/proxy.py
@@ -1,0 +1,82 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Wire capture for agents that run as a subprocess and cannot take an
+``http_client``: a local endpoint that forwards to the provider and records
+every request/response pair whole."""
+
+from __future__ import annotations
+
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+import threading
+from typing import Any
+
+import httpx
+
+from dimos.agents.llm_trace import tracing_http_client
+
+
+class RecordingProxy:
+    """``with RecordingProxy(raw_dir, upstream) as url:`` — a request to
+    ``url/<path>`` is sent to ``upstream/<path>`` through
+    :func:`~dimos.agents.llm_trace.tracing_http_client`, so each one becomes a
+    ``<seq>-request.json`` / ``-response.json`` pair under *raw_dir* (auth
+    header dropped). A reply is relayed whole once it has arrived, so a
+    streamed response reaches the caller in one piece."""
+
+    def __init__(self, raw_dir: Path, upstream: str) -> None:
+        self.raw_dir = raw_dir
+        self.upstream = upstream.rstrip("/")
+        self._server: ThreadingHTTPServer | None = None
+
+    def __enter__(self) -> str:
+        client = tracing_http_client(self.raw_dir, timeout=httpx.Timeout(600.0))
+        upstream = self.upstream
+
+        class Forward(BaseHTTPRequestHandler):
+            def do_POST(self) -> None:
+                body = self.rfile.read(int(self.headers.get("Content-Length") or 0))
+                # hop-by-hop headers belong to this connection, not the upstream one
+                skip = {
+                    "host",
+                    "content-length",
+                    "connection",
+                    "accept-encoding",
+                    "transfer-encoding",
+                }
+                headers = {k: v for k, v in self.headers.items() if k.lower() not in skip}
+                reply = client.request(
+                    self.command, upstream + self.path, content=body, headers=headers
+                )
+                self.send_response(reply.status_code)
+                self.send_header(
+                    "Content-Type", reply.headers.get("content-type", "application/json")
+                )
+                self.send_header("Content-Length", str(len(reply.content)))
+                self.end_headers()
+                self.wfile.write(reply.content)
+
+            def log_message(self, format: str, *args: Any) -> None:
+                return None
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), Forward)
+        threading.Thread(target=self._server.serve_forever, name="llm-proxy", daemon=True).start()
+        return f"http://127.0.0.1:{self._server.server_port}"
+
+    def __exit__(self, *exc: object) -> None:
+        if self._server is not None:
+            self._server.shutdown()
+            self._server.server_close()
+            self._server = None

--- a/dimos/evals/agents/lib/single_call.py
+++ b/dimos/evals/agents/lib/single_call.py
@@ -26,20 +26,16 @@ from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, System
 from langchain_core.outputs import ChatGeneration
 
 from dimos.agents.llm_trace import latest_pair, write_normalized
-from dimos.evals.agents.base import Agent, AgentConfig
+from dimos.evals.agents.base import Agent, ModelAgentConfig
 from dimos.evals.agents.lib.langchain_to_atif import append_ai_message_to_atif
 from dimos.evals.agents.lib.trajectory_builder import TrajectoryBuilder
 from dimos.evals.types import RunningEnvironment, Trajectory
 
-DEFAULT_MODEL = "gpt-5.6-luna"
-EVAL_SYSTEM_PROMPT = "Answer the question using only the provided observations."
-
 Blocks = list[str | dict[str, Any]]
 
 
-class SingleCallAgentConfig(AgentConfig):
-    model: str = DEFAULT_MODEL
-    system_prompt: str = EVAL_SYSTEM_PROMPT
+class SingleCallAgentConfig(ModelAgentConfig):
+    system_prompt: str = "Answer the question using only the provided observations."
     chat_model: BaseChatModel | None = None
 
 

--- a/dimos/evals/agents/lib/test_model_trace_proxy.py
+++ b/dimos/evals/agents/lib/test_model_trace_proxy.py
@@ -1,0 +1,124 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from contextlib import closing
+from http.server import ThreadingHTTPServer
+import json
+from queue import Queue
+from threading import Thread
+
+import httpx
+import pytest
+import requests
+
+from dimos.agents.llm_trace import tracing_http_client
+from dimos.evals.agents.lib import model_trace_proxy as proxy
+
+
+@pytest.fixture
+def proxy_server(tmp_path, mocker, request):
+    upstream = mocker.Mock(
+        side_effect=[
+            httpx.Response(503, text="retry"),
+            *[httpx.Response(201, json={"answer": 42}) for _ in range(2)],
+        ]
+    )
+    servers = Queue()
+
+    def make_server(*args):
+        server = ThreadingHTTPServer(*args)
+        servers.put(server)
+        return server
+
+    mocker.patch.object(proxy, "ThreadingHTTPServer", side_effect=make_server)
+    with closing(
+        tracing_http_client(tmp_path / "raw", transport=httpx.MockTransport(upstream))
+    ) as client:
+        mocker.patch.object(proxy, "tracing_http_client", return_value=client)
+        thread = Thread(
+            target=proxy._serve,
+            args=(tmp_path / "raw", "https://provider.test/v1", request.param, tmp_path / "limit"),
+        )
+        thread.start()
+        server = servers.get(timeout=5)
+        try:
+            yield f"http://127.0.0.1:{server.server_port}", upstream
+        finally:
+            server.shutdown()
+            thread.join(timeout=5)
+        assert not thread.is_alive()
+
+
+@pytest.mark.parametrize(
+    ("proxy_server", "last_status", "forwarded", "limited"),
+    [(None, 201, 3, False), (2, 400, 2, True)],
+    indirect=["proxy_server"],
+)
+def test_forwarding_records_retries_and_counts_failed_attempts(
+    proxy_server, tmp_path, last_status, forwarded, limited
+):
+    url, upstream = proxy_server
+    body = b'{"model": "pi", "stream": false}'
+    with requests.Session() as session:
+        session.trust_env = False
+        responses = [
+            session.post(
+                url + "/chat/completions?version=1",
+                data=body,
+                timeout=5,
+                headers={"Authorization": "Bearer secret", "Host": "client.test", "X-Run": "7"},
+            )
+            for _ in range(3)
+        ]
+    assert [response.status_code for response in responses] == [503, 201, last_status]
+    assert responses[0].content == b"retry"
+    assert responses[0].headers["Content-Type"] == "text/plain; charset=utf-8"
+    assert responses[1].json() == {"answer": 42}
+    assert (tmp_path / "limit").exists() == limited
+    assert upstream.call_count == forwarded
+    sent = upstream.call_args.args[0]
+    assert str(sent.url) == "https://provider.test/v1/chat/completions?version=1"
+    assert sent.content == body
+    assert sent.headers["host"] == "provider.test"
+    assert sent.headers["authorization"] == "Bearer secret"
+    recorded = {
+        path.name: json.loads(path.read_text()) for path in (tmp_path / "raw").glob("*.json")
+    }
+    assert len(recorded) == forwarded * 2
+    request = recorded["000-request.json"]
+    assert request["body"] == {"model": "pi", "stream": False}
+    assert request["headers"]["x-run"] == "7"
+    assert "authorization" not in request["headers"]
+    failed, success = recorded["000-response.json"], recorded[f"{forwarded - 1:03d}-response.json"]
+    assert (failed["status"], failed["body"]) == (503, "retry")
+    assert (success["status"], success["body"]) == (201, {"answer": 42})
+
+
+def test_proxy_stops_process_when_caller_fails(tmp_path, mocker):
+    popen = mocker.spy(proxy.subprocess, "Popen")
+    with requests.Session() as session:
+        session.trust_env = False
+        with (
+            pytest.raises(ValueError, match="caller failed"),
+            proxy.model_trace_proxy(
+                tmp_path / "raw",
+                "https://provider.test/",
+                max_requests=0,
+                limit_reached=tmp_path / "limit",
+            ) as url,
+        ):
+            assert session.post(url, json={}, timeout=5).status_code == 400
+            raise ValueError("caller failed")
+    assert popen.spy_return.poll() is not None
+    assert (tmp_path / "limit").exists()

--- a/dimos/evals/agents/pi.py
+++ b/dimos/evals/agents/pi.py
@@ -1,0 +1,364 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The Pi coding agent (pi.dev) as an eval agent."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import queue
+import shutil
+import subprocess
+import threading
+import time
+from typing import TYPE_CHECKING, Any
+
+from dimos.agents.llm_trace import latest_pair
+from dimos.evals.agents.lib.chat import DEFAULT_MODEL
+from dimos.evals.agents.lib.proxy import RecordingProxy
+from dimos.evals.agents.lib.trajectory_builder import TrajectoryBuilder
+from dimos.evals.types import (
+    EndedBy,
+    Environment,
+    Metrics,
+    RunningEnvironment,
+    ToolCall,
+    Trajectory,
+)
+
+if TYPE_CHECKING:
+    from dimos.memory.stream import Stream
+
+
+def render_tools(tools: list[dict[str, Any]]) -> str:
+    """One line per MCP tool: name, argument names, first line of the description."""
+    lines = []
+    for t in tools:
+        args = ", ".join((t.get("inputSchema") or {}).get("properties") or {})
+        summary = str(t.get("description") or "").strip().partition("\n")[0]
+        lines.append(f"- {t['name']}({args}): {summary}")
+    return "\n".join(lines)
+
+
+def tool_listing(mcp_url: str) -> str:
+    from dimos.agents.mcp.mcp_adapter import McpAdapter
+
+    return render_tools(McpAdapter(mcp_url).list_tools())
+
+
+def recording_file(streams: Sequence[Stream[Any, Any]], path: Path) -> Path:
+    """*streams* written to a memory store at *path*, under their own names,
+    so a subprocess can open what the case selected and nothing more."""
+    from dimos.memory.store.sqlite import SqliteStore
+
+    store = SqliteStore(path=str(path))
+    try:
+        for stream in streams:
+            if stream.name is None:
+                raise ValueError("a stream must be bound to a store to be written out")
+            target: Stream[Any, Any] = store.stream(stream.name, stream.data_type)
+            for obs in stream:
+                target.append(obs.data, ts=obs.ts, pose=obs.pose_tuple, tags=obs.tags)
+    finally:
+        store.stop()
+    return path
+
+
+def _registry_cost(cli: str, model: str) -> dict[str, Any] | None:
+    """*model*'s pricing from the installed Pi's model registry, so Pi can
+    price its own calls; None when the model is not in the registry."""
+    exe = shutil.which(cli)
+    for parent in Path(exe).resolve().parents if exe else ():
+        data = parent / "node_modules" / "@earendil-works" / "pi-ai" / "dist" / "providers" / "data"
+        if data.is_dir():
+            for f in sorted(data.glob("*.json")):
+                for models in json.loads(f.read_text()).values():
+                    entry = models.get(model) if isinstance(models, dict) else None
+                    if isinstance(entry, dict) and entry.get("provider") == "openai":
+                        return dict(entry["cost"]) if entry.get("cost") else None
+    return None
+
+
+def _result_text(result: Any) -> str:
+    content = result.get("content") if isinstance(result, dict) else None
+    if isinstance(content, list):
+        return "\n".join(str(c.get("text", "")) for c in content if c.get("type") == "text")
+    return str(result)
+
+
+def _pump(stream: Any, into: queue.Queue[str | None]) -> None:
+    """Every line of *stream* onto the queue, then None at EOF."""
+    for line in stream:
+        into.put(line)
+    into.put(None)
+
+
+class _Events:
+    """Pi's ``--mode json`` stream folded into a trajectory: one step per
+    assistant ``message_end``, each paired with the request/response the proxy
+    recorded for it; each tool result is attached to the call that produced it."""
+
+    def __init__(self, raw_dir: Path, trajectory: TrajectoryBuilder) -> None:
+        self.raw_dir = raw_dir
+        self.trajectory = trajectory
+        self.calls = 0  # model calls seen
+        self.wants_tool = False  # the latest one asked for a tool
+        self.error = ""
+        self._next_seq = 0
+
+    def feed(self, line: str) -> None:
+        event = json.loads(line)
+        if event.get("type") == "tool_execution_end" and self.calls:
+            self.trajectory.observe(str(event["toolCallId"]), _result_text(event.get("result")))
+        elif event.get("type") == "message_end" and event["message"].get("role") == "assistant":
+            self._step(event["message"])
+
+    def _step(self, message: dict[str, Any]) -> None:
+        pair = latest_pair(self.raw_dir, self._next_seq)
+        if pair is None:
+            raise RuntimeError(
+                f"Pi made a model call that left no trace under {self.raw_dir}; "
+                "every call must go through the recording proxy"
+            )
+        self._next_seq = pair[0] + 1
+        usage = message.get("usage") or {}
+        content = message.get("content") or []
+        if message.get("stopReason") in ("error", "aborted"):
+            self.error = str(message.get("errorMessage") or message["stopReason"])
+        tool_calls = tuple(
+            ToolCall(
+                tool_call_id=str(c["id"]),
+                function_name=str(c["name"]),
+                arguments=dict(c.get("arguments") or {}),
+            )
+            for c in content
+            if c.get("type") == "toolCall"
+        )
+        # Pi's ``input`` excludes cache traffic: what was sent is the three together.
+        cached = int(usage.get("cacheRead", 0))
+        self.trajectory.step(
+            message="".join(str(c.get("text", "")) for c in content if c.get("type") == "text"),
+            reasoning="\n\n".join(
+                str(c.get("thinking", "")) for c in content if c.get("type") == "thinking"
+            ),
+            tool_calls=tool_calls,
+            metrics=Metrics(
+                prompt_tokens=int(usage.get("input", 0)) + int(usage.get("cacheWrite", 0)) + cached,
+                completion_tokens=int(usage.get("output", 0)),
+                cached_tokens=cached,
+                cost_usd=float((usage.get("cost") or {}).get("total") or 0.0),
+            ),
+            model_name=str(message.get("responseModel") or message.get("model") or ""),
+            latency_s=float(json.loads(pair[2].read_text()).get("latency_s") or 0.0),
+            reasoning_tokens=int(usage.get("reasoning", 0)),
+            request=pair[1],
+            response=pair[2],
+        )
+        self.calls += 1
+        self.wants_tool = bool(tool_calls)
+
+
+@dataclass
+class Pi:
+    """The Pi coding agent, headless (``pi --mode json``), with the run dir as
+    its working directory. The case's artifacts and the recording are files
+    named in the system prompt; a live robot is reached through ``dimos mcp
+    call`` from Pi's ``bash`` tool. Model traffic goes through a local
+    :class:`RecordingProxy`, so every call is captured whole under ``run_dir/raw``.
+
+    Settings:
+
+    - ``system_prompt``: the first thing Pi reads. Its default just tells Pi
+      to answer from the files and tools it is given.
+    - ``instructions``: any extra text you want in the prompt for this run,
+      added right after ``system_prompt``. Empty by default.
+    - ``builtin_guidance``: when True, the prompt also explains how to open
+      the recording in Python and how to call the robot's tools from bash.
+      Set it to False if a skill file teaches that instead.
+    - ``skills``: paths to skill files or directories that Pi loads with its
+      ``--skill`` flag. Give absolute paths, or they are made absolute here,
+      since Pi runs inside the case directory.
+    - ``tools``: which of Pi's own tools it may use (read, bash, edit, write).
+      ``bash`` is required whenever there is a robot.
+    - ``max_steps``: how many model calls Pi may make. When it hits the limit
+      and still wants to act, it is killed and the steps so far are kept. The
+      case's time budget is enforced the same way.
+    - ``passthrough_env``: environment variables Pi's process inherits, on
+      top of every ``DIMOS_*`` variable.
+    """
+
+    model: str = DEFAULT_MODEL
+    system_prompt: str = (
+        "Answer the question from the files and tools listed below and nothing else."
+    )
+    instructions: str = ""
+    builtin_guidance: bool = True
+    tools: Sequence[str] = ("read", "bash", "edit", "write")
+    thinking: str = "medium"
+    max_steps: int | None = 40
+    cli: str = "pi"
+    modules: str = ""
+    skills: Sequence[str] = ()
+    passthrough_env: Sequence[str] = ("PATH", "HOME", "XDG_STATE_HOME", "OPENAI_API_KEY")
+
+    def available_tools(self, environment_tools: tuple[str, ...]) -> tuple[str, ...]:
+        """Pi's native tools plus robot tools exposed through its bash tool."""
+        return (*self.tools, *environment_tools)
+
+    def preflight(self, environment: Environment) -> None:
+        for name in ("skills", "tools", "passthrough_env"):
+            if isinstance(getattr(self, name), str):
+                raise RuntimeError(f"Pi.{name} is a string; pass a list (--set {name}='[...]')")
+        missing = [p for p in self.skills if not Path(p).expanduser().resolve().exists()]
+        if missing:
+            raise RuntimeError(f"Pi skill paths do not exist: {missing}")
+        if shutil.which(self.cli) is None:
+            raise RuntimeError(
+                f"{self.cli!r} is not on PATH (npm install -g @earendil-works/pi-coding-agent)"
+            )
+        if "OPENAI_API_KEY" not in os.environ:
+            raise RuntimeError("Pi needs OPENAI_API_KEY")
+        if environment.has_robot and "bash" not in self.tools:
+            raise RuntimeError("Pi reaches the robot through its bash tool, which is not enabled")
+        if environment.has_robot and shutil.which("dimos") is None:
+            raise RuntimeError("Pi reaches the robot through the dimos CLI, which is not on PATH")
+
+    def run(
+        self, inputs: str, env: RunningEnvironment, run_dir: Path, *, timeout_s: float
+    ) -> Trajectory:
+        raw_dir = run_dir / "raw"
+        events = _Events(
+            raw_dir, TrajectoryBuilder(inputs, name=type(self).__name__, model=self.model)
+        )
+        upstream = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
+        with RecordingProxy(raw_dir, upstream) as proxy_url:
+            self._write_agent_dir(run_dir, proxy_url)
+            ended_by = self._drive(self._command(inputs, env, run_dir), run_dir, events, timeout_s)
+        if events.error:
+            raise RuntimeError(f"Pi stopped: {events.error}")
+        return events.trajectory.build(ended_by)
+
+    def _command(self, inputs: str, env: RunningEnvironment, run_dir: Path) -> list[str]:
+        files = dict(env.artifacts)
+        if env.streams:  # the selection, not the whole source the artifact names
+            files["recording"] = recording_file(env.streams, run_dir / "recording.db")
+        parts = [self.system_prompt, self.instructions]
+        parts.append("Files:\n" + "\n".join(f"- {name}: {path}" for name, path in files.items()))
+        if self.builtin_guidance and "recording" in files:
+            parts.append(
+                "The recording is a dimos memory store (sqlite). In Python:\n"
+                "  from dimos.memory.store.sqlite import SqliteStore\n"
+                "  store = SqliteStore(path=PATH, must_exist=True)\n"
+                "store.streams.<name> is a stream, .last().data its latest message; iterating "
+                "a stream yields observations with .ts and .data. Inspect with dir() and help()."
+            )
+        if env.mcp_url:
+            if self.builtin_guidance:
+                parts.append(
+                    "The robot is live. Call one of its tools from bash as\n"
+                    "  dimos mcp call <tool> --json-args '{\"arg\": value}'"
+                )
+            parts.append("Tools:\n" + tool_listing(env.mcp_url))
+        prompt = "\n\n".join(p for p in parts if p)
+        (run_dir / "system-prompt.txt").write_text(prompt)
+        # Absolute before Pi changes to the run dir; --no-skills disables only
+        # ambient discovery, explicit --skill paths still load.
+        skills = [f for p in self.skills for f in ("--skill", str(Path(p).expanduser().resolve()))]
+        return [
+            self.cli, "--mode", "json", "--model", f"dimos/{self.model}",
+            "--thinking", self.thinking, "--session-dir", str(run_dir / "pi-session"),
+            "--tools", ",".join(self.tools),
+            "--no-extensions", "--no-skills", "--no-prompt-templates", "--no-themes",
+            "--no-context-files", "--no-approve", *skills,
+            "--system-prompt", prompt, inputs,
+        ]  # fmt: skip
+
+    def _write_agent_dir(self, run_dir: Path, proxy_url: str) -> None:
+        """A private Pi config dir with one provider, ``dimos``, which is the
+        proxy; ``_command`` names models as ``dimos/<model>``."""
+        agent_dir = run_dir / ".pi-agent"
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        model: dict[str, Any] = {"id": self.model, "reasoning": True}
+        if cost := _registry_cost(self.cli, self.model):
+            model["cost"] = cost
+        provider = {
+            "baseUrl": proxy_url,
+            "api": "openai-responses",
+            "apiKey": "$OPENAI_API_KEY",
+            "models": [model],
+        }
+        (agent_dir / "models.json").write_text(
+            json.dumps({"providers": {"dimos": provider}}, indent=2)
+        )
+
+    def _env(self, run_dir: Path) -> dict[str, str]:
+        keep = self.passthrough_env
+        passed = {k: v for k, v in os.environ.items() if k in keep or k.startswith("DIMOS_")}
+        return {
+            **passed,
+            "PI_CODING_AGENT_DIR": str(run_dir / ".pi-agent"),
+            "PI_SKIP_VERSION_CHECK": "1",
+            "PI_TELEMETRY": "0",
+        }
+
+    def _drive(
+        self, command: list[str], run_dir: Path, events: _Events, timeout_s: float
+    ) -> EndedBy:
+        """Run Pi to completion, or kill it at ``max_steps`` model calls or
+        when *timeout_s* runs out. Pi's events are read on a helper thread so
+        the wait for the next one can carry the deadline. A Pi that exits on
+        its own with a failure status (a rejected flag, say) is an error, not
+        an answer."""
+        deadline = time.monotonic() + timeout_s
+        lines: queue.Queue[str | None] = queue.Queue()
+        stderr_path = run_dir / "pi-stderr.txt"
+        with (
+            stderr_path.open("w") as stderr,
+            subprocess.Popen(
+                command,
+                cwd=run_dir,
+                env=self._env(run_dir),
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=stderr,
+                text=True,
+            ) as proc,  # fmt: skip
+        ):
+            reader = threading.Thread(target=_pump, args=(proc.stdout, lines), daemon=True)
+            reader.start()
+            try:
+                while True:
+                    try:
+                        line = lines.get(timeout=max(0.0, deadline - time.monotonic()))
+                    except queue.Empty:
+                        return "timeout"
+                    if line is None:
+                        break
+                    events.feed(line)
+                    if self._over_budget(events):
+                        return "max_steps"
+            finally:
+                proc.kill()  # a no-op once Pi has exited on its own
+                reader.join()
+        if proc.returncode and not events.error:
+            events.error = f"exit status {proc.returncode}: {stderr_path.read_text().strip()}"
+        return "answer"
+
+    def _over_budget(self, events: _Events) -> bool:
+        """``max_steps`` calls made and the last one still asks for a tool."""
+        return self.max_steps is not None and events.calls >= self.max_steps and events.wants_tool

--- a/dimos/evals/agents/pi.py
+++ b/dimos/evals/agents/pi.py
@@ -73,9 +73,8 @@ def recording_file(streams: Sequence[Stream[Any, Any]], path: Path) -> Path:
     return path
 
 
-def _registry_cost(cli: str, model: str) -> dict[str, Any] | None:
-    """*model*'s pricing from the installed Pi's model registry, so Pi can
-    price its own calls; None when the model is not in the registry."""
+def _registry_model(cli: str, model: str) -> dict[str, Any] | None:
+    """Copy Pi's model capabilities without its provider routing settings."""
     exe = shutil.which(cli)
     for parent in Path(exe).resolve().parents if exe else ():
         data = parent / "node_modules" / "@earendil-works" / "pi-ai" / "dist" / "providers" / "data"
@@ -84,7 +83,11 @@ def _registry_cost(cli: str, model: str) -> dict[str, Any] | None:
                 for models in json.loads(f.read_text()).values():
                     entry = models.get(model) if isinstance(models, dict) else None
                     if isinstance(entry, dict) and entry.get("provider") == "openai":
-                        return dict(entry["cost"]) if entry.get("cost") else None
+                        return {
+                            key: value
+                            for key, value in entry.items()
+                            if key not in ("provider", "api", "baseUrl")
+                        }
     return None
 
 
@@ -240,9 +243,9 @@ class PiAdapter(Agent):
         """Route the dimos/<model> provider through the model trace proxy."""
         agent_dir = run_dir / ".pi-agent"
         agent_dir.mkdir(parents=True, exist_ok=True)
-        model: dict[str, Any] = {"id": self.config.model, "reasoning": True}
-        if cost := _registry_cost(self.config.cli, self.config.model):
-            model["cost"] = cost
+        model = _registry_model(self.config.cli, self.config.model)
+        if model is None:
+            model = {"id": self.config.model, "reasoning": True}
         provider = {
             "baseUrl": proxy_url,
             "api": "openai-responses",

--- a/dimos/evals/agents/pi.py
+++ b/dimos/evals/agents/pi.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from dataclasses import dataclass
 import json
 import os
 from pathlib import Path
@@ -29,12 +28,12 @@ import time
 from typing import TYPE_CHECKING, Any
 
 from dimos.agents.llm_trace import latest_pair
-from dimos.evals.agents.lib.chat import DEFAULT_MODEL
+from dimos.evals.agents.base import Agent, ModelAgentConfig
 from dimos.evals.agents.lib.proxy import RecordingProxy
 from dimos.evals.agents.lib.trajectory_builder import TrajectoryBuilder
+from dimos.evals.environments.base import Environment
 from dimos.evals.types import (
     EndedBy,
-    Environment,
     Metrics,
     RunningEnvironment,
     ToolCall,
@@ -173,67 +172,66 @@ class _Events:
         self.wants_tool = bool(tool_calls)
 
 
-@dataclass
-class Pi:
+class PiAdapterConfig(ModelAgentConfig):
+    """Settings for the headless Pi adapter."""
+
+    # The first section of Pi's system prompt.
+    system_prompt: str = (
+        "Answer the question from the files and tools listed below and nothing else."
+    )
+
+    # Extra guidance appended after system_prompt.
+    instructions: str = ""
+
+    # Explain recording access and robot tools. Disable if a skill teaches these.
+    builtin_guidance: bool = True
+
+    # Pi's native tools to enable. bash is required for a robot.
+    tools: tuple[str, ...] = ("read", "bash", "edit", "write")
+
+    # Reasoning level passed to Pi's --thinking flag.
+    thinking: str = "medium"
+
+    # Stop after this many completed model calls if Pi still requests tools,
+    # preserving recorded steps. None disables this limit; the timeout still applies.
+    max_steps: int | None = 40
+
+    # Pi executable name or path.
+    cli: str = "pi"
+
+    # Skill files or directories loaded with --skill. Relative paths resolve
+    # against the caller's working directory before Pi starts in the case directory.
+    skills: tuple[str, ...] = ()
+
+    # Environment variables Pi inherits in addition to every DIMOS_* variable.
+    passthrough_env: tuple[str, ...] = ("PATH", "HOME", "XDG_STATE_HOME", "OPENAI_API_KEY")
+
+
+class PiAdapter(Agent):
     """The Pi coding agent, headless (``pi --mode json``), with the run dir as
     its working directory. The case's artifacts and the recording are files
     named in the system prompt; a live robot is reached through ``dimos mcp
     call`` from Pi's ``bash`` tool. Model traffic goes through a local
     :class:`RecordingProxy`, so every call is captured whole under ``run_dir/raw``.
-
-    Settings:
-
-    - ``system_prompt``: the first thing Pi reads. Its default just tells Pi
-      to answer from the files and tools it is given.
-    - ``instructions``: any extra text you want in the prompt for this run,
-      added right after ``system_prompt``. Empty by default.
-    - ``builtin_guidance``: when True, the prompt also explains how to open
-      the recording in Python and how to call the robot's tools from bash.
-      Set it to False if a skill file teaches that instead.
-    - ``skills``: paths to skill files or directories that Pi loads with its
-      ``--skill`` flag. Give absolute paths, or they are made absolute here,
-      since Pi runs inside the case directory.
-    - ``tools``: which of Pi's own tools it may use (read, bash, edit, write).
-      ``bash`` is required whenever there is a robot.
-    - ``max_steps``: how many model calls Pi may make. When it hits the limit
-      and still wants to act, it is killed and the steps so far are kept. The
-      case's time budget is enforced the same way.
-    - ``passthrough_env``: environment variables Pi's process inherits, on
-      top of every ``DIMOS_*`` variable.
     """
 
-    model: str = DEFAULT_MODEL
-    system_prompt: str = (
-        "Answer the question from the files and tools listed below and nothing else."
-    )
-    instructions: str = ""
-    builtin_guidance: bool = True
-    tools: Sequence[str] = ("read", "bash", "edit", "write")
-    thinking: str = "medium"
-    max_steps: int | None = 40
-    cli: str = "pi"
-    modules: str = ""
-    skills: Sequence[str] = ()
-    passthrough_env: Sequence[str] = ("PATH", "HOME", "XDG_STATE_HOME", "OPENAI_API_KEY")
+    config: PiAdapterConfig
 
     def available_tools(self, environment_tools: tuple[str, ...]) -> tuple[str, ...]:
         """Pi's native tools plus robot tools exposed through its bash tool."""
-        return (*self.tools, *environment_tools)
+        return (*self.config.tools, *environment_tools)
 
     def preflight(self, environment: Environment) -> None:
-        for name in ("skills", "tools", "passthrough_env"):
-            if isinstance(getattr(self, name), str):
-                raise RuntimeError(f"Pi.{name} is a string; pass a list (--set {name}='[...]')")
-        missing = [p for p in self.skills if not Path(p).expanduser().resolve().exists()]
+        missing = [p for p in self.config.skills if not Path(p).expanduser().resolve().exists()]
         if missing:
             raise RuntimeError(f"Pi skill paths do not exist: {missing}")
-        if shutil.which(self.cli) is None:
+        if shutil.which(self.config.cli) is None:
             raise RuntimeError(
-                f"{self.cli!r} is not on PATH (npm install -g @earendil-works/pi-coding-agent)"
+                f"{self.config.cli!r} is not on PATH (npm install -g @earendil-works/pi-coding-agent)"
             )
         if "OPENAI_API_KEY" not in os.environ:
             raise RuntimeError("Pi needs OPENAI_API_KEY")
-        if environment.has_robot and "bash" not in self.tools:
+        if environment.has_robot and "bash" not in self.config.tools:
             raise RuntimeError("Pi reaches the robot through its bash tool, which is not enabled")
         if environment.has_robot and shutil.which("dimos") is None:
             raise RuntimeError("Pi reaches the robot through the dimos CLI, which is not on PATH")
@@ -243,7 +241,7 @@ class Pi:
     ) -> Trajectory:
         raw_dir = run_dir / "raw"
         events = _Events(
-            raw_dir, TrajectoryBuilder(inputs, name=type(self).__name__, model=self.model)
+            raw_dir, TrajectoryBuilder(inputs, name=type(self).__name__, model=self.config.model)
         )
         upstream = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
         with RecordingProxy(raw_dir, upstream) as proxy_url:
@@ -257,9 +255,9 @@ class Pi:
         files = dict(env.artifacts)
         if env.streams:  # the selection, not the whole source the artifact names
             files["recording"] = recording_file(env.streams, run_dir / "recording.db")
-        parts = [self.system_prompt, self.instructions]
+        parts = [self.config.system_prompt, self.config.instructions]
         parts.append("Files:\n" + "\n".join(f"- {name}: {path}" for name, path in files.items()))
-        if self.builtin_guidance and "recording" in files:
+        if self.config.builtin_guidance and "recording" in files:
             parts.append(
                 "The recording is a dimos memory store (sqlite). In Python:\n"
                 "  from dimos.memory.store.sqlite import SqliteStore\n"
@@ -268,7 +266,7 @@ class Pi:
                 "a stream yields observations with .ts and .data. Inspect with dir() and help()."
             )
         if env.mcp_url:
-            if self.builtin_guidance:
+            if self.config.builtin_guidance:
                 parts.append(
                     "The robot is live. Call one of its tools from bash as\n"
                     "  dimos mcp call <tool> --json-args '{\"arg\": value}'"
@@ -278,11 +276,13 @@ class Pi:
         (run_dir / "system-prompt.txt").write_text(prompt)
         # Absolute before Pi changes to the run dir; --no-skills disables only
         # ambient discovery, explicit --skill paths still load.
-        skills = [f for p in self.skills for f in ("--skill", str(Path(p).expanduser().resolve()))]
+        skills = [
+            f for p in self.config.skills for f in ("--skill", str(Path(p).expanduser().resolve()))
+        ]
         return [
-            self.cli, "--mode", "json", "--model", f"dimos/{self.model}",
-            "--thinking", self.thinking, "--session-dir", str(run_dir / "pi-session"),
-            "--tools", ",".join(self.tools),
+            self.config.cli, "--mode", "json", "--model", f"dimos/{self.config.model}",
+            "--thinking", self.config.thinking, "--session-dir", str(run_dir / "pi-session"),
+            "--tools", ",".join(self.config.tools),
             "--no-extensions", "--no-skills", "--no-prompt-templates", "--no-themes",
             "--no-context-files", "--no-approve", *skills,
             "--system-prompt", prompt, inputs,
@@ -293,8 +293,8 @@ class Pi:
         proxy; ``_command`` names models as ``dimos/<model>``."""
         agent_dir = run_dir / ".pi-agent"
         agent_dir.mkdir(parents=True, exist_ok=True)
-        model: dict[str, Any] = {"id": self.model, "reasoning": True}
-        if cost := _registry_cost(self.cli, self.model):
+        model: dict[str, Any] = {"id": self.config.model, "reasoning": True}
+        if cost := _registry_cost(self.config.cli, self.config.model):
             model["cost"] = cost
         provider = {
             "baseUrl": proxy_url,
@@ -307,7 +307,7 @@ class Pi:
         )
 
     def _env(self, run_dir: Path) -> dict[str, str]:
-        keep = self.passthrough_env
+        keep = self.config.passthrough_env
         passed = {k: v for k, v in os.environ.items() if k in keep or k.startswith("DIMOS_")}
         return {
             **passed,
@@ -361,4 +361,8 @@ class Pi:
 
     def _over_budget(self, events: _Events) -> bool:
         """``max_steps`` calls made and the last one still asks for a tool."""
-        return self.max_steps is not None and events.calls >= self.max_steps and events.wants_tool
+        return (
+            self.config.max_steps is not None
+            and events.calls >= self.config.max_steps
+            and events.wants_tool
+        )

--- a/dimos/evals/agents/pi.py
+++ b/dimos/evals/agents/pi.py
@@ -16,27 +16,29 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Generator, Sequence
+from contextlib import closing
+import io
 import json
 import os
 from pathlib import Path
-import queue
+import selectors
 import shutil
 import subprocess
-import threading
 import time
-from typing import TYPE_CHECKING, Any
+from typing import IO, TYPE_CHECKING, Any
 
-from dimos.agents.llm_trace import latest_pair
+from pydantic import Field
+
+from dimos.core.coordination.process_lifecycle import kill_run_processes
 from dimos.evals.agents.base import Agent, ModelAgentConfig
-from dimos.evals.agents.lib.proxy import RecordingProxy
+from dimos.evals.agents.lib.model_trace_proxy import model_trace_proxy
+from dimos.evals.agents.lib.pi_to_atif import PiToAtif
 from dimos.evals.agents.lib.trajectory_builder import TrajectoryBuilder
 from dimos.evals.environments.base import Environment
 from dimos.evals.types import (
     EndedBy,
-    Metrics,
     RunningEnvironment,
-    ToolCall,
     Trajectory,
 )
 
@@ -44,20 +46,16 @@ if TYPE_CHECKING:
     from dimos.memory.stream import Stream
 
 
-def render_tools(tools: list[dict[str, Any]]) -> str:
-    """One line per MCP tool: name, argument names, first line of the description."""
+def tool_listing(mcp_url: str) -> str:
+    """List each MCP tool's name, arguments, and first description line for Pi."""
+    from dimos.agents.mcp.mcp_adapter import McpAdapter
+
     lines = []
-    for t in tools:
+    for t in McpAdapter(mcp_url).list_tools():
         args = ", ".join((t.get("inputSchema") or {}).get("properties") or {})
         summary = str(t.get("description") or "").strip().partition("\n")[0]
         lines.append(f"- {t['name']}({args}): {summary}")
     return "\n".join(lines)
-
-
-def tool_listing(mcp_url: str) -> str:
-    from dimos.agents.mcp.mcp_adapter import McpAdapter
-
-    return render_tools(McpAdapter(mcp_url).list_tools())
 
 
 def recording_file(streams: Sequence[Stream[Any, Any]], path: Path) -> Path:
@@ -65,16 +63,13 @@ def recording_file(streams: Sequence[Stream[Any, Any]], path: Path) -> Path:
     so a subprocess can open what the case selected and nothing more."""
     from dimos.memory.store.sqlite import SqliteStore
 
-    store = SqliteStore(path=str(path))
-    try:
+    with SqliteStore(path=str(path)) as store:
         for stream in streams:
             if stream.name is None:
                 raise ValueError("a stream must be bound to a store to be written out")
             target: Stream[Any, Any] = store.stream(stream.name, stream.data_type)
             for obs in stream:
                 target.append(obs.data, ts=obs.ts, pose=obs.pose_tuple, tags=obs.tags)
-    finally:
-        store.stop()
     return path
 
 
@@ -93,83 +88,26 @@ def _registry_cost(cli: str, model: str) -> dict[str, Any] | None:
     return None
 
 
-def _result_text(result: Any) -> str:
-    content = result.get("content") if isinstance(result, dict) else None
-    if isinstance(content, list):
-        return "\n".join(str(c.get("text", "")) for c in content if c.get("type") == "text")
-    return str(result)
-
-
-def _pump(stream: Any, into: queue.Queue[str | None]) -> None:
-    """Every line of *stream* onto the queue, then None at EOF."""
-    for line in stream:
-        into.put(line)
-    into.put(None)
-
-
-class _Events:
-    """Pi's ``--mode json`` stream folded into a trajectory: one step per
-    assistant ``message_end``, each paired with the request/response the proxy
-    recorded for it; each tool result is attached to the call that produced it."""
-
-    def __init__(self, raw_dir: Path, trajectory: TrajectoryBuilder) -> None:
-        self.raw_dir = raw_dir
-        self.trajectory = trajectory
-        self.calls = 0  # model calls seen
-        self.wants_tool = False  # the latest one asked for a tool
-        self.error = ""
-        self._next_seq = 0
-
-    def feed(self, line: str) -> None:
-        event = json.loads(line)
-        if event.get("type") == "tool_execution_end" and self.calls:
-            self.trajectory.observe(str(event["toolCallId"]), _result_text(event.get("result")))
-        elif event.get("type") == "message_end" and event["message"].get("role") == "assistant":
-            self._step(event["message"])
-
-    def _step(self, message: dict[str, Any]) -> None:
-        pair = latest_pair(self.raw_dir, self._next_seq)
-        if pair is None:
-            raise RuntimeError(
-                f"Pi made a model call that left no trace under {self.raw_dir}; "
-                "every call must go through the recording proxy"
-            )
-        self._next_seq = pair[0] + 1
-        usage = message.get("usage") or {}
-        content = message.get("content") or []
-        if message.get("stopReason") in ("error", "aborted"):
-            self.error = str(message.get("errorMessage") or message["stopReason"])
-        tool_calls = tuple(
-            ToolCall(
-                tool_call_id=str(c["id"]),
-                function_name=str(c["name"]),
-                arguments=dict(c.get("arguments") or {}),
-            )
-            for c in content
-            if c.get("type") == "toolCall"
-        )
-        # Pi's ``input`` excludes cache traffic: what was sent is the three together.
-        cached = int(usage.get("cacheRead", 0))
-        self.trajectory.step(
-            message="".join(str(c.get("text", "")) for c in content if c.get("type") == "text"),
-            reasoning="\n\n".join(
-                str(c.get("thinking", "")) for c in content if c.get("type") == "thinking"
-            ),
-            tool_calls=tool_calls,
-            metrics=Metrics(
-                prompt_tokens=int(usage.get("input", 0)) + int(usage.get("cacheWrite", 0)) + cached,
-                completion_tokens=int(usage.get("output", 0)),
-                cached_tokens=cached,
-                cost_usd=float((usage.get("cost") or {}).get("total") or 0.0),
-            ),
-            model_name=str(message.get("responseModel") or message.get("model") or ""),
-            latency_s=float(json.loads(pair[2].read_text()).get("latency_s") or 0.0),
-            reasoning_tokens=int(usage.get("reasoning", 0)),
-            request=pair[1],
-            response=pair[2],
-        )
-        self.calls += 1
-        self.wants_tool = bool(tool_calls)
+def read_pi_events(stream: IO[bytes], deadline: float) -> Generator[dict[str, Any], None, None]:
+    """Read Pi's JSON events until EOF, raising TimeoutError at the deadline."""
+    pending = b""
+    with selectors.DefaultSelector() as selector:
+        selector.register(stream, selectors.EVENT_READ)
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0 or not selector.select(timeout=remaining):
+                raise TimeoutError
+            chunk = os.read(stream.fileno(), io.DEFAULT_BUFFER_SIZE)
+            if not chunk:
+                if pending:
+                    yield json.loads(pending)
+                return
+            # Keep partial lines as bytes so split UTF-8 characters remain intact.
+            *lines, pending = (pending + chunk).split(b"\n")
+            for line in lines:
+                if time.monotonic() >= deadline:
+                    raise TimeoutError
+                yield json.loads(line)
 
 
 class PiAdapterConfig(ModelAgentConfig):
@@ -196,6 +134,9 @@ class PiAdapterConfig(ModelAgentConfig):
     # preserving recorded steps. None disables this limit; the timeout still applies.
     max_steps: int | None = 40
 
+    # Grace period for Pi, then remaining tools, before forceful termination.
+    shutdown_timeout_s: float = Field(default=2.0, ge=0.0, allow_inf_nan=False)
+
     # Pi executable name or path.
     cli: str = "pi"
 
@@ -208,12 +149,7 @@ class PiAdapterConfig(ModelAgentConfig):
 
 
 class PiAdapter(Agent):
-    """The Pi coding agent, headless (``pi --mode json``), with the run dir as
-    its working directory. The case's artifacts and the recording are files
-    named in the system prompt; a live robot is reached through ``dimos mcp
-    call`` from Pi's ``bash`` tool. Model traffic goes through a local
-    :class:`RecordingProxy`, so every call is captured whole under ``run_dir/raw``.
-    """
+    """Run headless Pi against case files and robot tools, recording an ATIF trajectory."""
 
     config: PiAdapterConfig
 
@@ -240,21 +176,23 @@ class PiAdapter(Agent):
         self, inputs: str, env: RunningEnvironment, run_dir: Path, *, timeout_s: float
     ) -> Trajectory:
         raw_dir = run_dir / "raw"
-        events = _Events(
+        events = PiToAtif(
             raw_dir, TrajectoryBuilder(inputs, name=type(self).__name__, model=self.config.model)
         )
         upstream = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
-        with RecordingProxy(raw_dir, upstream) as proxy_url:
-            self._write_agent_dir(run_dir, proxy_url)
-            ended_by = self._drive(self._command(inputs, env, run_dir), run_dir, events, timeout_s)
+        with model_trace_proxy(raw_dir, upstream) as proxy_url:
+            self._write_model_config(run_dir, proxy_url)
+            files = dict(env.artifacts)
+            if env.streams:
+                files["recording"] = recording_file(env.streams, run_dir / "recording.db")
+            system_prompt = self._write_system_prompt(files, env.mcp_url, run_dir)
+            command = self._build_pi_command(inputs, system_prompt, run_dir)
+            ended_by = self._run_pi_process(command, run_dir, events, timeout_s)
         if events.error:
             raise RuntimeError(f"Pi stopped: {events.error}")
         return events.trajectory.build(ended_by)
 
-    def _command(self, inputs: str, env: RunningEnvironment, run_dir: Path) -> list[str]:
-        files = dict(env.artifacts)
-        if env.streams:  # the selection, not the whole source the artifact names
-            files["recording"] = recording_file(env.streams, run_dir / "recording.db")
+    def _write_system_prompt(self, files: dict[str, Path], mcp_url: str, run_dir: Path) -> str:
         parts = [self.config.system_prompt, self.config.instructions]
         parts.append("Files:\n" + "\n".join(f"- {name}: {path}" for name, path in files.items()))
         if self.config.builtin_guidance and "recording" in files:
@@ -265,15 +203,18 @@ class PiAdapter(Agent):
                 "store.streams.<name> is a stream, .last().data its latest message; iterating "
                 "a stream yields observations with .ts and .data. Inspect with dir() and help()."
             )
-        if env.mcp_url:
+        if mcp_url:
             if self.config.builtin_guidance:
                 parts.append(
                     "The robot is live. Call one of its tools from bash as\n"
                     "  dimos mcp call <tool> --json-args '{\"arg\": value}'"
                 )
-            parts.append("Tools:\n" + tool_listing(env.mcp_url))
+            parts.append("Tools:\n" + tool_listing(mcp_url))
         prompt = "\n\n".join(p for p in parts if p)
         (run_dir / "system-prompt.txt").write_text(prompt)
+        return prompt
+
+    def _build_pi_command(self, inputs: str, system_prompt: str, run_dir: Path) -> list[str]:
         # Absolute before Pi changes to the run dir; --no-skills disables only
         # ambient discovery, explicit --skill paths still load.
         skills = [
@@ -285,12 +226,11 @@ class PiAdapter(Agent):
             "--tools", ",".join(self.config.tools),
             "--no-extensions", "--no-skills", "--no-prompt-templates", "--no-themes",
             "--no-context-files", "--no-approve", *skills,
-            "--system-prompt", prompt, inputs,
+            "--system-prompt", system_prompt, inputs,
         ]  # fmt: skip
 
-    def _write_agent_dir(self, run_dir: Path, proxy_url: str) -> None:
-        """A private Pi config dir with one provider, ``dimos``, which is the
-        proxy; ``_command`` names models as ``dimos/<model>``."""
+    def _write_model_config(self, run_dir: Path, proxy_url: str) -> None:
+        """Route the dimos/<model> provider through the model trace proxy."""
         agent_dir = run_dir / ".pi-agent"
         agent_dir.mkdir(parents=True, exist_ok=True)
         model: dict[str, Any] = {"id": self.config.model, "reasoning": True}
@@ -306,7 +246,7 @@ class PiAdapter(Agent):
             json.dumps({"providers": {"dimos": provider}}, indent=2)
         )
 
-    def _env(self, run_dir: Path) -> dict[str, str]:
+    def _build_process_env(self, run_dir: Path) -> dict[str, str]:
         keep = self.config.passthrough_env
         passed = {k: v for k, v in os.environ.items() if k in keep or k.startswith("DIMOS_")}
         return {
@@ -316,53 +256,57 @@ class PiAdapter(Agent):
             "PI_TELEMETRY": "0",
         }
 
-    def _drive(
-        self, command: list[str], run_dir: Path, events: _Events, timeout_s: float
+    def _run_pi_process(
+        self, command: list[str], run_dir: Path, events: PiToAtif, timeout_s: float
     ) -> EndedBy:
-        """Run Pi to completion, or kill it at ``max_steps`` model calls or
-        when *timeout_s* runs out. Pi's events are read on a helper thread so
-        the wait for the next one can carry the deadline. A Pi that exits on
-        its own with a failure status (a rejected flag, say) is an error, not
-        an answer."""
+        """Run Pi, consume its events, and stop its tools when the run ends."""
         deadline = time.monotonic() + timeout_s
-        lines: queue.Queue[str | None] = queue.Queue()
+        max_steps = self.config.max_steps
         stderr_path = run_dir / "pi-stderr.txt"
+        process_env = self._build_process_env(run_dir)
         with (
             stderr_path.open("w") as stderr,
             subprocess.Popen(
                 command,
                 cwd=run_dir,
-                env=self._env(run_dir),
+                env=process_env,
                 stdin=subprocess.DEVNULL,
                 stdout=subprocess.PIPE,
                 stderr=stderr,
-                text=True,
+                start_new_session=True,
             ) as proc,  # fmt: skip
         ):
-            reader = threading.Thread(target=_pump, args=(proc.stdout, lines), daemon=True)
-            reader.start()
+            assert proc.stdout is not None
             try:
-                while True:
-                    try:
-                        line = lines.get(timeout=max(0.0, deadline - time.monotonic()))
-                    except queue.Empty:
-                        return "timeout"
-                    if line is None:
-                        break
-                    events.feed(line)
-                    if self._over_budget(events):
-                        return "max_steps"
+                with closing(read_pi_events(proc.stdout, deadline)) as event_stream:
+                    for event in event_stream:
+                        events.append_event(event)
+                        if (
+                            max_steps is not None
+                            and events.calls >= max_steps
+                            and events.wants_tool
+                        ):
+                            return "max_steps"
+                # EOF can precede process exit. Preserve Pi's own exit status.
+                proc.wait(timeout=max(0.0, deadline - time.monotonic()))
+            except (TimeoutError, subprocess.TimeoutExpired):
+                return "timeout"
             finally:
-                proc.kill()  # a no-op once Pi has exited on its own
-                reader.join()
+                # Pi handles SIGTERM by stopping its active bash process groups.
+                proc.terminate()  # a no-op once Pi has exited on its own
+                try:
+                    proc.wait(timeout=self.config.shutdown_timeout_s)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait()
+                # Background tools may already be orphaned or in separate sessions.
+                # Their inherited Pi directory identifies this run after Pi exits.
+                kill_run_processes(
+                    process_env["PI_CODING_AGENT_DIR"],
+                    env_var="PI_CODING_AGENT_DIR",
+                    exclude_pids=(proc.pid,),
+                    term_timeout=self.config.shutdown_timeout_s,
+                )
         if proc.returncode and not events.error:
             events.error = f"exit status {proc.returncode}: {stderr_path.read_text().strip()}"
         return "answer"
-
-    def _over_budget(self, events: _Events) -> bool:
-        """``max_steps`` calls made and the last one still asks for a tool."""
-        return (
-            self.config.max_steps is not None
-            and events.calls >= self.config.max_steps
-            and events.wants_tool
-        )

--- a/dimos/evals/agents/pi.py
+++ b/dimos/evals/agents/pi.py
@@ -130,9 +130,9 @@ class PiAdapterConfig(ModelAgentConfig):
     # Reasoning level passed to Pi's --thinking flag.
     thinking: str = "medium"
 
-    # Stop after this many completed model calls if Pi still requests tools,
-    # preserving recorded steps. None disables this limit; the timeout still applies.
-    max_steps: int | None = 40
+    # Maximum model HTTP requests, including retries. Zero skips Pi entirely;
+    # None disables this limit. Completed steps are preserved when stopping.
+    max_steps: int | None = Field(default=40, ge=0)
 
     # Grace period for Pi, then remaining tools, before forceful termination.
     shutdown_timeout_s: float = Field(default=2.0, ge=0.0, allow_inf_nan=False)
@@ -179,8 +179,13 @@ class PiAdapter(Agent):
         events = PiToAtif(
             raw_dir, TrajectoryBuilder(inputs, name=type(self).__name__, model=self.config.model)
         )
+        if self.config.max_steps == 0:
+            return events.trajectory.build("max_steps")
         upstream = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
-        with model_trace_proxy(raw_dir, upstream) as proxy_url:
+        limit_reached = run_dir / "pi-request-limit-reached"
+        with model_trace_proxy(
+            raw_dir, upstream, max_requests=self.config.max_steps, limit_reached=limit_reached
+        ) as proxy_url:
             self._write_model_config(run_dir, proxy_url)
             files = dict(env.artifacts)
             if env.streams:
@@ -188,6 +193,8 @@ class PiAdapter(Agent):
             system_prompt = self._write_system_prompt(files, env.mcp_url, run_dir)
             command = self._build_pi_command(inputs, system_prompt, run_dir)
             ended_by = self._run_pi_process(command, run_dir, events, timeout_s)
+        if limit_reached.exists():
+            return events.trajectory.build("max_steps")
         if events.error:
             raise RuntimeError(f"Pi stopped: {events.error}")
         return events.trajectory.build(ended_by)

--- a/dimos/evals/agents/test_pi.py
+++ b/dimos/evals/agents/test_pi.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 from dimos.evals.agents.pi import PiAdapter, recording_file
 from dimos.evals.cli import load_agent
+from dimos.evals.types import RunningEnvironment
 from dimos.memory.store.sqlite import SqliteStore
 
 
@@ -31,6 +32,17 @@ def test_cli_overrides_reach_pi_adapter() -> None:
     assert agent.config.model == "eval-model"
     assert agent.config.max_steps == 3
     assert agent.config.modules == ("rangefinder-skill",)
+
+
+def test_zero_budget_returns_without_starting_pi(tmp_path: Path) -> None:
+    agent = PiAdapter(max_steps=0, cli=str(tmp_path / "pi-not-installed"))
+    environment = RunningEnvironment(mcp_url="", streams=(), artifacts={})
+
+    trajectory = agent.run("Answer the question.", environment, tmp_path, timeout_s=10)
+
+    assert trajectory.extra.ended_by == "max_steps"
+    assert [step.source for step in trajectory.steps] == ["user"]
+    assert list(tmp_path.iterdir()) == []
 
 
 def test_recording_export_contains_only_selected_data(dataset: str, tmp_path: Path) -> None:

--- a/dimos/evals/agents/test_pi.py
+++ b/dimos/evals/agents/test_pi.py
@@ -1,0 +1,48 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Check Pi's CLI configuration and recording export without launching an agent."""
+
+from pathlib import Path
+
+from dimos.evals.agents.pi import PiAdapter, recording_file
+from dimos.evals.cli import load_agent
+from dimos.memory.store.sqlite import SqliteStore
+
+
+def test_cli_overrides_reach_pi_adapter() -> None:
+    agent = load_agent(
+        "dimos.evals.agents.pi",
+        ["model=eval-model", "max_steps=3", 'modules=["rangefinder-skill"]'],
+    )
+
+    assert isinstance(agent, PiAdapter)
+    assert agent.config.model == "eval-model"
+    assert agent.config.max_steps == 3
+    assert agent.config.modules == ("rangefinder-skill",)
+
+
+def test_recording_export_contains_only_selected_data(dataset: str, tmp_path: Path) -> None:
+    """Pi must receive the case's selected observations, not the full recording."""
+    exported = tmp_path / "selected.db"
+    with SqliteStore(path=dataset, must_exist=True) as source:
+        source.stream("excluded", str).append("not selected", ts=1000.0)
+        recording_file((source.streams.odom.limit(2),), exported)
+
+    with SqliteStore(path=str(exported), must_exist=True) as copy:
+        assert copy.list_streams() == ["odom"]
+        assert [(obs.ts, obs.data.position.x) for obs in copy.streams.odom] == [
+            (1000.0, 0.0),
+            (1001.0, 1.0),
+        ]

--- a/dimos/evals/agents/test_pi.py
+++ b/dimos/evals/agents/test_pi.py
@@ -12,13 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Check Pi's CLI configuration and recording export without launching an agent."""
+"""Exercise Pi's configuration, event handling and shutdown without an external agent."""
 
+from contextlib import nullcontext
+import json
+import os
 from pathlib import Path
+import subprocess
 
+import pytest
+
+from dimos.agents.llm_trace import request_path, response_path
+from dimos.evals.agents import pi
 from dimos.evals.agents.pi import PiAdapter, recording_file
 from dimos.evals.cli import load_agent
-from dimos.evals.types import RunningEnvironment
+from dimos.evals.types import (
+    FinalMetrics,
+    Observation,
+    ObservationResult,
+    RunningEnvironment,
+    StepExtra,
+    ToolCall,
+)
 from dimos.memory.store.sqlite import SqliteStore
 
 
@@ -58,3 +73,170 @@ def test_recording_export_contains_only_selected_data(dataset: str, tmp_path: Pa
             (1000.0, 0.0),
             (1001.0, 1.0),
         ]
+
+
+@pytest.fixture
+def pi_process(mocker):
+    """Replace external processes; retain real pipe reads and event conversion."""
+    mocker.patch.object(pi, "model_trace_proxy", return_value=nullcontext("http://provider.test"))
+    spawn = mocker.patch.object(pi.subprocess, "Popen")
+    process = spawn.return_value.__enter__.return_value
+    process.returncode = 0
+    sweep = mocker.patch.object(pi, "kill_run_processes")
+    read_fd, write_fd = os.pipe()
+    with os.fdopen(read_fd, "rb") as incoming, os.fdopen(write_fd, "wb") as outgoing:
+        process.stdout = incoming
+        yield process, outgoing, sweep
+
+
+def test_run_preserves_retried_tool_exchange_and_matching_traces(pi_process, tmp_path):
+    process, outgoing, _ = pi_process
+    raw = tmp_path / "raw"
+    raw.mkdir()
+    # All responses predate stdout consumption, including an incomplete retry.
+    for seq, body in enumerate(
+        [
+            "{",
+            '{"body": {"error": "retry"}}',
+            json.dumps({"body": 'event: response.created\ndata: {"response":{"id":"tool"}}\n'}),
+            json.dumps({"body": {"id": "answer"}, "latency_s": 0.5}),
+        ]
+    ):
+        request_path(raw, seq).write_text("{}")
+        response_path(raw, seq).write_text(body)
+    messages = [
+        {"role": "assistant", "stopReason": "error", "errorMessage": "retry"},
+        {
+            "role": "assistant",
+            "responseId": "tool",
+            "responseModel": "actual-model",
+            "content": [
+                {"type": "thinking", "thinking": "inspect"},
+                {
+                    "type": "toolCall",
+                    "id": "call-1",
+                    "name": "read",
+                    "arguments": {"path": "facts.txt"},
+                },
+            ],
+            "usage": {
+                "input": 2,
+                "cacheWrite": 3,
+                "cacheRead": 5,
+                "output": 7,
+                "reasoning": 4,
+                "cost": {"total": 0.25},
+            },
+        },
+        {
+            "role": "assistant",
+            "responseId": "answer",
+            "content": [{"type": "text", "text": "42"}],
+            "usage": {"input": 1, "output": 2, "cost": {"total": 0.5}},
+        },
+    ]
+    events = [{"type": "message_end", "message": message} for message in messages]
+    events.insert(
+        2,
+        {
+            "type": "tool_execution_end",
+            "toolCallId": "call-1",
+            "result": {
+                "content": [
+                    {"type": "text", "text": "first"},
+                    {"type": "image"},
+                    {"type": "text", "text": "second"},
+                ]
+            },
+        },
+    )
+    # The final line deliberately lacks a newline: EOF must not discard it.
+    outgoing.write("\n".join(json.dumps(event) for event in events).encode())
+    outgoing.close()
+    agent = PiAdapter(cli=str(tmp_path / "pi"), max_steps=None)
+
+    result = agent.run(
+        "Question", RunningEnvironment(mcp_url="", streams=(), artifacts={}), tmp_path, timeout_s=10
+    )
+
+    assert result.extra.ended_by == "answer"
+    assert result.final_answer == "42"
+    assert result.final_metrics == FinalMetrics(
+        total_prompt_tokens=11,
+        total_completion_tokens=9,
+        total_cached_tokens=5,
+        total_cost_usd=0.75,
+        total_steps=3,
+    )
+    _, tool, answer = result.steps
+    assert tool.extra == StepExtra(
+        request=request_path(raw, 2), response=response_path(raw, 2), reasoning_tokens=4
+    )
+    assert answer.extra == StepExtra(
+        request=request_path(raw, 3), response=response_path(raw, 3), latency_s=0.5
+    )
+    assert tool.model_name == "actual-model"
+    assert tool.reasoning_content == "inspect"
+    assert tool.tool_calls == (
+        ToolCall(tool_call_id="call-1", function_name="read", arguments={"path": "facts.txt"}),
+    )
+    assert tool.observation == Observation(
+        results=(ObservationResult(source_call_id="call-1", content="first\nsecond"),)
+    )
+    process.terminate.assert_called_once()
+
+
+@pytest.mark.parametrize("stop", ["timeout", "exit_error", "budget"])
+def test_run_reports_stop_reason_and_cleans_up_pi(stop, pi_process, tmp_path):
+    process, outgoing, sweep = pi_process
+    process.returncode = 17
+    outgoing.close()
+    # The normal wait (after EOF) may time out; shutdown must still escalate.
+    expired = subprocess.TimeoutExpired("pi", 0)
+    process.wait.side_effect = [expired, expired, 17] if stop == "timeout" else [17, 17]
+    if stop == "budget":
+        (tmp_path / "pi-request-limit-reached").touch()
+    agent = PiAdapter(cli=str(tmp_path / "pi"), shutdown_timeout_s=0)
+    environment = RunningEnvironment(mcp_url="", streams=(), artifacts={})
+    expectation = (
+        pytest.raises(RuntimeError, match="exit status 17")
+        if stop == "exit_error"
+        else nullcontext()
+    )
+
+    with expectation:
+        result = agent.run("Question", environment, tmp_path, timeout_s=10)
+        assert result.extra.ended_by == ("max_steps" if stop == "budget" else "timeout")
+    process.terminate.assert_called_once()
+    assert process.kill.call_count == int(stop == "timeout")
+    sweep.assert_called_once_with(
+        str(tmp_path / ".pi-agent"),
+        env_var="PI_CODING_AGENT_DIR",
+        exclude_pids=(process.pid,),
+        term_timeout=0,
+    )
+
+
+def test_model_proxy_routing_preserves_registry_capabilities(tmp_path, mocker):
+    data = tmp_path / "node_modules/@earendil-works/pi-ai/dist/providers/data"
+    data.mkdir(parents=True)
+    model = {
+        "id": "eval-model",
+        "input": ["text", "image"],
+        "reasoning": False,
+        "contextWindow": 128000,
+        "maxTokens": 4096,
+    }
+    registered = {**model, "provider": "openai", "api": "original-api", "baseUrl": "original-url"}
+    (data / "openai.json").write_text(json.dumps({"openai": {"eval-model": registered}}))
+    mocker.patch.object(pi.shutil, "which", return_value=str(tmp_path / "bin/pi"))
+
+    PiAdapter(model="eval-model")._write_model_config(tmp_path, "http://provider.test")
+
+    provider = json.loads((tmp_path / ".pi-agent/models.json").read_text())["providers"]["dimos"]
+    assert provider == {
+        "models": [model],
+        "baseUrl": "http://provider.test",
+        "api": "openai-responses",
+        "apiKey": "$OPENAI_API_KEY",
+    }

--- a/dimos/evals/conftest.py
+++ b/dimos/evals/conftest.py
@@ -1,0 +1,38 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+import pytest
+
+from dimos.memory.store.sqlite import SqliteStore
+from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
+from dimos.msgs.geometry_msgs.Quaternion import Quaternion
+from dimos.msgs.geometry_msgs.Vector3 import make_vector3
+
+
+@pytest.fixture
+def dataset(tmp_path: Path) -> str:
+    """A tiny on-disk memory dataset: 5 odom poses walking 4m in +x over 4s."""
+    path = tmp_path / "tiny.db"
+    with SqliteStore(path=str(path)) as store:
+        stream = store.stream("odom", PoseStamped)
+        for i in range(5):
+            pose = PoseStamped(
+                position=make_vector3(float(i), 0.0, 0.0),
+                orientation=Quaternion(0.0, 0.0, 0.0, 1.0),
+                frame_id="world",
+            )
+            stream.append(pose, ts=1000.0 + i)
+    return str(path)

--- a/dimos/evals/environments/sim.py
+++ b/dimos/evals/environments/sim.py
@@ -39,6 +39,8 @@ if TYPE_CHECKING:
 
 class SimConfig(BaseConfig):
     blueprint: list[str]
+    # Module registry names to disable in the composed blueprint.
+    disable: tuple[str, ...] = ()
     simulator: str = "dimsim"
     scene: str = "apartment"
     setup: Callable[[DimSimClient], None] | None = None
@@ -75,7 +77,7 @@ class Sim(Environment):
             if not McpAdapter(mcp_url).wait_for_ready(timeout=2.0):
                 raise RuntimeError(f"attach needs a running dimos at {mcp_url}")
             return
-        validate_blueprints((*self.config.blueprint, *agent.config.modules))
+        validate_blueprints((*self.config.blueprint, *agent.config.modules, *self.config.disable))
 
     def start(self, modules: Sequence[str]) -> RunningEnvironment:
         # SQLite memory codecs are only needed for a running simulator.
@@ -87,7 +89,8 @@ class Sim(Environment):
             proc = DimosCliCall()
             proc.simulator = self.config.simulator
             proc.global_args = ["--dimsim-scene", self.config.scene, "--record"]
-            proc.demo_args = ["run", *self.config.blueprint, *modules]
+            disabled = [arg for name in self.config.disable for arg in ("--disable", name)]
+            proc.demo_args = ["run", *self.config.blueprint, *modules, *disabled]
             self._resources.callback(proc.stop)
             proc.start()
             assert proc.process is not None

--- a/dimos/evals/module.py
+++ b/dimos/evals/module.py
@@ -41,13 +41,13 @@ def list_suites() -> list[str]:
 
 
 def list_agents() -> list[str]:
-    """Dotted module paths of the agents under dimos.evals.agents."""
+    """Agent module paths, excluding tests and shared helpers."""
     from dimos.evals import agents
 
     return [
-        name
-        for _, name, ispkg in pkgutil.iter_modules(agents.__path__, prefix=f"{agents.__name__}.")
-        if not ispkg and not name.endswith(".base")
+        f"{agents.__name__}.{name}"
+        for _, name, ispkg in pkgutil.iter_modules(agents.__path__)
+        if not ispkg and name not in {"base", "conftest"} and not name.startswith(("_", "test_"))
     ]
 
 

--- a/dimos/evals/suites/dimsim_pointcloud_mapping.py
+++ b/dimos/evals/suites/dimsim_pointcloud_mapping.py
@@ -1,0 +1,95 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Map a live DimSim apartment and count its rooms.
+
+    uv run dimos evals run dimos.evals.suites.dimsim_pointcloud_mapping \
+        --agent <agent module>
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import math
+
+from dimos.evals.environments.sim import Sim
+from dimos.evals.scorers import exact, first_number
+from dimos.evals.types import EvalCase, Outcome, Suite, recording
+
+# unitree-go2 decomposed into its atoms
+# (dimos/robot/unitree/go2/blueprints/smart/unitree_go2.py) minus the
+# autonomous WavefrontFrontierExplorer and PatrollingModule: deliberate
+# move_to navigation keeps working, the exploration shortcut is removed at
+# the source.
+STACK = (
+    "unitree-go2-basic voxel-grid-mapper cost-mapper replanning-a-star-planner "
+    "movement-manager mcp-server unitree-skill-container"
+)
+
+ROOMS: dict[str, tuple[float, float]] = {
+    "living_dining": (2.0, 2.5),  # sectional, TV, dining table
+    "kitchen": (-4.0, 2.5),  # fridge, gas range, sink
+    "bedroom": (-3.0, -2.5),  # queen bed, desk
+    "bathroom": (3.0, -2.5),  # bathtub, toilet, vanity
+}
+N_ROOMS = len(ROOMS)
+
+INSTRUCTION = (
+    "Map the entire reachable apartment and determine how many distinct rooms "
+    "it contains. Count wall-separated interior rooms: an open-plan area is "
+    "one room, and outdoor space is not a room. Move only with deliberate "
+    "move_to calls using world x/y coordinates; do not use exploration, "
+    "patrol, follow, or other autonomous navigation tools. Decide what lidar "
+    "history you need. When you are confident, answer with one integer and "
+    "nothing else."
+)
+
+
+def grade_rooms(visit_radius_m: float = 1.5) -> Callable[[Outcome], float]:
+    """0.5 for the exact room count in the reply, plus 0.5 times the fraction
+    of rooms whose representative point the recorded odometry came within
+    *visit_radius_m* of. Every representative point sits ~2 m past its room's
+    doorway, so the default radius requires actually entering the room.
+    Passing at the default threshold of 1.0 means the count was right and
+    every room was physically entered."""
+
+    def grade(o: Outcome) -> float:
+        try:
+            count = exact(float(N_ROOMS), first_number(o.trajectory.final_answer))
+        except ValueError:  # no number in the reply — coverage can still score
+            count = 0.0
+        store = recording(o)
+        try:
+            path = [(p.data.position.x, p.data.position.y) for p in store.streams.odom]
+        finally:
+            store.stop()
+        visited = sum(
+            any(math.hypot(x - rx, y - ry) <= visit_radius_m for x, y in path)
+            for rx, ry in ROOMS.values()
+        )
+        return 0.5 * count + 0.5 * visited / N_ROOMS
+
+    return grade
+
+
+count_rooms = EvalCase(
+    id="dimsim_count_rooms",
+    inputs=INSTRUCTION,
+    environment=Sim(blueprint=STACK, simulator="dimsim", scene="apartment"),
+    grade=grade_rooms(),
+    timeout_s=1200.0,  # room for several blocking move_to calls (each up to ~100 s)
+    tags=frozenset({"nav", "pointcloud", "system"}),
+)
+
+SUITE: Suite = [count_rooms]

--- a/dimos/evals/suites/dimsim_pointcloud_mapping.py
+++ b/dimos/evals/suites/dimsim_pointcloud_mapping.py
@@ -32,10 +32,15 @@ from dimos.evals.types import EvalCase, Outcome, Suite, recording
 # autonomous WavefrontFrontierExplorer and PatrollingModule: deliberate
 # move_to navigation keeps working, the exploration shortcut is removed at
 # the source.
-STACK = (
-    "unitree-go2-basic voxel-grid-mapper cost-mapper replanning-a-star-planner "
-    "movement-manager mcp-server unitree-skill-container"
-)
+STACK = [
+    "unitree-go2-basic",
+    "voxel-grid-mapper",
+    "cost-mapper",
+    "replanning-a-star-planner",
+    "movement-manager",
+    "mcp-server",
+    "unitree-skill-container",
+]
 
 ROOMS: dict[str, tuple[float, float]] = {
     "living_dining": (2.0, 2.5),  # sectional, TV, dining table

--- a/dimos/evals/suites/dimsim_pointcloud_mapping.py
+++ b/dimos/evals/suites/dimsim_pointcloud_mapping.py
@@ -27,21 +27,6 @@ from dimos.evals.environments.sim import Sim
 from dimos.evals.scorers import exact, first_number
 from dimos.evals.types import EvalCase, Outcome, Suite, recording
 
-# unitree-go2 decomposed into its atoms
-# (dimos/robot/unitree/go2/blueprints/smart/unitree_go2.py) minus the
-# autonomous WavefrontFrontierExplorer and PatrollingModule: deliberate
-# move_to navigation keeps working, the exploration shortcut is removed at
-# the source.
-STACK = [
-    "unitree-go2-basic",
-    "voxel-grid-mapper",
-    "cost-mapper",
-    "replanning-a-star-planner",
-    "movement-manager",
-    "mcp-server",
-    "unitree-skill-container",
-]
-
 ROOMS: dict[str, tuple[float, float]] = {
     "living_dining": (2.0, 2.5),  # sectional, TV, dining table
     "kitchen": (-4.0, 2.5),  # fridge, gas range, sink
@@ -91,7 +76,13 @@ def grade_rooms(visit_radius_m: float = 1.5) -> Callable[[Outcome], float]:
 count_rooms = EvalCase(
     id="dimsim_count_rooms",
     inputs=INSTRUCTION,
-    environment=Sim(blueprint=STACK, simulator="dimsim", scene="apartment"),
+    environment=Sim(
+        blueprint=["unitree-go2", "mcp-server", "unitree-skill-container"],
+        # Keep the configured stack, but require deliberate move_to navigation.
+        disable=("wavefront-frontier-explorer", "patrolling-module"),
+        simulator="dimsim",
+        scene="apartment",
+    ),
     grade=grade_rooms(),
     timeout_s=1200.0,  # room for several blocking move_to calls (each up to ~100 s)
     tags=frozenset({"nav", "pointcloud", "system"}),

--- a/dimos/evals/test_evals.py
+++ b/dimos/evals/test_evals.py
@@ -20,11 +20,14 @@ stub, and runner environments implement the same lifecycle as real environments.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 from datetime import datetime
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import json
 from pathlib import Path
+import sys
 import threading
+import time
 from types import SimpleNamespace
 from typing import Any
 
@@ -40,6 +43,8 @@ from dimos.evals.agents.base import Agent
 from dimos.evals.agents.blind import BLIND_BLOCK, Blind
 from dimos.evals.agents.lib.trajectory_builder import TrajectoryBuilder
 from dimos.evals.agents.mcp_client_adapter import McpClientAdapter
+import dimos.evals.agents.pi as pi_mod
+from dimos.evals.agents.pi import Pi, render_tools
 from dimos.evals.agents.question_answer import QuestionAnswer
 from dimos.evals.cli import load_agent
 from dimos.evals.environments.base import Environment
@@ -60,7 +65,8 @@ from dimos.evals.scorers import (
     within,
     yes_no,
 )
-from dimos.evals.suites import dimsim_house, examples, go2_smoke, go2_vqa
+from dimos.evals.suites import dimsim_house, dimsim_pointcloud_mapping, examples, go2_smoke, go2_vqa
+from dimos.evals.suites.dimsim_pointcloud_mapping import N_ROOMS, ROOMS, grade_rooms
 from dimos.evals.types import (
     EvalCase,
     Observation,
@@ -69,6 +75,7 @@ from dimos.evals.types import (
     RunningEnvironment,
     ToolCall,
     Trajectory,
+    recording,
 )
 from dimos.memory.store.memory import MemoryStore
 from dimos.memory.store.sqlite import SqliteStore
@@ -646,16 +653,55 @@ def test_runner_missing_artifact_is_an_error(tmp_path: Path) -> None:
     assert result.error == "missing artifacts: ['recording']" and not graded
 
 
+def test_recording_helper_opens_the_artifact(dataset: str) -> None:
+    with recording(
+        Outcome(trajectory=_trajectory("", Path()), artifacts={"recording": Path(dataset)})
+    ) as store:
+        assert store.streams.odom.last().data.position.x == 4.0
+
+
+def test_count_rooms_grader_scores_reply_and_coverage(tmp_path: Path) -> None:
+    """Half credit for the exact room count, half for the fraction of room
+    points the recorded odometry approached; an unparseable reply loses the
+    count half but the world still scores."""
+    radius = 1.5
+    grade = grade_rooms(radius)
+
+    def written(db_path: Path, points: list[tuple[float, float]]) -> Path:
+        with SqliteStore(path=str(db_path)) as store:
+            stream = store.stream("odom", PoseStamped)
+            for i, (x, y) in enumerate(points):
+                stream.append(_pose(x, y), ts=1000.0 + i)
+        return db_path
+
+    def score(db: Path, answer: str) -> float:
+        outcome = Outcome(trajectory=_trajectory(answer, tmp_path), artifacts={"recording": db})
+        return grade(outcome)
+
+    rooms = list(ROOMS.values())
+    two = written(tmp_path / "two.db", [(x + radius / 2, y) for x, y in rooms[:2]])
+    coverage = 0.5 * 2 / N_ROOMS
+    assert score(two, str(N_ROOMS)) == pytest.approx(0.5 + coverage)
+    assert score(two, f"{N_ROOMS} rooms, I think") == pytest.approx(0.5 + coverage)
+    assert score(two, str(N_ROOMS + 1)) == pytest.approx(coverage), "wrong count"
+    assert score(two, "no idea") == pytest.approx(coverage), "unparseable reply"
+
+    every = written(tmp_path / "every.db", rooms)
+    assert score(every, str(N_ROOMS)) == 1.0
+    assert score(written(tmp_path / "still.db", [(50.0, 50.0)]), str(N_ROOMS)) == 0.5
+
+
 def test_suites_and_agents_importable() -> None:
     """Modules construct without data or network (lambdas stay lazy)."""
 
-    for module in (examples, go2_smoke, go2_vqa, dimsim_house):
+    for module in (examples, go2_smoke, go2_vqa, dimsim_house, dimsim_pointcloud_mapping):
         assert module.SUITE, module.__name__
     agents = list_agents()
     assert {m.rsplit(".", 1)[1] for m in agents} == {
         "question_answer",
         "blind",
         "mcp_client_adapter",
+        "pi",
     }
     for module in agents:
         assert callable(load_agent(module).run), module
@@ -769,9 +815,285 @@ def test_mcp_client_adapter_drives_a_turn_over_real_transports(
     assert datetime.fromisoformat(last.timestamp).timestamp() == 1_700_000_001.0
 
 
+# -- Pi -------------------------------------------------------------------------------
+
+FAKE_PI = """\
+import json, os, sys, time, urllib.request
+from pathlib import Path
+
+args = sys.argv[1:]
+agent_dir = Path(os.environ["PI_CODING_AGENT_DIR"])
+base = json.loads((agent_dir / "models.json").read_text())["providers"]["dimos"]["baseUrl"]
+model = args[args.index("--model") + 1].split("/", 1)[1]  # pi strips the provider prefix
+tool_steps = int(Path(__file__).with_name("tool_steps").read_text())
+step_delay = Path(__file__).with_name("step_delay")
+
+
+def call(n):
+    req = urllib.request.Request(
+        base + "/responses",
+        data=json.dumps({"model": model, "n": n}).encode(),
+        headers={"Content-Type": "application/json", "Authorization": "Bearer " + os.environ["OPENAI_API_KEY"]},
+    )
+    urllib.request.urlopen(req).read()
+
+
+def emit(event):
+    print(json.dumps(event), flush=True)
+
+
+def assistant(content, stop):
+    return {"role": "assistant", "model": "gpt-fake", "stopReason": stop, "content": content,
+            "usage": {"input": 10, "output": 2, "cacheRead": 5, "cacheWrite": 1, "reasoning": 1,
+                      "cost": {"total": 0.005}}}
+
+
+emit({"type": "session", "version": 3})
+for i in range(tool_steps):
+    if step_delay.exists():
+        time.sleep(float(step_delay.read_text()))
+    call(i)
+    emit({"type": "message_end", "message": assistant([
+        {"type": "thinking", "thinking": "measuring"},
+        {"type": "text", "text": "looking"},
+        {"type": "toolCall", "id": f"c{i}", "name": "bash", "arguments": {"command": "python probe.py"}},
+    ], "toolUse")})
+    emit({"type": "tool_execution_start", "toolCallId": f"c{i}", "toolName": "bash", "args": {}})
+    emit({"type": "tool_execution_end", "toolCallId": f"c{i}", "toolName": "bash", "isError": False,
+          "result": {"content": [{"type": "text", "text": "x=4.0"}]}})
+call(tool_steps)
+emit({"type": "message_end", "message": assistant([{"type": "text", "text": "4.0"}], "stop")})
+emit({"type": "agent_end"})
+"""
+
+
+@pytest.fixture
+def fake_pi(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    """A ``pi`` that calls the provider it was configured with and emits Pi's
+    JSON events, plus an upstream that echoes each request. ``tool_steps``
+    next to the script is how many tool rounds it plays before answering;
+    ``step_delay`` (optional) is how long it sleeps before each of them."""
+
+    class Upstream(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:
+            body = self.rfile.read(int(self.headers["Content-Length"]))
+            reply = json.dumps({"echo": json.loads(body)}).encode()
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(reply)))
+            self.end_headers()
+            self.wfile.write(reply)
+
+        def log_message(self, format: str, *args: Any) -> None:
+            return None
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Upstream)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    monkeypatch.setenv("OPENAI_BASE_URL", f"http://127.0.0.1:{server.server_port}/v1")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    script = tmp_path / "bin" / "pi"
+    script.parent.mkdir()
+    script.write_text(f"#!{sys.executable}\n{FAKE_PI}")
+    script.chmod(0o755)
+    script.with_name("tool_steps").write_text("1")
+    yield script
+    server.shutdown()
+
+
+def test_pi_runs_headless_over_the_recording_and_records_every_call(
+    dataset: str, fake_pi: Path, tmp_path: Path
+) -> None:
+    env = Dataset(dataset, select=(lambda s: s.streams.odom.limit(2),))
+    running = env.start(())
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    try:
+        agent = Pi(cli=str(fake_pi), model="gpt-fake")
+        agent.preflight(env)
+        trajectory = agent.run("how far?", running, run_dir, timeout_s=60.0)
+    finally:
+        env.stop()
+    assert (trajectory.final_answer, trajectory.extra.ended_by, trajectory.agent.model_name) == (
+        "4.0",
+        "answer",
+        "gpt-fake",
+    )
+    user, first, last = trajectory.steps
+    assert user.source == "user" and user.message == "how far?"
+    assert first.tool_calls == (
+        ToolCall(tool_call_id="c0", function_name="bash", arguments={"command": "python probe.py"}),
+    )
+    assert first.observation == Observation(
+        results=(ObservationResult(source_call_id="c0", content="x=4.0"),)
+    )
+    assert first.reasoning_content == "measuring" and not last.tool_calls
+    totals = trajectory.final_metrics
+    assert (totals.total_prompt_tokens, totals.total_completion_tokens) == (
+        32,  # (input 10 + cacheWrite 1 + cacheRead 5) per step
+        4,
+    )
+    assert totals.total_cached_tokens == 10 and totals.total_cost_usd == pytest.approx(0.01)
+    assert sum(s.extra.reasoning_tokens for s in trajectory.steps if s.extra) == 2
+    for i, step in enumerate((first, last)):  # every call captured whole, auth dropped
+        assert step.extra is not None
+        request = json.loads(step.extra.request.read_text())
+        assert request["body"] == {"model": "gpt-fake", "n": i}
+        assert "authorization" not in {k.lower() for k in request["headers"]}
+        assert json.loads(step.extra.response.read_text())["body"] == {"echo": request["body"]}
+    prompt = (run_dir / "system-prompt.txt").read_text()
+    assert f"- recording: {run_dir / 'recording.db'}" in prompt and "dimos mcp call" not in prompt
+    # The selection, not the source dataset.
+    with SqliteStore(path=str(run_dir / "recording.db"), must_exist=True) as copy:
+        assert [o.ts for o in copy.streams.odom] == [1000.0, 1001.0]
+
+
+def test_pi_is_told_the_robots_tools_and_stopped_at_max_steps(
+    dataset: str, fake_pi: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(pi_mod, "tool_listing", lambda mcp_url: "- move_to(x, y): Go there.")
+    fake_pi.with_name("tool_steps").write_text("5")
+    env = Dataset(dataset, mcp_url="http://localhost:1/mcp")
+    running = env.start(())
+    try:
+        trajectory = Pi(cli=str(fake_pi), max_steps=2).run("go", running, tmp_path, timeout_s=60.0)
+    finally:
+        env.stop()
+    assert (trajectory.extra.ended_by, len(trajectory.steps), trajectory.final_answer) == (
+        "max_steps",
+        3,  # the instruction, then the two calls allowed
+        "",
+    )
+    prompt = (tmp_path / "system-prompt.txt").read_text()
+    assert "dimos mcp call <tool> --json-args" in prompt and "- move_to(x, y): Go there." in prompt
+
+
+def test_pi_is_killed_at_the_time_budget_and_keeps_its_steps(
+    dataset: str, fake_pi: Path, tmp_path: Path
+) -> None:
+    fake_pi.with_name("tool_steps").write_text("50")
+    fake_pi.with_name("step_delay").write_text("0.2")
+    env = Dataset(dataset)
+    running = env.start(())
+    try:
+        started = time.monotonic()
+        trajectory = Pi(cli=str(fake_pi)).run("go", running, tmp_path, timeout_s=0.5)
+        took = time.monotonic() - started
+    finally:
+        env.stop()
+    assert trajectory.extra.ended_by == "timeout" and took < 5.0
+    assert 2 <= len(trajectory.steps) <= 4  # the instruction plus the calls it got to
+    assert all(s.tool_calls for s in trajectory.steps[1:]) and trajectory.final_answer == ""
+
+
+def test_pi_preflight_and_tool_rendering(
+    dataset: str, fake_pi: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with pytest.raises(RuntimeError, match="not on PATH"):
+        Pi(cli=str(tmp_path / "missing")).preflight(ImageFile(tmp_path / "x.png"))
+    with pytest.raises(RuntimeError, match="Pi.tools is a string"):
+        Pi(cli=str(fake_pi), tools="read,bash").preflight(ImageFile(tmp_path / "x.png"))
+    robot = Dataset(dataset, mcp_url="http://localhost:1/mcp")
+    with pytest.raises(RuntimeError, match="bash tool, which is not enabled"):
+        Pi(cli=str(fake_pi), tools=("read",)).preflight(robot)
+    tools = [
+        {
+            "name": "move_to",
+            "description": "Go to a pose.\n\nArgs: x, y",
+            "inputSchema": {"properties": {"x": {}, "y": {}}},
+        }
+    ]
+    assert render_tools(tools) == "- move_to(x, y): Go to a pose."
+
+
+def test_pi_skills_become_native_flags_and_preflight_checks_paths(
+    dataset: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Explicit skill paths become repeated ``--skill`` flags, absolute (Pi's
+    cwd is the run dir) with ambient discovery still off; a missing path or a
+    bare string fails preflight before a simulator or model starts."""
+    skill = tmp_path / "spatial" / "SKILL.md"
+    skill.parent.mkdir()
+    skill.write_text("# spatial skill")
+    monkeypatch.chdir(tmp_path)
+
+    env = Dataset(dataset)
+    running = env.start(())
+    for d in ("with-skills", "bare"):
+        (tmp_path / d).mkdir()
+    try:
+        agent = Pi(skills=(str(skill), "spatial/SKILL.md"))  # absolute and relative
+        command = agent._command("go", running, tmp_path / "with-skills")
+        bare = Pi()._command("go", running, tmp_path / "bare")
+    finally:
+        env.stop()
+    assert [command[i + 1] for i, a in enumerate(command) if a == "--skill"] == [
+        str(skill),
+        str(skill),
+    ]
+    assert "--no-skills" in command, "ambient discovery stays off alongside explicit skills"
+    assert "--skill" not in bare
+
+    with pytest.raises(RuntimeError, match="do not exist"):
+        Pi(skills=(str(tmp_path / "missing.md"),)).preflight(env)
+    with pytest.raises(RuntimeError, match="Pi.skills is a string"):
+        Pi(skills="spatial/SKILL.md").preflight(env)
+
+
+def test_pi_prompt_is_composed_from_its_fields(
+    dataset: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The run's instructions follow the agent's own contract; the built-in
+    guidance can be switched off so a skill can carry it, while the robot's
+    tool listing stays."""
+    monkeypatch.setattr(pi_mod, "tool_listing", lambda mcp_url: "- move_to(x, y): Go there.")
+    env = Dataset(dataset, mcp_url="http://localhost:1/mcp")
+    running = env.start(())
+    for d in ("default", "bare"):
+        (tmp_path / d).mkdir()
+    try:
+        Pi(instructions="Use only odometry.")._command("go", running, tmp_path / "default")
+        Pi(builtin_guidance=False, tools=("read", "bash"))._command(
+            "go", running, tmp_path / "bare"
+        )
+    finally:
+        env.stop()
+    default = (tmp_path / "default" / "system-prompt.txt").read_text()
+    bare = (tmp_path / "bare" / "system-prompt.txt").read_text()
+    assert default.startswith(
+        "Answer the question from the files and tools listed below and nothing else.\n\n"
+        "Use only odometry.\n\nFiles:\n"
+    )
+    assert "SqliteStore" in default and "dimos mcp call" in default and "- move_to" in default
+    assert "SqliteStore" not in bare and "dimos mcp call" not in bare and "- move_to" in bare
+    assert bare.startswith(
+        "Answer the question from the files and tools listed below and nothing else.\n\nFiles:\n"
+    )
+
+
+def test_pi_that_exits_with_a_failure_status_is_an_error(
+    dataset: str, fake_pi: Path, tmp_path: Path
+) -> None:
+    fake_pi.write_text(f"#!{sys.executable}\nimport sys; sys.exit('unknown tool: bahs')")
+    env = Dataset(dataset)
+    running = env.start(())
+    try:
+        with pytest.raises(RuntimeError, match="exit status 1: unknown tool: bahs"):
+            Pi(cli=str(fake_pi), tools=("read", "bahs")).run(
+                "go", running, tmp_path, timeout_s=60.0
+            )
+    finally:
+        env.stop()
+
+
 def test_agents_report_every_available_tool() -> None:
     environment_tools = ("move_to", "speak")
 
     assert QuestionAnswer().available_tools(environment_tools) == ()
     assert Blind().available_tools(environment_tools) == ()
     assert McpClientAdapter().available_tools(environment_tools) == environment_tools
+    assert Pi().available_tools(environment_tools) == (
+        "read",
+        "bash",
+        "edit",
+        "write",
+        *environment_tools,
+    )

--- a/dimos/evals/test_evals.py
+++ b/dimos/evals/test_evals.py
@@ -276,7 +276,12 @@ def test_sim_launches_base_blueprints_and_agent_modules_in_order(
     adapter.return_value.wait_for_ready.return_value = True
     sim_client = mocker.patch("dimos.evals.environments.sim.DimSimClient")
     setup = mocker.Mock()
-    env = _sim(scene="empty", launch_timeout_s=4.0, setup=setup)
+    env = _sim(
+        scene="empty",
+        launch_timeout_s=4.0,
+        setup=setup,
+        disable=("wavefront-frontier-explorer", "patrolling-module"),
+    )
     mocker.patch.object(env, "_wait_recording", return_value=Path(dataset))
 
     try:
@@ -288,6 +293,10 @@ def test_sim_launches_base_blueprints_and_agent_modules_in_order(
             "unitree-skill-container",
             "mcp-client",
             "speak-skill",
+            "--disable",
+            "wavefront-frontier-explorer",
+            "--disable",
+            "patrolling-module",
         ]
         assert proc.global_args == ["--dimsim-scene", "empty", "--record"]
         adapter.return_value.wait_for_ready.assert_called_once_with(timeout=4.0, interval=2.0)

--- a/dimos/evals/test_evals.py
+++ b/dimos/evals/test_evals.py
@@ -44,7 +44,7 @@ from dimos.evals.agents.blind import BLIND_BLOCK, Blind
 from dimos.evals.agents.lib.trajectory_builder import TrajectoryBuilder
 from dimos.evals.agents.mcp_client_adapter import McpClientAdapter
 import dimos.evals.agents.pi as pi_mod
-from dimos.evals.agents.pi import Pi, render_tools
+from dimos.evals.agents.pi import PiAdapter, render_tools
 from dimos.evals.agents.question_answer import QuestionAnswer
 from dimos.evals.cli import load_agent
 from dimos.evals.environments.base import Environment
@@ -732,6 +732,37 @@ def test_load_agent_is_the_module_plus_set_overrides() -> None:
         load_agent("dimos.evals.agents.question_answer", ["frames_per_stream=0"])
 
 
+@pytest.mark.parametrize(("override", "max_steps"), [("null", None), ("3", 3)])
+def test_load_pi_adapter_with_config_overrides(override: str, max_steps: int | None) -> None:
+    agent = load_agent(
+        "dimos.evals.agents.pi",
+        [f"max_steps={override}", 'modules=["rangefinder-skill"]', "model=x"],
+    )
+
+    assert isinstance(agent, PiAdapter)
+    assert (agent.config.max_steps, agent.config.modules, agent.config.model) == (
+        max_steps,
+        ("rangefinder-skill",),
+        "x",
+    )
+
+
+@pytest.mark.parametrize(
+    ("override", "field"),
+    [
+        ("modules=rangefinder-skill", "modules"),
+        ("tools=read,bash", "tools"),
+        ("skills=spatial/SKILL.md", "skills"),
+        ("passthrough_env=OPENAI_API_KEY", "passthrough_env"),
+        ("max_steps=several", "max_steps"),
+        ("frames_per_stream=3", "frames_per_stream"),
+    ],
+)
+def test_load_pi_adapter_rejects_invalid_config(override: str, field: str) -> None:
+    with pytest.raises(ValidationError, match=field):
+        load_agent("dimos.evals.agents.pi", [override])
+
+
 @pytest.mark.parametrize("goes_idle", [True, False])
 def test_mcp_client_adapter_drives_a_turn_over_real_transports(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, goes_idle: bool
@@ -907,11 +938,12 @@ def test_pi_runs_headless_over_the_recording_and_records_every_call(
     run_dir = tmp_path / "run"
     run_dir.mkdir()
     try:
-        agent = Pi(cli=str(fake_pi), model="gpt-fake")
+        agent = PiAdapter(cli=str(fake_pi), model="gpt-fake")
         agent.preflight(env)
         trajectory = agent.run("how far?", running, run_dir, timeout_s=60.0)
     finally:
         env.stop()
+    assert trajectory.agent.name == "PiAdapter"
     assert (trajectory.final_answer, trajectory.extra.ended_by, trajectory.agent.model_name) == (
         "4.0",
         "answer",
@@ -954,7 +986,9 @@ def test_pi_is_told_the_robots_tools_and_stopped_at_max_steps(
     env = Dataset(dataset, mcp_url="http://localhost:1/mcp")
     running = env.start(())
     try:
-        trajectory = Pi(cli=str(fake_pi), max_steps=2).run("go", running, tmp_path, timeout_s=60.0)
+        trajectory = PiAdapter(cli=str(fake_pi), max_steps=2).run(
+            "go", running, tmp_path, timeout_s=60.0
+        )
     finally:
         env.stop()
     assert (trajectory.extra.ended_by, len(trajectory.steps), trajectory.final_answer) == (
@@ -975,7 +1009,7 @@ def test_pi_is_killed_at_the_time_budget_and_keeps_its_steps(
     running = env.start(())
     try:
         started = time.monotonic()
-        trajectory = Pi(cli=str(fake_pi)).run("go", running, tmp_path, timeout_s=0.5)
+        trajectory = PiAdapter(cli=str(fake_pi)).run("go", running, tmp_path, timeout_s=0.5)
         took = time.monotonic() - started
     finally:
         env.stop()
@@ -988,12 +1022,12 @@ def test_pi_preflight_and_tool_rendering(
     dataset: str, fake_pi: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     with pytest.raises(RuntimeError, match="not on PATH"):
-        Pi(cli=str(tmp_path / "missing")).preflight(ImageFile(tmp_path / "x.png"))
-    with pytest.raises(RuntimeError, match="Pi.tools is a string"):
-        Pi(cli=str(fake_pi), tools="read,bash").preflight(ImageFile(tmp_path / "x.png"))
+        PiAdapter(cli=str(tmp_path / "missing")).preflight(ImageFile(tmp_path / "x.png"))
+    with pytest.raises(ValidationError, match="tools"):
+        PiAdapter(cli=str(fake_pi), tools="read,bash")
     robot = Dataset(dataset, mcp_url="http://localhost:1/mcp")
     with pytest.raises(RuntimeError, match="bash tool, which is not enabled"):
-        Pi(cli=str(fake_pi), tools=("read",)).preflight(robot)
+        PiAdapter(cli=str(fake_pi), tools=("read",)).preflight(robot)
     tools = [
         {
             "name": "move_to",
@@ -1009,7 +1043,7 @@ def test_pi_skills_become_native_flags_and_preflight_checks_paths(
 ) -> None:
     """Explicit skill paths become repeated ``--skill`` flags, absolute (Pi's
     cwd is the run dir) with ambient discovery still off; a missing path or a
-    bare string fails preflight before a simulator or model starts."""
+    bare string fails validation before a simulator or model starts."""
     skill = tmp_path / "spatial" / "SKILL.md"
     skill.parent.mkdir()
     skill.write_text("# spatial skill")
@@ -1020,9 +1054,9 @@ def test_pi_skills_become_native_flags_and_preflight_checks_paths(
     for d in ("with-skills", "bare"):
         (tmp_path / d).mkdir()
     try:
-        agent = Pi(skills=(str(skill), "spatial/SKILL.md"))  # absolute and relative
+        agent = PiAdapter(skills=(str(skill), "spatial/SKILL.md"))  # absolute and relative
         command = agent._command("go", running, tmp_path / "with-skills")
-        bare = Pi()._command("go", running, tmp_path / "bare")
+        bare = PiAdapter()._command("go", running, tmp_path / "bare")
     finally:
         env.stop()
     assert [command[i + 1] for i, a in enumerate(command) if a == "--skill"] == [
@@ -1033,9 +1067,9 @@ def test_pi_skills_become_native_flags_and_preflight_checks_paths(
     assert "--skill" not in bare
 
     with pytest.raises(RuntimeError, match="do not exist"):
-        Pi(skills=(str(tmp_path / "missing.md"),)).preflight(env)
-    with pytest.raises(RuntimeError, match="Pi.skills is a string"):
-        Pi(skills="spatial/SKILL.md").preflight(env)
+        PiAdapter(skills=(str(tmp_path / "missing.md"),)).preflight(env)
+    with pytest.raises(ValidationError, match="skills"):
+        PiAdapter(skills="spatial/SKILL.md")
 
 
 def test_pi_prompt_is_composed_from_its_fields(
@@ -1050,8 +1084,8 @@ def test_pi_prompt_is_composed_from_its_fields(
     for d in ("default", "bare"):
         (tmp_path / d).mkdir()
     try:
-        Pi(instructions="Use only odometry.")._command("go", running, tmp_path / "default")
-        Pi(builtin_guidance=False, tools=("read", "bash"))._command(
+        PiAdapter(instructions="Use only odometry.")._command("go", running, tmp_path / "default")
+        PiAdapter(builtin_guidance=False, tools=("read", "bash"))._command(
             "go", running, tmp_path / "bare"
         )
     finally:
@@ -1077,7 +1111,7 @@ def test_pi_that_exits_with_a_failure_status_is_an_error(
     running = env.start(())
     try:
         with pytest.raises(RuntimeError, match="exit status 1: unknown tool: bahs"):
-            Pi(cli=str(fake_pi), tools=("read", "bahs")).run(
+            PiAdapter(cli=str(fake_pi), tools=("read", "bahs")).run(
                 "go", running, tmp_path, timeout_s=60.0
             )
     finally:
@@ -1090,7 +1124,7 @@ def test_agents_report_every_available_tool() -> None:
     assert QuestionAnswer().available_tools(environment_tools) == ()
     assert Blind().available_tools(environment_tools) == ()
     assert McpClientAdapter().available_tools(environment_tools) == environment_tools
-    assert Pi().available_tools(environment_tools) == (
+    assert PiAdapter().available_tools(environment_tools) == (
         "read",
         "bash",
         "edit",

--- a/dimos/evals/test_evals.py
+++ b/dimos/evals/test_evals.py
@@ -20,14 +20,11 @@ stub, and runner environments implement the same lifecycle as real environments.
 
 from __future__ import annotations
 
-from collections.abc import Iterator, Sequence
+from collections.abc import Sequence
 from datetime import datetime
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import json
 from pathlib import Path
-import sys
 import threading
-import time
 from types import SimpleNamespace
 from typing import Any
 
@@ -43,8 +40,6 @@ from dimos.evals.agents.base import Agent
 from dimos.evals.agents.blind import BLIND_BLOCK, Blind
 from dimos.evals.agents.lib.trajectory_builder import TrajectoryBuilder
 from dimos.evals.agents.mcp_client_adapter import McpClientAdapter
-import dimos.evals.agents.pi as pi_mod
-from dimos.evals.agents.pi import PiAdapter, render_tools
 from dimos.evals.agents.question_answer import QuestionAnswer
 from dimos.evals.cli import load_agent
 from dimos.evals.environments.base import Environment
@@ -91,17 +86,6 @@ def _pose(x: float, y: float) -> PoseStamped:
         orientation=Quaternion(0.0, 0.0, 0.0, 1.0),
         frame_id="world",
     )
-
-
-@pytest.fixture
-def dataset(tmp_path: Path) -> str:
-    """A tiny on-disk memory dataset: 5 odom poses walking 4m in +x over 4s."""
-    path = tmp_path / "tiny.db"
-    with SqliteStore(path=str(path)) as store:
-        stream = store.stream("odom", PoseStamped)
-        for i in range(5):
-            stream.append(_pose(float(i), 0.0), ts=1000.0 + i)
-    return str(path)
 
 
 def _sim(**kwargs: Any) -> Sim:
@@ -732,37 +716,6 @@ def test_load_agent_is_the_module_plus_set_overrides() -> None:
         load_agent("dimos.evals.agents.question_answer", ["frames_per_stream=0"])
 
 
-@pytest.mark.parametrize(("override", "max_steps"), [("null", None), ("3", 3)])
-def test_load_pi_adapter_with_config_overrides(override: str, max_steps: int | None) -> None:
-    agent = load_agent(
-        "dimos.evals.agents.pi",
-        [f"max_steps={override}", 'modules=["rangefinder-skill"]', "model=x"],
-    )
-
-    assert isinstance(agent, PiAdapter)
-    assert (agent.config.max_steps, agent.config.modules, agent.config.model) == (
-        max_steps,
-        ("rangefinder-skill",),
-        "x",
-    )
-
-
-@pytest.mark.parametrize(
-    ("override", "field"),
-    [
-        ("modules=rangefinder-skill", "modules"),
-        ("tools=read,bash", "tools"),
-        ("skills=spatial/SKILL.md", "skills"),
-        ("passthrough_env=OPENAI_API_KEY", "passthrough_env"),
-        ("max_steps=several", "max_steps"),
-        ("frames_per_stream=3", "frames_per_stream"),
-    ],
-)
-def test_load_pi_adapter_rejects_invalid_config(override: str, field: str) -> None:
-    with pytest.raises(ValidationError, match=field):
-        load_agent("dimos.evals.agents.pi", [override])
-
-
 @pytest.mark.parametrize("goes_idle", [True, False])
 def test_mcp_client_adapter_drives_a_turn_over_real_transports(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, goes_idle: bool
@@ -846,288 +799,9 @@ def test_mcp_client_adapter_drives_a_turn_over_real_transports(
     assert datetime.fromisoformat(last.timestamp).timestamp() == 1_700_000_001.0
 
 
-# -- Pi -------------------------------------------------------------------------------
-
-FAKE_PI = """\
-import json, os, sys, time, urllib.request
-from pathlib import Path
-
-args = sys.argv[1:]
-agent_dir = Path(os.environ["PI_CODING_AGENT_DIR"])
-base = json.loads((agent_dir / "models.json").read_text())["providers"]["dimos"]["baseUrl"]
-model = args[args.index("--model") + 1].split("/", 1)[1]  # pi strips the provider prefix
-tool_steps = int(Path(__file__).with_name("tool_steps").read_text())
-step_delay = Path(__file__).with_name("step_delay")
-
-
-def call(n):
-    req = urllib.request.Request(
-        base + "/responses",
-        data=json.dumps({"model": model, "n": n}).encode(),
-        headers={"Content-Type": "application/json", "Authorization": "Bearer " + os.environ["OPENAI_API_KEY"]},
-    )
-    urllib.request.urlopen(req).read()
-
-
-def emit(event):
-    print(json.dumps(event), flush=True)
-
-
-def assistant(content, stop):
-    return {"role": "assistant", "model": "gpt-fake", "stopReason": stop, "content": content,
-            "usage": {"input": 10, "output": 2, "cacheRead": 5, "cacheWrite": 1, "reasoning": 1,
-                      "cost": {"total": 0.005}}}
-
-
-emit({"type": "session", "version": 3})
-for i in range(tool_steps):
-    if step_delay.exists():
-        time.sleep(float(step_delay.read_text()))
-    call(i)
-    emit({"type": "message_end", "message": assistant([
-        {"type": "thinking", "thinking": "measuring"},
-        {"type": "text", "text": "looking"},
-        {"type": "toolCall", "id": f"c{i}", "name": "bash", "arguments": {"command": "python probe.py"}},
-    ], "toolUse")})
-    emit({"type": "tool_execution_start", "toolCallId": f"c{i}", "toolName": "bash", "args": {}})
-    emit({"type": "tool_execution_end", "toolCallId": f"c{i}", "toolName": "bash", "isError": False,
-          "result": {"content": [{"type": "text", "text": "x=4.0"}]}})
-call(tool_steps)
-emit({"type": "message_end", "message": assistant([{"type": "text", "text": "4.0"}], "stop")})
-emit({"type": "agent_end"})
-"""
-
-
-@pytest.fixture
-def fake_pi(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
-    """A ``pi`` that calls the provider it was configured with and emits Pi's
-    JSON events, plus an upstream that echoes each request. ``tool_steps``
-    next to the script is how many tool rounds it plays before answering;
-    ``step_delay`` (optional) is how long it sleeps before each of them."""
-
-    class Upstream(BaseHTTPRequestHandler):
-        def do_POST(self) -> None:
-            body = self.rfile.read(int(self.headers["Content-Length"]))
-            reply = json.dumps({"echo": json.loads(body)}).encode()
-            self.send_response(200)
-            self.send_header("Content-Length", str(len(reply)))
-            self.end_headers()
-            self.wfile.write(reply)
-
-        def log_message(self, format: str, *args: Any) -> None:
-            return None
-
-    server = ThreadingHTTPServer(("127.0.0.1", 0), Upstream)
-    threading.Thread(target=server.serve_forever, daemon=True).start()
-    monkeypatch.setenv("OPENAI_BASE_URL", f"http://127.0.0.1:{server.server_port}/v1")
-    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
-    script = tmp_path / "bin" / "pi"
-    script.parent.mkdir()
-    script.write_text(f"#!{sys.executable}\n{FAKE_PI}")
-    script.chmod(0o755)
-    script.with_name("tool_steps").write_text("1")
-    yield script
-    server.shutdown()
-
-
-def test_pi_runs_headless_over_the_recording_and_records_every_call(
-    dataset: str, fake_pi: Path, tmp_path: Path
-) -> None:
-    env = Dataset(dataset, select=(lambda s: s.streams.odom.limit(2),))
-    running = env.start(())
-    run_dir = tmp_path / "run"
-    run_dir.mkdir()
-    try:
-        agent = PiAdapter(cli=str(fake_pi), model="gpt-fake")
-        agent.preflight(env)
-        trajectory = agent.run("how far?", running, run_dir, timeout_s=60.0)
-    finally:
-        env.stop()
-    assert trajectory.agent.name == "PiAdapter"
-    assert (trajectory.final_answer, trajectory.extra.ended_by, trajectory.agent.model_name) == (
-        "4.0",
-        "answer",
-        "gpt-fake",
-    )
-    user, first, last = trajectory.steps
-    assert user.source == "user" and user.message == "how far?"
-    assert first.tool_calls == (
-        ToolCall(tool_call_id="c0", function_name="bash", arguments={"command": "python probe.py"}),
-    )
-    assert first.observation == Observation(
-        results=(ObservationResult(source_call_id="c0", content="x=4.0"),)
-    )
-    assert first.reasoning_content == "measuring" and not last.tool_calls
-    totals = trajectory.final_metrics
-    assert (totals.total_prompt_tokens, totals.total_completion_tokens) == (
-        32,  # (input 10 + cacheWrite 1 + cacheRead 5) per step
-        4,
-    )
-    assert totals.total_cached_tokens == 10 and totals.total_cost_usd == pytest.approx(0.01)
-    assert sum(s.extra.reasoning_tokens for s in trajectory.steps if s.extra) == 2
-    for i, step in enumerate((first, last)):  # every call captured whole, auth dropped
-        assert step.extra is not None
-        request = json.loads(step.extra.request.read_text())
-        assert request["body"] == {"model": "gpt-fake", "n": i}
-        assert "authorization" not in {k.lower() for k in request["headers"]}
-        assert json.loads(step.extra.response.read_text())["body"] == {"echo": request["body"]}
-    prompt = (run_dir / "system-prompt.txt").read_text()
-    assert f"- recording: {run_dir / 'recording.db'}" in prompt and "dimos mcp call" not in prompt
-    # The selection, not the source dataset.
-    with SqliteStore(path=str(run_dir / "recording.db"), must_exist=True) as copy:
-        assert [o.ts for o in copy.streams.odom] == [1000.0, 1001.0]
-
-
-def test_pi_is_told_the_robots_tools_and_stopped_at_max_steps(
-    dataset: str, fake_pi: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setattr(pi_mod, "tool_listing", lambda mcp_url: "- move_to(x, y): Go there.")
-    fake_pi.with_name("tool_steps").write_text("5")
-    env = Dataset(dataset, mcp_url="http://localhost:1/mcp")
-    running = env.start(())
-    try:
-        trajectory = PiAdapter(cli=str(fake_pi), max_steps=2).run(
-            "go", running, tmp_path, timeout_s=60.0
-        )
-    finally:
-        env.stop()
-    assert (trajectory.extra.ended_by, len(trajectory.steps), trajectory.final_answer) == (
-        "max_steps",
-        3,  # the instruction, then the two calls allowed
-        "",
-    )
-    prompt = (tmp_path / "system-prompt.txt").read_text()
-    assert "dimos mcp call <tool> --json-args" in prompt and "- move_to(x, y): Go there." in prompt
-
-
-def test_pi_is_killed_at_the_time_budget_and_keeps_its_steps(
-    dataset: str, fake_pi: Path, tmp_path: Path
-) -> None:
-    fake_pi.with_name("tool_steps").write_text("50")
-    fake_pi.with_name("step_delay").write_text("0.2")
-    env = Dataset(dataset)
-    running = env.start(())
-    try:
-        started = time.monotonic()
-        trajectory = PiAdapter(cli=str(fake_pi)).run("go", running, tmp_path, timeout_s=0.5)
-        took = time.monotonic() - started
-    finally:
-        env.stop()
-    assert trajectory.extra.ended_by == "timeout" and took < 5.0
-    assert 2 <= len(trajectory.steps) <= 4  # the instruction plus the calls it got to
-    assert all(s.tool_calls for s in trajectory.steps[1:]) and trajectory.final_answer == ""
-
-
-def test_pi_preflight_and_tool_rendering(
-    dataset: str, fake_pi: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    with pytest.raises(RuntimeError, match="not on PATH"):
-        PiAdapter(cli=str(tmp_path / "missing")).preflight(ImageFile(tmp_path / "x.png"))
-    with pytest.raises(ValidationError, match="tools"):
-        PiAdapter(cli=str(fake_pi), tools="read,bash")
-    robot = Dataset(dataset, mcp_url="http://localhost:1/mcp")
-    with pytest.raises(RuntimeError, match="bash tool, which is not enabled"):
-        PiAdapter(cli=str(fake_pi), tools=("read",)).preflight(robot)
-    tools = [
-        {
-            "name": "move_to",
-            "description": "Go to a pose.\n\nArgs: x, y",
-            "inputSchema": {"properties": {"x": {}, "y": {}}},
-        }
-    ]
-    assert render_tools(tools) == "- move_to(x, y): Go to a pose."
-
-
-def test_pi_skills_become_native_flags_and_preflight_checks_paths(
-    dataset: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Explicit skill paths become repeated ``--skill`` flags, absolute (Pi's
-    cwd is the run dir) with ambient discovery still off; a missing path or a
-    bare string fails validation before a simulator or model starts."""
-    skill = tmp_path / "spatial" / "SKILL.md"
-    skill.parent.mkdir()
-    skill.write_text("# spatial skill")
-    monkeypatch.chdir(tmp_path)
-
-    env = Dataset(dataset)
-    running = env.start(())
-    for d in ("with-skills", "bare"):
-        (tmp_path / d).mkdir()
-    try:
-        agent = PiAdapter(skills=(str(skill), "spatial/SKILL.md"))  # absolute and relative
-        command = agent._command("go", running, tmp_path / "with-skills")
-        bare = PiAdapter()._command("go", running, tmp_path / "bare")
-    finally:
-        env.stop()
-    assert [command[i + 1] for i, a in enumerate(command) if a == "--skill"] == [
-        str(skill),
-        str(skill),
-    ]
-    assert "--no-skills" in command, "ambient discovery stays off alongside explicit skills"
-    assert "--skill" not in bare
-
-    with pytest.raises(RuntimeError, match="do not exist"):
-        PiAdapter(skills=(str(tmp_path / "missing.md"),)).preflight(env)
-    with pytest.raises(ValidationError, match="skills"):
-        PiAdapter(skills="spatial/SKILL.md")
-
-
-def test_pi_prompt_is_composed_from_its_fields(
-    dataset: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """The run's instructions follow the agent's own contract; the built-in
-    guidance can be switched off so a skill can carry it, while the robot's
-    tool listing stays."""
-    monkeypatch.setattr(pi_mod, "tool_listing", lambda mcp_url: "- move_to(x, y): Go there.")
-    env = Dataset(dataset, mcp_url="http://localhost:1/mcp")
-    running = env.start(())
-    for d in ("default", "bare"):
-        (tmp_path / d).mkdir()
-    try:
-        PiAdapter(instructions="Use only odometry.")._command("go", running, tmp_path / "default")
-        PiAdapter(builtin_guidance=False, tools=("read", "bash"))._command(
-            "go", running, tmp_path / "bare"
-        )
-    finally:
-        env.stop()
-    default = (tmp_path / "default" / "system-prompt.txt").read_text()
-    bare = (tmp_path / "bare" / "system-prompt.txt").read_text()
-    assert default.startswith(
-        "Answer the question from the files and tools listed below and nothing else.\n\n"
-        "Use only odometry.\n\nFiles:\n"
-    )
-    assert "SqliteStore" in default and "dimos mcp call" in default and "- move_to" in default
-    assert "SqliteStore" not in bare and "dimos mcp call" not in bare and "- move_to" in bare
-    assert bare.startswith(
-        "Answer the question from the files and tools listed below and nothing else.\n\nFiles:\n"
-    )
-
-
-def test_pi_that_exits_with_a_failure_status_is_an_error(
-    dataset: str, fake_pi: Path, tmp_path: Path
-) -> None:
-    fake_pi.write_text(f"#!{sys.executable}\nimport sys; sys.exit('unknown tool: bahs')")
-    env = Dataset(dataset)
-    running = env.start(())
-    try:
-        with pytest.raises(RuntimeError, match="exit status 1: unknown tool: bahs"):
-            PiAdapter(cli=str(fake_pi), tools=("read", "bahs")).run(
-                "go", running, tmp_path, timeout_s=60.0
-            )
-    finally:
-        env.stop()
-
-
 def test_agents_report_every_available_tool() -> None:
     environment_tools = ("move_to", "speak")
 
     assert QuestionAnswer().available_tools(environment_tools) == ()
     assert Blind().available_tools(environment_tools) == ()
     assert McpClientAdapter().available_tools(environment_tools) == environment_tools
-    assert PiAdapter().available_tools(environment_tools) == (
-        "read",
-        "bash",
-        "edit",
-        "write",
-        *environment_tools,
-    )

--- a/docs/usage/evals.md
+++ b/docs/usage/evals.md
@@ -5,7 +5,7 @@
 - **Case**: a discrete scenario being tested. This specifies the prompt sent to the agent, the environment, and scoring functions for the final world state and agent response.
 - **Environment**: this is either a dataset, a live simulation, or an image file being passed to the agent.
 - **Suite**: a collection of cases.
-- **Agent**: this is a wrapper that might contain an entire agent loop, a single request to an llm provider, and it may contain tools. Agents include our mcp client as well as a simple single-turn question/answer with no tools.
+- **Agent**: this is a wrapper that might contain an entire agent loop, a single request to an llm provider, and it may contain tools. Agents include our mcp client, pi, as well as a simple single-turn question/answer with no tools.
 
 ## Quick start (CLI)
 
@@ -15,6 +15,9 @@ dimos evals run dimos.evals.suites.examples --agent dimos.evals.agents.question_
 
 # same cases with observations withheld (the guessing ablation)
 dimos evals run dimos.evals.suites.examples --agent dimos.evals.agents.blind
+
+# same cases, the Pi coding agent over the recording as a file (needs pi on PATH)
+dimos evals run dimos.evals.suites.examples --agent dimos.evals.agents.pi
 
 # list suites
 dimos evals list


### PR DESCRIPTION
## Contribution path

- Small, safe change that does not need a tracking issue

## Problem

We should have a control or baseline when doing agent evals. None such existed. An example of a control or baseline would simply be having Claude Code, Codex, OpenCode, Pi, or some similar established coding agent run against our agent evals.

## Solution

Add a wrapper for the Pi agent harness.

## How to Test

```sh
# Uncomment if Pi is not installed 
# npm install -g @earendil-works/pi-coding-agent && \

DIMOS_TRANSPORT=lcm uv run dimos evals run \
    dimos.evals.suites.dimsim_pointcloud_mapping \
    --agent dimos.evals.agents.pi \
    --set max_steps=30
    # --set instructions="custom instructions that are appended to the prompt that will influence the agent to approach the task in a particular way"
```

## AI assistance

I used Fable 5 to write the code changes and I further iterated on it from there.

## Checklist

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
