### PR TITLE
fix(deps): pin rerun-sdk to the version dimos-viewer is built on

### DIFF
--- a/dimos/msgs/foxglove_msgs/CompressedVideo.py
+++ b/dimos/msgs/foxglove_msgs/CompressedVideo.py
@@ -92,8 +92,7 @@ class CompressedVideo(Timestamped):
             "h264": rr.VideoCodec.H264,
             "h265": rr.VideoCodec.H265,
             "av1": rr.VideoCodec.AV1,
-            "vp8": rr.VideoCodec.VP8,
-            "vp9": rr.VideoCodec.VP9,
+            # no vp8/vp9: the pinned rerun 0.32.0-alpha.1 has no such codec
         }
         codec = codecs.get(self.format.lower())
         if codec is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,7 +146,7 @@ dependencies = [
     "llvmlite>=0.42.0", # Required by numba 0.60+
     # TODO: rerun shouldn't be required but rn its in core (there is NO WAY to use dimos without rerun rn)
     # remove this once rerun is optional in core
-    "rerun-sdk==0.32.0",
+    "rerun-sdk==0.32.0a1", # must match the dimos-viewer build (v0.32.0-alpha.1) or the SDK warns on spawn
     "dimos-viewer==0.32.0a2",
     "toolz>=1.1.0",
     "protobuf>=6.33.5,<7",
@@ -210,7 +210,7 @@ spot = [
 ]
 
 visualization = [
-    "rerun-sdk==0.32.0",
+    "rerun-sdk==0.32.0a1", # keep in sync with dimos-viewer, see core deps
     "dimos-viewer==0.32.0a2",
     # Rerun URDF robot visualization. yourdfpy depends on trimesh[easy],
     # which pulls embreex; embreex has no Linux aarch64 wheel.

--- a/uv.lock
+++ b/uv.lock
@@ -2405,8 +2405,8 @@ requires-dist = [
     { name = "qpsolvers", extras = ["proxqp"], specifier = ">=4.12.0" },
     { name = "reactivex" },
     { name = "reportlab", marker = "extra == 'apriltag'", specifier = ">=4.5.0" },
-    { name = "rerun-sdk", specifier = "==0.32.0" },
-    { name = "rerun-sdk", marker = "extra == 'visualization'", specifier = "==0.32.0" },
+    { name = "rerun-sdk", specifier = "==0.32.0a1" },
+    { name = "rerun-sdk", marker = "extra == 'visualization'", specifier = "==0.32.0a1" },
     { name = "roboplan", marker = "extra == 'manipulation'", specifier = ">=0.6.0,<0.7.0" },
     { name = "scipy", specifier = ">=1.15.1" },
     { name = "sentencepiece", marker = "extra == 'perception'", specifier = ">=0.2.0" },
@@ -8831,22 +8831,21 @@ wheels = [
 
 [[package]]
 name = "rerun-sdk"
-version = "0.32.0"
+version = "0.32.0a1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pillow" },
-    { name = "psutil" },
     { name = "pyarrow" },
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/c5/456bf0f0d08da33c4d8e6d1cc4d8b37ae0a6d9f7b0c8b8f9933fbf9ddde2/rerun_sdk-0.32.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:f61eda2cc87ec279ad3a16c8cc1f74a99f93002d834aae05db84df8f49a2094e", size = 125148629, upload-time = "2026-05-12T22:15:27.523Z" },
-    { url = "https://files.pythonhosted.org/packages/67/b8/3ee028b0306f718abd1f08140fdc6cdd090e4fcf6989005876f93f49f394/rerun_sdk-0.32.0-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:f6652ad052712cd50621893d022bfbf9b4d6b9fb2afb32a9b0c674b0f64dccef", size = 134646228, upload-time = "2026-05-12T22:15:35.365Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/a6/1d63b51f2fb9b1f4153ac7c1e2c6d12da37fef1600d045ba1771c396d17f/rerun_sdk-0.32.0-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:5ba3f389065c9ec303445a9ba23ec59c711e5a0fd1327aa327733ff54d9d09b4", size = 138941516, upload-time = "2026-05-12T22:15:40.87Z" },
-    { url = "https://files.pythonhosted.org/packages/83/a2/4e090ddb35af23d1ab6f57d957b0fd641b5d07976805e0730bbf8512b3d8/rerun_sdk-0.32.0-cp310-abi3-win_amd64.whl", hash = "sha256:381a77e2c368475715e1c34f01419fa928cc2b99c9c570e36543298711c42669", size = 119822233, upload-time = "2026-05-12T22:15:46.728Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/e0/5d92c02d6ca63b5692e72ad3c5b89e32d44c3a6a99a74be3cb9a9d2c9741/rerun_sdk-0.32.0a1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:704e031c4ed3eb83837ce37b73741082ab669a2b4c88348a08ba61e3ba6d8656", size = 123843351, upload-time = "2026-04-29T18:59:44.469Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/97/1daa4751a281bdb6cda3473229b2746779093ffaba70dd868a3074ef3392/rerun_sdk-0.32.0a1-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0a821b30f287dabbf694aa1715e4dad0e31990cf4b612757c895f096885512e9", size = 133447478, upload-time = "2026-04-29T18:59:49.946Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9d/84170e6722a09294b57d578fc1d01266c6e78408a544876f5271ecfa66a9/rerun_sdk-0.32.0a1-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:8045beb820372e092a6cf100fb87091fa804168e5cf8a0c29f97cdee56b134d8", size = 137724590, upload-time = "2026-04-29T18:59:55.238Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/2f/09845dcdf14047cc8118566572628c533f57f6a232ee0b3fd61283b153e8/rerun_sdk-0.32.0a1-cp310-abi3-win_amd64.whl", hash = "sha256:1d6f8c3d50699ae075551a62e971730870a685cb74189b550a348561f37f9fe5", size = 118766780, upload-time = "2026-04-29T19:00:00.121Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`dimos-viewer==0.32.0a2` reports itself as `v0.32.0-alpha.1`; `rerun-sdk` was pinned to `0.32.0` final. `re_sdk`'s spawn check treats an alpha as incompatible with the release, so every spawn prints:

```
⚠ The version of the Rerun Viewer available on your PATH does not match the version of your Rerun SDK ⚠
> Rerun Viewer: v0.32.0-alpha.1 (executable: "dimos-viewer")
> Rerun SDK: v0.32.0
```

The SDK was moved from `0.32.0a1` to `0.32.0` in 74d6b9e6a (#2671) without moving the viewer with it. This moves it back so the two match.

`VideoCodec.VP8`/`VP9` only exist from 0.32.0 final (and the shipped viewer can't decode them anyway), so they're dropped from the `CompressedVideo.to_rerun` codec map — unsupported formats already raise a clear `ValueError`.