### PR TITLE
fix(cli): revalidate record flags after partial global config updates

### DIFF
--- a/dimos/core/global_config.py
+++ b/dimos/core/global_config.py
@@ -161,6 +161,8 @@ class GlobalConfig(BaseSettings):
             if key not in type(self).model_fields:
                 raise AttributeError(f"GlobalConfig has no field '{key}'")
             setattr(self, key, value)
+        self.record_engine = self.record_engine
+        self.record_encoding_threads = self.record_encoding_threads
 
     @property
     def unitree_connection_type(self) -> str:

--- a/dimos/core/test_global_config.py
+++ b/dimos/core/test_global_config.py
@@ -44,6 +44,15 @@ class TestRecordingConfig:
             == "mcap"
         )
 
+    def test_mcap_cannot_be_updated_without_rust(self) -> None:
+        config = GlobalConfig.model_validate({})
+
+        with pytest.raises(ValidationError, match="MCAP recording requires --record-engine rust"):
+            config.update(record="mcap")
+
+        config.update(record="mcap", record_engine="rust")
+        assert config.record == "mcap"
+
     def test_encoding_threads_require_rust(self) -> None:
         with pytest.raises(ValidationError, match="valid only with --record-engine rust"):
             GlobalConfig.model_validate({"record_encoding_threads": 8})


### PR DESCRIPTION
Closes a validation gap in #3924: `dimos --record mcap run ...` without `--record-engine rust` passes config validation, because `GlobalConfig.update()` assigns one field at a time and the mcap-requires-rust rule lives on the `record_engine` field validator, which never re-runs when only `record` is assigned. The run then silently records a SQLite `memory.db` through the python engine instead of MCAP.

Repro on the current branch head:

```python
from dimos.core.global_config import GlobalConfig
c = GlobalConfig.model_validate({})
c.update(record="mcap")  # accepted; record_engine is still "python"
```

Fix: `update()` re-assigns `record_engine` and `record_encoding_threads` after applying the batch, so `validate_assignment` re-runs their field validators against the merged state. Raises the same `ValidationError` messages the CLI already catches. Field validators are kept as-is — moving the rules to a `model_validator(mode="after")` breaks per-field assignment orders (including pytest monkeypatch teardown, 69 errors).

All 66 tests from #3924 pass with this change (including the rust recorder e2e), plus one new test for the repro. mypy clean.

The pip-install/library gap (wheels ship no `rust/` crate, so `--record-engine rust` fails with a raw `FileNotFoundError`) is intentionally left out of this PR per review discussion.