### PR TITLE
feat(web): dtop stats page in the cockpit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -490,7 +490,8 @@ jobs:
           dimos/e2e_tests/test_sdk_browser.py
           dimos/e2e_tests/test_custom_channel_browser.py
           dimos/e2e_tests/test_publish_browser.py
-          dimos/e2e_tests/test_voice_browser.py --no-cov
+          dimos/e2e_tests/test_voice_browser.py
+          dimos/e2e_tests/test_stats_browser.py --no-cov
 
   tests:
     if: |

--- a/dimos/e2e_tests/test_stats_browser.py
+++ b/dimos/e2e_tests/test_stats_browser.py
@@ -1,0 +1,134 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Stats page browser e2e (the T9 acceptance demo, in CI).
+
+Starts a cockpit(pages=[Stats()]) bridge - a generated RelayBridgeModule
+subclass with a resource_stats In[dict] port and the registry-resolved
+stats.json.v1 encoder - serving the real cockpit dist from its own local
+relay, and plays the resource monitor: pickled dicts on the port's topic at
+the monitor's 1 Hz (no coordinator runs in-process, so no StatsMonitor). The
+Stats tab must show a row per process from those dicts, dtop's way: pickled
+dict -> bridge encoder -> relay -> page.
+
+Marked web_browser: excluded from the default suite (needs the
+`browser-tests` dependency group, Playwright browsers, and built web dists).
+Locally:
+`uv run --group browser-tests pytest -m web_browser dimos/e2e_tests/test_stats_browser.py`.
+"""
+
+from collections.abc import Iterator
+from dataclasses import asdict, replace
+import threading
+
+import pytest
+
+from dimos.core.resource_monitor.stats import ChildProcessStats, ProcessStats, WorkerStats
+from dimos.core.transport import pLCMTransport
+from dimos.web.cockpit import Stats, Video, cockpit
+from dimos.web.relay_bridge.e2e_support import stop_module
+
+pytest.importorskip("playwright")
+
+from playwright.sync_api import Page, expect, sync_playwright
+
+pytestmark = pytest.mark.web_browser
+
+TOPIC = "/stats_e2e/resource_stats"
+
+COORDINATOR = ProcessStats(
+    pid=4242, alive=True, cpu_percent=12.5, pss=47_400_000, num_threads=4, num_fds=32
+)
+WORKERS = [
+    WorkerStats(
+        pid=4243,
+        alive=True,
+        cpu_percent=34.5,
+        pss=125_829_120,
+        num_threads=8,
+        num_children=1,
+        num_fds=64,
+        worker_id=0,
+        modules=["Navigation", "Lidar"],
+        children=[ChildProcessStats(pid=4300, name="ffmpeg", cpu_percent=5.5)],
+    ),
+    WorkerStats(pid=0, alive=False, worker_id=1, modules=["Vision"], dedicated=True),
+]
+
+
+@pytest.fixture(scope="module")
+def stats_page_url() -> Iterator[str]:
+    (atom,) = cockpit(layout=Video("color_image"), pages=[Stats()]).blueprints
+    module = atom.module(local_port=0, open_browser=False, robot_id="stats-e2e", **atom.kwargs)
+    bridge_transport = pLCMTransport(TOPIC)
+    bridge_transport.start()
+    module.resource_stats.transport = bridge_transport
+    publisher = pLCMTransport(TOPIC)
+    publisher.start()
+    stop = threading.Event()
+
+    def monitor() -> None:
+        # The monitor's cadence; frames flow only once the bridge lazily
+        # subscribes, so keep them coming. A wobbling CPU moves the sparkline.
+        tick = 0
+        while not stop.is_set():
+            coordinator = replace(COORDINATOR, cpu_percent=10.0 + tick % 5)
+            workers = [asdict(w) for w in WORKERS]
+            publisher.publish({"coordinator": asdict(coordinator), "workers": workers})
+            tick += 1
+            stop.wait(1.0)
+
+    thread = threading.Thread(target=monitor, daemon=True)
+    try:
+        module.start()  # builds web dists if stale, spawns the relay, registers
+        thread.start()
+        relay = module._relay
+        assert relay is not None and relay.info is not None
+        yield relay.info.open_url
+    finally:
+        stop.set()
+        thread.join(timeout=2)
+        stop_module(module)
+        publisher.stop()
+        bridge_transport.stop()
+
+
+@pytest.fixture
+def chromium_page() -> Iterator[Page]:
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        try:
+            yield browser.new_page()
+        finally:
+            browser.close()
+
+
+def test_stats_tab_lists_every_process(stats_page_url: str, chromium_page: Page) -> None:
+    chromium_page.goto(stats_page_url)
+    # p0 is the video panel on the overview; p1 the page.
+    tab = chromium_page.get_by_test_id("tab-p1")
+    expect(tab).to_have_text("Stats", timeout=120_000)
+    tab.click()
+    worker = chromium_page.get_by_test_id("stats-resource_stats-row-worker-0")
+    expect(worker).to_contain_text("Navigation, Lidar", timeout=60_000)
+    expect(worker).to_contain_text("120.0 MB")
+    coordinator = chromium_page.get_by_test_id("stats-resource_stats-row-coordinator")
+    expect(coordinator).to_contain_text("[4242]")
+    child = chromium_page.get_by_test_id("stats-resource_stats-row-child-4300")
+    expect(child).to_contain_text("ffmpeg")
+    dead = chromium_page.get_by_test_id("stats-resource_stats-row-worker-1")
+    expect(dead).to_have_attribute("data-dead", "true")
+    expect(dead).to_contain_text("dead")
+    badge = chromium_page.get_by_test_id("stats-resource_stats-badge")
+    expect(badge).to_contain_text("Hz", timeout=30_000)

--- a/dimos/robot/unitree/go2/blueprints/agentic/unitree_go2_agentic_cockpit.py
+++ b/dimos/robot/unitree/go2/blueprints/agentic/unitree_go2_agentic_cockpit.py
@@ -29,7 +29,7 @@ from dimos.agents.web_human_input import WebInput
 from dimos.core.coordination.blueprints import autoconnect
 from dimos.robot.unitree.go2.blueprints.agentic.unitree_go2_agentic import unitree_go2_agentic
 from dimos.stream.audio.decode import ffmpeg_requirement
-from dimos.web.cockpit import Chat, Col, Map2D, Row, Teleop, Video, cockpit
+from dimos.web.cockpit import Chat, Col, Map2D, Row, Stats, Teleop, Video, cockpit
 
 unitree_go2_agentic_cockpit = (
     autoconnect(
@@ -45,7 +45,7 @@ unitree_go2_agentic_cockpit = (
                 Chat(title="Agent chat"),
                 shares=[2, 1, 1],
             ),
-            pages=[Video("color_image", title="Front camera")],
+            pages=[Video("color_image", title="Front camera"), Stats()],
         ),
         VoiceInput.blueprint(),
     )

--- a/dimos/web/cockpit.py
+++ b/dimos/web/cockpit.py
@@ -447,6 +447,35 @@ class Chat(Panel):
         return tuple(replace(_request_of(channel), paced=True) for channel in self._channels())
 
 
+@dataclass(frozen=True)
+class Stats(Panel):
+    """dtop as a page: per-process CPU, memory, thread, fd and child stats
+    of the running system, one row per worker. The bridge subscribes the
+    resource monitor's /resource_stats topic (dimos/core/resource_monitor/,
+    a pickled dict at 1 Hz; the monitor publishes nowhere else) and
+    re-encodes it as stats.json.v1. Meant for `pages=`; works in the grid
+    too. The monitor runs only under GlobalConfig.dtop, so cockpit()
+    switches that on whenever a Stats panel is present (a page that stays
+    empty unless you remember a flag is a trap); `--no-dtop` still wins.
+    """
+
+    kind: ClassVar[str] = "stats"
+    title: str = field(default="Stats", kw_only=True)
+
+    def _channels(self) -> tuple[Channel, ...]:
+        # A 1 Hz producer through the bridge's sampling gate at exactly 1 Hz
+        # would lose every arrival that lands a hair early; 2 Hz passes it
+        # losslessly without pacing.
+        return (
+            Channel(
+                "resource_stats", dict, encoding="stats.json.v1", delivery="latest", max_hz=2.0
+            ),
+        )
+
+    def _channel_requests(self) -> tuple[ChannelRequest, ...]:
+        return tuple(_request_of(channel) for channel in self._channels())
+
+
 class _Split:
     """Base for Row/Col: children plus optional flex shares."""
 
@@ -835,4 +864,11 @@ def cockpit(
     # Generated classes carry only the custom ports; the built-ins are
     # inherited. No custom streams means the plain static class.
     module_class = make_relay_bridge_class(ports) if ports else RelayBridgeModule
-    return autoconnect(module_class.blueprint(manifest=data, channels=tuple(specs)))
+    blueprint = autoconnect(module_class.blueprint(manifest=data, channels=tuple(specs)))
+    if any(isinstance(p, Stats) for p in (*_panels(layout), *_panels(tuple(pages)))):
+        # Blueprint-level config is the lowest-precedence source, applied by
+        # ModuleCoordinator.build before the worker pool (and its
+        # StatsMonitor) starts; every other source, --no-dtop included,
+        # overrides it.
+        blueprint = blueprint.global_config(dtop=True)
+    return blueprint

--- a/dimos/web/relay_bridge/builtin_codecs.py
+++ b/dimos/web/relay_bridge/builtin_codecs.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Built-in web codecs (jpeg.v1, pose.json.v1, costmap.zlib.v1, text.json.v1).
+"""Built-in web codecs (jpeg.v1, pose.json.v1, costmap.zlib.v1, text.json.v1,
+stats.json.v1).
 
 Registered into dimos.web.codecs at import time; relay_bridge_module imports
 this module so every bridge process (parent and worker) has the built-ins.
@@ -111,3 +112,46 @@ def encode_costmap(msg: OccupancyGrid) -> EncodedPayload | None:
         "origin": [origin.position.x, origin.position.y, origin.yaw],
     }
     return EncodedPayload(zlib.compress(cells, _COSTMAP_ZLIB_LEVEL), meta)
+
+
+# stats.json.v1: the resource monitor's /resource_stats dict (asdict of
+# ProcessStats/WorkerStats/ChildProcessStats, dimos/core/resource_monitor/)
+# as JSON with exactly the keys the Stats page reads and dtop renders. Picked
+# by name on purpose: a renamed producer field raises KeyError here (an
+# encode error the bridge logs) instead of silently vanishing from the page,
+# and test_stats_encoding.py pins the subset against the dataclasses.
+_STATS_PROCESS_KEYS = (
+    "pid",
+    "alive",
+    "cpu_percent",
+    "cpu_time_user",
+    "cpu_time_system",
+    "cpu_time_iowait",
+    "pss",
+    "num_threads",
+    "num_children",
+    "num_fds",
+    "io_read_bytes",
+    "io_write_bytes",
+)
+_STATS_WORKER_KEYS = (*_STATS_PROCESS_KEYS, "worker_id", "modules", "dedicated")
+_STATS_CHILD_KEYS = ("pid", "name", "cpu_percent")
+
+
+def _pick(stats: Mapping[str, Any], keys: tuple[str, ...]) -> dict[str, Any]:
+    return {key: stats[key] for key in keys}
+
+
+# The registry keys encoders by the bare message class (dict[str, Any] is not
+# a class), hence the unparameterized annotation.
+@web_encoder("stats.json.v1")
+def encode_stats(msg: dict) -> bytes:  # type: ignore[type-arg]
+    workers = [
+        {
+            **_pick(worker, _STATS_WORKER_KEYS),
+            "children": [_pick(child, _STATS_CHILD_KEYS) for child in worker["children"]],
+        }
+        for worker in msg["workers"]
+    ]
+    stats = {"coordinator": _pick(msg["coordinator"], _STATS_PROCESS_KEYS), "workers": workers}
+    return json.dumps(stats, separators=(",", ":")).encode()

--- a/dimos/web/relay_bridge/manifest.py
+++ b/dimos/web/relay_bridge/manifest.py
@@ -19,7 +19,7 @@ from both pytest and deno test). The transport (protocol.py) carries the
 manifest as one opaque dict; this module is the single owner of its
 structure and domain rules: version gate, bounded unique ids, positive
 rates, panel/layout/pages references that resolve, and kind-specific panel
-rules (video, map2d, teleop, chat).
+rules (video, map2d, teleop, chat, stats).
 
 Manifest v1 is frozen. Additive changes (new panel kinds, new params) ride
 the existing shape: unknown keys and kinds pass through validation.
@@ -362,6 +362,17 @@ def parse_manifest(data: Any) -> Manifest:
                     "invalid_chat_panel",
                     f"chat panel {panel.id} needs an audio.json.v1 reliable shared tx "
                     "channel fourth",
+                )
+        if panel.kind == "stats":
+            if len(panel.channels) != 1:
+                raise ManifestError(
+                    "invalid_stats_panel", f"stats panel {panel.id} must bind exactly one channel"
+                )
+            stats = ch_ids[panel.channels[0]]
+            if stats.encoding != "stats.json.v1" or stats.delivery != "latest" or stats.dir != "rx":
+                raise ManifestError(
+                    "invalid_stats_panel",
+                    f"stats panel {panel.id} needs a stats.json.v1 latest rx channel",
                 )
 
     seen: set[str] = set()

--- a/dimos/web/relay_bridge/test_relay_bridge_authoring.py
+++ b/dimos/web/relay_bridge/test_relay_bridge_authoring.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
-from dataclasses import replace
+from dataclasses import asdict, replace
 import json
 import pickle
 import struct
@@ -33,13 +33,14 @@ import pytest
 
 from dimos.core.coordination.blueprints import autoconnect
 from dimos.core.module import Module, ModuleConfig
+from dimos.core.resource_monitor.stats import ProcessStats, WorkerStats
 from dimos.core.stream import In, Out
 from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
 from dimos.msgs.geometry_msgs.Twist import Twist
 from dimos.msgs.nav_msgs.OccupancyGrid import OccupancyGrid
 from dimos.msgs.nav_msgs.Path import Path as NavPath
 from dimos.msgs.sensor_msgs.Image import Image
-from dimos.web.cockpit import Channel, Chat, Video, cockpit
+from dimos.web.cockpit import Channel, Chat, Stats, Video, cockpit
 from dimos.web.codecs import EncodedPayload, PublishContext, web_decoder, web_encoder
 from dimos.web.relay_bridge import builtin_codecs, relay_bridge_module
 from dimos.web.relay_bridge.audio_codec import AudioChunk
@@ -524,6 +525,30 @@ def test_chat_panel_forwards_every_message(monkeypatch) -> None:
         assert wait_until(lambda: clients[0].control_frames)
         assert seen == ["walk forward"]
         assert isinstance(clients[0].control_frames[0], PubAck)
+    finally:
+        stop_module(module)
+
+
+def test_stats_panel_forwards_snapshots(monkeypatch) -> None:
+    # The resource monitor's pickled dict crosses as stats.json.v1 on a latest
+    # channel (the newest snapshot wins), whitelisted keys only.
+    message = {
+        "coordinator": {**asdict(ProcessStats(pid=1234, alive=True, cpu_percent=12.5)), "rss": 1},
+        "workers": [asdict(WorkerStats(pid=1235, alive=True, worker_id=0, modules=["Nav"]))],
+    }
+    module, clients = start_authored(monkeypatch, cockpit(layout=Stats()), wire=("resource_stats",))
+    try:
+        stats = transport_of(module, "resource_stats")
+        push(module, clients[0], Subs(chs=["resource_stats"], n=1))
+        assert wait_until(lambda: stats.subscribers)
+        stats.publish(message)
+        writer = lambda: clients[0].writers.get("resource_stats")  # noqa: E731
+        assert wait_until(lambda: writer() is not None and writer().offers)
+        ((payload, meta),) = writer().offers
+        assert meta is None
+        frame = json.loads(payload)
+        assert frame["coordinator"]["cpu_percent"] == 12.5 and "rss" not in frame["coordinator"]
+        assert [(w["worker_id"], w["modules"]) for w in frame["workers"]] == [(0, ["Nav"])]
     finally:
         stop_module(module)
 

--- a/dimos/web/relay_bridge/test_stats_encoding.py
+++ b/dimos/web/relay_bridge/test_stats_encoding.py
@@ -1,0 +1,137 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""stats.json.v1: the resource monitor's /resource_stats dict -> the Stats page's JSON."""
+
+from dataclasses import asdict
+import json
+
+import pytest
+
+from dimos.core.resource_monitor.stats import ChildProcessStats, ProcessStats, WorkerStats
+from dimos.web.codecs import resolve_encoder
+from dimos.web.relay_bridge.builtin_codecs import encode_stats
+
+# The input is what LCMResourceLogger.log_stats publishes: asdict() of the
+# producer's own dataclasses. A renamed field changes this dict and fails the
+# golden below, so producer drift is loud here rather than silent in the page.
+COORDINATOR = ProcessStats(
+    pid=1234,
+    alive=True,
+    cpu_percent=12.3,
+    cpu_time_user=1.2,
+    cpu_time_system=0.3,
+    pss=47_400_000,
+    num_threads=4,
+    num_fds=32,
+    io_read_bytes=12_582_912,
+    io_write_bytes=4_194_304,
+)
+WORKERS = [
+    WorkerStats(
+        pid=1235,
+        alive=True,
+        cpu_percent=34.0,
+        cpu_time_user=5.1,
+        cpu_time_system=1.0,
+        cpu_time_iowait=0.2,
+        pss=125_829_120,
+        num_threads=8,
+        num_children=2,
+        num_fds=64,
+        io_read_bytes=47_185_920,
+        io_write_bytes=12_582_912,
+        worker_id=0,
+        modules=["Navigation", "Lidar"],
+        children=[ChildProcessStats(pid=1300, name="ffmpeg", cpu_percent=5.5)],
+    ),
+    # A dead worker: pid 0 and every metric at its default, identity kept.
+    WorkerStats(pid=0, alive=False, worker_id=1, modules=["Vision"], dedicated=True),
+]
+MESSAGE = {"coordinator": asdict(COORDINATOR), "workers": [asdict(w) for w in WORKERS]}
+
+# Every key the Stats page (web/cockpit/src/panels/stats.ts) reads, in the
+# producer's declaration order.
+GOLDEN = {
+    "coordinator": {
+        "pid": 1234,
+        "alive": True,
+        "cpu_percent": 12.3,
+        "cpu_time_user": 1.2,
+        "cpu_time_system": 0.3,
+        "cpu_time_iowait": 0.0,
+        "pss": 47400000,
+        "num_threads": 4,
+        "num_children": 0,
+        "num_fds": 32,
+        "io_read_bytes": 12582912,
+        "io_write_bytes": 4194304,
+    },
+    "workers": [
+        {
+            "pid": 1235,
+            "alive": True,
+            "cpu_percent": 34.0,
+            "cpu_time_user": 5.1,
+            "cpu_time_system": 1.0,
+            "cpu_time_iowait": 0.2,
+            "pss": 125829120,
+            "num_threads": 8,
+            "num_children": 2,
+            "num_fds": 64,
+            "io_read_bytes": 47185920,
+            "io_write_bytes": 12582912,
+            "worker_id": 0,
+            "modules": ["Navigation", "Lidar"],
+            "dedicated": False,
+            "children": [{"pid": 1300, "name": "ffmpeg", "cpu_percent": 5.5}],
+        },
+        {
+            "pid": 0,
+            "alive": False,
+            "cpu_percent": 0.0,
+            "cpu_time_user": 0.0,
+            "cpu_time_system": 0.0,
+            "cpu_time_iowait": 0.0,
+            "pss": 0,
+            "num_threads": 0,
+            "num_children": 0,
+            "num_fds": 0,
+            "io_read_bytes": 0,
+            "io_write_bytes": 0,
+            "worker_id": 1,
+            "modules": ["Vision"],
+            "dedicated": True,
+            "children": [],
+        },
+    ],
+}
+
+
+def test_golden_frame() -> None:
+    assert encode_stats(MESSAGE) == json.dumps(GOLDEN, separators=(",", ":")).encode()
+    assert resolve_encoder("stats.json.v1", dict).encode is encode_stats
+
+
+def test_only_the_pinned_keys_cross() -> None:
+    coordinator = {**MESSAGE["coordinator"], "rss": 1, "cmdline": "dimos"}
+    payload = encode_stats({**MESSAGE, "coordinator": coordinator})
+    assert json.loads(payload)["coordinator"] == GOLDEN["coordinator"]
+
+
+def test_missing_key_is_loud() -> None:
+    coordinator = dict(MESSAGE["coordinator"])
+    del coordinator["pss"]
+    with pytest.raises(KeyError, match="pss"):
+        encode_stats({**MESSAGE, "coordinator": coordinator})

--- a/dimos/web/test_cockpit.py
+++ b/dimos/web/test_cockpit.py
@@ -23,6 +23,8 @@ import sys
 from langchain_core.messages import BaseMessage
 import pytest
 
+from dimos.core.coordination.blueprint_config.parser import BlueprintConfigParser
+from dimos.core.coordination.blueprints import autoconnect
 from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
 from dimos.msgs.geometry_msgs.Twist import Twist
 from dimos.msgs.nav_msgs.Path import Path
@@ -35,13 +37,14 @@ from dimos.web.cockpit import (
     Map2D,
     Panel,
     Row,
+    Stats,
     Teleop,
     Video,
     cockpit,
 )
 from dimos.web.codecs import EncodedPayload, decode_json_v1, encode_json_v1, web_encoder
 from dimos.web.relay_bridge.audio_codec import AudioChunk, decode_audio_chunk
-from dimos.web.relay_bridge.builtin_codecs import decode_text
+from dimos.web.relay_bridge.builtin_codecs import decode_text, encode_stats
 from dimos.web.relay_bridge.chat_codec import encode_chat
 from dimos.web.relay_bridge.manifest import ManifestError, parse_manifest
 from dimos.web.relay_bridge.protocol import (
@@ -534,6 +537,55 @@ def test_chat_panel_declarations_merge_or_conflict() -> None:
     agent = next(c for c in atom.kwargs["manifest"]["channels"] if c["ch"] == "agent")
     assert agent["maxHz"] == 50.0
     assert next(s for s in atom.kwargs["channels"] if s.ch == "agent").paced
+
+
+def test_stats_panel_blueprint() -> None:
+    blueprint = cockpit(layout=Video("color_image"), pages=[Stats()])
+    (atom,) = blueprint.blueprints
+    manifest = atom.kwargs["manifest"]
+    assert manifest["channels"][1] == {
+        "ch": "resource_stats",
+        "dir": "rx",
+        "encoding": "stats.json.v1",
+        "delivery": "latest",
+        "maxHz": 2.0,
+        "params": {},
+        "publish": "none",
+        "requiredScope": None,
+    }
+    assert manifest["panels"][1] == {
+        "id": "p1",
+        "kind": "stats",
+        "title": "Stats",
+        "channels": ["resource_stats"],
+        "params": {},
+    }
+    assert manifest["pages"] == ["p1"]
+    assert parse_manifest(manifest).model_dump() == manifest
+    # The producer is the coordinator's resource monitor, not a module: the
+    # generated In[dict] port autoconnects to its pickled /resource_stats
+    # topic by name.
+    ports = {(s.name, s.direction): s.type for s in atom.streams}
+    assert ports[("resource_stats", "in")] is dict
+    spec = next(s for s in atom.kwargs["channels"] if s.ch == "resource_stats")
+    assert spec.encoder is encode_stats and not spec.paced
+    restored = pickle.loads(pickle.dumps(blueprint))
+    (ratom,) = restored.blueprints
+    assert {s.ch: s.encoder for s in ratom.kwargs["channels"]}["resource_stats"] is encode_stats
+
+
+def test_stats_panel_switches_stats_publishing_on() -> None:
+    # The resource monitor only runs under GlobalConfig.dtop: the panel flips
+    # it, composition keeps it, and the CLI's own sources still win.
+    blueprint = cockpit(layout=Stats())
+    assert dict(blueprint.global_config_overrides) == {"dtop": True}
+    composed = autoconnect(blueprint).global_config(n_workers=9)
+    assert dict(composed.global_config_overrides) == {"dtop": True, "n_workers": 9}
+    assert dict(cockpit(layout=Video("color_image")).global_config_overrides) == {}
+    parser = BlueprintConfigParser(blueprint)
+    assert parser.parse(environ={}).global_config["dtop"] is True
+    parsed = parser.parse(environ={}, global_overrides={"dtop": False})
+    assert parsed.global_config["dtop"] is False
 
 
 def test_publish_tx_generic_json_and_dataclass_rejection() -> None:

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -476,7 +476,7 @@ agentspy
 
 ### `dtop`
 
-Live resource monitor TUI: CPU, memory, and process stats. Can also be activated during a run with `--dtop`:
+Live resource monitor TUI: CPU, memory, and process stats. The cockpit shows the same data on its Stats tab (`Stats()` in `cockpit(pages=[...])`), which switches the monitor on by itself. Can also be activated during a run with `--dtop`:
 
 ```bash
 dimos --dtop run unitree-go2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -763,4 +763,6 @@ ignore = [
     "dimos/manipulation/test_roboplan.py",
     "misc/DimSim/scenes/apartment/objects/manifest.json",
     "misc/DimSim/src/engine.js",
+    # Generated golden vectors (web/shared/fixtures/gen.ts); grows per panel kind.
+    "web/shared/fixtures/manifests.json",
 ]

--- a/web/README.md
+++ b/web/README.md
@@ -102,6 +102,11 @@ deno task check          # tsc --noEmit
 deno task build          # dist/ (what the relay serves at /)
 ```
 
+Panels are authored in Python (`dimos.web.cockpit`: `Video`, `Map2D`, `Teleop`, `Chat`, `Stats`) and
+compiled into the manifest; `cockpit(pages=[...])` panels render as full-page tabs. `Stats()` is
+dtop as a tab: the bridge re-encodes the resource monitor's `/resource_stats` dict as
+`stats.json.v1`, and the blueprint switches the monitor on (`GlobalConfig.dtop`) by itself.
+
 Dev workflow: run the relay (`deno task dev` in `web/`, or just `dimos run <bp> --local-relay`) and
 the vite server side by side. `localhost:5173` is a secure context; vite proxies `/api` to the relay
 on `:7780` and the WebTransport connection goes straight to the advertised `wtUrl`.

--- a/web/cockpit/src/layout/PanelFrame.tsx
+++ b/web/cockpit/src/layout/PanelFrame.tsx
@@ -18,13 +18,14 @@ export interface DrawHealth {
   failures: number;
 }
 
-/** Hz/staleness readout for a canvas panel's primary channel. Re-rendered on
- * the 500 ms UI tick via useChannel; `health` is mutated by the sink at draw
- * rate and simply sampled here (intended coupling). */
+/** Hz/staleness readout for a panel's primary channel. Re-rendered on the
+ * 500 ms UI tick via useChannel; `health` is mutated by a canvas sink at
+ * draw rate and simply sampled here (intended coupling); a panel that
+ * renders through React (stats) has no sink and omits it. */
 export function Badge({ store, ch, health, staleMs, unit, testId }: {
   store: ChannelStore;
   ch: string;
-  health: DrawHealth;
+  health?: DrawHealth;
   staleMs: number;
   unit: string;
   testId: string;
@@ -36,14 +37,14 @@ export function Badge({ store, ch, health, staleMs, unit, testId }: {
   if (stats.frames === 0) {
     // Nothing ever arrived; a corrupt first frame is an error, not "waiting".
     text = "waiting";
-  } else if (stats.decodeFailing || health.failures > 0) {
+  } else if (stats.decodeFailing || (health !== undefined && health.failures > 0)) {
     // A single bad frame trips this; the next success clears it.
     text = "decode failing";
     error = true;
   } else if (stats.ageMs !== null && stats.ageMs > staleMs) {
     text = `stale ${(stats.ageMs / 1000).toFixed(1)} s`;
     stale = true;
-  } else if (stats.lastFrameAtMs - health.lastDrawOkAtMs > staleMs) {
+  } else if (health !== undefined && stats.lastFrameAtMs - health.lastDrawOkAtMs > staleMs) {
     // Frames arrive but nothing draws (e.g. a decoder that never settles);
     // both operands are browser milliseconds.
     text = "stalled";

--- a/web/cockpit/src/layout/Tabs.test.tsx
+++ b/web/cockpit/src/layout/Tabs.test.tsx
@@ -10,8 +10,8 @@ import { Tabs } from "./Tabs.tsx";
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 function panel(id: string, title = ""): PanelSpec {
-  // stats is an unknown kind in this build: pages render via UnknownPanel.
-  return { id, kind: "stats", title, channels: [], params: {} };
+  // voxels is an unknown kind in this build: pages render via UnknownPanel.
+  return { id, kind: "voxels", title, channels: [], params: {} };
 }
 
 function manifest(pages: string[], panels: PanelSpec[]): Manifest {
@@ -66,7 +66,7 @@ describe("Tabs", () => {
     // The grid unmounts: a hidden canvas would keep decoding.
     expect(container.querySelector('[data-testid="grid-content"]')).toBeNull();
     expect(container.querySelector('[data-testid="panel-st"]')).not.toBeNull();
-    expect(container.textContent).toContain("unknown panel kind stats");
+    expect(container.textContent).toContain("unknown panel kind voxels");
 
     act(() => tab("overview")!.click());
     expect(container.querySelector('[data-testid="grid-content"]')).not.toBeNull();

--- a/web/cockpit/src/panels/StatsPanel.module.css
+++ b/web/cockpit/src/panels/StatsPanel.module.css
@@ -1,0 +1,114 @@
+.page {
+  background: #14171a;
+  height: 100%;
+  overflow: auto;
+  transition: opacity 0.3s;
+  width: 100%;
+}
+
+.page[data-stale] {
+  opacity: 0.45;
+}
+
+.hint {
+  color: #8b949e;
+  display: block;
+  padding: 0.75rem;
+}
+
+.error {
+  color: #f85149;
+  font-size: 12px;
+  padding: 0.3rem 0.75rem;
+}
+
+.table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.table th {
+  border-bottom: 1px solid #30363d;
+  color: #8b949e;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 0.3rem 0.75rem;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.table td {
+  border-bottom: 1px solid #21262d;
+  padding: 0.25rem 0.75rem;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
+.table tbody tr:hover td {
+  background: #1b1f24;
+}
+
+.table .num,
+.table .cpu {
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+
+.table .cpu {
+  font-weight: 600;
+}
+
+.name {
+  font-weight: 600;
+}
+
+.pid {
+  color: #8b949e;
+  font-variant-numeric: tabular-nums;
+  font-weight: 400;
+  margin-left: 0.4rem;
+}
+
+.chip,
+.chipDead {
+  border: 1px solid #30363d;
+  border-radius: 999px;
+  color: #8b949e;
+  font-size: 11px;
+  font-weight: 400;
+  margin-left: 0.4rem;
+  padding: 0 0.45rem;
+  vertical-align: 1px;
+}
+
+.chipDead {
+  border-color: #f85149;
+  color: #f85149;
+}
+
+.child .name {
+  color: #8b949e;
+  font-weight: 400;
+  padding-left: 1.6rem;
+}
+
+.dead .name {
+  color: #f85149;
+}
+
+.dead td {
+  color: #8b949e;
+}
+
+.modules {
+  color: #8b949e;
+  max-width: 22rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.spark {
+  display: block;
+  height: 20px;
+  width: 96px;
+}

--- a/web/cockpit/src/panels/StatsPanel.test.tsx
+++ b/web/cockpit/src/panels/StatsPanel.test.tsx
@@ -1,0 +1,203 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import type { PanelSpec } from "@dimos/shared";
+import { ChannelStore } from "@dimos/sdk";
+import { StatsPanel } from "./StatsPanel.tsx";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const CH = "resource_stats";
+const SPEC: PanelSpec = { id: "p1", kind: "stats", title: "Stats", channels: [CH], params: {} };
+// dtop's preview data, as the bridge encodes it.
+const FRAME = {
+  coordinator: {
+    pid: 1234,
+    alive: true,
+    cpu_percent: 12.3,
+    cpu_time_user: 1.2,
+    cpu_time_system: 0.3,
+    cpu_time_iowait: 0,
+    pss: 47_400_000,
+    num_threads: 4,
+    num_children: 0,
+    num_fds: 32,
+    io_read_bytes: 12_582_912,
+    io_write_bytes: 4_194_304,
+  },
+  workers: [
+    {
+      pid: 1235,
+      alive: true,
+      cpu_percent: 34,
+      cpu_time_user: 5.1,
+      cpu_time_system: 1,
+      cpu_time_iowait: 0.2,
+      pss: 125_829_120,
+      num_threads: 8,
+      num_children: 2,
+      num_fds: 64,
+      io_read_bytes: 47_185_920,
+      io_write_bytes: 12_582_912,
+      worker_id: 0,
+      modules: ["nav", "lidar"],
+      dedicated: false,
+      children: [{ pid: 1300, name: "ffmpeg", cpu_percent: 5.5 }],
+    },
+    {
+      pid: 0,
+      alive: false,
+      cpu_percent: 0,
+      cpu_time_user: 0,
+      cpu_time_system: 0,
+      cpu_time_iowait: 0,
+      pss: 0,
+      num_threads: 0,
+      num_children: 0,
+      num_fds: 0,
+      io_read_bytes: 0,
+      io_write_bytes: 0,
+      worker_id: 1,
+      modules: ["vision"],
+      dedicated: true,
+      children: [],
+    },
+  ],
+};
+
+describe("StatsPanel", () => {
+  let container: HTMLElement;
+  let root: Root;
+  let now: number;
+  let store: ChannelStore;
+  let ctx: Record<string, ReturnType<typeof vi.fn>>;
+  const testId = (id: string) => container.querySelector(`[data-testid="${id}"]`)!;
+  const cells = (row: Element) => [...row.querySelectorAll("td")].map((td) => td.textContent);
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    now = 1_000_000;
+    store = new ChannelStore(() => now);
+    // The sparklines grab a 2D context; happy-dom has no real one.
+    ctx = {
+      clearRect: vi.fn(),
+      beginPath: vi.fn(),
+      moveTo: vi.fn(),
+      lineTo: vi.fn(),
+      stroke: vi.fn(),
+      closePath: vi.fn(),
+      fill: vi.fn(),
+      fillRect: vi.fn(),
+    };
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(
+      ctx as unknown as CanvasRenderingContext2D,
+    );
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  function frame(seq: number, value: unknown = FRAME): void {
+    act(() => {
+      store.ingest(CH, { ch: CH, seq, ts: now / 1000, delivery: "latest" }, value, true);
+      store.publishUi();
+    });
+  }
+
+  it("waits, then lists every process with dtop's units and a sparkline each", () => {
+    act(() => root.render(<StatsPanel spec={SPEC} store={store} />));
+    expect(container.textContent).toContain("waiting for resource stats");
+    expect(testId(`stats-${CH}-badge`).textContent).toBe("waiting");
+
+    frame(1);
+    expect(container.textContent).not.toContain("waiting for resource stats");
+    const coordinator = testId(`stats-${CH}-row-coordinator`);
+    expect(coordinator.textContent).toContain("coordinator");
+    expect(coordinator.textContent).toContain("[1234]");
+    expect(cells(coordinator).slice(3)).toEqual([
+      "12%",
+      "45.2 MB",
+      "4",
+      "32",
+      "0",
+      "1.2s",
+      "0.3s",
+      "0.0s",
+      "12/4 MB",
+    ]);
+    const worker = testId(`stats-${CH}-row-worker-0`);
+    expect(worker.getAttribute("data-dead")).toBeNull();
+    expect(worker.textContent).toContain("worker 0");
+    expect(worker.textContent).toContain("nav, lidar");
+    expect(cells(worker)[3]).toBe("34%");
+    expect(cells(worker)[4]).toBe("120.0 MB");
+    const child = testId(`stats-${CH}-row-child-1300`);
+    expect(child.textContent).toContain("ffmpeg");
+    expect(child.textContent).toContain("[1300]");
+    expect(cells(child).slice(3)).toEqual(["6%", "", "", "", "", "", "", "", ""]);
+    // A single sample draws a dot; the second frame draws the line.
+    expect(ctx.fillRect).toHaveBeenCalled();
+    expect(ctx.stroke).not.toHaveBeenCalled();
+    frame(2);
+    expect(ctx.stroke).toHaveBeenCalled();
+    expect(testId(`stats-${CH}-badge`).textContent).toMatch(/Hz$/);
+  });
+
+  it("marks a dead worker and shows dashes for its zeros", () => {
+    act(() => root.render(<StatsPanel spec={SPEC} store={store} />));
+    frame(1);
+    const dead = testId(`stats-${CH}-row-worker-1`);
+    expect(dead.getAttribute("data-dead")).toBe("true");
+    expect(dead.textContent).toContain("worker 1");
+    expect(dead.textContent).toContain("dedicated");
+    expect(dead.textContent).toContain("dead");
+    expect(dead.textContent).not.toContain("[0]");
+    expect(cells(dead).slice(2)).toEqual(["", "-", "-", "-", "-", "-", "-", "-", "-", "-"]);
+  });
+
+  it("dims the table and flags the badge once snapshots stop", () => {
+    act(() => root.render(<StatsPanel spec={SPEC} store={store} />));
+    frame(1);
+    expect(testId(`stats-${CH}`).getAttribute("data-stale")).toBeNull();
+    act(() => {
+      now += 5000;
+      store.publishUi();
+    });
+    expect(testId(`stats-${CH}`).getAttribute("data-stale")).toBe("true");
+    expect(testId(`stats-${CH}-badge`).textContent).toMatch(/^stale/);
+    // The rows stay: the last snapshot is still the best information.
+    expect(testId(`stats-${CH}-row-coordinator`).textContent).toContain("[1234]");
+  });
+
+  it("reports an unreadable frame without dropping the last good one", () => {
+    act(() => root.render(<StatsPanel spec={SPEC} store={store} />));
+    frame(1);
+    frame(2, { workers: "nope" });
+    expect(container.querySelector("[role=alert]")!.textContent).toBe("unreadable stats frame");
+    expect(testId(`stats-${CH}-row-coordinator`).textContent).toContain("[1234]");
+  });
+
+  it("forgets everything on a store reset", () => {
+    act(() => root.render(<StatsPanel spec={SPEC} store={store} />));
+    frame(1);
+    expect(testId(`stats-${CH}-table`)).not.toBeNull();
+    act(() => store.reset());
+    expect(container.textContent).toContain("waiting for resource stats");
+    // The window restarts from the next frame: a single-sample dot per row,
+    // never a line joining it to the pre-reset sample.
+    frame(1);
+    expect(testId(`stats-${CH}-table`)).not.toBeNull();
+    expect(ctx.stroke).not.toHaveBeenCalled();
+  });
+
+  it("degrades to a hint when the manifest binds no stats channel", () => {
+    act(() => root.render(<StatsPanel spec={{ ...SPEC, channels: [] }} store={store} />));
+    expect(container.textContent).toContain("stats panel p1: no stats channel bound");
+  });
+});

--- a/web/cockpit/src/panels/StatsPanel.tsx
+++ b/web/cockpit/src/panels/StatsPanel.tsx
@@ -1,0 +1,273 @@
+// Stats page: dtop in a tab. The resource monitor's snapshot arrives as one
+// stats.json.v1 frame per tick (1 Hz) on a latest channel; the table shows
+// the coordinator, then every worker with its children indented beneath,
+// each with a rolling CPU sparkline. The history is the page's own: Tabs
+// unmounts inactive pages, so the window restarts when the tab is reopened.
+// When frames stop the whole table dims (dtop does the same) and the badge
+// says for how long.
+
+import { Fragment, type ReactNode, useEffect, useRef, useState } from "react";
+import type { PanelSpec } from "@dimos/shared";
+import type { ChannelStore } from "@dimos/sdk";
+import { useStoreChannel } from "@dimos/sdk/react";
+import { Badge, PanelFrame } from "../layout/PanelFrame.tsx";
+import type { PanelProps } from "./registry.tsx";
+import { drawSparkline } from "./sparkline.ts";
+import {
+  childKey,
+  COORDINATOR_KEY,
+  cpuColor,
+  EMPTY_SNAPSHOT,
+  fmtIo,
+  fmtMem,
+  fmtPct,
+  fmtSecs,
+  foldSnapshot,
+  type ProcessStats,
+  type StatsSnapshot,
+  WINDOW,
+  workerKey,
+} from "./stats.ts";
+import styles from "./StatsPanel.module.css";
+
+/** Two missed 1 Hz snapshots: the monitor, or its process, is gone. */
+export const STATS_STALE_MS = 3000;
+
+const HEADERS = [
+  "process",
+  "modules",
+  `cpu (${WINDOW} s)`,
+  "cpu",
+  "pss",
+  "threads",
+  "fds",
+  "children",
+  "user",
+  "sys",
+  "iowait",
+  "io r/w",
+];
+const TEXT_COLUMNS = 3;
+
+function Sparkline({ samples }: { samples: readonly number[] }) {
+  const ref = useRef<HTMLCanvasElement | null>(null);
+  useEffect(() => {
+    const canvas = ref.current;
+    const ctx = canvas === null ? null : canvas.getContext("2d");
+    if (canvas === null || ctx === null) return;
+    const dpr = globalThis.devicePixelRatio || 1;
+    // clientWidth is 0 before layout (and under happy-dom): keep the
+    // attribute size then.
+    const w = Math.round(canvas.clientWidth * dpr) || canvas.width;
+    const h = Math.round(canvas.clientHeight * dpr) || canvas.height;
+    if (canvas.width !== w || canvas.height !== h) {
+      canvas.width = w;
+      canvas.height = h;
+    }
+    const newest = samples[samples.length - 1] ?? 0;
+    drawSparkline(ctx, samples, WINDOW, w, h, cpuColor(newest), dpr);
+  }, [samples]);
+  return <canvas ref={ref} className={styles.spark} width={96} height={20} aria-hidden="true" />;
+}
+
+function Metrics({ stats }: { stats: ProcessStats }) {
+  const cells = [
+    fmtMem(stats.pss),
+    String(stats.num_threads),
+    String(stats.num_fds),
+    String(stats.num_children),
+    fmtSecs(stats.cpu_time_user),
+    fmtSecs(stats.cpu_time_system),
+    fmtSecs(stats.cpu_time_iowait),
+    fmtIo(stats.io_read_bytes, stats.io_write_bytes),
+  ];
+  return (
+    <>
+      {cells.map((text, i) => (
+        <td key={i} className={styles.num}>
+          {text}
+        </td>
+      ))}
+    </>
+  );
+}
+
+/** One table row: a process (coordinator or live worker, all metrics), a
+ * dead worker (dashes: the producer sends zeros and pid 0), or a child
+ * process (CPU only, indented). */
+function Row({ testId, name, pid, tags, modules, kind, cpu, samples, stats }: {
+  testId: string;
+  name: string;
+  pid: number;
+  tags?: ReactNode;
+  modules?: string;
+  kind: "process" | "dead" | "child";
+  cpu: number;
+  samples: readonly number[];
+  stats?: ProcessStats;
+}) {
+  const dead = kind === "dead";
+  const filler = dead ? "-" : "";
+  return (
+    <tr
+      className={dead ? styles.dead : kind === "child" ? styles.child : undefined}
+      data-testid={testId}
+      data-dead={dead || undefined}
+    >
+      <td className={styles.name}>
+        {kind === "child" && "↳ "}
+        {name}
+        {pid > 0 && <span className={styles.pid}>[{pid}]</span>}
+        {tags}
+      </td>
+      <td className={styles.modules} title={modules}>
+        {modules}
+      </td>
+      <td>{!dead && <Sparkline samples={samples} />}</td>
+      <td className={styles.cpu} style={dead ? undefined : { color: cpuColor(cpu) }}>
+        {dead ? filler : fmtPct(cpu)}
+      </td>
+      {stats !== undefined && !dead ? <Metrics stats={stats} /> : (
+        Array.from(
+          { length: HEADERS.length - TEXT_COLUMNS - 1 },
+          (_, i) => (
+            <td key={i} className={styles.num}>
+              {filler}
+            </td>
+          ),
+        )
+      )}
+    </tr>
+  );
+}
+
+function StatsTable({ ch, snapshot }: { ch: string; snapshot: StatsSnapshot }) {
+  const frame = snapshot.frame;
+  if (frame === null) return null;
+  const samples = (key: string): readonly number[] => snapshot.cpu.get(key) ?? [];
+  return (
+    <table className={styles.table} data-testid={`stats-${ch}-table`}>
+      <thead>
+        <tr>
+          {HEADERS.map((label, i) => (
+            <th key={label} className={i < TEXT_COLUMNS ? undefined : styles.num}>
+              {label}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        <Row
+          testId={`stats-${ch}-row-coordinator`}
+          name="coordinator"
+          pid={frame.coordinator.pid}
+          kind="process"
+          cpu={frame.coordinator.cpu_percent}
+          samples={samples(COORDINATOR_KEY)}
+          stats={frame.coordinator}
+        />
+        {frame.workers.map((worker) => (
+          <Fragment key={worker.worker_id}>
+            <Row
+              testId={`stats-${ch}-row-worker-${worker.worker_id}`}
+              name={`worker ${worker.worker_id}`}
+              pid={worker.pid}
+              tags={
+                <>
+                  {worker.dedicated && <span className={styles.chip}>dedicated</span>}
+                  {!worker.alive && <span className={styles.chipDead}>dead</span>}
+                </>
+              }
+              modules={worker.modules.join(", ")}
+              kind={worker.alive ? "process" : "dead"}
+              cpu={worker.cpu_percent}
+              samples={samples(workerKey(worker.worker_id))}
+              stats={worker}
+            />
+            {worker.children.map((child) => (
+              <Row
+                key={child.pid}
+                testId={`stats-${ch}-row-child-${child.pid}`}
+                name={child.name}
+                pid={child.pid}
+                kind="child"
+                cpu={child.cpu_percent}
+                samples={samples(childKey(child.pid))}
+              />
+            ))}
+          </Fragment>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+/** The channel's frames folded into per-row CPU history while mounted, one
+ * sample per frame (direct store notifications, not the UI tick); a store
+ * reset (producer gone or changed) empties it. */
+function useStatsHistory(store: ChannelStore, ch: string): StatsSnapshot {
+  const [snapshot, setSnapshot] = useState(EMPTY_SNAPSHOT);
+  useEffect(() => {
+    let seen = 0;
+    let current = EMPTY_SNAPSHOT;
+    const pull = (): void => {
+      const slot = store.get(ch);
+      if (slot === null) {
+        if (seen === 0) return;
+        seen = 0;
+        current = EMPTY_SNAPSHOT;
+      } else if (slot.version > seen) {
+        seen = slot.version;
+        current = foldSnapshot(current, slot.value);
+      } else {
+        return;
+      }
+      setSnapshot(current);
+    };
+    const unsubscribe = store.subscribe(ch, pull);
+    pull(); // a slot may predate the mount
+    return unsubscribe;
+  }, [store, ch]);
+  return snapshot;
+}
+
+function StatsPage({ spec, store }: { spec: PanelSpec; store: ChannelStore }) {
+  const ch = spec.channels[0];
+  const snapshot = useStatsHistory(store, ch);
+  const { stats } = useStoreChannel(store, ch);
+  const stale = stats.ageMs !== null && stats.ageMs > STATS_STALE_MS;
+  const badge = (
+    <Badge
+      store={store}
+      ch={ch}
+      staleMs={STATS_STALE_MS}
+      unit="Hz"
+      testId={`stats-${ch}-badge`}
+    />
+  );
+  return (
+    <PanelFrame spec={spec} badge={badge}>
+      <div className={styles.page} data-testid={`stats-${ch}`} data-stale={stale || undefined}>
+        {snapshot.unreadable && (
+          <div className={styles.error} role="alert">
+            unreadable stats frame
+          </div>
+        )}
+        {snapshot.frame === null
+          ? <span className={styles.hint}>waiting for resource stats...</span>
+          : <StatsTable ch={ch} snapshot={snapshot} />}
+      </div>
+    </PanelFrame>
+  );
+}
+
+export function StatsPanel({ spec, store }: PanelProps) {
+  if (spec.channels.length !== 1) {
+    return (
+      <PanelFrame spec={spec}>
+        <span className={styles.hint}>stats panel {spec.id}: no stats channel bound</span>
+      </PanelFrame>
+    );
+  }
+  return <StatsPage spec={spec} store={store} />;
+}

--- a/web/cockpit/src/panels/registry.tsx
+++ b/web/cockpit/src/panels/registry.tsx
@@ -16,6 +16,7 @@ import { ChatPanel } from "./ChatPanel.tsx";
 import { MapPanel } from "./MapPanel.tsx";
 import styles from "./registry.module.css";
 import type { TeleopHooks } from "@dimos/sdk/internal/teleop";
+import { StatsPanel } from "./StatsPanel.tsx";
 import { TeleopPanel } from "./TeleopPanel.tsx";
 import { VideoPanel } from "./VideoPanel.tsx";
 
@@ -54,3 +55,4 @@ registerPanel("video", VideoPanel);
 registerPanel("map2d", MapPanel);
 registerPanel("teleop", TeleopPanel);
 registerPanel("chat", ChatPanel);
+registerPanel("stats", StatsPanel);

--- a/web/cockpit/src/panels/sparkline.ts
+++ b/web/cockpit/src/panels/sparkline.ts
@@ -1,0 +1,44 @@
+// Canvas sparkline for the Stats page: CPU history on dtop's fixed 0..100
+// scale (rows stay comparable), the newest sample at the right edge, a line
+// in the given color with a faint fill beneath. Pure drawing on a context the
+// caller sized in device pixels; `dpr` scales the stroke.
+
+export function drawSparkline(
+  ctx: CanvasRenderingContext2D,
+  samples: readonly number[],
+  window: number,
+  w: number,
+  h: number,
+  color: string,
+  dpr: number,
+): void {
+  ctx.clearRect(0, 0, w, h);
+  const n = samples.length;
+  if (n === 0) return;
+  const pad = dpr; // half the stroke: 0 and 100 stay inside the box
+  const step = w / Math.max(window - 1, 1);
+  const x = (i: number): number => w - (n - 1 - i) * step;
+  const y = (v: number): number => {
+    const ratio = Math.min(Math.max(v, 0), 100) / 100;
+    return pad + (h - 2 * pad) * (1 - ratio);
+  };
+  ctx.fillStyle = color;
+  ctx.strokeStyle = color;
+  if (n === 1) {
+    ctx.fillRect(x(0) - dpr, y(samples[0]) - dpr, 2 * dpr, 2 * dpr);
+    return;
+  }
+  ctx.beginPath();
+  ctx.moveTo(x(0), y(samples[0]));
+  for (let i = 1; i < n; i++) ctx.lineTo(x(i), y(samples[i]));
+  ctx.lineWidth = 1.5 * dpr;
+  ctx.lineJoin = "round";
+  ctx.stroke();
+  // The same path closed along the bottom edge, filled faintly.
+  ctx.lineTo(x(n - 1), h);
+  ctx.lineTo(x(0), h);
+  ctx.closePath();
+  ctx.globalAlpha = 0.2;
+  ctx.fill();
+  ctx.globalAlpha = 1;
+}

--- a/web/cockpit/src/panels/stats.test.ts
+++ b/web/cockpit/src/panels/stats.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import {
+  childKey,
+  type ChildStats,
+  COORDINATOR_KEY,
+  cpuColor,
+  EMPTY_SNAPSHOT,
+  fmtIo,
+  fmtMem,
+  fmtPct,
+  fmtSecs,
+  foldSnapshot,
+  heat,
+  parseStats,
+  pushSample,
+  WINDOW,
+  workerKey,
+} from "./stats.ts";
+
+const PROCESS = {
+  pid: 1234,
+  alive: true,
+  cpu_percent: 12.3,
+  cpu_time_user: 1.2,
+  cpu_time_system: 0.3,
+  cpu_time_iowait: 0,
+  pss: 47_400_000,
+  num_threads: 4,
+  num_children: 0,
+  num_fds: 32,
+  io_read_bytes: 12_582_912,
+  io_write_bytes: 4_194_304,
+};
+const WORKER = {
+  ...PROCESS,
+  pid: 1235,
+  cpu_percent: 34,
+  worker_id: 0,
+  modules: ["nav", "lidar"],
+  dedicated: false,
+  children: [{ pid: 1300, name: "ffmpeg", cpu_percent: 5.5 }],
+};
+
+describe("parseStats", () => {
+  it("accepts the stats.json.v1 shape", () => {
+    const frame = parseStats({ coordinator: PROCESS, workers: [WORKER] });
+    expect(frame?.coordinator.pss).toBe(47_400_000);
+    expect(frame?.workers[0].children[0].name).toBe("ffmpeg");
+  });
+
+  it("rejects anything off-contract", () => {
+    expect(parseStats(null)).toBeNull();
+    expect(parseStats([])).toBeNull();
+    expect(parseStats({ coordinator: PROCESS })).toBeNull();
+    expect(parseStats({ coordinator: { ...PROCESS, pss: "47 MB" }, workers: [] })).toBeNull();
+    expect(parseStats({ coordinator: PROCESS, workers: [{ ...WORKER, modules: [1] }] }))
+      .toBeNull();
+    expect(parseStats({ coordinator: PROCESS, workers: [{ ...WORKER, children: [{ pid: 1 }] }] }))
+      .toBeNull();
+  });
+});
+
+describe("dtop formatting", () => {
+  it("matches the TUI's units", () => {
+    expect(fmtPct(12.3)).toBe("12%");
+    expect(fmtMem(47_400_000)).toBe("45.2 MB");
+    expect(fmtMem(1_073_741_824)).toBe("1.0 GB");
+    expect(fmtSecs(1.234)).toBe("1.2s");
+    expect(fmtSecs(90)).toBe("1.5m");
+    expect(fmtSecs(5400)).toBe("1.5h");
+    expect(fmtIo(12_582_912, 4_194_304)).toBe("12/4 MB");
+  });
+
+  it("colors load cyan -> yellow -> red on dtop's scale", () => {
+    expect(heat(0)).toBe("#00eeee");
+    expect(heat(0.5)).toBe("#ffcc00");
+    expect(heat(1)).toBe("#ff0000");
+    expect(heat(2)).toBe("#ff0000");
+    expect(cpuColor(25)).toBe("#80dd77");
+  });
+});
+
+describe("pushSample", () => {
+  it("keeps the newest window, as a new array", () => {
+    const a = pushSample([], 1, 3);
+    const b = pushSample(a, 2, 3);
+    const c = pushSample(b, 3, 3);
+    expect(pushSample(c, 4, 3)).toEqual([2, 3, 4]);
+    expect(c).toEqual([1, 2, 3]);
+  });
+});
+
+describe("foldSnapshot", () => {
+  const frame = (cpu: number, children: ChildStats[] = []) => ({
+    coordinator: { ...PROCESS, cpu_percent: cpu },
+    workers: [{ ...WORKER, cpu_percent: cpu * 2, children }],
+  });
+
+  it("appends one CPU sample per frame to every row and drops vanished rows", () => {
+    const child = { pid: 7, name: "ffmpeg", cpu_percent: 1 };
+    const one = foldSnapshot(EMPTY_SNAPSHOT, frame(10, [child]));
+    expect(one.cpu.get(childKey(7))).toEqual([1]);
+    const two = foldSnapshot(one, frame(20));
+    expect(two.frame?.coordinator.cpu_percent).toBe(20);
+    expect(two.cpu.get(COORDINATOR_KEY)).toEqual([10, 20]);
+    expect(two.cpu.get(workerKey(0))).toEqual([20, 40]);
+    expect(two.cpu.has(childKey(7))).toBe(false);
+  });
+
+  it("bounds every row to the window", () => {
+    let snapshot = EMPTY_SNAPSHOT;
+    for (let i = 1; i <= WINDOW + 5; i++) snapshot = foldSnapshot(snapshot, frame(i));
+    const samples = snapshot.cpu.get(COORDINATOR_KEY)!;
+    expect(samples).toHaveLength(WINDOW);
+    expect(samples[0]).toBe(6);
+    expect(samples[WINDOW - 1]).toBe(WINDOW + 5);
+  });
+
+  it("flags an unreadable payload and keeps the last good frame", () => {
+    const good = foldSnapshot(EMPTY_SNAPSHOT, frame(10));
+    const bad = foldSnapshot(good, { workers: "nope" });
+    expect(bad.unreadable).toBe(true);
+    expect(bad.frame).toBe(good.frame);
+    expect(bad.cpu).toBe(good.cpu);
+    const next = foldSnapshot(bad, frame(30));
+    expect(next.unreadable).toBe(false);
+    expect(next.cpu.get(COORDINATOR_KEY)).toEqual([10, 30]);
+  });
+});

--- a/web/cockpit/src/panels/stats.ts
+++ b/web/cockpit/src/panels/stats.ts
@@ -1,0 +1,208 @@
+// The Stats page's data: a stats.json.v1 frame is the resource monitor's
+// /resource_stats dict (dimos/core/resource_monitor/stats.py, published at
+// 1 Hz) with the keys the page reads, under the producer's own names, so the
+// tab and the dtop TUI consume the same thing. The formatters and the CPU
+// heat scale are dtop's (dimos/cli/dtop.py). Nothing here touches the DOM.
+
+export interface ProcessStats {
+  pid: number;
+  alive: boolean;
+  cpu_percent: number;
+  cpu_time_user: number;
+  cpu_time_system: number;
+  cpu_time_iowait: number;
+  pss: number;
+  num_threads: number;
+  num_children: number;
+  num_fds: number;
+  io_read_bytes: number;
+  io_write_bytes: number;
+}
+
+export interface ChildStats {
+  pid: number;
+  name: string;
+  cpu_percent: number;
+}
+
+export interface WorkerStats extends ProcessStats {
+  worker_id: number;
+  modules: string[];
+  dedicated: boolean;
+  /** Direct children; the worker's cpu_percent already includes theirs. */
+  children: ChildStats[];
+}
+
+export interface StatsFrame {
+  coordinator: ProcessStats;
+  workers: WorkerStats[];
+}
+
+const PROCESS_NUMBERS = [
+  "pid",
+  "cpu_percent",
+  "cpu_time_user",
+  "cpu_time_system",
+  "cpu_time_iowait",
+  "pss",
+  "num_threads",
+  "num_children",
+  "num_fds",
+  "io_read_bytes",
+  "io_write_bytes",
+] as const;
+
+type Rec = Record<string, unknown>;
+
+function isRec(v: unknown): v is Rec {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function readProcess(v: unknown): ProcessStats | null {
+  if (!isRec(v) || typeof v.alive !== "boolean") return null;
+  for (const key of PROCESS_NUMBERS) {
+    if (typeof v[key] !== "number") return null;
+  }
+  return v as unknown as ProcessStats;
+}
+
+function readChild(v: unknown): ChildStats | null {
+  if (
+    !isRec(v) || typeof v.pid !== "number" || typeof v.name !== "string" ||
+    typeof v.cpu_percent !== "number"
+  ) {
+    return null;
+  }
+  return { pid: v.pid, name: v.name, cpu_percent: v.cpu_percent };
+}
+
+function readWorker(v: unknown): WorkerStats | null {
+  const process = readProcess(v);
+  if (process === null) return null;
+  const rec = v as Rec;
+  if (typeof rec.worker_id !== "number" || typeof rec.dedicated !== "boolean") return null;
+  if (!Array.isArray(rec.modules) || !rec.modules.every((m) => typeof m === "string")) return null;
+  if (!Array.isArray(rec.children)) return null;
+  const children: ChildStats[] = [];
+  for (const c of rec.children) {
+    const child = readChild(c);
+    if (child === null) return null;
+    children.push(child);
+  }
+  return {
+    ...process,
+    worker_id: rec.worker_id,
+    modules: rec.modules,
+    dedicated: rec.dedicated,
+    children,
+  };
+}
+
+/** The frame, or null when the payload is not stats.json.v1-shaped. */
+export function parseStats(value: unknown): StatsFrame | null {
+  if (!isRec(value) || !Array.isArray(value.workers)) return null;
+  const coordinator = readProcess(value.coordinator);
+  if (coordinator === null) return null;
+  const workers: WorkerStats[] = [];
+  for (const w of value.workers) {
+    const worker = readWorker(w);
+    if (worker === null) return null;
+    workers.push(worker);
+  }
+  return { coordinator, workers };
+}
+
+const MIB = 1048576;
+
+/** dtop's `{v:3.0f}%`, unpadded. */
+export function fmtPct(v: number): string {
+  return `${Math.round(v)}%`;
+}
+
+/** dtop's _fmt_mem: MB below a GiB, GB from there, one decimal. */
+export function fmtMem(bytes: number): string {
+  const mb = bytes / MIB;
+  return mb >= 1024 ? `${(mb / 1024).toFixed(1)} GB` : `${mb.toFixed(1)} MB`;
+}
+
+/** dtop's _fmt_secs: s, m past a minute, h past an hour, one decimal. */
+export function fmtSecs(s: number): string {
+  if (s >= 3600) return `${(s / 3600).toFixed(1)}h`;
+  if (s >= 60) return `${(s / 60).toFixed(1)}m`;
+  return `${s.toFixed(1)}s`;
+}
+
+/** dtop's `IO r/w` compound: whole MB read and written. */
+export function fmtIo(read: number, write: number): string {
+  return `${Math.round(read / MIB)}/${Math.round(write / MIB)} MB`;
+}
+
+// dtop's gradient stops (dimos/cli/theme.py CYAN, YELLOW, RED).
+const HEAT_CYAN = [0x00, 0xee, 0xee];
+const HEAT_YELLOW = [0xff, 0xcc, 0x00];
+const HEAT_RED = [0xff, 0x00, 0x00];
+
+/** Color for a 0..1 load ratio: cyan -> yellow -> red, dtop's scale. */
+export function heat(ratio: number): string {
+  const r = Math.min(Math.max(ratio, 0), 1);
+  const lower = r <= 0.5;
+  const from = lower ? HEAT_CYAN : HEAT_YELLOW;
+  const to = lower ? HEAT_YELLOW : HEAT_RED;
+  const t = lower ? r * 2 : (r - 0.5) * 2;
+  const hex = from.map((a, i) => Math.round(a + (to[i] - a) * t).toString(16).padStart(2, "0"));
+  return `#${hex.join("")}`;
+}
+
+/** CPU percent -> heat color; dtop colors CPU on the absolute 0..100 scale. */
+export function cpuColor(percent: number): string {
+  return heat(percent / 100);
+}
+
+/** `samples` plus `value`, keeping the newest `window`. A new array: the
+ * page compares identities (state, effect deps). */
+export function pushSample(samples: readonly number[], value: number, window: number): number[] {
+  const next = samples.slice(Math.max(samples.length - window + 1, 0));
+  next.push(value);
+  return next;
+}
+
+/** Sparkline length in samples: 60 s at the resource monitor's 1 Hz. */
+export const WINDOW = 60;
+
+export interface StatsSnapshot {
+  /** The newest readable frame; null before the first. */
+  frame: StatsFrame | null;
+  /** True when the newest frame was not stats.json.v1-shaped. */
+  unreadable: boolean;
+  /** CPU samples per row key (see the key helpers), oldest first. */
+  cpu: ReadonlyMap<string, readonly number[]>;
+}
+
+export const EMPTY_SNAPSHOT: StatsSnapshot = { frame: null, unreadable: false, cpu: new Map() };
+
+export const COORDINATOR_KEY = "coordinator";
+export function workerKey(id: number): string {
+  return `worker:${id}`;
+}
+export function childKey(pid: number): string {
+  return `child:${pid}`;
+}
+
+/** `previous` folded with one more frame payload: one CPU sample per row
+ * (dtop samples its UI clock and doubles up), the newest WINDOW kept, rows
+ * absent from the frame dropped with their history. An off-contract payload
+ * only raises the flag. */
+export function foldSnapshot(previous: StatsSnapshot, value: unknown): StatsSnapshot {
+  const frame = parseStats(value);
+  if (frame === null) return { ...previous, unreadable: true };
+  const cpu = new Map<string, number[]>();
+  const push = (key: string, sample: number): void => {
+    cpu.set(key, pushSample(previous.cpu.get(key) ?? [], sample, WINDOW));
+  };
+  push(COORDINATOR_KEY, frame.coordinator.cpu_percent);
+  for (const worker of frame.workers) {
+    push(workerKey(worker.worker_id), worker.cpu_percent);
+    for (const child of worker.children) push(childKey(child.pid), child.cpu_percent);
+  }
+  return { frame, unreadable: false, cpu };
+}

--- a/web/shared/fixtures/gen.ts
+++ b/web/shared/fixtures/gen.ts
@@ -249,7 +249,14 @@ const chAudio = {
   maxHz: 20.5,
   publish: "shared",
 };
+const chStats = {
+  ch: "resource_stats",
+  encoding: "stats.json.v1",
+  delivery: "latest",
+  maxHz: 2.5,
+};
 const pCamera = { id: "camera", kind: "video", channels: ["color_image"] };
+const pStats = { id: "stats", kind: "stats", channels: ["resource_stats"] };
 const pChat = {
   id: "chat",
   kind: "chat",
@@ -647,6 +654,23 @@ const manifestCases: Record<string, unknown> = {
       { ch: "audio_in", dir: "tx", encoding: "audio.json.v1", delivery: "reliable", maxHz: 20.5 },
     ],
     panels: [pChat],
+  },
+  // Stats page: one stats.json.v1 latest rx channel, placed as a page tab.
+  stats_panel: { version: 1, channels: [chStats], panels: [pStats], pages: ["stats"] },
+  stats_panel_two_channels: {
+    version: 1,
+    channels: [chStats, chOdom],
+    panels: [{ ...pStats, channels: ["resource_stats", "odom"] }],
+  },
+  stats_panel_wrong_encoding: {
+    version: 1,
+    channels: [chOdom],
+    panels: [{ ...pStats, channels: ["odom"] }],
+  },
+  stats_panel_wrong_delivery: {
+    version: 1,
+    channels: [{ ...chStats, delivery: "reliable" }],
+    panels: [pStats],
   },
 };
 

--- a/web/shared/fixtures/manifests.json
+++ b/web/shared/fixtures/manifests.json
@@ -3462,6 +3462,141 @@
         ]
       },
       "error": "invalid_chat_panel"
+    },
+    {
+      "name": "stats_panel",
+      "data": {
+        "version": 1,
+        "channels": [
+          {
+            "ch": "resource_stats",
+            "encoding": "stats.json.v1",
+            "delivery": "latest",
+            "maxHz": 2.5
+          }
+        ],
+        "panels": [
+          {
+            "id": "stats",
+            "kind": "stats",
+            "channels": [
+              "resource_stats"
+            ]
+          }
+        ],
+        "pages": [
+          "stats"
+        ]
+      },
+      "manifest": {
+        "version": 1,
+        "channels": [
+          {
+            "ch": "resource_stats",
+            "dir": "rx",
+            "encoding": "stats.json.v1",
+            "delivery": "latest",
+            "maxHz": 2.5,
+            "params": {},
+            "publish": "none",
+            "requiredScope": null
+          }
+        ],
+        "panels": [
+          {
+            "id": "stats",
+            "kind": "stats",
+            "title": "",
+            "channels": [
+              "resource_stats"
+            ],
+            "params": {}
+          }
+        ],
+        "layout": null,
+        "pages": [
+          "stats"
+        ]
+      }
+    },
+    {
+      "name": "stats_panel_two_channels",
+      "data": {
+        "version": 1,
+        "channels": [
+          {
+            "ch": "resource_stats",
+            "encoding": "stats.json.v1",
+            "delivery": "latest",
+            "maxHz": 2.5
+          },
+          {
+            "ch": "odom",
+            "encoding": "pose.json.v1",
+            "delivery": "reliable",
+            "maxHz": 20.5
+          }
+        ],
+        "panels": [
+          {
+            "id": "stats",
+            "kind": "stats",
+            "channels": [
+              "resource_stats",
+              "odom"
+            ]
+          }
+        ]
+      },
+      "error": "invalid_stats_panel"
+    },
+    {
+      "name": "stats_panel_wrong_encoding",
+      "data": {
+        "version": 1,
+        "channels": [
+          {
+            "ch": "odom",
+            "encoding": "pose.json.v1",
+            "delivery": "reliable",
+            "maxHz": 20.5
+          }
+        ],
+        "panels": [
+          {
+            "id": "stats",
+            "kind": "stats",
+            "channels": [
+              "odom"
+            ]
+          }
+        ]
+      },
+      "error": "invalid_stats_panel"
+    },
+    {
+      "name": "stats_panel_wrong_delivery",
+      "data": {
+        "version": 1,
+        "channels": [
+          {
+            "ch": "resource_stats",
+            "encoding": "stats.json.v1",
+            "delivery": "reliable",
+            "maxHz": 2.5
+          }
+        ],
+        "panels": [
+          {
+            "id": "stats",
+            "kind": "stats",
+            "channels": [
+              "resource_stats"
+            ]
+          }
+        ]
+      },
+      "error": "invalid_stats_panel"
     }
   ]
 }

--- a/web/shared/manifest.ts
+++ b/web/shared/manifest.ts
@@ -6,7 +6,8 @@
 // The transport (protocol.ts) carries the manifest as one opaque record;
 // this module is the single owner of its structure and domain rules:
 // version gate, bounded unique ids, positive rates, panel/layout/pages
-// references that resolve, and kind-specific panel rules (video, map2d).
+// references that resolve, and kind-specific panel rules (video, map2d,
+// teleop, chat, stats).
 //
 // Manifest v1 is frozen. Additive changes (new panel kinds, new params)
 // ride the existing shape: unknown keys and kinds pass through validation.
@@ -433,6 +434,23 @@ export function parseManifest(value: unknown): Manifest {
         throw new ManifestError(
           "invalid_chat_panel",
           `chat panel ${panel.id} needs an audio.json.v1 reliable shared tx channel fourth`,
+        );
+      }
+    }
+    if (panel.kind === "stats") {
+      if (panel.channels.length !== 1) {
+        throw new ManifestError(
+          "invalid_stats_panel",
+          `stats panel ${panel.id} must bind exactly one channel`,
+        );
+      }
+      const stats = chIds.get(panel.channels[0])!;
+      if (
+        stats.encoding !== "stats.json.v1" || stats.delivery !== "latest" || dirOf(stats) !== "rx"
+      ) {
+        throw new ManifestError(
+          "invalid_stats_panel",
+          `stats panel ${panel.id} needs a stats.json.v1 latest rx channel`,
         );
       }
     }


### PR DESCRIPTION
Closes DIM-1171

- Adds a Stats panel to the web cockpit (similar to `dtop` in the CLI).
- Automatically enables resource monitoring when a cockpit includes the Stats panel. Users can still disable it with `--no-dtop`.
- Adds a Stats tab to the Go2 agentic cockpit.
