### PR TITLE
realsense: tell the linker where nix actually put librealsense2

### DIFF
--- a/dimos/hardware/sensors/camera/realsense/rust/Cargo.lock
+++ b/dimos/hardware/sensors/camera/realsense/rust/Cargo.lock
@@ -553,20 +553,17 @@ dependencies = [
 name = "dimos-module"
 version = "0.1.0"
 dependencies = [
- "approx",
- "bytemuck",
  "dimos-lcm",
  "dimos-module-macros",
  "lcm-msgs",
  "nalgebra",
- "num-rational",
- "num-traits",
  "rayon",
  "serde",
  "serde_json",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "url",
  "validator",
  "zenoh",
 ]
@@ -1643,7 +1640,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]

--- a/dimos/hardware/sensors/camera/realsense/rust/build.rs
+++ b/dimos/hardware/sensors/camera/realsense/rust/build.rs
@@ -14,7 +14,8 @@
 
 // realsense-sys only emits -L for librealsense2; bake its directory in as an
 // rpath so the binary runs outside the nix shell that built it. nixpkgs' .pc
-// names lib/x86_64-linux-gnu while the .so sits in lib/, so walk up to it.
+// names lib/x86_64-linux-gnu while the .so sits in lib/, so walk up to it --
+// for the linker too, or `-lrealsense2` is not found at all.
 fn main() {
     let lib = pkg_config::probe_library("realsense2").expect("librealsense2 via pkg-config");
     for path in lib.link_paths {
@@ -22,6 +23,7 @@ fn main() {
             .ancestors()
             .find(|d| d.join("librealsense2.so").exists())
             .unwrap_or(&path);
+        println!("cargo:rustc-link-search=native={}", dir.display());
         println!("cargo:rustc-link-arg=-Wl,-rpath,{}", dir.display());
     }
 }


### PR DESCRIPTION
`dimos run` of anything with a `RealSenseCamera` fails its native build with

```
rust-lld: error: unable to find library -lrealsense2
```
