### PR TITLE
feat(web): cockpit robot picker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -493,7 +493,8 @@ jobs:
           dimos/e2e_tests/test_custom_channel_browser.py
           dimos/e2e_tests/test_publish_browser.py
           dimos/e2e_tests/test_voice_browser.py
-          dimos/e2e_tests/test_stats_browser.py --no-cov
+          dimos/e2e_tests/test_stats_browser.py
+          dimos/e2e_tests/test_robot_picker_browser.py --no-cov
 
   tests:
     if: |

--- a/dimos/e2e_tests/test_robot_picker_browser.py
+++ b/dimos/e2e_tests/test_robot_picker_browser.py
@@ -1,0 +1,121 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Robot picker browser e2e (the T12b acceptance demo, in CI).
+
+Two RelayBridgeModules attach to one hand-started relay through relay_url
+(two robots sharing a relay), each with its own cockpit manifest: "Alpha"
+has a video panel, "Bravo" adds a Stats page. Nothing publishes data: the
+panels render in their "waiting for data" state, which is enough to prove
+that the picked robot's own manifest was adopted (data flow through the
+relay is covered by the other browser e2e files). The page must list both
+robots sorted by name whatever the registration order, render the picked
+robot's panels, and switch to the other one from the status bar.
+
+Marked web_browser: excluded from the default suite (needs the
+`browser-tests` dependency group, Playwright browsers, and built web dists).
+Locally:
+`uv run --group browser-tests pytest -m web_browser dimos/e2e_tests/test_robot_picker_browser.py`.
+"""
+
+from collections.abc import Iterator
+from contextlib import ExitStack
+
+import pytest
+
+from dimos.core.coordination.blueprints import Blueprint
+from dimos.web.cockpit import Stats, Video, cockpit
+from dimos.web.relay_bridge.e2e_support import stop_module
+from dimos.web.relay_bridge.locate import find_web_dir
+from dimos.web.relay_bridge.relay_process import RelayProcess, ensure_web_dist
+
+pytest.importorskip("playwright")
+
+from playwright.sync_api import Page, expect, sync_playwright
+
+pytestmark = pytest.mark.web_browser
+
+
+def _attach(
+    cleanup: ExitStack,
+    relay_url: str,
+    robot_id: str,
+    name: str,
+    blueprint: Blueprint,
+) -> None:
+    """A bridge registered on the relay at relay_url (the --relay-url path)."""
+    (atom,) = blueprint.blueprints
+    module = atom.module(
+        relay_url=relay_url,
+        open_browser=False,
+        web_build=False,
+        robot_id=robot_id,
+        robot_name=name,
+        **atom.kwargs,
+    )
+    cleanup.callback(stop_module, module)
+    module.start()
+
+
+@pytest.fixture(scope="module")
+def two_robots_url() -> Iterator[str]:
+    # A bare RelayProcess serves whatever cockpit dist exists: build (or
+    # refresh) it first, the way a spawned local relay would.
+    ensure_web_dist(find_web_dir())
+    with RelayProcess() as ready, ExitStack() as cleanup:
+        # Bravo registers first, so the relay's list is [bravo, alpha] and the
+        # sorted order on the page is the picker's doing.
+        bravo = cockpit(layout=Video("color_image"), pages=[Stats()])
+        _attach(cleanup, ready.open_url, "bravo", "Bravo", bravo)
+        _attach(
+            cleanup,
+            ready.open_url,
+            "alpha",
+            "Alpha",
+            cockpit(layout=Video("color_image")),
+        )
+        yield ready.open_url
+
+
+@pytest.fixture
+def chromium_page() -> Iterator[Page]:
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        try:
+            yield browser.new_page()
+        finally:
+            browser.close()
+
+
+def test_picker_lists_both_robots_and_switches(two_robots_url: str, chromium_page: Page) -> None:
+    page = chromium_page
+    page.goto(two_robots_url)
+    entries = page.locator('[data-testid^="robot-pick-"]')
+    # Count and order: sorted by name, not the registration order.
+    expect(entries).to_contain_text(["Alpha", "Bravo"], timeout=120_000)
+    expect(page.get_by_test_id("robot")).to_have_text("no robot")
+
+    page.get_by_test_id("robot-pick-bravo").click()
+    expect(page.get_by_test_id("robot")).to_contain_text("Bravo", timeout=30_000)
+    expect(page.get_by_test_id("robot-picker")).to_have_count(0)
+    expect(page.get_by_test_id("tab-page-p1")).to_have_text("Stats", timeout=30_000)
+    expect(page.get_by_test_id("panel-p0")).to_be_visible()
+
+    page.get_by_test_id("switch-robot").click()
+    expect(page.get_by_test_id("robot-pick-bravo")).to_have_attribute("aria-current", "true")
+    page.get_by_test_id("robot-pick-alpha").click()
+    expect(page.get_by_test_id("robot")).to_contain_text("Alpha", timeout=30_000)
+    expect(page.get_by_test_id("panel-p0")).to_be_visible(timeout=30_000)
+    expect(page.get_by_test_id("tab-page-p1")).to_have_count(0)
+    expect(page.get_by_test_id("switch-robot")).to_be_visible()

--- a/docs/usage/web_sdk.md
+++ b/docs/usage/web_sdk.md
@@ -46,6 +46,7 @@ The bridge discovers the WebTransport endpoint (an ephemeral QUIC port and certi
 - A bridge killed without a clean close keeps its robot id registered until the relay's 30 s idle timeout. Restarting it inside that window waits the conflict out.
 - `--serve-dir` belongs to the relay here (`deno task dev --serve-dir DIR`). `dimos run --serve-dir` is rejected together with `--relay-url`.
 - A second robot on the same relay needs its own `--robot-id`. A synthetic one: `uv run python -m dimos.web.relay_bridge.demo_smoke --url http://localhost:7780`.
+- With several robots on the relay the cockpit lists them; pick one to watch it. "switch robot" in the status bar reopens the list.
 - Another machine cannot use this relay yet: its certificate is ephemeral and self-signed, which only loopback may trust.
 
 ## Your first page

--- a/web/cockpit/src/App.test.tsx
+++ b/web/cockpit/src/App.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { ChannelStore, type Session, StatusStore } from "@dimos/sdk";
@@ -12,6 +12,7 @@ import type { View } from "./ui/StatusBar.tsx";
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 const ROBOT = { id: "a", name: "A", model: "go2" };
+const ROBOT_B = { id: "b", name: "B", model: "go2" };
 
 const ODOM: ChannelSpec = {
   ch: "odom",
@@ -38,12 +39,21 @@ function mf(channels: ChannelSpec[], panels: PanelSpec[] = []): Manifest {
   return { version: 1, channels, panels, layout: null, pages: [] };
 }
 
+const CAM: PanelSpec = {
+  id: "cam",
+  kind: "video",
+  title: "",
+  channels: ["color_image"],
+  params: {},
+};
+
 describe("App session states", () => {
   let container: HTMLElement;
   let root: Root;
   let status: StatusStore;
   let channels: ChannelStore;
   let session: Session;
+  let watch: Session["watch"];
 
   beforeEach(() => {
     container = document.createElement("div");
@@ -51,10 +61,11 @@ describe("App session states", () => {
     root = createRoot(container);
     status = new StatusStore();
     channels = new ChannelStore();
+    watch = vi.fn((_id: string) => new Promise<Manifest>(() => {}));
     session = {
       status,
       store: channels,
-      watch: () => new Promise(() => {}),
+      watch,
       subscribe: () => () => {},
       publish: () => new Promise(() => {}),
       close: () => {},
@@ -76,6 +87,13 @@ describe("App session states", () => {
   const view = (v: View) => {
     act(() => container.querySelector<HTMLElement>(`[data-testid="view-${v}"]`)!.click());
   };
+  const picker = () => container.querySelector('[data-testid="robot-picker"]');
+  const pickEntries = () => container.querySelectorAll('[data-testid^="robot-pick-"]');
+  const pick = (id: string) => {
+    act(() => container.querySelector<HTMLElement>(`[data-testid="robot-pick-${id}"]`)!.click());
+  };
+  const switchButton = () => container.querySelector<HTMLElement>('[data-testid="switch-robot"]');
+  const panel = () => container.querySelector('[data-testid="panel-cam"]');
 
   it("waits for a robot, shows its channels, and clears them when it leaves", () => {
     expect(container.textContent).toContain("Waiting for a robot");
@@ -253,13 +271,15 @@ describe("App session states", () => {
     act(() => {
       status.update({ watchedRobot: ROBOT, robots: [ROBOT], manifest: mf([ODOM, IMAGE], [cam]) });
     });
-    const panel = () => container.querySelector('[data-testid="panel-cam"]');
     const row = () => container.querySelector('[data-testid="ch-odom-seq"]');
     const selected = (v: View) =>
       container.querySelector(`[data-testid="view-${v}"]`)!.getAttribute("aria-selected");
     expect(panel()).not.toBeNull();
     expect(row()).toBeNull();
     expect(selected("panels")).toBe("true");
+    // A lone robot is auto-watched: nothing to pick or switch to.
+    expect(picker()).toBeNull();
+    expect(switchButton()).toBeNull();
 
     view("channels");
     expect(selected("channels")).toBe("true");
@@ -339,9 +359,69 @@ describe("App session states", () => {
     expect(container.querySelector('[data-testid="panel-cam"]')).not.toBeNull();
   });
 
-  it("shows the multi-robot notice instead of channels", () => {
-    act(() => status.update({ robots: [ROBOT, { id: "b", name: "B", model: "go2" }] }));
-    expect(container.textContent).toContain("2 robots connected");
+  it("watches the operator's pick and waits if that robot disappears", () => {
+    act(() => status.update({ robots: [ROBOT, ROBOT_B] }));
+    expect(picker()).not.toBeNull();
+    expect(pickEntries()).toHaveLength(2);
+    expect(switchButton()).toBeNull();
+    expect(container.textContent).not.toContain("Waiting for a robot");
+
+    pick("b");
+    expect(watch).toHaveBeenCalledWith("b");
+    act(() => status.update({ watchedRobot: ROBOT_B }));
+    expect(picker()).toBeNull();
+    expect(container.textContent).toContain("Waiting for a robot");
+    expect(switchButton()).not.toBeNull();
+
+    act(() => status.update({ manifest: mf([ODOM, IMAGE], [CAM]) }));
+    expect(panel()).not.toBeNull();
+
+    act(() => {
+      status.update({ watchedRobot: null, robots: [ROBOT], manifest: null, epoch: 1 });
+    });
+    expect(picker()).toBeNull();
+    expect(switchButton()).toBeNull();
+    expect(container.textContent).toContain("Waiting for a robot");
+  });
+
+  it("reopens the picker on 'switch robot' with the watched robot marked", () => {
+    act(() => {
+      status.update({ watchedRobot: ROBOT, robots: [ROBOT, ROBOT_B], manifest: mf([ODOM], [CAM]) });
+    });
+    expect(picker()).toBeNull();
+    act(() => switchButton()!.click());
+    expect(picker()).not.toBeNull();
+    expect(panel()).toBeNull();
+    expect(switchButton()).toBeNull();
+    const current = (id: string) =>
+      container.querySelector(`[data-testid="robot-pick-${id}"]`)!.getAttribute("aria-current");
+    expect(current("a")).toBe("true");
+    expect(current("b")).toBe("false");
+
+    // The other robot: the old producer is dropped until its manifest lands.
+    pick("b");
+    expect(watch).toHaveBeenCalledWith("b");
+    act(() => status.update({ watchedRobot: ROBOT_B, manifest: null, epoch: 1 }));
+    expect(picker()).toBeNull();
+    expect(container.textContent).toContain("Waiting for a robot");
+    act(() => status.update({ manifest: mf([ODOM, IMAGE], [CAM]) }));
+    expect(panel()).not.toBeNull();
+    expect(switchButton()).not.toBeNull();
+  });
+
+  it("drops a stale switch request when the other robot leaves", () => {
+    act(() => {
+      status.update({ watchedRobot: ROBOT, robots: [ROBOT, ROBOT_B], manifest: mf([ODOM], [CAM]) });
+    });
+    act(() => switchButton()!.click());
+    expect(picker()).not.toBeNull();
+    act(() => status.update({ robots: [ROBOT] }));
+    expect(picker()).toBeNull();
+    expect(panel()).not.toBeNull();
+    // The other robot returning must not pop the picker over the layout.
+    act(() => status.update({ robots: [ROBOT, ROBOT_B] }));
+    expect(picker()).toBeNull();
+    expect(switchButton()).not.toBeNull();
   });
 
   it("shows the polite notice on an unsupported manifest version", () => {

--- a/web/cockpit/src/App.tsx
+++ b/web/cockpit/src/App.tsx
@@ -6,17 +6,22 @@ import { LayoutTree } from "./layout/LayoutTree.tsx";
 import { type PageTab, pageTabs, PageView } from "./layout/PageView.tsx";
 import { startChatTranscripts } from "./panels/chatTranscript.ts";
 import { ChannelList } from "./ui/ChannelList.tsx";
+import { RobotPicker } from "./ui/RobotPicker.tsx";
 import { StatusBar, type View } from "./ui/StatusBar.tsx";
 import styles from "./App.module.css";
 
 export function App({ session }: { session: Session }) {
   const status = useStatus(session);
   const teleop = teleopHooks(session);
-  // Panels or the raw channel table, and the open page tab. Both live above
-  // the epoch-keyed <main> so a manifest change (robot restart) does not yank
-  // the operator off the table or their page.
+  // Panels or the raw channel table, the open page tab, and a pending
+  // "switch robot" request. All live above the epoch-keyed <main> so a
+  // manifest change (robot restart or switch) does not yank the operator off
+  // the table, their page, or the picker.
   const [view, setView] = useState<View>("panels");
   const [pageId, setPageId] = useState<string | null>(null);
+  const [picking, setPicking] = useState(false);
+  const watchedId = status.watchedRobot?.id ?? null;
+  const hasMultipleRobots = status.robots.length > 1;
   // Chat transcripts outlive their panels (an inactive page is unmounted),
   // so they start as soon as a manifest names them.
   useEffect(() => {
@@ -31,22 +36,37 @@ export function App({ session }: { session: Session }) {
     }
   }, [pageId, status.manifest]);
 
+  // Nothing to switch to (the list shrank, or a relay restart pushed an empty
+  // one): drop a stale request so a later registration does not pop the
+  // picker over the live layout unprompted.
+  useEffect(() => {
+    if (!hasMultipleRobots) setPicking(false);
+  }, [hasMultipleRobots]);
+
   const openPage = (id: string | null): void => {
     setPageId(id);
     setView("panels");
   };
+
+  const pickRobot = (id: string): void => {
+    setPicking(false);
+    // The promise rejects only with WatchRejectedError (superseded by a newer
+    // pick, or the session closed): nothing the operator can act on.
+    void session.watch(id).catch(() => {});
+  };
+
+  // Several robots and none watched: the operator has to pick (the SDK
+  // auto-watches only a lone robot). A pick pins the watch for the session;
+  // "switch robot" in the status bar reopens the list.
+  const showPicker = hasMultipleRobots && (picking || status.watchedRobot === null);
 
   let content;
   let pages: PageTab[] = [];
   let page: string | null = null;
   if (status.transport.phase === "failed") {
     content = <p className={styles.notice}>Connection failed: {status.transport.reason}</p>;
-  } else if (status.robots.length > 1) {
-    content = (
-      <p className={styles.notice}>
-        {status.robots.length} robots connected; the robot picker arrives in a later release.
-      </p>
-    );
+  } else if (showPicker) {
+    content = <RobotPicker robots={status.robots} current={watchedId} onPick={pickRobot} />;
   } else if (status.manifestUnsupported) {
     content = (
       <p className={styles.notice}>
@@ -100,6 +120,7 @@ export function App({ session }: { session: Session }) {
         pages={pages}
         page={page}
         onPageChange={openPage}
+        onSwitchRobot={hasMultipleRobots && !showPicker ? () => setPicking(true) : null}
       />
       {/* A changed manifest remounts everything below the status bar. */}
       <main className={styles.main} key={status.epoch}>

--- a/web/cockpit/src/ui/RobotPicker.module.css
+++ b/web/cockpit/src/ui/RobotPicker.module.css
@@ -1,0 +1,59 @@
+.picker {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 2rem auto;
+  max-width: 420px;
+  width: 100%;
+}
+
+.hint {
+  color: var(--fg-muted);
+  margin: 0 0 4px;
+  text-align: center;
+}
+
+.robot {
+  align-items: baseline;
+  background: var(--bg-2);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius);
+  cursor: pointer;
+  display: flex;
+  gap: 10px;
+  padding: 10px 14px;
+  text-align: left;
+  transition: background var(--dur), border-color var(--dur);
+}
+
+.robot:hover {
+  background: var(--bg-3);
+  border-color: var(--fg-faint);
+}
+
+.robot[aria-current="true"] {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-soft);
+}
+
+.name {
+  flex: 1;
+  font-weight: 600;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.meta {
+  color: var(--fg-muted);
+  display: inline-flex;
+  flex: none;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  gap: 8px;
+}
+
+.id {
+  color: var(--fg-faint);
+}

--- a/web/cockpit/src/ui/RobotPicker.test.tsx
+++ b/web/cockpit/src/ui/RobotPicker.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { RobotPicker } from "./RobotPicker.tsx";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const ALPHA = { id: "alpha", name: "Alpha", model: "go2" };
+const BRAVO = { id: "bravo", name: "Bravo", model: "" };
+
+describe("RobotPicker", () => {
+  let container: HTMLElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function entries(): HTMLElement[] {
+    return [...container.querySelectorAll<HTMLElement>('[data-testid^="robot-pick-"]')];
+  }
+
+  it("lists the robots sorted by name, then id, whatever the push order", () => {
+    const twin = { id: "a2", name: "Alpha", model: "go2" };
+    act(() =>
+      root.render(<RobotPicker robots={[BRAVO, twin, ALPHA]} current={null} onPick={() => {}} />)
+    );
+    expect(entries().map((el) => el.dataset.testid)).toEqual([
+      "robot-pick-a2",
+      "robot-pick-alpha",
+      "robot-pick-bravo",
+    ]);
+  });
+
+  it("shows name, model and id, skipping an empty model", () => {
+    act(() =>
+      root.render(<RobotPicker robots={[ALPHA, BRAVO]} current={null} onPick={() => {}} />)
+    );
+    const [alpha, bravo] = entries();
+    expect(alpha.textContent).toBe("Alphago2alpha");
+    expect(bravo.textContent).toBe("Bravobravo");
+  });
+
+  it("marks the watched robot and reports a pick by id", () => {
+    const picks: string[] = [];
+    act(() =>
+      root.render(
+        <RobotPicker robots={[ALPHA, BRAVO]} current="bravo" onPick={(id) => picks.push(id)} />,
+      )
+    );
+    const [alpha, bravo] = entries();
+    expect(alpha.getAttribute("aria-current")).toBe("false");
+    expect(bravo.getAttribute("aria-current")).toBe("true");
+    act(() => alpha.click());
+    expect(picks).toEqual(["alpha"]);
+  });
+});

--- a/web/cockpit/src/ui/RobotPicker.tsx
+++ b/web/cockpit/src/ui/RobotPicker.tsx
@@ -1,0 +1,39 @@
+import type { RobotInfo } from "@dimos/sdk";
+import styles from "./RobotPicker.module.css";
+
+/**
+ * The robots registered on the relay, one button each; picking one pins the
+ * session's watch to it. Sorted by name so a `robots` push (a robot joining
+ * or leaving) does not reorder the list under the operator's pointer.
+ */
+export function RobotPicker({ robots, current, onPick }: {
+  robots: RobotInfo[];
+  /** Id of the robot being watched, marked in the list; null when none. */
+  current: string | null;
+  onPick: (id: string) => void;
+}) {
+  const sorted = [...robots].sort((a, b) =>
+    a.name.localeCompare(b.name) || a.id.localeCompare(b.id)
+  );
+  return (
+    <div className={styles.picker} data-testid="robot-picker">
+      <p className={styles.hint}>Pick a robot to watch</p>
+      {sorted.map((robot) => (
+        <button
+          key={robot.id}
+          type="button"
+          className={styles.robot}
+          aria-current={robot.id === current}
+          data-testid={`robot-pick-${robot.id}`}
+          onClick={() => onPick(robot.id)}
+        >
+          <span className={styles.name}>{robot.name}</span>
+          <span className={styles.meta}>
+            {robot.model !== "" && <span>{robot.model}</span>}
+            <span className={styles.id}>{robot.id}</span>
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/web/cockpit/src/ui/StatusBar.module.css
+++ b/web/cockpit/src/ui/StatusBar.module.css
@@ -166,6 +166,25 @@
   color: var(--fg-faint);
 }
 
+.switchRobot {
+  background: none;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-s);
+  color: var(--fg-muted);
+  cursor: pointer;
+  flex: none;
+  font-size: 11px;
+  line-height: 18px;
+  padding: 0 7px;
+  transition: border-color var(--dur), color var(--dur);
+  white-space: nowrap;
+}
+
+.switchRobot:hover {
+  border-color: var(--fg-faint);
+  color: var(--fg);
+}
+
 .error {
   color: var(--danger);
   font-size: 11px;

--- a/web/cockpit/src/ui/StatusBar.test.tsx
+++ b/web/cockpit/src/ui/StatusBar.test.tsx
@@ -48,6 +48,7 @@ describe("StatusBar", () => {
           pages={[]}
           page={null}
           onPageChange={() => {}}
+          onSwitchRobot={null}
           {...over}
         />,
       )
@@ -65,6 +66,18 @@ describe("StatusBar", () => {
     expect(testId("status").getAttribute("data-phase")).toBe("connected");
     expect(testId("status").textContent).toBe("connected");
     expect(testId("robot").textContent).toBe("Go2 (go2)");
+  });
+
+  it("offers 'switch robot' only with a handler and keeps it out of the robot readout", () => {
+    const go2 = { id: "a", name: "Go2", model: "go2" };
+    render(makeStatus({ watchedRobot: go2 }));
+    expect(container.querySelector('[data-testid="switch-robot"]')).toBeNull();
+    let clicks = 0;
+    render(makeStatus({ watchedRobot: go2 }), { onSwitchRobot: () => clicks++ });
+    expect(testId("switch-robot").textContent).toBe("switch robot");
+    expect(testId("robot").textContent).toBe("Go2 (go2)");
+    act(() => (testId("switch-robot") as HTMLElement).click());
+    expect(clicks).toBe(1);
   });
 
   it("shows 'no robot' when none is picked", () => {

--- a/web/cockpit/src/ui/StatusBar.tsx
+++ b/web/cockpit/src/ui/StatusBar.tsx
@@ -27,15 +27,20 @@ const PHASE_LABEL: Record<string, string> = {
   failed: "failed",
 };
 
-export function StatusBar({ status, view, onViewChange, pages, page, onPageChange }: {
-  status: SessionStatus;
-  view: View;
-  onViewChange: (view: View) => void;
-  /** The manifest's page tabs (none: no tab strip), the open page, and the pick. */
-  pages: PageTab[];
-  page: string | null;
-  onPageChange: (id: string | null) => void;
-}) {
+export function StatusBar(
+  { status, view, onViewChange, pages, page, onPageChange, onSwitchRobot }: {
+    status: SessionStatus;
+    view: View;
+    onViewChange: (view: View) => void;
+    /** The manifest's page tabs (none: no tab strip), the open page, and the pick. */
+    pages: PageTab[];
+    page: string | null;
+    onPageChange: (id: string | null) => void;
+    /** Reopens the robot picker; null hides the button (nothing else to
+     * watch, or the picker is already open). */
+    onSwitchRobot: (() => void) | null;
+  },
+) {
   const transport = status.transport;
   const now = useNowWhile(transport.phase === "reconnecting", 250);
 
@@ -113,6 +118,16 @@ export function StatusBar({ status, view, onViewChange, pages, page, onPageChang
           )
           : "no robot"}
       </span>
+      {onSwitchRobot !== null && (
+        <button
+          type="button"
+          className={styles.switchRobot}
+          data-testid="switch-robot"
+          onClick={onSwitchRobot}
+        >
+          switch robot
+        </button>
+      )}
       {status.lastError !== null && <span className={styles.error}>{status.lastError.message}
       </span>}
     </header>


### PR DESCRIPTION
- Adds a robot picker to the web cockpit when multiple robots share a relay. Users can choose which robot to view from a list showing their names, models, and IDs.
- Displays the selected robot's own panels and page tabs, so robots with different cockpit layouts can share the same relay.
- Adds a "switch robot" button to the status bar. It reopens the list and highlights the current selection.
