### PR TITLE
bump zenoh to 1.10.1; use zenoh upstream: Fix multicast scouting mac

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -519,6 +519,8 @@ jobs:
       # redirects it to a per-process file under $RUNNER_TEMP/pytest-crash,
       # which is what makes a crash legible under xdist (one file per worker).
       PYTHONFAULTHANDLER: "1"
+      # Zenoh's own scouting decisions, for diagnosing workers that never link.
+      RUST_LOG: "zenoh::net::runtime::orchestrator=debug"
     permissions:
       contents: read  # For checkout
       id-token: write  # For codecov-action's OIDC upload

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -640,11 +640,10 @@ jobs:
                 - /var/cache/dimos-root-cache:/root/.cache
             markers: "self_hosted or skipif_no_ros"
             experimental: false
-          # macOS runner disabled for now — we don't want Mac tests.
-          # - os: macOS
-          #   container: null  # run on host — `container:` is Linux-only
-          #   markers: "self_hosted"
-          #   experimental: true
+          - os: macOS
+            container: null  # run on host — `container:` is Linux-only
+            markers: "self_hosted"
+            experimental: true
     runs-on:
       - self-hosted
       - ${{ matrix.os }}

--- a/dimos/protocol/service/test_zenoh_loopback_scouting.py
+++ b/dimos/protocol/service/test_zenoh_loopback_scouting.py
@@ -17,17 +17,11 @@
 Upstream: Fix multicast scouting on loopback#2671.
 """
 
+from collections.abc import Callable
 import json
-import socket
 import time
 
 import zenoh
-
-
-def _free_udp_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
-        sock.bind(("127.0.0.1", 0))
-        return int(sock.getsockname()[1])
 
 
 def _config(**settings: object) -> zenoh.Config:
@@ -46,8 +40,10 @@ def _loopback_multicast(address: str) -> dict[str, object]:
     }
 
 
-def test_multicast_scouting_works_on_loopback() -> None:
-    address = f"224.0.0.224:{_free_udp_port()}"
+def test_multicast_scouting_works_on_loopback(
+    unused_udp_port_factory: Callable[[], int],
+) -> None:
+    address = f"224.0.0.224:{unused_udp_port_factory()}"
     responder = zenoh.open(
         _config(
             mode="router",
@@ -71,8 +67,10 @@ def test_multicast_scouting_works_on_loopback() -> None:
         responder.close()
 
 
-def test_multicast_autoconnect_works_on_loopback() -> None:
-    address = f"224.0.0.224:{_free_udp_port()}"
+def test_multicast_autoconnect_works_on_loopback(
+    unused_udp_port_factory: Callable[[], int],
+) -> None:
+    address = f"224.0.0.224:{unused_udp_port_factory()}"
     peer1 = zenoh.open(_config(mode="peer", **_loopback_multicast(address)))
     peer2 = zenoh.open(_config(mode="peer", **_loopback_multicast(address)))
     try:

--- a/dimos/protocol/service/test_zenoh_loopback_scouting.py
+++ b/dimos/protocol/service/test_zenoh_loopback_scouting.py
@@ -1,0 +1,88 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Zenoh's own loopback scouting regression tests, ported from zenoh/tests/scouting.rs.
+
+Upstream: Fix multicast scouting on loopback#2671.
+"""
+
+import json
+import socket
+import time
+
+import zenoh
+
+
+def _free_udp_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+        sock.bind(("", 0))
+        return int(sock.getsockname()[1])
+
+
+def _config(**settings: object) -> zenoh.Config:
+    config = zenoh.Config()
+    for key, value in settings.items():
+        config.insert_json5(key.replace("__", "/"), json.dumps(value))
+    return config
+
+
+def _loopback_multicast(address: str) -> dict[str, object]:
+    return {
+        "scouting__gossip__enabled": False,
+        "scouting__multicast__enabled": True,
+        "scouting__multicast__address": address,
+        "scouting__multicast__interface": "127.0.0.1",
+    }
+
+
+def test_multicast_scouting_works_on_loopback() -> None:
+    address = f"224.0.0.224:{_free_udp_port()}"
+    responder = zenoh.open(
+        _config(
+            mode="router",
+            listen__endpoints=[],
+            scouting__multicast__autoconnect=[],
+            **_loopback_multicast(address),
+        )
+    )
+    scout = zenoh.scout(what="router", config=_config(**_loopback_multicast(address)))
+    try:
+        deadline = time.monotonic() + 5.0
+        hello = scout.try_recv()
+        while hello is None and time.monotonic() < deadline:
+            time.sleep(0.05)
+            hello = scout.try_recv()
+        assert hello is not None, "timed out waiting for multicast scout Hello"
+        assert hello.whatami == zenoh.WhatAmI.ROUTER
+        assert str(hello.zid) == str(responder.info.zid())
+    finally:
+        scout.stop()
+        responder.close()
+
+
+def test_multicast_autoconnect_works_on_loopback() -> None:
+    address = f"224.0.0.224:{_free_udp_port()}"
+    peer1 = zenoh.open(_config(mode="peer", **_loopback_multicast(address)))
+    peer2 = zenoh.open(_config(mode="peer", **_loopback_multicast(address)))
+    try:
+        zid2 = str(peer2.info.zid())
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline and zid2 not in map(str, peer1.info.peers_zid()):
+            time.sleep(0.05)
+        assert zid2 in map(str, peer1.info.peers_zid()), (
+            "timed out waiting for loopback scout connection"
+        )
+    finally:
+        peer2.close()
+        peer1.close()

--- a/dimos/protocol/service/test_zenoh_loopback_scouting.py
+++ b/dimos/protocol/service/test_zenoh_loopback_scouting.py
@@ -26,7 +26,7 @@ import zenoh
 
 def _free_udp_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
-        sock.bind(("", 0))
+        sock.bind(("127.0.0.1", 0))
         return int(sock.getsockname()[1])
 
 

--- a/dimos/protocol/service/test_zenoh_scouting.py
+++ b/dimos/protocol/service/test_zenoh_scouting.py
@@ -14,9 +14,10 @@
 
 """Network scouting is optional, and start() waits for its connect endpoints."""
 
-import socket
+from collections.abc import Callable
 import time
-from typing import cast
+from typing import Any
+from unittest.mock import create_autospec
 
 import pytest
 import zenoh
@@ -147,28 +148,33 @@ class _FakeInfo:
         return self._links
 
 
-class _FakeSession:
-    def __init__(self, links: list[str]) -> None:
-        self.info = _FakeInfo([_FakeLink(dst) for dst in links])
+def _fake_session(links: list[str]) -> Any:
+    """A session whose only live part is the links _await_connect polls."""
+    return create_autospec(
+        zenoh.Session,
+        spec_set=True,
+        instance=True,
+        info=_FakeInfo([_FakeLink(dst) for dst in links]),
+    )
 
 
 def _await_elapsed(
-    session: _FakeSession, connect: list[str], connect_timeout: float, mode: ZenohMode = "peer"
+    session: zenoh.Session, connect: list[str], connect_timeout: float, mode: ZenohMode = "peer"
 ) -> float:
     """Seconds _await_connect blocks against a session with the given links."""
     service = ZenohService(mode=mode, connect=connect, connect_timeout=connect_timeout)
     started = time.monotonic()
-    service._await_connect(cast("zenoh.Session", session))
+    service._await_connect(session)
     return time.monotonic() - started
 
 
 def test_await_returns_once_endpoint_is_linked(zenoh_defaults: None) -> None:
-    session = _FakeSession(["tcp/192.0.2.10:7447"])
+    session = _fake_session(["tcp/192.0.2.10:7447"])
     assert _await_elapsed(session, connect=["tcp/192.0.2.10:7447"], connect_timeout=5.0) < 1.0
 
 
 def test_await_waits_for_every_endpoint(zenoh_defaults: None) -> None:
-    session = _FakeSession(["tcp/192.0.2.10:7447"])
+    session = _fake_session(["tcp/192.0.2.10:7447"])
     elapsed = _await_elapsed(
         session,
         connect=["tcp/192.0.2.10:7447", "tcp/192.0.2.11:7447"],
@@ -179,7 +185,7 @@ def test_await_waits_for_every_endpoint(zenoh_defaults: None) -> None:
 
 def test_client_mode_await_is_satisfied_by_one_link(zenoh_defaults: None) -> None:
     """A client session holds a single link, so one linked alternative is done."""
-    session = _FakeSession(["tcp/192.0.2.10:7447"])
+    session = _fake_session(["tcp/192.0.2.10:7447"])
     elapsed = _await_elapsed(
         session,
         connect=["tcp/192.0.2.10:7447", "tcp/192.0.2.11:7447"],
@@ -192,37 +198,33 @@ def test_client_mode_await_is_satisfied_by_one_link(zenoh_defaults: None) -> Non
 def test_duplicate_endpoints_do_not_satisfy_the_wait(zenoh_defaults: None) -> None:
     """One endpoint listed twice is still one link to wait for."""
     duplicate = "tcp/192.0.2.199:7447"
-    elapsed = _await_elapsed(_FakeSession([]), connect=[duplicate, duplicate], connect_timeout=0.3)
+    elapsed = _await_elapsed(_fake_session([]), connect=[duplicate, duplicate], connect_timeout=0.3)
     assert elapsed >= 0.3
 
 
 def test_await_gives_up_after_timeout(zenoh_defaults: None) -> None:
     elapsed = _await_elapsed(
-        _FakeSession([]), connect=["tcp/192.0.2.199:7447"], connect_timeout=0.3
+        _fake_session([]), connect=["tcp/192.0.2.199:7447"], connect_timeout=0.3
     )
     assert elapsed >= 0.3
 
 
 def test_await_is_skipped_without_connect_endpoints(zenoh_defaults: None) -> None:
-    assert _await_elapsed(_FakeSession([]), connect=[], connect_timeout=30.0) < 3.0
+    assert _await_elapsed(_fake_session([]), connect=[], connect_timeout=30.0) < 3.0
 
 
 def test_zero_timeout_disables_the_wait(zenoh_defaults: None) -> None:
     assert (
-        _await_elapsed(_FakeSession([]), connect=["tcp/192.0.2.199:7447"], connect_timeout=0.0)
+        _await_elapsed(_fake_session([]), connect=["tcp/192.0.2.199:7447"], connect_timeout=0.0)
         < 1.0
     )
 
 
-def _free_udp_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
-        sock.bind(("127.0.0.1", 0))
-        return int(sock.getsockname()[1])
-
-
-def test_stock_sessions_discover_each_other_over_loopback(zenoh_defaults: None) -> None:
+def test_stock_sessions_discover_each_other_over_loopback(
+    zenoh_defaults: None, unused_udp_port_factory: Callable[[], int]
+) -> None:
     """Two sessions with the stock config scout each other on loopback and link there."""
-    config = ZenohConfig(scout_addr=f"224.0.0.224:{_free_udp_port()}")
+    config = ZenohConfig(scout_addr=f"224.0.0.224:{unused_udp_port_factory()}")
     pools = [ZenohSessionPool(), ZenohSessionPool()]
     a, b = (pool.acquire(config) for pool in pools)
     try:

--- a/dimos/protocol/service/test_zenoh_scouting.py
+++ b/dimos/protocol/service/test_zenoh_scouting.py
@@ -216,7 +216,7 @@ def test_zero_timeout_disables_the_wait(zenoh_defaults: None) -> None:
 
 def _free_udp_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
-        sock.bind(("", 0))
+        sock.bind(("127.0.0.1", 0))
         return int(sock.getsockname()[1])
 
 
@@ -232,8 +232,8 @@ def test_stock_sessions_discover_each_other_over_loopback(zenoh_defaults: None) 
             time.sleep(0.05)
         assert zid_b in map(str, a.info.peers_zid())
         assert zid_a in map(str, b.info.peers_zid())
-        for link in a.info.links():
-            assert str(link.dst).startswith("tcp/127.0.0.1:"), str(link.dst)
+        links = [str(link.dst) for link in a.info.links()]
+        assert links and all(dst.startswith("tcp/127.0.0.1:") for dst in links), links
     finally:
         for pool in pools:
             pool.close_all()

--- a/dimos/protocol/service/test_zenoh_scouting.py
+++ b/dimos/protocol/service/test_zenoh_scouting.py
@@ -14,9 +14,12 @@
 
 """Network scouting is optional, and start() waits for its connect endpoints."""
 
+import socket
 import time
+from typing import cast
 
 import pytest
+import zenoh
 
 from dimos.core.global_config import ZenohMode, global_config
 from dimos.protocol.service.zenohservice import (
@@ -25,6 +28,7 @@ from dimos.protocol.service.zenohservice import (
     LOOPBACK_LISTEN,
     ZenohConfig,
     ZenohService,
+    ZenohSessionPool,
     endpoint_addresses,
 )
 
@@ -154,7 +158,7 @@ def _await_elapsed(
     """Seconds _await_connect blocks against a session with the given links."""
     service = ZenohService(mode=mode, connect=connect, connect_timeout=connect_timeout)
     started = time.monotonic()
-    service._await_connect(session)
+    service._await_connect(cast("zenoh.Session", session))
     return time.monotonic() - started
 
 
@@ -208,3 +212,28 @@ def test_zero_timeout_disables_the_wait(zenoh_defaults: None) -> None:
         _await_elapsed(_FakeSession([]), connect=["tcp/192.0.2.199:7447"], connect_timeout=0.0)
         < 1.0
     )
+
+
+def _free_udp_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+        sock.bind(("", 0))
+        return int(sock.getsockname()[1])
+
+
+def test_stock_sessions_discover_each_other_over_loopback(zenoh_defaults: None) -> None:
+    """Two sessions with the stock config scout each other on loopback and link there."""
+    config = ZenohConfig(scout_addr=f"224.0.0.224:{_free_udp_port()}")
+    pools = [ZenohSessionPool(), ZenohSessionPool()]
+    a, b = (pool.acquire(config) for pool in pools)
+    try:
+        zid_a, zid_b = str(a.info.zid()), str(b.info.zid())
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline and zid_b not in map(str, a.info.peers_zid()):
+            time.sleep(0.05)
+        assert zid_b in map(str, a.info.peers_zid())
+        assert zid_a in map(str, b.info.peers_zid())
+        for link in a.info.links():
+            assert str(link.dst).startswith("tcp/127.0.0.1:"), str(link.dst)
+    finally:
+        for pool in pools:
+            pool.close_all()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ classifiers = [
 dependencies = [
     # Transport Protocols
     "dimos-lcm>=0.1.3",
-    "eclipse-zenoh>=1.9.0,<2.0",
+    "eclipse-zenoh>=1.10.0,<2.0",
     "PyTurboJPEG==1.8.2",
     "imagecodecs>=2024.6.1", # JPEG-XL for CompressedImage
     "jsonlines>=4,<5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ classifiers = [
 dependencies = [
     # Transport Protocols
     "dimos-lcm>=0.1.3",
-    "eclipse-zenoh>=1.10.0,<2.0",
+    "eclipse-zenoh>=1.10.1,<2.0",
     "PyTurboJPEG==1.8.2",
     "imagecodecs>=2024.6.1", # JPEG-XL for CompressedImage
     "jsonlines>=4,<5",
@@ -525,7 +525,7 @@ dev = [
 required-version = ">=0.9.25"
 default-groups = ["tests"]
 exclude-newer = "7 days"
-exclude-newer-package = { dimos-viewer = false, dimos-lcm = false, lcm-dimos-fork = false, roboplan = false, md-babel-py = false, can-motor-control = false, edgetam-dimos = false, dim-odom = false }
+exclude-newer-package = { dimos-viewer = false, dimos-lcm = false, lcm-dimos-fork = false, roboplan = false, md-babel-py = false, can-motor-control = false, edgetam-dimos = false, dim-odom = false, eclipse-zenoh = false }
 override-dependencies = [
     # ultralytics, unitree-sdk2py-dimos and unitree-webrtc-connect depend on
     # opencv-python, which ships the same cv2/ tree as our opencv-contrib-python

--- a/uv.lock
+++ b/uv.lock
@@ -2331,7 +2331,7 @@ requires-dist = [
     { name = "dimos-viewer", marker = "extra == 'visualization'", specifier = "==0.32.0a2" },
     { name = "drake", marker = "platform_machine != 'aarch64' and sys_platform == 'darwin' and extra == 'manipulation'", specifier = "==1.45.0" },
     { name = "drake", marker = "platform_machine != 'aarch64' and sys_platform != 'darwin' and extra == 'manipulation'", specifier = ">=1.40.0" },
-    { name = "eclipse-zenoh", specifier = ">=1.9.0,<2.0" },
+    { name = "eclipse-zenoh", specifier = ">=1.10.0,<2.0" },
     { name = "edgetam-dimos", marker = "extra == 'misc'", specifier = ">=1.0.1" },
     { name = "einops", marker = "extra == 'perception'", specifier = ">=0.8.1" },
     { name = "fastapi", marker = "extra == 'web'", specifier = ">=0.115.6" },
@@ -2843,18 +2843,18 @@ wheels = [
 
 [[package]]
 name = "eclipse-zenoh"
-version = "1.9.0"
+version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d9/42/c8502d0e77f74b9cf4c192a01e620b3d15273d371464485796807d202d9d/eclipse_zenoh-1.9.0.tar.gz", hash = "sha256:b0477ab431132ebfe1096eccac13ea0066d50d1528d726c8872c00e0345070d1", size = 164557, upload-time = "2026-04-10T13:23:35.883Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/a5/c8defd28227a73bac8e7daf6de6274bbd7f22014f86fdd5e5c43c78bbd79/eclipse_zenoh-1.10.0.tar.gz", hash = "sha256:6904906783b7eb7ce8d5dbbb930b2e62c0ef93490b0e3dbf79e36fe4fd9727d6", size = 168852, upload-time = "2026-08-14T17:39:47.844Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/3b/22b9104b0a022bd2b1627b4866876831585eda2eacb9ca1f3b4b8e847945/eclipse_zenoh-1.9.0-cp39-abi3-linux_armv6l.whl", hash = "sha256:15b6f37c407617ea4de32d32835cbcab4d1a116b892477490fc6c10a7d27c73b", size = 10664168, upload-time = "2026-04-10T13:23:15.008Z" },
-    { url = "https://files.pythonhosted.org/packages/05/c5/ee0815c7ec49c5a29307cd935478305159bb3f0b2489f8c54fc6db3fdf36/eclipse_zenoh-1.9.0-cp39-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:6f66059b12e1ec53c70bc25192b0e74502751759064726dbb153ed6dd8f4dc8b", size = 19942168, upload-time = "2026-04-10T13:23:17.785Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/6a/42b83b4e8c262ebbb3bcae702394478326c807f54b3162130b0a603e1a01/eclipse_zenoh-1.9.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:180dd2a6da3b86b52e87f5e470a1f8a86db03c519978b22ffb1dc7c11f98ef3b", size = 10225694, upload-time = "2026-04-10T13:23:20.244Z" },
-    { url = "https://files.pythonhosted.org/packages/27/57/28e66893801b63df36fea355a64b6fc22637e1148a952ee11e3039ae955e/eclipse_zenoh-1.9.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:949d82851bc9e3ad646fd1307ee544ed23359dcfd18d4065075fc592f6ab6fa7", size = 10517069, upload-time = "2026-04-10T13:23:23.053Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/2f/be614f1f7f4e046da2764cd36227d19db3655839219744ce7a12e6e2dae6/eclipse_zenoh-1.9.0-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3a1fe847225cda21e3e74677cfd4ddfd2e72600d5a56968d4229d981c67f78d4", size = 11580068, upload-time = "2026-04-10T13:23:25.594Z" },
-    { url = "https://files.pythonhosted.org/packages/58/1b/2a074d4f4595bd37c3d12f1b2ad49bceef5c8cd0962cbfd97d1d39f32e1f/eclipse_zenoh-1.9.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:43299593891cfd648bca4b2aa00f3dca916508a49a0c9e6960902e6e867b247e", size = 10537556, upload-time = "2026-04-10T13:23:28.414Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/33/c3116f1bf7647ee0ea8972efbe0fe5710ae75ea7226440a8fda7f04a4cbc/eclipse_zenoh-1.9.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:8c139a43706c8ff3c94fa625008af8667687c161a8395ad1fa3faff29c16fae4", size = 10721249, upload-time = "2026-04-10T13:23:30.843Z" },
-    { url = "https://files.pythonhosted.org/packages/26/16/a94c4f37e3a088faadf4b5fbc64e5f69dea1023dc7efc49b3be0e0ecc953/eclipse_zenoh-1.9.0-cp39-abi3-win_amd64.whl", hash = "sha256:5dfb352eca4585b85edbbc84c6db58906008e202823ca280496c0b867f9719f0", size = 9124510, upload-time = "2026-04-10T13:23:34.119Z" },
+    { url = "https://files.pythonhosted.org/packages/78/36/4750c10aaeee1a7a4eb863f807230e7cd24eaeddb62856cf5498ec9859bf/eclipse_zenoh-1.10.0-cp39-abi3-linux_armv6l.whl", hash = "sha256:215e1154209bdb73777b29ee78138706bddcd4d60a93625fa5912a9337cd72a1", size = 10925818, upload-time = "2026-08-14T17:39:30.458Z" },
+    { url = "https://files.pythonhosted.org/packages/38/c5/37a04681fb95d825f4220a0d16d5e058c24bbd785ae8ee45caa2db0da8e0/eclipse_zenoh-1.10.0-cp39-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7cc386c2bc5f37999c9fecfec9f96c02d6b9302bb5d39a7d9c187d5d18bf49ec", size = 19279998, upload-time = "2026-08-14T17:39:32.993Z" },
+    { url = "https://files.pythonhosted.org/packages/19/3c/23ddbd4f9ed1785921beba52c903355f0ce66a4ff881aca5f99951f62624/eclipse_zenoh-1.10.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:9575f444584c6afaff2f5d2b8e9f23f4f9dee039b646abcb14c78d8485a5d596", size = 9867194, upload-time = "2026-08-14T17:39:34.972Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/74/5c1462537e3ee0d53569ac04858b2058d7c5c5f04e7b34eb3f0be3109f15/eclipse_zenoh-1.10.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7f9c270518cf72a2ded8635296f78e21f7a265c4b7a1e132cbf6dcd4a4f51765", size = 10772185, upload-time = "2026-08-14T17:39:37.13Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/38/864a24eb0117be0c9f4340b2f25b6f5c4fdc74c231ad9259e4cc785f6ef8/eclipse_zenoh-1.10.0-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1f7ebdf4ed4c267a52bd985ecf29d0d19807db4b4b27b308879fdf6f5b37a445", size = 11727596, upload-time = "2026-08-14T17:39:39.109Z" },
+    { url = "https://files.pythonhosted.org/packages/45/0b/ea24a4d213827bf5d6dd77aa91dbeb54509492494493e9cb91a33f0b4f12/eclipse_zenoh-1.10.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8a824188a2fb2033133175c8d8f8b49dd4c80ee4286121ae10c1c3ca71812339", size = 10328615, upload-time = "2026-08-14T17:39:41.325Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e5/36f3914156f08de895f7eebf104e217433f9db8957597918f9703039c17a/eclipse_zenoh-1.10.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5a07b44f43e3a1428544d0223f11afb7a41b39365358dcef0a7798ab1f24e3c1", size = 10872981, upload-time = "2026-08-14T17:39:43.453Z" },
+    { url = "https://files.pythonhosted.org/packages/41/49/15be7c1f59a3534374199a46ff2fb256bf521acc4254a1d2213fb73a8a4f/eclipse_zenoh-1.10.0-cp39-abi3-win_amd64.whl", hash = "sha256:012767abc4d60623eb77888fa891dd3f2931449c4692a8f98df2160d36329f6e", size = 9121884, upload-time = "2026-08-14T17:39:45.416Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -35,6 +35,7 @@ exclude-newer-span = "P7D"
 [options.exclude-newer-package]
 dimos-viewer = false
 dimos-lcm = false
+eclipse-zenoh = false
 edgetam-dimos = false
 can-motor-control = false
 lcm-dimos-fork = false
@@ -2331,7 +2332,7 @@ requires-dist = [
     { name = "dimos-viewer", marker = "extra == 'visualization'", specifier = "==0.32.0a2" },
     { name = "drake", marker = "platform_machine != 'aarch64' and sys_platform == 'darwin' and extra == 'manipulation'", specifier = "==1.45.0" },
     { name = "drake", marker = "platform_machine != 'aarch64' and sys_platform != 'darwin' and extra == 'manipulation'", specifier = ">=1.40.0" },
-    { name = "eclipse-zenoh", specifier = ">=1.10.0,<2.0" },
+    { name = "eclipse-zenoh", specifier = ">=1.10.1,<2.0" },
     { name = "edgetam-dimos", marker = "extra == 'misc'", specifier = ">=1.0.1" },
     { name = "einops", marker = "extra == 'perception'", specifier = ">=0.8.1" },
     { name = "fastapi", marker = "extra == 'web'", specifier = ">=0.115.6" },
@@ -2843,18 +2844,18 @@ wheels = [
 
 [[package]]
 name = "eclipse-zenoh"
-version = "1.10.0"
+version = "1.10.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4e/a5/c8defd28227a73bac8e7daf6de6274bbd7f22014f86fdd5e5c43c78bbd79/eclipse_zenoh-1.10.0.tar.gz", hash = "sha256:6904906783b7eb7ce8d5dbbb930b2e62c0ef93490b0e3dbf79e36fe4fd9727d6", size = 168852, upload-time = "2026-08-14T17:39:47.844Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/1f/54e50d0fdd2d41499b18fd2066add8a53460cddb85b5c2585afd0d3159ed/eclipse_zenoh-1.10.1.tar.gz", hash = "sha256:e601b9883746b742eb7210ec73348c9980a2e65cbd54b4a8017662de9aeb15cb", size = 170364, upload-time = "2026-09-07T15:25:53.179Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/36/4750c10aaeee1a7a4eb863f807230e7cd24eaeddb62856cf5498ec9859bf/eclipse_zenoh-1.10.0-cp39-abi3-linux_armv6l.whl", hash = "sha256:215e1154209bdb73777b29ee78138706bddcd4d60a93625fa5912a9337cd72a1", size = 10925818, upload-time = "2026-08-14T17:39:30.458Z" },
-    { url = "https://files.pythonhosted.org/packages/38/c5/37a04681fb95d825f4220a0d16d5e058c24bbd785ae8ee45caa2db0da8e0/eclipse_zenoh-1.10.0-cp39-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7cc386c2bc5f37999c9fecfec9f96c02d6b9302bb5d39a7d9c187d5d18bf49ec", size = 19279998, upload-time = "2026-08-14T17:39:32.993Z" },
-    { url = "https://files.pythonhosted.org/packages/19/3c/23ddbd4f9ed1785921beba52c903355f0ce66a4ff881aca5f99951f62624/eclipse_zenoh-1.10.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:9575f444584c6afaff2f5d2b8e9f23f4f9dee039b646abcb14c78d8485a5d596", size = 9867194, upload-time = "2026-08-14T17:39:34.972Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/74/5c1462537e3ee0d53569ac04858b2058d7c5c5f04e7b34eb3f0be3109f15/eclipse_zenoh-1.10.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7f9c270518cf72a2ded8635296f78e21f7a265c4b7a1e132cbf6dcd4a4f51765", size = 10772185, upload-time = "2026-08-14T17:39:37.13Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/38/864a24eb0117be0c9f4340b2f25b6f5c4fdc74c231ad9259e4cc785f6ef8/eclipse_zenoh-1.10.0-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1f7ebdf4ed4c267a52bd985ecf29d0d19807db4b4b27b308879fdf6f5b37a445", size = 11727596, upload-time = "2026-08-14T17:39:39.109Z" },
-    { url = "https://files.pythonhosted.org/packages/45/0b/ea24a4d213827bf5d6dd77aa91dbeb54509492494493e9cb91a33f0b4f12/eclipse_zenoh-1.10.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8a824188a2fb2033133175c8d8f8b49dd4c80ee4286121ae10c1c3ca71812339", size = 10328615, upload-time = "2026-08-14T17:39:41.325Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/e5/36f3914156f08de895f7eebf104e217433f9db8957597918f9703039c17a/eclipse_zenoh-1.10.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5a07b44f43e3a1428544d0223f11afb7a41b39365358dcef0a7798ab1f24e3c1", size = 10872981, upload-time = "2026-08-14T17:39:43.453Z" },
-    { url = "https://files.pythonhosted.org/packages/41/49/15be7c1f59a3534374199a46ff2fb256bf521acc4254a1d2213fb73a8a4f/eclipse_zenoh-1.10.0-cp39-abi3-win_amd64.whl", hash = "sha256:012767abc4d60623eb77888fa891dd3f2931449c4692a8f98df2160d36329f6e", size = 9121884, upload-time = "2026-08-14T17:39:45.416Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/24/d0802eec65a925bfef6f96924faa8c0285c8c584660881af938d92a92c7b/eclipse_zenoh-1.10.1-cp39-abi3-linux_armv6l.whl", hash = "sha256:f2351b810dbda09f6dbe668ca965560bf8cee98075b28b8b71e88428f613ed35", size = 10952070, upload-time = "2026-09-07T15:25:35.566Z" },
+    { url = "https://files.pythonhosted.org/packages/54/6d/2ffd5e7a18c5b90c6d8468fd48c3416a4615b3d346dd2bbfe88849adad14/eclipse_zenoh-1.10.1-cp39-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:9e99d5801e0e12a10dbc5d976d227ec7a1ff73d86c20ff4315102b8237ac3ee8", size = 19315408, upload-time = "2026-09-07T15:25:37.87Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e8/02f615c757ddc983152ce9fabe1f94f073678593b57a93654e10aeb827e5/eclipse_zenoh-1.10.1-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:ad269f1cb3e4a66a0130ea63a0b2bca214cbbe75181baa4fe12f27ddb5c42221", size = 9876094, upload-time = "2026-09-07T15:25:40.379Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/29/e856a2115f3a43cab68ec24d09f0d253466d7bc4083841bfd9bc1f6a1adb/eclipse_zenoh-1.10.1-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:476bfca6f15f1c68e71037efbbf61b880719ea1a8eaadc6f9df978e144cf44d2", size = 10796254, upload-time = "2026-09-07T15:25:42.969Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/32/b524fcf38ebc80f9c39e5104473a55a3354bbc3ac151d1cb79514cb0b8ad/eclipse_zenoh-1.10.1-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:eb73bce18afe43fdd799d2cf3f066c7ce353d2552ae2776badffe6144352e79f", size = 11747371, upload-time = "2026-09-07T15:25:44.906Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/a2/5a54606f5202581256a8bb405e51b6d69254aa84a44e716aedae21fb2964/eclipse_zenoh-1.10.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:faa4071aea57650594e8f4ea39147f791fbd6105cbd7afe15e96dc3589bd83db", size = 10331829, upload-time = "2026-09-07T15:25:46.947Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/21/976cd9e4091362bc25ed5031f229d72032363c611bd5260950284583861e/eclipse_zenoh-1.10.1-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:1950fdc8de72e5a3847d845d57e72dedf35275725e42be46a26454cfabb54c8c", size = 10905687, upload-time = "2026-09-07T15:25:48.924Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/24/10f71ebd91d1cfbfd68449a1c52b6e38303f4302f8dc5d612d0b0ff385a8/eclipse_zenoh-1.10.1-cp39-abi3-win_amd64.whl", hash = "sha256:44e368a6a509cf385d3657f48ed99f1d677ce9877e8893e15b9cf1b504dc9150", size = 9130747, upload-time = "2026-09-07T15:25:51.229Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

fix multicast issue on mac, as reported by @jetsonearth and @TomCC7 

"zenoh's multicast scouting can't send on macOS (binds to 127.0.0.1 without IP_MULTICAST_IF, kernel rejects with EADDRNOTAVAIL), so local workers never discover each other and every run dies with a 120s set_transport timeout. "


## Solution

bump zenoh to 1.10.0  where this issue is solved

https://github.com/eclipse-zenoh/zenoh/pull/2671

Port scouting tests from upstream zenoh

## UPD
bump zenoh to 1.10.1, to mitigate this bug causing CI failures,
https://github.com/eclipse-zenoh/zenoh/pull/2759


## Additional

since we are bumping zenoh to 1.10.1 - ensure we are not breaking cause the bump may surface new issues 