### PR TITLE
fix(unitree): tell users how to fetch the Go2/G1 AES key when the handshake needs it

### DIFF
--- a/dimos/robot/unitree/connection.py
+++ b/dimos/robot/unitree/connection.py
@@ -31,6 +31,7 @@ from unitree_webrtc_connect.constants import (
     SPORT_CMD,
     VUI_COLOR,
 )
+from unitree_webrtc_connect.unitree_auth import AesKeyRequiredError
 from unitree_webrtc_connect.webrtc_driver import (
     UnitreeWebRTCConnection as LegionConnection,
     WebRTCConnectionMethod,
@@ -96,6 +97,15 @@ class SerializableVideoFrame:
         return self.data
 
 
+_AES_KEY_HELP = """\
+Robot at {ip} runs firmware that needs its per-device AES-128 key (Go2 >= 1.1.15, G1 >= 1.5.1).
+Fetch the key from the Unitree account the robot is bound to (installed with dimos[unitree]):
+    unitree-fetch-aes-key --email <unitree account email> --sn <robot serial>
+Then pass it:
+    dimos --unitree-aes-128-key <32 hex chars> run unitree-go2
+or set unitree_aes_128_key in GlobalConfig."""
+
+
 class UnitreeWebRTCConnection(Resource):
     _SPORT_API_ID_RAGEMODE: int = 2059
 
@@ -141,7 +151,7 @@ class UnitreeWebRTCConnection(Resource):
         # Blocks until connected; re-raises connect failures (e.g. missing AES key).
         try:
             asyncio.run_coroutine_threadsafe(async_connect(), self.loop).result()
-        except Exception:
+        except Exception as e:
             # Best-effort disconnect — don't leave a half-open peer on the dog.
             try:
                 asyncio.run_coroutine_threadsafe(self.conn.disconnect(), self.loop).result(
@@ -151,6 +161,8 @@ class UnitreeWebRTCConnection(Resource):
                 logger.warning("best-effort disconnect on connect failure failed", exc_info=True)
             self.loop.call_soon_threadsafe(self.loop.stop)
             self.thread.join(timeout=DEFAULT_THREAD_JOIN_TIMEOUT)
+            if isinstance(e, AesKeyRequiredError):
+                raise RuntimeError(_AES_KEY_HELP.format(ip=self.ip)) from e
             raise
 
     def start(self) -> None:

--- a/dimos/robot/unitree/test_connection.py
+++ b/dimos/robot/unitree/test_connection.py
@@ -24,6 +24,7 @@ from unittest.mock import ANY, AsyncMock, MagicMock, call
 
 import pytest
 from unitree_webrtc_connect.constants import DATA_CHANNEL_TYPE, RTC_TOPIC, SPORT_CMD
+from unitree_webrtc_connect.unitree_auth import AesKeyRequiredError
 
 from dimos.constants import DEFAULT_THREAD_JOIN_TIMEOUT
 from dimos.core.global_config import GlobalConfig
@@ -50,6 +51,17 @@ def test_connect_failure_propagates_to_caller(monkeypatch: pytest.MonkeyPatch) -
 
     with pytest.raises(RuntimeError, match="aes_128_key required"):
         UnitreeWebRTCConnection(ip="10.0.0.99")
+
+
+def test_missing_aes_key_explains_how_to_get_one(monkeypatch: pytest.MonkeyPatch) -> None:
+    driver = _stub_driver(connect_exc=AesKeyRequiredError())
+    monkeypatch.setattr(conn_mod, "LegionConnection", MagicMock(return_value=driver))
+
+    with pytest.raises(
+        RuntimeError, match=r"(?s)unitree-fetch-aes-key.*--unitree-aes-128-key"
+    ) as ei:
+        UnitreeWebRTCConnection(ip="10.0.0.99")
+    assert isinstance(ei.value.__cause__, AesKeyRequiredError)
 
 
 @pytest.fixture

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -91,6 +91,13 @@ export ROBOT_IP=<YOUR_ROBOT_IP>
 dimos run unitree-go2
 ```
 
+Go2 firmware 1.1.15 and later (G1 1.5.1 and later) encrypts the LAN handshake with a per-device key. Fetch it once from the Unitree account the robot is bound to and pass it on the command line:
+
+```bash
+unitree-fetch-aes-key --email <unitree account email> --sn <robot serial>
+dimos --unitree-aes-128-key <32 hex chars> run unitree-go2
+```
+
 !!! warning
 
     Before driving real hardware, read the [Unitree Go2 platform guide](/docs/platforms/quadruped/go2/index.md). It covers network setup, latency, time sync, and the safety habits that keep you and the robot out of trouble. Do not skip it.


### PR DESCRIPTION
## Problem

On Go2 firmware >= 1.1.15 (G1 >= 1.5.1) `dimos run unitree-go2` fails deep inside `unitree-webrtc-connect` with:

```
AesKeyRequiredError: ... Pass `aes_128_key=...` to UnitreeWebRTCConnection.
Fetch it via `examples/fetch_aes_key.py` or `UnitreeCloud.list_devices()`.
```

That example script lives in the upstream package repo, not in dimos, and the message names the driver class rather than the dimos flag. Users have no path from the error to a working command.

## Fix

`UnitreeWebRTCConnection.connect` translates `AesKeyRequiredError` into a `RuntimeError` (chained, original kept as `__cause__`) that gives the dimos workflow:

```
Robot at 192.168.12.1 runs firmware that needs its per-device AES-128 key (Go2 >= 1.1.15, G1 >= 1.5.1).
Fetch the key from the Unitree account the robot is bound to (installed with dimos[unitree]):
    unitree-fetch-aes-key --email <unitree account email> --sn <robot serial>
Then pass it:
    dimos --unitree-aes-128-key <32 hex chars> run unitree-go2
or set unitree_aes_128_key in GlobalConfig.
```

`unitree-fetch-aes-key` is the console script `unitree-webrtc-connect` 2.1.2 installs alongside the driver. Quickstart gets the same two commands under **Real robot**.

Test covers the translation and the chained cause. The two pre-existing mypy errors in `test_connection.py` (kwargs splat at the `velocity_api` call) are untouched.