### PR TITLE
chore(codeowners): drop perception ownership from Ivan

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,6 @@
 * @leshy @paul-nechifor @spomichter @mustafab0 @Dreamsorcerer @aclauer
 /.github/ @Dreamsorcerer @leshy @paul-nechifor @spomichter
 /dimos/mapping/ @leshy @paul-nechifor @spomichter @aclauer
-/dimos/perception/ @leshy
 
 # Any experimental/ dir, anywhere
 # Last match wins, so this must stay at the bottom.


### PR DESCRIPTION
Removing myself as the codeowner on `/dimos/perception/`. 
