### PR TITLE
fix(porcelain): apply config overrides before resolving the blueprint

### DIFF
--- a/dimos/porcelain/dimos.py
+++ b/dimos/porcelain/dimos.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import atexit
 import importlib
 import inspect
+import sys
 import threading
 from typing import Any, TypeAlias
 
@@ -31,7 +32,7 @@ from dimos.porcelain.module_handle import ModuleHandle
 from dimos.porcelain.module_source import ModuleSource
 from dimos.porcelain.remote_module_source import RemoteModuleSource
 from dimos.porcelain.skills_proxy import SkillsProxy
-from dimos.robot.all_blueprints import all_modules
+from dimos.robot.all_blueprints import all_blueprints, all_modules
 from dimos.robot.get_all_blueprints import class_name_to_registry_key, get_by_name
 
 DescribeTarget: TypeAlias = str | ModuleHandle | RpcCall | ModuleInfo | RpcInfo
@@ -72,10 +73,33 @@ class Dimos:
                 _run_remote(target, self._source)
                 return
 
-            blueprint = _resolve_target(target)
+            # Resolving a name imports the blueprint, which reads global_config.
+            applying = self._coordinator is None and bool(self._config_overrides)
+            previous = (
+                {key: getattr(global_config, key) for key in self._config_overrides}
+                if applying
+                else {}
+            )
+            if applying:
+                stale = {
+                    key: value
+                    for key, value in self._config_overrides.items()
+                    if getattr(global_config, key, None) != value
+                }
+                imported = _already_imported_module(target) if stale else None
+                if imported is not None:
+                    raise RuntimeError(
+                        f"{imported} is already imported, so {sorted(stale)} cannot "
+                        f"take effect. Configure before the import, or use the CLI."
+                    )
+                global_config.update(**self._config_overrides)
+            try:
+                blueprint = _resolve_target(target)
+            except BaseException:
+                if applying:
+                    global_config.update(**previous)
+                raise
             if self._coordinator is None:
-                if self._config_overrides:
-                    global_config.update(**self._config_overrides)
                 self._coordinator = ModuleCoordinator.build(blueprint)
                 self._source = LocalModuleSource(self._coordinator)
             else:
@@ -383,6 +407,17 @@ def _resolve_target(target: str | Blueprint | type[ModuleBase]) -> Blueprint:
         f"run() expects a blueprint name (str), Blueprint, or Module class, "
         f"got {type(target).__name__}"
     )
+
+
+def _already_imported_module(target: str | Blueprint | type[ModuleBase]) -> str | None:
+    """The registry module behind a blueprint name, if it is already imported."""
+    if not isinstance(target, str):
+        return None
+    entry = all_blueprints.get(target) or all_modules.get(target)
+    if entry is None:
+        return None
+    path = entry.split(":")[0] if ":" in entry else entry.rsplit(".", 1)[0]
+    return path if path in sys.modules else None
 
 
 def _all_module_class_names() -> set[str]:

--- a/dimos/porcelain/test_dimos.py
+++ b/dimos/porcelain/test_dimos.py
@@ -20,8 +20,10 @@ import pytest
 
 from dimos.agents.mcp.mcp_server import McpServer
 from dimos.core.demos.stress_test_module import StressTestModule
+from dimos.core.global_config import global_config
 from dimos.core.module import Module
 from dimos.core.stream import Out
+from dimos.porcelain import dimos as porcelain_dimos
 from dimos.porcelain.dimos import Dimos, _resolve_target
 
 
@@ -93,6 +95,52 @@ def test_construction_with_overrides():
         assert instance._config_overrides == {"n_workers": 4}
     finally:
         instance.stop()
+
+
+def test_overrides_apply_before_the_blueprint_is_resolved_and_unwind_on_failure(
+    monkeypatch,
+):
+    """Overrides must be live during the resolve, and gone again if it raises."""
+    seen: list[str] = []
+    before = global_config.simulation
+
+    def resolve(target):
+        seen.append(global_config.simulation)
+        if target == "unknown-blueprint":
+            raise KeyError(target)
+        raise RuntimeError("stop before building a coordinator")
+
+    monkeypatch.setattr(porcelain_dimos, "_resolve_target", resolve)
+    instance = Dimos(simulation="mujoco")
+    try:
+        with pytest.raises(RuntimeError, match="stop before building"):
+            instance.run("any-blueprint")
+        with pytest.raises(KeyError):
+            instance.run("unknown-blueprint")
+        after_failures = global_config.simulation
+    finally:
+        instance.stop()
+        global_config.update(simulation=before)
+
+    assert seen == ["mujoco", "mujoco"]
+    assert after_failures == before
+
+
+def test_overrides_refuse_to_pretend_on_an_already_imported_blueprint():
+    """A cached import cannot see the override, so refuse rather than mislead."""
+    import dimos.robot.manipulators.xarm.blueprints.basic  # noqa: F401
+
+    before = global_config.simulation
+    instance = Dimos(simulation="mujoco")
+    try:
+        with pytest.raises(RuntimeError, match="already imported"):
+            instance.run("xarm7-planner-coordinator")
+        leaked = global_config.simulation
+    finally:
+        instance.stop()
+        global_config.update(simulation=before)
+
+    assert leaked == before
 
 
 def test_repr_when_stopped(app):


### PR DESCRIPTION
`Dimos.run()` resolved the target first and applied the instance's config overrides second. 

Resolving a blueprint name imports its module, and blueprints settle the arm-versus-sim split at import time, `SIMULATED = bool(global_config.simulation)` at module scope, so `Dimos(simulation="mujoco").run("xarm-grasp")` captured the default, composed the hardware stack, and then tried to reach an xArm and a RealSense that are not attached.


Found by greptile on #3873, which added the tenth such blueprint. The cause is here, not there.