### PR TITLE
fix(cloud): stamp content_encoding only when compression ran

### DIFF
--- a/dimos/cloud/data.py
+++ b/dimos/cloud/data.py
@@ -120,9 +120,11 @@ class MultipartBackend:
         if bp := _blueprint(path):
             manifest = dict(manifest or {}, blueprint=bp)
         with self._staging(path) as tmp:
-            if self.codec_id and path.suffix != codecs.suffix(self.codec_id):
+            # A file already carrying the codec's suffix uploads as-is; it must not be
+            # stamped, or pull would decompress bytes we never compressed.
+            compress = bool(self.codec_id) and path.suffix != codecs.suffix(self.codec_id)
+            if compress:
                 _require_space(Path(tmp), path.stat().st_size)
-            if self.codec_id and path.suffix != codecs.suffix(self.codec_id):
                 artifact = Path(tmp) / (path.name + codecs.suffix(self.codec_id))
                 tick("compress", 0, 0)
                 codecs.compress(self.codec_id, path, artifact)
@@ -134,7 +136,7 @@ class MultipartBackend:
                 size=size,
                 sha256=_sha256(artifact),
                 kind=kind,
-                content_encoding=self.codec_id or None,
+                content_encoding=self.codec_id if compress else None,
                 robot_id=robot_id,
                 manifest=manifest,
                 part_size=part_size,

--- a/dimos/cloud/test_data.py
+++ b/dimos/cloud/test_data.py
@@ -383,3 +383,16 @@ def test_upload_cli_exits_nonzero_on_server_error(
     with pytest.raises(typer.Exit) as e:
         cli.upload(db, None, None, None, None)
     assert e.value.exit_code == 1
+
+
+def test_matching_suffix_uploads_raw_and_unstamped(
+    env: tuple[CloudData, FakeTransport, Path],
+) -> None:
+    """A file already named *.lz4 is sent as-is: no encoding stamp, byte-identical pull."""
+    cloud, t, db = env
+    raw = db.parent / "artifact.lz4"  # arbitrary bytes, NOT lz4-compressed
+    raw.write_bytes(b"not actually lz4" * 1024)
+    r = cloud.upload(raw)
+    assert t.uploads[r["upload_id"]]["content_encoding"] is None
+    out = cloud.pull(r["upload_id"], dest=db.parent / "artifact.back.lz4")
+    assert out.read_bytes() == raw.read_bytes()


### PR DESCRIPTION
## Summary

a file already carrying the codec's suffix (any `*.lz4`, whatever its bytes) skips compression but was still stamped `content_encoding=lz4`, so `dimos data pull` decompressed bytes that were never compressed and failed instead of restoring the file.

Fix: track whether compression actually ran and stamp `content_encoding` only then (also collapses the duplicated suffix condition). Files named like the codec now round-trip raw and byte-identical.

## Test plan

- [x] `test_matching_suffix_uploads_raw_and_unstamped`: `artifact.lz4` with non-lz4 bytes uploads with `content_encoding=None` and pulls byte-identical
- [x] `pytest dimos/cloud/test_data.py`: 26 passed; mypy reports only the pre-existing `cd.time` fixture complaint (untouched lines)
