### PR TITLE
Ivan readme codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,7 @@
 /.github/ @Dreamsorcerer @leshy @paul-nechifor @spomichter
 /dimos/mapping/ @leshy @paul-nechifor @spomichter @aclauer
 /dimos/perception/ @leshy
+/README.md @leshy
 
 # Any experimental/ dir, anywhere
 # Last match wins, so this must stay at the bottom.


### PR DESCRIPTION
Broken installer added as our main install path to README.MD so making sure this type of stuff doesn't happen with owning readme