### PR TITLE
fix_7_mac_tests: 2 fix - 5 skip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -643,10 +643,10 @@ jobs:
                 - /var/cache/dimos-root-cache:/root/.cache
             markers: "self_hosted or skipif_no_ros"
             experimental: false
-#          - os: macOS
-#            container: null  # run on host — `container:` is Linux-only
-#            markers: "self_hosted"
-#            experimental: true
+          - os: macOS
+            container: null  # run on host — `container:` is Linux-only
+            markers: "self_hosted"
+            experimental: true
     runs-on:
       - self-hosted
       - ${{ matrix.os }}

--- a/dimos/experimental/memory/test_rust_recorder_e2e.py
+++ b/dimos/experimental/memory/test_rust_recorder_e2e.py
@@ -18,6 +18,7 @@ import importlib.util
 import os
 from pathlib import Path
 import select
+import shutil
 import signal
 import socket
 import subprocess
@@ -75,6 +76,8 @@ class FakeTransport:
 
 @pytest.fixture(scope="module")
 def rust_recorder_executable() -> Path:
+    if shutil.which("nix") is None:
+        pytest.skip("nix builds the recorder binary")
     subprocess.run(
         [
             "nix",

--- a/dimos/hardware/whole_body/dual_openyam_damiao/test_adapter.py
+++ b/dimos/hardware/whole_body/dual_openyam_damiao/test_adapter.py
@@ -29,7 +29,11 @@ pytestmark = pytest.mark.self_hosted
 
 @pytest.fixture
 def adapter(mocker: MockerFixture) -> Iterator[DualOpenYamDamiaoAdapter]:
-    mocker.patch.object(can_motor_control, "SocketCanBus", can_motor_control.MockCanBus)
+    mocker.patch.object(
+        DualOpenYamDamiaoAdapter,
+        "_make_can_bus",
+        side_effect=lambda name: can_motor_control.MockCanBus(name),
+    )
     result = DualOpenYamDamiaoAdapter(
         runtime_config=DamiaoRuntimeConfig(
             bus_devices={"left": "can8", "right": "can9"},

--- a/dimos/hardware/whole_body/openarm_damiao/test_adapter.py
+++ b/dimos/hardware/whole_body/openarm_damiao/test_adapter.py
@@ -30,7 +30,11 @@ from dimos.robot.manipulators.openarm.config import OPENARM_DOF, OPENARM_JOINTS
 
 @pytest.fixture
 def openarm_adapter(mocker: MockerFixture) -> Iterator[OpenArmDamiaoAdapter]:
-    mocker.patch.object(can_motor_control, "SocketCanBus", can_motor_control.MockCanBus)
+    mocker.patch.object(
+        OpenArmDamiaoAdapter,
+        "_make_can_bus",
+        side_effect=lambda name: can_motor_control.MockCanBus(name),
+    )
     adapter = OpenArmDamiaoAdapter(
         runtime_config=DamiaoRuntimeConfig(gravity_comp=False),
     )


### PR DESCRIPTION
Fix 7 failing tests on mac.

2 - real fix, they should now pass on macOS

The 5 nix ones: not fixable as tests, they are skipped