### PR TITLE
fix: humancli was broken

### DIFF
--- a/dimos/cli/human/humancli.py
+++ b/dimos/cli/human/humancli.py
@@ -23,7 +23,14 @@ import textwrap
 import threading
 from typing import TYPE_CHECKING, Any
 
-from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolCall, ToolMessage
+from langchain_core.messages import (
+    AIMessage,
+    BaseMessage,
+    HumanMessage,
+    SystemMessage,
+    ToolCall,
+    ToolMessage,
+)
 from rich.highlighter import JSONHighlighter
 from rich.panel import Panel
 from rich.text import Text
@@ -75,9 +82,9 @@ def _format_elapsed(delta: timedelta) -> str:
     return f"{total // 60:02d}:{total % 60:02d}"
 
 
-def _split_tool_message(content: Any) -> tuple[str, str] | None:
+def _split_tool_message(content: str) -> tuple[str, str] | None:
     """Parse a `[tool:NAME] <text>` tool-stream message into (name, text)."""
-    if not isinstance(content, str) or not content.startswith(TOOL_MSG_PREFIX):
+    if not content.startswith(TOOL_MSG_PREFIX):
         return None
     end = content.find("]")
     if end == -1:
@@ -343,85 +350,86 @@ class HumanCLIApp(App):  # type: ignore[type-arg]
     def _subscribe_to_agent(self) -> None:
         """Subscribe to agent messages in a separate thread."""
 
-        def receive_msg(msg) -> None:  # type: ignore[no-untyped-def]
+        def receive_msg(msg: BaseMessage) -> None:
             if not self._running:
                 return
-            assert self._tool_panels is not None
-            assert self._thinking is not None
-
-            timestamp = datetime.now().strftime("%H:%M:%S")
-
-            if isinstance(msg, SystemMessage):
+            try:
+                self._show_agent_message(msg)
+            except Exception as e:
+                # Otherwise the error hits stderr, hidden by the TUI, and the message vanishes.
                 self.call_from_thread(
                     self._add_message,
-                    timestamp,
+                    datetime.now().strftime("%H:%M:%S"),
                     "system",
-                    truncate_display_string(msg.content, 1000),
-                    theme.YELLOW,
+                    f"could not render {type(msg).__name__}: {e!r}",
+                    theme.ERROR,
                 )
-            elif isinstance(msg, AIMessage):
-                content = msg.content or ""
-                tool_calls = getattr(msg, "tool_calls", None) or msg.additional_kwargs.get(
-                    "tool_calls", []
-                )
-
-                # A reply to a tool-stream update goes inside that tool's box so
-                # it reads as an annotation of the stream, not the agent talking
-                # to itself. Replies to a typed message stay inline.
-                if content and self._reply_target is not None and isinstance(content, str):
-                    self.call_from_thread(
-                        self._tool_panels.update, self._reply_target, content, "agent", timestamp
-                    )
-                elif content:
-                    self.call_from_thread(
-                        self._add_message, timestamp, "agent", content, theme.AGENT
-                    )
-
-                # Tool calls are real actions; always show them inline, and
-                # remember each one so its result can be grouped under it.
-                if tool_calls:
-                    for tc in tool_calls:
-                        tool_info = self._format_tool_call(tc)
-                        self.call_from_thread(
-                            self._write_tool_call, timestamp, tool_info, tc.get("id")
-                        )
-
-                # If neither content nor tool calls, show a placeholder (but not
-                # for the silent step that can follow a tool-stream update).
-                if not content and not tool_calls and self._reply_target is None:
-                    self.call_from_thread(
-                        self._add_message, timestamp, "agent", "<no response>", theme.DIM
-                    )
-            elif isinstance(msg, ToolMessage):
-                self.call_from_thread(
-                    self._write_tool_result,
-                    timestamp,
-                    msg.content,
-                    getattr(msg, "tool_call_id", None),
-                )
-            elif isinstance(msg, HumanMessage):
-                # Tool-stream updates arrive here as `[tool:NAME] <text>`. Route
-                # the update into the tool's box and remember the tool so the
-                # following agent reply lands in the same box. A real typed
-                # message clears the target and renders inline.
-                parsed = _split_tool_message(msg.content)
-                if parsed is not None:
-                    name, text = parsed
-                    self._reply_target = name
-                    if text:
-                        self.call_from_thread(
-                            self._tool_panels.update, name, text, "tool", timestamp
-                        )
-                    return
-                self._reply_target = None
-                self.call_from_thread(
-                    self._add_message, timestamp, "human", msg.content, theme.HUMAN
-                )
-                # Keep the spinner up while this turn is processed (also re-shows
-                # it in the rare case a stale idle signal hid it post-submit).
-                self.call_from_thread(self._thinking.show)
 
         self._agent_transport.subscribe(receive_msg)
+
+    def _show_agent_message(self, msg: BaseMessage) -> None:
+        """Render one `/agent` message. Runs on the subscription thread."""
+        assert self._tool_panels is not None
+        assert self._thinking is not None
+
+        timestamp = datetime.now().strftime("%H:%M:%S")
+        content = msg.text
+
+        if isinstance(msg, SystemMessage):
+            self.call_from_thread(
+                self._add_message,
+                timestamp,
+                "system",
+                truncate_display_string(content, 1000),
+                theme.YELLOW,
+            )
+        elif isinstance(msg, AIMessage):
+            tool_calls = getattr(msg, "tool_calls", None) or msg.additional_kwargs.get(
+                "tool_calls", []
+            )
+
+            # Replies to a tool-stream update go in that tool's box. Replies to
+            # typed messages stay inline.
+            if content and self._reply_target is not None:
+                self.call_from_thread(
+                    self._tool_panels.update, self._reply_target, content, "agent", timestamp
+                )
+            elif content:
+                self.call_from_thread(self._add_message, timestamp, "agent", content, theme.AGENT)
+
+            # Tool calls always render inline, anchored so the result lands under them.
+            if tool_calls:
+                for tc in tool_calls:
+                    tool_info = self._format_tool_call(tc)
+                    self.call_from_thread(self._write_tool_call, timestamp, tool_info, tc.get("id"))
+
+            # No placeholder for the silent step that can follow a tool-stream update.
+            if not content and not tool_calls and self._reply_target is None:
+                self.call_from_thread(
+                    self._add_message, timestamp, "agent", "<no response>", theme.DIM
+                )
+        elif isinstance(msg, ToolMessage):
+            self.call_from_thread(
+                self._write_tool_result,
+                timestamp,
+                content,
+                getattr(msg, "tool_call_id", None),
+            )
+        elif isinstance(msg, HumanMessage):
+            # "[tool:NAME] <text>" updates go in the tool's box and make it the
+            # reply target. A typed message clears the target.
+            parsed = _split_tool_message(content)
+            if parsed is not None:
+                name, text = parsed
+                self._reply_target = name
+                if text:
+                    self.call_from_thread(self._tool_panels.update, name, text, "tool", timestamp)
+                return
+            self._reply_target = None
+            self.call_from_thread(self._add_message, timestamp, "human", content, theme.HUMAN)
+            # Keep the spinner up while this turn is processed (also re-shows
+            # it in the rare case a stale idle signal hid it post-submit).
+            self.call_from_thread(self._thinking.show)
 
     def _subscribe_to_idle(self) -> None:
         def receive_idle(is_idle: bool) -> None:

--- a/dimos/cli/human/test_humancli.py
+++ b/dimos/cli/human/test_humancli.py
@@ -1,0 +1,82 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from typing import Any
+
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+import pytest
+
+from dimos.agents.mcp import tool_stream
+from dimos.cli.human import humancli
+from dimos.cli.human.humancli import HumanCLIApp
+
+# What the OpenAI Responses API path produces: blocks, never a plain string.
+RESPONSES_CONTENT: list[Any] = [
+    {"type": "reasoning", "id": "rs_1", "summary": [{"type": "summary_text", "text": "hmm"}]},
+    {"type": "text", "text": "On my way.", "annotations": [], "id": "msg_1"},
+    {"type": "function_call", "call_id": "c1", "name": "move_to", "arguments": "{}"},
+]
+
+
+class FakeTransport:
+    def __init__(self) -> None:
+        self.callback: Any = None
+
+    def subscribe(self, callback: Any) -> Any:
+        self.callback = callback
+        return lambda: None
+
+    def publish(self, msg: Any) -> None:
+        pass
+
+
+async def test_block_content_messages_render(monkeypatch: pytest.MonkeyPatch) -> None:
+    transports: dict[str, FakeTransport] = {}
+
+    def fake_make_transport(name: str, *args: Any, **kwargs: Any) -> FakeTransport:
+        transports[name] = FakeTransport()
+        return transports[name]
+
+    monkeypatch.setattr(humancli, "make_transport", fake_make_transport)
+    monkeypatch.setattr(tool_stream, "subscribe", lambda cb: (lambda: None))
+
+    app = HumanCLIApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        while transports["/agent"].callback is None:
+            await pilot.pause(0.05)
+        receive = transports["/agent"].callback
+        loop = asyncio.get_running_loop()
+
+        messages = [
+            HumanMessage(content="go to the kitchen"),
+            AIMessage(
+                content=RESPONSES_CONTENT, tool_calls=[{"name": "move_to", "args": {}, "id": "c1"}]
+            ),
+            ToolMessage(content=[{"type": "text", "text": "arrived"}], tool_call_id="c1"),
+            AIMessage(content=[{"type": "text", "text": "Done."}]),
+        ]
+        for msg in messages:
+            # The real callback runs on the transport thread, never the app's.
+            await loop.run_in_executor(None, receive, msg)
+        await pilot.pause(0.1)
+
+        assert app.chat_log is not None
+        text = "\n".join(strip.text for strip in app.chat_log.lines)
+        assert "go to the kitchen" in text
+        assert "On my way." in text
+        assert "▶ move_to({})" in text
+        assert "↳ arrived" in text
+        assert "Done." in text
+        assert "could not render" not in text


### PR DESCRIPTION
Closes DIM-1504

## Problem

- humancli assumed `msg.content` is a string and called `.strip()` on it. This hasn't been the case since [#2999](https://github.com/dimensionalOS/dimos/pull/2999) was merged. The result was that messages from tool calls were never displayed

## Solution

- `_content_text()` flattens `str | list` content to text (text blocks only) and is used for all four message types.
- The receive callback catches render errors and prints a `could not render ...` system line, so a bad message can no longer disappear silently.
