### PR TITLE
fix(zenoh): bootstrap peer workers deterministically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -607,6 +607,49 @@ jobs:
           use_pypi: true
           version: "11.2.8"
 
+  macos-zenoh-e2e:
+    timeout-minutes: 15
+    runs-on: macos-14
+    permissions:
+      contents: read
+    env:
+      PYTHONFAULTHANDLER: "1"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install uv
+        uses: astral-sh/setup-uv@v10.0.1
+        with:
+          enable-cache: true
+          prune-cache: true
+      - name: Setup Python
+        uses: actions/setup-python@v7.0.0
+        with:
+          python-version: "3.12"
+      - name: Install PortAudio
+        run: brew install portaudio
+      - name: Install dependencies
+        run: uv sync --group tests --frozen
+      - name: Exercise deterministic Zenoh startup repeatedly
+        shell: bash
+        run: |
+          for attempt in {1..5}; do
+            echo "::group::attempt ${attempt}"
+            uv run pytest dimos/core/test_daemon_zenoh.py --no-cov -q
+            echo "::endgroup::"
+          done
+      - name: Print crash diagnostics
+        if: failure()
+        shell: bash
+        run: |
+          shopt -s nullglob
+          for f in "$RUNNER_TEMP"/pytest-crash/*.log; do
+            echo "::group::$(basename "$f")"
+            cat "$f"
+            echo "::endgroup::"
+          done
+
   self-hosted-tests:
     # Runs on push, merge_group (trusted — a maintainer must approve + queue the
     # PR), and same-repo PRs. Skipped on fork PRs, which would expose the
@@ -639,11 +682,10 @@ jobs:
                 - /var/cache/dimos-root-cache:/root/.cache
             markers: "self_hosted or skipif_no_ros"
             experimental: false
-          # macOS runner disabled for now — we don't want Mac tests.
-          # - os: macOS
-          #   container: null  # run on host — `container:` is Linux-only
-          #   markers: "self_hosted"
-          #   experimental: true
+          - os: macOS
+            container: null  # run on host — `container:` is Linux-only
+            markers: "self_hosted"
+            experimental: false
     runs-on:
       - self-hosted
       - ${{ matrix.os }}
@@ -965,6 +1007,7 @@ jobs:
     - md-babel
     - web
     - tests
+    - macos-zenoh-e2e
     - self-hosted-tests
     #- self-hosted-large-tests
 

--- a/dimos/cli/commands/lifecycle.py
+++ b/dimos/cli/commands/lifecycle.py
@@ -270,6 +270,7 @@ def run(
                 cli_args=list(blueprint_names),
                 config_overrides=global_option_overrides,
                 original_argv=sys.argv,
+                zenoh_peer_endpoint=coordinator.zenoh_peer_endpoint,
             )
             entry.save()
             spawn_watchdog(run_id, log_dir=log_dir)
@@ -308,6 +309,7 @@ def run(
             cli_args=list(blueprint_names),
             config_overrides=global_option_overrides,
             original_argv=sys.argv,
+            zenoh_peer_endpoint=coordinator.zenoh_peer_endpoint,
         )
         entry.save()
         spawn_watchdog(run_id, log_dir=log_dir)

--- a/dimos/cli/test_dimos.py
+++ b/dimos/cli/test_dimos.py
@@ -176,6 +176,7 @@ def stubbed_run(
     class FakeCoordinator:
         n_modules = 1
         transports: dict[tuple[str, type], Any] = {}
+        zenoh_peer_endpoint: str | None = None
 
         @classmethod
         def build(cls, blueprint: Any, parsed_config: Any = None) -> "FakeCoordinator":

--- a/dimos/core/conftest.py
+++ b/dimos/core/conftest.py
@@ -12,17 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import Iterator
+
 import pytest
 
 from dimos.core.coordination.module_coordinator import ModuleCoordinator
 from dimos.core.global_config import global_config
+from dimos.protocol.service.zenohservice import ZenohPeerSeed
 
 
 @pytest.fixture(params=["lcm", "zenoh"])
-def each_transport(request, monkeypatch):
-    """Run the requesting test once per transport backend."""
+def each_transport(request, monkeypatch) -> Iterator[str]:
+    """Run each backend against an isolated, already-reachable test fabric."""
     monkeypatch.setattr(global_config, "transport", request.param)
-    return request.param
+    if request.param != "zenoh":
+        yield request.param
+        return
+
+    seed = ZenohPeerSeed(global_config)
+    seed.start()
+    try:
+        yield request.param
+    finally:
+        seed.stop()
 
 
 @pytest.fixture

--- a/dimos/core/coordination/coordinator_rpc.py
+++ b/dimos/core/coordination/coordinator_rpc.py
@@ -18,7 +18,10 @@ import time
 from typing import TYPE_CHECKING, Any
 
 from dimos.core.global_config import global_config
+from dimos.core.run_registry import get_most_recent
 from dimos.core.transport_factory import rpc_backend
+from dimos.protocol.rpc.zenohrpc import ZenohRPC
+from dimos.protocol.service.zenohservice import LOOPBACK_LISTEN
 from dimos.utils.logging_config import setup_logger
 
 if TYPE_CHECKING:
@@ -51,7 +54,20 @@ class CoordinatorRPC:
     @classmethod
     def connect(cls, *, timeout: float) -> CoordinatorRPC:
         """Attach to a running Coordinator, raising `TimeoutError` if none answers."""
-        rpc = rpc_backend()()
+        backend = rpc_backend()
+        entry = get_most_recent() if backend is ZenohRPC else None
+        rpc: RPCSpec
+        if entry is not None and entry.zenoh_peer_endpoint is not None:
+            rpc = ZenohRPC(
+                mode="peer",
+                connect=[entry.zenoh_peer_endpoint],
+                listen=[LOOPBACK_LISTEN],
+                multicast=False,
+                gossip=True,
+                connect_timeout=min(global_config.zenoh_connect_timeout, timeout),
+            )
+        else:
+            rpc = backend()
         rpc.start()
         client = cls(rpc)
         deadline = time.monotonic() + timeout

--- a/dimos/core/coordination/module_coordinator.py
+++ b/dimos/core/coordination/module_coordinator.py
@@ -43,6 +43,7 @@ from dimos.core.transport import (
     pZenohTransport,
 )
 from dimos.core.transport_factory import make_transport
+from dimos.protocol.service.zenohservice import ZenohPeerSeed
 from dimos.spec.utils import is_spec, spec_annotation_compliance, spec_structural_compliance
 from dimos.utils.generic import short_id
 from dimos.utils.logging_config import setup_logger
@@ -78,6 +79,7 @@ class ModuleCoordinator(Resource):
         g: GlobalConfig = global_config,
     ) -> None:
         self._global_config = g
+        self._zenoh_peer_seed = ZenohPeerSeed.for_config(g)
         manager_types: list[type[WorkerManager]] = [WorkerManagerPython]
         self._managers = {cls.deployment_identifier: cls(g=g) for cls in manager_types}
         self._deployed_modules = {}
@@ -96,8 +98,14 @@ class ModuleCoordinator(Resource):
         from dimos.core.o3dpickle import register_picklers
 
         register_picklers()
-        for m in self._managers.values():
-            m.start()
+        if self._zenoh_peer_seed is not None:
+            self._zenoh_peer_seed.start()
+        try:
+            for m in self._managers.values():
+                m.start()
+        except BaseException:
+            self._stop_peer_seed()
+            raise
         self._started = True
 
     def stop(self) -> None:
@@ -121,6 +129,19 @@ class ModuleCoordinator(Resource):
                 logger.error("Error stopping manager", manager=type(m).__name__, exc_info=True)
 
         safe_thread_map(tuple(self._managers.values()), _stop_manager)
+        self._stop_peer_seed()
+
+    def _stop_peer_seed(self) -> None:
+        if self._zenoh_peer_seed is None:
+            return
+        self._zenoh_peer_seed.stop()
+
+    @property
+    def zenoh_peer_endpoint(self) -> str | None:
+        """Loopback peer entry point, when this coordinator owns one."""
+        if self._zenoh_peer_seed is None:
+            return None
+        return self._zenoh_peer_seed.endpoint
 
     def start_rpc_service(self) -> None:
         """Expose the coordinator's API as @rpc methods over LCM."""

--- a/dimos/core/coordination/test_coordinator_rpc.py
+++ b/dimos/core/coordination/test_coordinator_rpc.py
@@ -61,3 +61,31 @@ def test_connect_stops_transport_after_retry_budget_expires(mocker) -> None:
         CoordinatorRPC.connect(timeout=1.0)
 
     rpc.stop.assert_called_once_with()
+
+
+def test_zenoh_connect_dials_the_seed_advertised_by_the_latest_run(mocker) -> None:
+    rpc = mocker.Mock()
+    rpc.call_sync.return_value = ("pong", mocker.Mock())
+    zenoh_rpc = mocker.Mock(return_value=rpc)
+    mocker.patch("dimos.core.coordination.coordinator_rpc.ZenohRPC", zenoh_rpc)
+    mocker.patch(
+        "dimos.core.coordination.coordinator_rpc.rpc_backend",
+        return_value=zenoh_rpc,
+    )
+    entry = mocker.Mock(zenoh_peer_endpoint="tcp/127.0.0.1:51234")
+    mocker.patch(
+        "dimos.core.coordination.coordinator_rpc.get_most_recent",
+        return_value=entry,
+    )
+
+    client = CoordinatorRPC.connect(timeout=1.0)
+
+    assert client.rpc is rpc
+    zenoh_rpc.assert_called_once_with(
+        mode="peer",
+        connect=["tcp/127.0.0.1:51234"],
+        listen=["tcp/127.0.0.1:0"],
+        multicast=False,
+        gossip=True,
+        connect_timeout=1.0,
+    )

--- a/dimos/core/coordination/test_module_coordinator.py
+++ b/dimos/core/coordination/test_module_coordinator.py
@@ -51,6 +51,7 @@ from dimos.core.transport_factory import transport_topic
 from dimos.msgs.geometry_msgs.Transform import Transform
 from dimos.msgs.sensor_msgs.Image import Image
 from dimos.msgs.tf2_msgs.TFMessage import TFMessage
+from dimos.protocol.service.zenohservice import ZenohPeerSeed
 import dimos.robot.get_all_blueprints as resolver
 from dimos.spec.utils import Spec
 
@@ -65,6 +66,82 @@ class Data2:
 
 class Data3:
     pass
+
+
+def test_unconfigured_peer_coordinator_owns_a_local_seed() -> None:
+    coordinator = ModuleCoordinator(
+        g=GlobalConfig(
+            transport="zenoh",
+            zenoh_mode="peer",
+            zenoh_connect="",
+            robot_ip=None,
+            robot_ips=None,
+            n_workers=0,
+        )
+    )
+
+    assert isinstance(coordinator._zenoh_peer_seed, ZenohPeerSeed)
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        GlobalConfig(transport="lcm"),
+        GlobalConfig(transport="zenoh", zenoh_mode="client"),
+        GlobalConfig(transport="zenoh", zenoh_connect="tcp/192.0.2.1:7447"),
+        GlobalConfig(transport="zenoh", robot_ip="192.0.2.2"),
+        GlobalConfig(transport="zenoh", robot_ips="192.0.2.2,192.0.2.3"),
+    ],
+)
+def test_configured_or_non_peer_coordinator_does_not_add_a_seed(config: GlobalConfig) -> None:
+    coordinator = ModuleCoordinator(g=config)
+
+    assert coordinator._zenoh_peer_seed is None
+
+
+def test_peer_seed_reuses_global_config_worker_propagation(mocker) -> None:
+    config = GlobalConfig(
+        transport="zenoh",
+        zenoh_mode="peer",
+        zenoh_connect="",
+        robot_ip=None,
+        robot_ips=None,
+        n_workers=0,
+    )
+    coordinator = ModuleCoordinator(g=config)
+    seed = mocker.Mock(endpoint="tcp/127.0.0.1:51234")
+    seed.start.side_effect = lambda: setattr(config, "zenoh_connect", seed.endpoint)
+    seed.stop.side_effect = lambda: setattr(config, "zenoh_connect", "")
+    coordinator._zenoh_peer_seed = seed
+
+    coordinator.start()
+
+    assert config.zenoh_connect == seed.endpoint
+    assert coordinator._global_config is config
+    assert coordinator._managers["python"]._cfg is config
+
+    coordinator.stop()
+
+    assert config.zenoh_connect == ""
+    seed.stop.assert_called_once_with()
+
+
+def test_peer_seed_restores_config_when_worker_start_fails(mocker) -> None:
+    config = GlobalConfig(transport="zenoh", n_workers=0)
+    coordinator = ModuleCoordinator(g=config)
+    seed = mocker.Mock(endpoint="tcp/127.0.0.1:51234")
+    seed.start.side_effect = lambda: setattr(config, "zenoh_connect", seed.endpoint)
+    seed.stop.side_effect = lambda: setattr(config, "zenoh_connect", "")
+    manager = mocker.Mock()
+    manager.start.side_effect = RuntimeError("worker failed")
+    coordinator._zenoh_peer_seed = seed
+    coordinator._managers = {"python": manager}
+
+    with pytest.raises(RuntimeError, match="worker failed"):
+        coordinator.start()
+
+    assert config.zenoh_connect == ""
+    seed.stop.assert_called_once_with()
 
 
 class ModuleA(Module):

--- a/dimos/core/run_registry.py
+++ b/dimos/core/run_registry.py
@@ -45,6 +45,7 @@ class RunEntry:
     cli_args: list[str] = field(default_factory=list)
     config_overrides: dict[str, object] = field(default_factory=dict)
     original_argv: list[str] = field(default_factory=list)
+    zenoh_peer_endpoint: str | None = None
 
     @property
     def registry_path(self) -> Path:

--- a/dimos/core/test_daemon_zenoh.py
+++ b/dimos/core/test_daemon_zenoh.py
@@ -12,18 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""E2e regression test for issue #3395: `dimos run --daemon` with zenoh.
+"""E2e regression test for `dimos run --daemon` with deterministic local Zenoh.
 
 Everything runs in subprocesses: the daemon must survive a real double fork
 (zenoh's tokio runtime does not survive fork, so the daemon process must not
 inherit any zenoh state), and the client must be a genuinely separate process.
 This also keeps zenoh threads out of the pytest process.
 
-Assumption: the zenoh `Coordinator/*` RPC keys are host-global over loopback
-multicast (not namespaced per run). Since zenoh became the default, several
-other tests serve a Coordinator too; what keeps them from answering this one's
-probe is the per-worker scouting group conftest pins (`ZENOH_SCOUT_ADDR`),
-with `--dist=loadfile` keeping this file on a single xdist worker.
+Multicast is disabled so the coordinator, workers, and external client can
+communicate only through the coordinator-owned loopback peer seed and gossip.
+This turns the macOS discovery race into a deterministic contract. The
+per-worker state directory keeps this run's advertised seed isolated, with
+`--dist=loadfile` keeping this file on one xdist worker.
 """
 
 from __future__ import annotations
@@ -63,6 +63,8 @@ def _sweep_leftover_daemons(state_dir: Path) -> None:
 def test_daemon_serves_coordinator_ping_over_zenoh(tmp_path: Path) -> None:
     env = os.environ | {
         "DIMOS_TRANSPORT": "zenoh",
+        # Prove bootstrap and RPC do not depend on multicast discovery.
+        "ZENOH_MULTICAST": "0",
         # Never touch the developer's real registry/config, even without xdist.
         "XDG_STATE_HOME": str(tmp_path / "state"),
         "XDG_CONFIG_HOME": str(tmp_path / "config"),

--- a/dimos/hardware/whole_body/dual_openyam_damiao/test_adapter.py
+++ b/dimos/hardware/whole_body/dual_openyam_damiao/test_adapter.py
@@ -29,7 +29,11 @@ pytestmark = pytest.mark.self_hosted
 
 @pytest.fixture
 def adapter(mocker: MockerFixture) -> Iterator[DualOpenYamDamiaoAdapter]:
-    mocker.patch.object(can_motor_control, "SocketCanBus", can_motor_control.MockCanBus)
+    mocker.patch.object(
+        DualOpenYamDamiaoAdapter,
+        "_make_can_bus",
+        side_effect=lambda name: can_motor_control.MockCanBus(name),
+    )
     result = DualOpenYamDamiaoAdapter(
         runtime_config=DamiaoRuntimeConfig(
             bus_devices={"left": "can8", "right": "can9"},

--- a/dimos/hardware/whole_body/openarm_damiao/test_adapter.py
+++ b/dimos/hardware/whole_body/openarm_damiao/test_adapter.py
@@ -30,7 +30,11 @@ from dimos.robot.manipulators.openarm.config import OPENARM_DOF, OPENARM_JOINTS
 
 @pytest.fixture
 def openarm_adapter(mocker: MockerFixture) -> Iterator[OpenArmDamiaoAdapter]:
-    mocker.patch.object(can_motor_control, "SocketCanBus", can_motor_control.MockCanBus)
+    mocker.patch.object(
+        OpenArmDamiaoAdapter,
+        "_make_can_bus",
+        side_effect=lambda name: can_motor_control.MockCanBus(name),
+    )
     adapter = OpenArmDamiaoAdapter(
         runtime_config=DamiaoRuntimeConfig(gravity_comp=False),
     )

--- a/dimos/protocol/rpc/test_spec.py
+++ b/dimos/protocol/rpc/test_spec.py
@@ -25,11 +25,12 @@ from typing import Any
 
 import pytest
 
+from dimos.core.global_config import GlobalConfig
 from dimos.protocol.rpc.pubsubrpc import LCMRPC, ShmRPC
 from dimos.protocol.rpc.rpc_utils import RemoteError
 from dimos.protocol.rpc.spec import DEFAULT_RPC_TIMEOUT, RPCSpec
 from dimos.protocol.rpc.zenohrpc import ZenohRPC
-from dimos.protocol.service.zenohservice import ZenohSessionPool
+from dimos.protocol.service.zenohservice import LOOPBACK_LISTEN, ZenohPeerSeed, ZenohSessionPool
 
 
 class CustomTestError(Exception):
@@ -119,6 +120,22 @@ def test_call_sync_unsubscribes_timed_out_callback(mocker) -> None:
         RPCSpec.call_sync(client, "missing", ([], {}), rpc_timeout=0.0)
 
     unsubscribe.assert_called_once_with()
+
+
+def test_zenoh_sync_timeout_undeclares_matching_resources(mocker) -> None:
+    client = ZenohRPC()
+    session = mocker.Mock()
+    querier = session.declare_querier.return_value
+    querier.matching_status.matching = False
+    listener = querier.declare_matching_listener.return_value
+    client._session = session
+
+    with pytest.raises(TimeoutError, match="timed out waiting for a Zenoh queryable"):
+        client.call_sync("missing", ([], {}), rpc_timeout=0.0)
+
+    listener.undeclare.assert_called_once_with()
+    querier.undeclare.assert_called_once_with()
+    assert client._pending == {}
 
 
 # Try to add RedisRPC if available
@@ -363,6 +380,75 @@ def test_nonexistent_service(rpc_context, impl_name: str) -> None:
             client.call_sync("nonexistent", ([1, 2], {}), rpc_timeout=0.1)
         assert "nonexistent" in str(exc_info.value)
         assert "timed out" in str(exc_info.value)
+
+
+def test_zenoh_call_waits_for_a_late_queryable_across_peers() -> None:
+    """A worker may declare its RPC after another worker starts the call."""
+    seed = ZenohPeerSeed(
+        GlobalConfig(
+            transport="zenoh",
+            zenoh_mode="peer",
+            zenoh_scouting=False,
+            zenoh_multicast=False,
+            zenoh_gossip=True,
+            zenoh_connect_timeout=2.0,
+        )
+    )
+    server_pool = ZenohSessionPool()
+    client_pool = ZenohSessionPool()
+    seed.start()
+    peer_config = {
+        "mode": "peer",
+        "connect": [seed.endpoint],
+        "listen": [LOOPBACK_LISTEN],
+        "scouting": False,
+        "multicast": False,
+        "gossip": True,
+        "connect_timeout": 2.0,
+    }
+    server = ZenohRPC(session_pool=server_pool, **peer_config)
+    client = ZenohRPC(session_pool=client_pool, **peer_config)
+    server.start()
+    client.start()
+    wait_started = threading.Event()
+    original_wait = client._wait_for_queryable
+
+    def observed_wait(key: str, deadline: float) -> None:
+        wait_started.set()
+        original_wait(key, deadline)
+
+    client._wait_for_queryable = observed_wait  # type: ignore[method-assign]
+    result: list[Any] = []
+    errors: list[BaseException] = []
+
+    def call() -> None:
+        try:
+            value, _ = client.call_sync("late", ([20, 22], {}), rpc_timeout=2.0)
+            result.append(value)
+        except BaseException as error:
+            errors.append(error)
+
+    call_thread = threading.Thread(target=call)
+    unsubscribe = None
+
+    try:
+        call_thread.start()
+        assert wait_started.wait(1.0)
+        assert call_thread.is_alive()
+        unsubscribe = server.serve_rpc(add_function, "late")
+        call_thread.join(2.0)
+        assert not call_thread.is_alive()
+        assert errors == []
+        assert result == [42]
+    finally:
+        if unsubscribe is not None:
+            unsubscribe()
+        client.stop()
+        server.stop()
+        client_pool.close_all()
+        server_pool.close_all()
+        seed.stop()
+        call_thread.join(2.0)
 
 
 @pytest.mark.parametrize("rpc_context, impl_name", testdata)

--- a/dimos/protocol/rpc/zenohrpc.py
+++ b/dimos/protocol/rpc/zenohrpc.py
@@ -161,6 +161,43 @@ class ZenohRPC(RPCSpec, ZenohService):
             payload=payload,
         )
 
+    def call_sync(
+        self, name: str, arguments: Args, rpc_timeout: float | None = None
+    ) -> tuple[Any, Callable[[], None]]:
+        if rpc_timeout is None:
+            method = name.rsplit("/", 1)[-1]
+            rpc_timeout = self.rpc_timeouts.get(name) or self.rpc_timeouts.get(
+                method, self.default_rpc_timeout
+            )
+        deadline = time.monotonic() + rpc_timeout
+        self._wait_for_queryable(f"dimos/rpc/{name}", deadline)
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError(f"RPC call to '{name}' timed out after {rpc_timeout} seconds")
+        return super().call_sync(name, arguments, rpc_timeout=remaining)
+
+    def _wait_for_queryable(self, key: str, deadline: float) -> None:
+        matched = threading.Event()
+        remaining = max(deadline - time.monotonic(), 0.001)
+        querier = self.session.declare_querier(
+            key,
+            target=zenoh.QueryTarget.ALL,
+            consolidation=zenoh.ConsolidationMode.NONE,
+            congestion_control=zenoh.CongestionControl.BLOCK,
+            timeout=remaining,
+        )
+        listener = querier.declare_matching_listener(
+            lambda status: matched.set() if status.matching else None
+        )
+        try:
+            if querier.matching_status.matching:  # type: ignore[attr-defined]
+                matched.set()
+            if not matched.wait(max(deadline - time.monotonic(), 0)):
+                raise TimeoutError(f"RPC call to '{key}' timed out waiting for a Zenoh queryable")
+        finally:
+            listener.undeclare()
+            querier.undeclare()
+
     def call_nowait(self, name: str, arguments: Args) -> None:
         method = name.rsplit("/", 1)[-1]
         timeout = self.rpc_timeouts.get(name) or self.rpc_timeouts.get(

--- a/dimos/protocol/service/test_zenohservice.py
+++ b/dimos/protocol/service/test_zenohservice.py
@@ -22,10 +22,17 @@ from typing import Any
 import pytest
 import zenoh
 
+from dimos.core.global_config import GlobalConfig
 from dimos.protocol.pubsub.impl.zenohpubsub import ZenohPubSubBase
 from dimos.protocol.rpc.zenohrpc import ZenohRPC
 from dimos.protocol.service import zenohservice
-from dimos.protocol.service.zenohservice import ZenohConfig, ZenohService, ZenohSessionPool
+from dimos.protocol.service.zenohservice import (
+    LOOPBACK_LISTEN,
+    ZenohConfig,
+    ZenohPeerSeed,
+    ZenohService,
+    ZenohSessionPool,
+)
 
 
 @pytest.fixture()
@@ -206,3 +213,54 @@ def test_start_is_idempotent(session_pool) -> None:
     svc.start()
     session2 = svc.session
     assert session1 is session2
+
+
+def test_peer_dialing_only_a_loopback_seed_keeps_a_loopback_listener() -> None:
+    config = ZenohConfig(connect=["tcp/127.0.0.1:51234"])
+
+    assert config.listen_endpoints == [LOOPBACK_LISTEN]
+
+
+def test_peer_dialing_a_remote_endpoint_uses_zenohs_default_listener() -> None:
+    config = ZenohConfig(connect=["tcp/192.0.2.10:7447"])
+
+    assert config.listen_endpoints == []
+
+
+def test_automatic_peer_seed_requires_gossip() -> None:
+    seed = ZenohPeerSeed(
+        GlobalConfig(
+            transport="zenoh",
+            zenoh_mode="peer",
+            zenoh_gossip=False,
+        )
+    )
+
+    with pytest.raises(ValueError, match="requires gossip"):
+        seed.start()
+
+
+def test_peer_seed_publishes_and_restores_its_endpoint(mocker) -> None:
+    config = GlobalConfig(
+        transport="zenoh",
+        zenoh_mode="peer",
+        zenoh_connect="",
+        robot_ip=None,
+        robot_ips=None,
+    )
+    pool = mocker.Mock()
+    mocker.patch.object(zenohservice, "ZenohSessionPool", return_value=pool)
+    mocker.patch.object(zenohservice.secrets, "randbelow", return_value=123)
+    close_sessions = mocker.patch.object(zenohservice.default_session_pool, "close_all")
+    seed = ZenohPeerSeed(config)
+
+    seed.start()
+
+    assert config.zenoh_connect == "tcp/127.0.0.1:49275"
+    pool.acquire.assert_called_once()
+
+    seed.stop()
+
+    assert config.zenoh_connect == ""
+    pool.close_all.assert_called_once_with()
+    assert close_sessions.call_count == 2

--- a/dimos/protocol/service/zenohservice.py
+++ b/dimos/protocol/service/zenohservice.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import json
 import os
 import platform
+import secrets
 import socket
 import threading
 import time
@@ -25,7 +26,7 @@ from typing import Any, ClassVar
 from pydantic import Field, model_validator
 import zenoh
 
-from dimos.core.global_config import TransportBackend, ZenohMode, global_config
+from dimos.core.global_config import GlobalConfig, TransportBackend, ZenohMode, global_config
 from dimos.protocol.service.spec import Service, SessionConfig
 from dimos.utils.logging_config import setup_logger
 
@@ -51,22 +52,41 @@ ALL_INTERFACES = "auto"
 # listens here instead: loopback only, on a port the kernel picks.
 LOOPBACK_LISTEN = "tcp/127.0.0.1:0"
 
+_DYNAMIC_PORT_MIN = 49_152
+_DYNAMIC_PORT_COUNT = 65_536 - _DYNAMIC_PORT_MIN
+
 
 def _locators(value: str) -> list[str]:
     return [item.strip() for item in value.split(",") if item.strip()]
 
 
-def _default_connect_endpoints() -> list[str]:
+def _connect_endpoints(g: GlobalConfig = global_config) -> list[str]:
     """Dial known robots directly instead of trusting multicast scouting.
 
     Many APs filter multicast between WiFi clients, so a robot reachable over
     TCP never answers a scout. An IP carrying its own port is used as given.
     """
-    if global_config.transport != "zenoh":
+    if g.transport != "zenoh":
         return []
-    ips = _locators(f"{global_config.robot_ip or ''},{global_config.robot_ips or ''}")
+    ips = _locators(f"{g.robot_ip or ''},{g.robot_ips or ''}")
     robots = [f"tcp/{ip}" if ":" in ip else f"tcp/{ip}:{ROBOT_ZENOH_PORT}" for ip in ips]
-    return list(dict.fromkeys(robots + _locators(global_config.zenoh_connect)))
+    return list(dict.fromkeys(robots + _locators(g.zenoh_connect)))
+
+
+def _default_connect_endpoints() -> list[str]:
+    return _connect_endpoints()
+
+
+def _is_loopback_tcp_endpoint(endpoint: str) -> bool:
+    scheme, separator, address = endpoint.partition("/")
+    host, port_separator, port = address.rpartition(":")
+    return (
+        scheme == "tcp"
+        and bool(separator)
+        and host == "127.0.0.1"
+        and bool(port_separator)
+        and port.isdigit()
+    )
 
 
 def _default_scouting() -> bool:
@@ -166,6 +186,14 @@ class ZenohConfig(SessionConfig):
             # A client dials its router and accepts no links, so it has no
             # listener to pin in the first place.
             return self.listen
+        if (
+            self.connect
+            and self.multicast_interface == LOOPBACK_INTERFACE
+            and all(_is_loopback_tcp_endpoint(endpoint) for endpoint in self.connect)
+        ):
+            # A local peer seed introduces these sessions through gossip. They
+            # still need loopback listeners so Zenoh can connect them directly.
+            return [LOOPBACK_LISTEN]
         if self.connect or self.multicast_interface != LOOPBACK_INTERFACE:
             return []
         return [LOOPBACK_LISTEN]
@@ -290,6 +318,77 @@ class ZenohSessionPool:
                 except zenoh.ZError as e:
                     logger.warning("Zenoh session close failed", session_key=key, error=str(e))
             self._sessions.clear()
+
+
+class ZenohPeerSeed:
+    """Own one loopback peer that introduces this run's processes."""
+
+    def __init__(self, g: GlobalConfig = global_config) -> None:
+        self._config = g
+        self._original_connect = g.zenoh_connect
+        self._pool: ZenohSessionPool | None = None
+        self._endpoint: str | None = None
+
+    @classmethod
+    def for_config(cls, g: GlobalConfig) -> ZenohPeerSeed | None:
+        if g.transport != "zenoh" or g.zenoh_mode != "peer" or _connect_endpoints(g):
+            return None
+        return cls(g)
+
+    @property
+    def endpoint(self) -> str:
+        if self._endpoint is None:
+            raise RuntimeError("Zenoh peer seed has not started")
+        return self._endpoint
+
+    def start(self) -> None:
+        if self._endpoint is not None:
+            return
+        if self._config.zenoh_gossip is False:
+            raise ValueError(
+                "automatic Zenoh peer bootstrap requires gossip; remove "
+                "--no-zenoh-gossip or configure --zenoh-connect"
+            )
+
+        default_session_pool.close_all()
+        deadline = time.monotonic() + self._config.zenoh_connect_timeout
+        last_error: zenoh.ZError | None = None
+        while True:
+            endpoint = f"tcp/127.0.0.1:{_DYNAMIC_PORT_MIN + secrets.randbelow(_DYNAMIC_PORT_COUNT)}"
+            pool = ZenohSessionPool()
+            try:
+                pool.acquire(
+                    ZenohConfig(
+                        mode="peer",
+                        connect=[],
+                        listen=[endpoint],
+                        scouting=self._config.zenoh_scouting,
+                        scouting_interface=self._config.zenoh_interface,
+                        multicast=self._config.zenoh_multicast,
+                        scout_addr=self._config.zenoh_scout_addr,
+                        gossip=self._config.zenoh_gossip,
+                        connect_timeout=0,
+                    )
+                )
+            except zenoh.ZError as error:
+                last_error = error
+                pool.close_all()
+                if time.monotonic() >= deadline:
+                    raise RuntimeError("could not bind a local Zenoh peer seed") from last_error
+                continue
+            self._pool = pool
+            self._endpoint = endpoint
+            self._config.zenoh_connect = endpoint
+            return
+
+    def stop(self) -> None:
+        default_session_pool.close_all()
+        self._config.zenoh_connect = self._original_connect
+        pool = self._pool
+        self._pool = None
+        self._endpoint = None
+        if pool is not None:
+            pool.close_all()
 
 
 # Process-default pool used by production code. Constructing it opens no sessions.

--- a/docs/usage/transports/index.md
+++ b/docs/usage/transports/index.md
@@ -45,9 +45,15 @@ Generally LCM is legacy and we suggest using zenoh (the default) going forward
 
 ### What the default talks to
 
-A stock zenoh session is pinned to localhost. It listens on `tcp/127.0.0.1:0` and
-scouts for peers over loopback only, so sibling dimOS processes on this machine
-find each other and nothing on the LAN can link to them.
+A stock dimOS run starts one loopback-only Zenoh peer seed. Every worker dials
+that seed and listens on `tcp/127.0.0.1:0`; Zenoh gossip then introduces the
+workers to one another. The seed is a discovery rendezvous, not a router, so
+module traffic continues directly between peers. This avoids relying on the
+timing and platform behavior of multicast discovery.
+
+The run registry advertises the seed endpoint to local CLI clients such as
+`dimos shell`. Because every endpoint is loopback-only, nothing on the LAN can
+link to an otherwise unconfigured run.
 
 Peers on this machine carry their data through shared memory, not the socket.
 Zenoh negotiates it per link at handshake, a remote peer keeps getting the
@@ -62,7 +68,10 @@ Reaching off the machine is opt-in
 | Peers discovered across the LAN             | `ZENOH_SCOUTING=1`            |
 | Scouting on one named interface             | `ZENOH_INTERFACE=wlan0`       |
 
-Every one of these unpins the listener back to zenoh's all-interfaces default.
+Explicit connect endpoints suppress the automatic local seed and dial the
+configured remote Zenoh fabric. LAN scouting remains available alongside the
+local seed when no explicit endpoint is configured. Both paths stay in peer
+mode; neither requires a router.
 
 **Two ways to override for one run or for your shell:**
 


### PR DESCRIPTION
## Contribution path

- [x] Small, safe change that does not need a tracking issue

## Problem

Each worker owns a separate Zenoh peer session. Local startup relied on multicast discovery, so synchronous lifecycle RPCs could run before a worker discovered the other peers and declared its queryables. macOS exposes this timing window consistently enough to make CI flaky. A sleep changes the odds but cannot establish readiness.

## Solution

An unconfigured peer-mode coordinator now starts one ordinary Zenoh peer on a random loopback port before its worker pool. `ZenohPeerSeed` temporarily publishes that endpoint through the existing `GlobalConfig.zenoh_connect` path. Workers already receive `GlobalConfig` in `DeployModuleRequest`, so this needs no Zenoh-specific worker bootstrap protocol and no changes to `python_worker.py` or `worker_manager_python.py`.

Workers dial the seed and keep loopback listeners. Zenoh gossip introduces them, after which traffic flows directly between peers. The seed is a rendezvous peer, not a router.

Synchronous Zenoh RPC calls now declare a temporary `Querier`, wait for a matching queryable under the call's existing deadline, release the matching resources, and use the existing request/reply implementation. Callback and fire-and-forget calls are unchanged.

The run registry records the seed endpoint so a separate local CLI process can join a daemon whose multicast discovery is disabled.

## Remote modules

`--robot-ip`, `--robot-ips`, and `--zenoh-connect` remain authoritative. Any of them suppresses the automatic local seed, and sessions dial the configured remote peer or router as before. This PR therefore preserves both peer-to-peer remote deployments and router-backed deployments.

## Scope

The runtime change touches six production files:

- Zenoh session/seed and synchronous RPC readiness
- coordinator resource lifecycle
- run-registry publication and CLI attachment

Shared worker startup, worker management, and global configuration remain unchanged from `main`. The independent shared-memory race fix moved to draft PR #3946.

## macOS and CI coverage

- A required `macos-14` job disables multicast, launches a real daemon and workers, calls `Coordinator/ping` from a separate process, and repeats the test five times.
- The required self-hosted macOS matrix is enabled again.
- Damiao adapter tests mock the platform-neutral `_make_can_bus()` seam, so motor-control tests do not assume Linux SocketCAN.
- Transport-matrix tests start an isolated peer fabric before standalone probes and workers.

## Validation

- focused Zenoh service, coordinator, and RPC tests: 108 passed
- LCM/Zenoh async-module transport matrix: 24 passed
- daemon stress command used by macOS CI: 5/5 passed
- Damiao adapter tests: 6 passed across default and self-hosted marker selections
- broad default suite before interruption: 1,086 passed; its sole failure used system Python 3.14 instead of the repo venv, and passed when rerun with the venv activated
- mypy on all changed production modules: passed
- Ruff check/format and all pre-commit hooks: passed

## Checklist

- [ ] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
