### PR TITLE
fix(shm): retry zero-sized attachments

### DIFF
--- a/dimos/utils/shm.py
+++ b/dimos/utils/shm.py
@@ -84,7 +84,15 @@ def create_or_attach_shm(
 
 def _try_attach(name: str) -> tuple[SharedMemory | None, str]:
     try:
-        return unregister(SharedMemory(name=name)), ""
+        shm = unregister(SharedMemory(name=name))
+        # Free-threaded CPython can return a handle for the shm_open ->
+        # ftruncate window instead of raising ``ValueError``. It is no more
+        # ready than the exception path: mapping it would expose an empty
+        # segment to the caller.
+        if shm.size == 0:
+            shm.close()
+            return None, "creator has not sized the segment yet"
+        return shm, ""
     except FileNotFoundError:
         return None, "segment does not exist"
     except ValueError:

--- a/dimos/utils/test_shm.py
+++ b/dimos/utils/test_shm.py
@@ -99,6 +99,24 @@ def test_attach_shm_waits_out_the_race(name, slow_ftruncate):
     assert result == [SIZE], f"attacher did not survive the window: {result}"
 
 
+def test_attach_shm_retries_a_zero_sized_handle(name, monkeypatch, mocker):
+    """CPython may expose the creation window as a size-zero handle."""
+    empty = mocker.Mock(size=0)
+    ready = mocker.Mock(size=SIZE)
+    shared_memory = mocker.patch(
+        "dimos.utils.shm.SharedMemory",
+        side_effect=[empty, ready],
+    )
+    mocker.patch("dimos.utils.shm.resource_tracker.unregister")
+    monkeypatch.setattr("dimos.utils.shm._POLL_S", 0)
+
+    attached = attach_shm(name, timeout=1.0)
+
+    assert attached is ready
+    empty.close.assert_called_once_with()
+    assert shared_memory.call_count == 2
+
+
 def test_attach_shm_times_out_instead_of_hanging(name):
     started = time.monotonic()
     with pytest.raises(ShmNotReadyError) as excinfo:


### PR DESCRIPTION
## Summary

- retry shared-memory attachment while a newly created segment still reports size zero
- preserve `FileNotFoundError` semantics when the segment never becomes attachable
- cover the creation/attachment race and timeout behavior

## Why

A reader can discover a shared-memory segment after the creator has named it but before the operating system reports its final size. Attaching during that window raises `ValueError`. Treating the error as final makes startup depend on process timing.

This change keeps the retry inside the shared-memory utility, separate from the Zenoh peer-startup fix.

## Validation

- `pytest dimos/utils/test_shm.py -q --no-cov` — 7 passed
- `ruff check dimos/utils/shm.py dimos/utils/test_shm.py`
