### PR TITLE
fix(hardware): transport adapters follow the active pub/sub backend

### DIFF
--- a/dimos/core/test_zenoh_transport.py
+++ b/dimos/core/test_zenoh_transport.py
@@ -39,13 +39,6 @@ from dimos.core.transport import (
     pLCMTransport,
     pZenohTransport,
 )
-from dimos.hardware.drive_trains.transport.adapter import (
-    transport_lcm_factory as twist_transport_factory,
-)
-from dimos.hardware.whole_body.transport.adapter import (
-    transport_lcm_factory as wholebody_transport_factory,
-)
-from dimos.msgs.geometry_msgs.Twist import Twist
 from dimos.msgs.sensor_msgs.Image import Image
 from dimos.protocol.pubsub.impl.zenohpubsub import (
     QOS_LATEST_WINS,
@@ -272,16 +265,3 @@ def test_coerce_identity_when_backend_matches(use_lcm) -> None:
 def test_coerce_leaves_deliberate_jpeg_untouched(use_zenoh) -> None:
     jpeg = JpegLcmTransport("/color_image", Image)
     assert _coerce_transport_to_backend(jpeg) is jpeg
-
-
-@pytest.mark.parametrize("backend", ["use_lcm", "use_zenoh"])
-@pytest.mark.parametrize("factory", [twist_transport_factory, wholebody_transport_factory])
-def test_transport_adapters_meet_the_driver_on_the_active_backend(
-    backend, factory, request
-) -> None:
-    # The driver module's side is a blueprint-pinned LCMTransport, coerced at build.
-    request.getfixturevalue(backend)
-    ours = factory(hardware_id="go2")._transport_cls("/go2/cmd_vel", Twist)
-    driver = _coerce_transport_to_backend(LCMTransport("/go2/cmd_vel", Twist))
-    assert type(ours) is type(driver)
-    assert ours.topic == driver.topic

--- a/dimos/core/test_zenoh_transport.py
+++ b/dimos/core/test_zenoh_transport.py
@@ -39,6 +39,13 @@ from dimos.core.transport import (
     pLCMTransport,
     pZenohTransport,
 )
+from dimos.hardware.drive_trains.transport.adapter import (
+    transport_lcm_factory as twist_transport_factory,
+)
+from dimos.hardware.whole_body.transport.adapter import (
+    transport_lcm_factory as wholebody_transport_factory,
+)
+from dimos.msgs.geometry_msgs.Twist import Twist
 from dimos.msgs.sensor_msgs.Image import Image
 from dimos.protocol.pubsub.impl.zenohpubsub import (
     QOS_LATEST_WINS,
@@ -265,3 +272,16 @@ def test_coerce_identity_when_backend_matches(use_lcm) -> None:
 def test_coerce_leaves_deliberate_jpeg_untouched(use_zenoh) -> None:
     jpeg = JpegLcmTransport("/color_image", Image)
     assert _coerce_transport_to_backend(jpeg) is jpeg
+
+
+@pytest.mark.parametrize("backend", ["use_lcm", "use_zenoh"])
+@pytest.mark.parametrize("factory", [twist_transport_factory, wholebody_transport_factory])
+def test_transport_adapters_meet_the_driver_on_the_active_backend(
+    backend, factory, request
+) -> None:
+    # The driver module's side is a blueprint-pinned LCMTransport, coerced at build.
+    request.getfixturevalue(backend)
+    ours = factory(hardware_id="go2")._transport_cls("/go2/cmd_vel", Twist)
+    driver = _coerce_transport_to_backend(LCMTransport("/go2/cmd_vel", Twist))
+    assert type(ours) is type(driver)
+    assert ours.topic == driver.topic

--- a/dimos/hardware/drive_trains/transport/adapter.py
+++ b/dimos/hardware/drive_trains/transport/adapter.py
@@ -145,11 +145,7 @@ class TransportTwistAdapter:
 
 
 def transport_lcm_factory(**kwargs: Any) -> TransportTwistAdapter:
-    """Factory for the ``transport_lcm`` adapter (see ``_registry.py``).
-
-    Despite the name it follows the active backend, so it meets the driver
-    module's blueprint-pinned topics, which are coerced the same way.
-    """
+    """Factory for the ``transport_lcm`` adapter (see ``_registry.py``)."""
     kwargs.setdefault("transport_cls", make_transport)
     return TransportTwistAdapter(**kwargs)
 

--- a/dimos/hardware/drive_trains/transport/adapter.py
+++ b/dimos/hardware/drive_trains/transport/adapter.py
@@ -19,10 +19,11 @@ Topics derived from hardware_id: /{hardware_id}/cmd_vel, /{hardware_id}/odom.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 import threading
 from typing import Any
 
-from dimos.core.transport import LCMTransport
+from dimos.core.transport_factory import make_transport
 from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
 from dimos.msgs.geometry_msgs.Twist import Twist
 from dimos.msgs.geometry_msgs.Vector3 import Vector3
@@ -43,7 +44,7 @@ class TransportTwistAdapter:
         self,
         dof: int = 3,
         hardware_id: str = "base",
-        transport_cls: type = LCMTransport,
+        transport_cls: Callable[[str, type], Any] = make_transport,
         **_: object,
     ) -> None:
         self._dof = dof
@@ -144,8 +145,12 @@ class TransportTwistAdapter:
 
 
 def transport_lcm_factory(**kwargs: Any) -> TransportTwistAdapter:
-    """Factory for the ``transport_lcm`` adapter (see ``_registry.py``)."""
-    kwargs.setdefault("transport_cls", LCMTransport)
+    """Factory for the ``transport_lcm`` adapter (see ``_registry.py``).
+
+    Despite the name it follows the active backend, so it meets the driver
+    module's blueprint-pinned topics, which are coerced the same way.
+    """
+    kwargs.setdefault("transport_cls", make_transport)
     return TransportTwistAdapter(**kwargs)
 
 

--- a/dimos/hardware/whole_body/transport/adapter.py
+++ b/dimos/hardware/whole_body/transport/adapter.py
@@ -184,11 +184,7 @@ class TransportWholeBodyAdapter:
 
 
 def transport_lcm_factory(**kwargs: Any) -> TransportWholeBodyAdapter:
-    """Factory for the ``transport_lcm`` adapter (see ``_registry.py``).
-
-    Despite the name it follows the active backend, so it meets the driver
-    module's blueprint-pinned topics, which are coerced the same way.
-    """
+    """Factory for the ``transport_lcm`` adapter (see ``_registry.py``)."""
     kwargs.setdefault("transport_cls", make_transport)
     return TransportWholeBodyAdapter(**kwargs)
 

--- a/dimos/hardware/whole_body/transport/adapter.py
+++ b/dimos/hardware/whole_body/transport/adapter.py
@@ -20,10 +20,11 @@ Subscribes /{hardware_id}/motor_states + /{hardware_id}/imu, publishes
 
 from __future__ import annotations
 
+from collections.abc import Callable
 import threading
 from typing import Any
 
-from dimos.core.transport import LCMTransport
+from dimos.core.transport_factory import make_transport
 from dimos.hardware.spec import JointLimits
 from dimos.hardware.whole_body.spec import IMUState, MotorCommand, MotorState
 from dimos.msgs.sensor_msgs.Imu import Imu
@@ -41,7 +42,7 @@ class TransportWholeBodyAdapter:
         self,
         dof: int = 29,
         hardware_id: str = "wholebody",
-        transport_cls: type = LCMTransport,
+        transport_cls: Callable[[str, type], Any] = make_transport,
         network_interface: int | str = "",  # accepted-and-ignored — see module docstring
         **_: object,
     ) -> None:
@@ -183,8 +184,12 @@ class TransportWholeBodyAdapter:
 
 
 def transport_lcm_factory(**kwargs: Any) -> TransportWholeBodyAdapter:
-    """Factory for the ``transport_lcm`` adapter (see ``_registry.py``)."""
-    kwargs.setdefault("transport_cls", LCMTransport)
+    """Factory for the ``transport_lcm`` adapter (see ``_registry.py``).
+
+    Despite the name it follows the active backend, so it meets the driver
+    module's blueprint-pinned topics, which are coerced the same way.
+    """
+    kwargs.setdefault("transport_cls", make_transport)
     return TransportWholeBodyAdapter(**kwargs)
 
 

--- a/dimos/robot/galaxea/r1pro/blueprints/basic/r1pro_coordinator.py
+++ b/dimos/robot/galaxea/r1pro/blueprints/basic/r1pro_coordinator.py
@@ -34,7 +34,6 @@ from dimos.control.tasks.trajectory_task.trajectory_task import joint_trajectory
 from dimos.core.coordination.blueprints import Blueprint, TransportSpec, autoconnect
 from dimos.core.global_config import global_config
 from dimos.core.transport import ZenohTransport
-from dimos.core.transport_factory import make_transport
 from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
 from dimos.msgs.geometry_msgs.Twist import Twist
 from dimos.msgs.nav_msgs.Odometry import Odometry
@@ -193,14 +192,12 @@ def r1pro_control(
                         hardware_type=HardwareType.WHOLE_BODY,
                         joints=R1PRO_UPPER_BODY_JOINTS,
                         adapter_type="transport_lcm",
-                        adapter_kwargs={"transport_cls": make_transport},
                     ),
                     HardwareComponent(
                         hardware_id="chassis",
                         hardware_type=HardwareType.BASE,
                         joints=_chassis_joints,
                         adapter_type="transport_lcm",
-                        adapter_kwargs={"transport_cls": make_transport},
                     ),
                 ],
                 tasks=resolved_tasks,


### PR DESCRIPTION
Since #3617 made Zenoh the default, `_coerce_transport_to_backend` rewrites blueprint-pinned `LCMTransport`s to Zenoh, but the `transport_lcm` twist and whole-body adapters built raw `LCMTransport`s themselves. 

So the coordinator sent `/go2/cmd_vel` over LCM while `GO2Connection` listened on Zenoh, and odom was split the other way: the Go2 ignored every teleop and path command without any error.

Both adapters now default to `make_transport`, so they follow the global backend the same way the driver side does. R1 Pro had already opted into that per blueprint, so its override goes. The G1 coordinator had the same split.

Checked with a Zenoh round trip between the adapter and a coerced driver-side transport; tested on hardware.
