### PR TITLE
fix(cli): dimos data ls shows upload times in local time with tz label

### DIFF
--- a/dimos/cloud/cli.py
+++ b/dimos/cloud/cli.py
@@ -94,6 +94,8 @@ def ls() -> None:
     from rich.filesize import decimal
     from rich.table import Table
 
+    tz_now = datetime.now().astimezone().tzname()
+
     def local(ts: str) -> str:
         try:
             d = datetime.fromisoformat(ts)
@@ -101,7 +103,10 @@ def ls() -> None:
             return ts[:16].replace("T", " ")
         if d.tzinfo is None:
             d = d.replace(tzinfo=timezone.utc)
-        return d.astimezone().strftime("%Y-%m-%d %H:%M")
+        d = d.astimezone()
+        # A row across a DST boundary carries its own label (PST vs the PDT header).
+        suffix = "" if d.tzname() == tz_now else f" {d.tzname()}"
+        return d.strftime("%Y-%m-%d %H:%M") + suffix
 
     rows = CloudData().ls()
     org = any(u.get("uploader_email") for u in rows)

--- a/dimos/cloud/cli.py
+++ b/dimos/cloud/cli.py
@@ -87,17 +87,30 @@ def upload(
 
 @handle_fail
 def ls() -> None:
+    from datetime import datetime, timezone
+
     from rich import box
     from rich.console import Console
     from rich.filesize import decimal
     from rich.table import Table
+
+    def local(ts: str) -> str:
+        try:
+            d = datetime.fromisoformat(ts)
+        except ValueError:
+            return ts[:16].replace("T", " ")
+        if d.tzinfo is None:
+            d = d.replace(tzinfo=timezone.utc)
+        return d.astimezone().strftime("%Y-%m-%d %H:%M")
 
     rows = CloudData().ls()
     org = any(u.get("uploader_email") for u in rows)
     table = Table(box=box.SIMPLE_HEAVY, header_style="bold")
     table.add_column("id", style="cyan", no_wrap=True)
     table.add_column("file", style="bold")
-    table.add_column("uploaded", style="dim", no_wrap=True)
+    table.add_column(
+        f"uploaded ({datetime.now().astimezone().tzname()})", style="dim", no_wrap=True
+    )
     table.add_column("kind")
     if org:
         table.add_column("uploader", style="dim")
@@ -112,7 +125,7 @@ def ls() -> None:
         table.add_row(
             u["id"][:12],
             u["filename"],
-            str(u.get("created_at") or "")[:16].replace("T", " ") or "—",
+            local(str(u.get("created_at") or "")) or "—",
             u.get("kind", ""),
             *([u.get("uploader_email") or "—"] if org else []),
             mani.get("blueprint") or "—",


### PR DESCRIPTION
Server timestamps are UTC and were printed raw. The uploaded column now converts to the machine's local zone (correct across DST and for teammates in other zones, unlike hardcoding PST) and the header carries the zone label: uploaded (PDT). Naive strings are treated as UTC; unparseable ones fall back to the old rendering.