### PR TITLE
feat(web): chat panel push-to-talk mic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -474,10 +474,10 @@ jobs:
         uses: actions/setup-python@v7.0.0
         with:
           python-version: '3.12'
-      - name: Install native dependencies (pyaudio build, JPEG encoding)
+      - name: Install native dependencies (pyaudio build, JPEG encoding, audio decode)
         run: |
           sudo apt-get update
-          sudo apt-get install -y portaudio19-dev libturbojpeg
+          sudo apt-get install -y portaudio19-dev libturbojpeg ffmpeg
       - name: Fetch the go2_short replay dataset
         run: git lfs pull --include="data/.lfs/go2_short.db.tar.gz" --exclude=""
       - name: Install dependencies
@@ -489,7 +489,8 @@ jobs:
           uv run pytest -m web_browser dimos/e2e_tests/test_cockpit_browser.py
           dimos/e2e_tests/test_sdk_browser.py
           dimos/e2e_tests/test_custom_channel_browser.py
-          dimos/e2e_tests/test_publish_browser.py --no-cov
+          dimos/e2e_tests/test_publish_browser.py
+          dimos/e2e_tests/test_voice_browser.py --no-cov
 
   tests:
     if: |
@@ -546,12 +547,12 @@ jobs:
         with:
           deno-version: ${{ steps.deno-version.outputs.version }}
           cache: true
-      # pyaudio needs portaudio; the relay bridge tests encode JPEG via PyTurboJPEG.
+      # pyaudio needs portaudio; relay/audio tests need TurboJPEG and ffmpeg.
       - name: Install system dependencies (Ubuntu)
         if: startsWith(matrix.os, 'ubuntu')
         run: |
           sudo apt-get update
-          sudo apt-get install -y portaudio19-dev libturbojpeg
+          sudo apt-get install -y portaudio19-dev libturbojpeg ffmpeg
       - name: Install dependency for pyaudio (macOS)
         if: startsWith(matrix.os, 'macos')
         run: brew install portaudio

--- a/dimos/agents/test_voice_input.py
+++ b/dimos/agents/test_voice_input.py
@@ -1,0 +1,307 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""VoiceInput: audio_in chunks -> decode -> STT pipeline -> human_input text.
+
+The real normalizer and WhisperNode wiring run against a fake Whisper model;
+the ffmpeg boundary runs for real in the container test and is otherwise
+replaced with a byte-mirroring stub.
+"""
+
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass, field
+import io
+import math
+import struct
+from threading import Event
+import time
+from typing import Any
+import wave
+
+import numpy as np
+import pytest
+
+from dimos.agents import voice_input as voice_input_module
+from dimos.agents.voice_input import VoiceInput
+from dimos.stream.audio.base import AudioEvent
+from dimos.stream.audio.node_normalizer import AudioNormalizer
+from dimos.stream.audio.stt import node_whisper as whisper_module
+from dimos.web.relay_bridge.audio_codec import AudioChunk
+from dimos.web.relay_bridge.module_test_support import FakeTransport
+
+
+def _chunk(sid: str = "u1", seq: int = 0, data: bytes = b"", final: bool = False) -> AudioChunk:
+    return AudioChunk(sid=sid, seq=seq, mime="audio/webm", data=data, final=final)
+
+
+def _wav_bytes(seconds: float = 0.25) -> bytes:
+    """A real container: 48-kHz stereo 16-bit WAV of a 440 Hz tone."""
+    buffer = io.BytesIO()
+    with wave.open(buffer, "wb") as writer:
+        writer.setnchannels(2)
+        writer.setsampwidth(2)
+        writer.setframerate(48_000)
+        samples = (
+            int(12_000 * math.sin(2 * math.pi * 440 * i / 48_000))
+            for i in range(int(48_000 * seconds))
+        )
+        writer.writeframes(b"".join(struct.pack("<hh", v, v) for v in samples))
+    return buffer.getvalue()
+
+
+@dataclass
+class _Harness:
+    module: VoiceInput
+    texts: list[str] = field(default_factory=list)
+    events: list[AudioEvent] = field(default_factory=list)
+    decoded: list[bytes] = field(default_factory=list)
+    # What the fake STT pipeline "hears" for one PCM event.
+    transcribe: Callable[[AudioEvent], str] = lambda event: f"heard {event.data.shape[0]} samples"
+
+    def send(self, chunk: AudioChunk) -> None:
+        self.module.audio_in.transport.publish(chunk)
+
+    def assembly_ids(self) -> set[str]:
+        with self.module._lock:
+            return set(self.module._assemblies)
+
+
+_MakeVoice = Callable[..., _Harness]
+
+
+@pytest.fixture
+def make_voice(monkeypatch: pytest.MonkeyPatch) -> Iterator[_MakeVoice]:
+    modules: list[VoiceInput] = []
+    normalize_audio = AudioNormalizer._normalize_audio
+
+    def make(*, real_decode: bool = False, **config: Any) -> _Harness:
+        module = VoiceInput(**config)
+        modules.append(module)
+        harness = _Harness(module)
+
+        def record_normalized(normalizer: AudioNormalizer, event: AudioEvent) -> AudioEvent:
+            normalized = normalize_audio(normalizer, event)
+            harness.events.append(normalized)
+            return normalized
+
+        class FakeModel:
+            def transcribe(self, _data: np.ndarray, **_modelopts: Any) -> dict[str, str]:
+                return {"text": harness.transcribe(harness.events[-1])}
+
+        class FakeWhisper:
+            @staticmethod
+            def load_model(_model: str) -> FakeModel:
+                return FakeModel()
+
+        monkeypatch.setattr(AudioNormalizer, "_normalize_audio", record_normalized)
+        monkeypatch.setattr(whisper_module, "_USE_FASTER_WHISPER", False)
+        monkeypatch.setattr(whisper_module, "whisper", FakeWhisper())
+        if not real_decode:
+
+            def fake_decode(raw: bytes) -> AudioEvent | None:
+                harness.decoded.append(raw)
+                if raw == b"undecodable":
+                    return None
+                return AudioEvent(
+                    data=np.frombuffer(raw, dtype=np.uint8), sample_rate=16_000, timestamp=0.0
+                )
+
+            monkeypatch.setattr(voice_input_module, "decode_audio_bytes", fake_decode)
+        # In ports deliver through a transport; the test thread plays LCM.
+        module.audio_in.transport = FakeTransport()
+        module.human_input.subscribe(harness.texts.append)
+        module.start()
+        return harness
+
+    yield make
+    for module in modules:
+        if not module._module_closed:
+            module.stop()
+
+
+def test_chunks_reassemble_through_decode_to_human_input(
+    make_voice: _MakeVoice, wait_until: Any
+) -> None:
+    h = make_voice()
+    h.send(_chunk(seq=0, data=b"come to"))
+    h.send(_chunk(seq=1, data=b" the kitchen"))
+    h.send(_chunk(seq=2, final=True))
+    wait_until(lambda: h.texts == ["heard 19 samples"], timeout=5.0)
+    # The decoder saw the exact reassembled container byte stream, once.
+    assert h.decoded == [b"come to the kitchen"]
+
+
+def test_real_container_bytes_reach_pcm_and_human_input(
+    make_voice: _MakeVoice, wait_until: Any
+) -> None:
+    # A real WAV through the real ffmpeg decode: the pipeline receives the
+    # 16-kHz mono float32 PCM WhisperNode assumes, and text reaches the port.
+    h = make_voice(real_decode=True)
+    raw = _wav_bytes()
+    for seq, offset in enumerate(range(0, len(raw), 16_384)):
+        h.send(_chunk(seq=seq, data=raw[offset : offset + 16_384]))
+    h.send(_chunk(seq=seq + 1, final=True))
+    wait_until(lambda: len(h.texts) == 1, timeout=15.0)
+    (event,) = h.events
+    assert event.sample_rate == 16_000
+    assert event.data.ndim == 1 and event.data.dtype == np.float32
+    # 0.25 s resampled from 48 kHz: ~4000 samples.
+    assert 3_000 < event.data.shape[0] < 5_000
+
+
+def test_seq_gap_discards_utterance_but_not_the_next(
+    make_voice: _MakeVoice, wait_until: Any
+) -> None:
+    h = make_voice()
+    h.send(_chunk(sid="gap", seq=0, data=b"lost"))
+    h.send(_chunk(sid="gap", seq=2, data=b"lost", final=True))
+    # The gapped sid is gone; its stragglers no longer start an utterance.
+    h.send(_chunk(sid="gap", seq=3, final=True))
+    h.send(_chunk(sid="ok", seq=0, data=b"kept"))
+    h.send(_chunk(sid="ok", seq=1, final=True))
+    wait_until(lambda: h.texts == ["heard 4 samples"], timeout=5.0)
+    assert h.decoded == [b"kept"]
+
+
+def test_interleaved_sids_assemble_independently(make_voice: _MakeVoice, wait_until: Any) -> None:
+    h = make_voice()
+    h.send(_chunk(sid="a", seq=0, data=b"one"))
+    h.send(_chunk(sid="b", seq=0, data=b"seven"))
+    h.send(_chunk(sid="a", seq=1, final=True))
+    h.send(_chunk(sid="b", seq=1, final=True))
+    wait_until(lambda: sorted(h.texts) == ["heard 3 samples", "heard 5 samples"], timeout=5.0)
+    assert sorted(h.decoded) == [b"one", b"seven"]
+
+
+def test_blank_transcript_not_published(make_voice: _MakeVoice, wait_until: Any) -> None:
+    h = make_voice()
+    h.transcribe = lambda event: "   " if event.data.shape[0] == 5 else "talk"
+    h.send(_chunk(sid="blank", seq=0, data=b"quiet"))
+    h.send(_chunk(sid="blank", seq=1, final=True))
+    h.send(_chunk(sid="real", seq=0, data=b"speech!"))
+    h.send(_chunk(sid="real", seq=1, final=True))
+    wait_until(lambda: h.texts == ["talk"], timeout=5.0)
+    assert len(h.events) == 2
+
+
+def test_empty_utterance_never_reaches_the_decoder(make_voice: _MakeVoice, wait_until: Any) -> None:
+    h = make_voice()
+    # A hold released before any audio arrived: just the final frame.
+    h.send(_chunk(sid="empty", seq=0, final=True))
+    h.send(_chunk(sid="real", seq=0, data=b"talk"))
+    h.send(_chunk(sid="real", seq=1, final=True))
+    wait_until(lambda: h.texts == ["heard 4 samples"], timeout=5.0)
+    assert h.decoded == [b"talk"]
+
+
+def test_decode_failure_does_not_kill_the_worker(make_voice: _MakeVoice, wait_until: Any) -> None:
+    h = make_voice()
+    h.send(_chunk(sid="bad", seq=0, data=b"undecodable"))
+    h.send(_chunk(sid="bad", seq=1, final=True))
+    h.send(_chunk(sid="next", seq=0, data=b"still alive"))
+    h.send(_chunk(sid="next", seq=1, final=True))
+    wait_until(lambda: h.texts == ["heard 11 samples"], timeout=5.0)
+    assert h.decoded == [b"undecodable", b"still alive"]
+
+
+def test_transcription_error_does_not_kill_the_pipeline(
+    make_voice: _MakeVoice, wait_until: Any
+) -> None:
+    h = make_voice()
+    attempts = 0
+
+    def transcribe(event: AudioEvent) -> str:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("model failed once")
+        return "recovered"
+
+    h.transcribe = transcribe
+    h.send(_chunk(sid="bad", seq=0, data=b"first"))
+    h.send(_chunk(sid="bad", seq=1, final=True))
+    h.send(_chunk(sid="next", seq=0, data=b"second"))
+    h.send(_chunk(sid="next", seq=1, final=True))
+    wait_until(lambda: h.texts == ["recovered"], timeout=5.0)
+    assert attempts == 2 and len(h.events) == 2
+
+
+def test_cancelled_utterance_reaped_without_new_traffic(
+    make_voice: _MakeVoice, wait_until: Any
+) -> None:
+    # A cancelled hold sends no final frame and may be the browser's last
+    # traffic ever; the worker's idle tick must still expire it.
+    h = make_voice(stale_utterance_s=0.02)
+    h.send(_chunk(sid="cancelled", seq=0, data=b"never sent"))
+    assert h.assembly_ids() == {"cancelled"}
+    wait_until(lambda: h.assembly_ids() == set(), timeout=5.0)
+    assert h.texts == [] and h.decoded == []
+
+
+def test_oversized_utterance_dropped(make_voice: _MakeVoice, wait_until: Any) -> None:
+    h = make_voice(max_utterance_bytes=8)
+    h.send(_chunk(sid="big", seq=0, data=b"123456789"))
+    h.send(_chunk(sid="big", seq=1, final=True))
+    h.send(_chunk(sid="ok", seq=0, data=b"tiny"))
+    h.send(_chunk(sid="ok", seq=1, final=True))
+    wait_until(lambda: h.texts == ["heard 4 samples"], timeout=5.0)
+    assert h.decoded == [b"tiny"]
+
+
+def test_stale_straggler_cannot_resume_a_reaped_utterance(
+    make_voice: _MakeVoice, wait_until: Any
+) -> None:
+    h = make_voice(stale_utterance_s=0.02)
+    h.send(_chunk(sid="cancelled", seq=0, data=b"never sent"))
+    wait_until(lambda: h.assembly_ids() == set(), timeout=5.0)
+    h.send(_chunk(sid="cancelled", seq=1, final=True))
+    h.send(_chunk(sid="fresh", seq=0, data=b"kept"))
+    h.send(_chunk(sid="fresh", seq=1, final=True))
+    wait_until(lambda: h.texts == ["heard 4 samples"], timeout=5.0)
+    assert h.decoded == [b"kept"]
+
+
+def test_incoming_traffic_reaps_stale_assemblies_while_stt_is_busy(
+    make_voice: _MakeVoice, wait_until: Any
+) -> None:
+    entered = Event()
+    release = Event()
+    h = make_voice(stale_utterance_s=0.02)
+
+    def blocking_transcribe(event: AudioEvent) -> str:
+        entered.set()
+        release.wait(timeout=5.0)
+        return "done"
+
+    h.transcribe = blocking_transcribe
+    h.send(_chunk(sid="busy", seq=0, data=b"work"))
+    h.send(_chunk(sid="busy", seq=1, final=True))
+    assert entered.wait(timeout=5.0)
+    h.send(_chunk(sid="cancelled", seq=0, data=b"partial"))
+    with h.module._lock:
+        h.module._assemblies["cancelled"].last_at = time.monotonic() - 1.0
+    try:
+        h.send(_chunk(sid="trigger", seq=0, data=b"new"))
+        remaining = h.assembly_ids()
+    finally:
+        release.set()
+    assert remaining == {"trigger"}
+    wait_until(lambda: h.texts == ["done"], timeout=5.0)
+
+
+def test_stop_joins_worker(make_voice: _MakeVoice) -> None:
+    h = make_voice()
+    assert h.module._thread.is_alive()
+    h.module.stop()
+    assert not h.module._thread.is_alive()

--- a/dimos/agents/voice_input.py
+++ b/dimos/agents/voice_input.py
@@ -1,0 +1,199 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Cockpit push-to-talk to agent text: the chat panel mic's robot side.
+
+`audio_in` carries one utterance per button hold as ordered AudioChunk
+slices (dimos/web/relay_bridge/audio_codec.py pins the wire contract). The
+reassembled container bytes go through the owned local STT chain - ffmpeg
+decode to PCM, AudioNormalizer, WhisperNode (the exact pipeline behind the
+legacy WebInput upload) - and the transcript is published on `human_input`,
+entering the agent conversation exactly like a typed chat message. A
+cancelled hold simply stops sending; its half-built utterance is reaped
+after `stale_utterance_s`.
+"""
+
+from dataclasses import dataclass, field
+from queue import Empty, Full, Queue
+from threading import Event, Lock, Thread
+import time
+from typing import Any
+
+import reactivex as rx
+from reactivex.disposable import Disposable
+
+from dimos.constants import DEFAULT_THREAD_JOIN_TIMEOUT
+from dimos.core.core import rpc
+from dimos.core.module import Module, ModuleConfig
+from dimos.core.stream import In, Out
+from dimos.stream.audio.base import AudioEvent
+from dimos.stream.audio.decode import decode_audio_bytes, ffmpeg_requirement
+from dimos.stream.audio.pipeline import whisper_pipeline
+from dimos.utils.logging_config import setup_logger
+from dimos.web.relay_bridge.audio_codec import AudioChunk
+
+logger = setup_logger()
+
+
+@dataclass
+class _Assembly:
+    """One in-flight utterance: ordered slices of its container bytes."""
+
+    expected_seq: int = 0
+    total_bytes: int = 0
+    last_at: float = 0.0
+    parts: list[bytes] = field(default_factory=list)
+
+
+class VoiceInputConfig(ModuleConfig):
+    # A cancelled hold sends no final frame; reap its assembly after this.
+    stale_utterance_s: float = 15.0
+    max_utterance_bytes: int = 2 * 1024 * 1024
+    max_pending_utterances: int = 4
+
+
+class VoiceInput(Module):
+    config: VoiceInputConfig
+
+    audio_in: In[AudioChunk]
+    human_input: Out[str]
+
+    _assemblies: dict[str, _Assembly]
+    _lock: Lock
+    _queue: Queue[bytes]
+    _thread: Thread
+    _stop_event: Event
+    _audio_subject: rx.subject.Subject[AudioEvent] | None
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._assemblies = {}
+        self._lock = Lock()
+        self._queue = Queue(maxsize=self.config.max_pending_utterances)
+        self._thread = Thread(
+            target=self._worker_loop,
+            name=f"{self.__class__.__name__}-thread",
+            daemon=True,
+        )
+        self._stop_event = Event()
+        self._audio_subject = None
+
+    def __reduce__(self) -> Any:
+        return (self.__class__, (), {})
+
+    @rpc
+    def start(self) -> None:
+        requirement_error = ffmpeg_requirement()
+        if requirement_error is not None:
+            raise RuntimeError(requirement_error)
+        super().start()
+        self._audio_subject, transcripts = whisper_pipeline()
+        self.register_disposable(
+            transcripts.subscribe(
+                on_next=self._publish_text,
+                # Upstream stream failures still terminate the subscription.
+                on_error=lambda e: logger.error("voice STT pipeline failed: %s", e),
+            )
+        )
+        # Not handle_audio_in: the auto-bound handler mailbox is latest-wins
+        # and would drop chunks; a manual subscription sees every one.
+        self.register_disposable(Disposable(self.audio_in.subscribe(self._on_chunk)))
+        if not self._thread.is_alive():
+            self._thread.start()
+
+    @rpc
+    def stop(self) -> None:
+        self._stop_event.set()
+        if self._thread.is_alive():
+            self._thread.join(timeout=DEFAULT_THREAD_JOIN_TIMEOUT)
+        super().stop()
+
+    def _on_chunk(self, chunk: AudioChunk) -> None:
+        """Transport-thread hot path: bookkeeping only, decode and STT queued."""
+        now = time.monotonic()
+        finished: bytes | None = None
+        with self._lock:
+            self._reap_stale_locked(now)
+            assembly = self._assemblies.get(chunk.sid)
+            if assembly is None:
+                if chunk.seq != 0:
+                    logger.warning("voice utterance %s dropped: no start chunk", chunk.sid)
+                    return
+                assembly = _Assembly()
+                self._assemblies[chunk.sid] = assembly
+            if chunk.seq != assembly.expected_seq:
+                del self._assemblies[chunk.sid]
+                logger.warning(
+                    "voice utterance %s dropped: chunk gap (got seq %d, expected %d)",
+                    chunk.sid,
+                    chunk.seq,
+                    assembly.expected_seq,
+                )
+                return
+            assembly.expected_seq += 1
+            assembly.last_at = now
+            assembly.total_bytes += len(chunk.data)
+            if assembly.total_bytes > self.config.max_utterance_bytes:
+                del self._assemblies[chunk.sid]
+                logger.warning(
+                    "voice utterance %s dropped: over %d bytes",
+                    chunk.sid,
+                    self.config.max_utterance_bytes,
+                )
+                return
+            if chunk.data:
+                assembly.parts.append(chunk.data)
+            if chunk.final:
+                del self._assemblies[chunk.sid]
+                data = b"".join(assembly.parts)
+                if data:
+                    finished = data
+        if finished is not None:
+            try:
+                self._queue.put_nowait(finished)
+            except Full:
+                logger.warning("voice utterance dropped: transcription queue full")
+
+    def _reap_stale(self) -> None:
+        now = time.monotonic()
+        with self._lock:
+            self._reap_stale_locked(now)
+
+    def _reap_stale_locked(self, now: float) -> None:
+        for sid, assembly in list(self._assemblies.items()):
+            if now - assembly.last_at > self.config.stale_utterance_s:
+                del self._assemblies[sid]
+                logger.info("voice utterance %s reaped: cancelled or sender gone", sid)
+
+    def _worker_loop(self) -> None:
+        while not self._stop_event.is_set():
+            try:
+                raw = self._queue.get(timeout=0.5)
+            except Empty:
+                # Expiry must not depend on new traffic: a cancelled hold may
+                # be the last thing a browser ever sends.
+                self._reap_stale()
+                continue
+            try:
+                event = decode_audio_bytes(raw)
+                if event is not None and self._audio_subject is not None:
+                    self._audio_subject.on_next(event)
+            except Exception:
+                # One bad clip must not end voice input for the process.
+                logger.exception("voice transcription failed")
+
+    def _publish_text(self, text: str) -> None:
+        text = text.strip()
+        if text:
+            self.human_input.publish(text)

--- a/dimos/agents/web_human_input.py
+++ b/dimos/agents/web_human_input.py
@@ -13,22 +13,17 @@
 # limitations under the License.
 
 from threading import Thread
-from typing import TYPE_CHECKING
 
 import reactivex as rx
-import reactivex.operators as ops
 
 from dimos.constants import DEFAULT_THREAD_JOIN_TIMEOUT
 from dimos.core.core import rpc
 from dimos.core.module import Module
 from dimos.core.transport import PubSubTransport
 from dimos.core.transport_factory import make_transport
-from dimos.stream.audio.node_normalizer import AudioNormalizer
+from dimos.stream.audio.pipeline import whisper_pipeline
 from dimos.utils.logging_config import setup_logger
 from dimos.web.robot_web_interface import RobotWebInterface
-
-if TYPE_CHECKING:
-    from dimos.stream.audio.base import AudioEvent
 
 logger = setup_logger()
 
@@ -44,7 +39,8 @@ class WebInput(Module):
 
         self._human_transport = make_transport("/human_input")
 
-        audio_subject: rx.subject.Subject[AudioEvent] = rx.subject.Subject()
+        # Browser audio -> the owned STT chain (normalizer -> whisper).
+        audio_subject, transcripts = whisper_pipeline()
 
         self._web_interface = RobotWebInterface(
             port=5555,
@@ -52,24 +48,13 @@ class WebInput(Module):
             audio_subject=audio_subject,
         )
 
-        normalizer = AudioNormalizer()
-
-        # Here to prevent unwanted imports in the file.
-        from dimos.stream.audio.stt.node_whisper import WhisperNode
-
-        stt_node = WhisperNode()
-
-        # Connect audio pipeline: browser audio → normalizer → whisper
-        normalizer.consume_audio(audio_subject.pipe(ops.share()))
-        stt_node.consume_audio(normalizer.emit_audio())
-
         # Subscribe to both text input sources
         # 1. Direct text from web interface
         unsub = self._web_interface.query_stream.subscribe(self._human_transport.publish)
         self.register_disposable(unsub)
 
         # 2. Transcribed text from STT
-        unsub = stt_node.emit_text().subscribe(self._human_transport.publish)
+        unsub = transcripts.subscribe(self._human_transport.publish)
         self.register_disposable(unsub)
 
         self._thread = Thread(target=self._web_interface.run, daemon=True)

--- a/dimos/core/transport_factory.py
+++ b/dimos/core/transport_factory.py
@@ -60,8 +60,9 @@ def transport_topic(name: str, g: GlobalConfig = global_config) -> str:
 # publisher. Matched by message type since that is what makes them high-rate.
 _LATEST_WINS_TYPES = ("sensor_msgs.Image", "sensor_msgs.PointCloud2")
 # Low-rate channels where a drop loses something that never comes back: a whole
-# turn of agent/human conversation, or a one-shot robot action verb.
-_NEVER_DROP_CHANNELS = ("human_input", "agent", "agent_idle", "command")
+# turn of agent/human conversation, a one-shot robot action verb, or a
+# push-to-talk chunk (one gap discards the whole utterance).
+_NEVER_DROP_CHANNELS = ("human_input", "agent", "agent_idle", "command", "audio_in")
 
 
 def zenoh_key_expr(name: str, msg_name: str) -> str:

--- a/dimos/e2e_tests/test_voice_browser.py
+++ b/dimos/e2e_tests/test_voice_browser.py
@@ -1,0 +1,126 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Chat-mic push-to-talk browser e2e (the T14 acceptance demo, in CI).
+
+Starts a cockpit(layout=Chat()) bridge - a generated RelayBridgeModule
+subclass with a typed audio_in Out port and the registry-resolved
+audio.json.v1 decoder - serving the real cockpit dist from its own local
+relay. Both engines run with a fake microphone (T14's named risk is
+MediaRecorder container variance, so Chromium's webm is not enough);
+holding the chat composer's mic records real audio, ships it as chunked
+publishes, and the test asserts the reassembled byte stream (one sid,
+contiguous seqs, empty final frame) lands on the module's port AND survives
+the real ffmpeg decode into the 16-kHz PCM the Whisper pipeline assumes.
+VoiceInput/Whisper stay out of scope: chunk delivery and decodability are
+the wire contract under test; transcription wiring is pytest-covered.
+
+Marked web_browser: excluded from the default suite (needs the
+`browser-tests` dependency group, Playwright browsers, built web dists, and
+the ffmpeg binary). Locally:
+`uv run --group browser-tests pytest -m web_browser dimos/e2e_tests/test_voice_browser.py`.
+"""
+
+from collections.abc import Iterator
+import time
+
+import pytest
+
+from dimos.stream.audio.decode import decode_audio_bytes
+from dimos.web.cockpit import Chat, cockpit
+from dimos.web.relay_bridge.audio_codec import AudioChunk
+from dimos.web.relay_bridge.e2e_support import stop_module
+
+pytest.importorskip("playwright")
+
+from playwright.sync_api import Page, expect, sync_playwright
+
+pytestmark = pytest.mark.web_browser
+
+
+@pytest.fixture(scope="module")
+def voice_bridge() -> Iterator[tuple[str, list[AudioChunk]]]:
+    (atom,) = cockpit(layout=Chat()).blueprints
+    module = atom.module(local_port=0, open_browser=False, robot_id="voice-e2e", **atom.kwargs)
+    chunks: list[AudioChunk] = []
+    module.audio_in.subscribe(chunks.append)
+    try:
+        module.start()  # builds web dists if stale, spawns the relay, registers
+        relay = module._relay
+        assert relay is not None and relay.info is not None
+        yield relay.info.open_url, chunks
+    finally:
+        stop_module(module)
+
+
+@pytest.fixture(params=["chromium", "firefox"])
+def fake_mic_page(request: pytest.FixtureRequest, playwright_browsers: None) -> Iterator[Page]:
+    with sync_playwright() as p:
+        if request.param == "chromium":
+            browser = p.chromium.launch(
+                args=["--use-fake-device-for-media-stream", "--use-fake-ui-for-media-stream"]
+            )
+            context = browser.new_context(permissions=["microphone"])
+        else:
+            # Firefox has no permissions API in Playwright; the prefs both
+            # fake the capture device and suppress the permission prompt.
+            browser = p.firefox.launch(
+                firefox_user_prefs={
+                    "media.navigator.streams.fake": True,
+                    "media.navigator.permission.disabled": True,
+                }
+            )
+            context = browser.new_context()
+        try:
+            yield context.new_page()
+        finally:
+            browser.close()
+
+
+def test_hold_to_talk_ships_a_decodable_recording(
+    voice_bridge: tuple[str, list[AudioChunk]], fake_mic_page: Page
+) -> None:
+    url, chunks = voice_bridge
+    chunks.clear()  # the module fixture is shared across both engines
+    fake_mic_page.goto(url)
+    mic = fake_mic_page.get_by_test_id("chat-audio_in-mic")
+    # Enabled == transport connected; the manifest already placed the panel.
+    expect(mic).to_be_enabled(timeout=120_000)
+    expect(mic).to_have_attribute("data-state", "idle")
+
+    mic.hover()
+    fake_mic_page.mouse.down()
+    expect(mic).to_have_attribute("data-state", "recording", timeout=15_000)
+    fake_mic_page.wait_for_timeout(1_500)
+    fake_mic_page.mouse.up()
+    expect(mic).to_have_attribute("data-state", "idle", timeout=30_000)
+
+    # The bridge acks each frame only after Out.publish() returned, so by the
+    # time the page settled back to idle the port has (about) everything;
+    # tolerate the last callback still crossing threads.
+    deadline = time.monotonic() + 10.0
+    while time.monotonic() < deadline and not any(chunk.final for chunk in chunks):
+        time.sleep(0.1)
+
+    assert chunks and chunks[-1].final and chunks[-1].data == b""
+    assert {chunk.sid for chunk in chunks} == {chunks[0].sid}
+    assert [chunk.seq for chunk in chunks] == list(range(len(chunks)))
+    assert chunks[0].mime.startswith("audio/")
+    audio = b"".join(chunk.data for chunk in chunks)
+    assert len(audio) > 1_000  # ~1.5 s of compressed audio, not an empty shell
+    # Whatever container this engine produced, the owned ffmpeg decode turns
+    # it into the PCM shape the Whisper pipeline assumes.
+    event = decode_audio_bytes(audio)
+    assert event is not None and event.sample_rate == 16_000
+    assert event.data.ndim == 1 and event.data.shape[0] > 8_000  # > 0.5 s

--- a/dimos/robot/all_blueprints.py
+++ b/dimos/robot/all_blueprints.py
@@ -325,6 +325,7 @@ all_modules = {
     "video-arm-teleop-module": "dimos.teleop.quest.quest_extensions.VideoArmTeleopModule",
     "virtual-mid360": "dimos.hardware.sensors.lidar.virtual_mid360.module.VirtualMid360",
     "vlm-agent": "dimos.agents.vlm_agent.VLMAgent",
+    "voice-input": "dimos.agents.voice_input.VoiceInput",
     "voxel-grid-mapper": "dimos.mapping.voxels.module.VoxelGridMapper",
     "wavefront-frontier-explorer": "dimos.navigation.frontier_exploration.wavefront_frontier_goal_selector.WavefrontFrontierExplorer",
     "web-input": "dimos.agents.web_human_input.WebInput",

--- a/dimos/robot/unitree/go2/blueprints/agentic/unitree_go2_agentic_cockpit.py
+++ b/dimos/robot/unitree/go2/blueprints/agentic/unitree_go2_agentic_cockpit.py
@@ -14,24 +14,36 @@
 
 """The agentic go2 with an authored cockpit: video left, costmap+pose over
 keyboard teleop in the middle, the agent chat right (the humancli
-conversation on McpClient's human_input/agent/agent_idle streams).
+conversation on McpClient's human_input/agent/agent_idle streams, with the
+composer's push-to-talk mic feeding VoiceInput -> the shared Whisper
+pipeline). The cockpit replaces the legacy :5555 WebInput page, so that
+module is disabled here rather than started alongside.
 
 Separate file on purpose: cockpit() needs the [web] extra at import time,
 and `unitree-go2-agentic` itself must stay importable without it.
 """
 
+from dimos.agents.voice_input import VoiceInput
+from dimos.agents.web_human_input import WebInput
 from dimos.core.coordination.blueprints import autoconnect
 from dimos.robot.unitree.go2.blueprints.agentic.unitree_go2_agentic import unitree_go2_agentic
+from dimos.stream.audio.decode import ffmpeg_requirement
 from dimos.web.cockpit import Chat, Col, Map2D, Row, Teleop, Video, cockpit
 
-unitree_go2_agentic_cockpit = autoconnect(
-    unitree_go2_agentic,
-    cockpit(
-        layout=Row(
-            Video("color_image"),
-            Col(Map2D(costmap="global_costmap", pose="odom"), Teleop(), shares=[3, 1]),
-            Chat(),
-            shares=[2, 1, 1],
+unitree_go2_agentic_cockpit = (
+    autoconnect(
+        unitree_go2_agentic,
+        cockpit(
+            layout=Row(
+                Video("color_image"),
+                Col(Map2D(costmap="global_costmap", pose="odom"), Teleop(), shares=[3, 1]),
+                Chat(),
+                shares=[2, 1, 1],
+            ),
         ),
-    ),
-).global_config(n_workers=9, robot_model="unitree_go2")
+        VoiceInput.blueprint(),
+    )
+    .disabled_modules(WebInput)
+    .requirements(ffmpeg_requirement)
+    .global_config(n_workers=9, robot_model="unitree_go2")
+)

--- a/dimos/stream/audio/decode.py
+++ b/dimos/stream/audio/decode.py
@@ -1,0 +1,67 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Browser audio container -> PCM AudioEvent, via ffmpeg.
+
+The one decoder for recorded uploads: ffmpeg sniffs whatever container the
+browser produced (webm/opus, ogg, mp4/aac, wav) and absorbs the
+MediaRecorder variance, so callers never transcode client-side.
+"""
+
+import io
+import shutil
+import time
+
+import ffmpeg  # type: ignore[import-untyped]
+import numpy as np
+import soundfile as sf  # type: ignore[import-untyped]
+
+from dimos.stream.audio.base import AudioEvent
+from dimos.utils.logging_config import setup_logger
+
+logger = setup_logger()
+
+
+def ffmpeg_requirement() -> str | None:
+    """Return a startup error when the ffmpeg executable is unavailable."""
+    if shutil.which("ffmpeg") is None:
+        return "ffmpeg is required for browser audio; install the ffmpeg system package"
+    return None
+
+
+def decode_audio_bytes(raw: bytes) -> AudioEvent | None:
+    """One whole recording -> a mono 16-kHz float32 AudioEvent (the shape
+    WhisperNode assumes), or None when ffmpeg cannot decode it."""
+    try:
+        out, _ = (
+            ffmpeg.input("pipe:0")
+            .output(
+                "pipe:1",
+                format="wav",
+                acodec="pcm_s16le",
+                ac=1,
+                ar="16000",
+                loglevel="quiet",
+            )
+            .run(input=raw, capture_stdout=True, capture_stderr=True)
+        )
+        audio, sample_rate = sf.read(io.BytesIO(out), dtype="float32")
+    except Exception:
+        logger.exception("audio decode failed")
+        return None
+    if audio.ndim > 1:
+        audio = audio[:, 0]
+    return AudioEvent(
+        data=np.asarray(audio), sample_rate=sample_rate, timestamp=time.time(), channels=1
+    )

--- a/dimos/stream/audio/pipeline.py
+++ b/dimos/stream/audio/pipeline.py
@@ -1,0 +1,50 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The one owned speech-to-text chain: normalize -> local Whisper.
+
+Every audio-to-text transport adapter (the legacy WebInput HTTP upload, the
+cockpit VoiceInput chunks) feeds this same pipeline rather than growing its
+own transcription implementation.
+"""
+
+from typing import TYPE_CHECKING
+
+import reactivex as rx
+import reactivex.operators as ops
+
+from dimos.stream.audio.node_normalizer import AudioNormalizer
+
+if TYPE_CHECKING:
+    from reactivex import Observable
+
+    from dimos.stream.audio.base import AudioEvent
+
+
+def whisper_pipeline() -> "tuple[rx.subject.Subject[AudioEvent], Observable[str]]":
+    """AudioEvents in, transcribed text out.
+
+    Loads the Whisper model (blocking); call from a module's start(), not
+    its constructor.
+    """
+    # Here to prevent unwanted imports in the file: whisper backends belong
+    # to the optional [agents] extra and load a model at construction.
+    from dimos.stream.audio.stt.node_whisper import WhisperNode
+
+    audio_subject: rx.subject.Subject[AudioEvent] = rx.subject.Subject()
+    normalizer = AudioNormalizer()
+    stt_node = WhisperNode()
+    normalizer.consume_audio(audio_subject.pipe(ops.share()))
+    stt_node.consume_audio(normalizer.emit_audio())
+    return audio_subject, stt_node.emit_text()

--- a/dimos/stream/audio/stt/node_whisper.py
+++ b/dimos/stream/audio/stt/node_whisper.py
@@ -31,6 +31,7 @@ try:
 
     _USE_FASTER_WHISPER = False
 except ImportError:
+    whisper = None
     try:
         from faster_whisper import WhisperModel  # type: ignore[import-untyped]
 
@@ -40,11 +41,8 @@ except ImportError:
         )
         _USE_FASTER_WHISPER = True
     except ImportError:
-        raise ImportError(
-            "No whisper backend found. "
-            "Install faster-whisper (pip install faster-whisper) "
-            "or openai-whisper (pip install dimos[whisper])."
-        )
+        # No backend: importing stays possible, WhisperNode() raises.
+        _USE_FASTER_WHISPER = False
 
 
 class WhisperNode(AbstractAudioConsumer, AbstractTextEmitter):
@@ -67,6 +65,12 @@ class WhisperNode(AbstractAudioConsumer, AbstractTextEmitter):
             modelopts = {k: v for k, v in modelopts.items() if k != "fp16"}
             self.modelopts = modelopts
             self.model = WhisperModel(model, device="auto", compute_type=compute_type)
+        elif whisper is None:
+            raise ImportError(
+                "No whisper backend found. "
+                "Install faster-whisper (pip install faster-whisper) "
+                "or openai-whisper (pip install dimos[agents])."
+            )
         else:
             self.modelopts = modelopts
             self.model = whisper.load_model(model)
@@ -109,9 +113,10 @@ class WhisperNode(AbstractAudioConsumer, AbstractTextEmitter):
                         result = self.model.transcribe(event.data.flatten(), **self.modelopts)
                         text = result["text"].strip()
                     observer.on_next(text)
-                except Exception as e:
-                    logger.error(f"Error processing audio event: {e}")
-                    observer.on_error(e)
+                except Exception:
+                    # A bad clip or transient model failure must not terminate
+                    # the observable and silently disable every later utterance.
+                    logger.exception("Error processing audio event")
 
             # Set up subscription to audio source
             subscription = self.audio_observable.subscribe(

--- a/dimos/stream/audio/test_decode.py
+++ b/dimos/stream/audio/test_decode.py
@@ -1,0 +1,31 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Failure behavior and runtime requirements for browser-audio decoding."""
+
+import pytest
+
+from dimos.stream.audio import decode as decode_module
+from dimos.stream.audio.decode import decode_audio_bytes, ffmpeg_requirement
+
+
+def test_garbage_returns_none() -> None:
+    assert decode_audio_bytes(b"definitely not an audio container") is None
+
+
+def test_ffmpeg_requirement_reports_missing_executable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(decode_module.shutil, "which", lambda _name: None)
+    assert ffmpeg_requirement() == (
+        "ffmpeg is required for browser audio; install the ffmpeg system package"
+    )

--- a/dimos/web/cockpit.py
+++ b/dimos/web/cockpit.py
@@ -396,27 +396,34 @@ class Chat(Panel):
     goes out on `input` (McpClient.human_input); the LangChain transcript
     comes back on `messages` (McpClient.agent, one chat.json.v1 frame per
     message, none dropped) and `idle` (McpClient.agent_idle) drives the
-    thinking spinner. A grid panel next to video/map; works as a page too.
+    thinking spinner. The composer's push-to-talk mic ships recordings as
+    audio.json.v1 chunks on `audio` (VoiceInput.audio_in); the transcript
+    joins the conversation like typed text. A grid panel next to video/map;
+    works as a page too.
     """
 
     kind: ClassVar[str] = "chat"
     input: str = "human_input"
     messages: str = "agent"
     idle: str = "agent_idle"
+    audio: str = "audio_in"
     title: str = field(default="", kw_only=True)
 
     def __post_init__(self) -> None:
         _check_stream("input", self.input)
         _check_stream("messages", self.messages)
         _check_stream("idle", self.idle)
+        _check_stream("audio", self.audio)
 
     def _channels(self) -> tuple[Channel, ...]:
         # Inline on purpose: langchain-core belongs to the optional [agents]
-        # extra, so only a Chat panel pays for it; the codec module import
-        # registers chat.json.v1 for cockpit()'s encoder resolution.
+        # extra, so only a Chat panel pays for it; the codec module imports
+        # register chat.json.v1 and audio.json.v1 for cockpit()'s codec
+        # resolution.
         from langchain_core.messages import BaseMessage
 
         from dimos.web.relay_bridge import chat_codec  # noqa: F401
+        from dimos.web.relay_bridge.audio_codec import AudioChunk
 
         return (
             Channel(
@@ -424,6 +431,14 @@ class Chat(Panel):
             ),
             Channel(self.messages, BaseMessage, encoding="chat.json.v1", max_hz=20.0),
             Channel(self.idle, bool, delivery="latest", max_hz=20.0),
+            Channel(
+                self.audio,
+                AudioChunk,
+                dir="tx",
+                encoding="audio.json.v1",
+                publish="shared",
+                max_hz=20.0,
+            ),
         )
 
     def _channel_requests(self) -> tuple[ChannelRequest, ...]:

--- a/dimos/web/dimos_interface/api/server.py
+++ b/dimos/web/dimos_interface/api/server.py
@@ -26,30 +26,23 @@
 
 # Fast Api & Uvicorn
 import asyncio
-
-# For audio processing
-import io
 from pathlib import Path
 from queue import Empty, Queue
 import subprocess
 from threading import Lock
-import time
 
 from fastapi import FastAPI, File, Form, HTTPException, Request, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
 from fastapi.templating import Jinja2Templates
-import ffmpeg  # type: ignore[import-untyped]
-import numpy as np
 import reactivex as rx
 from reactivex import operators as ops
 from reactivex.disposable import SingleAssignmentDisposable
-import soundfile as sf  # type: ignore[import-untyped]
 from sse_starlette.sse import EventSourceResponse
 import uvicorn
 
 from dimos.core.global_config import global_config
-from dimos.stream.audio.base import AudioEvent
+from dimos.stream.audio.decode import decode_audio_bytes
 from dimos.web.edge_io import EdgeIO
 
 # TODO: Resolve threading, start/stop stream functionality.
@@ -211,33 +204,6 @@ class FastAPIServer(EdgeIO):
         finally:
             self.text_clients.remove(client_id)
 
-    @staticmethod
-    def _decode_audio(raw: bytes) -> tuple[np.ndarray, int]:
-        """Convert the webm/opus blob sent by the browser into mono 16-kHz PCM."""
-        try:
-            # Use ffmpeg to convert to 16-kHz mono 16-bit PCM WAV in memory
-            out, _ = (
-                ffmpeg.input("pipe:0")
-                .output(
-                    "pipe:1",
-                    format="wav",
-                    acodec="pcm_s16le",
-                    ac=1,
-                    ar="16000",
-                    loglevel="quiet",
-                )
-                .run(input=raw, capture_stdout=True, capture_stderr=True)
-            )
-            # Load with soundfile (returns float32 by default)
-            audio, sr = sf.read(io.BytesIO(out), dtype="float32")
-            # Ensure 1-D array (mono)
-            if audio.ndim > 1:
-                audio = audio[:, 0]
-            return np.array(audio), sr
-        except Exception as exc:
-            print(f"ffmpeg decoding failed: {exc}")
-            return None, None  # type: ignore[return-value]
-
     def setup_routes(self) -> None:
         """Set up FastAPI routes."""
 
@@ -293,23 +259,16 @@ class FastAPIServer(EdgeIO):
 
             try:
                 data = await file.read()
-                audio_np, sr = self._decode_audio(data)
-                if audio_np is None:
+                event = decode_audio_bytes(data)
+                if event is None:
                     return JSONResponse(
                         status_code=400,
                         content={"success": False, "message": "Unable to decode audio"},
                     )
 
-                event = AudioEvent(
-                    data=audio_np,
-                    sample_rate=sr,
-                    timestamp=time.time(),
-                    channels=1 if audio_np.ndim == 1 else audio_np.shape[1],
-                )
-
                 # Push to reactive stream
                 self.audio_subject.on_next(event)
-                print(f"Received audio - {event.data.shape[0] / sr:.2f} s, {sr} Hz")
+                print(f"Received audio - {event.data.shape[0] / event.sample_rate:.2f} s")
                 return {"success": True}
             except Exception as e:
                 print(f"Failed to process uploaded audio: {e}")

--- a/dimos/web/relay_bridge/audio_codec.py
+++ b/dimos/web/relay_bridge/audio_codec.py
@@ -1,0 +1,82 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""audio.json.v1: browser push-to-talk audio chunks (the chat panel's mic).
+
+Wire contract (browser -> robot, publish tx): one JSON object per frame,
+`{"sid": str, "seq": int, "mime": str, "data": str, "final": bool}`.
+`sid` names one utterance (one per button hold), `seq` counts contiguously
+from 0 within it, `mime` is the recorder's container type (e.g.
+"audio/webm;codecs=opus") and `data` is standard base64 of at most 16 KiB of
+container bytes ("" allowed). The sender always ends an utterance with a
+`final` frame of empty data; a cancelled hold simply stops sending and the
+consumer reaps the sid. Concatenating the decoded `data` of seq 0..N yields
+the recorder's exact byte stream - slices need not align with recorder
+chunks, so the container survives re-framing untouched.
+"""
+
+import base64
+from dataclasses import dataclass
+from typing import Any
+
+from dimos.web.codecs import web_decoder
+
+# Utterance/mime ids are short tags, not data carriers.
+_MAX_ID_CHARS = 64
+# The serialized frame is capped at 32 KiB upstream (MAX_PUB_DATA_BYTES, both
+# SDK- and relay-enforced); senders slice at 16 KiB raw. Defense in depth.
+_MAX_DATA_BYTES = 24_000
+_MAX_SEQ = 1_000_000
+
+
+@dataclass(frozen=True)
+class AudioChunk:
+    """One decoded slice of an utterance's container byte stream."""
+
+    sid: str
+    seq: int
+    mime: str
+    data: bytes
+    final: bool
+
+
+def _checked_id(value: dict[str, Any], key: str) -> str:
+    tag = value.get(key)
+    if not isinstance(tag, str) or not 1 <= len(tag) <= _MAX_ID_CHARS:
+        raise ValueError(f"{key} must be a 1..{_MAX_ID_CHARS} char string")
+    return tag
+
+
+@web_decoder("audio.json.v1")
+def decode_audio_chunk(value: dict[str, Any]) -> AudioChunk:
+    if not isinstance(value, dict):
+        raise ValueError("audio chunk must be a JSON object")
+    sid = _checked_id(value, "sid")
+    mime = _checked_id(value, "mime")
+    seq = value.get("seq")
+    if isinstance(seq, bool) or not isinstance(seq, int) or not 0 <= seq <= _MAX_SEQ:
+        raise ValueError(f"seq must be an int in 0..{_MAX_SEQ}")
+    final = value.get("final")
+    if not isinstance(final, bool):
+        raise ValueError("final must be a bool")
+    encoded = value.get("data")
+    if not isinstance(encoded, str):
+        raise ValueError("data must be a base64 string")
+    try:
+        data = base64.b64decode(encoded, validate=True)
+    except ValueError as e:
+        raise ValueError(f"bad base64 data: {e}") from e
+    if len(data) > _MAX_DATA_BYTES:
+        raise ValueError(f"data is {len(data)} B decoded (limit {_MAX_DATA_BYTES})")
+    return AudioChunk(sid=sid, seq=seq, mime=mime, data=data, final=final)

--- a/dimos/web/relay_bridge/manifest.py
+++ b/dimos/web/relay_bridge/manifest.py
@@ -321,12 +321,13 @@ def parse_manifest(data: Any) -> Manifest:
                     f"teleop panel {panel.id} needs a twist.json.v1 latest tx channel",
                 )
         if panel.kind == "chat":
-            # channels: the text input (publish tx), the messages, the idle flag.
-            if len(panel.channels) != 3:
+            # channels: the text input (publish tx), the messages, the idle
+            # flag, the push-to-talk audio (publish tx).
+            if len(panel.channels) != 4:
                 raise ManifestError(
-                    "invalid_chat_panel", f"chat panel {panel.id} must bind three channels"
+                    "invalid_chat_panel", f"chat panel {panel.id} must bind four channels"
                 )
-            text, messages, idle = (ch_ids[ch] for ch in panel.channels)
+            text, messages, idle, audio = (ch_ids[ch] for ch in panel.channels)
             if (
                 text.encoding != "text.json.v1"
                 or text.delivery != "reliable"
@@ -350,6 +351,17 @@ def parse_manifest(data: Any) -> Manifest:
                 raise ManifestError(
                     "invalid_chat_panel",
                     f"chat panel {panel.id} needs a json.v1 latest rx channel third",
+                )
+            if (
+                audio.encoding != "audio.json.v1"
+                or audio.delivery != "reliable"
+                or audio.dir != "tx"
+                or audio.publish != "shared"
+            ):
+                raise ManifestError(
+                    "invalid_chat_panel",
+                    f"chat panel {panel.id} needs an audio.json.v1 reliable shared tx "
+                    "channel fourth",
                 )
 
     seen: set[str] = set()

--- a/dimos/web/relay_bridge/test_audio_codec.py
+++ b/dimos/web/relay_bridge/test_audio_codec.py
@@ -1,0 +1,109 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""audio.json.v1: browser push-to-talk frames -> AudioChunk."""
+
+import base64
+from typing import Any
+
+import pytest
+
+from dimos.web.codecs import resolve_decoder
+from dimos.web.relay_bridge.audio_codec import _MAX_DATA_BYTES, AudioChunk, decode_audio_chunk
+
+
+def _frame(**overrides: Any) -> dict[str, Any]:
+    frame: dict[str, Any] = {
+        "sid": "u1",
+        "seq": 0,
+        "mime": "audio/webm;codecs=opus",
+        "data": base64.b64encode(b"\x1aE\xdf\xa3 opus bytes").decode(),
+        "final": False,
+    }
+    frame.update(overrides)
+    return frame
+
+
+def test_decode_valid_chunk_roundtrips_bytes() -> None:
+    chunk = decode_audio_chunk(_frame(seq=3))
+    assert chunk == AudioChunk(
+        sid="u1",
+        seq=3,
+        mime="audio/webm;codecs=opus",
+        data=b"\x1aE\xdf\xa3 opus bytes",
+        final=False,
+    )
+
+
+def test_decode_final_empty_data() -> None:
+    chunk = decode_audio_chunk(_frame(seq=7, data="", final=True))
+    assert chunk.data == b"" and chunk.final
+
+
+def test_extra_keys_are_tolerated() -> None:
+    # Forward compatibility: a newer panel may add fields.
+    assert decode_audio_chunk(_frame(later=1.5)).sid == "u1"
+
+
+def test_bad_b64_raises() -> None:
+    with pytest.raises(ValueError, match="bad base64"):
+        decode_audio_chunk(_frame(data="not base64!"))
+
+
+@pytest.mark.parametrize(
+    "frame",
+    [
+        ["not", "an", "object"],
+        _frame(sid=None),
+        _frame(sid=""),
+        _frame(sid="x" * 65),
+        _frame(mime=""),
+        _frame(seq=True),
+        _frame(seq=-1),
+        _frame(seq=1.5),
+        _frame(seq=1_000_001),
+        _frame(data=None),
+        _frame(final="yes"),
+        {"sid": "u1"},
+    ],
+    ids=[
+        "not_an_object",
+        "sid_none",
+        "sid_empty",
+        "sid_long",
+        "mime_empty",
+        "seq_bool",
+        "seq_negative",
+        "seq_float",
+        "seq_huge",
+        "data_none",
+        "final_string",
+        "fields_missing",
+    ],
+)
+def test_wrong_shape_raises(frame: Any) -> None:
+    with pytest.raises(ValueError):
+        decode_audio_chunk(frame)
+
+
+def test_oversize_data_raises() -> None:
+    over = base64.b64encode(b"x" * (_MAX_DATA_BYTES + 1)).decode()
+    with pytest.raises(ValueError, match="decoded"):
+        decode_audio_chunk(_frame(data=over))
+
+
+def test_resolve_decoder_binds_audio_chunk() -> None:
+    definition = resolve_decoder("audio.json.v1", AudioChunk)
+    assert definition.decode is decode_audio_chunk
+    assert definition.takes_context is False

--- a/dimos/web/relay_bridge/test_relay_bridge_authoring.py
+++ b/dimos/web/relay_bridge/test_relay_bridge_authoring.py
@@ -20,6 +20,7 @@ no-network harness as test_relay_bridge_module.py (see module_test_support).
 from __future__ import annotations
 
 import asyncio
+import base64
 from dataclasses import replace
 import json
 import pickle
@@ -41,6 +42,7 @@ from dimos.msgs.sensor_msgs.Image import Image
 from dimos.web.cockpit import Channel, Chat, Video, cockpit
 from dimos.web.codecs import EncodedPayload, PublishContext, web_decoder, web_encoder
 from dimos.web.relay_bridge import builtin_codecs, relay_bridge_module
+from dimos.web.relay_bridge.audio_codec import AudioChunk
 from dimos.web.relay_bridge.e2e_support import stop_module
 from dimos.web.relay_bridge.module_test_support import (
     FakeClient,
@@ -522,6 +524,45 @@ def test_chat_panel_forwards_every_message(monkeypatch) -> None:
         assert wait_until(lambda: clients[0].control_frames)
         assert seen == ["walk forward"]
         assert isinstance(clients[0].control_frames[0], PubAck)
+    finally:
+        stop_module(module)
+
+
+def test_voice_chunk_frame_decodes_publishes_then_acks(monkeypatch) -> None:
+    # The chat panel's mic leg: audio frames land on the generated audio_in
+    # Out port (VoiceInput's feed), independent of the text input.
+    module, clients = start_authored(
+        monkeypatch, cockpit(layout=Chat()), wire=("agent", "agent_idle")
+    )
+    try:
+        seen: list[AudioChunk] = []
+        module.audio_in.subscribe(seen.append)
+        frame = {
+            "sid": "u1",
+            "seq": 0,
+            "mime": "audio/webm;codecs=opus",
+            "data": base64.b64encode(b"\x1aE\xdf\xa3 opus").decode(),
+            "final": False,
+        }
+        push(module, clients[0], _pub_frame(json.dumps(frame).encode(), ch="audio_in"))
+        assert wait_until(lambda: clients[0].control_frames)
+        (chunk,) = seen
+        assert chunk == AudioChunk(
+            sid="u1", seq=0, mime="audio/webm;codecs=opus", data=b"\x1aE\xdf\xa3 opus", final=False
+        )
+        assert isinstance(clients[0].control_frames[0], PubAck)
+        # Bad base64 nacks as a decode failure and publishes nothing.
+        push(
+            module,
+            clients[0],
+            _pub_frame(
+                json.dumps({**frame, "seq": 1, "data": "!!"}).encode(), ch="audio_in", seq=2
+            ),
+        )
+        assert wait_until(lambda: len(clients[0].control_frames) == 2)
+        nack = clients[0].control_frames[1]
+        assert isinstance(nack, PubNack) and nack.code == "decode_failed"
+        assert len(seen) == 1
     finally:
         stop_module(module)
 

--- a/dimos/web/test_cockpit.py
+++ b/dimos/web/test_cockpit.py
@@ -40,6 +40,7 @@ from dimos.web.cockpit import (
     cockpit,
 )
 from dimos.web.codecs import EncodedPayload, decode_json_v1, encode_json_v1, web_encoder
+from dimos.web.relay_bridge.audio_codec import AudioChunk, decode_audio_chunk
 from dimos.web.relay_bridge.builtin_codecs import decode_text
 from dimos.web.relay_bridge.chat_codec import encode_chat
 from dimos.web.relay_bridge.manifest import ManifestError, parse_manifest
@@ -485,7 +486,8 @@ def test_publish_tx_channel_blueprint() -> None:
 
 
 def test_chat_panel_blueprint() -> None:
-    (atom,) = cockpit(layout=Chat()).blueprints
+    blueprint = cockpit(layout=Chat())
+    (atom,) = blueprint.blueprints
     manifest = atom.kwargs["manifest"]
     assert [
         (c["ch"], c["dir"], c["encoding"], c["delivery"], c["publish"])
@@ -494,21 +496,28 @@ def test_chat_panel_blueprint() -> None:
         ("agent", "rx", "chat.json.v1", "reliable", "none"),
         ("agent_idle", "rx", "json.v1", "latest", "none"),
         ("human_input", "tx", "text.json.v1", "reliable", "shared"),
+        ("audio_in", "tx", "audio.json.v1", "reliable", "shared"),
     ]
     (panel,) = manifest["panels"]
     assert panel["kind"] == "chat"
-    assert panel["channels"] == ["human_input", "agent", "agent_idle"]
+    assert panel["channels"] == ["human_input", "agent", "agent_idle", "audio_in"]
     assert parse_manifest(manifest).model_dump() == manifest
-    # The agent streams ride a generated subclass whose ports autoconnect to
-    # McpClient's by name + type.
+    # The agent and mic streams ride a generated subclass whose ports
+    # autoconnect to McpClient's and VoiceInput's by name + type.
     ports = {(s.name, s.direction): s.type for s in atom.streams}
     assert ports[("agent", "in")] is BaseMessage
     assert ports[("agent_idle", "in")] is bool
     assert ports[("human_input", "out")] is str
+    assert ports[("audio_in", "out")] is AudioChunk
     specs = {s.ch: s for s in atom.kwargs["channels"]}
     assert specs["agent"].encoder is encode_chat and specs["agent"].paced
     assert specs["agent_idle"].paced
     assert specs["human_input"].decoder is decode_text
+    assert specs["audio_in"].decoder is decode_audio_chunk
+    assert not specs["audio_in"].decoder_takes_context and specs["audio_in"].encoder is None
+    restored = pickle.loads(pickle.dumps(blueprint))
+    (ratom,) = restored.blueprints
+    assert {s.ch: s.decoder for s in ratom.kwargs["channels"]}["audio_in"] is decode_audio_chunk
     # Pacing is the chat panel's, not the stream's: the same streams declared
     # by hand are sampled like any channel.
     (atom,) = cockpit(channels=[Channel("agent", BaseMessage, encoding="chat.json.v1")]).blueprints

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -56,6 +56,10 @@ pip install 'dimos[base,unitree,manipulation]'       # + Arm control
 | `base` | Standard stack (agents + web + viz) | langchain, fastapi, rerun-sdk | No |
 | `dds` | DDS transport (CycloneDDS) | cyclonedds | No |
 
+Cockpit voice input and the legacy browser audio upload require the `ffmpeg`
+executable in addition to the Python `web` extra. On Ubuntu/Debian, install it
+with `sudo apt-get install ffmpeg`.
+
 ## Headless / Server Environments
 
 If running on a headless Ubuntu server (no display), install OpenGL libraries for visualization dependencies:

--- a/web/cockpit/src/App.test.tsx
+++ b/web/cockpit/src/App.test.tsx
@@ -191,11 +191,12 @@ describe("App session states", () => {
       encoding: "json.v1",
       delivery: "latest",
     };
+    const AUDIO: ChannelSpec = { ...TEXT, ch: "audio_in", encoding: "audio.json.v1", maxHz: 20 };
     const chat: PanelSpec = {
       id: "chat",
       kind: "chat",
       title: "",
-      channels: ["human_input", "agent", "agent_idle"],
+      channels: ["human_input", "agent", "agent_idle", "audio_in"],
       params: {},
     };
     const line = (seq: number, text: string) => {
@@ -213,7 +214,7 @@ describe("App session states", () => {
       status.update({
         watchedRobot: ROBOT,
         robots: [ROBOT],
-        manifest: { ...mf([ODOM, TEXT, AGENT, IDLE], [chat]), pages: ["chat"] },
+        manifest: { ...mf([ODOM, TEXT, AGENT, IDLE, AUDIO], [chat]), pages: ["chat"] },
       });
     });
     // Frames before the page is first opened, and while another tab shows.

--- a/web/cockpit/src/panels/ChatMic.test.tsx
+++ b/web/cockpit/src/panels/ChatMic.test.tsx
@@ -1,0 +1,228 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import type { Session } from "@dimos/sdk";
+import { ChatMic } from "./ChatMic.tsx";
+import type { AudioFrame } from "./voiceRecorder.ts";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+class FakeMediaRecorder {
+  static instances: FakeMediaRecorder[] = [];
+  static supported = ["audio/webm;codecs=opus"];
+  static isTypeSupported = (mime: string): boolean => FakeMediaRecorder.supported.includes(mime);
+  state: "inactive" | "recording" = "inactive";
+  mimeType: string;
+  started: number[] = [];
+  ondataavailable: ((e: { data: { arrayBuffer(): Promise<ArrayBuffer> } }) => void) | null = null;
+  onstop: (() => void) | null = null;
+  onerror: ((e: unknown) => void) | null = null;
+  constructor(readonly stream: unknown, options?: { mimeType?: string }) {
+    this.mimeType = options?.mimeType ?? "";
+    FakeMediaRecorder.instances.push(this);
+  }
+  start(timesliceMs: number): void {
+    this.state = "recording";
+    this.started.push(timesliceMs);
+  }
+  stop(): void {
+    this.state = "inactive";
+    this.onstop?.();
+  }
+  emit(bytes: Uint8Array): void {
+    const buffer = bytes.slice().buffer as ArrayBuffer;
+    this.ondataavailable?.({ data: { arrayBuffer: () => Promise.resolve(buffer) } });
+  }
+  emitUnreadable(): void {
+    this.ondataavailable?.({ data: { arrayBuffer: () => Promise.reject(new Error("blob gone")) } });
+  }
+}
+
+describe("ChatMic", () => {
+  let container: HTMLElement;
+  let root: Root;
+  let published: [string, AudioFrame][];
+  let errors: (string | null)[];
+  let tracks: { stop: ReturnType<typeof vi.fn> }[];
+  let micGrants: number;
+  const session = {
+    publish: (ch: string, value: unknown) => {
+      published.push([ch, value as AudioFrame]);
+      return Promise.resolve({ ch, relayTs: 1, bridgeTs: 2 });
+    },
+  } as unknown as Session;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    published = [];
+    errors = [];
+    FakeMediaRecorder.instances = [];
+    FakeMediaRecorder.supported = ["audio/webm;codecs=opus"];
+    tracks = [{ stop: vi.fn() }];
+    micGrants = 0;
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  function stubMicApis(): void {
+    vi.stubGlobal("isSecureContext", true);
+    vi.stubGlobal("MediaRecorder", FakeMediaRecorder);
+    Object.defineProperty(navigator, "mediaDevices", {
+      configurable: true,
+      value: {
+        getUserMedia: () => {
+          micGrants++;
+          return Promise.resolve({ getTracks: () => tracks });
+        },
+      },
+    });
+  }
+
+  function mount(connected = true): void {
+    act(() =>
+      root.render(
+        <ChatMic
+          session={session}
+          ch="audio_in"
+          connected={connected}
+          onError={(m) => errors.push(m)}
+        />,
+      )
+    );
+  }
+
+  function button(): HTMLButtonElement {
+    const el = container.querySelector<HTMLButtonElement>('[data-testid="chat-audio_in-mic"]');
+    if (el === null) throw new Error("mic button not rendered");
+    return el;
+  }
+
+  function press(): void {
+    act(() => {
+      button().dispatchEvent(new Event("pointerdown", { bubbles: true }));
+    });
+  }
+
+  function release(): void {
+    act(() => {
+      button().dispatchEvent(new Event("pointerup", { bubbles: true }));
+    });
+  }
+
+  async function settle(state: string): Promise<void> {
+    // Real (not fake) time: the machine paces sends with a 60 ms floor.
+    for (let i = 0; i < 100 && button().dataset.state !== state; i++) {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      });
+    }
+    expect(button().dataset.state).toBe(state);
+  }
+
+  it("renders nothing without microphone APIs", () => {
+    mount();
+    expect(container.querySelector("button")).toBeNull();
+  });
+
+  it("hold-speak-release publishes the recording and a final frame", async () => {
+    stubMicApis();
+    mount();
+    expect(button().dataset.state).toBe("idle");
+    press();
+    await settle("recording");
+    const [recorder] = FakeMediaRecorder.instances;
+    expect(recorder.started).toEqual([500]);
+    expect(recorder.mimeType).toBe("audio/webm;codecs=opus");
+    act(() => recorder.emit(Uint8Array.from([1, 2, 3, 4])));
+    release();
+    await settle("idle");
+    expect(published.every(([ch]) => ch === "audio_in")).toBe(true);
+    const frames = published.map(([, frame]) => frame);
+    expect(frames.length).toBe(2);
+    expect(frames[0]).toMatchObject({ seq: 0, mime: "audio/webm;codecs=opus", final: false });
+    expect(atob(frames[0].data)).toBe("\x01\x02\x03\x04");
+    expect(frames[1]).toMatchObject({ seq: 1, data: "", final: true });
+    expect(frames[0].sid).toBe(frames[1].sid);
+
+    // The second hold reuses the granted mic and starts a fresh sid.
+    press();
+    await settle("recording");
+    release();
+    await settle("idle");
+    expect(micGrants).toBe(1);
+    expect(published.at(-1)?.[1].sid).not.toBe(frames[0].sid);
+  });
+
+  it("falls back to mp4 when webm is unsupported and stamps it on frames", async () => {
+    stubMicApis();
+    FakeMediaRecorder.supported = ["audio/mp4"];
+    mount();
+    press();
+    await settle("recording");
+    const [recorder] = FakeMediaRecorder.instances;
+    expect(recorder.mimeType).toBe("audio/mp4");
+    act(() => recorder.emit(Uint8Array.from([9])));
+    release();
+    await settle("idle");
+    expect(published.every(([, frame]) => frame.mime === "audio/mp4")).toBe(true);
+  });
+
+  it("a failed Blob read errors out instead of wedging in sending", async () => {
+    stubMicApis();
+    mount();
+    press();
+    await settle("recording");
+    act(() => FakeMediaRecorder.instances[0].emitUnreadable());
+    release();
+    await settle("error");
+    expect(errors.at(-1)).toBe("voice failed: blob gone");
+    expect(published.some(([, frame]) => frame.final)).toBe(false);
+    // The next press clears the reported error and records again.
+    press();
+    await settle("recording");
+    expect(errors.at(-1)).toBeNull();
+    act(() => root.unmount());
+  });
+
+  it("Escape cancels the hold without a final frame", async () => {
+    stubMicApis();
+    mount();
+    press();
+    await settle("recording");
+    act(() => FakeMediaRecorder.instances[0].emit(Uint8Array.from([7])));
+    act(() => {
+      button().dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }),
+      );
+    });
+    await settle("idle");
+    await act(async () => {});
+    expect(published.some(([, frame]) => frame.final)).toBe(false);
+  });
+
+  it("stays usable mid-hold if the connection drops, and unmount releases the mic", async () => {
+    stubMicApis();
+    mount();
+    press();
+    await settle("recording");
+    mount(false); // connected flips mid-hold: the button must not disable
+    expect(button().disabled).toBe(false);
+    release();
+    await settle("idle");
+    act(() => root.unmount());
+    expect(tracks[0].stop).toHaveBeenCalled();
+  });
+
+  it("is disabled while idle and disconnected", () => {
+    stubMicApis();
+    mount(false);
+    expect(button().disabled).toBe(true);
+  });
+});

--- a/web/cockpit/src/panels/ChatMic.tsx
+++ b/web/cockpit/src/panels/ChatMic.tsx
@@ -1,0 +1,146 @@
+// Push-to-talk mic for the chat composer. Hold to record, release to send:
+// the recording ships as audio.json.v1 chunks on the chat panel's audio
+// channel, and the robot-side VoiceInput module transcribes it onto
+// /human_input - the utterance then appears in the transcript when the
+// agent echoes it, exactly like typed text. Renders nothing when the
+// microphone APIs are unavailable (insecure context, no MediaRecorder).
+// Element-scoped listeners only: holding the mic never drives the robot.
+
+import { useEffect, useMemo, useSyncExternalStore } from "react";
+import type { Session } from "@dimos/sdk";
+import { type RecorderPort, VoiceRecorder } from "./voiceRecorder.ts";
+import styles from "./ChatPanel.module.css";
+
+// Whatever the browser records is shipped as-is (mime rides every frame);
+// the preference order just picks the smallest container Chrome/Firefox
+// offer before Safari's mp4.
+const MIME_CANDIDATES = ["audio/webm;codecs=opus", "audio/webm", "audio/mp4"];
+const AUDIO_BITS_PER_SECOND = 32_000;
+
+function supported(): boolean {
+  return globalThis.isSecureContext === true &&
+    typeof navigator !== "undefined" &&
+    typeof navigator.mediaDevices?.getUserMedia === "function" &&
+    "MediaRecorder" in globalThis;
+}
+
+/** A MediaRecorder on the shared mic stream, adapted to the machine's port. */
+async function openRecorder(
+  mic: { current: MediaStream | null },
+  ondata: (bytes: Uint8Array) => void,
+): Promise<RecorderPort> {
+  if (mic.current === null) {
+    mic.current = await navigator.mediaDevices.getUserMedia({ audio: true });
+  }
+  const mimeType = typeof MediaRecorder.isTypeSupported === "function"
+    ? MIME_CANDIDATES.find((m) => MediaRecorder.isTypeSupported(m))
+    : undefined;
+  const recorder = new MediaRecorder(mic.current, {
+    ...(mimeType === undefined ? {} : { mimeType }),
+    audioBitsPerSecond: AUDIO_BITS_PER_SECOND,
+  });
+  // Blob -> bytes is async; the chain keeps delivery in recording order.
+  // stop() settles only after the last delivery - resolving on success,
+  // rejecting when capture or a Blob read failed, so a broken recording
+  // surfaces as the machine's error phase instead of wedging in `sending`.
+  let failure: Error | null = null;
+  const fail = (err: unknown): void => {
+    failure ??= err instanceof Error ? err : new Error(String(err));
+  };
+  let deliveries = Promise.resolve();
+  let settle: () => void = () => {};
+  const lastData = new Promise<void>((resolve, reject) => {
+    settle = () => (failure === null ? resolve() : reject(failure));
+  });
+  recorder.ondataavailable = (event) => {
+    deliveries = deliveries.then(async () => {
+      try {
+        const bytes = new Uint8Array(await event.data.arrayBuffer());
+        if (failure === null && bytes.length > 0) ondata(bytes);
+      } catch (err) {
+        fail(err);
+      }
+    });
+  };
+  recorder.onerror = (event) => {
+    fail((event as { error?: unknown }).error ?? new Error("recorder failed"));
+  };
+  recorder.onstop = () => void deliveries.then(settle);
+  return {
+    mimeType: recorder.mimeType || mimeType || "audio/webm",
+    start: (timesliceMs) => recorder.start(timesliceMs),
+    stop: () => {
+      if (recorder.state === "inactive") void deliveries.then(settle);
+      else recorder.stop();
+      return lastData;
+    },
+  };
+}
+
+export interface ChatMicProps {
+  session: Session;
+  ch: string;
+  connected: boolean;
+  /** Errors land in the chat panel's existing alert row; null clears. */
+  onError: (message: string | null) => void;
+}
+
+export function ChatMic(props: ChatMicProps) {
+  if (!supported()) return null;
+  return <Mic {...props} />;
+}
+
+function Mic({ session, ch, connected, onError }: ChatMicProps) {
+  const recorder = useMemo(() => {
+    // The mic stream stays open between holds: press-to-speak must not lose
+    // the first words to a getUserMedia round-trip. The cost is the OS
+    // record indicator while the panel lives; unmount releases it.
+    const mic = { current: null as MediaStream | null };
+    return {
+      mic,
+      machine: new VoiceRecorder({
+        openMic: (ondata) => openRecorder(mic, ondata),
+        publish: (frame) => session.publish(ch, frame),
+      }),
+    };
+  }, [session, ch]);
+  const state = useSyncExternalStore(recorder.machine.subscribe, recorder.machine.getSnapshot);
+  useEffect(() => () => {
+    recorder.machine.cancel();
+    recorder.mic.current?.getTracks().forEach((track) => track.stop());
+    recorder.mic.current = null;
+  }, [recorder]);
+  useEffect(() => {
+    if (state.phase === "error") onError(`voice failed: ${state.message}`);
+    else if (state.phase === "arming") onError(null);
+  }, [state, onError]);
+
+  const held = state.phase === "arming" || state.phase === "recording";
+  return (
+    <button
+      type="button"
+      className={styles.mic}
+      data-state={state.phase}
+      data-testid={`chat-${ch}-mic`}
+      aria-label="hold to talk"
+      // Never disable mid-hold: a disabled button swallows the pointerup
+      // that must end the recording.
+      disabled={!connected && !held && state.phase !== "sending"}
+      onPointerDown={(e) => {
+        // Capture keeps the release on the button even if the pointer
+        // drifts off it mid-hold (guarded: synthetic events lack ids).
+        if (typeof e.currentTarget.setPointerCapture === "function" && e.pointerId >= 0) {
+          e.currentTarget.setPointerCapture(e.pointerId);
+        }
+        recorder.machine.press();
+      }}
+      onPointerUp={() => recorder.machine.release()}
+      onPointerCancel={() => recorder.machine.cancel()}
+      onKeyDown={(e) => {
+        if (e.key === "Escape") recorder.machine.cancel();
+      }}
+    >
+      {state.phase === "recording" ? "listening" : state.phase === "sending" ? "sending" : "talk"}
+    </button>
+  );
+}

--- a/web/cockpit/src/panels/ChatPanel.module.css
+++ b/web/cockpit/src/panels/ChatPanel.module.css
@@ -123,6 +123,35 @@
   opacity: 0.5;
 }
 
+.mic {
+  background: #21262d;
+  border: 1px solid #30363d;
+  border-radius: 4px;
+  color: #d7dde3;
+  cursor: pointer;
+  font: inherit;
+  padding: 0.35rem 0.6rem;
+  touch-action: none;
+  user-select: none;
+}
+
+.mic:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+.mic[data-state="arming"],
+.mic[data-state="recording"] {
+  background: #8f1f2b;
+  border-color: #f85149;
+  color: #fff;
+}
+
+.mic[data-state="sending"] {
+  border-color: #2f81f7;
+  color: #2f81f7;
+}
+
 .thinking {
   color: #2f81f7;
 }

--- a/web/cockpit/src/panels/ChatPanel.test.tsx
+++ b/web/cockpit/src/panels/ChatPanel.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import type { FrameHeader, Msg, PanelSpec } from "@dimos/shared";
@@ -11,11 +11,23 @@ import { TeleopPanel } from "./TeleopPanel.tsx";
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
+vi.mock("./ChatMic.tsx", () => ({
+  ChatMic: ({ ch, onError }: { ch: string; onError: (message: string | null) => void }) => (
+    <button
+      type="button"
+      data-testid="chat-mic-stub"
+      onClick={() => onError("voice failed: test")}
+    >
+      {ch}
+    </button>
+  ),
+}));
+
 const SPEC: PanelSpec = {
   id: "p0",
   kind: "chat",
   title: "",
-  channels: ["human_input", "agent", "agent_idle"],
+  channels: ["human_input", "agent", "agent_idle", "audio_in"],
   params: {},
 };
 const TELEOP_SPEC: PanelSpec = {
@@ -36,6 +48,16 @@ const MANIFEST: Manifest = {
       maxHz: 15,
       params: { maxLinear: 0.8, maxAngular: 1.0, boost: 2.0, watchdogMs: 300 },
       publish: "none",
+      requiredScope: null,
+    },
+    {
+      ch: "audio_in",
+      dir: "tx",
+      encoding: "audio.json.v1",
+      delivery: "reliable",
+      maxHz: 20,
+      params: {},
+      publish: "shared",
       requiredScope: null,
     },
   ],
@@ -203,6 +225,14 @@ describe("ChatPanel", () => {
   it("renders a notice without a send path", () => {
     act(() => root.render(<ChatPanel spec={SPEC} store={session.store} />));
     expect(container.textContent).toContain("no send path bound");
+  });
+
+  it("binds the composer mic to the audio channel and displays its errors", () => {
+    mount();
+    const mic = find<HTMLButtonElement>("chat-mic-stub");
+    expect(mic.textContent).toBe("audio_in");
+    act(() => mic.click());
+    expect(container.textContent).toContain("voice failed: test");
   });
 
   it("typing in the chat never drives the robot", () => {

--- a/web/cockpit/src/panels/ChatPanel.tsx
+++ b/web/cockpit/src/panels/ChatPanel.tsx
@@ -3,15 +3,17 @@
 // LangChain message) on a reliable channel; the transcript lives in
 // chatTranscript.ts for the session's life, not the panel's. Typed text goes
 // out through session.publish on the tx channel and renders when the agent
-// echoes it back on the message channel, exactly like humancli. Nothing typed
-// here can drive the robot: the teleop pad listens on its own subtree and
-// disarms when focus leaves it.
+// echoes it back on the message channel, exactly like humancli; the
+// composer's push-to-talk mic (ChatMic) joins the same conversation through
+// the audio channel. Nothing typed or held here can drive the robot: the
+// teleop pad listens on its own subtree and disarms when focus leaves it.
 
 import { type FormEvent, useEffect, useRef, useState, useSyncExternalStore } from "react";
 import type { PanelSpec } from "@dimos/shared";
 import type { ChannelStore, Session } from "@dimos/sdk";
 import { useStatus, useStoreChannel } from "@dimos/sdk/react";
 import { PanelFrame } from "../layout/PanelFrame.tsx";
+import { ChatMic } from "./ChatMic.tsx";
 import { type ChatLine, chatTranscript } from "./chatTranscript.ts";
 import type { PanelProps } from "./registry.tsx";
 import styles from "./ChatPanel.module.css";
@@ -51,7 +53,7 @@ function LineView({ line }: { line: ChatLine }) {
 }
 
 export function ChatPanel({ spec, store, session }: PanelProps) {
-  if (spec.channels.length < 3 || session === undefined) {
+  if (spec.channels.length < 4 || session === undefined) {
     return (
       <PanelFrame spec={spec}>
         <span className={styles.hint}>chat panel {spec.id}: no send path bound</span>
@@ -66,7 +68,7 @@ function Conversation({ spec, store, session }: {
   store: ChannelStore;
   session: Session;
 }) {
-  const [inputCh, messagesCh, idleCh] = spec.channels;
+  const [inputCh, messagesCh, idleCh, audioCh] = spec.channels;
   const transcript = chatTranscript(store, messagesCh);
   const lines = useSyncExternalStore(transcript.subscribe, transcript.getSnapshot);
   const idle = useStoreChannel(store, idleCh).slot?.value;
@@ -101,7 +103,7 @@ function Conversation({ spec, store, session }: {
       .publish(inputCh, text)
       .catch((err: unknown) => {
         // A PublishError message already reads "<code>: <reason>".
-        setError(err instanceof Error ? err.message : String(err));
+        setError(`send failed: ${err instanceof Error ? err.message : String(err)}`);
         // Give a failed message back unless the user already typed on.
         setDraft((current) => (current === "" ? text : current));
       })
@@ -125,7 +127,7 @@ function Conversation({ spec, store, session }: {
         </div>
         {error !== null && (
           <div className={styles.error} role="alert">
-            send failed: {error}
+            {error}
           </div>
         )}
         <form className={styles.composer} onSubmit={onSubmit}>
@@ -138,6 +140,7 @@ function Conversation({ spec, store, session }: {
             data-testid={`chat-${inputCh}-input`}
             onChange={(e) => setDraft(e.target.value)}
           />
+          <ChatMic session={session} ch={audioCh} connected={connected} onError={setError} />
           <button
             type="submit"
             className={styles.send}

--- a/web/cockpit/src/panels/chatTranscript.ts
+++ b/web/cockpit/src/panels/chatTranscript.ts
@@ -92,7 +92,7 @@ export function chatTranscript(store: ChannelStore, ch: string): ChatTranscript 
 /** Start the transcript of every chat panel's message channel (slot 1). */
 export function startChatTranscripts(store: ChannelStore, manifest: Manifest): void {
   for (const panel of manifest.panels) {
-    if (panel.kind === "chat" && panel.channels.length === 3) {
+    if (panel.kind === "chat" && panel.channels.length === 4) {
       chatTranscript(store, panel.channels[1]);
     }
   }

--- a/web/cockpit/src/panels/voiceRecorder.test.ts
+++ b/web/cockpit/src/panels/voiceRecorder.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from "vitest";
+import {
+  type AudioFrame,
+  MAX_SLICE_BYTES,
+  MAX_UTTERANCE_MS,
+  MIN_SEND_INTERVAL_MS,
+  type RecorderPort,
+  TIMESLICE_MS,
+  VoiceRecorder,
+  type VoiceRecorderDeps,
+} from "./voiceRecorder.ts";
+
+const tick = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+
+interface Harness {
+  recorder: VoiceRecorder;
+  published: AudioFrame[];
+  mic: { started: number[]; stopped: number };
+  slept: number[];
+  ondata: (bytes: Uint8Array) => void;
+  arm: () => void;
+  wakeAutoRelease: () => void;
+  rejectSeq: number;
+  settle: (phase?: string) => Promise<void>;
+}
+
+function harness(opts: { manualArm?: boolean } = {}): Harness {
+  const h = {} as Harness;
+  h.published = [];
+  h.mic = { started: [], stopped: 0 };
+  h.slept = [];
+  h.ondata = () => {};
+  h.arm = () => {};
+  h.wakeAutoRelease = () => {};
+  h.rejectSeq = -1;
+  let sid = 0;
+  const deps: VoiceRecorderDeps = {
+    openMic: (ondata) => {
+      h.ondata = ondata;
+      const port: RecorderPort = {
+        mimeType: "audio/webm",
+        start: (timesliceMs) => h.mic.started.push(timesliceMs),
+        stop: () => {
+          h.mic.stopped++;
+          return Promise.resolve();
+        },
+      };
+      if (!opts.manualArm) return Promise.resolve(port);
+      return new Promise((resolve) => {
+        h.arm = () => resolve(port);
+      });
+    },
+    publish: (frame) => {
+      h.published.push(frame);
+      return frame.seq === h.rejectSeq
+        ? Promise.reject(new Error("rate_limited: slow down"))
+        : Promise.resolve({});
+    },
+    newSid: () => `sid-${++sid}`,
+    sleep: (ms) => {
+      h.slept.push(ms);
+      // The auto-release hold must not fire on its own; everything else
+      // (the inter-send floor) resolves immediately.
+      if (ms < MAX_UTTERANCE_MS) return Promise.resolve();
+      return new Promise((resolve) => {
+        h.wakeAutoRelease = resolve;
+      });
+    },
+  };
+  h.recorder = new VoiceRecorder(deps);
+  h.settle = async (phase = "idle") => {
+    for (let i = 0; i < 200 && h.recorder.getSnapshot().phase !== phase; i++) await tick();
+    expect(h.recorder.getSnapshot().phase).toBe(phase);
+  };
+  return h;
+}
+
+function bytesOf(frames: AudioFrame[]): Uint8Array {
+  const text = frames.map((f) => atob(f.data)).join("");
+  return Uint8Array.from(text, (c) => c.charCodeAt(0));
+}
+
+describe("VoiceRecorder", () => {
+  it("press arms then records at the timeslice", async () => {
+    const h = harness();
+    expect(h.recorder.getSnapshot().phase).toBe("idle");
+    h.recorder.press();
+    expect(h.recorder.getSnapshot().phase).toBe("arming");
+    await h.settle("recording");
+    expect(h.mic.started).toEqual([TIMESLICE_MS]);
+    expect(h.published).toEqual([]);
+  });
+
+  it("release stops, drains slices in order, and closes with an empty final frame", async () => {
+    const h = harness();
+    h.recorder.press();
+    await h.settle("recording");
+    const source = Uint8Array.from({ length: MAX_SLICE_BYTES * 2 + 100 }, (_, i) => i % 256);
+    h.ondata(source);
+    h.recorder.release();
+    await h.settle();
+    expect(h.mic.stopped).toBe(1);
+    expect(h.published.map((f) => [f.seq, f.data.length > 0, f.final])).toEqual([
+      [0, true, false],
+      [1, true, false],
+      [2, true, false],
+      [3, false, true],
+    ]);
+    expect(h.published.every((f) => f.sid === "sid-1" && f.mime === "audio/webm")).toBe(true);
+    expect(bytesOf(h.published)).toEqual(source);
+  });
+
+  it("paces every non-final send by the interval floor", async () => {
+    const h = harness();
+    h.recorder.press();
+    await h.settle("recording");
+    h.ondata(new Uint8Array(MAX_SLICE_BYTES * 3));
+    h.recorder.release();
+    await h.settle();
+    expect(h.slept.filter((ms) => ms === MIN_SEND_INTERVAL_MS).length).toBe(3);
+  });
+
+  it("cancel before any audio sends nothing", async () => {
+    const h = harness();
+    h.recorder.press();
+    await h.settle("recording");
+    h.recorder.cancel();
+    expect(h.recorder.getSnapshot().phase).toBe("idle");
+    await tick();
+    expect(h.published).toEqual([]);
+    expect(h.mic.stopped).toBe(1);
+  });
+
+  it("cancel mid-utterance never sends a final frame", async () => {
+    const h = harness();
+    h.recorder.press();
+    await h.settle("recording");
+    h.ondata(new Uint8Array(10));
+    await tick();
+    h.recorder.cancel();
+    await tick();
+    await tick();
+    expect(h.published.some((f) => f.final)).toBe(false);
+    expect(h.recorder.getSnapshot().phase).toBe("idle");
+  });
+
+  it("release while arming aborts cleanly with nothing recorded", async () => {
+    const h = harness({ manualArm: true });
+    h.recorder.press();
+    expect(h.recorder.getSnapshot().phase).toBe("arming");
+    h.recorder.release();
+    h.arm();
+    await h.settle();
+    expect(h.published).toEqual([]);
+    expect(h.mic.started).toEqual([]);
+    expect(h.mic.stopped).toBe(1);
+  });
+
+  it("a denied microphone lands in the error phase", async () => {
+    const denied = new VoiceRecorder({
+      openMic: () => Promise.reject(new Error("Permission denied")),
+      publish: () => Promise.resolve({}),
+    });
+    denied.press();
+    for (let i = 0; i < 50 && denied.getSnapshot().phase !== "error"; i++) await tick();
+    expect(denied.getSnapshot()).toEqual({
+      phase: "error",
+      message: "microphone unavailable: Permission denied",
+    });
+  });
+
+  it("a rejected publish aborts the utterance into the error phase", async () => {
+    const h = harness();
+    h.rejectSeq = 1;
+    h.recorder.press();
+    await h.settle("recording");
+    h.ondata(new Uint8Array(MAX_SLICE_BYTES * 3));
+    h.recorder.release();
+    await h.settle("error");
+    expect(h.recorder.getSnapshot().message).toBe("rate_limited: slow down");
+    expect(h.published.length).toBe(2);
+    expect(h.published.some((f) => f.final)).toBe(false);
+    // The next press starts fresh and clears the error.
+    h.recorder.press();
+    expect(h.recorder.getSnapshot().phase).toBe("arming");
+    await h.settle("recording");
+    h.recorder.cancel();
+  });
+
+  it("auto-releases at the utterance cap", async () => {
+    const h = harness();
+    h.recorder.press();
+    await h.settle("recording");
+    h.ondata(new Uint8Array(5));
+    h.wakeAutoRelease();
+    await h.settle();
+    expect(h.published.at(-1)?.final).toBe(true);
+  });
+
+  it("each utterance gets a fresh sid with seqs from zero", async () => {
+    const h = harness();
+    for (const _ of [1, 2]) {
+      h.recorder.press();
+      await h.settle("recording");
+      h.ondata(new Uint8Array(4));
+      h.recorder.release();
+      await h.settle();
+    }
+    const bySid = new Map<string, number[]>();
+    for (const frame of h.published) {
+      bySid.set(frame.sid, [...(bySid.get(frame.sid) ?? []), frame.seq]);
+    }
+    expect([...bySid.entries()]).toEqual([
+      ["sid-1", [0, 1]],
+      ["sid-2", [0, 1]],
+    ]);
+  });
+});

--- a/web/cockpit/src/panels/voiceRecorder.ts
+++ b/web/cockpit/src/panels/voiceRecorder.ts
@@ -1,0 +1,229 @@
+// Push-to-talk recorder: the chat mic's press/hold/release/cancel state
+// machine and chunk sender, free of DOM and MediaRecorder so tests drive it
+// with fakes (ChatMic adapts the real APIs).
+//
+// One button hold is one utterance (a fresh sid): container bytes stream in
+// through ondata while recording, are sliced to <=16 KiB and published in
+// order as audio.json.v1 frames, and a final empty frame closes the
+// utterance after release. Each send awaits the previous ack and a 60 ms
+// floor, staying inside the channel's 20 Hz relay token buckets (capacity
+// 20, refill 20/s). Cancel drops everything unsent and sends no final frame;
+// the robot reaps the half-built utterance instead.
+
+/** One audio.json.v1 frame (a type alias, so it assigns to JsonValue). */
+export type AudioFrame = {
+  sid: string;
+  seq: number;
+  mime: string;
+  data: string;
+  final: boolean;
+};
+
+export type VoicePhase = "idle" | "arming" | "recording" | "sending" | "error";
+
+export interface VoiceSnapshot {
+  phase: VoicePhase;
+  /** Set in the error phase (a PublishError message reads "code: reason"). */
+  message?: string;
+}
+
+export interface RecorderPort {
+  mimeType: string;
+  start(timesliceMs: number): void;
+  /** Stops capture; resolves once every recorded byte has reached ondata. */
+  stop(): Promise<void>;
+}
+
+export interface VoiceRecorderDeps {
+  /** Opens the mic; ondata receives the container byte stream in order. */
+  openMic(ondata: (bytes: Uint8Array) => void): Promise<RecorderPort>;
+  publish(frame: AudioFrame): Promise<unknown>;
+  newSid?(): string;
+  sleep?(ms: number): Promise<void>;
+}
+
+export const TIMESLICE_MS = 500;
+export const MAX_SLICE_BYTES = 16 * 1024;
+export const MIN_SEND_INTERVAL_MS = 60;
+export const MAX_UTTERANCE_MS = 90_000;
+
+function b64(bytes: Uint8Array): string {
+  let s = "";
+  for (const b of bytes) s += String.fromCharCode(b);
+  return btoa(s);
+}
+
+function messageOf(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+interface Utterance {
+  sid: string;
+  seq: number;
+  mime: string;
+  port: RecorderPort | null;
+  queue: Uint8Array[];
+  released: boolean;
+  cancelled: boolean;
+  kick: () => void;
+}
+
+export class VoiceRecorder {
+  #openMic: VoiceRecorderDeps["openMic"];
+  #publish: VoiceRecorderDeps["publish"];
+  #newSid: () => string;
+  #sleep: (ms: number) => Promise<void>;
+  #snapshot: VoiceSnapshot = { phase: "idle" };
+  #listeners = new Set<() => void>();
+  #current: Utterance | null = null;
+
+  constructor(deps: VoiceRecorderDeps) {
+    this.#openMic = deps.openMic;
+    this.#publish = deps.publish;
+    this.#newSid = deps.newSid ?? (() => crypto.randomUUID());
+    this.#sleep = deps.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+  }
+
+  /** useSyncExternalStore pair; the snapshot identity changes per transition. */
+  subscribe = (cb: () => void): () => void => {
+    this.#listeners.add(cb);
+    return () => this.#listeners.delete(cb);
+  };
+  getSnapshot = (): VoiceSnapshot => this.#snapshot;
+
+  /** Button pressed: start an utterance (also clears a shown error). */
+  press(): void {
+    if (this.#snapshot.phase !== "idle" && this.#snapshot.phase !== "error") return;
+    const utterance: Utterance = {
+      sid: this.#newSid(),
+      seq: 0,
+      mime: "",
+      port: null,
+      queue: [],
+      released: false,
+      cancelled: false,
+      kick: () => {},
+    };
+    this.#current = utterance;
+    this.#set({ phase: "arming" });
+    void this.#run(utterance);
+  }
+
+  /** Button released: flush what was recorded and close with a final frame. */
+  release(): void {
+    const u = this.#current;
+    if (u === null || u.released || u.cancelled) return;
+    u.released = true;
+    u.kick();
+  }
+
+  /** Escape / pointer cancel: drop the utterance; nothing more is sent. */
+  cancel(): void {
+    const u = this.#current;
+    if (u === null || u.cancelled) return;
+    u.cancelled = true;
+    u.kick();
+    u.port?.stop().catch(() => {});
+    this.#finish(u, { phase: "idle" });
+  }
+
+  #set(snapshot: VoiceSnapshot): void {
+    this.#snapshot = snapshot;
+    for (const cb of this.#listeners) cb();
+  }
+
+  #setFor(u: Utterance, snapshot: VoiceSnapshot): void {
+    if (this.#current === u) this.#set(snapshot);
+  }
+
+  #finish(u: Utterance, snapshot: VoiceSnapshot): void {
+    if (this.#current !== u) return;
+    this.#current = null;
+    this.#set(snapshot);
+  }
+
+  async #run(u: Utterance): Promise<void> {
+    let port: RecorderPort;
+    try {
+      port = await this.#openMic((bytes) => {
+        for (let i = 0; i < bytes.length; i += MAX_SLICE_BYTES) {
+          u.queue.push(bytes.subarray(i, i + MAX_SLICE_BYTES));
+        }
+        u.kick();
+      });
+    } catch (err) {
+      this.#finish(u, { phase: "error", message: `microphone unavailable: ${messageOf(err)}` });
+      return;
+    }
+    u.port = port;
+    u.mime = port.mimeType;
+    if (u.cancelled) {
+      port.stop().catch(() => {});
+      return;
+    }
+    if (u.released) {
+      // Released before capture began: nothing recorded, nothing sent.
+      port.stop().catch(() => {});
+      this.#finish(u, { phase: "idle" });
+      return;
+    }
+    port.start(TIMESLICE_MS);
+    this.#setFor(u, { phase: "recording" });
+    void this.#autoRelease(u);
+    try {
+      await this.#pump(u);
+    } catch (err) {
+      if (!u.cancelled) {
+        u.cancelled = true;
+        port.stop().catch(() => {});
+        this.#finish(u, { phase: "error", message: messageOf(err) });
+      }
+      return;
+    }
+    this.#finish(u, { phase: "idle" });
+  }
+
+  async #pump(u: Utterance): Promise<void> {
+    let flushed = false;
+    while (true) {
+      if (u.cancelled) return;
+      if (u.released && !flushed) {
+        this.#setFor(u, { phase: "sending" });
+        // Resolves after the recorder's last bytes landed in the queue.
+        await u.port!.stop();
+        flushed = true;
+        continue;
+      }
+      const piece = u.queue.shift();
+      if (piece !== undefined) {
+        await this.#send(u, b64(piece), false);
+        continue;
+      }
+      if (flushed) break;
+      // Install the waker before re-checking, so a byte arriving between
+      // the empty shift() above and this point cannot be a lost wakeup.
+      const wake = new Promise<void>((resolve) => {
+        u.kick = resolve;
+      });
+      if (u.queue.length > 0 || u.released || u.cancelled) continue;
+      await wake;
+    }
+    if (u.cancelled) return;
+    await this.#send(u, "", true);
+  }
+
+  async #send(u: Utterance, data: string, final: boolean): Promise<void> {
+    const frame: AudioFrame = { sid: u.sid, seq: u.seq++, mime: u.mime, data, final };
+    // The floor runs concurrently with the ack wait: the next send starts
+    // after both, spacing frames >= MIN_SEND_INTERVAL_MS apart.
+    await Promise.all([
+      this.#publish(frame),
+      final ? Promise.resolve() : this.#sleep(MIN_SEND_INTERVAL_MS),
+    ]);
+  }
+
+  async #autoRelease(u: Utterance): Promise<void> {
+    await this.#sleep(MAX_UTTERANCE_MS);
+    if (this.#current === u && !u.released && !u.cancelled) this.release();
+  }
+}

--- a/web/shared/fixtures/gen.ts
+++ b/web/shared/fixtures/gen.ts
@@ -241,8 +241,20 @@ const chChat = {
 };
 const chAgent = { ch: "agent", encoding: "chat.json.v1", delivery: "reliable", maxHz: 20.5 };
 const chIdle = { ch: "agent_idle", encoding: "json.v1", delivery: "latest", maxHz: 20.5 };
+const chAudio = {
+  ch: "audio_in",
+  dir: "tx",
+  encoding: "audio.json.v1",
+  delivery: "reliable",
+  maxHz: 20.5,
+  publish: "shared",
+};
 const pCamera = { id: "camera", kind: "video", channels: ["color_image"] };
-const pChat = { id: "chat", kind: "chat", channels: ["human_input", "agent", "agent_idle"] };
+const pChat = {
+  id: "chat",
+  kind: "chat",
+  channels: ["human_input", "agent", "agent_idle", "audio_in"],
+};
 const pPose = { id: "pose", kind: "readout", channels: ["odom"] };
 const longId = "x".repeat(65);
 const manifestCases: Record<string, unknown> = {
@@ -588,10 +600,11 @@ const manifestCases: Record<string, unknown> = {
   pages_not_list: { version: 1, channels: [chOdom], panels: [pPose], pages: {} },
   pages_not_strings: { version: 1, channels: [chOdom], panels: [pPose], pages: [1.5] },
   pages_null: { version: 1, channels: [chOdom], panels: [pPose], pages: null },
-  // Chat panel: text input (publish tx), messages, idle flag, in that order.
+  // Chat panel: text input (publish tx), messages, idle flag, push-to-talk
+  // audio (publish tx), in that order.
   chat_panel: {
     version: 1,
-    channels: [chChat, chAgent, chIdle],
+    channels: [chChat, chAgent, chIdle, chAudio],
     panels: [pChat],
   },
   chat_panel_two_channels: {
@@ -599,23 +612,40 @@ const manifestCases: Record<string, unknown> = {
     channels: [chChat, chAgent],
     panels: [{ ...pChat, channels: ["human_input", "agent"] }],
   },
+  // The pre-audio shape: three channels stopped being a chat panel.
+  chat_panel_three_channels: {
+    version: 1,
+    channels: [chChat, chAgent, chIdle],
+    panels: [{ ...pChat, channels: ["human_input", "agent", "agent_idle"] }],
+  },
   chat_panel_input_not_publishable: {
     version: 1,
     channels: [
       { ch: "human_input", dir: "tx", encoding: "text.json.v1", delivery: "reliable", maxHz: 2.5 },
       chAgent,
       chIdle,
+      chAudio,
     ],
     panels: [pChat],
   },
   chat_panel_messages_wrong_encoding: {
     version: 1,
-    channels: [chChat, chOdom, chIdle],
-    panels: [{ ...pChat, channels: ["human_input", "odom", "agent_idle"] }],
+    channels: [chChat, chOdom, chIdle, chAudio],
+    panels: [{ ...pChat, channels: ["human_input", "odom", "agent_idle", "audio_in"] }],
   },
   chat_panel_idle_wrong_delivery: {
     version: 1,
-    channels: [chChat, chAgent, { ...chIdle, delivery: "reliable" }],
+    channels: [chChat, chAgent, { ...chIdle, delivery: "reliable" }, chAudio],
+    panels: [pChat],
+  },
+  chat_panel_audio_not_publishable: {
+    version: 1,
+    channels: [
+      chChat,
+      chAgent,
+      chIdle,
+      { ch: "audio_in", dir: "tx", encoding: "audio.json.v1", delivery: "reliable", maxHz: 20.5 },
+    ],
     panels: [pChat],
   },
 };

--- a/web/shared/fixtures/manifests.json
+++ b/web/shared/fixtures/manifests.json
@@ -3106,6 +3106,14 @@
             "encoding": "json.v1",
             "delivery": "latest",
             "maxHz": 20.5
+          },
+          {
+            "ch": "audio_in",
+            "dir": "tx",
+            "encoding": "audio.json.v1",
+            "delivery": "reliable",
+            "maxHz": 20.5,
+            "publish": "shared"
           }
         ],
         "panels": [
@@ -3115,7 +3123,8 @@
             "channels": [
               "human_input",
               "agent",
-              "agent_idle"
+              "agent_idle",
+              "audio_in"
             ]
           }
         ]
@@ -3152,6 +3161,16 @@
             "params": {},
             "publish": "none",
             "requiredScope": null
+          },
+          {
+            "ch": "audio_in",
+            "dir": "tx",
+            "encoding": "audio.json.v1",
+            "delivery": "reliable",
+            "maxHz": 20.5,
+            "params": {},
+            "publish": "shared",
+            "requiredScope": null
           }
         ],
         "panels": [
@@ -3162,7 +3181,8 @@
             "channels": [
               "human_input",
               "agent",
-              "agent_idle"
+              "agent_idle",
+              "audio_in"
             ],
             "params": {}
           }
@@ -3206,7 +3226,7 @@
       "error": "invalid_chat_panel"
     },
     {
-      "name": "chat_panel_input_not_publishable",
+      "name": "chat_panel_three_channels",
       "data": {
         "version": 1,
         "channels": [
@@ -3215,7 +3235,9 @@
             "dir": "tx",
             "encoding": "text.json.v1",
             "delivery": "reliable",
-            "maxHz": 2.5
+            "maxHz": 2.5,
+            "publish": "shared",
+            "requiredScope": "chat:send"
           },
           {
             "ch": "agent",
@@ -3238,6 +3260,54 @@
               "human_input",
               "agent",
               "agent_idle"
+            ]
+          }
+        ]
+      },
+      "error": "invalid_chat_panel"
+    },
+    {
+      "name": "chat_panel_input_not_publishable",
+      "data": {
+        "version": 1,
+        "channels": [
+          {
+            "ch": "human_input",
+            "dir": "tx",
+            "encoding": "text.json.v1",
+            "delivery": "reliable",
+            "maxHz": 2.5
+          },
+          {
+            "ch": "agent",
+            "encoding": "chat.json.v1",
+            "delivery": "reliable",
+            "maxHz": 20.5
+          },
+          {
+            "ch": "agent_idle",
+            "encoding": "json.v1",
+            "delivery": "latest",
+            "maxHz": 20.5
+          },
+          {
+            "ch": "audio_in",
+            "dir": "tx",
+            "encoding": "audio.json.v1",
+            "delivery": "reliable",
+            "maxHz": 20.5,
+            "publish": "shared"
+          }
+        ],
+        "panels": [
+          {
+            "id": "chat",
+            "kind": "chat",
+            "channels": [
+              "human_input",
+              "agent",
+              "agent_idle",
+              "audio_in"
             ]
           }
         ]
@@ -3269,6 +3339,14 @@
             "encoding": "json.v1",
             "delivery": "latest",
             "maxHz": 20.5
+          },
+          {
+            "ch": "audio_in",
+            "dir": "tx",
+            "encoding": "audio.json.v1",
+            "delivery": "reliable",
+            "maxHz": 20.5,
+            "publish": "shared"
           }
         ],
         "panels": [
@@ -3278,7 +3356,8 @@
             "channels": [
               "human_input",
               "odom",
-              "agent_idle"
+              "agent_idle",
+              "audio_in"
             ]
           }
         ]
@@ -3310,6 +3389,14 @@
             "encoding": "json.v1",
             "delivery": "reliable",
             "maxHz": 20.5
+          },
+          {
+            "ch": "audio_in",
+            "dir": "tx",
+            "encoding": "audio.json.v1",
+            "delivery": "reliable",
+            "maxHz": 20.5,
+            "publish": "shared"
           }
         ],
         "panels": [
@@ -3319,7 +3406,57 @@
             "channels": [
               "human_input",
               "agent",
-              "agent_idle"
+              "agent_idle",
+              "audio_in"
+            ]
+          }
+        ]
+      },
+      "error": "invalid_chat_panel"
+    },
+    {
+      "name": "chat_panel_audio_not_publishable",
+      "data": {
+        "version": 1,
+        "channels": [
+          {
+            "ch": "human_input",
+            "dir": "tx",
+            "encoding": "text.json.v1",
+            "delivery": "reliable",
+            "maxHz": 2.5,
+            "publish": "shared",
+            "requiredScope": "chat:send"
+          },
+          {
+            "ch": "agent",
+            "encoding": "chat.json.v1",
+            "delivery": "reliable",
+            "maxHz": 20.5
+          },
+          {
+            "ch": "agent_idle",
+            "encoding": "json.v1",
+            "delivery": "latest",
+            "maxHz": 20.5
+          },
+          {
+            "ch": "audio_in",
+            "dir": "tx",
+            "encoding": "audio.json.v1",
+            "delivery": "reliable",
+            "maxHz": 20.5
+          }
+        ],
+        "panels": [
+          {
+            "id": "chat",
+            "kind": "chat",
+            "channels": [
+              "human_input",
+              "agent",
+              "agent_idle",
+              "audio_in"
             ]
           }
         ]

--- a/web/shared/manifest.ts
+++ b/web/shared/manifest.ts
@@ -393,14 +393,15 @@ export function parseManifest(value: unknown): Manifest {
       }
     }
     if (panel.kind === "chat") {
-      // channels: the text input (publish tx), the messages, the idle flag.
-      if (panel.channels.length !== 3) {
+      // channels: the text input (publish tx), the messages, the idle flag,
+      // the push-to-talk audio (publish tx).
+      if (panel.channels.length !== 4) {
         throw new ManifestError(
           "invalid_chat_panel",
-          `chat panel ${panel.id} must bind three channels`,
+          `chat panel ${panel.id} must bind four channels`,
         );
       }
-      const [text, messages, idle] = panel.channels.map((ch) => chIds.get(ch)!);
+      const [text, messages, idle, audio] = panel.channels.map((ch) => chIds.get(ch)!);
       if (
         text.encoding !== "text.json.v1" || text.delivery !== "reliable" ||
         dirOf(text) !== "tx" || publishOf(text) !== "shared"
@@ -423,6 +424,15 @@ export function parseManifest(value: unknown): Manifest {
         throw new ManifestError(
           "invalid_chat_panel",
           `chat panel ${panel.id} needs a json.v1 latest rx channel third`,
+        );
+      }
+      if (
+        audio.encoding !== "audio.json.v1" || audio.delivery !== "reliable" ||
+        dirOf(audio) !== "tx" || publishOf(audio) !== "shared"
+      ) {
+        throw new ManifestError(
+          "invalid_chat_panel",
+          `chat panel ${panel.id} needs an audio.json.v1 reliable shared tx channel fourth`,
         );
       }
     }


### PR DESCRIPTION
Closes DIM-1176

- Adds a push-to-talk microphone button to the cockpit chat panel. Users hold it to record and release it to submit a voice message.
- Adds a `VoiceInput` module that converts recordings into text with local Whisper transcription. Spoken messages enter the same agent conversation as typed messages, using a speech pipeline shared with the existing browser audio upload.