### PR TITLE
fix: restore Python 3.10 Self compatibility

### DIFF
--- a/dimos/protocol/service/spec.py
+++ b/dimos/protocol/service/spec.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 from abc import ABC
-from typing import Any, ClassVar, Self, get_type_hints
+from typing import Any, ClassVar, get_type_hints
 
 from pydantic import BaseModel
+from typing_extensions import Self
 
 from dimos.core.global_config import TransportBackend
 


### PR DESCRIPTION
## Summary
- import `Self` from `typing_extensions`
- restore CLI imports on supported Python 3.10 environments

## Test
- `python -c 'from dimos.protocol.service.spec import SessionConfig'`
- `dimos list`