### PR TITLE
fix(ci): prune the uv cache before saving it

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           enable-cache: true
           prune-cache: true
+          cache-suffix: autofix
       - name: Install dependencies
         run: uv sync --only-group autofix --frozen
       - name: Ruff fix

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -20,6 +20,7 @@ jobs:
         uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
+          prune-cache: true
       - name: Install dependencies
         run: uv sync --only-group autofix --frozen
       - name: Ruff fix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,7 @@ jobs:
         uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
+          prune-cache: true
       - name: Install lint dependencies
         run: uv sync --only-group lint --frozen
       - name: Mypy
@@ -227,6 +228,7 @@ jobs:
         uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
+          prune-cache: true
       - name: Install dependency for pyaudio
         run: |
           sudo apt-get update
@@ -344,6 +346,7 @@ jobs:
         uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
+          prune-cache: true
       - uses: actions/setup-node@v7
         with:
           node-version: 'lts/*'
@@ -460,6 +463,7 @@ jobs:
         uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
+          prune-cache: true
       - name: Setup Python
         uses: actions/setup-python@v7.0.0
         with:
@@ -519,6 +523,7 @@ jobs:
         uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
+          prune-cache: true
       - name: Setup Python
         uses: actions/setup-python@v7.0.0
         with:

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -40,6 +40,7 @@ jobs:
         uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
+          prune-cache: true
 
       # --only-group, not --group: the site build imports nothing from dimos,
       # and syncing the project drags in the default groups, where pyaudio

--- a/.github/workflows/release-build-check.yml
+++ b/.github/workflows/release-build-check.yml
@@ -55,6 +55,7 @@ jobs:
         uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
+          prune-cache: true
       - name: Build sdist
         run: uv build --sdist
       - name: Check sdist contents

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
         uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
+          prune-cache: true
       - name: Verify dispatched from a release/* branch
         run: |
           branch="${GITHUB_REF#refs/heads/}"
@@ -82,6 +83,7 @@ jobs:
         uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
+          prune-cache: true
       - name: Build cockpit dist  # shipped pre-built in the sdist and wheels
         uses: ./.github/actions/build-cockpit
       - name: Build sdist


### PR DESCRIPTION
## Contribution path

- Small, safe change that does not need a tracking issue

## Problem

`astral-sh/setup-uv:prune-cache` defaulted to `true` in 8.3.2 ([source](https://github.com/astral-sh/setup-uv/blob/v8.3.2/action.yml#L64)). dependabot [bumped its version](https://github.com/dimensionalos/dimos/pull/3636) to 10.0.1. Now, `prune-cache` defaults to false ([source](https://github.com/astral-sh/setup-uv/blob/v10.0.1/action.yml#L64)).

With that change, every job uploads the whole uv cache under the same shared key and the cache has grown to 4GB.

poor autofix job has a time limit of 1m. It couldn't download the whole 4GB cache and complete it's task in time before timing out.

autofix job no longer passes.

## Solution

add `prune-cache: true` to the jobs. also give the autofix job its own cache-suffix so it wont read from other jobs' caches.

## AI assistance

I chatted with Fable 5.1 throughout this whole thing and simulated warm/cold starts locally with prune-cache true and false.

## Checklist

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
