### PR TITLE
chore: exclude cargo.lock from diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,12 @@
 * text=auto eol=lf
 # Ensure Python files always use LF for line endings.
 *.py text eol=lf
+# Keep dependency lockfiles tracked without including their generated contents in diffs.
+Cargo.lock -diff linguist-generated
+uv.lock -diff linguist-generated
+deno.lock -diff linguist-generated
+flake.lock -diff linguist-generated
+package-lock.json -diff linguist-generated
 # Treat designated file types as binary and do not alter their contents or line endings.
 *.png filter=lfs diff=lfs merge=lfs -text binary
 *.jpg filter=lfs diff=lfs merge=lfs -text binary


### PR DESCRIPTION
## Problem

`Cargo.lock` files show up in diff collapsed, but they still count as part of the number of line changes. This means that a 500 line PR shows up as 5000 if you include a 4500-line Cargo.lock file change.

## Solution

Exclude them from diffs (essentially treat them as binary since they're not meant to be edited by hand).
