### PR TITLE
fix(cli): dimos data quota shows the daily limit too

### DIFF
--- a/dimos/cloud/cli.py
+++ b/dimos/cloud/cli.py
@@ -138,7 +138,12 @@ def status(upload_id: str) -> None:
 
 @handle_fail
 def quota() -> None:
+    from rich.filesize import decimal
+
     q = CloudData().quota()
+    lim = q["limits"]
     typer.echo(
-        f"{q['pct']}% used ({q['state']}) — {q['used_total']} bytes of {q['limits']['total_gb']} GB"
+        f"{q['pct']}% used ({q['state']}) — total {decimal(q['used_total'])}"
+        f" of {lim['total_gb']} GB, today {decimal(q['used_today'])}"
+        f" of {lim['daily_gb']} GB"
     )

--- a/dimos/cloud/test_data.py
+++ b/dimos/cloud/test_data.py
@@ -54,7 +54,16 @@ class FakeTransport:
             )
             return self._pending(uid)
         if path.endswith("/quota"):
-            return {"state": "ok"}
+            # The real /v1/data/quota always returns the full shape (quota_status
+            # in dimos-cloud); a minimal stub here would hide contract breaks.
+            return {
+                "state": "ok",
+                "pct": 0.0,
+                "used_total": 0,
+                "used_today": 0,
+                "limits": {"total_gb": 250, "daily_gb": 25, "max_file_gb": 50, "trust": "new"},
+                "message": "storage at 0% of quota",
+            }
         if path.endswith("/uploads"):
             return {"uploads": [dict(id=k, **v) for k, v in self.uploads.items()]}
         uid = path.split("/")[4]


### PR DESCRIPTION
Companion to dimensionalOS/dimos-cloud quota-message fix: a daily-limit 429 looked absurd next to '0.0% used of 250 GB' because quota only printed the total line. Now: '0.0% used (ok) — total 2.6 MB of 250 GB, today 2.6 MB of 25 GB'.