### PR TITLE
fix(control): arm streamed paths before the follower task is active

### DIFF
--- a/dimos/control/tasks/holonomic_pose_follower_task/holonomic_pose_follower_task.py
+++ b/dimos/control/tasks/holonomic_pose_follower_task/holonomic_pose_follower_task.py
@@ -150,7 +150,7 @@ class HolonomicPoseFollowerTask(BaseControlTask):
         )
 
     def is_active(self) -> bool:
-        return self._state in ("tracking", "settling", "stopping")
+        return self._state in ("tracking", "settling", "stopping") or self._pending_path is not None
 
     def compute(self, state: CoordinatorState) -> JointCommandOutput | None:
         if self._pending_path is not None:

--- a/dimos/control/tasks/holonomic_pose_follower_task/holonomic_pose_follower_task.py
+++ b/dimos/control/tasks/holonomic_pose_follower_task/holonomic_pose_follower_task.py
@@ -150,6 +150,8 @@ class HolonomicPoseFollowerTask(BaseControlTask):
         )
 
     def is_active(self) -> bool:
+        # A latched path counts: the tick loop only calls compute() on active
+        # tasks, and compute() is what arms it.
         return self._state in ("tracking", "settling", "stopping") or self._pending_path is not None
 
     def compute(self, state: CoordinatorState) -> JointCommandOutput | None:
@@ -190,6 +192,7 @@ class HolonomicPoseFollowerTask(BaseControlTask):
         if joints & self._joint_names and self.is_active():
             logger.warning(f"HolonomicPoseFollowerTask '{self._name}' preempted by {by_task}")
             self._state = "aborted"
+            self._pending_path = None
 
     # Control law
 
@@ -488,6 +491,7 @@ class HolonomicPoseFollowerTask(BaseControlTask):
         if not self.is_active():
             return False
         self._state = "aborted"
+        self._pending_path = None
         return True
 
     def reset(self) -> bool:

--- a/dimos/control/tasks/holonomic_pose_follower_task/holonomic_pose_follower_task.py
+++ b/dimos/control/tasks/holonomic_pose_follower_task/holonomic_pose_follower_task.py
@@ -152,7 +152,10 @@ class HolonomicPoseFollowerTask(BaseControlTask):
     def is_active(self) -> bool:
         # A latched path counts: the tick loop only calls compute() on active
         # tasks, and compute() is what arms it.
-        return self._state in ("tracking", "settling", "stopping") or self._pending_path is not None
+        return self._running() or self._pending_path is not None
+
+    def _running(self) -> bool:
+        return self._state in ("tracking", "settling", "stopping")
 
     def compute(self, state: CoordinatorState) -> JointCommandOutput | None:
         if self._pending_path is not None:
@@ -162,7 +165,7 @@ class HolonomicPoseFollowerTask(BaseControlTask):
             if armed is not None:
                 path, self._pending_path = self._pending_path, None
                 self.start_path(path, _pose_stamped(armed))
-        if not self.is_active() or self._reference is None:
+        if not self._running() or self._reference is None:
             return None
 
         pose = self._read_pose(state)
@@ -437,7 +440,7 @@ class HolonomicPoseFollowerTask(BaseControlTask):
         self.set_speed(float(msg.data))
 
     def set_speed(self, speed: float) -> None:
-        if self.is_active():
+        if self._running():
             logger.warning(
                 f"HolonomicPoseFollowerTask '{self._name}': ignoring set_speed while active"
             )
@@ -459,7 +462,7 @@ class HolonomicPoseFollowerTask(BaseControlTask):
     ) -> bool:
         """Override per-run knobs before start_path. Unknown kwargs are accepted
         so callers built for a sibling follower's signature work unchanged."""
-        if self.is_active():
+        if self._running():
             logger.warning(
                 f"HolonomicPoseFollowerTask '{self._name}': cannot configure while active"
             )
@@ -495,7 +498,7 @@ class HolonomicPoseFollowerTask(BaseControlTask):
         return True
 
     def reset(self) -> bool:
-        if self.is_active():
+        if self._running():
             return False
         self._state = "idle"
         self._reference = None

--- a/dimos/control/tasks/holonomic_pose_follower_task/test_holonomic_pose_follower_task.py
+++ b/dimos/control/tasks/holonomic_pose_follower_task/test_holonomic_pose_follower_task.py
@@ -142,11 +142,11 @@ def test_streamed_path_arms_on_the_first_tick_with_a_pose():
     on the first tick that has a pose — never dropped for arriving early."""
     task = _task()
     task.on_path(straight_rotate(), t_now=0.0)
-    assert not task.is_active()  # latched, not armed
+    assert task.get_state() == "idle"  # latched, not armed
     task.compute(CoordinatorState(joints=JointStateSnapshot(), t_now=0.0, dt=_DT))
-    assert not task.is_active()  # still no pose available
+    assert task.get_state() == "idle"  # still no pose available
     task.compute(_state(0.0, 0.0, 0.0, t=_DT))
-    assert task.is_active()
+    assert task.get_state() == "tracking"
 
 
 def test_streamed_speed_applies_before_the_path():

--- a/dimos/control/tasks/holonomic_pose_follower_task/test_holonomic_pose_follower_task.py
+++ b/dimos/control/tasks/holonomic_pose_follower_task/test_holonomic_pose_follower_task.py
@@ -149,8 +149,9 @@ def test_streamed_path_arms_on_the_first_tick_with_a_pose():
     assert task.get_state() == "tracking"
 
 
-def test_streamed_speed_applies_before_the_path():
+def test_streamed_speed_applies_until_the_path_arms():
     task = _task()
+    task.on_path(straight_rotate(), t_now=0.0)  # separate streams: speed may land second
     task.on_speed(Float32(data=0.8), t_now=0.0)
     assert task._config.speed == pytest.approx(0.8)
 

--- a/dimos/control/tasks/path_follower_task/path_follower_task.py
+++ b/dimos/control/tasks/path_follower_task/path_follower_task.py
@@ -210,10 +210,10 @@ class PathFollowerTask(BaseControlTask):
     def is_active(self) -> bool:
         # A latched path counts: the tick loop only calls compute() on active
         # tasks, and compute() is what arms it.
-        return (
-            self._state in ("initial_rotation", "path_following", "final_rotation")
-            or self._pending_path is not None
-        )
+        return self._running() or self._pending_path is not None
+
+    def _running(self) -> bool:
+        return self._state in ("initial_rotation", "path_following", "final_rotation")
 
     def compute(self, state: CoordinatorState) -> JointCommandOutput | None:
         if self._pending_path is not None:
@@ -233,7 +233,7 @@ class PathFollowerTask(BaseControlTask):
                         orientation=Quaternion.from_euler(Vector3(0.0, 0.0, float(pyaw))),
                     ),
                 )
-        if not self.is_active():
+        if not self._running():
             return None
         if self._path is None or self._distancer is None:
             return None
@@ -454,7 +454,7 @@ class PathFollowerTask(BaseControlTask):
         sibling task's configure signature (e.g. the trajectory tracker's
         eso/deadtime knobs) work unchanged.
         """
-        if self.is_active():
+        if self._running():
             logger.warning(f"PathFollowerTask '{self._name}': cannot configure while active")
             return False
         if speed is not None:
@@ -581,7 +581,7 @@ class PathFollowerTask(BaseControlTask):
         while actively driving — a mid-run jump would discontinuously move the
         cap; the next path picks up the new speed cleanly.
         """
-        if self.is_active():
+        if self._running():
             logger.warning(f"PathFollowerTask '{self._name}': ignoring set_speed while active")
             return
         speed = float(speed)
@@ -612,7 +612,7 @@ class PathFollowerTask(BaseControlTask):
         return True
 
     def reset(self) -> bool:
-        if self.is_active():
+        if self._running():
             return False
         self._state = "idle"
         self._path = None

--- a/dimos/control/tasks/path_follower_task/path_follower_task.py
+++ b/dimos/control/tasks/path_follower_task/path_follower_task.py
@@ -208,7 +208,12 @@ class PathFollowerTask(BaseControlTask):
         )
 
     def is_active(self) -> bool:
-        return self._state in ("initial_rotation", "path_following", "final_rotation")
+        # A latched path counts: the tick loop only calls compute() on active
+        # tasks, and compute() is what arms it.
+        return (
+            self._state in ("initial_rotation", "path_following", "final_rotation")
+            or self._pending_path is not None
+        )
 
     def compute(self, state: CoordinatorState) -> JointCommandOutput | None:
         if self._pending_path is not None:
@@ -329,6 +334,7 @@ class PathFollowerTask(BaseControlTask):
         if joints & self._joint_names and self.is_active():
             logger.warning(f"PathFollowerTask '{self._name}' preempted by {by_task}")
             self._state = "aborted"
+            self._pending_path = None
 
     # State-machine bodies (mirrors LocalPlanner._compute_*)
 
@@ -602,6 +608,7 @@ class PathFollowerTask(BaseControlTask):
         if not self.is_active():
             return False
         self._state = "aborted"
+        self._pending_path = None
         return True
 
     def reset(self) -> bool:

--- a/dimos/control/test_path_following_coordinator.py
+++ b/dimos/control/test_path_following_coordinator.py
@@ -25,15 +25,16 @@ from dimos.control.benchmarking.paths import straight_rotate
 from dimos.control.components import HardwareComponent, HardwareType, make_twist_base_joints
 from dimos.control.coordinator import TaskConfig
 from dimos.control.path_following_coordinator import PathFollowingCoordinator
-from dimos.control.task import CoordinatorState, JointStateSnapshot
 from dimos.control.tasks.registry import control_task_registry
+from dimos.control.tick_loop import TickLoop
 from dimos.msgs.std_msgs.Float32 import Float32
 
 JOINTS = make_twist_base_joints("go2")
 
 
 @pytest.fixture
-def coordinator(mocker) -> Any:
+def coordinator(mocker, request) -> Any:
+    task_type = getattr(request, "param", "holonomic_pose_follower")
     mocker.patch("dimos.control.coordinator.TickLoop")
     coord = PathFollowingCoordinator(
         publish_joint_state=False,
@@ -48,7 +49,7 @@ def coordinator(mocker) -> Any:
         tasks=[
             TaskConfig(
                 name="follower",
-                type="holonomic_pose_follower",
+                type=task_type,
                 joint_names=JOINTS,
                 priority=10,
                 params={"speed": 0.5},
@@ -73,21 +74,26 @@ def _emit(taps: dict[str, list], stream: str, msg: Any) -> None:
         cb(msg)
 
 
-def test_published_path_reaches_the_follower_and_arms_it(coordinator):
+@pytest.mark.parametrize(
+    "coordinator",
+    ["holonomic_pose_follower", "rpp_path_follower", "path_follower"],
+    indirect=True,
+)
+def test_published_path_arms_the_follower_through_the_tick_loop(coordinator):
     coord, taps = coordinator
-    follower = coord.get_task("follower")
-
     _emit(taps, "path", straight_rotate(length=2.0))
-    state = CoordinatorState(
-        joints=JointStateSnapshot(
-            joint_positions=dict.fromkeys(JOINTS, 0.0),
-            joint_velocities=dict.fromkeys(JOINTS, 0.0),
-        ),
-        t_now=0.0,
-        dt=0.1,
-    )
-    follower.compute(state)
-    assert follower.get_state() == "tracking"
+
+    # A real tick, not a hand-called compute(): the loop skips inactive tasks.
+    TickLoop(
+        tick_rate=100.0,
+        hardware=coord._hardware,
+        hardware_lock=coord._hardware_lock,
+        tasks=coord._tasks,
+        task_lock=coord._task_lock,
+        joint_to_hardware=coord._joint_to_hardware,
+    )._tick()
+
+    assert coord.get_task("follower").get_state() != "idle"
 
 
 def test_published_speed_retunes_the_follower(coordinator):


### PR DESCRIPTION
Supersedes #3159. Tvisha's commit is kept as-is; I couldn't push to her fork, so this carries it plus the follow-ups from review.

A path arriving on the follower's `path` port is only latched, and `compute()` is what arms it, but the tick loop only calls `compute()` on tasks that are already active. So a streamed path never started: the Go2 logged "received path" and sat still. `is_active()` now counts a latched path, in both the holonomic follower and `PathFollowerTask` (which the RPP follower inherits), and cancel or preemption drops the latched path so cancelled work can't start later.

The existing tests called `compute()` by hand, which skips the tick loop's gate and is how this got past CI. The coordinator test now runs a real tick.

Tvisha ran 50 Go2 runs with her one-liner. The cancel/preempt and `PathFollowerTask` changes aren't hardware-tested yet.
