### PR TITLE
fix(cli): refresh expired presigned part URLs during long uploads

### DIFF
--- a/dimos/cloud/data.py
+++ b/dimos/cloud/data.py
@@ -129,7 +129,7 @@ class MultipartBackend:
             else:
                 artifact = path
             size = artifact.stat().st_size
-            create = self.api.create(
+            spec = dict(
                 filename=artifact.name,
                 size=size,
                 sha256=_sha256(artifact),
@@ -139,6 +139,7 @@ class MultipartBackend:
                 manifest=manifest,
                 part_size=part_size,
             )
+            create = self.api.create(**spec)
             if create["state"] == "complete":
                 return {**create, "skipped": True}
             uid = create["upload_id"]
@@ -146,16 +147,31 @@ class MultipartBackend:
             ps = create["part_size"]
             done = min(len(have) * ps, size)
             tick("upload", done, size)
+            urls = {p["part_number"]: p["url"] for p in create["part_urls"]}
             with artifact.open("rb") as f:
-                for part in create["part_urls"]:
-                    if part["part_number"] in have:
+                for n in sorted(urls):
+                    if n in have:
                         continue
-                    f.seek((part["part_number"] - 1) * ps)
+                    f.seek((n - 1) * ps)
                     chunk = f.read(ps)
-                    self._retry(
-                        functools.partial(self.api.put_part, part["url"], chunk),
-                        f"part {part['part_number']}",
-                    )
+                    try:
+                        self._retry(
+                            functools.partial(self.api.put_part, urls[n], chunk), f"part {n}"
+                        )
+                    except RuntimeError as e:
+                        if "403" not in str(e):
+                            raise
+                        # Part URLs are presigned at create and share one expiry
+                        # clock; an upload slower than the TTL outlives them and
+                        # S3 answers 403. create is idempotent by sha256 and
+                        # re-signs every URL.
+                        fresh = self.api.create(**spec)
+                        if fresh["state"] == "complete":
+                            return {**fresh, "skipped": True}
+                        urls = {p["part_number"]: p["url"] for p in fresh["part_urls"]}
+                        self._retry(
+                            functools.partial(self.api.put_part, urls[n], chunk), f"part {n}"
+                        )
                     done += len(chunk)
                     tick("upload", done, size)
             parts = sorted(self.status(uid)["parts"], key=lambda p: p["part_number"])

--- a/dimos/cloud/test_data.py
+++ b/dimos/cloud/test_data.py
@@ -36,6 +36,8 @@ class FakeTransport:
         self.parts: dict[str, dict[int, bytes]] = {}
         self.part_size = 128 * 1024
         self.fail_at = 0  # fail the Nth put, once
+        self.epoch = 0  # presign generation; URLs from older epochs are expired
+        self.expire_at = 0  # bump epoch before the Nth put, once
 
     def request(self, method: str, path: str, body: dict[str, Any] | None = None) -> dict[str, Any]:
         if path.endswith("/uploads") and method == "POST":
@@ -82,12 +84,20 @@ class FakeTransport:
             "state": "pending",
             "upload_id": uid,
             "part_size": self.part_size,
-            "part_urls": [{"part_number": i, "url": f"{uid}/{i}"} for i in range(1, n + 1)],
+            "part_urls": [
+                {"part_number": i, "url": f"{uid}/{i}?e={self.epoch}"} for i in range(1, n + 1)
+            ],
             "quota": {"state": "ok"},
         }
 
     def put(self, url: str, body: bytes) -> None:
-        uid, n = url.split("/")
+        path, _, epoch = url.partition("?e=")
+        uid, n = path.split("/")
+        if self.expire_at and len(self.parts[uid]) + 1 == self.expire_at:
+            self.expire_at = 0
+            self.epoch += 1
+        if int(epoch) != self.epoch:
+            raise OSError("403 Forbidden: Request has expired")
         if self.fail_at and len(self.parts[uid]) + 1 == self.fail_at:
             self.fail_at = 0
             raise OSError("link dropped")
@@ -150,12 +160,22 @@ def test_resume_sends_only_missing_parts(tmp_path: Path, monkeypatch: pytest.Mon
     real_put = t.put
 
     def spying_put(url: str, body: bytes) -> None:
-        sent.append(int(url.split("/")[1]))
+        sent.append(int(url.split("/")[1].partition("?")[0]))
         real_put(url, body)
 
     monkeypatch.setattr(t, "put", spying_put)
     assert cloud.upload(db)["state"] == "complete"
     assert before and set(sent).isdisjoint(before)
+
+
+def test_upload_refreshes_expired_part_urls(env: tuple[CloudData, FakeTransport, Path]) -> None:
+    """An upload slower than the presign TTL: URLs from create die mid-run; the
+    client must re-create (same sha256 -> fresh URLs) and finish, not abort."""
+    cloud, t, db = env
+    t.expire_at = 2  # URLs signed at create expire before part 2 lands
+    r = cloud.upload(db)
+    assert r["state"] == "complete" and not r["skipped"]
+    assert t.epoch == 1  # completed on re-signed URLs, not the originals
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
A 38.5GB `dimos data upload` dies partway with 403s: every part URL is presigned at create with one shared 1-hour TTL, so any upload slower than ~90Mbps outlives its URLs (server: `storage.presign_parts`, `url_ttl=3600`). Today the only recovery is manually re-running the CLI every hour.

Fix is client-side only: when a part PUT exhausts its retries with a 403, re-call `create` — idempotent by sha256, returns the same upload with every URL freshly signed — and retry the part once. Non-403 failures still abort as before. Raising `url_ttl` server-side is not a substitute: presigned URLs are capped by the signing credentials' lifetime, and the API signs with rotating ECS task-role creds.

Verified three ways:
- unit: `FakeTransport` now stamps part URLs with a signing epoch and expires them mid-upload; the new test fails on main with the exact production error (`part 2 failed after 2 attempts: 403`) and passes here
- E2E against **real S3** (moto does not enforce presigned expiry): dimos-cloud app in-process with `url_ttl=10s`, real bucket, 12MB/3 parts, 12s stall between parts — the main client reproduces the production failure, this client refreshes and completes with a sha-verified pull
- all 26 existing cloud tests unchanged and green; mypy clean

## Test locally

```sh
uv run pytest dimos/cloud/test_data.py -v -k refresh
```

Real-world shape without waiting an hour: throttle your uplink (`trickle`/`tc`) so a multi-GB upload crosses the real 1h TTL — it should print nothing new, just keep going where main's client dies at the first expired part.
