### PR TITLE
ci: reject Claude and Codex co-authors in PR commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,28 @@ env:
   UV_NO_SYNC: "1"
 
 jobs:
+  commit-messages:
+    name: No AI co-authors
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Check incoming commit messages
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        env:
+          PRE_COMMIT_FROM_REF: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          PRE_COMMIT_TO_REF: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+        run: |
+          : "${PRE_COMMIT_FROM_REF:?Missing base SHA}"
+          : "${PRE_COMMIT_TO_REF:?Missing head SHA}"
+          python3 bin/hooks/filter_commit_message.py --check
+
   compute-ros-pin:
     # Extracts the ros-dev image digest pinned in docker/ros-dev-pin/Dockerfile
     # so downstream jobs can reference it from their `container:` field.
@@ -181,6 +203,8 @@ jobs:
           prune-cache: true
       - name: Install lint dependencies
         run: uv sync --only-group lint --frozen
+      - name: Test commit message check
+        run: uv run pytest -c /dev/null --rootdir . --noconftest bin/hooks/test_filter_commit_message.py
       - name: Mypy
         run: uv run mypy
 
@@ -1025,6 +1049,7 @@ jobs:
     if: always()
 
     needs:
+    - commit-messages
     - lint
     - rust
     - native

--- a/bin/hooks/filter_commit_message.py
+++ b/bin/hooks/filter_commit_message.py
@@ -15,6 +15,7 @@
 
 import os
 from pathlib import Path
+import re
 import subprocess
 import sys
 
@@ -23,6 +24,12 @@ TRUNCATE_PATTERNS = [
     "Generated with",
     "Co-Authored-By",
 ]
+
+AI_COAUTHOR = re.compile(
+    r"^[ \t]*Co-authored-by[ \t]*:[^\r\n]*"
+    r"(?:\bClaude\b|\bCodex\b|<[^<>\r\n]*@(?:anthropic\.com|openai\.com)>)",
+    re.IGNORECASE | re.MULTILINE,
+)
 
 
 def filter_text(text: str) -> tuple[str, str | None]:
@@ -52,13 +59,16 @@ def check_commits() -> int:
 
     Locally on `git commit` no range is supplied, so we no-op rather than
     blocking commits on the state of HEAD — the commit-msg hook is in
-    charge there. In CI, code-cleanup.yml passes `--from-ref/--to-ref` to
-    pre-commit, which exports PRE_COMMIT_FROM_REF / PRE_COMMIT_TO_REF.
+    charge there. CI supplies PRE_COMMIT_FROM_REF / PRE_COMMIT_TO_REF
+    explicitly to check the incoming commits for AI co-authors.
     """
     from_ref = os.environ.get("PRE_COMMIT_FROM_REF")
     to_ref = os.environ.get("PRE_COMMIT_TO_REF")
-    if not (from_ref and to_ref):
+    if not from_ref and not to_ref:
         return 0
+    if not (from_ref and to_ref):
+        print("Both PRE_COMMIT_FROM_REF and PRE_COMMIT_TO_REF are required.", file=sys.stderr)
+        return 1
 
     try:
         rev_list = subprocess.run(
@@ -89,20 +99,19 @@ def check_commits() -> int:
                 file=sys.stderr,
             )
             return 1
-        _, matched = filter_text(msg)
+        matched = AI_COAUTHOR.search(msg)
         if matched is not None:
-            failures.append((sha, matched))
+            failures.append((sha, matched.group().strip()))
 
     if failures:
         for sha, pattern in failures:
             print(
-                f"{sha[:12]}: contains forbidden pattern: {pattern!r}",
+                f"{sha[:12]}: AI co-author: {pattern!r}",
                 file=sys.stderr,
             )
         print(
-            "\nInstall the commit-msg hook "
-            "(`pre-commit install -t commit-msg`) or amend the offending "
-            "commits to strip the trailer.",
+            "\nAmend the offending commits to remove AI co-author trailers, "
+            "then push the updated branch.",
             file=sys.stderr,
         )
         return 1

--- a/bin/hooks/test_filter_commit_message.py
+++ b/bin/hooks/test_filter_commit_message.py
@@ -1,0 +1,123 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+import subprocess
+import sys
+
+from filter_commit_message import AI_COAUTHOR
+import pytest
+
+SCRIPT = Path(__file__).with_name("filter_commit_message.py")
+
+
+@pytest.mark.parametrize(
+    ("message", "rejected"),
+    [
+        ("Co-authored-by: Claude Opus 5 (1M context) <noreply@anthropic.com>", True),
+        ("CO-AUTHORED-BY: CODEX <codex@users.noreply.github.com>", True),
+        ("Co-Authored-By: OpenAI Codex <noreply@openai.com>", True),
+        ("\tco-authored-by : Assistant <noreply@anthropic.com>", True),
+        ("Co-authored-by: Assistant <noreply@openai.com>", True),
+        ("Co-authored-by: Claude <bot@example.com>", True),
+        ("Co-authored-by: Codex <bot@example.com>", True),
+        ("Co-authored-by: Alice Smith <alice@example.com>", False),
+        ("Co-authored-by: Claudette <claudette@example.com>", False),
+        ("Fix Claude and Codex integration", False),
+        ("Document Co-authored-by: Claude trailers", False),
+        ("Generated with a code generator", False),
+        ("Co-authored-by: Alice <alice@example.com>\n\nFix Codex integration", False),
+    ],
+)
+def test_ai_coauthor_detection(message: str, rejected: bool) -> None:
+    assert bool(AI_COAUTHOR.search(f"Subject\n\n{message}\n")) == rejected
+
+
+@pytest.fixture
+def repository(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", "/dev/null")
+    monkeypatch.setenv("GIT_CONFIG_NOSYSTEM", "1")
+    for role in ("AUTHOR", "COMMITTER"):
+        monkeypatch.setenv(f"GIT_{role}_NAME", "Test User")
+        monkeypatch.setenv(f"GIT_{role}_EMAIL", "test@example.com")
+    monkeypatch.delenv("PRE_COMMIT_FROM_REF", raising=False)
+    monkeypatch.delenv("PRE_COMMIT_TO_REF", raising=False)
+    subprocess.run(["git", "init", "--quiet"], check=True)
+
+
+def commit(message: str, *parents: str) -> str:
+    tree = subprocess.run(
+        ["git", "mktree"], input="", capture_output=True, text=True, check=True
+    ).stdout.strip()
+    args = ["git", "-c", "commit.gpgsign=false", "commit-tree", tree, "-m", message]
+    for parent in parents:
+        args.extend(["-p", parent])
+    return subprocess.run(args, capture_output=True, text=True, check=True).stdout.strip()
+
+
+def check_range(
+    monkeypatch: pytest.MonkeyPatch, base: str, head: str
+) -> subprocess.CompletedProcess[str]:
+    monkeypatch.setenv("PRE_COMMIT_FROM_REF", base)
+    monkeypatch.setenv("PRE_COMMIT_TO_REF", head)
+    return subprocess.run([sys.executable, str(SCRIPT), "--check"], capture_output=True, text=True)
+
+
+def test_checks_older_commits_and_merge_parents(
+    repository: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    base = commit("Base")
+    claude = commit("Change\n\nCo-authored-by: Claude <noreply@anthropic.com>", base)
+    codex = commit("Other change\n\nCo-authored-by: Codex <noreply@openai.com>", base)
+    head = commit("Clean merge message", claude, codex)
+
+    result = check_range(monkeypatch, base, head)
+
+    assert result.returncode == 1
+    assert claude[:12] in result.stderr
+    assert codex[:12] in result.stderr
+    assert head[:12] not in result.stderr
+
+
+def test_excludes_base_history_and_allows_human_coauthors(
+    repository: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ancestor = commit("Existing\n\nCo-authored-by: Claude <noreply@anthropic.com>")
+    base = commit("Main-only\n\nCo-authored-by: Codex <noreply@openai.com>", ancestor)
+    head = commit("Change\n\nCo-authored-by: Alice <alice@example.com>", ancestor)
+
+    result = check_range(monkeypatch, base, head)
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+
+
+@pytest.mark.parametrize("base", ["missing-ref", ""])
+def test_invalid_or_incomplete_range_fails(
+    repository: None, monkeypatch: pytest.MonkeyPatch, base: str
+) -> None:
+    head = commit("Clean")
+
+    result = check_range(monkeypatch, base, head)
+
+    assert result.returncode == 1
+
+
+def test_local_hook_without_range_is_noop(repository: None) -> None:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--check"], capture_output=True, text=True
+    )
+
+    assert result.returncode == 0


### PR DESCRIPTION
## Contribution path

Small CI fix; no tracking issue.

## Problem

Commit 11f49585ceec6998a2017a2f7ecb8972034f7a7a reached main with a Claude co-author trailer. The existing check was case-sensitive and CI did not supply the commit range it needed to inspect.

## Solution

Add a `No AI co-authors` job to the existing `ci-complete` gate, which main's active ruleset already requires. Check every incoming commit for pull requests and merge groups using full Git history and the event's base/head SHAs.

Reject co-author lines containing Claude, Codex, or an anthropic.com/openai.com email, regardless of capitalization. Report offending commit SHAs and ask contributors to amend them. Ordinary human co-authors and mentions of AI tools in commit prose pass; existing base-branch history is excluded.

Reuse the existing commit-check script and run its regression tests in lint CI. No new dependencies or repository settings changes.

## How to Test

`uv run pytest -c /dev/null --rootdir . --noconftest bin/hooks/test_filter_commit_message.py`

18 tests passed, covering mixed-case trailers, both tools, human co-authors, older commits, merge parents, base-history exclusion, and invalid ranges. Also verified that the exact reported commit fails. Ruff, targeted mypy, workflow YAML validation, and commit hooks passed.

## AI assistance

Codex (GPT-6) implemented and locally validated this change.

## Checklist

- [ ] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
