### PR TITLE
Fix ros-dev install

### DIFF
--- a/docker/python/Dockerfile
+++ b/docker/python/Dockerfile
@@ -30,10 +30,12 @@ RUN apt-get update && apt-get install -y \
     qt5-qmake \
     qtbase5-dev-tools \
     supervisor \
-    iproute2 # for LCM networking system config \
+    # for LCM networking system config
+    iproute2 \
     liblcm-dev \
     libturbojpeg0-dev \
-    cyclonedds-dev  # For unitree-sdk2py
+    # For unitree-sdk2py
+    cyclonedds-dev
 
 # Fix distutils-installed packages that block pip upgrades
 RUN apt-get purge -y python3-blinker python3-sympy python3-oauthlib || true


### PR DESCRIPTION
The comments may be causing problems with line continuation (which maybe asks if we even need the extra 2 dependencies that were not being installed at all; I only need the cyclone one).