### PR TITLE
fix(core): expose RPC methods to shell completion

### DIFF
--- a/dimos/core/rpc_client.py
+++ b/dimos/core/rpc_client.py
@@ -168,6 +168,9 @@ class RPCClient:
             (self.actor_instance, self.actor_class, self.remote_name),
         )
 
+    def __dir__(self) -> list[str]:
+        return sorted(set(super().__dir__()) | set(self.rpcs))
+
     # passthrough
     def __getattr__(self, name: str):  # type: ignore[no-untyped-def]
         # Check if accessing a known safe attribute to avoid recursion

--- a/dimos/core/test_rpc_client.py
+++ b/dimos/core/test_rpc_client.py
@@ -1,0 +1,76 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import atexit
+import inspect
+
+from IPython.core.completer import provisionalcompleter
+from IPython.core.interactiveshell import InteractiveShell
+import pytest
+from traitlets.config import Config
+
+from dimos.core.demos.stress_test_module import StressTestModule
+from dimos.core.rpc_client import RPCClient
+from dimos.protocol.rpc.spec import RPCSpec
+
+
+@pytest.fixture
+def proxy(mocker):
+    transport = mocker.Mock(spec=RPCSpec)
+    client = RPCClient(None, StressTestModule, rpc=transport)
+    try:
+        yield client, transport
+    finally:
+        client.stop_rpc_client()
+
+
+@pytest.fixture
+def ipython(proxy, tmp_path):
+    client, _ = proxy
+    shell = InteractiveShell(
+        user_ns={"motion": client},
+        ipython_dir=str(tmp_path),
+        config=Config({"HistoryManager": {"enabled": False}}),
+    )
+    try:
+        yield shell
+    finally:
+        shell.cleanup()
+        atexit.unregister(shell.atexit_operations)
+        shell.atexit_operations()
+
+
+def test_dir_exposes_rpcs_and_proxy_attributes_without_transport_calls(proxy):
+    client, transport = proxy
+
+    names = dir(client)
+
+    assert set(StressTestModule.rpcs) <= set(names)
+    assert {"remote_name", "stop_rpc_client"} <= set(names)
+    assert names == sorted(set(names))
+    assert transport.mock_calls == []
+
+
+def test_ipython_completes_and_inspects_rpc_without_transport_calls(ipython, proxy):
+    _, transport = proxy
+
+    with provisionalcompleter():
+        completions = list(ipython.Completer.completions("motion.ec", len("motion.ec")))
+
+    assert "echo" in {completion.text for completion in completions}
+    info = ipython.object_inspect("motion.echo")
+    assert "message" in info["definition"]
+    assert "self" not in info["definition"]
+    assert info["docstring"] == inspect.getdoc(StressTestModule.echo)
+    assert transport.mock_calls == []


### PR DESCRIPTION
## Contribution path

Small, safe change that does not need a tracking issue.

<img width="988" height="646" alt="image" src="https://github.com/user-attachments/assets/cbdde43a-3d3f-4043-82e2-b77ef30e7af4" />

## Problem

`RPCClient` exposes RPC methods through `__getattr__`, but omits them from `dir()`. IPython cannot complete their names in `dimos shell`.

## Solution

Add RPC names to `RPCClient.__dir__`, alongside its normal attributes. Runtime types, method signatures, and transport ownership are unchanged.

Based on #4009. This is a sibling of #3944, not dependent on the arm SDK.

## How to Test

In a provisioned DimOS environment, start the mock dual-arm blueprint:

```bash
uv run dimos run dual-xarm6-planner-coordinator
```

In another terminal:

```bash
uv run dimos shell
```

Inside the shell:

```python
from dimos.manipulation.manipulation_spec import ManipulationSpec
motion = app.find_module_by_spec(ManipulationSpec)
```

- Type `motion.list_` and press Tab. `list_planning_groups` should appear.
- Run `motion.list_planning_groups?`. Check that its signature and docstring appear, without a `self` parameter.
- Run `motion.list_planning_groups()` to query the available groups. This does not command motion.
- Run `type(motion)`. It should still be `dimos.core.rpc_client.RPCClient`.

Exit the shell, then stop the blueprint with Ctrl-C in the first terminal.

## AI assistance

Codex implemented the change, added regression tests, and drafted this description.

## Checklist

- [ ] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
