### PR TITLE
Fix minimum uv version for cooldown opt-outs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ The agentic operating system for generalist robotics. `Modules` communicate via 
 ## Quick Start
 
 ```bash
-# Install
+# Install (requires uv >=0.9.25)
 uv sync --extra all
 
 # List all runnable blueprints

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -522,7 +522,7 @@ dev = [
 ]
 
 [tool.uv]
-required-version = ">=0.9.17"
+required-version = ">=0.9.25"
 default-groups = ["tests"]
 exclude-newer = "7 days"
 exclude-newer-package = { dimos-viewer = false, dimos-lcm = false, lcm-dimos-fork = false, roboplan = false, md-babel-py = false, can-motor-control = false, edgetam-dimos = false, dim-odom = false }


### PR DESCRIPTION
uv sync fails on uv versions before 0.9.25 because the cooldown opt-outs from #2231 use syntax they cant parse.

This PR sets 0.9.25 as the minimum and notes it next to the install command. The existing required-version doesnt help here since parsing fails before uv can read it.

Tested with 0.9.24, 0.9.25 and 0.12.9. No lockfile changes.
