### PR TITLE
make mcp_timeout to be client owned

### DIFF
--- a/dimos/agents/mcp/mcp_adapter.py
+++ b/dimos/agents/mcp/mcp_adapter.py
@@ -41,8 +41,6 @@ from dimos.utils.logging_config import setup_logger
 
 logger = setup_logger()
 
-DEFAULT_TIMEOUT = 30
-
 
 class McpError(Exception):
     """Raised when the MCP server returns a JSON-RPC error."""
@@ -55,13 +53,13 @@ class McpError(Exception):
 class McpAdapter:
     """Thin JSON-RPC client for a running MCP server."""
 
-    def __init__(self, url: str | None = None, timeout: int = DEFAULT_TIMEOUT) -> None:
-        if url is None:
-            from dimos.core.global_config import global_config
+    def __init__(self, url: str | None = None, timeout: int | None = None) -> None:
+        from dimos.core.global_config import global_config
 
+        if url is None:
             url = f"http://localhost:{global_config.mcp_port}/mcp"
         self.url = url
-        self.timeout = timeout
+        self.timeout = global_config.mcp_timeout if timeout is None else timeout
 
     def call(self, method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
         """Send a JSON-RPC request and return the parsed response.
@@ -137,7 +135,7 @@ class McpAdapter:
         return False
 
     @classmethod
-    def from_run_entry(cls, entry: Any | None = None, timeout: int = DEFAULT_TIMEOUT) -> McpAdapter:
+    def from_run_entry(cls, entry: Any | None = None, timeout: int | None = None) -> McpAdapter:
         """Create an adapter from a RunEntry, or discover the latest one.
 
         Falls back to the default URL if no entry is found.

--- a/dimos/agents/mcp/test_mcp_adapter.py
+++ b/dimos/agents/mcp/test_mcp_adapter.py
@@ -1,0 +1,38 @@
+# Copyright 2025-2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from dimos.agents.mcp.mcp_adapter import McpAdapter
+from dimos.core.global_config import global_config
+
+
+def test_call_sends_config_timeout_unless_overridden(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(global_config, "mcp_timeout", 11)
+    posted: list[object] = []
+
+    def test_post(*args: object, **kwargs: object) -> SimpleNamespace:
+        posted.append(kwargs["timeout"])
+        return SimpleNamespace(raise_for_status=lambda: None, json=lambda: {"result": {}})
+
+    monkeypatch.setattr("dimos.agents.mcp.mcp_adapter.requests.post", test_post)
+
+    McpAdapter(url="http://127.0.0.1:9/mcp").call("initialize")
+    McpAdapter(url="http://127.0.0.1:9/mcp", timeout=7).call("initialize")
+
+    assert posted == [11, 7]

--- a/dimos/cli/commands/mcp.py
+++ b/dimos/cli/commands/mcp.py
@@ -27,9 +27,9 @@ from dimos.agents.mcp.mcp_adapter import McpAdapter, McpError
 mcp_app = typer.Typer(help="Interact with the running MCP server")
 
 
-def _get_adapter() -> McpAdapter:
+def _get_adapter(timeout: int | None = None) -> McpAdapter:
     """Get an McpAdapter from the latest RunEntry or default URL."""
-    return McpAdapter.from_run_entry()
+    return McpAdapter.from_run_entry(timeout=timeout)
 
 
 @mcp_app.command("list-tools")
@@ -72,6 +72,9 @@ def mcp_call_tool(
         [], "--arg", "-a", callback=_validate_key_value_args, help="Arguments as key=value"
     ),
     json_args: str = typer.Option("", "--json-args", "-j", help="Arguments as JSON string"),
+    timeout: int = typer.Option(
+        None, "--timeout", "-t", help="Seconds to wait for the tool (default: mcp_timeout)"
+    ),
 ) -> None:
     """Call an MCP tool by name."""
     arguments: dict[str, Any] = {}
@@ -89,7 +92,7 @@ def mcp_call_tool(
             raise typer.Exit(1)
 
     try:
-        result = _get_adapter().call_tool(tool_name, arguments)
+        result = _get_adapter(timeout).call_tool(tool_name, arguments)
     except requests.ConnectionError:
         typer.echo("Error: no running MCP server (is DimOS running?)", err=True)
         raise typer.Exit(1)

--- a/dimos/core/global_config.py
+++ b/dimos/core/global_config.py
@@ -104,6 +104,10 @@ class GlobalConfig(BaseSettings):
     robot_rotation_diameter: float = 0.6
     nerf_speed: float = 1.0
     mcp_port: int = 9990
+    # Seconds an MCP client waits for a tool to answer. A skill that thinks
+    # for longer than this is cut off at the client, not the server, so the
+    # caller owns the number.
+    mcp_timeout: int = 30
     # `DIMOS_TRANSPORT` (or `.env`) is the single switch read by every process
     # (dimos, humancli, agentspy, dtop). The `transport` alias keeps the bare
     # env name and the `--transport` CLI flag (which sets the field by name) working.

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -426,7 +426,6 @@ dimos mcp call move_to --arg x=3.2 --arg y=-0.5
 dimos mcp call move_to --json-args '{"x": 2.0, "y": 0, "relative": true}'
 dimos mcp call observe
 dimos mcp call land
-dimos mcp call scan --timeout 120 --arg prompt='["mug"]'
 ```
 
 #### `dimos mcp status`

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -412,19 +412,21 @@ Returns JSON with tool names, descriptions, and parameter schemas.
 Call a skill by name.
 
 ```bash
-dimos mcp call <tool_name> [--arg key=value ...] [--json-args '{}']
+dimos mcp call <tool_name> [--arg key=value ...] [--json-args '{}'] [--timeout SECONDS]
 ```
 
 | Option | Description |
 |--------|-------------|
 | `--arg`, `-a` | Arguments as `key=value` pairs (repeatable) |
 | `--json-args`, `-j` | Arguments as a JSON string |
+| `--timeout`, `-t` | Seconds to wait for the tool. Default is `mcp_timeout` (30). The client cuts off a skill that runs longer. |
 
 ```bash
 dimos mcp call move_to --arg x=3.2 --arg y=-0.5
 dimos mcp call move_to --json-args '{"x": 2.0, "y": 0, "relative": true}'
 dimos mcp call observe
 dimos mcp call land
+dimos mcp call scan --timeout 120 --arg prompt='["mug"]'
 ```
 
 #### `dimos mcp status`

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -122,6 +122,7 @@ Config(
         robot_rotation_diameter=0.6,
         nerf_speed=1.0,
         mcp_port=9990,
+        mcp_timeout=30,
         transport='zenoh',
         build_native=False,
         dtop=False,


### PR DESCRIPTION
## Problem

mcp calls well may exceed default 30 second timeout 

## Solution
let the caller decide how long the mcp call should take

`dimos mcp call <call_name> --timeout <N>`, N default is still 30.

## AI assistance

none

## Checklist

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
