### PR TITLE
test: auto-rerun the two shm creation-window races

### DIFF
--- a/dimos/protocol/pubsub/shm/test_ipc_factory.py
+++ b/dimos/protocol/pubsub/shm/test_ipc_factory.py
@@ -201,6 +201,7 @@ def slow_ftruncate(monkeypatch):
     monkeypatch.setattr(os, "ftruncate", delayed)
 
 
+@pytest.mark.flaky(reruns=2)
 def test_concurrent_open_survives_the_creation_window(slow_ftruncate) -> None:
     """Two peers opening the same segment at once: one creates, one waits it out.
 

--- a/dimos/utils/test_shm.py
+++ b/dimos/utils/test_shm.py
@@ -76,6 +76,7 @@ def test_bare_attach_hits_the_race(name, slow_ftruncate):
     assert "cannot mmap an empty file" in str(seen[0])
 
 
+@pytest.mark.flaky(reruns=2)
 def test_attach_shm_waits_out_the_race(name, slow_ftruncate):
     """attach_shm blocks through the window and returns a fully sized segment."""
     result: list[object] = []


### PR DESCRIPTION
The shm creation-window races (test_attach_shm_waits_out_the_race, test_concurrent_open_survives_the_creation_window) fail unrelated PRs and main itself (today: 3 red attempts on two CLI PRs, main run 33698882890, three other PRs green only on attempt 2). flaky(reruns=2) follows existing precedent (e2e_tests/test_person_follow.py, test_security_module.py); a real regression still fails after three attempts. Scoped to the two shm tests only. The underlying fix is readiness-by-size in attach_shm; this stops the rerun tax meanwhile.