### PR TITLE
fix(mem): skip streams whose payload type cannot be imported in mem rerun

### DIFF
--- a/dimos/memory/cli/render.py
+++ b/dimos/memory/cli/render.py
@@ -77,10 +77,13 @@ def render_store(
     renderable = []
     t0: float | None = None
     for name in store.list_streams():
-        stream = store.streams[name]
         try:
+            stream = store.streams[name]
             first = stream.first()
         except LookupError:
+            continue
+        except (ImportError, AttributeError) as e:
+            print(f"  skip {name}: payload type unavailable ({e})")
             continue
         data = first.data
         if not hasattr(data, "to_rerun"):

--- a/dimos/memory/cli/test_render.py
+++ b/dimos/memory/cli/test_render.py
@@ -1,0 +1,49 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from pathlib import Path
+import sqlite3
+
+import pytest
+
+from dimos.memory.cli.render import render_store
+from dimos.memory.store.sqlite import SqliteStore
+from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
+
+
+def test_render_skips_stream_with_unresolvable_payload_type(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    path = tmp_path / "memory.db"
+    store = SqliteStore(path=str(path))
+    store.start()
+    store.stream("odom", PoseStamped).append(PoseStamped(ts=1.0), ts=1.0)
+    store.stop()
+
+    # A stream recorded with a type whose module no longer exists. Sorts before "odom".
+    conn = sqlite3.connect(path)
+    cfg = json.loads(conn.execute("SELECT config FROM _streams WHERE name = 'odom'").fetchone()[0])
+    cfg["payload_module"] = "dimos.gone.Missing.Missing"
+    conn.execute("INSERT INTO _streams (name, config) VALUES ('april_tag', ?)", (json.dumps(cfg),))
+    conn.commit()
+    conn.close()
+
+    store = SqliteStore(path=str(path), must_exist=True)
+    store.start()
+    out = render_store(store, out=str(tmp_path / "out.rrd"), no_gui=True)
+    store.stop()
+
+    assert "skip april_tag: payload type unavailable" in capsys.readouterr().out
+    assert Path(out).stat().st_size > 0


### PR DESCRIPTION
## Problem

`dimos mem rerun <db>` crashed with `ModuleNotFoundError` when the store contained a stream whose payload class does not exist on the current branch, e.g. `april_tag` (pickled `TagInfo` from `dimos.mapping.recording`) or `pose_graph` (`dimos.navigation.jnav.msgs`).

Opening the stream resolves the stored payload class by import path, and that happened one line before the existing "no `to_rerun()`" skip.

## Fix

Treat an unresolvable payload type like a non-renderable stream: print a skip line and continue with the rest.

```
  skip april_tag: payload type unavailable (No module named 'dimos.mapping.recording')
  skip pose_graph: payload type unavailable (No module named 'dimos.navigation.jnav')
april_tags 100% [17/17] ...
color_image ...
```

Verified on a 2026-09-03 recording that renders everything else.