### PR TITLE
feat(web): agent chat panel

### DIFF
--- a/dimos/robot/all_blueprints.py
+++ b/dimos/robot/all_blueprints.py
@@ -137,6 +137,7 @@ all_blueprints = {
     "unitree-g1-teleop": "dimos.robot.unitree.g1.blueprints.basic.unitree_g1_teleop:unitree_g1_teleop",
     "unitree-go2": "dimos.robot.unitree.go2.blueprints.smart.unitree_go2:unitree_go2",
     "unitree-go2-agentic": "dimos.robot.unitree.go2.blueprints.agentic.unitree_go2_agentic:unitree_go2_agentic",
+    "unitree-go2-agentic-cockpit": "dimos.robot.unitree.go2.blueprints.agentic.unitree_go2_agentic_cockpit:unitree_go2_agentic_cockpit",
     "unitree-go2-agentic-huggingface": "dimos.robot.unitree.go2.blueprints.agentic.unitree_go2_agentic_huggingface:unitree_go2_agentic_huggingface",
     "unitree-go2-agentic-ollama": "dimos.robot.unitree.go2.blueprints.agentic.unitree_go2_agentic_ollama:unitree_go2_agentic_ollama",
     "unitree-go2-basic": "dimos.robot.unitree.go2.blueprints.basic.unitree_go2_basic:unitree_go2_basic",

--- a/dimos/robot/unitree/go2/blueprints/agentic/unitree_go2_agentic_cockpit.py
+++ b/dimos/robot/unitree/go2/blueprints/agentic/unitree_go2_agentic_cockpit.py
@@ -1,0 +1,37 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The agentic go2 with an authored cockpit: video left, costmap+pose over
+keyboard teleop in the middle, the agent chat right (the humancli
+conversation on McpClient's human_input/agent/agent_idle streams).
+
+Separate file on purpose: cockpit() needs the [web] extra at import time,
+and `unitree-go2-agentic` itself must stay importable without it.
+"""
+
+from dimos.core.coordination.blueprints import autoconnect
+from dimos.robot.unitree.go2.blueprints.agentic.unitree_go2_agentic import unitree_go2_agentic
+from dimos.web.cockpit import Chat, Col, Map2D, Row, Teleop, Video, cockpit
+
+unitree_go2_agentic_cockpit = autoconnect(
+    unitree_go2_agentic,
+    cockpit(
+        layout=Row(
+            Video("color_image"),
+            Col(Map2D(costmap="global_costmap", pose="odom"), Teleop(), shares=[3, 1]),
+            Chat(),
+            shares=[2, 1, 1],
+        ),
+    ),
+).global_config(n_workers=9, robot_model="unitree_go2")

--- a/dimos/web/cockpit.py
+++ b/dimos/web/cockpit.py
@@ -34,7 +34,7 @@ extra; only cockpit() touches the relay bridge module.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Mapping, Sequence, Set as AbstractSet
+from collections.abc import Iterator, Mapping, Sequence, Set as AbstractSet
 from dataclasses import dataclass, field, replace
 import json
 import math
@@ -139,6 +139,10 @@ class ChannelRequest:
     delivery: Delivery = field(default="reliable", kw_only=True)
     publish: Publish = field(default="none", kw_only=True)
     required_scope: str | None = field(default=None, kw_only=True)
+    # Event streams (chat): the bridge meets max_hz by spacing sends, never by
+    # dropping, so a burst of messages crosses complete and in order. Panels
+    # only; a plain Channel is sampled at max_hz.
+    paced: bool = field(default=False, kw_only=True)
 
 
 @dataclass(frozen=True)
@@ -242,6 +246,22 @@ class Channel:
         object.__setattr__(self, "params", _freeze_params(params))
 
 
+def _request_of(channel: Channel) -> ChannelRequest:
+    """The manifest request a declaration compiles to."""
+    return ChannelRequest(
+        channel.stream,
+        channel.dir,
+        channel.encoding,
+        channel.max_hz,
+        # Deep plain copy: the manifest and specs must not alias the (frozen)
+        # authoring record's nested values.
+        _thaw_params(channel.params or {}),
+        delivery=channel.delivery,
+        publish=channel.publish,
+        required_scope=channel.required_scope,
+    )
+
+
 class Panel(ABC):
     """Base for cockpit panels. `kind` is the Cockpit component registry
     key; `title` "" means untitled (the panel frame falls back to the panel
@@ -252,6 +272,12 @@ class Panel(ABC):
 
     @abstractmethod
     def _channel_requests(self) -> tuple[ChannelRequest, ...]: ...
+
+    def _channels(self) -> tuple[Channel, ...]:
+        """Declarations for the panel's non-built-in streams (typed like an
+        explicit cockpit(channels=[...]) entry, so cockpit() generates the
+        bridge ports)."""
+        return ()
 
     def _panel_params(self) -> dict[str, Any]:
         return {}
@@ -364,6 +390,48 @@ class Teleop(Panel):
         )
 
 
+@dataclass(frozen=True)
+class Chat(Panel):
+    """Agent conversation: the humancli contract as a panel. Typed text
+    goes out on `input` (McpClient.human_input); the LangChain transcript
+    comes back on `messages` (McpClient.agent, one chat.json.v1 frame per
+    message, none dropped) and `idle` (McpClient.agent_idle) drives the
+    thinking spinner. A grid panel next to video/map; works as a page too.
+    """
+
+    kind: ClassVar[str] = "chat"
+    input: str = "human_input"
+    messages: str = "agent"
+    idle: str = "agent_idle"
+    title: str = field(default="", kw_only=True)
+
+    def __post_init__(self) -> None:
+        _check_stream("input", self.input)
+        _check_stream("messages", self.messages)
+        _check_stream("idle", self.idle)
+
+    def _channels(self) -> tuple[Channel, ...]:
+        # Inline on purpose: langchain-core belongs to the optional [agents]
+        # extra, so only a Chat panel pays for it; the codec module import
+        # registers chat.json.v1 for cockpit()'s encoder resolution.
+        from langchain_core.messages import BaseMessage
+
+        from dimos.web.relay_bridge import chat_codec  # noqa: F401
+
+        return (
+            Channel(
+                self.input, str, dir="tx", encoding="text.json.v1", publish="shared", max_hz=5.0
+            ),
+            Channel(self.messages, BaseMessage, encoding="chat.json.v1", max_hz=20.0),
+            Channel(self.idle, bool, delivery="latest", max_hz=20.0),
+        )
+
+    def _channel_requests(self) -> tuple[ChannelRequest, ...]:
+        # Every agent message and idle flip must reach the viewer: paced,
+        # not sampled.
+        return tuple(replace(_request_of(channel), paced=True) for channel in self._channels())
+
+
 class _Split:
     """Base for Row/Col: children plus optional flex shares."""
 
@@ -395,6 +463,19 @@ class Row(_Split):
 
 class Col(_Split):
     """Vertical split; absent shares mean an equal split."""
+
+
+def _panels(node: Any) -> Iterator[Panel]:
+    """Panels of a layout tree or a pages sequence, depth-first. Anything
+    else is skipped here and rejected by build_manifest_data."""
+    if isinstance(node, Panel):
+        yield node
+    elif isinstance(node, _Split):
+        for child in node.children:
+            yield from _panels(child)
+    elif isinstance(node, (list, tuple)):
+        for child in node:
+            yield from _panels(child)
 
 
 def _default_preset() -> Row:
@@ -643,30 +724,31 @@ def cockpit(
     from dimos.core.coordination.blueprints import autoconnect
     from dimos.web.codecs import resolve_decoder, resolve_encoder
 
+    layout = _default_preset() if layout is None and not declared else layout
+    # Panels binding non-built-in streams (Chat) declare them like explicit
+    # channels. An explicit declaration for the same stream stands, provided
+    # it agrees (the rest of the agreement check is build_manifest_data's).
+    paced: set[str] = set()
+    for panel in (*_panels(layout), *_panels(tuple(pages))):
+        paced.update(r.stream for r in panel._channel_requests() if r.paced)
+        for channel in panel._channels():
+            previous = declared.setdefault(channel.stream, channel)
+            if previous.message_type is not channel.message_type:
+                raise ValueError(
+                    f"conflicting declarations for stream {channel.stream!r}: "
+                    f"{previous!r} vs {channel!r}"
+                )
+
     atom = RelayBridgeModule.blueprint().blueprints[0]
     port_types = {s.name: s.type for s in atom.streams}
     builtin_by_ch = {b.ch: b for b in BUILTIN_CHANNELS}
     data = build_manifest_data(
-        _default_preset() if layout is None and not declared else layout,
+        layout,
         tuple(pages),
         registry={b.ch: (b.encoding, b.delivery) for b in BUILTIN_CHANNELS},
         tx_streams={s.name for s in atom.streams if s.direction == "out"},
         tx_registry={ch: (encoding, delivery) for ch, encoding, delivery in TX_CHANNELS},
-        channels=tuple(
-            ChannelRequest(
-                c.stream,
-                c.dir,
-                c.encoding,
-                c.max_hz,
-                # Deep plain copy: the manifest and specs must not alias the
-                # (frozen) authoring record's nested values.
-                _thaw_params(c.params or {}),
-                delivery=c.delivery,
-                publish=c.publish,
-                required_scope=c.required_scope,
-            )
-            for c in declared.values()
-        ),
+        channels=tuple(_request_of(c) for c in declared.values()),
     )
     # The domain parser is the authority; authoring bugs must fail at
     # blueprint definition time, not at robot start.
@@ -732,6 +814,7 @@ def cockpit(
                 encoder=codec.encode,
                 encoder_takes_params=codec.takes_params,
                 resend_on_subscribe=builtin.resend_on_subscribe if builtin is not None else False,
+                paced=ch in paced,
             )
         )
     # Generated classes carry only the custom ports; the built-ins are

--- a/dimos/web/relay_bridge/chat_codec.py
+++ b/dimos/web/relay_bridge/chat_codec.py
@@ -1,0 +1,82 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""chat.json.v1: LangChain agent messages -> chat lines (the Chat panel).
+
+Kept out of builtin_codecs on purpose: langchain-core belongs to the [agents]
+extra, so the generic bridge and authoring modules must import without it.
+The Chat panel imports this module (registering the encoder) only when used.
+
+Wire contract: one frame per message, the payload a JSON array of lines
+`{"role": str, "text": str, "ts": float, "tool"?: str}` (ts = seconds since
+the epoch at encode time; tool = the tool name on the condensed tool
+call/result/progress lines).
+"""
+
+import json
+import time
+from typing import Any
+
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage, ToolMessage
+
+from dimos.web.codecs import web_encoder
+
+# Tool progress rides /agent as HumanMessage("[tool:NAME] text")
+# (mcp_client._on_tool_stream_message); same parse as humancli.
+_TOOL_MSG_PREFIX = "[tool:"
+# A tool result can be megabytes and the cockpit's JSON decoder drops payloads
+# above 256 KiB; a chat line is for reading, not for carrying data.
+_CHAT_TEXT_MAX_CHARS = 4000
+
+
+def chat_lines(msg: BaseMessage, ts: float) -> list[dict[str, Any]]:
+    """The chat lines of one LangChain message: humancli's rendering as
+    data. Known kinds are human, ai, tool and system; any other message type
+    is passed through as its role so new kinds degrade visibly, not
+    silently. Content blocks flatten to their text (images never cross the
+    wire); empty lines are dropped."""
+    text = msg.text
+    lines: list[dict[str, Any]]
+    if isinstance(msg, HumanMessage):
+        end = text.find("]")
+        if text.startswith(_TOOL_MSG_PREFIX) and end != -1:
+            tool = text[len(_TOOL_MSG_PREFIX) : end]
+            lines = [{"role": "tool", "tool": tool, "text": text[end + 1 :].lstrip()}]
+        else:
+            lines = [{"role": "human", "text": text}]
+    elif isinstance(msg, AIMessage):
+        lines = [{"role": "ai", "text": text}]
+        for call in msg.tool_calls:
+            args = json.dumps(call["args"], separators=(",", ":"))
+            lines.append({"role": "ai", "tool": call["name"], "text": f"{call['name']}({args})"})
+    elif isinstance(msg, ToolMessage):
+        lines = [{"role": "tool", "tool": msg.name or "tool", "text": text}]
+    elif isinstance(msg, SystemMessage):
+        lines = [{"role": "system", "text": text}]
+    else:
+        lines = [{"role": msg.type, "text": text}]
+    for line in lines:
+        if len(line["text"]) > _CHAT_TEXT_MAX_CHARS:
+            line["text"] = line["text"][:_CHAT_TEXT_MAX_CHARS] + "..."
+        line["ts"] = ts
+    return [line for line in lines if line["text"]]
+
+
+@web_encoder("chat.json.v1")
+def encode_chat(msg: BaseMessage) -> bytes | None:
+    """None skips a message with nothing to show (an empty AI turn)."""
+    lines = chat_lines(msg, time.time())
+    if not lines:
+        return None
+    return json.dumps(lines, separators=(",", ":")).encode()

--- a/dimos/web/relay_bridge/manifest.py
+++ b/dimos/web/relay_bridge/manifest.py
@@ -19,7 +19,7 @@ from both pytest and deno test). The transport (protocol.py) carries the
 manifest as one opaque dict; this module is the single owner of its
 structure and domain rules: version gate, bounded unique ids, positive
 rates, panel/layout/pages references that resolve, and kind-specific panel
-rules (video, map2d, teleop).
+rules (video, map2d, teleop, chat).
 
 Manifest v1 is frozen. Additive changes (new panel kinds, new params) ride
 the existing shape: unknown keys and kinds pass through validation.
@@ -319,6 +319,37 @@ def parse_manifest(data: Any) -> Manifest:
                 raise ManifestError(
                     "invalid_teleop_panel",
                     f"teleop panel {panel.id} needs a twist.json.v1 latest tx channel",
+                )
+        if panel.kind == "chat":
+            # channels: the text input (publish tx), the messages, the idle flag.
+            if len(panel.channels) != 3:
+                raise ManifestError(
+                    "invalid_chat_panel", f"chat panel {panel.id} must bind three channels"
+                )
+            text, messages, idle = (ch_ids[ch] for ch in panel.channels)
+            if (
+                text.encoding != "text.json.v1"
+                or text.delivery != "reliable"
+                or text.dir != "tx"
+                or text.publish != "shared"
+            ):
+                raise ManifestError(
+                    "invalid_chat_panel",
+                    f"chat panel {panel.id} needs a text.json.v1 reliable shared tx channel first",
+                )
+            if (
+                messages.encoding != "chat.json.v1"
+                or messages.delivery != "reliable"
+                or messages.dir != "rx"
+            ):
+                raise ManifestError(
+                    "invalid_chat_panel",
+                    f"chat panel {panel.id} needs a chat.json.v1 reliable rx channel second",
+                )
+            if idle.encoding != "json.v1" or idle.delivery != "latest" or idle.dir != "rx":
+                raise ManifestError(
+                    "invalid_chat_panel",
+                    f"chat panel {panel.id} needs a json.v1 latest rx channel third",
                 )
 
     seen: set[str] = set()

--- a/dimos/web/relay_bridge/relay_bridge_module.py
+++ b/dimos/web/relay_bridge/relay_bridge_module.py
@@ -36,6 +36,7 @@ restarts (respawning the local child when it died).
 from __future__ import annotations
 
 import asyncio
+from collections import deque
 from collections.abc import AsyncIterator, Callable, Collection
 from dataclasses import dataclass, field, replace
 import functools
@@ -231,6 +232,10 @@ class RuntimeChannelSpec:
     # viewer: a new session must not wait for the next publish (the producer
     # may have gone quiet, possibly before the first viewer ever attached).
     resend_on_subscribe: bool = False
+    # Event channels (chat): the maxHz cap is met by spacing sends (a paced
+    # FIFO on the loop), never by dropping, so a burst of messages crosses
+    # complete and in order and a state flag keeps its newest value.
+    paced: bool = False
 
 
 class RelayBridgeConfig(ModuleConfig):
@@ -363,6 +368,55 @@ class _Session:
     last_n: int | float = 0
     unsubs: dict[str, Callable[[], None]] = field(default_factory=dict)
     retired: threading.Event = field(default_factory=threading.Event)
+
+
+# A producer sustaining more than maxHz for this many frames is pathological
+# (the agent chats at a few messages a second); beyond it the oldest go.
+_PACED_QUEUE_MAX = 256
+
+
+class _PacedSender:
+    """Send cap by spacing, not sampling: frames queue on the loop and go out
+    one per interval, in order, so an event channel (chat) never thins a
+    burst. Wraps the channel's real sender."""
+
+    def __init__(self, loop: asyncio.AbstractEventLoop, interval: float, send: _Sender) -> None:
+        self._loop = loop
+        self._interval = interval
+        self._send = send
+        self._queue: deque[tuple[bytes, _FrameMeta, float | None]] = deque()
+        self._due = 0.0
+        self._handle: asyncio.TimerHandle | None = None
+        self.dropped = 0
+
+    def __call__(self, payload: bytes, meta: _FrameMeta, ts: float | None) -> None:
+        self._queue.append((payload, meta, ts))
+        if len(self._queue) > _PACED_QUEUE_MAX:
+            self._queue.popleft()
+            self.dropped += 1
+        if self._handle is None:
+            self._drain()
+
+    def _drain(self) -> None:
+        self._handle = None
+        now = self._loop.time()
+        if now < self._due:
+            self._handle = self._loop.call_at(self._due, self._drain)
+            return
+        payload, meta, ts = self._queue.popleft()
+        self._due = now + self._interval
+        if self._queue:
+            self._handle = self._loop.call_at(self._due, self._drain)
+        try:
+            self._send(payload, meta, ts)
+        except Exception:
+            return  # session mid-teardown, same as _offer
+
+    def close(self) -> None:
+        if self._handle is not None:
+            self._handle.cancel()
+            self._handle = None
+        self._queue.clear()
 
 
 def _no_default_params(config: RelayBridgeConfig) -> dict[str, Any]:
@@ -881,10 +935,14 @@ class RelayBridgeModule(Module):
     def _build_senders(self, client: RelayClient) -> dict[str, _Sender]:
         senders: dict[str, _Sender] = {}
         for spec in self._channel_specs:
+            sender: _Sender
             if spec.delivery == "latest":
-                senders[spec.ch] = client.latest_writer(spec.ch).offer
+                sender = client.latest_writer(spec.ch).offer
             else:
-                senders[spec.ch] = functools.partial(self._send_reliable, client, spec.ch)
+                sender = functools.partial(self._send_reliable, client, spec.ch)
+            if spec.paced:
+                sender = _PacedSender(asyncio.get_running_loop(), 1.0 / spec.max_hz, sender)
+            senders[spec.ch] = sender
         return senders
 
     def _send_reliable(
@@ -1239,7 +1297,9 @@ class RelayBridgeModule(Module):
         if session.retired.is_set():
             return
         now = time.monotonic()
-        if not _passes_rate_gate(self._last_input, spec.ch, now, self._min_interval[spec.ch]):
+        if not spec.paced and not _passes_rate_gate(
+            self._last_input, spec.ch, now, self._min_interval[spec.ch]
+        ):
             return
         encoded = self._run_encoder(spec, msg)
         if encoded is None:
@@ -1279,6 +1339,9 @@ class RelayBridgeModule(Module):
         target.retired.set()
         if self._session is target:
             self._session = None
+        for sender in target.senders.values():
+            if isinstance(sender, _PacedSender):
+                sender.close()
         # A driving teleop stream cannot outlive its session (this also
         # covers module stop, KeyboardTeleop.stop() parity). Idempotent:
         # the edge gate makes the second call of a double-disconnect a no-op.

--- a/dimos/web/relay_bridge/test_chat_encoding.py
+++ b/dimos/web/relay_bridge/test_chat_encoding.py
@@ -1,0 +1,98 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""chat.json.v1: LangChain messages -> chat lines (humancli's rendering as data)."""
+
+import json
+
+from langchain_core.messages import (
+    AIMessage,
+    BaseMessage,
+    ChatMessage,
+    HumanMessage,
+    SystemMessage,
+    ToolMessage,
+)
+import pytest
+
+from dimos.web.codecs import resolve_encoder
+from dimos.web.relay_bridge.chat_codec import _CHAT_TEXT_MAX_CHARS, chat_lines, encode_chat
+
+_IMAGE = {"type": "image", "data": "AAAA", "mime_type": "image/png"}
+_TS = 1752576000.5
+
+
+@pytest.mark.parametrize(
+    ("msg", "lines"),
+    [
+        (HumanMessage("walk forward"), [{"role": "human", "text": "walk forward"}]),
+        (
+            HumanMessage("[tool:nav] 40% there"),
+            [{"role": "tool", "tool": "nav", "text": "40% there"}],
+        ),
+        (HumanMessage("[tool:nav]"), []),
+        (AIMessage("on my way"), [{"role": "ai", "text": "on my way"}]),
+        (
+            AIMessage("sure", tool_calls=[{"name": "nav", "args": {"x": 1.5, "y": 0}, "id": "c1"}]),
+            [
+                {"role": "ai", "text": "sure"},
+                {"role": "ai", "tool": "nav", "text": 'nav({"x":1.5,"y":0})'},
+            ],
+        ),
+        (AIMessage(""), []),
+        (
+            ToolMessage("arrived", tool_call_id="c1", name="nav"),
+            [{"role": "tool", "tool": "nav", "text": "arrived"}],
+        ),
+        (
+            ToolMessage("arrived", tool_call_id="c1"),
+            [{"role": "tool", "tool": "tool", "text": "arrived"}],
+        ),
+        (SystemMessage("be brief"), [{"role": "system", "text": "be brief"}]),
+        (
+            HumanMessage(content=[{"type": "text", "text": "artefact"}, _IMAGE]),
+            [{"role": "human", "text": "artefact"}],
+        ),
+        (ChatMessage("hm", role="critic"), [{"role": "chat", "text": "hm"}]),
+    ],
+    ids=[
+        "human",
+        "tool_progress",
+        "tool_progress_empty",
+        "ai",
+        "ai_tool_calls",
+        "ai_empty",
+        "tool",
+        "tool_unnamed",
+        "system",
+        "multimodal",
+        "unknown_kind",
+    ],
+)
+def test_chat_lines(msg: BaseMessage, lines: list[dict[str, str]]) -> None:
+    assert chat_lines(msg, _TS) == [{**line, "ts": _TS} for line in lines]
+
+
+def test_long_text_is_capped() -> None:
+    (line,) = chat_lines(ToolMessage("x" * (_CHAT_TEXT_MAX_CHARS + 1), tool_call_id="c1"), _TS)
+    assert line["text"] == "x" * _CHAT_TEXT_MAX_CHARS + "..."
+
+
+def test_encoder_emits_compact_json_or_skips() -> None:
+    assert resolve_encoder("chat.json.v1", BaseMessage).encode is encode_chat
+    payload = encode_chat(HumanMessage(content=[{"type": "text", "text": "artefact"}, _IMAGE]))
+    assert payload is not None and b"image" not in payload
+    (line,) = json.loads(payload)
+    assert line["role"] == "human" and line["text"] == "artefact" and line["ts"] > 0
+    assert encode_chat(AIMessage("")) is None

--- a/dimos/web/relay_bridge/test_relay_bridge_authoring.py
+++ b/dimos/web/relay_bridge/test_relay_bridge_authoring.py
@@ -19,12 +19,14 @@ no-network harness as test_relay_bridge_module.py (see module_test_support).
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import replace
 import json
 import pickle
 import struct
 from typing import Any
 
+from langchain_core.messages import AIMessage
 import numpy as np
 import pytest
 
@@ -36,7 +38,7 @@ from dimos.msgs.geometry_msgs.Twist import Twist
 from dimos.msgs.nav_msgs.OccupancyGrid import OccupancyGrid
 from dimos.msgs.nav_msgs.Path import Path as NavPath
 from dimos.msgs.sensor_msgs.Image import Image
-from dimos.web.cockpit import Channel, Video, cockpit
+from dimos.web.cockpit import Channel, Chat, Video, cockpit
 from dimos.web.codecs import EncodedPayload, PublishContext, web_decoder, web_encoder
 from dimos.web.relay_bridge import builtin_codecs, relay_bridge_module
 from dimos.web.relay_bridge.e2e_support import stop_module
@@ -456,6 +458,70 @@ def test_publish_frame_decodes_publishes_then_acks(monkeypatch) -> None:
         push(module, clients[0], _pub_frame(json.dumps("salut β").encode(), seq=2))
         assert wait_until(lambda: len(clients[0].control_frames) == 2)
         assert [value for value, _ in seen] == ["salut β", "salut β"]
+    finally:
+        stop_module(module)
+
+
+def test_paced_sender_spaces_frames_in_order_and_bounds_its_queue() -> None:
+    async def run() -> None:
+        loop = asyncio.get_running_loop()
+        sent: list[tuple[bytes, float]] = []
+        pacer = relay_bridge_module._PacedSender(
+            loop, 0.02, lambda payload, meta, ts: sent.append((payload, loop.time()))
+        )
+        for i in range(3):
+            pacer(bytes([i]), None, None)
+        assert [p for p, _ in sent] == [b"\x00"]  # the first goes now, the rest wait
+        await asyncio.sleep(0.1)
+        assert [p for p, _ in sent] == [b"\x00", b"\x01", b"\x02"]
+        assert sent[2][1] - sent[0][1] >= 0.04 - 0.005
+        # One goes out immediately; the queue keeps the newest of the rest.
+        for i in range(relay_bridge_module._PACED_QUEUE_MAX + 10):
+            pacer(bytes([i % 256]), None, None)
+        assert pacer.dropped == 9
+        pacer.close()
+        await asyncio.sleep(0.05)
+        assert len(sent) == 4  # closed: nothing queued goes out
+
+    asyncio.run(run())
+
+
+def test_chat_panel_forwards_every_message(monkeypatch) -> None:
+    # Chat channels are paced, not sampled: back-to-back agent messages all
+    # cross, in order, and the idle flag's False/True pair both reach the
+    # mailbox.
+    module, clients = start_authored(
+        monkeypatch, cockpit(layout=Chat()), wire=("agent", "agent_idle")
+    )
+    try:
+        agent, idle = transport_of(module, "agent"), transport_of(module, "agent_idle")
+        push(module, clients[0], Subs(chs=["agent", "agent_idle"], n=1))
+        assert wait_until(lambda: agent.subscribers and idle.subscribers)
+        for text in ("one", "two", "three"):
+            agent.publish(AIMessage(text))
+        idle.publish(False)
+        idle.publish(True)
+        assert wait_until(lambda: len(clients[0].frames) == 3)
+        assert [(ch, delivery) for ch, _, delivery, _ in clients[0].frames] == [
+            ("agent", "reliable")
+        ] * 3
+        lines = [json.loads(payload) for _, payload, _, _ in clients[0].frames]
+        assert [[line["text"] for line in frame] for frame in lines] == [
+            ["one"],
+            ["two"],
+            ["three"],
+        ]
+        assert all(line["ts"] > 0 for frame in lines for line in frame)
+        assert wait_until(lambda: len(clients[0].writers["agent_idle"].offers) == 2)
+        assert [json.loads(p) for p, _ in clients[0].writers["agent_idle"].offers] == [False, True]
+
+        # The tx leg: a browser publish lands on the bridge's human_input port.
+        seen: list[str] = []
+        module.human_input.subscribe(seen.append)
+        push(module, clients[0], _pub_frame(json.dumps("walk forward").encode()))
+        assert wait_until(lambda: clients[0].control_frames)
+        assert seen == ["walk forward"]
+        assert isinstance(clients[0].control_frames[0], PubAck)
     finally:
         stop_module(module)
 

--- a/dimos/web/relay_bridge/test_relay_bridge_module.py
+++ b/dimos/web/relay_bridge/test_relay_bridge_module.py
@@ -452,12 +452,15 @@ def test_stop_disposes_costmap_cache_subscription(monkeypatch) -> None:
     assert transport.unsubscribed == 1
 
 
-def test_bridge_import_does_not_pull_matplotlib() -> None:
+def test_bridge_import_does_not_pull_matplotlib_or_langchain() -> None:
     # OccupancyGrid's visualization imports are lazy so the bridge does not
-    # cost every relay worker matplotlib's ~0.5 s / ~28 MiB (review issue 9).
+    # cost every relay worker matplotlib's ~0.5 s / ~28 MiB (review issue 9),
+    # and langchain belongs to the [agents] extra: a web-only install must
+    # still run the bridge (the chat codec loads with the Chat panel).
     code = (
         "import sys; import dimos.web.relay_bridge.relay_bridge_module; "
-        "assert 'matplotlib' not in sys.modules"
+        "assert 'matplotlib' not in sys.modules; "
+        "assert 'langchain_core' not in sys.modules"
     )
     subprocess.run([sys.executable, "-c", code], check=True)
 

--- a/dimos/web/test_cockpit.py
+++ b/dimos/web/test_cockpit.py
@@ -20,6 +20,7 @@ import struct
 import subprocess
 import sys
 
+from langchain_core.messages import BaseMessage
 import pytest
 
 from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
@@ -29,6 +30,7 @@ from dimos.msgs.sensor_msgs.Image import Image
 from dimos.web.cockpit import (
     Channel,
     ChannelRequest,
+    Chat,
     Col,
     Map2D,
     Panel,
@@ -39,6 +41,7 @@ from dimos.web.cockpit import (
 )
 from dimos.web.codecs import EncodedPayload, decode_json_v1, encode_json_v1, web_encoder
 from dimos.web.relay_bridge.builtin_codecs import decode_text
+from dimos.web.relay_bridge.chat_codec import encode_chat
 from dimos.web.relay_bridge.manifest import ManifestError, parse_manifest
 from dimos.web.relay_bridge.protocol import (
     MAX_CONTROL_PAYLOAD_BYTES,
@@ -481,6 +484,49 @@ def test_publish_tx_channel_blueprint() -> None:
     assert ratom.kwargs["channels"][0].decoder is decode_text
 
 
+def test_chat_panel_blueprint() -> None:
+    (atom,) = cockpit(layout=Chat()).blueprints
+    manifest = atom.kwargs["manifest"]
+    assert [
+        (c["ch"], c["dir"], c["encoding"], c["delivery"], c["publish"])
+        for c in manifest["channels"]
+    ] == [
+        ("agent", "rx", "chat.json.v1", "reliable", "none"),
+        ("agent_idle", "rx", "json.v1", "latest", "none"),
+        ("human_input", "tx", "text.json.v1", "reliable", "shared"),
+    ]
+    (panel,) = manifest["panels"]
+    assert panel["kind"] == "chat"
+    assert panel["channels"] == ["human_input", "agent", "agent_idle"]
+    assert parse_manifest(manifest).model_dump() == manifest
+    # The agent streams ride a generated subclass whose ports autoconnect to
+    # McpClient's by name + type.
+    ports = {(s.name, s.direction): s.type for s in atom.streams}
+    assert ports[("agent", "in")] is BaseMessage
+    assert ports[("agent_idle", "in")] is bool
+    assert ports[("human_input", "out")] is str
+    specs = {s.ch: s for s in atom.kwargs["channels"]}
+    assert specs["agent"].encoder is encode_chat and specs["agent"].paced
+    assert specs["agent_idle"].paced
+    assert specs["human_input"].decoder is decode_text
+    # Pacing is the chat panel's, not the stream's: the same streams declared
+    # by hand are sampled like any channel.
+    (atom,) = cockpit(channels=[Channel("agent", BaseMessage, encoding="chat.json.v1")]).blueprints
+    assert not atom.kwargs["channels"][0].paced
+
+
+def test_chat_panel_declarations_merge_or_conflict() -> None:
+    with pytest.raises(ValueError, match="conflicting declarations for stream 'agent'"):
+        cockpit(layout=Chat(), channels=[Channel("agent", dict, encoding="chat.json.v1")])
+    (atom,) = cockpit(
+        layout=Chat(),
+        channels=[Channel("agent", BaseMessage, encoding="chat.json.v1", max_hz=50.0)],
+    ).blueprints
+    agent = next(c for c in atom.kwargs["manifest"]["channels"] if c["ch"] == "agent")
+    assert agent["maxHz"] == 50.0
+    assert next(s for s in atom.kwargs["channels"] if s.ch == "agent").paced
+
+
 def test_publish_tx_generic_json_and_dataclass_rejection() -> None:
     (atom,) = cockpit(channels=[Channel("counter", int, dir="tx", publish="shared")]).blueprints
     (spec,) = atom.kwargs["channels"]
@@ -646,11 +692,13 @@ def test_channel_ordering_builtins_then_customs_then_publish() -> None:
 
 
 def test_import_stays_light() -> None:
-    # The authoring surface must be importable without the [web] extra:
-    # neither the bridge module nor aioquic may load until cockpit() runs.
+    # The authoring surface must be importable without the [web] extra
+    # (neither the bridge module nor aioquic may load until cockpit() runs)
+    # and without the [agents] extra (langchain is the Chat panel's, on use).
     code = (
         "import sys; import dimos.web.cockpit; "
         "assert 'dimos.web.relay_bridge.relay_bridge_module' not in sys.modules; "
-        "assert 'aioquic' not in sys.modules"
+        "assert 'aioquic' not in sys.modules; "
+        "assert 'langchain_core' not in sys.modules"
     )
     subprocess.run([sys.executable, "-c", code], check=True)

--- a/web/cockpit/src/App.test.tsx
+++ b/web/cockpit/src/App.test.tsx
@@ -173,6 +173,65 @@ describe("App session states", () => {
     expect(value().textContent).toContain("waiting for data...");
   });
 
+  it("keeps a chat page's transcript since join across tab switches", () => {
+    const TEXT: ChannelSpec = {
+      ch: "human_input",
+      dir: "tx",
+      encoding: "text.json.v1",
+      delivery: "reliable",
+      maxHz: 5,
+      params: {},
+      publish: "shared",
+      requiredScope: null,
+    };
+    const AGENT: ChannelSpec = { ...ODOM, ch: "agent", encoding: "chat.json.v1" };
+    const IDLE: ChannelSpec = {
+      ...ODOM,
+      ch: "agent_idle",
+      encoding: "json.v1",
+      delivery: "latest",
+    };
+    const chat: PanelSpec = {
+      id: "chat",
+      kind: "chat",
+      title: "",
+      channels: ["human_input", "agent", "agent_idle"],
+      params: {},
+    };
+    const line = (seq: number, text: string) => {
+      channels.ingest(
+        "agent",
+        { ch: "agent", seq, ts: seq, delivery: "reliable" },
+        [{ role: "ai", text, ts: seq }],
+        true,
+      );
+    };
+    const tab = (id: string) => {
+      act(() => container.querySelector<HTMLElement>(`[data-testid="tab-${id}"]`)!.click());
+    };
+    act(() => {
+      status.update({
+        watchedRobot: ROBOT,
+        robots: [ROBOT],
+        manifest: { ...mf([ODOM, TEXT, AGENT, IDLE], [chat]), pages: ["chat"] },
+      });
+    });
+    // Frames before the page is first opened, and while another tab shows.
+    act(() => {
+      line(1, "one");
+      line(2, "two");
+    });
+    tab("chat");
+    expect(container.querySelectorAll("[data-role]")).toHaveLength(2);
+    tab("overview");
+    act(() => line(3, "three"));
+    tab("chat");
+    const lines = [...container.querySelectorAll("[data-role]")].map((el) => el.textContent);
+    expect(lines).toHaveLength(3);
+    expect(lines.join(" ")).toContain("one");
+    expect(lines.join(" ")).toContain("three");
+  });
+
   it("shows the multi-robot notice instead of channels", () => {
     act(() => status.update({ robots: [ROBOT, { id: "b", name: "B", model: "go2" }] }));
     expect(container.textContent).toContain("2 robots connected");

--- a/web/cockpit/src/App.tsx
+++ b/web/cockpit/src/App.tsx
@@ -1,7 +1,9 @@
+import { useEffect } from "react";
 import type { Session } from "@dimos/sdk";
 import { teleopHooks } from "@dimos/sdk/internal/teleop";
 import { useStatus } from "@dimos/sdk/react";
 import { LayoutTree } from "./layout/LayoutTree.tsx";
+import { startChatTranscripts } from "./panels/chatTranscript.ts";
 import { Tabs } from "./layout/Tabs.tsx";
 import { ChannelList } from "./ui/ChannelList.tsx";
 import { StatusBar } from "./ui/StatusBar.tsx";
@@ -10,6 +12,11 @@ import styles from "./App.module.css";
 export function App({ session }: { session: Session }) {
   const status = useStatus(session);
   const teleop = teleopHooks(session);
+  // Chat transcripts outlive their panels (an inactive page is unmounted),
+  // so they start as soon as a manifest names them.
+  useEffect(() => {
+    if (status.manifest !== null) startChatTranscripts(session.store, status.manifest);
+  }, [session, status.manifest]);
 
   let content;
   if (status.transport.phase === "failed") {
@@ -31,8 +38,13 @@ export function App({ session }: { session: Session }) {
     content = <p className={styles.notice}>Waiting for a robot to register...</p>;
   } else {
     content = (
-      <Tabs manifest={status.manifest} store={session.store} teleop={teleop}>
-        <LayoutTree manifest={status.manifest} store={session.store} teleop={teleop} />
+      <Tabs manifest={status.manifest} store={session.store} teleop={teleop} session={session}>
+        <LayoutTree
+          manifest={status.manifest}
+          store={session.store}
+          teleop={teleop}
+          session={session}
+        />
         <ChannelList
           channels={status.manifest.channels}
           panels={status.manifest.panels}

--- a/web/cockpit/src/panels/ChatPanel.module.css
+++ b/web/cockpit/src/panels/ChatPanel.module.css
@@ -1,0 +1,128 @@
+.chat {
+  background: #14171a;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+}
+
+.lines {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 0.6rem;
+}
+
+.hint {
+  color: #8b949e;
+  padding: 0.5rem;
+}
+
+.human,
+.ai,
+.system,
+.other {
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  font-size: 0.9rem;
+  gap: 0.15rem;
+  max-width: 85%;
+  padding: 0.35rem 0.6rem;
+}
+
+.human {
+  align-self: flex-end;
+  background: #1f4b8f;
+  color: #fff;
+}
+
+.ai {
+  align-self: flex-start;
+  background: #1b1f24;
+  border: 1px solid #30363d;
+}
+
+.system {
+  align-self: center;
+  color: #8b949e;
+  font-style: italic;
+}
+
+.other {
+  align-self: flex-start;
+  border: 1px dashed #d29922;
+}
+
+.roleTag {
+  color: #d29922;
+  font-size: 0.75rem;
+}
+
+.text {
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.time {
+  align-self: flex-end;
+  color: #8b949e;
+  font-size: 0.7rem;
+}
+
+.toolLine {
+  align-self: flex-start;
+  color: #8b949e;
+  font-family: monospace;
+  font-size: 0.8rem;
+  max-width: 100%;
+  overflow: hidden;
+  padding: 0 0.4rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.error {
+  color: #f85149;
+  font-size: 0.8rem;
+  padding: 0 0.6rem 0.3rem;
+}
+
+.composer {
+  border-top: 1px solid #30363d;
+  display: flex;
+  gap: 0.4rem;
+  padding: 0.5rem 0.6rem;
+}
+
+.input {
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 4px;
+  color: #d7dde3;
+  flex: 1;
+  font: inherit;
+  min-width: 0;
+  padding: 0.35rem 0.5rem;
+}
+
+.send {
+  background: #2f81f7;
+  border: 0;
+  border-radius: 4px;
+  color: #fff;
+  cursor: pointer;
+  padding: 0.35rem 0.8rem;
+}
+
+.send:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+.thinking {
+  color: #2f81f7;
+}

--- a/web/cockpit/src/panels/ChatPanel.test.tsx
+++ b/web/cockpit/src/panels/ChatPanel.test.tsx
@@ -1,0 +1,236 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import type { FrameHeader, Msg, PanelSpec } from "@dimos/shared";
+import type { Manifest } from "@dimos/shared/manifest";
+import { ChannelStore, PublishError, type Session, StatusStore } from "@dimos/sdk";
+import type { TeleopHooks } from "@dimos/sdk/internal/teleop";
+import { ChatPanel } from "./ChatPanel.tsx";
+import { TeleopPanel } from "./TeleopPanel.tsx";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const SPEC: PanelSpec = {
+  id: "p0",
+  kind: "chat",
+  title: "",
+  channels: ["human_input", "agent", "agent_idle"],
+  params: {},
+};
+const TELEOP_SPEC: PanelSpec = {
+  id: "p1",
+  kind: "teleop",
+  title: "",
+  channels: ["tele_cmd_vel"],
+  params: {},
+};
+const MANIFEST: Manifest = {
+  version: 1,
+  channels: [
+    {
+      ch: "tele_cmd_vel",
+      dir: "tx",
+      encoding: "twist.json.v1",
+      delivery: "latest",
+      maxHz: 15,
+      params: { maxLinear: 0.8, maxAngular: 1.0, boost: 2.0, watchdogMs: 300 },
+      publish: "none",
+      requiredScope: null,
+    },
+  ],
+  panels: [SPEC, TELEOP_SPEC],
+  layout: { row: ["p0", "p1"] },
+  pages: [],
+};
+
+function header(ch: string, seq: number): FrameHeader {
+  return { ch, seq, ts: 1_700_000_000 + seq, delivery: ch === "agent" ? "reliable" : "latest" };
+}
+
+class FakeSession implements Session {
+  status = new StatusStore();
+  store = new ChannelStore();
+  published: [string, unknown][] = [];
+  reject: PublishError | null = null;
+  watch = () => new Promise<never>(() => {});
+  subscribe = () => () => {};
+  publish = (ch: string, value: unknown) => {
+    this.published.push([ch, value]);
+    return this.reject === null
+      ? Promise.resolve({ ch, relayTs: 1, bridgeTs: 2 })
+      : Promise.reject(this.reject);
+  };
+  close = () => {};
+}
+
+class FakeHooks implements TeleopHooks {
+  controls: Msg[] = [];
+  datagrams: Msg[] = [];
+  cbs = new Set<(msg: Msg) => void>();
+  constructor(readonly status: StatusStore) {}
+  control = (msg: Msg) => this.controls.push(msg);
+  datagram = (msg: Msg) => this.datagrams.push(msg);
+  onMsg = (cb: (msg: Msg) => void) => {
+    this.cbs.add(cb);
+    return () => this.cbs.delete(cb);
+  };
+  reply(msg: Msg): void {
+    for (const cb of this.cbs) cb(msg);
+  }
+}
+
+// React tracks controlled inputs through the value setter; go around it.
+const setValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+
+describe("ChatPanel", () => {
+  let container: HTMLElement;
+  let root: Root;
+  let session: FakeSession;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    session = new FakeSession();
+    session.status.update({ transport: { phase: "connected" }, manifest: MANIFEST });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function mount(): void {
+    act(() => root.render(<ChatPanel spec={SPEC} store={session.store} session={session} />));
+  }
+
+  function frame(ch: string, seq: number, value: unknown): void {
+    act(() => {
+      session.store.ingest(ch, header(ch, seq), value, true);
+      session.store.publishUi();
+    });
+  }
+
+  function find<T extends HTMLElement>(testId: string): T {
+    const el = container.querySelector<T>(`[data-testid="${testId}"]`);
+    if (el === null) throw new Error(`${testId} not rendered`);
+    return el;
+  }
+
+  function roles(): string[] {
+    return [...container.querySelectorAll<HTMLElement>("[data-role]")].map((el) =>
+      el.dataset.role ?? ""
+    );
+  }
+
+  function type(text: string): void {
+    act(() => {
+      const input = find<HTMLInputElement>("chat-human_input-input");
+      setValue?.call(input, text);
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+  }
+
+  function submit(): void {
+    act(() => {
+      find<HTMLInputElement>("chat-human_input-input").form?.dispatchEvent(
+        new Event("submit", { bubbles: true, cancelable: true }),
+      );
+    });
+  }
+
+  it("accumulates every frame in order and renders each role", () => {
+    frame("agent", 1, [{ role: "human", text: "walk forward", ts: 1 }]); // predates the mount
+    mount();
+    frame("agent", 2, [
+      { role: "ai", text: "sure", ts: 2 },
+      { role: "ai", tool: "nav", text: 'nav({"x":1})', ts: 2 },
+    ]);
+    frame("agent", 3, [{ role: "tool", tool: "nav", text: "arrived", ts: 3 }]);
+    frame("agent", 4, [{ role: "function", text: "legacy", ts: 4 }]);
+    expect(roles()).toEqual(["human", "ai", "ai", "tool", "function"]);
+    expect(container.textContent).toContain('▶ nav({"x":1})');
+    expect(container.textContent).toContain("↳ nav: arrived");
+    expect(container.textContent).toContain("[function]");
+
+    frame("agent", 5, "not an array of lines");
+    frame("agent", 6, [{ role: "ai", text: "no timestamp" }]);
+    expect(container.textContent).toContain("unreadable message");
+    expect(container.textContent).not.toContain("no timestamp");
+
+    act(() => session.store.reset());
+    expect(roles()).toEqual([]);
+    expect(container.textContent).toContain("no messages yet");
+  });
+
+  it("shows the thinking spinner while the agent is busy", () => {
+    mount();
+    expect(container.querySelector('[data-testid="chat-agent-thinking"]')).toBeNull();
+    frame("agent_idle", 1, false);
+    expect(container.querySelector('[data-testid="chat-agent-thinking"]')).not.toBeNull();
+    frame("agent_idle", 2, true);
+    expect(container.querySelector('[data-testid="chat-agent-thinking"]')).toBeNull();
+  });
+
+  it("publishes the draft and reports a rejection", async () => {
+    mount();
+    type("walk forward");
+    submit();
+    expect(session.published).toEqual([["human_input", "walk forward"]]);
+    expect(find<HTMLInputElement>("chat-human_input-input").value).toBe("");
+    // The echo, not the submit, puts the message in the transcript.
+    expect(roles()).toEqual([]);
+    await act(async () => {});
+
+    session.reject = new PublishError("rejected", "rate_limited", "slow down");
+    type("again");
+    submit();
+    await act(async () => {});
+    expect(container.textContent).toContain("send failed: rate_limited: slow down");
+    expect(find<HTMLInputElement>("chat-human_input-input").value).toBe("again");
+  });
+
+  it("disables the input while disconnected", () => {
+    session.status.update({ transport: { phase: "reconnecting", attempt: 1, retryAtMs: 0 } });
+    mount();
+    expect(find<HTMLInputElement>("chat-human_input-input").disabled).toBe(true);
+    type("hello");
+    submit();
+    expect(session.published).toEqual([]);
+  });
+
+  it("renders a notice without a send path", () => {
+    act(() => root.render(<ChatPanel spec={SPEC} store={session.store} />));
+    expect(container.textContent).toContain("no send path bound");
+  });
+
+  it("typing in the chat never drives the robot", () => {
+    const hooks = new FakeHooks(session.status);
+    act(() =>
+      root.render(
+        <div>
+          <TeleopPanel spec={TELEOP_SPEC} store={session.store} teleop={hooks} />
+          <ChatPanel spec={SPEC} store={session.store} session={session} />
+        </div>,
+      )
+    );
+    const pad = find<HTMLElement>("teleop-tele_cmd_vel");
+    act(() => pad.focus());
+    act(() => hooks.reply({ t: "teleop_started" }));
+    expect(pad.dataset.state).toBe("armed");
+
+    // Focusing the chat input disarms teleop (its one zero twist), and
+    // keys typed there never reach the pad.
+    act(() => find<HTMLInputElement>("chat-human_input-input").focus());
+    expect(pad.dataset.state).toBe("disarmed");
+    const sent = hooks.datagrams.length;
+    act(() => {
+      find<HTMLInputElement>("chat-human_input-input").dispatchEvent(
+        new KeyboardEvent("keydown", { code: "KeyW", key: "w", bubbles: true, cancelable: true }),
+      );
+    });
+    expect(hooks.datagrams.length).toBe(sent);
+    expect(pad.dataset.state).toBe("disarmed");
+  });
+});

--- a/web/cockpit/src/panels/ChatPanel.tsx
+++ b/web/cockpit/src/panels/ChatPanel.tsx
@@ -1,0 +1,152 @@
+// Agent chat panel: the humancli conversation as a panel. Messages arrive as
+// chat.json.v1 frames (one array of {role, text, ts, tool?} lines per
+// LangChain message) on a reliable channel; the transcript lives in
+// chatTranscript.ts for the session's life, not the panel's. Typed text goes
+// out through session.publish on the tx channel and renders when the agent
+// echoes it back on the message channel, exactly like humancli. Nothing typed
+// here can drive the robot: the teleop pad listens on its own subtree and
+// disarms when focus leaves it.
+
+import { type FormEvent, useEffect, useRef, useState, useSyncExternalStore } from "react";
+import type { PanelSpec } from "@dimos/shared";
+import type { ChannelStore, Session } from "@dimos/sdk";
+import { useStatus, useStoreChannel } from "@dimos/sdk/react";
+import { PanelFrame } from "../layout/PanelFrame.tsx";
+import { type ChatLine, chatTranscript } from "./chatTranscript.ts";
+import type { PanelProps } from "./registry.tsx";
+import styles from "./ChatPanel.module.css";
+
+const KNOWN_ROLES = new Set(["human", "ai", "system"]);
+
+function LineView({ line }: { line: ChatLine }) {
+  if (line.tool !== undefined) {
+    // Condensed one-liners, humancli style: the agent's call, then results
+    // and progress under the tool's name.
+    const text = line.role === "ai" ? `▶ ${line.text}` : `↳ ${line.tool}: ${line.text}`;
+    return (
+      <div
+        className={styles.toolLine}
+        title={line.text}
+        data-role={line.role}
+        data-tool={line.tool}
+      >
+        {text}
+      </div>
+    );
+  }
+  const cls = line.role === "human"
+    ? styles.human
+    : line.role === "ai"
+    ? styles.ai
+    : line.role === "system"
+    ? styles.system
+    : styles.other;
+  return (
+    <div className={cls} data-role={line.role}>
+      {!KNOWN_ROLES.has(line.role) && <span className={styles.roleTag}>[{line.role}]</span>}
+      <span className={styles.text}>{line.text}</span>
+      <span className={styles.time}>{new Date(line.ts * 1000).toLocaleTimeString()}</span>
+    </div>
+  );
+}
+
+export function ChatPanel({ spec, store, session }: PanelProps) {
+  if (spec.channels.length < 3 || session === undefined) {
+    return (
+      <PanelFrame spec={spec}>
+        <span className={styles.hint}>chat panel {spec.id}: no send path bound</span>
+      </PanelFrame>
+    );
+  }
+  return <Conversation spec={spec} store={store} session={session} />;
+}
+
+function Conversation({ spec, store, session }: {
+  spec: PanelSpec;
+  store: ChannelStore;
+  session: Session;
+}) {
+  const [inputCh, messagesCh, idleCh] = spec.channels;
+  const transcript = chatTranscript(store, messagesCh);
+  const lines = useSyncExternalStore(transcript.subscribe, transcript.getSnapshot);
+  const idle = useStoreChannel(store, idleCh).slot?.value;
+  const connected = useStatus(session).transport.phase === "connected";
+  const [draft, setDraft] = useState("");
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const listRef = useRef<HTMLDivElement | null>(null);
+  // Autoscroll follows new lines unless the user scrolled up to read back.
+  const pinned = useRef(true);
+
+  useEffect(() => {
+    const list = listRef.current;
+    if (list !== null && pinned.current) list.scrollTop = list.scrollHeight;
+  }, [lines]);
+
+  const onScroll = (): void => {
+    const list = listRef.current;
+    if (list !== null) {
+      pinned.current = list.scrollHeight - list.scrollTop - list.clientHeight < 8;
+    }
+  };
+
+  const onSubmit = (e: FormEvent): void => {
+    e.preventDefault();
+    const text = draft.trim();
+    if (text === "" || pending || !connected) return;
+    setDraft("");
+    setError(null);
+    setPending(true);
+    session
+      .publish(inputCh, text)
+      .catch((err: unknown) => {
+        // A PublishError message already reads "<code>: <reason>".
+        setError(err instanceof Error ? err.message : String(err));
+        // Give a failed message back unless the user already typed on.
+        setDraft((current) => (current === "" ? text : current));
+      })
+      .finally(() => setPending(false));
+  };
+
+  const thinking = pending || idle === false;
+  const badge = thinking
+    ? (
+      <span className={styles.thinking} data-testid={`chat-${messagesCh}-thinking`}>
+        thinking...
+      </span>
+    )
+    : undefined;
+  return (
+    <PanelFrame spec={spec} badge={badge}>
+      <div className={styles.chat} data-testid={`chat-${messagesCh}`}>
+        <div className={styles.lines} ref={listRef} onScroll={onScroll}>
+          {lines.length === 0 && <span className={styles.hint}>no messages yet</span>}
+          {lines.map((line, i) => <LineView key={i} line={line} />)}
+        </div>
+        {error !== null && (
+          <div className={styles.error} role="alert">
+            send failed: {error}
+          </div>
+        )}
+        <form className={styles.composer} onSubmit={onSubmit}>
+          <input
+            className={styles.input}
+            value={draft}
+            placeholder={connected ? "message the agent" : "not connected"}
+            disabled={!connected}
+            aria-label={`chat input ${inputCh}`}
+            data-testid={`chat-${inputCh}-input`}
+            onChange={(e) => setDraft(e.target.value)}
+          />
+          <button
+            type="submit"
+            className={styles.send}
+            disabled={!connected || pending || draft.trim() === ""}
+          >
+            send
+          </button>
+        </form>
+      </div>
+    </PanelFrame>
+  );
+}

--- a/web/cockpit/src/panels/chatTranscript.ts
+++ b/web/cockpit/src/panels/chatTranscript.ts
@@ -1,0 +1,99 @@
+// A chat channel's transcript since join, kept for the life of the channel
+// store (the session), not of the panel: Tabs unmounts inactive pages and
+// ChannelStore keeps only the newest frame. The App starts one per chat
+// panel as soon as a manifest names it, so nothing received since join is
+// lost before the page is first opened. Bounded to the newest MAX_LINES; a
+// store reset (producer gone or changed) empties it.
+
+import type { ChannelStore } from "@dimos/sdk";
+import type { Manifest } from "@dimos/shared/manifest";
+
+/** One chat.json.v1 line: ts is seconds since the epoch at encode time,
+ * tool the tool name on the condensed call/result/progress lines. */
+export interface ChatLine {
+  role: string;
+  text: string;
+  ts: number;
+  tool?: string;
+}
+
+export const MAX_LINES = 1000;
+
+/** A frame's lines, with anything off-contract rendered as a visible line. */
+function linesOf(value: unknown, frameTs: number): ChatLine[] {
+  const items = Array.isArray(value) ? value : [null];
+  return items.map((item): ChatLine => {
+    const line = item as { role?: unknown; text?: unknown; ts?: unknown; tool?: unknown } | null;
+    if (
+      line === null || typeof line.role !== "string" || typeof line.text !== "string" ||
+      typeof line.ts !== "number"
+    ) {
+      return { role: "unknown", text: "unreadable message", ts: frameTs };
+    }
+    return {
+      role: line.role,
+      text: line.text,
+      ts: line.ts,
+      tool: typeof line.tool === "string" ? line.tool : undefined,
+    };
+  });
+}
+
+export class ChatTranscript {
+  #lines: ChatLine[] = [];
+  #seen = 0;
+  #listeners = new Set<() => void>();
+
+  constructor(store: ChannelStore, readonly ch: string) {
+    store.subscribe(ch, () => this.#pull(store));
+    this.#pull(store);
+  }
+
+  #pull(store: ChannelStore): void {
+    const slot = store.get(this.ch);
+    if (slot === null) {
+      if (this.#seen === 0) return;
+      this.#seen = 0;
+      this.#lines = [];
+    } else if (slot.version > this.#seen) {
+      this.#seen = slot.version;
+      this.#lines = [...this.#lines, ...linesOf(slot.value, slot.ts)].slice(-MAX_LINES);
+    } else {
+      return;
+    }
+    for (const cb of this.#listeners) cb();
+  }
+
+  /** useSyncExternalStore pair: the array identity changes with the content. */
+  subscribe = (cb: () => void): () => void => {
+    this.#listeners.add(cb);
+    return () => this.#listeners.delete(cb);
+  };
+  getSnapshot = (): ChatLine[] => this.#lines;
+}
+
+const transcripts = new WeakMap<ChannelStore, Map<string, ChatTranscript>>();
+
+/** The transcript of `ch` on `store`, started on first use. */
+export function chatTranscript(store: ChannelStore, ch: string): ChatTranscript {
+  let byCh = transcripts.get(store);
+  if (byCh === undefined) {
+    byCh = new Map();
+    transcripts.set(store, byCh);
+  }
+  let transcript = byCh.get(ch);
+  if (transcript === undefined) {
+    transcript = new ChatTranscript(store, ch);
+    byCh.set(ch, transcript);
+  }
+  return transcript;
+}
+
+/** Start the transcript of every chat panel's message channel (slot 1). */
+export function startChatTranscripts(store: ChannelStore, manifest: Manifest): void {
+  for (const panel of manifest.panels) {
+    if (panel.kind === "chat" && panel.channels.length === 3) {
+      chatTranscript(store, panel.channels[1]);
+    }
+  }
+}

--- a/web/cockpit/src/panels/panels.test.tsx
+++ b/web/cockpit/src/panels/panels.test.tsx
@@ -8,6 +8,7 @@ import { ChannelStore } from "@dimos/sdk";
 import type { DrawHealth } from "../layout/PanelFrame.tsx";
 import { MapPanel, startMapSink } from "./MapPanel.tsx";
 import { fitTransform, posePath } from "./mapRenderer.ts";
+import { ChatPanel } from "./ChatPanel.tsx";
 import { getPanel, UnknownPanel } from "./registry.tsx";
 import { startVideoSink, VideoPanel } from "./VideoPanel.tsx";
 
@@ -340,6 +341,7 @@ describe("registry", () => {
     // channel of a newer bridge (see channelSubscribable in session.ts).
     expect(getPanel("video")).toBe(VideoPanel);
     expect(getPanel("map2d")).toBe(MapPanel);
+    expect(getPanel("chat")).toBe(ChatPanel);
     expect(getPanel("hologram")).toBeUndefined();
   });
 

--- a/web/cockpit/src/panels/registry.tsx
+++ b/web/cockpit/src/panels/registry.tsx
@@ -11,7 +11,8 @@
 import type { ComponentType } from "react";
 import type { PanelSpec } from "@dimos/shared";
 import { PanelFrame } from "../layout/PanelFrame.tsx";
-import type { ChannelStore } from "@dimos/sdk";
+import type { ChannelStore, Session } from "@dimos/sdk";
+import { ChatPanel } from "./ChatPanel.tsx";
 import { MapPanel } from "./MapPanel.tsx";
 import styles from "./registry.module.css";
 import type { TeleopHooks } from "@dimos/sdk/internal/teleop";
@@ -24,6 +25,9 @@ export interface PanelProps {
   /** Session send surface for tx panels (teleop); optional so rx-only
    * panels and their tests need not care. */
   teleop?: TeleopHooks;
+  /** The session for panels on the public publish API (chat); optional for
+   * the same reason. */
+  session?: Session;
 }
 
 const registry = new Map<string, ComponentType<PanelProps>>();
@@ -49,3 +53,4 @@ export function UnknownPanel({ spec }: PanelProps) {
 registerPanel("video", VideoPanel);
 registerPanel("map2d", MapPanel);
 registerPanel("teleop", TeleopPanel);
+registerPanel("chat", ChatPanel);

--- a/web/shared/fixtures/gen.ts
+++ b/web/shared/fixtures/gen.ts
@@ -239,7 +239,10 @@ const chChat = {
   publish: "shared",
   requiredScope: "chat:send",
 };
+const chAgent = { ch: "agent", encoding: "chat.json.v1", delivery: "reliable", maxHz: 20.5 };
+const chIdle = { ch: "agent_idle", encoding: "json.v1", delivery: "latest", maxHz: 20.5 };
 const pCamera = { id: "camera", kind: "video", channels: ["color_image"] };
+const pChat = { id: "chat", kind: "chat", channels: ["human_input", "agent", "agent_idle"] };
 const pPose = { id: "pose", kind: "readout", channels: ["odom"] };
 const longId = "x".repeat(65);
 const manifestCases: Record<string, unknown> = {
@@ -585,6 +588,36 @@ const manifestCases: Record<string, unknown> = {
   pages_not_list: { version: 1, channels: [chOdom], panels: [pPose], pages: {} },
   pages_not_strings: { version: 1, channels: [chOdom], panels: [pPose], pages: [1.5] },
   pages_null: { version: 1, channels: [chOdom], panels: [pPose], pages: null },
+  // Chat panel: text input (publish tx), messages, idle flag, in that order.
+  chat_panel: {
+    version: 1,
+    channels: [chChat, chAgent, chIdle],
+    panels: [pChat],
+  },
+  chat_panel_two_channels: {
+    version: 1,
+    channels: [chChat, chAgent],
+    panels: [{ ...pChat, channels: ["human_input", "agent"] }],
+  },
+  chat_panel_input_not_publishable: {
+    version: 1,
+    channels: [
+      { ch: "human_input", dir: "tx", encoding: "text.json.v1", delivery: "reliable", maxHz: 2.5 },
+      chAgent,
+      chIdle,
+    ],
+    panels: [pChat],
+  },
+  chat_panel_messages_wrong_encoding: {
+    version: 1,
+    channels: [chChat, chOdom, chIdle],
+    panels: [{ ...pChat, channels: ["human_input", "odom", "agent_idle"] }],
+  },
+  chat_panel_idle_wrong_delivery: {
+    version: 1,
+    channels: [chChat, chAgent, { ...chIdle, delivery: "reliable" }],
+    panels: [pChat],
+  },
 };
 
 const control = {

--- a/web/shared/fixtures/manifests.json
+++ b/web/shared/fixtures/manifests.json
@@ -3080,6 +3080,251 @@
         "pages": null
       },
       "error": "invalid_shape"
+    },
+    {
+      "name": "chat_panel",
+      "data": {
+        "version": 1,
+        "channels": [
+          {
+            "ch": "human_input",
+            "dir": "tx",
+            "encoding": "text.json.v1",
+            "delivery": "reliable",
+            "maxHz": 2.5,
+            "publish": "shared",
+            "requiredScope": "chat:send"
+          },
+          {
+            "ch": "agent",
+            "encoding": "chat.json.v1",
+            "delivery": "reliable",
+            "maxHz": 20.5
+          },
+          {
+            "ch": "agent_idle",
+            "encoding": "json.v1",
+            "delivery": "latest",
+            "maxHz": 20.5
+          }
+        ],
+        "panels": [
+          {
+            "id": "chat",
+            "kind": "chat",
+            "channels": [
+              "human_input",
+              "agent",
+              "agent_idle"
+            ]
+          }
+        ]
+      },
+      "manifest": {
+        "version": 1,
+        "channels": [
+          {
+            "ch": "human_input",
+            "dir": "tx",
+            "encoding": "text.json.v1",
+            "delivery": "reliable",
+            "maxHz": 2.5,
+            "params": {},
+            "publish": "shared",
+            "requiredScope": "chat:send"
+          },
+          {
+            "ch": "agent",
+            "dir": "rx",
+            "encoding": "chat.json.v1",
+            "delivery": "reliable",
+            "maxHz": 20.5,
+            "params": {},
+            "publish": "none",
+            "requiredScope": null
+          },
+          {
+            "ch": "agent_idle",
+            "dir": "rx",
+            "encoding": "json.v1",
+            "delivery": "latest",
+            "maxHz": 20.5,
+            "params": {},
+            "publish": "none",
+            "requiredScope": null
+          }
+        ],
+        "panels": [
+          {
+            "id": "chat",
+            "kind": "chat",
+            "title": "",
+            "channels": [
+              "human_input",
+              "agent",
+              "agent_idle"
+            ],
+            "params": {}
+          }
+        ],
+        "layout": null,
+        "pages": []
+      }
+    },
+    {
+      "name": "chat_panel_two_channels",
+      "data": {
+        "version": 1,
+        "channels": [
+          {
+            "ch": "human_input",
+            "dir": "tx",
+            "encoding": "text.json.v1",
+            "delivery": "reliable",
+            "maxHz": 2.5,
+            "publish": "shared",
+            "requiredScope": "chat:send"
+          },
+          {
+            "ch": "agent",
+            "encoding": "chat.json.v1",
+            "delivery": "reliable",
+            "maxHz": 20.5
+          }
+        ],
+        "panels": [
+          {
+            "id": "chat",
+            "kind": "chat",
+            "channels": [
+              "human_input",
+              "agent"
+            ]
+          }
+        ]
+      },
+      "error": "invalid_chat_panel"
+    },
+    {
+      "name": "chat_panel_input_not_publishable",
+      "data": {
+        "version": 1,
+        "channels": [
+          {
+            "ch": "human_input",
+            "dir": "tx",
+            "encoding": "text.json.v1",
+            "delivery": "reliable",
+            "maxHz": 2.5
+          },
+          {
+            "ch": "agent",
+            "encoding": "chat.json.v1",
+            "delivery": "reliable",
+            "maxHz": 20.5
+          },
+          {
+            "ch": "agent_idle",
+            "encoding": "json.v1",
+            "delivery": "latest",
+            "maxHz": 20.5
+          }
+        ],
+        "panels": [
+          {
+            "id": "chat",
+            "kind": "chat",
+            "channels": [
+              "human_input",
+              "agent",
+              "agent_idle"
+            ]
+          }
+        ]
+      },
+      "error": "invalid_chat_panel"
+    },
+    {
+      "name": "chat_panel_messages_wrong_encoding",
+      "data": {
+        "version": 1,
+        "channels": [
+          {
+            "ch": "human_input",
+            "dir": "tx",
+            "encoding": "text.json.v1",
+            "delivery": "reliable",
+            "maxHz": 2.5,
+            "publish": "shared",
+            "requiredScope": "chat:send"
+          },
+          {
+            "ch": "odom",
+            "encoding": "pose.json.v1",
+            "delivery": "reliable",
+            "maxHz": 20.5
+          },
+          {
+            "ch": "agent_idle",
+            "encoding": "json.v1",
+            "delivery": "latest",
+            "maxHz": 20.5
+          }
+        ],
+        "panels": [
+          {
+            "id": "chat",
+            "kind": "chat",
+            "channels": [
+              "human_input",
+              "odom",
+              "agent_idle"
+            ]
+          }
+        ]
+      },
+      "error": "invalid_chat_panel"
+    },
+    {
+      "name": "chat_panel_idle_wrong_delivery",
+      "data": {
+        "version": 1,
+        "channels": [
+          {
+            "ch": "human_input",
+            "dir": "tx",
+            "encoding": "text.json.v1",
+            "delivery": "reliable",
+            "maxHz": 2.5,
+            "publish": "shared",
+            "requiredScope": "chat:send"
+          },
+          {
+            "ch": "agent",
+            "encoding": "chat.json.v1",
+            "delivery": "reliable",
+            "maxHz": 20.5
+          },
+          {
+            "ch": "agent_idle",
+            "encoding": "json.v1",
+            "delivery": "reliable",
+            "maxHz": 20.5
+          }
+        ],
+        "panels": [
+          {
+            "id": "chat",
+            "kind": "chat",
+            "channels": [
+              "human_input",
+              "agent",
+              "agent_idle"
+            ]
+          }
+        ]
+      },
+      "error": "invalid_chat_panel"
     }
   ]
 }

--- a/web/shared/manifest.ts
+++ b/web/shared/manifest.ts
@@ -392,6 +392,40 @@ export function parseManifest(value: unknown): Manifest {
         );
       }
     }
+    if (panel.kind === "chat") {
+      // channels: the text input (publish tx), the messages, the idle flag.
+      if (panel.channels.length !== 3) {
+        throw new ManifestError(
+          "invalid_chat_panel",
+          `chat panel ${panel.id} must bind three channels`,
+        );
+      }
+      const [text, messages, idle] = panel.channels.map((ch) => chIds.get(ch)!);
+      if (
+        text.encoding !== "text.json.v1" || text.delivery !== "reliable" ||
+        dirOf(text) !== "tx" || publishOf(text) !== "shared"
+      ) {
+        throw new ManifestError(
+          "invalid_chat_panel",
+          `chat panel ${panel.id} needs a text.json.v1 reliable shared tx channel first`,
+        );
+      }
+      if (
+        messages.encoding !== "chat.json.v1" || messages.delivery !== "reliable" ||
+        dirOf(messages) !== "rx"
+      ) {
+        throw new ManifestError(
+          "invalid_chat_panel",
+          `chat panel ${panel.id} needs a chat.json.v1 reliable rx channel second`,
+        );
+      }
+      if (idle.encoding !== "json.v1" || idle.delivery !== "latest" || dirOf(idle) !== "rx") {
+        throw new ManifestError(
+          "invalid_chat_panel",
+          `chat panel ${panel.id} needs a json.v1 latest rx channel third`,
+        );
+      }
+    }
   }
 
   const seen = new Set<string>();


### PR DESCRIPTION
Closes DIM-1170

- Adds a `Chat()` panel to the web cockpit so users can message the robot's agent from the browser. It displays replies, tool activity, and an indicator while the agent is thinking.

- Adds a `unitree-go2-agentic-cockpit` blueprint that places chat alongside the previous other panels
