### PR TITLE
refactor: simplify manipulation to one robot model

### DIFF
--- a/dimos/manipulation/manipulation_module.py
+++ b/dimos/manipulation/manipulation_module.py
@@ -30,7 +30,7 @@ import math
 import threading
 import time
 import traceback
-from typing import Any, Literal, TypeAlias, cast
+from typing import Any, Literal, TypeAlias
 
 import numpy as np
 from pydantic import Field
@@ -60,7 +60,6 @@ from dimos.manipulation.planning.groups.models import PlanningGroup, PlanningGro
 from dimos.manipulation.planning.groups.utils import (
     filter_joint_state_to_selected_joints,
     normalize_joint_target,
-    planning_group_id_from_selector,
 )
 from dimos.manipulation.planning.kinematics.config import (
     ManipulationKinematicsConfig,
@@ -771,16 +770,7 @@ class ManipulationModule(Module):
             logger.warning("Pose planning unavailable", error=str(exc))
             self._record_error(str(exc))
             return False
-        return self.plan_to_pose_targets({selected_group_id: pose})
-
-    @rpc
-    def plan_to_pose_targets(
-        self,
-        pose_targets: Mapping[PlanningGroupID | PlanningGroup, Pose],
-        auxiliary_groups: Sequence[PlanningGroupID | PlanningGroup] = (),
-    ) -> bool:
-        """Plan to one or more group pose targets with optional auxiliary groups."""
-        return self.generate_plan_to_pose_targets(pose_targets, auxiliary_groups) is not None
+        return self.generate_plan_to_pose_targets({selected_group_id: pose}) is not None
 
     @rpc
     def plan_to_joints(
@@ -792,10 +782,7 @@ class ManipulationModule(Module):
         self._clear_pending_plan()
         if not targets:
             return PlanResult(PlanStatus.INVALID_TARGET, "At least one target is required")
-        plan = self.generate_plan_to_joint_targets(
-            cast("Mapping[PlanningGroupID | PlanningGroup, JointState]", targets),
-            speed_scale=speed_scale,
-        )
+        plan = self.generate_plan_to_joint_targets(targets, speed_scale=speed_scale)
         if plan is None:
             return PlanResult(PlanStatus.FAILED, self._error_message or "Planning failed")
         return PlanResult(PlanStatus.SUCCEEDED, plan.message, plan)
@@ -810,24 +797,14 @@ class ManipulationModule(Module):
         self._clear_pending_plan()
         if not targets:
             return PlanResult(PlanStatus.INVALID_TARGET, "At least one target is required")
-        plan = self.generate_plan_to_pose_targets(
-            cast("Mapping[PlanningGroupID | PlanningGroup, Pose]", targets),
-            speed_scale=speed_scale,
-        )
+        plan = self.generate_plan_to_pose_targets(targets, speed_scale=speed_scale)
         if plan is None:
             return PlanResult(PlanStatus.FAILED, self._error_message or "Planning failed")
         return PlanResult(PlanStatus.SUCCEEDED, plan.message, plan)
 
-    @rpc
-    def plan_to_joint_targets(
-        self, joint_targets: Mapping[PlanningGroupID | PlanningGroup, JointState]
-    ) -> bool:
-        """Plan to joint targets keyed by planning group."""
-        return self.generate_plan_to_joint_targets(joint_targets) is not None
-
     def generate_plan_to_joint_targets(
         self,
-        joint_targets: Mapping[PlanningGroupID | PlanningGroup, JointState],
+        joint_targets: Mapping[PlanningGroupID, JointState],
         speed_scale: float | None = None,
     ) -> GeneratedPlan | None:
         """Plan to joint targets and return the exact stored GeneratedPlan."""
@@ -837,9 +814,7 @@ class ManipulationModule(Module):
             self._fail("At least one joint target is required")
             return None
 
-        group_ids = tuple(
-            dict.fromkeys(planning_group_id_from_selector(group) for group in joint_targets)
-        )
+        group_ids = tuple(joint_targets)
         planning = self._begin_group_planning(speed_scale)
         if planning is None:
             return None
@@ -852,17 +827,16 @@ class ManipulationModule(Module):
 
         goal_names: list[str] = []
         goal_positions: list[float] = []
-        for group, target in joint_targets.items():
-            group_id = planning_group_id_from_selector(group)
+        for group_id, target in joint_targets.items():
             try:
                 target_group = self._world_monitor.planning_groups.get(group_id)
-                target_global = normalize_joint_target(target_group, target)
+                normalized_target = normalize_joint_target(target_group, target)
             except (KeyError, ValueError) as exc:
                 logger.error(str(exc))
                 self._fail_planning_epoch(planning_epoch, f"Invalid joint target for '{group_id}'")
                 return None
-            goal_names.extend(target_global.name)
-            goal_positions.extend(target_global.position)
+            goal_names.extend(normalized_target.name)
+            goal_positions.extend(normalized_target.position)
 
         goal = JointState(name=goal_names, position=goal_positions)
         return self._plan_selected_path(
@@ -871,8 +845,8 @@ class ManipulationModule(Module):
 
     def generate_plan_to_pose_targets(
         self,
-        pose_targets: Mapping[PlanningGroupID | PlanningGroup, Pose],
-        auxiliary_groups: Sequence[PlanningGroupID | PlanningGroup] = (),
+        pose_targets: Mapping[PlanningGroupID, Pose],
+        auxiliary_groups: Sequence[PlanningGroupID] = (),
         speed_scale: float | None = None,
     ) -> GeneratedPlan | None:
         """Plan to pose targets and return the exact stored GeneratedPlan."""
@@ -882,14 +856,14 @@ class ManipulationModule(Module):
             self._fail("At least one pose target is required")
             return None
         stamped_targets = {
-            planning_group_id_from_selector(group): PoseStamped(
+            group_id: PoseStamped(
                 frame_id="world",
                 position=pose.position,
                 orientation=pose.orientation,
             )
-            for group, pose in pose_targets.items()
+            for group_id, pose in pose_targets.items()
         }
-        auxiliary_ids = tuple(planning_group_id_from_selector(group) for group in auxiliary_groups)
+        auxiliary_ids = tuple(auxiliary_groups)
         group_ids = tuple(dict.fromkeys((*stamped_targets.keys(), *auxiliary_ids)))
         planning = self._begin_group_planning(speed_scale)
         if planning is None:
@@ -913,30 +887,11 @@ class ManipulationModule(Module):
             group_ids, start, ik.joint_state, planning_epoch, resolved_speed_scale
         )
 
-    @rpc
-    def plan_cartesian_targets(
-        self,
-        targets: Mapping[PlanningGroupID | PlanningGroup, CartesianTarget],
-        config: CartesianPathConfig,
-        auxiliary_groups: Sequence[PlanningGroupID | PlanningGroup] = (),
-        check_collision: bool = True,
-    ) -> bool:
-        """Plan TCP motion through absolute or relative Cartesian waypoints."""
-        return (
-            self.generate_cartesian_plan(
-                targets,
-                config,
-                auxiliary_groups,
-                check_collision=check_collision,
-            )
-            is not None
-        )
-
     def generate_cartesian_plan(
         self,
-        targets: Mapping[PlanningGroupID | PlanningGroup, CartesianTarget],
+        targets: Mapping[PlanningGroupID, CartesianTarget],
         config: CartesianPathConfig,
-        auxiliary_groups: Sequence[PlanningGroupID | PlanningGroup] = (),
+        auxiliary_groups: Sequence[PlanningGroupID] = (),
         speed_scale: float | None = None,
         check_collision: bool = True,
     ) -> GeneratedPlan | None:
@@ -946,14 +901,8 @@ class ManipulationModule(Module):
         if not targets:
             self._fail("At least one Cartesian target is required")
             return None
-        normalized_targets = {
-            planning_group_id_from_selector(group): target for group, target in targets.items()
-        }
-        if len(normalized_targets) != len(targets):
-            self._fail("Cartesian target groups must be unique")
-            return None
-        auxiliary_ids = tuple(planning_group_id_from_selector(group) for group in auxiliary_groups)
-        group_ids = tuple((*normalized_targets.keys(), *auxiliary_ids))
+        auxiliary_ids = tuple(auxiliary_groups)
+        group_ids = tuple((*targets.keys(), *auxiliary_ids))
         planning = self._begin_group_planning(speed_scale)
         if planning is None:
             return None
@@ -972,7 +921,7 @@ class ManipulationModule(Module):
             world=self._world_monitor.world,
             selection=selection,
             start=start,
-            targets=normalized_targets,
+            targets=targets,
             config=scaled_config,
             auxiliary_groups=auxiliary_ids,
             check_collision=check_collision,
@@ -1139,15 +1088,9 @@ class ManipulationModule(Module):
         """Get information about the configured logical robot model."""
         config = self.config.model
         planning_groups = self.list_planning_groups()
-        pose_tip_links = [
-            group.tip_frame for group in planning_groups if group.tip_frame is not None
-        ]
-        end_effector_link = pose_tip_links[0] if len(pose_tip_links) == 1 else None
-
         return {
             "joint_names": config.joint_names,
             "planning_groups": list(planning_groups),
-            "end_effector_link": end_effector_link,
             "base_link": config.base_link,
             "max_velocity": config.max_velocity,
             "max_acceleration": config.max_acceleration,

--- a/dimos/manipulation/planning/README.md
+++ b/dimos/manipulation/planning/README.md
@@ -31,7 +31,7 @@ execute()               # Execute via coordinator
 ```
 ┌─────────────────────────────────────────────────────────────┐
 │                    ManipulationModule                       │
-│         (RPC interface, state machine, multi-robot)         │
+│       (RPC interface, state machine, one robot model)       │
 └─────────────────────────────────────────────────────────────┘
                               │
 ┌─────────────────────────────────────────────────────────────┐
@@ -61,7 +61,12 @@ execute()               # Execute via coordinator
 
 ```python skip
 from dimos.manipulation import ManipulationModule
+from dimos.manipulation.planning.groups.models import PlanningGroupDefinition
 from dimos.manipulation.planning.spec import RobotModelConfig
+from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
+from dimos.msgs.geometry_msgs.Quaternion import Quaternion
+from dimos.msgs.geometry_msgs.Vector3 import Vector3
+from dimos.msgs.sensor_msgs.JointState import JointState
 from dimos.robot.assets.model import RobotModel
 
 config = RobotModelConfig(
@@ -89,7 +94,9 @@ module = ManipulationModule(
     kinematics={"backend": "drake_optimization"}, # Or "jacobian" / "pink"
 )
 module.start()
-module.plan_to_joints([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7])
+module.plan_to_joints(
+    {"arm": JointState(position=[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7])}
+)
 module.execute()  # Sends to coordinator
 ```
 
@@ -118,9 +125,9 @@ DimOS skips parametrization, preserves its timing, and applies the same
 canonical structural validation. This is not fallback: a failure of the
 selected parametrizer never invokes another backend.
 
-Preview and execution both consume the accepted stored trajectory. Execution
-may project globally named joints into each robot's local order, but it does not
-regenerate or retime the trajectory.
+Preview and execution both consume the accepted stored trajectory. The same
+canonical joint names and ordering flow through planning, visualization, and
+coordinator execution without renaming, splitting, or retiming.
 
 When Viser is enabled, its **Next plan speed** slider selects a runtime
 reduction from `0.05` to `1.0`. The value multiplies the configured velocity
@@ -164,12 +171,12 @@ not the collision-checked geometric path.
 `roboplan_toppra` can parametrize a geometric path from any planner, but only
 when `world_backend="roboplan"`: it reuses the finalized `RoboPlanWorld` model
 and planning groups. Selecting it with another world fails during startup.
-DimOS pins RoboPlan to `0.5.1` for this integration.
+DimOS supports RoboPlan `0.6.x` for this integration.
 
 For every selected movable joint, the RoboPlan URDF must provide a finite,
 positive velocity limit. DimOS uses an authored extended acceleration limit
-when present; otherwise it temporarily inserts a global `2.0 rad/s²` fallback
-while composing the RoboPlan model. Formal per-joint acceleration overrides
+when present; otherwise it temporarily inserts a default `2.0 rad/s²` limit
+while preparing the RoboPlan model. Formal per-joint acceleration overrides
 will replace this fallback.
 
 ```xml
@@ -186,7 +193,7 @@ RoboPlan scene limits are authoritative for this backend. The current
 `RobotModelConfig.max_velocity`, `velocity_limits`, and `max_acceleration`
 fields are not substituted when a URDF limit is missing. Missing or invalid
 limits fail plan materialization with the affected joint named. Formal
-globally named per-joint overrides are future work.
+canonical per-joint overrides are future work.
 
 ## RobotModelConfig Fields
 

--- a/dimos/manipulation/planning/groups/models.py
+++ b/dimos/manipulation/planning/groups/models.py
@@ -32,7 +32,7 @@ class PlanningGroupDefinition:
     """Model-level declaration of a planning group.
 
     Joint names are exact canonical model names. The definition is safe to store on
-    ``RobotModelConfig`` and is not bound to any runtime world robot ID.
+    ``RobotModelConfig`` and is selected directly by its declared name.
     """
 
     name: str

--- a/dimos/manipulation/planning/groups/registry.py
+++ b/dimos/manipulation/planning/groups/registry.py
@@ -17,28 +17,21 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import TYPE_CHECKING
 
-from dimos.manipulation.planning.groups.models import PlanningGroup, PlanningGroupSelection
+from dimos.manipulation.planning.groups.models import (
+    PlanningGroup,
+    PlanningGroupDefinition,
+    PlanningGroupSelection,
+)
 from dimos.manipulation.planning.spec.models import PlanningGroupID
-
-if TYPE_CHECKING:
-    from dimos.manipulation.planning.spec.config import RobotModelConfig
 
 
 class PlanningGroupRegistry:
     """Registry of public planning groups derived from one model config."""
 
-    def __init__(self, model_configs: Iterable[RobotModelConfig] = ()) -> None:
+    def __init__(self, definitions: Iterable[PlanningGroupDefinition] = ()) -> None:
         self._groups: dict[PlanningGroupID, PlanningGroup] = {}
-        for config in model_configs:
-            self.add_model(config)
-
-    def add_model(self, config: RobotModelConfig) -> None:
-        """Register all planning groups declared by the model config."""
-        if self._groups:
-            raise ValueError("A model is already registered")
-        for definition in config.planning_groups:
+        for definition in definitions:
             group_id = definition.name
             if group_id in self._groups:
                 raise ValueError(f"Planning group '{group_id}' is already registered")
@@ -52,7 +45,7 @@ class PlanningGroupRegistry:
             self._groups[group_id] = group
 
     def list(self) -> tuple[PlanningGroup, ...]:
-        """List planning groups in robot registration order."""
+        """List planning groups in declaration order."""
         return tuple(self._groups.values())
 
     def get(self, group_id: PlanningGroupID) -> PlanningGroup:

--- a/dimos/manipulation/planning/groups/test_planning_groups.py
+++ b/dimos/manipulation/planning/groups/test_planning_groups.py
@@ -32,7 +32,6 @@ from dimos.manipulation.planning.groups.utils import (
     filter_joint_state_to_selected_joints,
     joint_state_to_ordered_positions,
     normalize_joint_target,
-    planning_group_id_from_selector,
 )
 from dimos.manipulation.planning.spec.config import RobotModelConfig
 from dimos.msgs.sensor_msgs.JointState import JointState
@@ -127,7 +126,7 @@ def test_discovery_rejects_missing_explicit_srdf(tmp_path: Path) -> None:
 
 
 def test_registry_uses_stable_unprefixed_ids_and_canonical_joints() -> None:
-    registry = PlanningGroupRegistry([_config()])
+    registry = PlanningGroupRegistry(_config().planning_groups)
     assert [group.id for group in registry.list()] == ["left_arm", "right_arm"]
     assert registry.get("left_arm").joint_names == ("left/j1", "left/j2")
     assert registry.default_group_id() is None
@@ -137,14 +136,14 @@ def test_registry_uses_stable_unprefixed_ids_and_canonical_joints() -> None:
 
 def test_registry_default_requires_exactly_one_compatible_group() -> None:
     registry = PlanningGroupRegistry(
-        [_config([PlanningGroupDefinition("arm", ("left/j1",), "base", "tool")])]
+        _config([PlanningGroupDefinition("arm", ("left/j1",), "base", "tool")]).planning_groups
     )
     assert registry.default_group_id() == "arm"
     assert registry.primary_pose_group_id() == "arm"
 
 
 def test_selection_preserves_order_and_rejects_overlap() -> None:
-    registry = PlanningGroupRegistry([_config()])
+    registry = PlanningGroupRegistry(_config().planning_groups)
     selection = registry.select(("right_arm", "left_arm"))
     assert selection.group_ids == ("right_arm", "left_arm")
     assert selection.joint_names == ("right/j1", "left/j1", "left/j2")
@@ -156,7 +155,7 @@ def test_selection_preserves_order_and_rejects_overlap() -> None:
         ]
     )
     with pytest.raises(ValueError, match="overlap"):
-        PlanningGroupRegistry([overlap]).select(("one", "two"))
+        PlanningGroupRegistry(overlap.planning_groups).select(("one", "two"))
 
 
 def test_normalize_joint_target_accepts_exact_or_unnamed_target() -> None:
@@ -185,20 +184,3 @@ def test_state_projection_requires_exact_canonical_names() -> None:
     ).tolist() == [1.0, 2.0, 3.0]
     with pytest.raises(ValueError, match="missing"):
         filter_joint_state_to_selected_joints(state, ("missing",))
-
-
-def test_selector_accepts_id_or_group() -> None:
-    group = PlanningGroup("arm", ("left/j1",), "base", "tool")
-    assert planning_group_id_from_selector("arm") == "arm"
-    assert planning_group_id_from_selector(group) == "arm"
-
-
-def test_model_config_rejects_obsolete_name_and_mapping_fields() -> None:
-    base = {
-        "model": RobotModel.from_file(Path("/tmp/model.urdf")),
-        "joint_names": ["joint1"],
-    }
-    with pytest.raises(ValueError):
-        RobotModelConfig(**base, name="arm")
-    with pytest.raises(ValueError):
-        RobotModelConfig(**base, joint_name_mapping={"arm/joint1": "joint1"})

--- a/dimos/manipulation/planning/groups/utils.py
+++ b/dimos/manipulation/planning/groups/utils.py
@@ -20,13 +20,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from dimos.manipulation.planning.groups.models import PlanningGroup
-from dimos.manipulation.planning.spec.models import PlanningGroupID
 from dimos.msgs.sensor_msgs.JointState import JointState
-
-
-def planning_group_id_from_selector(selector: PlanningGroupID | PlanningGroup) -> PlanningGroupID:
-    """Return the planning-group ID represented by a selector."""
-    return selector.id if isinstance(selector, PlanningGroup) else selector
 
 
 def filter_joint_state_to_selected_joints(

--- a/dimos/manipulation/planning/monitor/world_monitor.py
+++ b/dimos/manipulation/planning/monitor/world_monitor.py
@@ -89,7 +89,7 @@ class WorldMonitor:
             self._validate_planning_group_config(config)
             self._world.load_model(config)
             self._model_config = config
-            self._planning_groups.add_model(config)
+            self._planning_groups = PlanningGroupRegistry(config.planning_groups)
 
     @property
     def planning_groups(self) -> PlanningGroupRegistry:

--- a/dimos/manipulation/planning/planners/test_rrt_planner_selection.py
+++ b/dimos/manipulation/planning/planners/test_rrt_planner_selection.py
@@ -162,7 +162,7 @@ def test_plan_selected_joint_path_rejects_bad_targets(
     assert message in result.message
 
 
-def test_plan_selected_joint_path_rejects_local_names_for_multi_group_selection() -> None:
+def test_plan_selected_joint_path_rejects_noncanonical_names() -> None:
     selection = PlanningGroupSelection.from_groups(
         (_group("arm", ("joint_a",)), _group("gripper", ("gripper",)))
     )

--- a/dimos/manipulation/planning/spec/config.py
+++ b/dimos/manipulation/planning/spec/config.py
@@ -29,13 +29,12 @@ from dimos.robot.assets.model import RobotModel
 
 
 class RobotModelConfig(ModuleConfig):
-    """Configuration for adding a robot to the world.
+    """Configuration for the logical robot model loaded into the world.
 
     Attributes:
         model: Portable robot model loaded by backend adapters
         srdf_path: Optional path to SRDF file containing planning group definitions
-        base_pose: Placement transform. This is the canonical world placement for
-            robot instances.
+        base_pose: Placement transform for the model's base link in the world.
         joint_names: Ordered list of controllable joints in the canonical model
             namespace. This is not a planning group.
         base_link: Robot-scoped link that base_pose places in the world and

--- a/dimos/manipulation/planning/spec/protocols.py
+++ b/dimos/manipulation/planning/spec/protocols.py
@@ -105,7 +105,7 @@ class WorldSpec(Protocol):
 
     # Lifecycle
     def finalize(self) -> None:
-        """Finalize the world. Must be called after adding robots."""
+        """Finalize the world after loading the model."""
         ...
 
     @property
@@ -226,7 +226,7 @@ class VisualizationSpec(Protocol):
     def animate_trajectory(
         self, trajectory: JointTrajectory, duration: float | None = None
     ) -> None:
-        """Animate a raw globally named trajectory."""
+        """Animate a raw canonical trajectory."""
         ...
 
     def cancel_preview_animation(self) -> None:

--- a/dimos/manipulation/planning/spec/test_config.py
+++ b/dimos/manipulation/planning/spec/test_config.py
@@ -14,30 +14,10 @@
 
 from pathlib import Path
 
-from pydantic import ValidationError
-import pytest
-
 from dimos.core.coordination.blueprint_config.parser import BlueprintConfigParser
 from dimos.manipulation.manipulation_module import ManipulationModule
 from dimos.manipulation.planning.spec.config import RobotModelConfig
 from dimos.robot.assets.model import RobotModel
-
-
-@pytest.mark.parametrize(
-    "obsolete_field",
-    ["model_path", "urdf_path", "package_paths", "xacro_args", "urdf_processors"],
-)
-def test_robot_model_config_rejects_obsolete_description_fields(
-    obsolete_field: str,
-) -> None:
-    with pytest.raises(ValidationError):
-        RobotModelConfig.model_validate(
-            {
-                "model": RobotModel.from_file("robot.urdf"),
-                "joint_names": [],
-                obsolete_field: Path("obsolete.urdf"),
-            }
-        )
 
 
 def test_robot_model_survives_blueprint_config_round_trip(tmp_path: Path) -> None:

--- a/dimos/manipulation/planning/trajectory_generator/test_roboplan_toppra_parametrizer.py
+++ b/dimos/manipulation/planning/trajectory_generator/test_roboplan_toppra_parametrizer.py
@@ -79,8 +79,6 @@ def _model(*, unbounded_acceleration: bool = False) -> RoboPlanModel:
     return RoboPlanModel(
         scene=_Scene(unbounded_acceleration=unbounded_acceleration),
         groups={frozenset(group.group_ids): group},
-        native_joints={},
-        native_links={},
         all_group=group,
     )
 

--- a/dimos/manipulation/planning/world/drake_world.py
+++ b/dimos/manipulation/planning/world/drake_world.py
@@ -1061,7 +1061,7 @@ class DrakeWorld(WorldSpec, VisualizationSpec):
         return self.get_group_jacobian(ctx, group_id)
 
     def get_group_jacobian(self, ctx: Context, group_id: PlanningGroupID) -> NDArray[np.float64]:
-        """Get geometric Jacobian (6 x group joints) in group-local order."""
+        """Get geometric Jacobian (6 x group joints) in planning-group order."""
         with self._lock:
             self._require_finalized()
             return self._get_group_jacobian(ctx, group_id)

--- a/dimos/manipulation/planning/world/roboplan_model.py
+++ b/dimos/manipulation/planning/world/roboplan_model.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Private composite-model construction for :mod:`roboplan_world`."""
+"""Private prepared-model construction for :mod:`roboplan_world`."""
 
 from __future__ import annotations
 
@@ -39,7 +39,7 @@ ROBOPLAN_WORLD_FRAME = "dimos_world"
 _ROOT_LINK = ROBOPLAN_WORLD_FRAME
 _ROOT_JOINT = "dimos_world_joint"
 _FREE_ROOTS = {"world", "map", _ROOT_LINK}
-# TODO: Remove this global fallback when formal per-joint acceleration overrides are available.
+# TODO: Remove this default when formal per-joint acceleration overrides are available.
 _DEFAULT_ACCELERATION_LIMIT = 2.0
 _REFERENCE_ATTRIBUTES = (
     "reference",
@@ -50,12 +50,7 @@ _REFERENCE_ATTRIBUTES = (
     "parent_frame_id",
     "child_frame_id",
 )
-_MODEL_KEY = "model"
 _MODEL_NAME = "dimos_model"
-
-
-class _BuildRobot(Protocol):
-    config: RobotModelConfig
 
 
 class _SceneFactory(Protocol):
@@ -86,130 +81,93 @@ class RoboPlanGroup:
 
 @dataclass(frozen=True)
 class RoboPlanModel:
-    """The scene and small amount of mapping state needed by its adapter."""
+    """The scene and backend planning-group layouts needed by its adapter."""
 
     scene: Any
     groups: Mapping[frozenset[PlanningGroupID], RoboPlanGroup]
-    native_joints: Mapping[str, str]
-    native_links: Mapping[str, str]
     all_group: RoboPlanGroup
 
-    def native_joint(self, canonical_name: str) -> str:
-        return self.native_joints[canonical_name]
-
-    def native_link(self, canonical_name: str) -> str:
-        return self.native_links[canonical_name]
-
 
 @dataclass(frozen=True)
-class _NameMap:
-    links: Mapping[str, str]
-    joints: Mapping[str, str]
-    materials: Mapping[str, str]
-    frames: Mapping[str, str]
-
-
-@dataclass(frozen=True)
-class _Composed:
+class _PreparedModel:
     xml: str
-    maps: Mapping[str, _NameMap]
     adjacent_links: tuple[tuple[str, str], ...]
 
 
 def build_roboplan_model(
-    robot: _BuildRobot,
+    config: RobotModelConfig,
     registry: PlanningGroupRegistry,
     scene_factory: _SceneFactory,
 ) -> RoboPlanModel:
-    """Build one composite scene transactionally."""
-    prepared = [
-        (
-            robot,
-            prepare_urdf_for_drake(
-                robot.config.model.load(),
-                convert_meshes=robot.config.auto_convert_meshes,
-            ),
-        )
-    ]
-    composed = _compose(prepared, False)
-    groups, all_group = _groups(robot, registry, composed.maps)
-    srdf = _srdf(_MODEL_NAME, [robot], groups, composed)
-    package_paths = [str(path) for path in prepared[0][1].package_paths.values()]
+    """Build the configured model scene transactionally."""
+    description = prepare_urdf_for_drake(
+        config.model.load(),
+        convert_meshes=config.auto_convert_meshes,
+    )
+    prepared = _prepare_model(config, description)
+    groups, all_group = _groups(config, registry)
+    srdf = _srdf(_MODEL_NAME, config, groups, prepared)
+    package_paths = [str(path) for path in description.package_paths.values()]
     scene = scene_factory(
         name=_MODEL_NAME,
-        urdf=composed.xml,
+        urdf=prepared.xml,
         srdf=srdf,
         package_paths=package_paths,
     )
     groups = _validate_group_order(scene, groups)
     all_group = groups[frozenset(all_group.group_ids)]
     _apply_collision_exclusions(scene, srdf)
-    mapping = composed.maps[_MODEL_KEY]
     return RoboPlanModel(
         scene=scene,
         groups=groups,
-        native_joints={name: mapping.joints[name] for name in robot.config.joint_names},
-        native_links=mapping.links,
         all_group=all_group,
     )
 
 
-def _compose(
-    prepared: Sequence[tuple[_BuildRobot, LoadedRobotModel]], composite: bool
-) -> _Composed:
-    result = ET.Element(
-        "robot",
-        {"name": "dimos_composite" if composite else _MODEL_NAME},
-    )
+def _prepare_model(config: RobotModelConfig, description: LoadedRobotModel) -> _PreparedModel:
+    result = ET.Element("robot", {"name": _MODEL_NAME})
     ET.SubElement(result, "link", {"name": _ROOT_LINK})
-    maps: dict[str, _NameMap] = {}
-    used_names: set[str] = {_ROOT_LINK}
-    for robot, description in prepared:
-        config = robot.config
-        root = ET.fromstring(description.xml)
-        if _tag(root.tag) != "robot":
-            raise ValueError("Prepared model is not a URDF robot")
-        _add_missing_acceleration_limits(root)
-        mapping = _name_map(root, _MODEL_KEY, composite)
-        mapped_names = {
-            value
-            for table in (mapping.links, mapping.joints, mapping.materials, mapping.frames)
-            for value in table.values()
+    root = ET.fromstring(description.xml)
+    if _tag(root.tag) != "robot":
+        raise ValueError("Prepared model is not a URDF robot")
+    _add_missing_acceleration_limits(root)
+    names = {
+        tag: {
+            name
+            for element in root.iter()
+            if _tag(element.tag) == tag
+            if (name := element.get("name"))
         }
-        duplicates = used_names & mapped_names
-        if duplicates:
-            raise ValueError(f"Duplicate composed model names: {sorted(duplicates)}")
-        used_names.update(mapped_names)
-        if config.base_link not in mapping.links:
-            raise ValueError(f"Model base link '{config.base_link}' is missing")
-        missing_joints = set(config.joint_names) - set(mapping.joints)
-        if missing_joints:
-            raise ValueError(f"Configured model joints are missing: {sorted(missing_joints)}")
-        authored_root = _authored_root(root, config.base_link, _MODEL_KEY)
-        authored_parent = (
-            _joint_link(authored_root, "parent") if authored_root is not None else None
-        )
-        for element in list(root):
-            if element is authored_root:
-                continue
-            if (
-                authored_parent
-                and _tag(element.tag) == "link"
-                and element.get("name") == authored_parent
-            ):
-                continue
-            copied = ET.fromstring(ET.tostring(element, encoding="unicode"))
-            _rewrite(copied, mapping)
-            result.append(copied)
-        attachment_name = _qualified(_MODEL_KEY, _ROOT_JOINT) if composite else _ROOT_JOINT
-        if attachment_name in used_names:
-            raise ValueError("Model collides with its synthetic attachment name")
-        used_names.add(attachment_name)
-        joint = ET.SubElement(result, "joint", {"name": attachment_name, "type": "fixed"})
-        ET.SubElement(joint, "parent", {"link": _ROOT_LINK})
-        ET.SubElement(joint, "child", {"link": mapping.links[config.base_link]})
-        ET.SubElement(joint, "origin", _pose_attributes(config.base_pose))
-        maps[_MODEL_KEY] = mapping
+        for tag in ("link", "joint", "material", "frame")
+    }
+    all_names = set().union(*names.values())
+    if _ROOT_LINK in all_names:
+        raise ValueError(f"Model collides with synthetic world link '{_ROOT_LINK}'")
+    if config.base_link not in names["link"]:
+        raise ValueError(f"Model base link '{config.base_link}' is missing")
+    missing_joints = set(config.joint_names) - names["joint"]
+    if missing_joints:
+        raise ValueError(f"Configured model joints are missing: {sorted(missing_joints)}")
+    authored_root = _authored_root(root, config.base_link)
+    authored_parent = _joint_link(authored_root, "parent") if authored_root is not None else None
+    for element in list(root):
+        if element is authored_root:
+            continue
+        if (
+            authored_parent
+            and _tag(element.tag) == "link"
+            and element.get("name") == authored_parent
+        ):
+            continue
+        copied = ET.fromstring(ET.tostring(element, encoding="unicode"))
+        _normalize_references(copied, names)
+        result.append(copied)
+    if _ROOT_JOINT in all_names:
+        raise ValueError("Model collides with its synthetic attachment name")
+    joint = ET.SubElement(result, "joint", {"name": _ROOT_JOINT, "type": "fixed"})
+    ET.SubElement(joint, "parent", {"link": _ROOT_LINK})
+    ET.SubElement(joint, "child", {"link": config.base_link})
+    ET.SubElement(joint, "origin", _pose_attributes(config.base_pose))
     adjacent: list[tuple[str, str]] = []
     for joint in result:
         if _tag(joint.tag) != "joint":
@@ -217,9 +175,8 @@ def _compose(
         parent, child = _joint_link(joint, "parent"), _joint_link(joint, "child")
         if parent and child and _ROOT_LINK not in (parent, child):
             adjacent.append((parent, child))
-    return _Composed(
+    return _PreparedModel(
         ET.tostring(result, encoding="unicode", xml_declaration=True),
-        maps,
         tuple(adjacent),
     )
 
@@ -233,19 +190,7 @@ def _add_missing_acceleration_limits(root: ET.Element) -> None:
             limit.set("acceleration", str(_DEFAULT_ACCELERATION_LIMIT))
 
 
-def _name_map(root: ET.Element, model_key: str, prefix: bool) -> _NameMap:
-    def names(tag: str) -> dict[str, str]:
-        return {
-            name: _qualified(model_key, name) if prefix else name
-            for element in root.iter()
-            if _tag(element.tag) == tag
-            if (name := element.get("name"))
-        }
-
-    return _NameMap(names("link"), names("joint"), names("material"), names("frame"))
-
-
-def _authored_root(root: ET.Element, base_link: str, model_key: str) -> ET.Element | None:
+def _authored_root(root: ET.Element, base_link: str) -> ET.Element | None:
     links = {element.get("name") for element in root if _tag(element.tag) == "link"}
     roots = {"world", "map", root.get("name", "")} & links | {"world", "map"}
     matches = [
@@ -256,46 +201,32 @@ def _authored_root(root: ET.Element, base_link: str, model_key: str) -> ET.Eleme
         if _joint_link(joint, "child") == base_link
     ]
     if len(matches) > 1:
-        raise ValueError(f"Model '{model_key}' has ambiguous world attachment")
+        raise ValueError("Model has ambiguous world attachment")
     if not matches:
         return None
     if matches[0].get("type") != "fixed":
-        raise ValueError(f"Model '{model_key}' world attachment must be fixed")
+        raise ValueError("Model world attachment must be fixed")
     return matches[0]
 
 
-def _rewrite(element: ET.Element, mapping: _NameMap) -> None:
+def _normalize_references(element: ET.Element, names: Mapping[str, set[str]]) -> None:
     element.tag = _tag(element.tag)
-    tables = {
-        "link": mapping.links,
-        "joint": mapping.joints,
-        "material": mapping.materials,
-        "frame": mapping.frames,
-    }
-    name = element.get("name")
-    if name and element.tag in tables and name in tables[element.tag]:
-        element.set("name", tables[element.tag][name])
-    for attribute, table in (("link", mapping.links), ("joint", mapping.joints)):
+    for attribute in ("link", "joint"):
         value = element.get(attribute)
-        if value is not None and value in table:
-            element.set(attribute, table[value])
-        elif value is not None and value not in table.values() and value not in _FREE_ROOTS:
+        if value is not None and value not in names[attribute] and value not in _FREE_ROOTS:
             raise ValueError(f"Unresolved URDF {attribute} reference: {value}")
-    references = {**mapping.links, **mapping.joints, **mapping.frames}
+    references = names["link"] | names["joint"] | names["frame"]
     for attribute in _REFERENCE_ATTRIBUTES:
         value = element.get(attribute)
-        if value in references:
-            element.set(attribute, references[value])
-        elif value is not None and value not in references.values() and value not in _FREE_ROOTS:
+        if value is not None and value not in references and value not in _FREE_ROOTS:
             raise ValueError(f"Unresolved URDF reference '{attribute}': {value}")
     for child in element:
-        _rewrite(child, mapping)
+        _normalize_references(child, names)
 
 
 def _groups(
-    robot: _BuildRobot,
+    config: RobotModelConfig,
     registry: PlanningGroupRegistry,
-    maps: Mapping[str, _NameMap],
 ) -> tuple[
     dict[frozenset[PlanningGroupID], RoboPlanGroup],
     RoboPlanGroup,
@@ -303,21 +234,20 @@ def _groups(
     groups: dict[frozenset[PlanningGroupID], RoboPlanGroup] = {}
     configured = registry.list()
     for group in configured:
-        layout = _group_layout((group,), maps)
+        layout = _group_layout((group,))
         groups[frozenset(layout.group_ids)] = layout
     for size in range(2, len(configured) + 1):
         for selected in itertools.combinations(configured, size):
             joint_names = tuple(name for group in selected for name in group.joint_names)
             if len(joint_names) != len(set(joint_names)):
                 continue
-            layout = _group_layout(selected, maps)
+            layout = _group_layout(selected)
             groups[frozenset(layout.group_ids)] = layout
     all_id = "__dimos_all_configured__"
-    config = robot.config
     all_group = RoboPlanGroup(
         (all_id,),
         all_id,
-        tuple(maps[_MODEL_KEY].joints[name] for name in config.joint_names),
+        tuple(config.joint_names),
         tuple(config.joint_names),
     )
     groups[frozenset(all_group.group_ids)] = all_group
@@ -329,45 +259,47 @@ def _groups(
 
 def _group_layout(
     selected: Sequence[PlanningGroup],
-    maps: Mapping[str, _NameMap],
 ) -> RoboPlanGroup:
     ids = tuple(group.id for group in selected)
     return RoboPlanGroup(
         ids,
         _composite_group_name(ids) if len(selected) > 1 else selected[0].id,
-        tuple(maps[_MODEL_KEY].joints[name] for group in selected for name in group.joint_names),
+        tuple(name for group in selected for name in group.joint_names),
         tuple(name for group in selected for name in group.joint_names),
     )
 
 
 def _srdf(
     model_name: str,
-    robots: Sequence[_BuildRobot],
+    config: RobotModelConfig,
     groups: Mapping[frozenset[PlanningGroupID], RoboPlanGroup],
-    composed: _Composed,
+    prepared: _PreparedModel,
 ) -> str:
     lines = [f'<robot name="{escape(model_name)}">']
     for group in groups.values():
         lines.append(f'  <group name="{escape(group.name)}">')
         lines.extend(f'    <joint name="{escape(name)}"/>' for name in group.native_names)
         lines.append("  </group>")
-    pairs = {tuple(sorted(pair)) for pair in composed.adjacent_links if _ROOT_LINK not in pair}
-    for robot in robots:
-        config = robot.config
-        mapping = composed.maps[_MODEL_KEY]
-        configured = list(config.collision_exclusion_pairs)
-        if config.srdf_path is not None:
-            configured.extend(_source_exclusions(config.srdf_path))
-        for first, second in configured:
-            first_exists = first in mapping.links
-            second_exists = second in mapping.links
-            if not first_exists and not second_exists:
-                continue
-            if not first_exists or not second_exists:
-                raise ValueError(
-                    f"Model collision exclusion references unknown links: {first} <-> {second}"
-                )
-            pairs.add(tuple(sorted((mapping.links[first], mapping.links[second]))))
+    pairs = {tuple(sorted(pair)) for pair in prepared.adjacent_links if _ROOT_LINK not in pair}
+    links = {
+        name
+        for element in ET.fromstring(prepared.xml).iter()
+        if _tag(element.tag) == "link"
+        if (name := element.get("name"))
+    }
+    configured = list(config.collision_exclusion_pairs)
+    if config.srdf_path is not None:
+        configured.extend(_source_exclusions(config.srdf_path))
+    for first, second in configured:
+        first_exists = first in links
+        second_exists = second in links
+        if not first_exists and not second_exists:
+            continue
+        if not first_exists or not second_exists:
+            raise ValueError(
+                f"Model collision exclusion references unknown links: {first} <-> {second}"
+            )
+        pairs.add(tuple(sorted((first, second))))
     lines.extend(
         f'  <disable_collisions link1="{escape(first)}" link2="{escape(second)}" '
         'reason="DimOS configured"/>'
@@ -385,7 +317,7 @@ def _validate_group_order(
     for key, group in groups.items():
         reported = tuple(scene.getJointGroupInfo(group.name).joint_names)
         if len(reported) != len(set(reported)) or set(reported) != set(group.native_names):
-            raise ValueError(f"RoboPlan group '{group.name}' does not match the composed model")
+            raise ValueError(f"RoboPlan group '{group.name}' does not match the prepared model")
         public_by_native = dict(zip(group.native_names, group.public_names, strict=True))
         validated[key] = replace(
             group,
@@ -444,10 +376,6 @@ def _joint_link(joint: ET.Element | None, tag: str) -> str | None:
         (child.get("link") for child in joint if _tag(child.tag) == tag),
         None,
     )
-
-
-def _qualified(model_key: str, local_name: str) -> str:
-    return f"{_safe(model_key)}__{_safe(local_name)}"
 
 
 def _safe(value: str) -> str:

--- a/dimos/manipulation/planning/world/roboplan_world.py
+++ b/dimos/manipulation/planning/world/roboplan_world.py
@@ -71,7 +71,7 @@ logger = setup_logger()
 
 
 @dataclass
-class _RoboPlanRobotData:
+class _RoboPlanModelData:
     config: RobotModelConfig
     lower_limits: NDArray[np.float64] | None = None
     upper_limits: NDArray[np.float64] | None = None
@@ -94,7 +94,7 @@ class RoboPlanWorld:
         if enable_viz:
             logger.warning("RoboPlanWorld does not currently provide manipulation visualization")
 
-        self._model_data: _RoboPlanRobotData | None = None
+        self._model_data: _RoboPlanModelData | None = None
         self._planning_groups = PlanningGroupRegistry()
         self._obstacles: dict[str, Obstacle] = {}
         self._has_authoritative_state = False
@@ -109,14 +109,14 @@ class RoboPlanWorld:
     def load_model(self, config: RobotModelConfig) -> None:
         """Register the logical robot model for :meth:`finalize`."""
         if self._finalized:
-            raise RuntimeError("Cannot add robot after world is finalized")
+            raise RuntimeError("Cannot load a model after the world is finalized")
         if self._model_data is not None:
             raise ValueError("A model is already loaded")
         validate_robot_model_config(config)
         self._validate_planning_group_config(config)
-        self._validate_robot_config(config)
-        self._model_data = _RoboPlanRobotData(config=config)
-        self._planning_groups.add_model(config)
+        self._validate_model_config(config)
+        self._model_data = _RoboPlanModelData(config=config)
+        self._planning_groups = PlanningGroupRegistry(config.planning_groups)
         self._live_context.q = np.zeros(len(config.joint_names), dtype=np.float64)
 
     def get_model_config(self) -> RobotModelConfig:
@@ -124,11 +124,11 @@ class RoboPlanWorld:
         return self._get_model_data().config
 
     def get_joint_limits(self) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
-        """Get joint limits in DimOS joint order."""
-        robot = self._get_model_data()
-        if robot.lower_limits is None or robot.upper_limits is None:
+        """Get joint limits in canonical model order."""
+        model_data = self._get_model_data()
+        if model_data.lower_limits is None or model_data.upper_limits is None:
             raise RuntimeError("Joint limits are available after RoboPlan finalization")
-        return robot.lower_limits.copy(), robot.upper_limits.copy()
+        return model_data.lower_limits.copy(), model_data.upper_limits.copy()
 
     def ordered_joint_positions(self, joint_state: JointState) -> NDArray[np.float64]:
         """Return a canonical joint state in configured model order."""
@@ -148,8 +148,8 @@ class RoboPlanWorld:
         return self._require_model().all_group
 
     def native_link_name(self, canonical_name: str) -> str:
-        """Return the backend link name for a canonical model link."""
-        return self._require_model().native_link(canonical_name)
+        """Return a canonical model link name for the backend."""
+        return canonical_name
 
     # Obstacle Management
 
@@ -241,18 +241,18 @@ class RoboPlanWorld:
             if self._finalized:
                 return
             model = build_roboplan_model(
-                self._get_model_data(),
+                self._get_model_data().config,
                 self._planning_groups,
                 roboplan_core.Scene,
             )
             self._model = model
             self._scene = model.scene
             try:
-                robot = self._get_model_data()
+                model_data = self._get_model_data()
                 group = model.all_group
-                lower, upper = self._extract_joint_limits(robot.config, group)
-                robot.lower_limits = lower
-                robot.upper_limits = upper
+                lower, upper = self._extract_joint_limits(model_data.config, group)
+                model_data.lower_limits = lower
+                model_data.upper_limits = upper
                 for obstacle_id, obstacle in self._obstacles.items():
                     self._add_obstacle_to_scene(obstacle, obstacle_id)
             except BaseException:
@@ -299,11 +299,11 @@ class RoboPlanWorld:
 
     def get_joint_state(self, ctx: RoboPlanContext) -> JointState:
         """Get robot joint state from a context."""
-        robot = self._get_model_data()
+        model_data = self._get_model_data()
         q = ctx.q
         if not len(q):
-            q = np.zeros(len(robot.config.joint_names), dtype=np.float64)
-        return JointState(name=robot.config.joint_names, position=q.astype(float).tolist())
+            q = np.zeros(len(model_data.config.joint_names), dtype=np.float64)
+        return JointState(name=model_data.config.joint_names, position=q.astype(float).tolist())
 
     # Collision Checking
 
@@ -343,8 +343,8 @@ class RoboPlanWorld:
 
     def get_ee_pose(self, ctx: RoboPlanContext) -> PoseStamped:
         """Get end-effector pose if RoboPlan exposes FK."""
-        robot = self._get_model_data()
-        group_id = self._primary_pose_group_id_for_config(robot.config)
+        model_data = self._get_model_data()
+        group_id = self._primary_pose_group_id_for_config(model_data.config)
         if group_id is None:
             raise ValueError("Model has no pose-targetable planning group")
         return self.get_group_ee_pose(ctx, group_id)
@@ -376,15 +376,15 @@ class RoboPlanWorld:
             scene.setJointPositions(scene_q)
             result = scene.forwardKinematics(
                 scene_q,
-                self._require_model().native_link(link_name),
+                link_name,
                 "",
             )
         return np.asarray(result, dtype=np.float64)
 
     def get_jacobian(self, ctx: RoboPlanContext) -> NDArray[np.float64]:
         """Get end-effector Jacobian if RoboPlan exposes a compatible API."""
-        robot = self._get_model_data()
-        group_id = self._primary_pose_group_id_for_config(robot.config)
+        model_data = self._get_model_data()
+        group_id = self._primary_pose_group_id_for_config(model_data.config)
         if group_id is None:
             raise ValueError("Model has no pose-targetable planning group")
         return self.get_group_jacobian(ctx, group_id)
@@ -392,18 +392,17 @@ class RoboPlanWorld:
     def get_group_jacobian(
         self, ctx: RoboPlanContext, group_id: PlanningGroupID
     ) -> NDArray[np.float64]:
-        """Get planning-group Jacobian projected to group-local joint order."""
+        """Get a planning-group Jacobian in planning-group joint order."""
         group = self._planning_group_from_id(group_id)
         if group.tip_link is None:
             raise ValueError(f"Planning group '{group_id}' has no tip link")
         scene = self._require_scene()
-        model = self._require_model()
         with self._lock:
             scene_q = self._full_scene_q(ctx)
             scene.setJointPositions(scene_q)
             result = scene.computeFrameJacobian(
                 scene_q,
-                model.native_link(group.tip_link),
+                group.tip_link,
                 True,
             )
         arr = np.asarray(result, dtype=np.float64)
@@ -411,15 +410,14 @@ class RoboPlanWorld:
             raise ValueError(f"Unexpected RoboPlan Jacobian shape: {arr.shape}; expected 6 x n")
         scene_joint_order = list(scene.getJointNames())
         if arr.shape[1] == len(scene_joint_order):
-            native_names = [model.native_joint(name) for name in group.joint_names]
-            return arr[:, [scene_joint_order.index(name) for name in native_names]]
+            return arr[:, [scene_joint_order.index(name) for name in group.joint_names]]
         raise ValueError(
             f"Unexpected RoboPlan Jacobian shape: {arr.shape}; cannot project group '{group_id}'"
         )
 
     # PlannerSpec for native RoboPlan planning
 
-    def _validate_robot_config(self, config: RobotModelConfig) -> None:
+    def _validate_model_config(self, config: RobotModelConfig) -> None:
         if not config.joint_names:
             raise ValueError("RoboPlanWorld requires explicit joint_names")
         if config.base_pose.frame_id not in ("", "world"):
@@ -436,20 +434,10 @@ class RoboPlanWorld:
             lower, upper = scene.getPositionLimitVectors(group.name, False)
             lower = np.asarray(lower, dtype=np.float64)
             upper = np.asarray(upper, dtype=np.float64)
-            native_names = tuple(scene.getJointGroupInfo(group.name).joint_names)
-            native_to_canonical = {
-                native: canonical
-                for canonical, native in self._require_model().native_joints.items()
-            }
-            try:
-                canonical_names = tuple(native_to_canonical[name] for name in native_names)
-            except KeyError as exc:
-                raise ValueError(
-                    f"RoboPlan joint-limit group contains unknown native joint '{exc.args[0]}'"
-                ) from exc
+            canonical_names = tuple(scene.getJointGroupInfo(group.name).joint_names)
             if set(canonical_names) != set(config.joint_names):
                 raise ValueError(
-                    "RoboPlan joint-limit group does not match the composed model: "
+                    "RoboPlan joint-limit group does not match the prepared model: "
                     f"{sorted(canonical_names)} != {sorted(config.joint_names)}"
                 )
             by_name = dict(zip(canonical_names, zip(lower, upper, strict=True), strict=True))
@@ -463,7 +451,7 @@ class RoboPlanWorld:
 
     def _validate_planning_group_config(self, config: RobotModelConfig) -> None:
         """Validate planning groups before mutating backend state."""
-        PlanningGroupRegistry([config])
+        PlanningGroupRegistry(config.planning_groups)
 
     def _planning_group_from_id(self, group_id: PlanningGroupID) -> PlanningGroup:
         return self._planning_groups.get(group_id)
@@ -471,16 +459,16 @@ class RoboPlanWorld:
     def _primary_pose_group_id_for_config(self, config: RobotModelConfig) -> PlanningGroupID | None:
         return self._planning_groups.primary_pose_group_id()
 
-    def _get_model_data(self) -> _RoboPlanRobotData:
+    def _get_model_data(self) -> _RoboPlanModelData:
         if self._model_data is None:
             raise RuntimeError("Model is not loaded")
         return self._model_data
 
     def _joint_state_to_q(self, joint_state: JointState) -> NDArray[np.float64]:
-        robot = self._get_model_data()
+        model_data = self._get_model_data()
         return joint_state_to_ordered_positions(
             joint_state,
-            joint_names=robot.config.joint_names,
+            joint_names=model_data.config.joint_names,
         )
 
     def _require_finalized(self) -> None:
@@ -527,11 +515,11 @@ class RoboPlanWorld:
         overlay: NDArray[np.float64] | None = None,
     ) -> dict[str, float]:
         context = ctx if ctx is not None else self._live_context
-        robot = self._get_model_data()
+        model_data = self._get_model_data()
         q = overlay if overlay is not None else context.q
-        if len(q) != len(robot.config.joint_names):
+        if len(q) != len(model_data.config.joint_names):
             raise RuntimeError("Missing authoritative model state")
-        return dict(zip(robot.config.joint_names, map(float, q), strict=True))
+        return dict(zip(model_data.config.joint_names, map(float, q), strict=True))
 
     def _has_collisions(
         self,

--- a/dimos/manipulation/test_generated_plan_materialization.py
+++ b/dimos/manipulation/test_generated_plan_materialization.py
@@ -109,7 +109,7 @@ def _module(monkeypatch: pytest.MonkeyPatch, module_factory):
     module._world_monitor = MagicMock()
     module._world_monitor.world = MagicMock()
     module._world_monitor.world.get_model_config.return_value = model
-    module._world_monitor.planning_groups = PlanningGroupRegistry([model])
+    module._world_monitor.planning_groups = PlanningGroupRegistry(model.planning_groups)
     module._planner = MagicMock()
     module._trajectory_parametrizer = SimpleTrapezoidParametrizer(
         SimpleTrapezoidParametrizationConfig()

--- a/dimos/manipulation/test_manipulation_module.py
+++ b/dimos/manipulation/test_manipulation_module.py
@@ -187,9 +187,9 @@ class TestManipulationModuleIntegration:
         """Test planning to an explicit planning-group joint target."""
         module._on_joint_state(joint_state_zeros)
 
-        success = module.plan_to_joint_targets({"manipulator": JointState(position=[0.05] * 7)})
+        result = module.plan_to_joints({"manipulator": JointState(position=[0.05] * 7)})
 
-        assert success is True
+        assert result.is_success()
         assert module._state == ManipulationState.COMPLETED
         assert module._last_plan is not None
         assert module._last_plan.group_ids == ("manipulator",)
@@ -217,10 +217,10 @@ class TestManipulationModuleIntegration:
         info = module.get_model_info()
 
         assert len(info["joint_names"]) == 7
-        assert info["end_effector_link"] == "link7"
         groups = info["planning_groups"]
         assert len(groups) == 1
         assert groups[0].id == "manipulator"
+        assert groups[0].tip_frame == "link7"
 
         all_groups = module.list_planning_groups()
         assert [group.id for group in all_groups] == ["manipulator"]

--- a/dimos/manipulation/test_manipulation_monitor_preview.py
+++ b/dimos/manipulation/test_manipulation_monitor_preview.py
@@ -78,7 +78,7 @@ def _install_generated_plan(
 ) -> None:
     """Install a canonical generated plan and monitor state."""
     module._world_monitor = MagicMock()
-    module._world_monitor.planning_groups = PlanningGroupRegistry([config])
+    module._world_monitor.planning_groups = PlanningGroupRegistry(config.planning_groups)
     module._world_monitor.get_current_joint_state.return_value = JointState(
         name=config.joint_names,
         position=[0.0 for _ in config.joint_names],

--- a/dimos/manipulation/test_manipulation_primitives.py
+++ b/dimos/manipulation/test_manipulation_primitives.py
@@ -80,7 +80,7 @@ def _plan() -> GeneratedPlan:
 def _set_groups(module, model: RobotModelConfig) -> None:
     module.config.model = model
     module._world_monitor = MagicMock()
-    module._world_monitor.planning_groups = PlanningGroupRegistry((model,))
+    module._world_monitor.planning_groups = PlanningGroupRegistry(model.planning_groups)
 
 
 def test_move_linear_uses_world_relative_target_and_default_speed(

--- a/dimos/manipulation/test_manipulation_unit.py
+++ b/dimos/manipulation/test_manipulation_unit.py
@@ -136,7 +136,7 @@ def _install_generated_plan(
     """Install a canonical generated plan and current model state."""
     module.config.model = config
     module._world_monitor = MagicMock()
-    module._world_monitor.planning_groups = PlanningGroupRegistry([config])
+    module._world_monitor.planning_groups = PlanningGroupRegistry(config.planning_groups)
     module._world_monitor.current_model_joint_state.return_value = JointState(
         name=config.joint_names,
         position=[0.0 for _ in config.joint_names],
@@ -578,13 +578,13 @@ class TestPlanningInitialization:
         module._world_monitor = MagicMock()
         module._world_monitor.world = MagicMock()
         module._world_monitor.world.get_model_config.return_value = robot_config
-        module._world_monitor.planning_groups = PlanningGroupRegistry([robot_config])
+        module._world_monitor.planning_groups = PlanningGroupRegistry(robot_config.planning_groups)
         current = JointState(name=robot_config.joint_names, position=[0.0, 0.0, 0.0])
-        current_global = JointState(
+        current_model_state = JointState(
             name=["joint1", "joint2", "joint3"],
             position=[0.0, 0.0, 0.0],
         )
-        module._world_monitor.current_model_joint_state.return_value = current_global
+        module._world_monitor.current_model_joint_state.return_value = current_model_state
         expected = IKResult(
             status=IKStatus.SUCCESS,
             joint_state=JointState(name=robot_config.joint_names, position=[0.1, 0.2, 0.3]),
@@ -605,7 +605,7 @@ class TestPlanningInitialization:
         module._kinematics.solve_pose_targets.assert_called_once()
         _, kwargs = module._kinematics.solve_pose_targets.call_args
         assert kwargs["world"] is module._world_monitor.world
-        assert kwargs["seed"].name == current_global.name
+        assert kwargs["seed"].name == current_model_state.name
         assert kwargs["seed"].position == current.position
         assert kwargs["check_collision"] is True
         [(group, target_pose)] = kwargs["pose_targets"].items()
@@ -619,7 +619,7 @@ class TestPlanningInitialization:
         module.config.model = robot_config
         module.config.model = robot_config
         module._world_monitor = MagicMock()
-        module._world_monitor.planning_groups = PlanningGroupRegistry([robot_config])
+        module._world_monitor.planning_groups = PlanningGroupRegistry(robot_config.planning_groups)
         module._world_monitor.current_model_joint_state.return_value = JointState(
             name=[], position=[]
         )
@@ -642,7 +642,7 @@ class TestPlanningInitialization:
         module._world_monitor = MagicMock()
         module._world_monitor.world = MagicMock()
         module._world_monitor.world.get_model_config.return_value = robot_config
-        module._world_monitor.planning_groups = PlanningGroupRegistry([robot_config])
+        module._world_monitor.planning_groups = PlanningGroupRegistry(robot_config.planning_groups)
         module._world_monitor.current_model_joint_state.return_value = None
         explicit_seed = JointState(name=robot_config.joint_names, position=[0.2, 0.1, 0.0])
         expected = IKResult(status=IKStatus.SUCCESS, joint_state=explicit_seed)
@@ -664,7 +664,7 @@ class TestPlanningGroupApis:
     def test_list_planning_groups_and_model_info_include_groups(self, robot_config, module_factory):
         module = module_factory()
         module.config.model = robot_config
-        registry = PlanningGroupRegistry([robot_config])
+        registry = PlanningGroupRegistry(robot_config.planning_groups)
         module._world_monitor = MagicMock()
         module._world_monitor.planning_groups = registry
         module._init_joints = None
@@ -674,12 +674,12 @@ class TestPlanningGroupApis:
 
         assert [group.id for group in groups] == ["manipulator"]
         assert info["planning_groups"] == list(groups)
-        assert info["end_effector_link"] == "link_tcp"
+        assert info["planning_groups"][0].tip_frame == "link_tcp"
 
-    def test_plan_to_joint_targets_stores_generated_plan(self, robot_config, module_factory):
+    def test_generate_joint_plan_stores_generated_plan(self, robot_config, module_factory):
         module = module_factory()
         module.config.model = robot_config
-        registry = PlanningGroupRegistry([robot_config])
+        registry = PlanningGroupRegistry(robot_config.planning_groups)
         _enable_simple_parametrization(module)
         module._world_monitor = MagicMock()
         module._world_monitor.world = MagicMock()
@@ -709,7 +709,7 @@ class TestPlanningGroupApis:
             message="ok",
         )
 
-        success = module.plan_to_joint_targets(
+        plan = module.generate_plan_to_joint_targets(
             {
                 "manipulator": JointState(
                     name=robot_config.joint_names,
@@ -718,7 +718,7 @@ class TestPlanningGroupApis:
             }
         )
 
-        assert success is True
+        assert plan is not None
         assert module._last_plan is not None
         assert module._last_plan.group_ids == ("manipulator",)
         assert module._last_plan.path == result_path
@@ -732,7 +732,7 @@ class TestPlanningGroupApis:
             "joint3",
         ]
 
-        success = module.plan_to_joint_targets(
+        plan = module.generate_plan_to_joint_targets(
             {
                 "manipulator": JointState(
                     name=robot_config.joint_names,
@@ -741,15 +741,13 @@ class TestPlanningGroupApis:
             }
         )
 
-        assert success is True
+        assert plan is not None
         assert module._planner.plan_selected_joint_path.call_count == 2
 
-    def test_plan_to_pose_targets_uses_group_ik_and_selected_path(
-        self, robot_config, module_factory
-    ):
+    def test_generate_pose_plan_uses_group_ik_and_selected_path(self, robot_config, module_factory):
         module = module_factory()
         module.config.model = robot_config
-        registry = PlanningGroupRegistry([robot_config])
+        registry = PlanningGroupRegistry(robot_config.planning_groups)
         _enable_simple_parametrization(module)
         module._world_monitor = MagicMock()
         module._world_monitor.world = MagicMock()
@@ -781,9 +779,9 @@ class TestPlanningGroupApis:
         )
         pose = Pose(position=Vector3(x=0.45, y=0.0, z=0.25), orientation=Quaternion())
 
-        success = module.plan_to_pose_targets({"manipulator": pose})
+        plan = module.generate_plan_to_pose_targets({"manipulator": pose})
 
-        assert success is True
+        assert plan is not None
         module._kinematics.solve_pose_targets.assert_called_once()
         _, ik_kwargs = module._kinematics.solve_pose_targets.call_args
         target_groups = list(ik_kwargs["pose_targets"].keys())
@@ -801,7 +799,7 @@ class TestPlanningGroupApis:
     def test_failed_plan_materialization_clears_generated_plan(self, robot_config, module_factory):
         module = module_factory()
         module.config.model = robot_config
-        registry = PlanningGroupRegistry([robot_config])
+        registry = PlanningGroupRegistry(robot_config.planning_groups)
         module._world_monitor = MagicMock()
         module._world_monitor.world = MagicMock()
         module._world_monitor.planning_groups = registry
@@ -840,11 +838,11 @@ class TestPlanningGroupApis:
             ],
         )
 
-        success = module.plan_to_joint_targets(
+        plan = module.generate_plan_to_joint_targets(
             {"manipulator": JointState(position=[0.1, 0.2, 0.3])}
         )
 
-        assert success is False
+        assert plan is None
         assert module._state == ManipulationState.IDLE
         assert module._last_plan is None
         assert module.has_planned_path() is False
@@ -857,7 +855,7 @@ class TestPlanningGroupApis:
         module.config.model = model
         module._init_joints = JointState(name=model.joint_names, position=[0.1, -0.1])
         module._world_monitor = MagicMock(spec=WorldMonitor)
-        module._world_monitor.planning_groups = PlanningGroupRegistry([model])
+        module._world_monitor.planning_groups = PlanningGroupRegistry(model.planning_groups)
         module._world_monitor.current_group_joint_state.return_value = None
         module._world_monitor.get_group_ee_pose.return_value = None
 
@@ -873,7 +871,7 @@ class TestPlanningGroupApis:
         module = module_factory()
         module.config.model = model
         module._world_monitor = MagicMock(spec=WorldMonitor)
-        module._world_monitor.planning_groups = PlanningGroupRegistry([model])
+        module._world_monitor.planning_groups = PlanningGroupRegistry(model.planning_groups)
         module._world_monitor.get_group_ee_pose.side_effect = [
             PoseStamped(position=Vector3(0.4, 0.2, 0.3)),
             PoseStamped(position=Vector3(0.4, -0.2, 0.3)),
@@ -914,7 +912,9 @@ class TestPlanningGroupApis:
         module = module_factory()
         module.config.model = no_pose_config
         module._world_monitor = MagicMock()
-        module._world_monitor.planning_groups = PlanningGroupRegistry([no_pose_config])
+        module._world_monitor.planning_groups = PlanningGroupRegistry(
+            no_pose_config.planning_groups
+        )
         module._world_monitor.get_ee_pose.side_effect = ValueError("no pose group")
         module._kinematics = MagicMock()
 
@@ -952,7 +952,9 @@ class TestPlanningGroupApis:
         module = module_factory()
         module.config.model = multi_pose_config
         module._world_monitor = MagicMock()
-        module._world_monitor.planning_groups = PlanningGroupRegistry([multi_pose_config])
+        module._world_monitor.planning_groups = PlanningGroupRegistry(
+            multi_pose_config.planning_groups
+        )
         module._world_monitor.get_ee_pose.side_effect = ValueError("multiple pose groups")
         module._kinematics = MagicMock()
 
@@ -970,7 +972,7 @@ class TestPlanningGroupApis:
         module.config.model = robot_config
         module._world_monitor = MagicMock()
         module._world_monitor.world = MagicMock()
-        module._world_monitor.planning_groups = PlanningGroupRegistry([robot_config])
+        module._world_monitor.planning_groups = PlanningGroupRegistry(robot_config.planning_groups)
         module._world_monitor.current_model_joint_state.return_value = JointState(
             name=robot_config.joint_names,
             position=[0.0, 0.0, 0.0],
@@ -993,7 +995,7 @@ class TestPlanningDiagnostics:
         module = module_factory()
         module.config.model = robot_config
         module._world_monitor = MagicMock()
-        module._world_monitor.planning_groups = PlanningGroupRegistry([robot_config])
+        module._world_monitor.planning_groups = PlanningGroupRegistry(robot_config.planning_groups)
         module._world_monitor.current_model_joint_state.return_value = JointState(
             name=robot_config.joint_names,
             position=[0.0, 0.0, 0.0],

--- a/dimos/manipulation/test_planning_factory.py
+++ b/dimos/manipulation/test_planning_factory.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Generator
-import inspect
 from pathlib import Path
 import sys
 from types import ModuleType
@@ -29,7 +28,6 @@ import pytest
 from pytest_mock import MockerFixture
 
 from dimos.manipulation.manipulation_module import ManipulationModule, ManipulationModuleConfig
-from dimos.manipulation.pick_and_place_module import PickAndPlaceModule
 from dimos.manipulation.planning.factory import (
     create_kinematics,
     create_planner,
@@ -300,22 +298,9 @@ def test_create_planning_stack_defaults_to_roboplan(
     world.finalize.assert_called_once()
 
 
-def test_configuration_requires_one_model_and_rejects_robots() -> None:
+def test_configuration_requires_one_model() -> None:
     with pytest.raises(ValidationError, match="model"):
         ManipulationModuleConfig()
-    with pytest.raises(ValidationError, match="robots"):
-        ManipulationModuleConfig.model_validate({"robots": []})
-
-
-def test_public_manipulation_surface_has_no_robot_selectors_or_listing_apis() -> None:
-    forbidden_parameters = {"robot_name", "robot_id", "hardware_id"}
-    for module_type in (ManipulationModule, PickAndPlaceModule):
-        for _, method in inspect.getmembers(module_type, inspect.isfunction):
-            if getattr(method, "__rpc__", False):
-                assert forbidden_parameters.isdisjoint(inspect.signature(method).parameters)
-
-    for obsolete_method in ("get_robot_info", "list_robots", "preview_path"):
-        assert not hasattr(ManipulationModule, obsolete_method)
 
 
 def test_start_uses_configured_planner_and_kinematics(

--- a/dimos/manipulation/test_roboplan.py
+++ b/dimos/manipulation/test_roboplan.py
@@ -680,7 +680,7 @@ def test_scene_joint_limits_validate_joint_names(
     )
     monkeypatch.setattr(FakeScene, "joint_group_joint_names", ["joint2", "extra_joint"])
 
-    with pytest.raises(ValueError, match="does not match the composed model"):
+    with pytest.raises(ValueError, match="does not match the prepared model"):
         _make_world(fake_roboplan, config)
 
 

--- a/dimos/manipulation/test_roboplan.py
+++ b/dimos/manipulation/test_roboplan.py
@@ -568,10 +568,10 @@ def test_roboplan_loads_canonical_slash_names_natively(
 
 
 def _selection(
-    configs: tuple[RobotModelConfig, ...],
+    config: RobotModelConfig,
     *group_ids: str,
 ) -> PlanningGroupSelection:
-    registry = PlanningGroupRegistry(configs)
+    registry = PlanningGroupRegistry(config.planning_groups)
     return PlanningGroupSelection.from_groups(
         tuple(registry.get(group_id) for group_id in group_ids)
     )
@@ -1665,11 +1665,11 @@ def test_native_planner_names_path_from_robot_config_when_start_is_unnamed(
     assert [state.name for state in result.path] == [["joint1", "joint2"]] * 3
 
 
-def test_native_selected_planner_returns_global_selected_joint_names(
+def test_native_selected_planner_returns_canonical_selected_joint_names(
     fake_roboplan: None, robot_config: RobotModelConfig
 ) -> None:
     world = _make_world(fake_roboplan, robot_config)
-    selection = _selection((robot_config,), "manipulator")
+    selection = _selection(robot_config, "manipulator")
 
     result = _planner_for(world).plan_selected_joint_path(
         world,
@@ -1690,7 +1690,7 @@ def test_native_selected_planner_uses_explicit_start_after_live_state_advances(
     mocker: MockerFixture,
 ) -> None:
     world = _make_world(fake_roboplan, robot_config)
-    selection = _selection((robot_config,), "manipulator")
+    selection = _selection(robot_config, "manipulator")
     observed_scene_start: list[float] = []
     native_plan = FakeRRT.plan
 
@@ -1732,7 +1732,7 @@ def test_native_selected_planner_supports_non_overlapping_multi_group_selection(
         }
     )
     world = _make_world(fake_roboplan, config)
-    selection = _selection((config,), "left", "right")
+    selection = _selection(config, "left", "right")
 
     result = _planner_for(world).plan_selected_joint_path(
         world,
@@ -1746,11 +1746,11 @@ def test_native_selected_planner_supports_non_overlapping_multi_group_selection(
     assert result.path[-1].position == pytest.approx([0.1, 0.1])
 
 
-def test_cartesian_planner_returns_timed_global_joint_states_and_options(
+def test_cartesian_planner_returns_timed_canonical_joint_states_and_options(
     fake_roboplan: None, robot_config: RobotModelConfig
 ) -> None:
     world = _make_world(fake_roboplan, robot_config)
-    selection = _selection((robot_config,), "manipulator")
+    selection = _selection(robot_config, "manipulator")
     option_overrides = {
         "dt": 0.02,
         "max_linear_speed": 0.2,
@@ -1818,7 +1818,7 @@ def test_cartesian_zero_rotation_preserves_start_orientation(
     fake_roboplan: None, robot_config: RobotModelConfig
 ) -> None:
     world = _make_world(fake_roboplan, robot_config)
-    selection = _selection((robot_config,), "manipulator")
+    selection = _selection(robot_config, "manipulator")
 
     result = _planner_for(world).plan_cartesian_path(
         world,
@@ -1844,7 +1844,7 @@ def test_cartesian_uses_explicit_start_after_live_state_advances(
     fake_roboplan: None, robot_config: RobotModelConfig
 ) -> None:
     world = _make_world(fake_roboplan, robot_config)
-    selection = _selection((robot_config,), "manipulator")
+    selection = _selection(robot_config, "manipulator")
     start = JointState(name=list(selection.joint_names), position=[0.1, 0.0])
     world.sync_from_joint_state(
         JointState(name=["joint1", "joint2"], position=[0.3, 0.2]),
@@ -1870,7 +1870,7 @@ def test_cartesian_rejects_official_planner_failure(
     mocker: MockerFixture,
 ) -> None:
     world = _make_world(fake_roboplan, robot_config)
-    selection = _selection((robot_config,), "manipulator")
+    selection = _selection(robot_config, "manipulator")
     mocker.patch.object(
         FakeCartesianPathPlanner,
         "plan",
@@ -1896,7 +1896,7 @@ def test_cartesian_postvalidation_checks_between_waypoints(
     mocker: MockerFixture,
 ) -> None:
     world = _make_world(fake_roboplan, robot_config)
-    selection = _selection((robot_config,), "manipulator")
+    selection = _selection(robot_config, "manipulator")
 
     def two_point_trajectory(
         planner: FakeCartesianPathPlanner,

--- a/dimos/manipulation/visualization/operator.py
+++ b/dimos/manipulation/visualization/operator.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 import math
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from dimos.manipulation.planning.groups.models import PlanningGroup
 from dimos.manipulation.planning.planners.config import CartesianPathConfig
@@ -122,7 +122,7 @@ class ManipulationOperator:
         complete = self._complete_states(groups, request.target)
         if complete is None:
             return self._invalid(request.group_ids, "Incomplete model target state")
-        return self._evaluate_global_target(groups, JointState(request.target), complete)
+        return self._evaluate_complete_target(groups, JointState(request.target), complete)
 
     def evaluate_pose_target(self, request: PoseTargetRequest) -> TargetEvaluationResult:
         """Validate and evaluate explicit world-frame pose targets."""
@@ -146,7 +146,7 @@ class ManipulationOperator:
         groups = self._groups_for_ids(group_ids)
         if groups is None:
             return self._invalid(group_ids, "Unknown planning group")
-        return self._evaluate_global_target(groups, ik.joint_state)
+        return self._evaluate_complete_target(groups, ik.joint_state)
 
     def plan_to_joints(self, request: JointTargetRequest) -> GeneratedPlan | None:
         groups, validation = self._validate_joint_request(request)
@@ -165,7 +165,7 @@ class ManipulationOperator:
             for group, offset in self._group_offsets(groups)
         }
         return self._module.generate_plan_to_joint_targets(
-            cast("Mapping[PlanningGroupID | PlanningGroup, JointState]", targets),
+            targets,
             speed_scale=self._motion_speed,
         )
 
@@ -175,7 +175,7 @@ class ManipulationOperator:
             return None
         poses = {group_id: stamped for group_id, stamped in request.pose_targets.items()}
         return self._module.generate_plan_to_pose_targets(
-            cast("Mapping[PlanningGroupID | PlanningGroup, PoseStamped]", poses),
+            poses,
             request.auxiliary_group_ids,
             speed_scale=self._motion_speed,
         )
@@ -197,10 +197,7 @@ class ManipulationOperator:
             for group_id, target in request.pose_targets.items()
         }
         return self._module.generate_cartesian_plan(
-            cast(
-                "Mapping[PlanningGroupID | PlanningGroup, Sequence[PoseStamped]]",
-                targets,
-            ),
+            targets,
             request.config,
             request.auxiliary_group_ids,
             speed_scale=self._motion_speed,
@@ -320,7 +317,7 @@ class ManipulationOperator:
             positions.append(value)
         return JointState({"name": list(config.joint_names), "position": positions})
 
-    def _evaluate_global_target(
+    def _evaluate_complete_target(
         self,
         groups: Sequence[PlanningGroup],
         target: JointState,

--- a/dimos/manipulation/visualization/test_factory.py
+++ b/dimos/manipulation/visualization/test_factory.py
@@ -382,7 +382,7 @@ def test_drake_meshcat_visualization_lifecycle_is_noop_without_meshcat() -> None
     world.close()
 
 
-def test_create_viser_visualization_has_group_preview_protocol_without_legacy_path_api() -> None:
+def test_create_viser_visualization_has_group_preview_protocol() -> None:
     pytest.importorskip("viser")
 
     visualization = create_manipulation_visualization(
@@ -394,4 +394,3 @@ def test_create_viser_visualization_has_group_preview_protocol_without_legacy_pa
 
     assert isinstance(visualization, VisualizationSpec)
     assert isinstance(FakeVisualization(), VisualizationSpec)
-    assert not hasattr(visualization, "animate_path")

--- a/dimos/manipulation/visualization/test_operator.py
+++ b/dimos/manipulation/visualization/test_operator.py
@@ -89,7 +89,7 @@ def _operator() -> tuple[ManipulationOperator, MagicMock, MagicMock]:
     module.clear_planned_path.return_value = True
 
     monitor = MagicMock()
-    monitor.planning_groups = PlanningGroupRegistry([config])
+    monitor.planning_groups = PlanningGroupRegistry(config.planning_groups)
     monitor.get_current_joint_state.return_value = JointState(
         name=config.joint_names, position=[0.0, 0.0, 0.0]
     )
@@ -118,9 +118,11 @@ def test_joint_evaluation_overlays_selected_target_on_complete_model_state() -> 
     assert complete.position == [0.1, 0.2, 0.0]
 
 
-def test_joint_evaluation_rejects_local_unknown_and_overlapping_selection() -> None:
+def test_joint_evaluation_rejects_noncanonical_unknown_and_overlapping_selection() -> None:
     operator, _, _ = _operator()
-    local = JointTargetRequest(("left_arm",), JointState(name=["j1", "j2"], position=[0.1, 0.2]))
+    noncanonical = JointTargetRequest(
+        ("left_arm",), JointState(name=["j1", "j2"], position=[0.1, 0.2])
+    )
     unknown = JointTargetRequest(("missing",), JointState(name=["left/j1"], position=[0.1]))
     duplicate = JointTargetRequest(
         ("left_arm", "left_arm"),
@@ -128,7 +130,7 @@ def test_joint_evaluation_rejects_local_unknown_and_overlapping_selection() -> N
     )
     assert all(
         not operator.evaluate_joint_target(request).success
-        for request in (local, unknown, duplicate)
+        for request in (noncanonical, unknown, duplicate)
     )
 
 

--- a/dimos/manipulation/visualization/types.py
+++ b/dimos/manipulation/visualization/types.py
@@ -30,14 +30,3 @@ class TargetEvaluation(TypedDict, total=False):
     ee_pose: PoseStamped | Pose | None
     position_error: float
     orientation_error: float
-
-
-class ModelInfo(TypedDict):
-    joint_names: list[str]
-    end_effector_link: str | None
-    base_link: str
-    max_velocity: float
-    max_acceleration: float
-    home_joints: list[float] | None
-    pre_grasp_offset: float
-    init_joints: list[float] | None

--- a/dimos/manipulation/visualization/viser/gui.py
+++ b/dimos/manipulation/visualization/viser/gui.py
@@ -622,18 +622,16 @@ class ViserPanelGui:
             if config is None or target is None:
                 continue
             config_indexes = {str(name): index for index, name in enumerate(config.joint_names)}
-            for _global_name, local_name, value in zip(
-                group.joint_names, group.joint_names, target.position, strict=True
-            ):
-                index = config_indexes.get(str(local_name))
+            for joint_name, value in zip(group.joint_names, target.position, strict=True):
+                index = config_indexes.get(str(joint_name))
                 lower, upper = DEFAULT_JOINT_LIMITS
                 if index is not None and config.joint_limits_lower is not None:
                     lower = config.joint_limits_lower[index]
                 if index is not None and config.joint_limits_upper is not None:
                     upper = config.joint_limits_upper[index]
-                key = (group_id, str(local_name))
+                key = (group_id, str(joint_name))
                 handle = gui.add_slider(
-                    f"{group_id}/{local_name}",
+                    f"{group_id}/{joint_name}",
                     min=float(lower),
                     max=float(upper),
                     step=0.001,
@@ -643,7 +641,7 @@ class ViserPanelGui:
                 def on_slider_update(
                     _event: object,
                     selected_group_id: PlanningGroupID = group_id,
-                    name: str = str(local_name),
+                    name: str = str(joint_name),
                 ) -> None:
                     self._on_joint_slider_update(selected_group_id, name)
 
@@ -794,24 +792,24 @@ class ViserPanelGui:
             slider_values.append((group_id, group.joint_names, positions))
         self.state.group_joint_targets.update(targets)
         if any(
-            (group_id, str(local_name)) not in self._joint_sliders
-            for group_id, local_names, _positions in slider_values
-            for local_name in local_names
+            (group_id, str(joint_name)) not in self._joint_sliders
+            for group_id, joint_names, _positions in slider_values
+            for joint_name in joint_names
         ):
             self._build_joint_sliders()
-        for group_id, local_names, positions in slider_values:
-            self._set_group_slider_values(group_id, local_names, positions)
+        for group_id, joint_names, positions in slider_values:
+            self._set_group_slider_values(group_id, joint_names, positions)
         self._refresh_target_joints_from_groups()
         self._submit_joint_target_evaluation()
         self.refresh()
 
     def _set_group_slider_values(
-        self, group_id: PlanningGroupID, local_names: tuple[str, ...], values: list[float]
+        self, group_id: PlanningGroupID, joint_names: tuple[str, ...], values: list[float]
     ) -> None:
         self._suppress_target_callbacks = True
         try:
-            for local_name, value in zip(local_names, values, strict=True):
-                handle = self._joint_sliders.get((group_id, str(local_name)))
+            for joint_name, value in zip(joint_names, values, strict=True):
+                handle = self._joint_sliders.get((group_id, str(joint_name)))
                 if handle is not None:
                     handle.value = float(value)
         finally:
@@ -825,16 +823,16 @@ class ViserPanelGui:
                 self._set_error(f"Unknown planning group: {group_id}")
                 return None
             positions: list[float] = []
-            for local_name in group.joint_names:
-                handle = self._joint_sliders.get((group_id, str(local_name)))
+            for joint_name in group.joint_names:
+                handle = self._joint_sliders.get((group_id, str(joint_name)))
                 if handle is None:
-                    self._set_error(f"Missing target slider for {group_id}/{local_name}")
+                    self._set_error(f"Missing target slider for {group_id}/{joint_name}")
                     return None
                 positions.append(float(handle.value))
             targets[group_id] = JointState({"name": list(group.joint_names), "position": positions})
         return targets
 
-    def _on_joint_slider_update(self, _group_id: PlanningGroupID, _local_name: str) -> None:
+    def _on_joint_slider_update(self, _group_id: PlanningGroupID, _joint_name: str) -> None:
         if self._closed:
             return
         if self._suppress_target_callbacks:
@@ -901,7 +899,7 @@ class ViserPanelGui:
         state = self._target_ghost_state(targets)
         if state is not None:
             config = self.get_model_config()
-            self.scene.set_target_joints("model", config.joint_names, state.position)
+            self.scene.set_target_joints(config.joint_names, state.position)
 
     def _target_ghost_state(
         self, targets: Mapping[PlanningGroupID, JointState]
@@ -932,7 +930,7 @@ class ViserPanelGui:
             (group := self._groups_by_id().get(group_id)) is not None and group.has_pose_target
             for group_id in self.state.selected_group_ids
         )
-        self.scene.set_target_active("model", active)
+        self.scene.set_target_active(active)
 
     def _handle_target_evaluation_request(
         self, request: TargetEvaluationRequest
@@ -1075,7 +1073,7 @@ class ViserPanelGui:
             if group.has_pose_target:
                 self.scene.set_target_control_visual_state(str(group_id), feasible)
         if selected_groups:
-            self.scene.set_target_robot_visual_state("model", feasible)
+            self.scene.set_target_robot_visual_state(feasible)
 
     def _can_execute(self) -> bool:
         return self.state.can_execute()

--- a/dimos/manipulation/visualization/viser/scene.py
+++ b/dimos/manipulation/visualization/viser/scene.py
@@ -118,21 +118,20 @@ class ViserManipulationScene:
     ) -> None:
         self.server = server
         self.viser_urdf = viser_urdf
-        self._configs_by_id: dict[str, RobotModelConfig] = {}
-        self._models_by_id: dict[str, URDF] = {}
+        self._model_config: RobotModelConfig | None = None
+        self._model: URDF | None = None
         self._urdfs: dict[str, ViserUrdf] = {}
         self._joint_names_by_urdf: dict[int, tuple[str, ...]] = {}
         self._handles: dict[str, TransformControlsHandle] = {}
         self._root_frames: dict[str, FrameHandle] = {}
         self._grid_handle: GridHandle | None = None
         self._grid_visible = True
-        self._preview_visible: dict[str, bool] = {}
-        self._target_active: dict[str, bool] = {}
-        self._target_tracks_current: dict[str, bool] = {}
+        self._preview_visible = False
+        self._target_active = False
+        self._target_tracks_current = True
         self._scene_lock = RLock()
         self._animation_generation = 0
-        self._animation_generations: dict[str, int] = {}
-        self._collision_fallback_urdfs: dict[str, ViserUrdf] = {}
+        self._collision_fallback_urdf: ViserUrdf | None = None
         self._robot_display_mode = RobotDisplayMode.VISUAL
         self._obstacle_handles: dict[str, list[Any]] = {}
         self._obstacles: dict[str, Obstacle] = {}
@@ -382,16 +381,15 @@ class ViserManipulationScene:
         except ValueError as error:
             raise ValueError(f"Unsupported robot display mode: {mode!r}") from error
         self._robot_display_mode = normalized_mode
-        for model_key in self._configs_by_id:
-            self._apply_robot_display_mode(model_key)
+        self._apply_robot_display_mode()
 
     @property
     def collision_geometry_available(self) -> bool:
         """Return whether any primary robot has loaded collision geometry."""
-        return any(
-            self._model_has_collision_geometry(self._models_by_id[model_key])
-            for model_key in self._configs_by_id
-            if f"{model_key}:current" in self._urdfs
+        return (
+            self._model is not None
+            and "current" in self._urdfs
+            and self._model_has_collision_geometry(self._model)
         )
 
     @staticmethod
@@ -419,26 +417,21 @@ class ViserManipulationScene:
         self._grid_visible = visible
         self._set_handle_visibility(self._grid_handle, visible)
 
-    def _register_model_key(self, model_key: str, config: RobotModelConfig) -> None:
-        self._configs_by_id[model_key] = config
-        self._preview_visible.setdefault(model_key, False)
-        self._animation_generations.setdefault(model_key, 0)
-        self._target_active.setdefault(model_key, False)
-        self._target_tracks_current.setdefault(model_key, True)
-        if model_key not in self._models_by_id:
-            self._models_by_id[model_key] = self._load_robot_model(config)
-        self._ensure_robot_urdfs(model_key, config)
-
     def register_model(self, config: RobotModelConfig) -> None:
         """Register the one configured model."""
-        self._register_model_key("model", config)
+        if self._model_config is not None and self._model_config != config:
+            raise ValueError("A different model is already registered")
+        self._model_config = config
+        if self._model is None:
+            self._model = self._load_robot_model(config)
+        self._ensure_robot_urdfs(config)
 
-    def set_target_active(self, model_key: str, active: bool) -> None:
+    def set_target_active(self, active: bool) -> None:
         """Show the target ghost only while a pose-target group is selected."""
-        self._target_active[model_key] = active
+        self._target_active = active
         if not active:
-            self._target_tracks_current[model_key] = True
-        self._set_target_visibility(model_key, active)
+            self._target_tracks_current = True
+        self._set_target_visibility(active)
 
     def _ensure_reference_grid(self) -> None:
         try:
@@ -470,13 +463,13 @@ class ViserManipulationScene:
             self._grid_handle = None
 
     def ensure_target_controls(
-        self, model_key: str, on_update: Callable[[TransformControlsHandle], None]
+        self, control_id: str, on_update: Callable[[TransformControlsHandle], None]
     ) -> TransformControlsHandle | None:
-        handle_key = f"{model_key}:ee_control"
+        handle_key = f"{control_id}:ee_control"
         if handle_key in self._handles:
             return self._handles[handle_key]
         handle = self.server.scene.add_transform_controls(
-            f"/targets/{model_key}/ee_control", scale=0.25
+            f"/targets/{control_id}/ee_control", scale=0.25
         )
 
         def dispatch(event: TransformControlsEvent) -> None:
@@ -489,39 +482,30 @@ class ViserManipulationScene:
     def remove_target_controls(self, control_id: str) -> None:
         self._remove_handle(f"{control_id}:ee_control")
 
-    def _update_current_model_key(self, model_key: str, joint_state: JointState | None) -> None:
+    def update_current_model(self, joint_state: JointState | None) -> None:
+        """Update the one configured model's canonical joint state."""
         with self._scene_lock:
-            config = self._configs_by_id.get(model_key)
+            config = self._model_config
             if config is None or joint_state is None:
                 return
-            self._ensure_robot_urdfs(model_key, config)
-            current = self._urdfs.get(f"{model_key}:current")
+            self._ensure_robot_urdfs(config)
+            current = self._urdfs.get("current")
             self.set_urdf_joints(current, config.joint_names, joint_state.position)
-            if self._target_tracks_current.get(model_key, True):
-                self._set_target_joints(model_key, config.joint_names, joint_state.position)
-                self._set_target_visibility(model_key, self._target_active.get(model_key, False))
+            if self._target_tracks_current:
+                self._set_target_joints(config.joint_names, joint_state.position)
+                self._set_target_visibility(self._target_active)
         self.set_urdf_joints(
-            self._collision_fallback_urdfs.get(model_key),
+            self._collision_fallback_urdf,
             config.joint_names,
             joint_state.position,
         )
-
-    def update_current_model(self, joint_state: JointState | None) -> None:
-        """Update the one configured model's canonical joint state."""
-        self._update_current_model_key("model", joint_state)
 
     def cancel_preview_animation(self) -> None:
         """Prevent an old blocking animation from touching replacement handles."""
         with self._scene_lock:
             self._animation_generation += 1
-            for model_key in set(self._preview_visible):
-                self._animation_generations[model_key] = (
-                    self._animation_generations.get(model_key, 0) + 1
-                )
-                if model_key not in self._preview_visible:
-                    continue
-                self._preview_visible[model_key] = False
-                self._set_preview_visibility(model_key, False)
+            self._preview_visible = False
+            self._set_preview_visibility(False)
 
     def animate_preview(self, preview: PreviewAnimation, duration: float) -> bool:
         """Play the model preview from one normalized tick clock.
@@ -529,60 +513,54 @@ class ViserManipulationScene:
         Inputs are fully validated before ghosts become visible; a generation
         replacement, clear, or close stops mutation before the next tick.
         """
-        model_key = "model"
-        if not preview.frames or model_key not in self._configs_by_id:
+        if not preview.frames or self._model_config is None:
             return False
         with self._scene_lock:
             self._animation_generation += 1
-            generation = self._animation_generations.get(model_key, 0) + 1
-            self._animation_generations[model_key] = generation
-            self._preview_visible[model_key] = True
-            self._set_preview_visibility(model_key, True)
+            generation = self._animation_generation
+            self._preview_visible = True
+            self._set_preview_visibility(True)
         try:
             delays = scaled_frame_delays(preview.frames, duration)
             for index, frame in enumerate(preview.frames):
                 with self._scene_lock:
-                    if self._animation_generations.get(model_key) != generation:
+                    if self._animation_generation != generation:
                         return False
-                    self._set_preview_ghost_joints(model_key, preview.joint_names, frame.positions)
+                    self._set_preview_ghost_joints(preview.joint_names, frame.positions)
                 if index < len(delays):
                     time.sleep(delays[index])
             return True
         finally:
             with self._scene_lock:
-                if self._animation_generations.get(model_key) == generation:
-                    self._preview_visible[model_key] = False
-                    self._set_preview_visibility(model_key, False)
+                if self._animation_generation == generation:
+                    self._preview_visible = False
+                    self._set_preview_visibility(False)
 
-    def set_target_joints(
-        self, model_key: str, joint_names: Sequence[str], joints: Sequence[float]
-    ) -> bool:
-        target = self._urdfs.get(f"{model_key}:target")
+    def set_target_joints(self, joint_names: Sequence[str], joints: Sequence[float]) -> bool:
+        target = self._urdfs.get("target")
         if target is None:
             return False
-        self._target_tracks_current[model_key] = False
-        self._set_target_joints(model_key, joint_names, joints)
-        self._set_target_visibility(model_key, True)
+        self._target_tracks_current = False
+        self._set_target_joints(joint_names, joints)
+        self._set_target_visibility(True)
         return True
 
-    def clear_target(self, model_key: str) -> None:
+    def clear_target(self) -> None:
         """Return the persistent target ghost to current-state tracking."""
-        self._target_tracks_current[model_key] = True
+        self._target_tracks_current = True
 
-    def _set_target_joints(
-        self, model_key: str, joint_names: Sequence[str], joints: Sequence[float]
-    ) -> None:
-        target = self._urdfs.get(f"{model_key}:target")
+    def _set_target_joints(self, joint_names: Sequence[str], joints: Sequence[float]) -> None:
+        target = self._urdfs.get("target")
         self.set_urdf_joints(target, joint_names, joints)
 
     def _set_preview_ghost_joints(
-        self, model_key: str, joint_names: Sequence[str], joints: Sequence[float]
+        self, joint_names: Sequence[str], joints: Sequence[float]
     ) -> None:
-        ghost = self._urdfs.get(f"{model_key}:preview")
+        ghost = self._urdfs.get("preview")
         self.set_urdf_joints(ghost, joint_names, joints)
 
-    def set_target_pose(self, model_key: str, pose: Pose | None) -> None:
-        handle = self._handles.get(f"{model_key}:ee_control")
+    def set_target_pose(self, control_id: str, pose: Pose | None) -> None:
+        handle = self._handles.get(f"{control_id}:ee_control")
         if handle is None or pose is None:
             return
         handle.position = (
@@ -597,11 +575,6 @@ class ViserManipulationScene:
             float(pose.orientation.z),
         )
 
-    def set_target_visual_state(self, model_key: str, feasible: bool) -> None:
-        """Set the matching model and control target visual state."""
-        self.set_target_control_visual_state(model_key, feasible)
-        self.set_target_robot_visual_state(model_key, feasible)
-
     def set_target_control_visual_state(self, control_id: str, feasible: bool) -> None:
         """Set feasibility color for one planning-group keyed target control."""
         color = TARGET_CONTROL_FEASIBLE_COLOR if feasible else TARGET_CONTROL_INFEASIBLE_COLOR
@@ -609,11 +582,11 @@ class ViserManipulationScene:
         if handle is not None:
             cast("_ColorHandle", handle).color = color
 
-    def set_target_robot_visual_state(self, model_key: str, feasible: bool) -> None:
-        """Set feasibility material for one robot-ID keyed target ghost."""
+    def set_target_robot_visual_state(self, feasible: bool) -> None:
+        """Set feasibility material for the target ghost."""
         mesh_color = GOAL_ROBOT_FEASIBLE_COLOR if feasible else GOAL_ROBOT_INFEASIBLE_COLOR
         mesh_opacity = GOAL_ROBOT_FEASIBLE_OPACITY if feasible else GOAL_ROBOT_INFEASIBLE_OPACITY
-        target = self._urdfs.get(f"{model_key}:target")
+        target = self._urdfs.get("target")
         self._set_urdf_mesh_material(target, mesh_color, mesh_opacity)
 
     def close(self) -> None:
@@ -637,31 +610,30 @@ class ViserManipulationScene:
                 self._remove_scene_handle(urdf)
             for frame in self._root_frames.values():
                 self._remove_scene_handle(frame)
-            for urdf in self._collision_fallback_urdfs.values():
-                self._remove_scene_handle(urdf)
+            if self._collision_fallback_urdf is not None:
+                self._remove_scene_handle(self._collision_fallback_urdf)
             for handle in self._obstacle_gui_handles:
                 self._remove_scene_handle(handle)
             self._obstacle_gui_handles.clear()
             self._urdfs.clear()
             self._root_frames.clear()
-            self._models_by_id.clear()
+            self._model = None
+            self._model_config = None
             self._joint_names_by_urdf.clear()
-            self._collision_fallback_urdfs.clear()
-            self._configs_by_id.clear()
-            self._preview_visible.clear()
-            self._target_active.clear()
-            self._target_tracks_current.clear()
+            self._collision_fallback_urdf = None
+            self._preview_visible = False
+            self._target_active = False
+            self._target_tracks_current = True
             self._robot_display_mode = RobotDisplayMode.VISUAL
 
-    def _ensure_robot_urdfs(self, model_key: str, config: RobotModelConfig) -> None:
-        model = self._models_by_id.get(model_key)
+    def _ensure_robot_urdfs(self, config: RobotModelConfig) -> None:
+        model = self._model
         if model is None:
             return
         for kind in ("current", "target", "preview"):
-            key = f"{model_key}:{kind}"
-            if key in self._urdfs:
+            if kind in self._urdfs:
                 continue
-            root_node_name = self._urdf_root_node_name(model_key, kind, config)
+            root_node_name = self._urdf_root_node_name(kind, config)
             mesh_color_override = {
                 "current": None,
                 "target": GOAL_ROBOT_MESH_COLOR,
@@ -670,9 +642,9 @@ class ViserManipulationScene:
             if kind == "current":
                 # Keep both representations resident so changing the diagnostic
                 # view does not reload or replace the primary robot.
-                old_fallback = self._collision_fallback_urdfs.pop(model_key, None)
-                if old_fallback is not None:
-                    self._remove_scene_handle(old_fallback)
+                if self._collision_fallback_urdf is not None:
+                    self._remove_scene_handle(self._collision_fallback_urdf)
+                    self._collision_fallback_urdf = None
                 urdf = self.viser_urdf(
                     self.server,
                     urdf_or_path=model,
@@ -692,7 +664,7 @@ class ViserManipulationScene:
                     root_node_name=root_node_name,
                     mesh_color_override=mesh_color_override,
                 )
-            self._urdfs[key] = urdf
+            self._urdfs[kind] = urdf
             self._joint_names_by_urdf[id(urdf)] = tuple(
                 str(name) for name in model.actuated_joint_names
             )
@@ -701,7 +673,7 @@ class ViserManipulationScene:
                     fallback = self.viser_urdf(
                         self.server,
                         urdf_or_path=model,
-                        root_node_name=f"/robots/{model_key}/collision_fallback",
+                        root_node_name="/robots/model/collision_fallback",
                         mesh_color_override=(
                             *COLLISION_MESH_COLOR,
                             COLLISION_MESH_OPACITY,
@@ -709,34 +681,30 @@ class ViserManipulationScene:
                         load_meshes=True,
                         load_collision_meshes=False,
                     )
-                    self._collision_fallback_urdfs[model_key] = fallback
+                    self._collision_fallback_urdf = fallback
                     self._joint_names_by_urdf[id(fallback)] = tuple(
                         str(name) for name in model.actuated_joint_names
                     )
                     self._set_urdf_mesh_material(
                         fallback, COLLISION_MESH_COLOR, COLLISION_MESH_OPACITY
                     )
-                self._apply_robot_display_mode(model_key)
+                self._apply_robot_display_mode()
             if kind == "target":
                 self._set_urdf_mesh_material(
-                    self._urdfs[key], GOAL_ROBOT_FEASIBLE_COLOR, GOAL_ROBOT_FEASIBLE_OPACITY
+                    self._urdfs[kind], GOAL_ROBOT_FEASIBLE_COLOR, GOAL_ROBOT_FEASIBLE_OPACITY
                 )
-                self._set_handle_visibility(
-                    self._urdfs[key], self._target_active.get(model_key, False)
-                )
+                self._set_handle_visibility(self._urdfs[kind], self._target_active)
             elif kind == "preview":
                 self._set_urdf_mesh_material(
-                    self._urdfs[key], PREVIEW_ROBOT_COLOR, PREVIEW_ROBOT_OPACITY
+                    self._urdfs[kind], PREVIEW_ROBOT_COLOR, PREVIEW_ROBOT_OPACITY
                 )
-                self._set_handle_visibility(
-                    self._urdfs[key], self._preview_visible.get(model_key, False)
-                )
+                self._set_handle_visibility(self._urdfs[kind], self._preview_visible)
 
-    def _apply_robot_display_mode(self, model_key: str) -> None:
-        current = self._urdfs.get(f"{model_key}:current")
+    def _apply_robot_display_mode(self) -> None:
+        current = self._urdfs.get("current")
         if current is None:
             return
-        model = self._models_by_id.get(model_key)
+        model = self._model
         if model is None:
             return
         has_collision = self._model_has_collision_geometry(model)
@@ -749,7 +717,7 @@ class ViserManipulationScene:
             RobotDisplayMode.COLLISION,
             RobotDisplayMode.BOTH,
         }
-        fallback = self._collision_fallback_urdfs.get(model_key)
+        fallback = self._collision_fallback_urdf
         if fallback is not None:
             fallback.show_visual = mode in {
                 RobotDisplayMode.COLLISION,
@@ -825,26 +793,26 @@ class ViserManipulationScene:
             f"the prepared URDF root '{root_link}' because base_pose is applied to the URDF root"
         )
 
-    def _urdf_root_node_name(self, model_key: str, kind: str, config: RobotModelConfig) -> str:
+    def _urdf_root_node_name(self, kind: str, config: RobotModelConfig) -> str:
         root_node_name = {
-            "current": f"/robots/{model_key}/current",
-            "target": f"/targets/{model_key}/target",
-            "preview": f"/previews/{model_key}/ghost",
+            "current": "/robots/model/current",
+            "target": "/targets/model/target",
+            "preview": "/previews/model/ghost",
         }[kind]
         if not self._has_non_identity_base_pose(config):
             return root_node_name
-        self._ensure_base_pose_frame(model_key, kind, config)
+        self._ensure_base_pose_frame(kind, config)
         return f"{root_node_name}/base_pose/urdf"
 
-    def _ensure_base_pose_frame(self, model_key: str, kind: str, config: RobotModelConfig) -> None:
-        key = f"{model_key}:{kind}:base_pose"
+    def _ensure_base_pose_frame(self, kind: str, config: RobotModelConfig) -> None:
+        key = f"{kind}:base_pose"
         if key in self._root_frames:
             return
         pose = config.base_pose
         frame_name = {
-            "current": f"/robots/{model_key}/current/base_pose",
-            "target": f"/targets/{model_key}/target/base_pose",
-            "preview": f"/previews/{model_key}/ghost/base_pose",
+            "current": "/robots/model/current/base_pose",
+            "target": "/targets/model/target/base_pose",
+            "preview": "/previews/model/ghost/base_pose",
         }[kind]
         self._root_frames[key] = self.server.scene.add_frame(
             frame_name,
@@ -910,11 +878,11 @@ class ViserManipulationScene:
     def viser_actuated_joint_names(self, urdf: ViserUrdf) -> tuple[str, ...]:
         return self._joint_names_by_urdf.get(id(urdf), ())
 
-    def _set_preview_visibility(self, model_key: str, visible: bool) -> None:
-        self._set_handle_visibility(self._urdfs.get(f"{model_key}:preview"), visible)
+    def _set_preview_visibility(self, visible: bool) -> None:
+        self._set_handle_visibility(self._urdfs.get("preview"), visible)
 
-    def _set_target_visibility(self, model_key: str, visible: bool) -> None:
-        self._set_handle_visibility(self._urdfs.get(f"{model_key}:target"), visible)
+    def _set_target_visibility(self, visible: bool) -> None:
+        self._set_handle_visibility(self._urdfs.get("target"), visible)
 
     def _set_handle_visibility(self, handle: SceneHandle | None, visible: bool) -> None:
         if handle is None:

--- a/dimos/manipulation/visualization/viser/test_gui.py
+++ b/dimos/manipulation/visualization/viser/test_gui.py
@@ -236,7 +236,7 @@ def test_gui_feasibility_status_uses_exact_status_mapping(
     assert gui._feasibility_status(result, success, collision_free) == expected
 
 
-def test_group_status_composes_shared_panel_state_without_robot_dropdown(
+def test_group_status_composes_shared_panel_state(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     gui = make_gui()
@@ -250,7 +250,6 @@ def test_group_status_composes_shared_panel_state_without_robot_dropdown(
 
     gui._update_status_text()
 
-    assert "robot" not in gui._handles
     assert values == {
         "status": "### Status\n\n**State:** planner unavailable\n\n"
         "Target: `feasible` · Plan: `fresh`\n\nState stale: `True`",

--- a/dimos/manipulation/visualization/viser/test_visualizer_lifecycle.py
+++ b/dimos/manipulation/visualization/viser/test_visualizer_lifecycle.py
@@ -565,11 +565,11 @@ def test_selected_display_mode_survives_primary_recreation_and_joint_updates(
 
     scene.register_model(config)
     scene.robot_display_mode = mode
-    old_current = scene._urdfs["model:current"]
-    scene._urdfs.pop("model:current")
+    old_current = scene._urdfs["current"]
+    scene._urdfs.pop("current")
 
     scene.register_model(config)
-    current = scene._urdfs["model:current"]
+    current = scene._urdfs["current"]
     scene.update_current_model(JointState({"name": ["joint1"], "position": [0.75]}))
 
     assert current is not old_current

--- a/dimos/protocol/pubsub/benchmark/test_replay_bench.py
+++ b/dimos/protocol/pubsub/benchmark/test_replay_bench.py
@@ -174,14 +174,14 @@ def bench_results():
 
 
 @pytest.mark.parametrize("proto", ["lcm", "zenoh"])
-def test_benchmark_image_vs_compressed(proto, session_pool, bench_results) -> None:
+def test_benchmark_image_vs_compressed(proto, session_pool, bench_results, lcm_url) -> None:
     """Old path (raw Image on the wire) vs CompressedCodec(CompressedImage), same transport."""
     frame = make_image()  # 720p, 2.76 MB raw
     n = 15
 
     def inner(topic: str, typ: type):
         if proto == "lcm":
-            return LCMTransport(topic, typ)
+            return LCMTransport(topic, typ, url=f"{lcm_url}&recv_buf_size={2 * 1024 * 1024}")
         return ZenohTransport(topic, typ, session_pool=session_pool)
 
     raw_wire = len(frame.lcm_encode())

--- a/dimos/robot/manipulators/openarm/test_config.py
+++ b/dimos/robot/manipulators/openarm/test_config.py
@@ -52,9 +52,9 @@ def test_openarm_model_uses_pinned_official_bimanual_xacro() -> None:
     )
 
 
-def test_openarm_config_exposes_one_bimanual_robot() -> None:
+def test_openarm_config_exposes_one_bimanual_model() -> None:
     config = openarm_bimanual_model_config()
-    registry = PlanningGroupRegistry([config])
+    registry = PlanningGroupRegistry(config.planning_groups)
 
     assert config.model is OPENARM_BIMANUAL_MODEL
     assert config.joint_names == OPENARM_ARM_JOINTS

--- a/dimos/robot/manipulators/openarm/test_openarm_teleop.py
+++ b/dimos/robot/manipulators/openarm/test_openarm_teleop.py
@@ -128,7 +128,6 @@ def test_openarm_quest_blueprint_has_one_bimanual_mock_task() -> None:
     assert task.priority == 10
     assert trajectory.joint_names == OPENARM_JOINTS
     assert trajectory.priority == 20
-    assert "robots" not in manipulation_kwargs
     assert manipulation_kwargs["kinematics"] == task.params["pink"]
     assert manipulation_kwargs["visualization"] == {"backend": "viser"}
     assert teleop_kwargs == {}

--- a/docs/capabilities/manipulation/adding_a_custom_arm.md
+++ b/docs/capabilities/manipulation/adding_a_custom_arm.md
@@ -481,11 +481,11 @@ robot asset cache. Use `LfsPath` only when the description is intentionally
 vendored, locally modified, or has no suitable upstream source.
 
 If the planning blueprint selects the RoboPlan TOPP-RA trajectory
-parametrizer, dimOS currently pins RoboPlan to `0.5.1`. Every movable joint in
+parametrizer, dimOS requires RoboPlan `0.6.x`. Every movable joint in
 each selected planning group must provide finite, positive velocity limits.
 Authored extended acceleration limits take precedence; when absent, dimOS
-temporarily inserts a global `2.0 rad/s²` acceleration fallback during RoboPlan
-model composition:
+temporarily inserts a default `2.0 rad/s²` acceleration limit during RoboPlan
+model preparation:
 
 ```xml
 <joint name="joint1" type="revolute">

--- a/docs/capabilities/manipulation/index.md
+++ b/docs/capabilities/manipulation/index.md
@@ -161,8 +161,8 @@ velocities bypasses path parametrization and retains its existing timing after
 canonical validation. TOPP-RA follows the collision-checked geometric path
 without corner blending; collision checking remains the planner's concern.
 Explicit configuration overrides the world-based default.
-RoboPlan model composition preserves authored acceleration limits and inserts a
-temporary global `2.0 rad/s²` fallback where they are absent. Formal per-joint
+RoboPlan model preparation preserves authored acceleration limits and inserts a
+temporary default `2.0 rad/s²` limit where they are absent. Formal per-joint
 acceleration overrides will replace this fallback.
 
 The Viser panel's **Next plan speed** slider provides runtime speed tuning from
@@ -199,11 +199,6 @@ from dimos.manipulation.planning.planners.roboplan_config import (
 )
 
 path_config = RoboPlanCartesianPathConfig()
-
-module.plan_cartesian_targets(
-    {"arm/manipulator": (current_tcp_pose, goal_tcp_pose)},
-    path_config,
-)
 ```
 
 The default `time_optimal` mode returns the TOPP-RA trajectory constrained by
@@ -237,8 +232,8 @@ handling. RoboPlan 0.6 removed the former `limit_ratio_tolerance` and
 `max_attempts_per_step` settings.
 
 Cartesian path planning remains a low-level internal capability in this
-release. `ManipulationModule.plan_cartesian_targets()` accepts an ordered
-waypoint sequence for each target planning group. A sequence contains only
+release. The internal generator accepts an ordered waypoint sequence for each
+target planning group. A sequence contains only
 `PoseStamped` absolute waypoints or only `Transform` displacements relative to
 the planning start, and begins at the current TCP pose or identity transform.
 RoboPlan plans all target groups simultaneously. The Viser panel constructs a
@@ -343,7 +338,7 @@ from dimos.manipulation.manipulation_module import ManipulationModule, Manipulat
 
 manipulation = ManipulationModule.blueprint(
     config=ManipulationModuleConfig(
-        robots=[...],
+        model=robot_model,
         visualization={
             "backend": "viser",
             "host": "127.0.0.1",
@@ -383,19 +378,18 @@ failure leaves the plan unavailable. Preview and execution use RoboPlan's
 original synchronized timestamps and velocities.
 
 External manipulation visualizers are initialized from a backend-neutral
-`VisualizationSession` after the planning world has added its robots. The
-session contains static `PlanningSceneInfo` metadata: world robot IDs,
-`RobotModelConfig` values, and resolved planning groups. Runtime joint state is
+`VisualizationSession` after the planning world has loaded its model. The
+session contains static `PlanningSceneInfo` metadata: the `RobotModelConfig`
+and resolved planning groups. Runtime joint state is
 then pushed through `VisualizationStateFrame` updates so renderers do not poll
 world/module state or own freshness policy. Embedded Meshcat visualization does
 not need extra setup because it observes the Drake world directly.
 
 Previews use the stored synchronized `JointTrajectory` from the generated plan.
-Viser projects the globally named trajectory into robot-local preview ghosts and
-plays the stored timestamped points directly; optional preview duration only
-scales the stored delays. Execution projects that same accepted trajectory into
-each robot's local joint order while preserving timestamps and velocities; it
-does not regenerate or retime it. Execute freshness is enforced by the
+Viser plays the stored canonical trajectory directly; optional preview duration
+only scales the stored delays. Execution forwards that same accepted trajectory
+with unchanged joint names, ordering, timestamps, and velocities; it does not
+regenerate or retime it. Execute freshness is enforced by the
 manipulation module/operator immediately before dispatch, not by Viser-side
 telemetry snapshots.
 

--- a/docs/capabilities/manipulation/openarm_integration.md
+++ b/docs/capabilities/manipulation/openarm_integration.md
@@ -35,7 +35,8 @@ finger joints and preflights the remaining 14 joints against the declared arm
 order before enabling the motors.
 
 Planning treats the two arms as one robot with `left_arm`, `right_arm`, and
-`both_arms` planning groups because collision exclusions cannot span robots.
+`both_arms` planning groups. The single model supports cross-arm collision
+checking and synchronized bimanual planning.
 
 ## Bring-up
 

--- a/docs/capabilities/manipulation/pink_ik_tuning.md
+++ b/docs/capabilities/manipulation/pink_ik_tuning.md
@@ -60,7 +60,7 @@ with the same objective:
 ```python skip
 from dimos.robot.manipulators.common.blueprints import planner
 
-yourarm_planner = planner(robots=[robot_model], kinematics=pink)
+yourarm_planner = planner(model=robot_model, kinematics=pink)
 ```
 
 ## Customize the task stack

--- a/docs/capabilities/manipulation/planning_groups.md
+++ b/docs/capabilities/manipulation/planning_groups.md
@@ -84,7 +84,7 @@ Joint-space planning targets group IDs. Each target `JointState` may be
 unnamed in the group's joint order or named with the group's canonical joints.
 
 ```python skip
-ok = manip.plan_to_joint_targets(
+result = manip.plan_to_joints(
     {
         "left_arm": JointState(
             name=["left/joint1", "left/joint2", "left/joint3"],
@@ -94,30 +94,27 @@ ok = manip.plan_to_joint_targets(
 )
 ```
 
-Pose planning targets pose-capable group IDs. Add auxiliary groups when another
-chain should participate as free DOFs but does not have its own pose target.
-Pose targets are `Pose` values keyed by planning group ID:
+Pose planning targets pose-capable group IDs with `PoseStamped` values:
 
 ```python skip
-ok = manip.plan_to_pose_targets(
-    {"left_arm": target_pose},
-    auxiliary_groups=["torso"],
-)
+result = manip.plan_to_poses({"left_arm": target_pose})
 ```
 
 After a successful planning call, preview and execution use the module's current
 stored plan:
 
 ```python skip
-manip.preview_plan()
-manip.execute_plan()
+if result.succeeded:
+    manip.preview_plan(result.plan)
+    manip.execute()
 ```
 
-Callers that already hold a `GeneratedPlan` may pass it explicitly:
+Callers that already hold a `GeneratedPlan` may preview it explicitly; execution
+always consumes the module's current stored plan:
 
 ```python skip
 manip.preview_plan(plan)
-manip.execute_plan(plan)
+manip.execute()
 ```
 
 A generated plan is the execution boundary. The canonical trajectory is sent


### PR DESCRIPTION
## Contribution path

- Linked pull request: #3409

## Problem

The manipulation stack still carries transitional multi-model concepts after the planning-group work in #3409. Model selectors, wrapper RPCs, model-wide end-effector metadata, fake single-element RoboPlan composites, and keyed Viser model state obscure the current invariant: one robot model with one or more planning groups.

## Solution

- Make planning APIs and registries accept canonical planning-group IDs and definitions directly.
- Collapse RoboPlan preparation and Viser state to one logical robot model while preserving planning-group joint ordering, SRDF collision exclusions, and acceleration limits.
- Remove obsolete selector utilities, compatibility RPCs, model-wide end-effector projection, and compatibility tests.
- Update manipulation documentation and examples to use `plan_to_joints`, `plan_to_poses`, planning-group tip frames, and `execute`.
- Configure the high-bandwidth LCM replay benchmark with the receive buffer it requires and update its stale prepared-model assertion.

This intentionally removes the obsolete paths instead of preserving compatibility aliases.


## AI assistance

OpenAI Codex with GPT-5 implemented the cleanup, updated tests and documentation, and ran verification under user direction.

## Checklist

- [ ] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).