### PR TITLE
feat(native): zenoh transport for the C++ native module SDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,11 +260,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      # need liblcm installed for testing transport
+      # liblcm and zenoh-c back the SDK's two transports. zenoh-c has no apt
+      # package, so it comes from the upstream release (same 1.10 line the
+      # Rust module and the nix flakes pin).
       - name: Install system dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y liblcm-dev nlohmann-json3-dev
+          curl -fsSLo /tmp/zenohc.zip https://github.com/eclipse-zenoh/zenoh-c/releases/download/1.10.0/libzenohc-1.10.0-x86_64-unknown-linux-gnu-debian.zip
+          unzip -o /tmp/zenohc.zip -d /tmp/zenohc
+          sudo apt-get install -y /tmp/zenohc/libzenohc_1.10.0_amd64.deb /tmp/zenohc/libzenohc-dev_1.10.0_amd64.deb
       - name: Configure
         run: cmake -S native/cpp -B build/native-cpp -DDIMOS_NATIVE_BUILD_TESTS=ON
       - name: Build

--- a/dimos/hardware/sensors/lidar/fastlio2/cpp/flake.lock
+++ b/dimos/hardware/sensors/lidar/fastlio2/cpp/flake.lock
@@ -132,6 +132,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-zenoh": {
+      "locked": {
+        "lastModified": 1789012029,
+        "narHash": "sha256-1CBkBf+Nhggykzlx0jvXrj5rk20btl+tK8Fa8Ml/BL4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d5dfd8e6716dde34398bc14bc87c10dece9c8c68",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d5dfd8e6716dde34398bc14bc87c10dece9c8c68",
+        "type": "github"
+      }
+    },
     "pfr": {
       "flake": false,
       "locked": {
@@ -174,6 +190,7 @@
         "lcm-extended": "lcm-extended",
         "livox-sdk": "livox-sdk",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-zenoh": "nixpkgs-zenoh",
         "pfr": "pfr_2"
       }
     },

--- a/dimos/hardware/sensors/lidar/fastlio2/cpp/flake.nix
+++ b/dimos/hardware/sensors/lidar/fastlio2/cpp/flake.nix
@@ -2,6 +2,10 @@
   description = "FAST-LIO2 + Livox Mid-360 native module";
 
   inputs = {
+    # zenoh-c for the SDK's ZenohTransport, from a nixpkgs that carries the 1.10
+    # line the Rust module pins. Separate from `nixpkgs` so this module's other
+    # deps keep their binary-cache hits.
+    nixpkgs-zenoh.url = "github:NixOS/nixpkgs/d5dfd8e6716dde34398bc14bc87c10dece9c8c68";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     livox-sdk.url = "path:../../livox/cpp";
@@ -30,7 +34,7 @@
     };
   };
 
-  outputs = { self, nixpkgs, flake-utils, livox-sdk, dimos-lcm, pfr, fast-lio, lcm-extended, ... }:
+  outputs = { self, nixpkgs, nixpkgs-zenoh, flake-utils, livox-sdk, dimos-lcm, pfr, fast-lio, lcm-extended, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         # Overlay fixes for darwin-broken nixpkgs recipes in our transitive
@@ -70,6 +74,7 @@
         };
         livox-sdk2 = livox-sdk.packages.${system}.livox-sdk2;
         lcm = lcm-extended.packages.${system}.lcm;
+        zenohc = nixpkgs-zenoh.legacyPackages.${system}.zenoh-c;
 
         livox-common = ../../common;
 
@@ -83,6 +88,7 @@
           buildInputs = [
             livox-sdk2
             lcm
+            zenohc
             pkgs.glib
             pkgs.eigen
             pkgs.pcl

--- a/dimos/hardware/sensors/lidar/livox/cpp/flake.lock
+++ b/dimos/hardware/sensors/lidar/livox/cpp/flake.lock
@@ -74,6 +74,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-zenoh": {
+      "locked": {
+        "lastModified": 1789012029,
+        "narHash": "sha256-1CBkBf+Nhggykzlx0jvXrj5rk20btl+tK8Fa8Ml/BL4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d5dfd8e6716dde34398bc14bc87c10dece9c8c68",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d5dfd8e6716dde34398bc14bc87c10dece9c8c68",
+        "type": "github"
+      }
+    },
     "pfr": {
       "flake": false,
       "locked": {
@@ -97,6 +113,7 @@
         "flake-utils": "flake-utils",
         "lcm-extended": "lcm-extended",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-zenoh": "nixpkgs-zenoh",
         "pfr": "pfr"
       }
     },

--- a/dimos/hardware/sensors/lidar/livox/cpp/flake.nix
+++ b/dimos/hardware/sensors/lidar/livox/cpp/flake.nix
@@ -2,6 +2,10 @@
   description = "Livox SDK2 and Mid-360 native module";
 
   inputs = {
+    # zenoh-c for the SDK's ZenohTransport, from a nixpkgs that carries the 1.10
+    # line the Rust module pins. Separate from `nixpkgs` so this module's other
+    # deps keep their binary-cache hits.
+    nixpkgs-zenoh.url = "github:NixOS/nixpkgs/d5dfd8e6716dde34398bc14bc87c10dece9c8c68";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     dimos-lcm = {
@@ -20,11 +24,12 @@
     };
   };
 
-  outputs = { self, nixpkgs, flake-utils, dimos-lcm, pfr, lcm-extended, ... }:
+  outputs = { self, nixpkgs, nixpkgs-zenoh, flake-utils, dimos-lcm, pfr, lcm-extended, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs { inherit system; };
         lcm = lcm-extended.packages.${system}.lcm;
+        zenohc = nixpkgs-zenoh.legacyPackages.${system}.zenoh-c;
 
         livox-sdk2 = pkgs.stdenv.mkDerivation rec {
           pname = "livox-sdk2";
@@ -71,7 +76,7 @@
           src = ./.;
 
           nativeBuildInputs = [ pkgs.cmake pkgs.pkg-config ];
-          buildInputs = [ livox-sdk2 lcm pkgs.glib pkgs.nlohmann_json ];
+          buildInputs = [ livox-sdk2 lcm zenohc pkgs.glib pkgs.nlohmann_json ];
 
           cmakeFlags = [
             "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"

--- a/dimos/hardware/sensors/lidar/pointlio/cpp/flake.lock
+++ b/dimos/hardware/sensors/lidar/pointlio/cpp/flake.lock
@@ -132,6 +132,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-zenoh": {
+      "locked": {
+        "lastModified": 1789012029,
+        "narHash": "sha256-1CBkBf+Nhggykzlx0jvXrj5rk20btl+tK8Fa8Ml/BL4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d5dfd8e6716dde34398bc14bc87c10dece9c8c68",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d5dfd8e6716dde34398bc14bc87c10dece9c8c68",
+        "type": "github"
+      }
+    },
     "pfr": {
       "flake": false,
       "locked": {
@@ -174,6 +190,7 @@
         "lcm-extended": "lcm-extended",
         "livox-sdk": "livox-sdk",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-zenoh": "nixpkgs-zenoh",
         "pfr": "pfr_2"
       }
     },

--- a/dimos/hardware/sensors/lidar/pointlio/cpp/flake.nix
+++ b/dimos/hardware/sensors/lidar/pointlio/cpp/flake.nix
@@ -2,6 +2,10 @@
   description = "Point-LIO + Livox Mid-360 native module";
 
   inputs = {
+    # zenoh-c for the SDK's ZenohTransport, from a nixpkgs that carries the 1.10
+    # line the Rust module pins. Separate from `nixpkgs` so this module's other
+    # deps keep their binary-cache hits.
+    nixpkgs-zenoh.url = "github:NixOS/nixpkgs/d5dfd8e6716dde34398bc14bc87c10dece9c8c68";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     livox-sdk.url = "path:../../livox/cpp";
@@ -29,7 +33,7 @@
     };
   };
 
-  outputs = { self, nixpkgs, flake-utils, livox-sdk, dimos-lcm, pfr, fast-lio, lcm-extended, ... }:
+  outputs = { self, nixpkgs, nixpkgs-zenoh, flake-utils, livox-sdk, dimos-lcm, pfr, fast-lio, lcm-extended, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         # Overlay fixes for darwin-broken nixpkgs recipes in our transitive
@@ -69,6 +73,7 @@
         };
         livox-sdk2 = livox-sdk.packages.${system}.livox-sdk2;
         lcm = lcm-extended.packages.${system}.lcm;
+        zenohc = nixpkgs-zenoh.legacyPackages.${system}.zenoh-c;
 
         livox-common = ../../common;
 
@@ -92,6 +97,7 @@
           buildInputs = [
             livox-sdk2
             lcm
+            zenohc
             pkgs.glib
             pkgs.eigen
             pkgs.pcl

--- a/docs/usage/native_modules.md
+++ b/docs/usage/native_modules.md
@@ -2,11 +2,11 @@
 
 Prerequisite for this is to understand dimOS [Modules](/docs/usage/modules.md) and [Blueprints](/docs/usage/blueprints.md).
 
-Native modules let you wrap **any executable** as a first-class dimOS module, given it speaks LCM.
+Native modules let you wrap **any executable** as a first-class dimOS module, given it speaks LCM or zenoh.
 
 Python will handle blueprint wiring, lifecycle, and logging. Native binary handles the actual computation, publishing and subscribing directly on LCM.
 
-Python module **never touches the pubsub data**. It just passes configuration and LCM topic to use via CLI args to your executable.
+Python module **never touches the pubsub data**. It just passes configuration and the topics to use via CLI args to your executable.
 
 To learn how to communicate with the rest of dimOS over LCM, read our [LCM intro](/docs/usage/lcm.md).
 
@@ -181,7 +181,7 @@ Malformed lines fall back to plain text logging.
 
 ## Writing the C++ side
 
-The header-only C++ SDK lives at [native/cpp/](/native/cpp/). Set `stdin_config: bool = True` in the Python config. Topics and config then arrive as one JSON line on stdin instead of CLI args. A module includes `dimos/native.hpp`, subclasses `Module`, and calls `run_with_transport<M>()` from `main()`:
+The header-only C++ SDK lives at [native/cpp/](/native/cpp/). Set `stdin_config: bool = True` in the Python config. Topics, config, and the transport's session and QoS settings then arrive as one JSON line on stdin instead of CLI args. A module includes `dimos/native.hpp`, subclasses `Module`, and calls `run_with_transport<M>()` from `main()`:
 
 ```cpp
 #include "dimos/native.hpp"
@@ -223,6 +223,8 @@ int main() {
 ```
 
 The config is a plain aggregate struct. `config.parse<PongConfig>()` reflects over its fields (via PFR, C++20), so the struct declaration is the whole contract: every field is required, unknown fields are rejected, and there is no limit on field count. Python owns all defaults and always sends every field. Add a `void validate() const` method for range checks. It runs automatically after parsing. Input handlers run serialized on the dispatch thread. Each output publishes through its own worker, so a slow channel only stalls itself. A source-style module with no inputs (a sensor driver) overrides `handle()` with its own loop and `setup()`/`teardown()` for device lifecycle.
+
+`run_with_transport` picks LCM or zenoh from `DIMOS_TRANSPORT`, which the coordinator sets from the global `transport` setting. The zenoh side is built on [zenoh-c](https://github.com/eclipse-zenoh/zenoh-c) 1.10 (`zenohc::lib` in CMake, `zenoh-c` in nixpkgs). It opens the session the stdin `session` block describes and applies each output's publisher QoS, so a C++ module behaves like a Rust one on either transport.
 
 
 A complete ping-pong pair lives at [/examples/native-modules/cpp/](/examples/native-modules/cpp/), and [`dimos/hardware/sensors/lidar/livox/cpp/main.cpp`](/dimos/hardware/sensors/lidar/livox/cpp/main.cpp) is a real driver example.

--- a/examples/native-modules/cpp/flake.lock
+++ b/examples/native-modules/cpp/flake.lock
@@ -74,6 +74,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-zenoh": {
+      "locked": {
+        "lastModified": 1789012029,
+        "narHash": "sha256-1CBkBf+Nhggykzlx0jvXrj5rk20btl+tK8Fa8Ml/BL4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d5dfd8e6716dde34398bc14bc87c10dece9c8c68",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d5dfd8e6716dde34398bc14bc87c10dece9c8c68",
+        "type": "github"
+      }
+    },
     "pfr": {
       "flake": false,
       "locked": {
@@ -97,6 +113,7 @@
         "flake-utils": "flake-utils",
         "lcm-extended": "lcm-extended",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-zenoh": "nixpkgs-zenoh",
         "pfr": "pfr"
       }
     },

--- a/examples/native-modules/cpp/flake.nix
+++ b/examples/native-modules/cpp/flake.nix
@@ -2,6 +2,10 @@
   description = "dimos C++ native module ping-pong example";
 
   inputs = {
+    # zenoh-c for the SDK's ZenohTransport, from a nixpkgs that carries the 1.10
+    # line the Rust module pins. Separate from `nixpkgs` so this module's other
+    # deps keep their binary-cache hits.
+    nixpkgs-zenoh.url = "github:NixOS/nixpkgs/d5dfd8e6716dde34398bc14bc87c10dece9c8c68";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     lcm-extended = {
@@ -21,11 +25,12 @@
     };
   };
 
-  outputs = { self, nixpkgs, flake-utils, lcm-extended, dimos-lcm, pfr, ... }:
+  outputs = { self, nixpkgs, nixpkgs-zenoh, flake-utils, lcm-extended, dimos-lcm, pfr, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs { inherit system; };
         lcm = lcm-extended.packages.${system}.lcm;
+        zenohc = nixpkgs-zenoh.legacyPackages.${system}.zenoh-c;
       in {
         packages.default = pkgs.stdenv.mkDerivation {
           pname = "dimos-native-ping-pong";
@@ -33,7 +38,7 @@
           src = ./.;
 
           nativeBuildInputs = [ pkgs.cmake pkgs.pkg-config ];
-          buildInputs = [ lcm pkgs.glib pkgs.nlohmann_json ];
+          buildInputs = [ lcm zenohc pkgs.glib pkgs.nlohmann_json ];
 
           cmakeFlags = [
             "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"

--- a/examples/native-modules/cpp_ping_pong.py
+++ b/examples/native-modules/cpp_ping_pong.py
@@ -15,10 +15,10 @@
 """The ping-pong example, built on the C++ native module SDK.
 
 Ping publishes a Twist at 5 Hz on data. Pong echoes each one back on confirm,
-stamped with its sample_config. The C++ SDK supports LCM only.
+stamped with its sample_config.
 
 Run with:
-    python examples/native-modules/cpp_ping_pong.py
+    python examples/native-modules/cpp_ping_pong.py [--transport lcm|zenoh]
 """
 
 from __future__ import annotations
@@ -73,7 +73,7 @@ def blueprint() -> Blueprint:
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--transport", choices=["lcm"], default="lcm")
+    parser.add_argument("--transport", choices=["lcm", "zenoh"], default="lcm")
     args = parser.parse_args()
 
     bp = blueprint().global_config(viewer="none", transport=args.transport)

--- a/native/cpp/CMakeLists.txt
+++ b/native/cpp/CMakeLists.txt
@@ -28,6 +28,21 @@ if(NOT nlohmann_json_FOUND)
   FetchContent_MakeAvailable(nlohmann_json)
 endif()
 
+# zenoh-c backs ZenohTransport. Same 1.10 line the Rust native module pins;
+# nix provides it via buildInputs, CI installs the upstream deb. pkg-config
+# first: nixpkgs splits zenoh-c into dev/out and its CMake config points the
+# library at the wrong output, while its .pc is right. The deb ships only the
+# CMake config.
+find_package(PkgConfig QUIET)
+if(PkgConfig_FOUND)
+  pkg_check_modules(ZENOHC QUIET IMPORTED_TARGET zenohc>=1.10)
+endif()
+if(ZENOHC_FOUND)
+  add_library(zenohc::lib ALIAS PkgConfig::ZENOHC)
+else()
+  find_package(zenohc 1.10 REQUIRED CONFIG)
+endif()
+
 # module.hpp runs the dispatch loop and publish workers on std::thread.
 find_package(Threads REQUIRED)
 
@@ -40,6 +55,7 @@ target_compile_features(dimos_native INTERFACE cxx_std_20)
 target_link_libraries(dimos_native INTERFACE
   pfr
   nlohmann_json::nlohmann_json
+  zenohc::lib
   Threads::Threads
 )
 

--- a/native/cpp/include/dimos/native.hpp
+++ b/native/cpp/include/dimos/native.hpp
@@ -5,6 +5,11 @@
 
 #pragma once
 
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <utility>
+
 #include "dimos/native/config.hpp"
 #include "dimos/native/lcm_codec.hpp"
 #include "dimos/native/lcm_transport.hpp"
@@ -12,15 +17,32 @@
 #include "dimos/native/module.hpp"
 #include "dimos/native/transport.hpp"
 #include "dimos/native/transport_selection.hpp"
+#include "dimos/native/zenoh_transport.hpp"
 
 namespace dimos::native {
 
-/// Run module `M` over the transport named by DIMOS_TRANSPORT (LCM today).
+/// Construct the transport named by `DIMOS_TRANSPORT`. `launch` is the
+/// coordinator's stdin blob; zenoh reads its `session` and `qos` blocks.
+/// Errors clearly for an unknown or unset value.
+inline std::unique_ptr<Transport> make_transport_from_env(const nlohmann::json& launch) {
+    const char* env = std::getenv("DIMOS_TRANSPORT");
+    std::string name = env != nullptr ? env : "";
+    require_supported_transport(name);
+    if (name == "zenoh") {
+        return std::make_unique<ZenohTransport>(launch);
+    }
+    return std::make_unique<LcmTransport>();
+}
+
+/// Run module `M` over the transport named by DIMOS_TRANSPORT (LCM or zenoh).
 /// The coordinator always sets it. An unset or unknown value is fatal.
 template <class M>
 void run_with_transport() {
     try {
-        run<M>(make_transport_from_env());
+        StdinConfig parsed = read_stdin_config();
+        // Built before the call: the argument moves `parsed`.
+        std::unique_ptr<Transport> transport = make_transport_from_env(parsed.launch);
+        run_fallible<M>(std::move(transport), std::move(parsed));
     } catch (const std::exception& e) {
         log::error(e.what());
         std::exit(1);

--- a/native/cpp/include/dimos/native/lcm_transport.hpp
+++ b/native/cpp/include/dimos/native/lcm_transport.hpp
@@ -10,7 +10,6 @@
 
 #include <atomic>
 #include <cstdint>
-#include <cstdlib>
 #include <memory>
 #include <mutex>
 #include <stdexcept>
@@ -22,7 +21,6 @@
 
 #include "dimos/native/log.hpp"
 #include "dimos/native/transport.hpp"
-#include "dimos/native/transport_selection.hpp"
 
 namespace dimos::native {
 
@@ -115,13 +113,5 @@ private:
     std::thread recv_thread_;
 };
 
-/// Construct the transport named by `DIMOS_TRANSPORT`. Errors clearly for zenoh
-/// or any unknown/unset value.
-inline std::unique_ptr<Transport> make_transport_from_env() {
-    const char* env = std::getenv("DIMOS_TRANSPORT");
-    std::string name = env != nullptr ? env : "";
-    require_supported_transport(name);
-    return std::make_unique<LcmTransport>();
-}
 
 }  // namespace dimos::native

--- a/native/cpp/include/dimos/native/module.hpp
+++ b/native/cpp/include/dimos/native/module.hpp
@@ -375,11 +375,12 @@ private:
     Notifier* notifier_ = nullptr;
 };
 
-// Parse the coordinator's stdin line into topics / config. Other keys the
-// coordinator sends, such as qos, are ignored.
+// Parse the coordinator's stdin line into topics / config. The whole blob is
+// kept as `launch` for the transport (zenoh reads its session and qos blocks).
 struct StdinConfig {
     std::unordered_map<std::string, std::string> topics;
     nlohmann::json config;
+    nlohmann::json launch;
 };
 
 inline StdinConfig parse_stdin_config(const std::string& line) {
@@ -397,15 +398,18 @@ inline StdinConfig parse_stdin_config(const std::string& line) {
         }
     }
     out.config = blob.contains("config") ? blob["config"] : nlohmann::json();
+    out.launch = std::move(blob);
     return out;
 }
 
-template <class M>
-void run_fallible(std::unique_ptr<Transport> transport) {
+inline StdinConfig read_stdin_config() {
     std::string line;
     std::getline(std::cin, line);
-    StdinConfig parsed = parse_stdin_config(line);
+    return parse_stdin_config(line);
+}
 
+template <class M>
+void run_fallible(std::unique_ptr<Transport> transport, StdinConfig parsed) {
     Notifier notifier;
     Builder builder(std::move(parsed.topics), &notifier);
     M module;
@@ -460,6 +464,12 @@ void run_fallible(std::unique_ptr<Transport> transport) {
         throw;
     }
     module.teardown();
+}
+
+/// Run module `M` over `transport`, reading the launch line from stdin.
+template <class M>
+void run_fallible(std::unique_ptr<Transport> transport) {
+    run_fallible<M>(std::move(transport), read_stdin_config());
 }
 
 /// Run module `M` over `transport`, reading config from stdin and blocking until

--- a/native/cpp/include/dimos/native/transport_selection.hpp
+++ b/native/cpp/include/dimos/native/transport_selection.hpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // Transport selection. The coordinator sets DIMOS_TRANSPORT for every native
-// process, and this SDK implements LCM only.
+// process; this SDK implements LCM and zenoh.
 
 #pragma once
 
@@ -13,15 +13,10 @@ namespace dimos::native {
 
 /// Throw unless `name` is a transport this SDK implements.
 inline void require_supported_transport(const std::string& name) {
-    if (name == "lcm") {
+    if (name == "lcm" || name == "zenoh") {
         return;
     }
-    if (name == "zenoh") {
-        throw std::runtime_error(
-            "DIMOS_TRANSPORT=zenoh is not supported by the C++ native SDK (LCM only). "
-            "Set DIMOS_TRANSPORT=lcm, or use a Rust native module for zenoh.");
-    }
-    throw std::runtime_error("DIMOS_TRANSPORT must be 'lcm', got '" + name + "'");
+    throw std::runtime_error("DIMOS_TRANSPORT must be 'lcm' or 'zenoh', got '" + name + "'");
 }
 
 }  // namespace dimos::native

--- a/native/cpp/include/dimos/native/zenoh_transport.hpp
+++ b/native/cpp/include/dimos/native/zenoh_transport.hpp
@@ -1,0 +1,312 @@
+// Copyright 2026 Dimensional Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Zenoh implementation of the Transport seam over zenoh-c. The session settings
+// and per-channel publisher QoS come from the coordinator's launch line, the
+// same `session` and `qos` blocks the Rust native module reads.
+
+#pragma once
+
+#include <zenoh.h>
+
+#ifndef Z_FEATURE_UNSTABLE_API
+#error "dimos ZenohTransport needs zenoh-c built with Z_FEATURE_UNSTABLE_API (publisher reliability)"
+#endif
+
+#include <nlohmann/json.hpp>
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <optional>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "dimos/native/log.hpp"
+#include "dimos/native/transport.hpp"
+
+namespace dimos::native {
+
+/// Zenoh keys can't start with '/'.
+inline std::string zenoh_key(const std::string& channel) {
+    return channel.rfind('/', 0) == 0 ? channel.substr(1) : channel;
+}
+
+/// The `zenoh config key -> JSON text` inserts for the launch line's `session`
+/// block. Python owns every value, so each field is required and unknown ones
+/// are rejected. Empty endpoint lists and a zero timeout keep zenoh's defaults.
+inline std::vector<std::pair<std::string, std::string>> zenoh_config_inserts(
+    const nlohmann::json& session) {
+    static const std::set<std::string> known = {"mode",       "connect", "listen",
+                                                "multicast",  "scout_addr", "gossip",
+                                                "interface",  "connect_timeout_ms"};
+    if (!session.is_object()) {
+        throw std::runtime_error("zenoh session settings must be a JSON object");
+    }
+    for (const auto& item : session.items()) {
+        if (known.count(item.key()) == 0) {
+            throw std::runtime_error("unknown zenoh session setting: " + item.key());
+        }
+    }
+    auto require = [&](const char* key) -> const nlohmann::json& {
+        auto it = session.find(key);
+        if (it == session.end()) {
+            throw std::runtime_error(std::string("missing zenoh session setting: ") + key);
+        }
+        return *it;
+    };
+    std::vector<std::pair<std::string, std::string>> out = {
+        {"mode", require("mode").dump()},
+        {"scouting/multicast/enabled", require("multicast").dump()},
+        {"scouting/multicast/interface", require("interface").dump()},
+        {"scouting/gossip/enabled", require("gossip").dump()},
+    };
+    if (!require("scout_addr").get<std::string>().empty()) {
+        out.emplace_back("scouting/multicast/address", session["scout_addr"].dump());
+    }
+    if (!require("connect").empty()) {
+        out.emplace_back("connect/endpoints", session["connect"].dump());
+    }
+    if (!require("listen").empty()) {
+        out.emplace_back("listen/endpoints", session["listen"].dump());
+    }
+    if (require("connect_timeout_ms").get<std::int64_t>() > 0) {
+        out.emplace_back("connect/timeout_ms", session["connect_timeout_ms"].dump());
+    }
+    return out;
+}
+
+/// Publisher QoS for one channel. Unset fields keep zenoh's defaults.
+struct ChannelQos {
+    std::optional<z_reliability_t> reliability;
+    std::optional<z_congestion_control_t> congestion_control;
+    std::optional<z_locality_t> locality;
+};
+
+/// Parse the launch line's `qos` block (channel -> {reliability,
+/// congestion_control, locality}). Unknown or absent fields keep defaults.
+inline std::unordered_map<std::string, ChannelQos> parse_channel_qos(const nlohmann::json& qos) {
+    std::unordered_map<std::string, ChannelQos> out;
+    if (!qos.is_object()) {
+        return out;
+    }
+    for (const auto& item : qos.items()) {
+        const nlohmann::json& entry = item.value();
+        if (!entry.is_object()) {
+            continue;
+        }
+        auto field = [&](const char* key) {
+            auto it = entry.find(key);
+            return it != entry.end() && it->is_string() ? it->get<std::string>() : std::string();
+        };
+        ChannelQos q;
+        const std::string reliability = field("reliability");
+        if (reliability == "reliable") {
+            q.reliability = Z_RELIABILITY_RELIABLE;
+        } else if (reliability == "best_effort") {
+            q.reliability = Z_RELIABILITY_BEST_EFFORT;
+        }
+        const std::string congestion = field("congestion_control");
+        if (congestion == "drop") {
+            q.congestion_control = Z_CONGESTION_CONTROL_DROP;
+        } else if (congestion == "block") {
+            q.congestion_control = Z_CONGESTION_CONTROL_BLOCK;
+        }
+        const std::string locality = field("locality");
+        if (locality == "session_local") {
+            q.locality = Z_LOCALITY_SESSION_LOCAL;
+        } else if (locality == "remote") {
+            q.locality = Z_LOCALITY_REMOTE;
+        } else if (locality == "any") {
+            q.locality = Z_LOCALITY_ANY;
+        }
+        out[item.key()] = q;
+    }
+    return out;
+}
+
+class ZenohTransport : public Transport {
+public:
+    /// `launch` is the coordinator's stdin blob. Its `session` block configures
+    /// the session (absent keeps zenoh's defaults) and `qos` the publishers.
+    explicit ZenohTransport(const nlohmann::json& launch = nlohmann::json::object()) {
+        zc_init_log_from_env_or("warn");
+        const nlohmann::json session = launch.value("session", nlohmann::json());
+        z_owned_config_t config;
+        if (z_config_default(&config) != Z_OK) {
+            throw std::runtime_error("zenoh: default config failed");
+        }
+        if (session.is_null()) {
+            log::warn(
+                "no `session` block on the launch line, opening zenoh's defaults; "
+                "add one to pin the mode, interface and endpoints");
+        } else {
+            for (const auto& [key, value] : zenoh_config_inserts(session)) {
+                if (zc_config_insert_json5(z_loan_mut(config), key.c_str(), value.c_str()) !=
+                    Z_OK) {
+                    z_drop(z_move(config));
+                    throw std::runtime_error("zenoh config rejected " + key + "=" + value);
+                }
+            }
+        }
+        if (z_open(&session_, z_move(config), nullptr) != Z_OK) {
+            throw std::runtime_error("zenoh: session open failed");
+        }
+        qos_ = parse_channel_qos(launch.value("qos", nlohmann::json()));
+        log::info("zenoh session opened",
+                  {log::Field("zid", zid()), log::Field("mode", session.value("mode", "default")),
+                   log::Field("connect", session.value("connect", nlohmann::json::array()).dump()),
+                   log::Field("listen", session.value("listen", nlohmann::json::array()).dump())});
+        if (!session.is_null()) {
+            await_connect(session);
+        }
+    }
+
+    ~ZenohTransport() override {
+        for (auto& entry : publishers_) {
+            z_drop(z_move(entry.second));
+        }
+        z_drop(z_move(session_));
+    }
+
+    ZenohTransport(const ZenohTransport&) = delete;
+    ZenohTransport& operator=(const ZenohTransport&) = delete;
+
+    void publish(const std::string& channel, std::vector<uint8_t> data) override {
+        const z_loaned_publisher_t* publisher = publisher_for(channel);
+        if (publisher == nullptr) {
+            return;
+        }
+        z_owned_bytes_t payload;
+        z_bytes_copy_from_buf(&payload, data.data(), data.size());
+        if (z_publisher_put(publisher, z_move(payload), nullptr) != Z_OK) {
+            DIMOS_ERROR_THROTTLED(log::from_secs(1), "zenoh publish failed",
+                                  log::Field("channel", channel));
+        }
+    }
+
+    void subscribe(const std::string& channel, Dispatch on_msg) override {
+        const std::string key = zenoh_key(channel);
+        z_view_keyexpr_t keyexpr;
+        if (z_view_keyexpr_from_str(&keyexpr, key.c_str()) != Z_OK) {
+            throw std::runtime_error("zenoh: invalid key expression: " + key);
+        }
+        // Owned by the closure; freed by drop_dispatch when the session closes.
+        auto* dispatch = new Dispatch(std::move(on_msg));
+        z_owned_closure_sample_t callback;
+        z_closure(&callback, on_sample, drop_dispatch, dispatch);
+        if (z_declare_background_subscriber(z_loan(session_), z_loan(keyexpr), z_move(callback),
+                                            nullptr) != Z_OK) {
+            throw std::runtime_error("zenoh: subscribe failed: " + key);
+        }
+    }
+
+private:
+    static void on_sample(z_loaned_sample_t* sample, void* context) {
+        z_owned_slice_t slice;
+        if (z_bytes_to_slice(z_sample_payload(sample), &slice) != Z_OK) {
+            return;
+        }
+        (*static_cast<Dispatch*>(context))(z_slice_data(z_loan(slice)), z_slice_len(z_loan(slice)));
+        z_drop(z_move(slice));
+    }
+
+    static void drop_dispatch(void* context) { delete static_cast<Dispatch*>(context); }
+
+    static void count_zid(const z_id_t* /*zid*/, void* context) {
+        ++*static_cast<std::size_t*>(context);
+    }
+
+    std::string zid() const {
+        const z_id_t id = z_info_zid(z_loan(session_));
+        z_owned_string_t text;
+        z_id_to_string(&id, &text);
+        std::string out(z_string_data(z_loan(text)), z_string_len(z_loan(text)));
+        z_drop(z_move(text));
+        return out;
+    }
+
+    /// Remote sessions this one currently has a link to.
+    std::size_t linked_count() const {
+        std::size_t count = 0;
+        for (auto info : {z_info_peers_zid, z_info_routers_zid}) {
+            z_owned_closure_zid_t callback;
+            z_closure(&callback, count_zid, nullptr, &count);
+            info(z_loan(session_), z_move(callback));
+        }
+        return count;
+    }
+
+    /// Block until the dialed endpoints have links, bounded by the timeout. A
+    /// peer opens before its endpoints are dialed, so without this the first
+    /// published messages have nowhere to go.
+    void await_connect(const nlohmann::json& session) const {
+        const auto& endpoints = session["connect"];
+        const std::int64_t timeout_ms = session["connect_timeout_ms"].get<std::int64_t>();
+        if (endpoints.empty() || timeout_ms <= 0) {
+            return;
+        }
+        // A client holds one link; zenoh keeps the first endpoint that answers.
+        // ponytail: counts any linked session, not the dialed ones specifically;
+        // match link addresses against the endpoints if multicast peers fool it.
+        const std::size_t needed = session["mode"] == "client" ? 1 : endpoints.size();
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
+        while (linked_count() < needed) {
+            if (std::chrono::steady_clock::now() >= deadline) {
+                log::warn("zenoh endpoints not linked, published messages may be dropped",
+                          {log::Field("endpoints", endpoints.dump()),
+                           log::Field("timeout_ms", timeout_ms)});
+                return;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        }
+    }
+
+    /// The publisher for `channel`, declared on first use with its QoS. Null if
+    /// the declaration failed (logged). Released before the put so a stalled
+    /// channel can't block the others.
+    const z_loaned_publisher_t* publisher_for(const std::string& channel) {
+        std::lock_guard<std::mutex> lock(publishers_mu_);
+        auto it = publishers_.find(channel);
+        if (it != publishers_.end()) {
+            return z_loan(it->second);
+        }
+        const std::string key = zenoh_key(channel);
+        z_view_keyexpr_t keyexpr;
+        z_owned_publisher_t publisher;
+        z_publisher_options_t options;
+        z_publisher_options_default(&options);
+        if (auto qos = qos_.find(channel); qos != qos_.end()) {
+            if (qos->second.reliability) {
+                options.reliability = *qos->second.reliability;
+            }
+            if (qos->second.congestion_control) {
+                options.congestion_control = *qos->second.congestion_control;
+            }
+            if (qos->second.locality) {
+                options.allowed_destination = *qos->second.locality;
+            }
+        }
+        if (z_view_keyexpr_from_str(&keyexpr, key.c_str()) != Z_OK ||
+            z_declare_publisher(z_loan(session_), &publisher, z_loan(keyexpr), &options) != Z_OK) {
+            DIMOS_ERROR_THROTTLED(log::from_secs(1), "zenoh declare publisher failed",
+                                  log::Field("channel", channel));
+            return nullptr;
+        }
+        // Node-based map: the stored publisher's address survives later inserts.
+        return z_loan(publishers_.emplace(channel, publisher).first->second);
+    }
+
+    z_owned_session_t session_;
+    std::unordered_map<std::string, ChannelQos> qos_;
+    std::mutex publishers_mu_;
+    std::unordered_map<std::string, z_owned_publisher_t> publishers_;
+};
+
+}  // namespace dimos::native

--- a/native/cpp/tests/CMakeLists.txt
+++ b/native/cpp/tests/CMakeLists.txt
@@ -17,12 +17,17 @@ add_executable(dimos_native_tests
   test_config.cpp
   test_module.cpp
   test_lcm_codec.cpp
+  test_zenoh_transport.cpp
 )
 target_link_libraries(dimos_native_tests PRIVATE
   dimos_native
   doctest::doctest
 )
 target_compile_options(dimos_native_tests PRIVATE -Wall -Wextra -Werror)
+# Session-settings goldens shared with the Rust module and Python.
+target_compile_definitions(dimos_native_tests PRIVATE
+  DIMOS_RUST_FIXTURES_DIR="${CMAKE_CURRENT_SOURCE_DIR}/../../rust/dimos-module/tests/fixtures"
+)
 
 # LcmTransport needs liblcm, which isn't always present (system pkg-config often
 # lacks it, it comes in via nix). Compile-check the adapter only when LCM is

--- a/native/cpp/tests/test_lcm_transport.cpp
+++ b/native/cpp/tests/test_lcm_transport.cpp
@@ -1,7 +1,7 @@
 // Copyright 2026 Dimensional Inc.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Typechecks LcmTransport's inline bodies against the real LCM headers. Opens no
+// Typechecks LcmTransport and the umbrella header against the real LCM headers. Opens no
 // endpoint, so it never assumes a multicast route. Compiled only when liblcm is
 // available, see tests/CMakeLists.txt.
 
@@ -12,7 +12,7 @@
 #include <type_traits>
 #include <vector>
 
-#include "dimos/native/lcm_transport.hpp"
+#include "dimos/native.hpp"
 
 using namespace dimos::native;
 
@@ -23,7 +23,7 @@ using namespace dimos::native;
     Transport& base = t;
     base.publish("/c", std::vector<uint8_t>{1, 2, 3});
     base.subscribe("/c", [](const uint8_t*, std::size_t) {});
-    auto owned = make_transport_from_env();
+    auto owned = make_transport_from_env(nlohmann::json::object());
     (void)owned;
 }
 

--- a/native/cpp/tests/test_module.cpp
+++ b/native/cpp/tests/test_module.cpp
@@ -359,11 +359,12 @@ TEST_CASE("publishing on a default-constructed Output throws") {
     CHECK_THROWS_AS(out.publish({1}), std::runtime_error);
 }
 
-TEST_CASE("parse_stdin_config extracts topics and config, ignoring other keys") {
+TEST_CASE("parse_stdin_config extracts topics and config and keeps the launch blob") {
     StdinConfig p = parse_stdin_config(
         R"({"topics":{"data":"/d"},"config":{"x":1},"qos":{"/d":{"reliability":"reliable"}}})");
     CHECK(p.topics.at("data") == "/d");
     CHECK(p.config.at("x") == 1);
+    CHECK(p.launch.at("qos").at("/d").at("reliability") == "reliable");
 }
 
 TEST_CASE("parse_stdin_config tolerates a missing config") {

--- a/native/cpp/tests/test_transport_selection.cpp
+++ b/native/cpp/tests/test_transport_selection.cpp
@@ -10,20 +10,10 @@
 
 using namespace dimos::native;
 
-TEST_CASE("lcm is a supported transport") {
-    require_supported_transport("lcm");  // must not throw
+TEST_CASE("lcm and zenoh are supported transports") {
+    require_supported_transport("lcm");
+    require_supported_transport("zenoh");
     CHECK(true);
-}
-
-TEST_CASE("zenoh is rejected with a clear, actionable message") {
-    try {
-        require_supported_transport("zenoh");
-        FAIL("expected require_supported_transport(\"zenoh\") to throw");
-    } catch (const std::runtime_error& e) {
-        const std::string msg = e.what();
-        CHECK(msg.find("zenoh") != std::string::npos);
-        CHECK(msg.find("LCM only") != std::string::npos);
-    }
 }
 
 TEST_CASE("an unknown transport is rejected and names the offending value") {

--- a/native/cpp/tests/test_zenoh_transport.cpp
+++ b/native/cpp/tests/test_zenoh_transport.cpp
@@ -1,0 +1,138 @@
+// Copyright 2026 Dimensional Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+// ZenohTransport: session settings and QoS parsing against the goldens the
+// Rust module and Python share, plus an in-process round trip on a session
+// with discovery off, so it needs no network beyond loopback.
+
+#include <doctest/doctest.h>
+
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <fstream>
+#include <map>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "dimos/native/zenoh_transport.hpp"
+
+using namespace dimos::native;
+using nlohmann::json;
+
+namespace {
+
+json golden(const char* name) {
+    std::ifstream file(std::string(DIMOS_RUST_FIXTURES_DIR) + "/" + name);
+    REQUIRE(file.good());
+    return json::parse(file);
+}
+
+std::map<std::string, std::string> inserts(const json& session) {
+    std::map<std::string, std::string> out;
+    for (const auto& [key, value] : zenoh_config_inserts(session)) {
+        out[key] = value;
+    }
+    return out;
+}
+
+// A session only reachable from this process: discovery off, no endpoints.
+json local_session() {
+    return {{"mode", "peer"},        {"connect", json::array()}, {"listen", json::array()},
+            {"multicast", false},    {"scout_addr", ""},         {"gossip", false},
+            {"interface", "lo"},     {"connect_timeout_ms", 0}};
+}
+
+}  // namespace
+
+TEST_CASE("zenoh_key strips the leading slash") {
+    CHECK(zenoh_key("/cmd_vel/geometry_msgs.Twist") == "cmd_vel/geometry_msgs.Twist");
+    CHECK(zenoh_key("dimos/cmd_vel/geometry_msgs.Twist") == "dimos/cmd_vel/geometry_msgs.Twist");
+    CHECK(zenoh_key("") == "");
+}
+
+TEST_CASE("the client golden maps to the session config the Rust module builds") {
+    auto out = inserts(golden("session_wire_client.json"));
+    CHECK(out.at("mode") == R"("client")");
+    CHECK(out.at("connect/endpoints") == R"(["tcp/192.0.2.10:7447"])");
+    CHECK(out.count("listen/endpoints") == 0);
+    CHECK(out.at("scouting/multicast/enabled") == "true");
+    CHECK(out.count("scouting/multicast/address") == 0);
+    CHECK(out.at("scouting/gossip/enabled") == "false");
+    CHECK(out.at("scouting/multicast/interface") == R"("lo")");
+    CHECK(out.at("connect/timeout_ms") == "2000");
+}
+
+TEST_CASE("the router golden keeps zenoh's defaults for empty lists and a zero timeout") {
+    auto out = inserts(golden("session_wire_router.json"));
+    CHECK(out.at("mode") == R"("router")");
+    CHECK(out.at("listen/endpoints") == R"(["tcp/127.0.0.1:7447"])");
+    CHECK(out.count("connect/endpoints") == 0);
+    CHECK(out.count("connect/timeout_ms") == 0);
+    CHECK(out.at("scouting/multicast/enabled") == "false");
+    CHECK(out.at("scouting/gossip/enabled") == "true");
+}
+
+TEST_CASE("a moved scout group reaches the session config") {
+    json session = local_session();
+    session["scout_addr"] = "224.0.0.224:17700";
+    CHECK(inserts(session).at("scouting/multicast/address") == R"("224.0.0.224:17700")");
+}
+
+TEST_CASE("a missing or unknown setting is an error, not a default") {
+    CHECK_THROWS_AS(zenoh_config_inserts(json{{"mode", "peer"}}), std::runtime_error);
+    json session = local_session();
+    session["reliability"] = "reliable";
+    CHECK_THROWS_AS(zenoh_config_inserts(session), std::runtime_error);
+    CHECK_THROWS_AS(zenoh_config_inserts(json::array()), std::runtime_error);
+}
+
+TEST_CASE("parse_channel_qos reads the coordinator's qos block") {
+    auto qos = parse_channel_qos(json::parse(
+        R"({"a":{"reliability":"reliable","congestion_control":"block","locality":"session_local"},
+            "b":{"reliability":"best_effort","congestion_control":"drop","locality":"remote"},
+            "c":{"reliability":"bogus"},
+            "d":7})"));
+    CHECK(qos.at("a").reliability == Z_RELIABILITY_RELIABLE);
+    CHECK(qos.at("a").congestion_control == Z_CONGESTION_CONTROL_BLOCK);
+    CHECK(qos.at("a").locality == Z_LOCALITY_SESSION_LOCAL);
+    CHECK(qos.at("b").reliability == Z_RELIABILITY_BEST_EFFORT);
+    CHECK(qos.at("b").congestion_control == Z_CONGESTION_CONTROL_DROP);
+    CHECK(qos.at("b").locality == Z_LOCALITY_REMOTE);
+    CHECK_FALSE(qos.at("c").reliability.has_value());
+    CHECK(qos.count("d") == 0);
+    CHECK(parse_channel_qos(json()).empty());
+}
+
+TEST_CASE("ZenohTransport implements the Transport interface") {
+    CHECK(std::is_base_of<Transport, ZenohTransport>::value);
+}
+
+TEST_CASE("a message published on a channel reaches that channel's subscriber") {
+    json launch = {{"session", local_session()},
+                   {"qos", {{"/t/x", {{"reliability", "reliable"}, {"congestion_control", "block"}}}}}};
+    ZenohTransport transport(launch);
+
+    std::mutex mu;
+    std::condition_variable cv;
+    std::vector<std::vector<uint8_t>> got;
+    transport.subscribe("/t/x", [&](const uint8_t* data, std::size_t len) {
+        std::lock_guard<std::mutex> lock(mu);
+        got.emplace_back(data, data + len);
+        cv.notify_all();
+    });
+    transport.subscribe("/t/other", [&](const uint8_t*, std::size_t) {
+        std::lock_guard<std::mutex> lock(mu);
+        got.emplace_back(std::vector<uint8_t>{0xFF});
+        cv.notify_all();
+    });
+
+    transport.publish("/t/x", {1, 2, 3});
+    transport.publish("/t/x", {4});
+
+    std::unique_lock<std::mutex> lock(mu);
+    REQUIRE(cv.wait_for(lock, std::chrono::seconds(5), [&] { return got.size() >= 2; }));
+    CHECK(got[0] == std::vector<uint8_t>{1, 2, 3});
+    CHECK(got[1] == std::vector<uint8_t>{4});
+}


### PR DESCRIPTION
The C++ native SDK had the `Transport` seam and one implementation behind it. This adds the second one, so `DIMOS_TRANSPORT=zenoh` runs a C++ module instead of throwing "LCM only"