### PR TITLE
fix(memory): subscribe Zenoh recording streams concurrently

### DIFF
--- a/dimos/memory/tap.py
+++ b/dimos/memory/tap.py
@@ -24,8 +24,10 @@ Poses are not resolved here; ``tf`` is recorded like any other stream and
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Iterator, Mapping
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 import fnmatch
+from functools import partial
+from itertools import groupby
 import os
 from pathlib import Path
 import queue
@@ -35,14 +37,17 @@ from typing import TYPE_CHECKING, Any
 
 from dimos.constants import RECORDINGS_DIR
 from dimos.core.global_config import global_config
+from dimos.core.transport import ZenohTransport, pZenohTransport
 from dimos.memory.store.sqlite import SqliteStore
 from dimos.utils.logging_config import setup_logger
+from dimos.utils.safe_thread_map import safe_thread_map
 
 if TYPE_CHECKING:
     from dimos.core.stream import Transport
     from dimos.memory.stream import Stream
 
 logger = setup_logger()
+MAX_PARALLEL_TAPS = 32
 
 
 def recording_dir() -> Path:
@@ -99,10 +104,10 @@ class TransportRecorder:
         if self.dropped:
             logger.warning("--record: dropped %d messages (writer queue full)", self.dropped)
 
-    def tap(
+    def prepare_tap(
         self, name: str, stream_type: type, transport: Transport[Any]
-    ) -> Callable[[], None] | None:
-        """Subscribe *transport* and record into stream *name*; returns the unsubscribe."""
+    ) -> Callable[[], Callable[[], None]] | None:
+        """Prepare a transport subscription without starting it."""
         if not matching(self._topics, [name]):
             return None
         if not hasattr(stream_type, "lcm_encode"):
@@ -119,7 +124,18 @@ class TransportRecorder:
                     logger.warning("--record: writer queue full, %d dropped so far", self.dropped)
 
         logger.info("Recording %s (%s) via %s", name, stream_type.__name__, transport)
-        return transport.subscribe(on_msg)
+
+        def subscribe() -> Callable[[], None]:
+            return transport.subscribe(on_msg)
+
+        return subscribe
+
+    def tap(
+        self, name: str, stream_type: type, transport: Transport[Any]
+    ) -> Callable[[], None] | None:
+        """Subscribe *transport* and record into stream *name*; returns the unsubscribe."""
+        subscribe = self.prepare_tap(name, stream_type, transport)
+        return subscribe() if subscribe is not None else None
 
 
 @contextmanager
@@ -148,17 +164,51 @@ def recording(
     path = recording_dir() / "memory.db"
     store = SqliteStore(path=str(path))
     store.start()
-    recorder = TransportRecorder(store, global_config.record_topics)
-    unsubscribes = [
-        unsubscribe
-        for (name, payload_type), transport in transports.items()
-        if (unsubscribe := recorder.tap(name, payload_type, transport)) is not None
-    ]
-    logger.info("Recording to %s", path)
-    try:
+    with ExitStack() as cleanup:
+        cleanup.callback(store.stop)
+        recorder = TransportRecorder(store, global_config.record_topics)
+        cleanup.callback(recorder.close)
+
+        def cleanup_started(
+            _outcomes: list[
+                tuple[Callable[[], Callable[[], None]], Callable[[], None] | Exception]
+            ],
+            unsubscribes: list[Callable[[], None]],
+            errors: list[Exception],
+        ) -> None:
+            for unsubscribe in unsubscribes:
+                cleanup.callback(unsubscribe)
+            raise errors[0]
+
+        subscription_locks = {id(tr): threading.Lock() for tr in transports.values()}
+
+        def subscribe_transport(
+            tr: Transport[Any], subscribe: Callable[[], Callable[[], None]]
+        ) -> Callable[[], None]:
+            with subscription_locks[id(tr)]:
+                return subscribe()
+
+        subscriptions: list[tuple[bool, Callable[[], Callable[[], None]]]] = [
+            (
+                isinstance(tr, (ZenohTransport, pZenohTransport)),
+                partial(subscribe_transport, tr, subscribe),
+            )
+            for (name, t), tr in transports.items()
+            if (subscribe := recorder.prepare_tap(name, t, tr)) is not None
+        ]
+        # Do not start other backends past a failed subscription.
+        for parallel, group in groupby(subscriptions, key=lambda item: item[0]):
+            batch = [subscribe for _, subscribe in group]
+            if parallel:
+                for offset in range(0, len(batch), MAX_PARALLEL_TAPS):
+                    for unsubscribe in safe_thread_map(
+                        batch[offset : offset + MAX_PARALLEL_TAPS],
+                        lambda subscribe: subscribe(),
+                        on_errors=cleanup_started,
+                    ):
+                        cleanup.callback(unsubscribe)
+            else:
+                for subscribe in batch:
+                    cleanup.callback(subscribe())
+        logger.info("Recording to %s", path)
         yield
-    finally:
-        for unsubscribe in unsubscribes:
-            unsubscribe()
-        recorder.close()
-        store.stop()

--- a/dimos/memory/test_tap.py
+++ b/dimos/memory/test_tap.py
@@ -13,18 +13,22 @@
 # limitations under the License.
 
 from collections.abc import Callable
+from contextlib import ExitStack
 from pathlib import Path
-from typing import Any
+import threading
+from typing import Any, cast
 
 import pytest
 from pytest_mock import MockerFixture
 
 from dimos.core.global_config import global_config
 from dimos.core.stream import Transport
+from dimos.core.transport import ROSTransport, ZenohTransport, pZenohTransport
 from dimos.memory import tap
 from dimos.memory.store.sqlite import SqliteStore
 from dimos.memory.tap import TransportRecorder
 from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
+from dimos.protocol.pubsub.impl import rospubsub
 
 
 class _Transport(Transport[Any]):
@@ -46,6 +50,13 @@ class _Transport(Transport[Any]):
     def broadcast(self, selfstream: Any, msg: Any) -> None:
         for cb in self.callbacks:
             cb(msg)
+
+
+class _FailingTransport(_Transport):
+    def subscribe(
+        self, callback: Callable[[Any], None], selfstream: Any = None
+    ) -> Callable[[], None]:
+        raise RuntimeError("subscription failed")
 
 
 def test_taps_matching_dimos_streams(tmp_path: Path) -> None:
@@ -121,6 +132,222 @@ def test_recording_fails_loudly_when_no_stream_matches(
         ):
             pass
     assert not any(tmp_path.rglob("memory.db"))
+
+
+@pytest.mark.parametrize("transport_cls", [ZenohTransport, pZenohTransport])
+def test_recording_starts_zenoh_subscriptions_concurrently(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mocker: MockerFixture,
+    transport_cls: type[ZenohTransport[Any]] | type[pZenohTransport[Any]],
+) -> None:
+    monkeypatch.setattr(tap, "RECORDINGS_DIR", tmp_path)
+    monkeypatch.setattr(global_config, "record", "sqlite")
+    monkeypatch.setattr(global_config, "record_topics", "*")
+    barrier = threading.Barrier(4)
+    transports: dict[tuple[str, type], ZenohTransport[Any] | pZenohTransport[Any]] = {
+        (f"stream_{i}", PoseStamped): transport_cls(f"stream_{i}") for i in range(4)
+    }
+    unsubscribe = mocker.Mock()
+
+    def subscribe(*args: Any) -> Callable[[], None]:
+        barrier.wait(timeout=2.0)
+        return cast("Callable[[], None]", unsubscribe)
+
+    subscriptions = []
+    for transport in transports.values():
+        mocker.patch.object(transport.zenoh, "start")
+        subscriptions.append(
+            mocker.patch.object(transport.zenoh, "subscribe", side_effect=subscribe)
+        )
+
+    with tap.recording(transports):
+        assert [subscription.call_count for subscription in subscriptions] == [1, 1, 1, 1]
+
+    assert unsubscribe.call_count == 4
+
+
+def test_recording_serializes_subscriptions_on_shared_transport(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
+) -> None:
+    monkeypatch.setattr(tap, "RECORDINGS_DIR", tmp_path)
+    monkeypatch.setattr(global_config, "record", "sqlite")
+    monkeypatch.setattr(global_config, "record_topics", "*")
+    calls = threading.Barrier(2)
+    active = threading.Lock()
+    unsubscribe = mocker.Mock()
+
+    def subscribe(*args: Any) -> Callable[[], None]:
+        assert active.acquire(blocking=False), "overlapping subscriptions"
+        try:
+            try:
+                calls.wait(timeout=1.0)
+            except threading.BrokenBarrierError:
+                pass
+            return cast("Callable[[], None]", unsubscribe)
+        finally:
+            active.release()
+
+    shared = ZenohTransport[PoseStamped]("odom", PoseStamped)
+    start = mocker.patch.object(shared.zenoh, "start")
+    subscription = mocker.patch.object(shared.zenoh, "subscribe", side_effect=subscribe)
+    with tap.recording({("odom", PoseStamped): shared, ("pose", PoseStamped): shared}):
+        assert subscription.call_count == 2
+
+    start.assert_called_once_with()
+    assert unsubscribe.call_count == 2
+
+
+@pytest.mark.parametrize("fail", [False, True])
+def test_recording_bounds_zenoh_batches(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture, fail: bool
+) -> None:
+    monkeypatch.setattr(tap, "RECORDINGS_DIR", tmp_path)
+    monkeypatch.setattr(global_config, "record", "sqlite")
+    monkeypatch.setattr(global_config, "record_topics", "*")
+    monkeypatch.setattr(tap, "MAX_PARALLEL_TAPS", 2)
+    transports = [ZenohTransport[PoseStamped](f"stream_{i}", PoseStamped) for i in range(5)]
+    unsubscribe = mocker.Mock()
+    subscriptions = []
+    for transport in transports:
+        mocker.patch.object(transport.zenoh, "start")
+        subscriptions.append(
+            mocker.patch.object(transport.zenoh, "subscribe", return_value=unsubscribe)
+        )
+    batches = mocker.spy(tap, "safe_thread_map")
+    streams: dict[tuple[str, type], ZenohTransport[PoseStamped]] = {
+        (f"stream_{i}", PoseStamped): tr for i, tr in enumerate(transports)
+    }
+
+    if fail:
+        subscriptions[3].side_effect = RuntimeError("subscription failed")
+        with pytest.raises(RuntimeError, match="subscription failed"):
+            with tap.recording(streams):
+                pytest.fail("startup must fail")
+        assert [len(call.args[0]) for call in batches.call_args_list] == [2, 2]
+        assert unsubscribe.call_count == 3
+        subscriptions[4].assert_not_called()
+    else:
+        with tap.recording(streams):
+            assert [subscription.call_count for subscription in subscriptions] == [1] * 5
+        assert [len(call.args[0]) for call in batches.call_args_list] == [2, 2, 1]
+        assert unsubscribe.call_count == 5
+
+
+@pytest.mark.parametrize("already_started", [False, True])
+@pytest.mark.parametrize("zenoh_failure", [False, True])
+def test_failed_subscription_preserves_ros_lifecycle(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mocker: MockerFixture,
+    already_started: bool,
+    zenoh_failure: bool,
+) -> None:
+    monkeypatch.setattr(tap, "RECORDINGS_DIR", tmp_path)
+    monkeypatch.setattr(global_config, "record", "sqlite")
+    monkeypatch.setattr(global_config, "record_topics", "*")
+    mocker.patch.object(rospubsub, "ROS_AVAILABLE", True)
+    mocker.patch.object(rospubsub, "rclpy").ok.return_value = True
+    mocker.patch.object(rospubsub, "Node")
+    mocker.patch.object(
+        rospubsub.DimosROS, "_to_raw_topic", return_value=rospubsub.RawROSTopic("/odom", object)
+    )
+    halted = threading.Event()
+    executor = mocker.patch.object(rospubsub, "SingleThreadedExecutor").return_value
+    executor.spin_once.side_effect = lambda timeout_sec: halted.wait(timeout_sec)
+    executor.shutdown.side_effect = halted.set
+    ros = ROSTransport("/odom", PoseStamped, qos=mocker.Mock())
+    failing: Transport[Any] = _FailingTransport()
+    if zenoh_failure:
+        failing = ZenohTransport("bad", PoseStamped)
+        mocker.patch.object(failing.zenoh, "start", side_effect=RuntimeError("subscription failed"))
+
+    with ExitStack() as cleanup:
+        cleanup.callback(ros.stop)
+        if already_started:
+            ros.start()
+        threads_before = {t for t in threading.enumerate() if t.name == "ros_pubsub_spin"}
+        with pytest.raises(RuntimeError, match="subscription failed"):
+            with tap.recording({("bad", PoseStamped): failing, ("odom", PoseStamped): ros}):
+                pytest.fail("startup must fail")
+        assert {t for t in threading.enumerate() if t.name == "ros_pubsub_spin"} == threads_before
+        executor.shutdown.assert_not_called()
+
+
+def test_recording_cleans_up_after_partial_subscription_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(tap, "RECORDINGS_DIR", tmp_path)
+    monkeypatch.setattr(global_config, "record", "sqlite")
+    monkeypatch.setattr(global_config, "record_topics", "*")
+    successful = _Transport()
+
+    with pytest.raises(RuntimeError, match="subscription failed"):
+        with tap.recording(
+            {
+                ("successful", PoseStamped): successful,
+                ("failing", PoseStamped): _FailingTransport(),
+            }
+        ):
+            pass
+
+    assert not successful.callbacks
+    assert not any(t.name == "record-writer" for t in threading.enumerate())
+
+
+def test_failed_zenoh_batch_unsubscribes_and_does_not_start_next_backend(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
+) -> None:
+    monkeypatch.setattr(tap, "RECORDINGS_DIR", tmp_path)
+    monkeypatch.setattr(global_config, "record", "sqlite")
+    monkeypatch.setattr(global_config, "record_topics", "*")
+    barrier = threading.Barrier(2)
+    good, bad = [ZenohTransport[PoseStamped](name, PoseStamped) for name in ("good", "bad")]
+    unsubscribe = mocker.Mock()
+
+    def subscribe(*args: Any) -> Callable[[], None]:
+        barrier.wait(timeout=2.0)
+        return cast("Callable[[], None]", unsubscribe)
+
+    def fail(*args: Any) -> Callable[[], None]:
+        barrier.wait(timeout=2.0)
+        raise RuntimeError("subscription failed")
+
+    mocker.patch.object(good.zenoh, "start")
+    mocker.patch.object(bad.zenoh, "start")
+    mocker.patch.object(good.zenoh, "subscribe", side_effect=subscribe)
+    mocker.patch.object(bad.zenoh, "subscribe", side_effect=fail)
+    later = _Transport()
+    later_subscribe = mocker.spy(later, "subscribe")
+
+    with pytest.raises(RuntimeError, match="subscription failed"):
+        with tap.recording(
+            {("good", PoseStamped): good, ("bad", PoseStamped): bad, ("later", PoseStamped): later}
+        ):
+            pytest.fail("startup must fail")
+
+    unsubscribe.assert_called_once_with()
+    later_subscribe.assert_not_called()
+    assert not any(t.name == "record-writer" for t in threading.enumerate())
+
+
+def test_recording_cleans_up_after_tap_preparation_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
+) -> None:
+    monkeypatch.setattr(tap, "RECORDINGS_DIR", tmp_path)
+    monkeypatch.setattr(global_config, "record", "sqlite")
+    monkeypatch.setattr(global_config, "record_topics", "*")
+    mocker.patch.object(
+        TransportRecorder,
+        "prepare_tap",
+        side_effect=RuntimeError("prepare failed"),
+    )
+
+    with pytest.raises(RuntimeError, match="prepare failed"):
+        with tap.recording({("odom", PoseStamped): _Transport()}):
+            pass
+
+    assert not any(t.name == "record-writer" for t in threading.enumerate())
 
 
 def test_recording_delegates_to_rust_session(


### PR DESCRIPTION
Addresses #3926

Recording subscribes to streams one at a time, so a slow Zenoh connection delays every stream after it.

This PR starts adjacent Zenoh subscriptions in parallel, up to 32 at a time. If startup fails, it removes any subscriptions already created and closes the recorder and database. Other transports stay serial, and Rust recording is unchanged.

I ran both versions five times locally with 22 streams and connection timeouts. Median startup fell from 5.29s to 0.82s. After startup, each stream sent one message and all 22 were saved in every run.