### PR TITLE
feat(native): add JSON-RPC 2.0 support to NativeModule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,6 +251,8 @@ jobs:
             dimos/navigation/nav_3d/mls_planner/test_transformer.py
       - name: Bake e2e tests
         run: uv run pytest -m bake_e2e dimos/cli/bake/test_bake_e2e.py --no-cov
+      - name: Native RPC toy
+        run: uv run pytest examples/native_rpc/test_native_rpc.py --no-cov
 
   native:
     name: Native builds (C++ and Rust)

--- a/dimos/core/core.py
+++ b/dimos/core/core.py
@@ -34,6 +34,21 @@ P = ParamSpec("P")
 R = TypeVar("R")
 
 
+def native_rpc(fn: Callable[P, R]) -> Callable[P, R]:
+    """Declare a synchronous instance method served by a NativeModule's subprocess."""
+    if isinstance(fn, (staticmethod, classmethod)):
+        raise TypeError("native_rpc requires an instance method")
+    parameters = list(inspect.signature(fn).parameters.values())
+    if inspect.iscoroutinefunction(inspect.unwrap(fn)) or any(
+        p.kind not in (p.POSITIONAL_OR_KEYWORD, p.KEYWORD_ONLY) for p in parameters
+    ):
+        raise TypeError("native_rpc requires a sync method with named parameters")
+    if fn.__name__ in {"build", "start", "stop"} or fn.__name__.startswith("_"):
+        raise ValueError("native_rpc cannot replace lifecycle or private methods")
+    fn.__native_rpc__ = True  # type: ignore[attr-defined]
+    return rpc(fn)
+
+
 def rpc(fn: Callable[P, R]) -> Callable[P, R]:
     """Mark a method as an RPC body callable across modules.
 

--- a/dimos/core/demos/rpc_planner.py
+++ b/dimos/core/demos/rpc_planner.py
@@ -1,0 +1,24 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any
+
+from dimos.core.core import native_rpc
+from dimos.core.native_module import NativeModule
+
+
+class ToyPlanner(NativeModule):
+    @native_rpc
+    def plan(self, start: list[float], goal: list[float]) -> dict[str, Any]:
+        raise NotImplementedError("Served by the rpc_planner Rust example")

--- a/dimos/core/native_module.py
+++ b/dimos/core/native_module.py
@@ -50,9 +50,11 @@ from pathlib import Path
 import signal
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 from typing import IO, Any
+from uuid import uuid4
 
 from pydantic import Field, model_validator
 
@@ -61,6 +63,8 @@ from dimos.core.core import rpc
 from dimos.core.global_config import global_config
 from dimos.core.module import Module, ModuleConfig
 from dimos.core.transport_factory import session_config
+from dimos.protocol.rpc.jsonrpc import call as call_json
+from dimos.protocol.rpc.zenohrpc import ZenohRPC
 from dimos.protocol.service.spec import SessionConfig
 from dimos.utils.logging_config import setup_logger
 
@@ -126,6 +130,7 @@ class NativeModuleConfig(ModuleConfig):
     # the rest of the graph connects to. None follows the global config.
     session: SessionConfig | None = None
     shutdown_timeout: float = DEFAULT_THREAD_JOIN_TIMEOUT
+    native_rpc_start_timeout: float = Field(default=10.0, gt=0)
     log_format: LogFormat = LogFormat.JSON
     auto_build: bool = False
 
@@ -210,7 +215,16 @@ class NativeModule(Module):
     _process: subprocess.Popen[bytes] | None = None
     _watchdog: threading.Thread | None = None
     _stopping: bool = False
+    _native_rpc_ready: bool = False
     _stop_lock: threading.Lock
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        for name, method in inspect.getmembers_static(cls):
+            if isinstance(method, (staticmethod, classmethod)) and getattr(
+                method.__func__, "__native_rpc__", False
+            ):
+                raise TypeError(f"native_rpc requires an instance method: {cls.__name__}.{name}")
 
     @functools.cached_property
     def _module_label(self) -> str:
@@ -278,65 +292,120 @@ class NativeModule(Module):
         qos = self._collect_output_qos()
         if qos:
             blob["qos"] = qos
+        if self._native_rpc_methods:
+            self._native_rpc_token = uuid4().hex
+            blob["rpc"] = {
+                "name": self.config.instance_name or type(self).__name__,
+                "methods": self._native_rpc_methods,
+                "token": self._native_rpc_token,
+            }
         return json.dumps(blob).encode() + b"\n"
+
+    @functools.cached_property
+    def _native_rpc_methods(self) -> list[str]:
+        return sorted(
+            name for name, method in self.rpcs.items() if getattr(method, "__native_rpc__", False)
+        )
+
+    def _wait_native_rpc(self, process: subprocess.Popen[bytes]) -> None:
+        rpc = self.rpc
+        if not isinstance(rpc, ZenohRPC):
+            raise RuntimeError("Native RPC service stopped before startup completed")
+        session = rpc.session
+        name = self.config.instance_name or type(self).__name__
+        deadline = time.monotonic() + self.config.native_rpc_start_timeout
+        while process.poll() is None:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(f"Native RPC for {name} did not become ready")
+            try:
+                ready = call_json(session, f"{name}/_ready", timeout=min(remaining, 0.1))
+            except TimeoutError:
+                # A missing queryable can finalize immediately. Also notice an early exit.
+                try:
+                    process.wait(timeout=min(remaining, 0.02))
+                except subprocess.TimeoutExpired:
+                    pass
+                continue
+            if ready != {"methods": self._native_rpc_methods, "token": self._native_rpc_token}:
+                raise ValueError(f"Native RPC registration for {name} does not match: {ready!r}")
+            return
+        raise RuntimeError(f"Native process {name} exited before RPC was ready")
 
     @rpc
     def start(self) -> None:
+        with self._stop_lock:
+            if self._stopping:
+                raise RuntimeError("Native module has stopped; create a new instance")
+        if self._native_rpc_methods:
+            if not self.config.stdin_config:
+                raise ValueError("native_rpc requires stdin_config=True")
+            if global_config.transport != "zenoh" or not isinstance(self.rpc, ZenohRPC):
+                raise ValueError("native_rpc requires an active Zenoh RPC service")
         super().start()
-        if self._process is not None and self._process.poll() is None:
-            logger.warning(
-                "Native process already running",
-                module=self._module_label,
-                pid=self._process.pid,
-            )
-            return
-
         topics = self._collect_topics()
         cmd = self._argv(topics)
-
-        # Built before the spawn: a config that cannot be serialized must fail
-        # without leaving a child blocked on a stdin line it will never get.
-        stdin_blob = self._stdin_blob(topics) if self.config.stdin_config else None
-
         env = self._spawn_env()
         cwd = self.config.cwd or str(Path(self.config.executable).resolve().parent)
 
-        logger.info(
-            "Starting native process",
-            module=self._module_label,
-            cmd=" ".join(cmd),
-            cwd=cwd,
-        )
-
-        self._process = subprocess.Popen(
-            cmd,
-            env=env,
-            cwd=cwd,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            start_new_session=True,
-            preexec_fn=_set_process_to_die_when_parent_dies,
-        )
-        assert self._process.stdin is not None
-        if stdin_blob is not None:
-            self._process.stdin.write(stdin_blob)
-        self._process.stdin.close()
+        with self._stop_lock:
+            if self._stopping:
+                raise RuntimeError("Native module has stopped; create a new instance")
+            if self._process is not None and self._process.poll() is None:
+                if self._native_rpc_methods and not self._native_rpc_ready:
+                    raise RuntimeError("Native RPC is still starting")
+                logger.warning(
+                    "Native process already running",
+                    module=self._module_label,
+                    pid=self._process.pid,
+                )
+                return
+            stdin_blob = self._stdin_blob(topics) if self.config.stdin_config else b""
+            self._native_rpc_ready = False
+            logger.info(
+                "Starting native process",
+                module=self._module_label,
+                cmd=" ".join(cmd),
+                cwd=cwd,
+            )
+            # Preloaded stdin cannot block startup when the child never reads it.
+            with tempfile.TemporaryFile() as stdin:
+                stdin.write(stdin_blob)
+                stdin.seek(0)
+                self._process = subprocess.Popen(
+                    cmd,
+                    env=env,
+                    cwd=cwd,
+                    stdin=stdin,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    start_new_session=True,
+                    preexec_fn=_set_process_to_die_when_parent_dies,
+                )
+            process = self._process
+            self._watchdog = threading.Thread(
+                target=self._watch_process,
+                daemon=True,
+                name=f"native-watchdog-{self._module_label}",
+            )
+            self._watchdog.start()
         logger.info(
             "Native process started",
             module=self._module_label,
-            pid=self._process.pid,
+            pid=process.pid,
         )
-
-        watchdog = threading.Thread(
-            target=self._watch_process,
-            daemon=True,
-            name=f"native-watchdog-{self._module_label}",
-        )
-        with self._stop_lock:
-            self._stopping = False
-            self._watchdog = watchdog
-        watchdog.start()
+        if self._native_rpc_methods:
+            ready = False
+            try:
+                self._wait_native_rpc(process)
+                with self._stop_lock:
+                    if self._stopping or self._process is not process or process.poll() is not None:
+                        raise RuntimeError("Native process stopped during startup")
+                    ready = True
+                    self._native_rpc_ready = True
+            finally:
+                if not ready:
+                    self.stop()
 
     @rpc
     def stop(self) -> None:

--- a/dimos/core/rpc_client.py
+++ b/dimos/core/rpc_client.py
@@ -23,7 +23,9 @@ from typing import TYPE_CHECKING, Any, Protocol
 from dimos.core.coordination.python_worker import Actor, MethodCallProxy
 from dimos.core.stream import RemoteStream
 from dimos.core.transport_factory import rpc_backend
+from dimos.protocol.rpc.jsonrpc import call as call_json
 from dimos.protocol.rpc.spec import RPCSpec
+from dimos.protocol.rpc.zenohrpc import ZenohRPC
 from dimos.utils.logging_config import setup_logger
 
 if TYPE_CHECKING:
@@ -53,6 +55,7 @@ class RpcCall:
         self._remote_name = remote_name
         self._unsub_fns = unsub_fns
         self._stop_rpc_client = stop_client
+        self._native = bool(getattr(original_method, "__native_rpc__", False))
 
         self.__name__ = name
         self.__qualname__ = f"{self.__class__.__name__}.{name}"
@@ -60,7 +63,7 @@ class RpcCall:
             functools.update_wrapper(self, original_method)
             signature = inspect.signature(original_method)
             parameters = list(signature.parameters.values())
-            if parameters and parameters[0].name in {"self", "cls"}:
+            if parameters and (self._native or parameters[0].name in {"self", "cls"}):
                 parameters = parameters[1:]
             self.__signature__ = signature.replace(parameters=parameters)
 
@@ -78,6 +81,16 @@ class RpcCall:
         self._rpc = rpc
 
     def __call__(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        if self._native:
+            if not isinstance(self._rpc, ZenohRPC):
+                raise RuntimeError("native_rpc requires a running ZenohRPC client")
+            arguments = self.__signature__.bind(*args, **kwargs)
+            arguments.apply_defaults()
+            name = f"{self._remote_name}/{self._name}"
+            timeout = self._rpc.rpc_timeouts.get(name) or self._rpc.rpc_timeouts.get(
+                self._name, self._rpc.default_rpc_timeout
+            )
+            return call_json(self._rpc.session, name, arguments.arguments, timeout)
         if not self._rpc:
             logger.warning("RPC client not initialized")
             return None
@@ -98,10 +111,15 @@ class RpcCall:
         return result
 
     def __getstate__(self):  # type: ignore[no-untyped-def]
+        if self._native:
+            return (self._name, self._remote_name, self.__signature__)
         return (self._name, self._remote_name)
 
     def __setstate__(self, state) -> None:  # type: ignore[no-untyped-def]
-        self._name, self._remote_name = state
+        self._name, self._remote_name = state[:2]
+        self._native = len(state) == 3
+        if self._native:
+            self.__signature__ = state[2]
         self._unsub_fns = []
         self._rpc = None
         self._stop_rpc_client = None

--- a/dimos/protocol/rpc/jsonrpc.py
+++ b/dimos/protocol/rpc/jsonrpc.py
@@ -1,0 +1,85 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from typing import Any
+
+import zenoh
+
+ROUTE: str = "dimos/rpc/v1"
+
+
+class RpcError(Exception):
+    def __init__(self, code: int, message: str, data: Any = None) -> None:
+        super().__init__(message)
+        self.code = code
+        self.data = data
+
+
+def reject_constant(value: str) -> Any:
+    raise ValueError(f"Invalid JSON constant: {value}")
+
+
+def call(
+    session: zenoh.Session,
+    method: str,
+    params: dict[str, Any] | None = None,
+    timeout: float = 2.0,
+) -> Any:
+    if "*" in method:
+        raise ValueError("RPC requires an exact method, not a wildcard")
+    request = {"jsonrpc": "2.0", "id": 1, "method": method, "params": params or {}}
+    replies = list(
+        session.get(
+            zenoh.KeyExpr(f"{ROUTE}/{method}"),
+            payload=json.dumps(request, allow_nan=False),
+            encoding=zenoh.Encoding.APPLICATION_JSON,
+            timeout=timeout,
+            target=zenoh.QueryTarget.ALL,
+            consolidation=zenoh.ConsolidationMode.NONE,
+        )
+    )
+    if not replies:
+        raise TimeoutError(f"No reply for {method}")
+    if len(replies) != 1:
+        raise ValueError(f"Expected one reply for {method}, got {len(replies)}")
+    transport_error = replies[0].err
+    if transport_error is not None:
+        message = transport_error.payload.to_bytes().decode(errors="replace")
+        if message == "Timeout" and replies[0].replier_id is None:
+            raise TimeoutError(f"RPC timed out for {method}; it may have executed")
+        raise ConnectionError(f"Zenoh error answering {method}: {message}")
+    reply = replies[0].ok
+    assert reply is not None
+    response = json.loads(reply.payload.to_bytes(), parse_constant=reject_constant)
+    if (
+        not isinstance(response, dict)
+        or response.get("jsonrpc") != "2.0"
+        or "id" not in response
+        or ("result" in response) == ("error" in response)
+    ):
+        raise ValueError("Invalid JSON-RPC response")
+    error = response.get("error")
+    if "error" in response and (
+        not isinstance(error, dict)
+        or type(error.get("code")) is not int
+        or not isinstance(error.get("message"), str)
+    ):
+        raise ValueError("Invalid JSON-RPC error")
+    if not (type(response["id"]) is int and response["id"] == request["id"]):
+        if not (response["id"] is None and error and error["code"] in {-32700, -32600}):
+            raise ValueError("Mismatched JSON-RPC response id")
+    if error is not None:
+        raise RpcError(error["code"], error["message"], error.get("data"))
+    return response["result"]

--- a/dimos/protocol/rpc/spec.py
+++ b/dimos/protocol/rpc/spec.py
@@ -109,6 +109,8 @@ class RPCServer(Protocol):
 
     def serve_module_rpc(self, module: RPCInspectable, name: str | None = None) -> None:
         for fname in module.rpcs.keys():
+            if getattr(module.rpcs[fname], "__native_rpc__", False):
+                continue
             if not name:
                 name = module.__class__.__name__
 

--- a/examples/native_rpc/README.md
+++ b/examples/native_rpc/README.md
@@ -1,0 +1,18 @@
+# Native RPC toy
+
+Python starts a Rust `ToyPlanner` through `NativeModule` and calls `plan(start, goal)`.
+It returns the two points, not a collision-checked path. No robot needed.
+
+```sh
+uv run pytest examples/native_rpc/test_native_rpc.py --no-cov
+```
+
+`@native_rpc` declares Rust-owned methods. The stdin launch carries their names;
+`start()` waits for `_ready` to confirm this launch and its methods. Python RPC stays on pickle.
+
+JSON-RPC 2.0 request/reply over Zenoh only: named JSON parameters, no retries,
+notifications, batches or typed messages. The Rust runner handles one call at a time;
+streaming modules, concurrent handlers and bake are left for review. No authentication is added;
+use a trusted network. Tests use loopback with discovery off.
+
+Non-finite floats are rejected. Numbers outside serde_json's range return a parse error.

--- a/examples/native_rpc/test_native_rpc.py
+++ b/examples/native_rpc/test_native_rpc.py
@@ -1,0 +1,499 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
+import json
+from pathlib import Path
+import pickle
+import signal
+import socket
+import subprocess
+import sys
+import threading
+import time
+from typing import Any
+
+import pytest
+from pytest_mock import MockerFixture
+import zenoh
+
+from dimos.core.coordination.blueprints import autoconnect
+from dimos.core.coordination.module_coordinator import ModuleCoordinator
+from dimos.core.core import native_rpc, rpc as rpc_method
+from dimos.core.demos.rpc_planner import ToyPlanner
+from dimos.core.global_config import global_config
+from dimos.core.native_module import NativeModule, NativeModuleConfig
+from dimos.core.rpc_client import RPCClient
+from dimos.protocol.rpc.jsonrpc import ROUTE, RpcError, call
+from dimos.protocol.rpc.zenohrpc import ZenohRPC
+from dimos.protocol.service import zenohservice
+from dimos.protocol.service.zenohservice import ZenohSessionPool
+
+ROOT = Path(__file__).resolve().parents[2]
+START = [0.0, 0.0, 0.0]
+GOAL = [1.0, 2.0, 3.0]
+
+
+@pytest.fixture(scope="module")
+def binary() -> str:
+    build = subprocess.run(
+        [
+            "cargo",
+            "build",
+            "--locked",
+            "-p",
+            "dimos-module",
+            "--example",
+            "rpc_planner",
+            "--message-format=json-render-diagnostics",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return str(
+        next(
+            item["executable"]
+            for line in build.stdout.splitlines()
+            if (item := json.loads(line)).get("executable")
+            and item["target"]["name"] == "rpc_planner"
+        )
+    )
+
+
+@pytest.fixture
+def rpc(monkeypatch: pytest.MonkeyPatch) -> Iterator[ZenohRPC]:
+    pool = ZenohSessionPool()
+    monkeypatch.setattr(zenohservice, "default_session_pool", pool)
+    with socket.socket() as listener:
+        listener.bind(("127.0.0.1", 0))
+        endpoint = f"tcp/127.0.0.1:{listener.getsockname()[1]}"
+    config = zenoh.Config()
+    for key, value in {
+        "mode": "router",
+        "listen/endpoints": [endpoint],
+        "scouting/multicast/enabled": False,
+        "scouting/gossip/enabled": False,
+    }.items():
+        config.insert_json5(key, json.dumps(value))
+    with zenoh.open(config):
+        for key, value in {
+            "transport": "zenoh",
+            "robot_ip": None,
+            "robot_ips": None,
+            "zenoh_mode": "client",
+            "zenoh_connect": endpoint,
+            "zenoh_multicast": False,
+            "zenoh_gossip": False,
+            "zenoh_scouting": False,
+        }.items():
+            monkeypatch.setattr(global_config, key, value)
+        client = ZenohRPC(default_rpc_timeout=2.0)
+        client.start()
+        try:
+            yield client
+        finally:
+            client.stop()
+            pool.close_all()
+
+
+@pytest.fixture
+def planner(binary: str, rpc: ZenohRPC) -> Iterator[RPCClient]:
+    module = ToyPlanner(executable=binary, stdin_config=True, instance_name="toy")
+    proxy = RPCClient.remote(ToyPlanner, remote_name="toy", rpc=rpc)
+    try:
+        proxy.build()
+        proxy.start()
+        assert module._process is not None
+        process = module._process
+        yield proxy
+        proxy.stop()
+        assert process.wait(timeout=5) == -signal.SIGTERM
+    finally:
+        proxy.stop_rpc_client()
+        module.stop()
+
+
+def test_native_call_and_pickle_lifecycle(planner: RPCClient, rpc: ZenohRPC) -> None:
+    expected = {"waypoints": [START, GOAL], "toy": True}
+    assert planner.plan(START, goal=GOAL) == expected
+    assert call(rpc.session, "toy/_ready")["methods"] == ["plan"]
+    assert "plan" in planner.rpcs
+    restored = pickle.loads(pickle.dumps(planner.plan))
+    restored.set_rpc(rpc)
+    assert restored(start=START, goal=GOAL) == expected
+    with pytest.raises(TypeError):
+        planner.plan(START)
+    # The Python stub must never be served on the legacy pickle route.
+    assert not list(rpc.session.get("dimos/rpc/toy/plan", timeout=0.1))
+
+
+def test_blueprint(binary: str, rpc: ZenohRPC, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(global_config, "n_workers", 1)
+    blueprint = autoconnect(ToyPlanner.blueprint(executable=binary, stdin_config=True))
+    coordinator = ModuleCoordinator.build(blueprint)
+    try:
+        planner = coordinator.get_instance(ToyPlanner)
+        assert planner.plan(START, GOAL) == {"waypoints": [START, GOAL], "toy": True}
+        assert "plan" in coordinator.list_modules()[0].rpc_names
+    finally:
+        coordinator.stop()
+
+
+def test_receiver_name(planner: RPCClient, rpc: ZenohRPC) -> None:
+    class RenamedPlanner(ToyPlanner):
+        @native_rpc
+        def plan(module, start: list[float], goal: list[float]) -> dict[str, Any]:  # noqa: N805
+            raise NotImplementedError
+
+    proxy = RPCClient.remote(RenamedPlanner, remote_name="toy", rpc=rpc)
+    assert proxy.plan(START, GOAL) == {"waypoints": [START, GOAL], "toy": True}
+
+
+@pytest.mark.parametrize("start", [[0, 0], [True, 0, 0], ["bad", 0, 0]])
+def test_invalid_arguments(planner: RPCClient, start: Any) -> None:
+    with pytest.raises(RpcError) as error:
+        planner.plan(start, GOAL)
+    assert error.value.code == -32602
+    assert planner.plan(START, GOAL)["toy"] is True
+
+
+def test_bad_requests(planner: RPCClient, rpc: ZenohRPC) -> None:
+    with pytest.raises(RpcError) as error:
+        call(rpc.session, "toy/missing")
+    assert error.value.code == -32601
+    for payload, code in [
+        ("{", -32700),
+        (json.dumps({"jsonrpc": "2.0", "id": 1, "method": "other/plan"}), -32600),
+    ]:
+        replies = list(rpc.session.get(f"{ROUTE}/toy/plan", payload=payload, timeout=1))
+        assert len(replies) == 1 and replies[0].ok is not None
+        assert json.loads(replies[0].ok.payload.to_bytes())["error"]["code"] == code
+
+
+@pytest.mark.parametrize("id", [0, 1.5, None, "request-1"])
+def test_request_ids(planner: RPCClient, rpc: ZenohRPC, id: Any) -> None:
+    request = {
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "toy/plan",
+        "params": {"start": START, "goal": GOAL},
+    }
+    replies = list(rpc.session.get(f"{ROUTE}/toy/plan", payload=json.dumps(request), timeout=1))
+    assert len(replies) == 1
+    reply = replies[0].ok
+    assert reply is not None
+    assert json.loads(reply.payload.to_bytes()) == {
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": {"waypoints": [START, GOAL], "toy": True},
+    }
+
+
+@pytest.mark.parametrize("method", ["toy/plan", "toy/missing"])
+def test_notifications(planner: RPCClient, rpc: ZenohRPC, method: str) -> None:
+    request = {"jsonrpc": "2.0", "method": method, "params": {"start": START, "goal": GOAL}}
+    assert not list(rpc.session.get(f"{ROUTE}/toy/plan", payload=json.dumps(request), timeout=1))
+
+
+@pytest.mark.parametrize(
+    ("payload", "code"),
+    [
+        ('{"jsonrpc":"2.0","id":1,"method":"toy/plan","params":{"x":NaN}}', -32700),
+        ('{"jsonrpc":"1.0","id":1,"method":"toy/plan"}', -32600),
+        ('{"jsonrpc":"2.0","id":true,"method":"toy/plan"}', -32600),
+    ],
+)
+def test_invalid_envelopes(planner: RPCClient, rpc: ZenohRPC, payload: str, code: int) -> None:
+    replies = list(rpc.session.get(f"{ROUTE}/toy/plan", payload=payload, timeout=1))
+    assert len(replies) == 1
+    reply = replies[0].ok
+    assert reply is not None
+    response = json.loads(reply.payload.to_bytes())
+    assert response["id"] is None
+    assert response["error"]["code"] == code
+
+
+def test_large_number_preserves_parse_error(planner: RPCClient) -> None:
+    with pytest.raises(RpcError, match="Parse error") as error:
+        planner.plan([10**400, 0, 0], GOAL)
+    assert error.value.code == -32700
+    assert planner.plan(START, GOAL)["toy"] is True
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), -float("inf")])
+def test_nonfinite_params(planner: RPCClient, value: float) -> None:
+    with pytest.raises(ValueError, match="JSON compliant"):
+        planner.plan([value, 0, 0], GOAL)
+
+
+def test_timeout_does_not_repeat(rpc: ZenohRPC) -> None:
+    pending: list[zenoh.Query] = []
+    rpc.rpc_timeouts["slow/plan"] = 0.1
+    proxy = RPCClient.remote(ToyPlanner, remote_name="slow", rpc=rpc)
+    with rpc.session.declare_queryable(f"{ROUTE}/slow/plan", pending.append):
+        with pytest.raises(TimeoutError):
+            proxy.plan(START, GOAL)
+        assert len(pending) == 1
+    pending.clear()
+
+
+def test_peer_timeout_message_is_not_a_deadline(rpc: ZenohRPC) -> None:
+    def reply(query: zenoh.Query) -> None:
+        query.reply_err("Timeout")
+
+    with rpc.session.declare_queryable(f"{ROUTE}/test/plan", reply):
+        with pytest.raises(ConnectionError, match="Timeout"):
+            call(rpc.session, "test/plan")
+
+
+@pytest.mark.parametrize(
+    ("response", "exception"),
+    [
+        ({"id": True, "result": {}}, ValueError),
+        ({"id": 1, "result": {}, "error": {"code": -1, "message": "bad"}}, ValueError),
+        ({"id": 1, "error": {"code": "bad", "message": "bad"}}, ValueError),
+        ({"id": 1, "error": None}, ValueError),
+        ({"id": None, "error": {"code": -32700, "message": "Parse error"}}, RpcError),
+        ({"id": None, "error": {"code": -32600, "message": "Invalid Request"}}, RpcError),
+        ({"id": None, "result": {}}, ValueError),
+        ({"id": None, "error": {"code": -32602, "message": "Invalid params"}}, ValueError),
+        ({"id": 2, "error": {"code": -32700, "message": "Parse error"}}, ValueError),
+        ({"error": {"code": -32700, "message": "Parse error"}}, ValueError),
+    ],
+)
+def test_reply_validation(
+    rpc: ZenohRPC, response: dict[str, Any], exception: type[Exception]
+) -> None:
+    def reply(query: zenoh.Query) -> None:
+        query.reply(query.key_expr, json.dumps({"jsonrpc": "2.0", **response}))
+
+    with rpc.session.declare_queryable(f"{ROUTE}/test/plan", reply):
+        with pytest.raises(exception):
+            call(rpc.session, "test/plan")
+
+
+@pytest.mark.parametrize("code", ["import time; time.sleep(10)", "raise SystemExit(1)"])
+def test_failed_start_cleans_up(rpc: ZenohRPC, code: str) -> None:
+    module = ToyPlanner(
+        executable=sys.executable,
+        extra_args=["-c", code],
+        stdin_config=True,
+        native_rpc_start_timeout=0.2,
+    )
+    before = time.monotonic()
+    try:
+        with pytest.raises((TimeoutError, RuntimeError)):
+            module.start()
+        assert time.monotonic() - before < 3
+        assert module._process is None
+    finally:
+        module.stop()
+
+
+def test_stale_readiness_cannot_start_a_new_process(rpc: ZenohRPC) -> None:
+    module = ToyPlanner(
+        executable=sys.executable,
+        extra_args=["-c", "import time; time.sleep(10)"],
+        instance_name="stale",
+        stdin_config=True,
+        native_rpc_start_timeout=0.2,
+    )
+    try:
+        previous = json.loads(module._stdin_blob({}))["rpc"]
+        previous.pop("name")
+
+        def stale_reply(query: zenoh.Query) -> None:
+            query.reply(query.key_expr, json.dumps({"jsonrpc": "2.0", "id": 1, "result": previous}))
+
+        with rpc.session.declare_queryable(f"{ROUTE}/stale/_ready", stale_reply):
+            with pytest.raises(ValueError):
+                module.start()
+        assert module._process is None
+    finally:
+        module.stop()
+
+
+def test_unread_stdin_cannot_block_startup(rpc: ZenohRPC) -> None:
+    class LargeConfig(NativeModuleConfig):
+        payload: str
+        cli_exclude: frozenset[str] = frozenset({"payload"})
+
+    class LargePlanner(ToyPlanner):
+        config: LargeConfig
+
+    module = LargePlanner(
+        executable=sys.executable,
+        extra_args=["-c", "import time; time.sleep(2)"],
+        stdin_config=True,
+        native_rpc_start_timeout=0.1,
+        payload="x" * 200_000,
+    )
+    before = time.monotonic()
+    try:
+        with pytest.raises(TimeoutError):
+            module.start()
+        assert time.monotonic() - before < 1
+        assert module._process is None
+    finally:
+        module.stop()
+
+
+@pytest.mark.parametrize("module_type", [NativeModule, ToyPlanner])
+def test_stopped_instance_fails_before_spawn(
+    rpc: ZenohRPC, mocker: MockerFixture, module_type: type[NativeModule]
+) -> None:
+    module = module_type(executable=sys.executable, stdin_config=True)
+    module.stop()
+    spawn = mocker.spy(subprocess, "Popen")
+    start_main = mocker.spy(module, "_start_main")
+    bind_handlers = mocker.spy(module, "_auto_bind_handlers")
+    with pytest.raises(RuntimeError, match="stopped"):
+        module.start()
+    spawn.assert_not_called()
+    start_main.assert_not_called()
+    bind_handlers.assert_not_called()
+
+
+def test_invalid_transport_does_not_start_handlers(rpc: ZenohRPC, mocker: MockerFixture) -> None:
+    module = ToyPlanner(executable=sys.executable, stdin_config=True)
+    start_main = mocker.patch.object(module, "_start_main")
+    mocker.patch.object(global_config, "transport", "lcm")
+    try:
+        with pytest.raises(ValueError, match="active Zenoh"):
+            module.start()
+        start_main.assert_not_called()
+        assert module._process is None
+    finally:
+        module.stop()
+
+
+def test_stop_before_ready_reply_cannot_succeed(rpc: ZenohRPC, mocker: MockerFixture) -> None:
+    module = ToyPlanner(
+        executable=sys.executable,
+        extra_args=["-c", "import time; time.sleep(10)"],
+        stdin_config=True,
+    )
+
+    def reply(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        module.stop()
+        return {"methods": ["plan"], "token": module._native_rpc_token}
+
+    mocker.patch("dimos.core.native_module.call_json", side_effect=reply)
+    try:
+        with pytest.raises(RuntimeError, match="stopped"):
+            module.start()
+        assert module._process is None
+    finally:
+        module.stop()
+
+
+def test_overlapping_start_cannot_skip_readiness(rpc: ZenohRPC, mocker: MockerFixture) -> None:
+    module = ToyPlanner(
+        executable=sys.executable,
+        extra_args=["-c", "import time; time.sleep(10)"],
+        stdin_config=True,
+    )
+
+    def wait(process: subprocess.Popen[bytes]) -> None:
+        with pytest.raises(RuntimeError, match="still starting"):
+            module.start()
+
+    mocker.patch.object(module, "_wait_native_rpc", side_effect=wait)
+    try:
+        module.start()
+        module.start()
+    finally:
+        module.stop()
+
+
+def test_stop_during_spawn_cleans_up(rpc: ZenohRPC, mocker: MockerFixture) -> None:
+    module = ToyPlanner(
+        executable=sys.executable,
+        extra_args=["-c", "import sys,time; sys.stdin.readline(); time.sleep(10)"],
+        stdin_config=True,
+        native_rpc_start_timeout=0.2,
+    )
+    spawning, release = threading.Event(), threading.Event()
+    processes: list[subprocess.Popen[bytes]] = []
+    popen = subprocess.Popen
+
+    def spawn(*args: Any, **kwargs: Any) -> subprocess.Popen[bytes]:
+        spawning.set()
+        assert release.wait(3)
+        process = popen(*args, **kwargs)
+        processes.append(process)
+        return process
+
+    mocker.patch.object(subprocess, "Popen", side_effect=spawn)
+    try:
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            starting = executor.submit(module.start)
+            try:
+                assert spawning.wait(3)
+                stopping = executor.submit(module.stop)
+                try:
+                    stopping.result(timeout=0.1)
+                except TimeoutError:
+                    pass
+            finally:
+                release.set()
+            with pytest.raises(RuntimeError):
+                starting.result(timeout=3)
+            stopping.result(timeout=3)
+        assert processes[0].poll() is not None
+        assert module._process is None
+    finally:
+        module.stop()
+        for process in processes:
+            if process.poll() is None:
+                process.terminate()
+            process.wait(timeout=3)
+
+
+@pytest.mark.parametrize("descriptor", [staticmethod, classmethod])
+@pytest.mark.parametrize("native_outer", [False, True])
+def test_native_descriptors_are_rejected(descriptor: Any, native_outer: bool) -> None:
+    def plan(receiver: Any, goal: list[float]) -> list[float]:
+        raise NotImplementedError
+
+    with pytest.raises(TypeError, match="instance method"):
+        method = native_rpc(descriptor(plan)) if native_outer else descriptor(native_rpc(plan))
+        type("InvalidPlanner", (NativeModule,), {"plan": method})
+
+
+@pytest.mark.parametrize("wrapped", [False, True])
+def test_async_native_declaration_is_rejected(wrapped: bool) -> None:
+    async def plan(self: Any, goal: list[float]) -> list[float]:
+        return goal
+
+    with pytest.raises(TypeError, match="sync method"):
+        native_rpc(rpc_method(plan) if wrapped else plan)
+
+
+def test_registration_must_match(binary: str, rpc: ZenohRPC) -> None:
+    class WrongPlanner(ToyPlanner):
+        @native_rpc
+        def missing(self) -> None:
+            raise NotImplementedError
+
+    module = WrongPlanner(executable=binary, stdin_config=True)
+    try:
+        with pytest.raises(RuntimeError):
+            module.start()
+        assert module._process is None
+    finally:
+        module.stop()

--- a/native/rust/dimos-module/examples/rpc_planner.rs
+++ b/native/rust/dimos-module/examples/rpc_planner.rs
@@ -1,0 +1,38 @@
+// Copyright 2026 Dimensional Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use dimos_module::rpc::{self, Error};
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Plan {
+    start: [f64; 3],
+    goal: [f64; 3],
+}
+
+fn plan(params: Value) -> Result<Value, Error> {
+    let request: Plan = serde_json::from_value(params).map_err(|e| Error {
+        code: -32602,
+        message: e.to_string(),
+    })?;
+    // A wire-test result, not a collision-checked route.
+    Ok(json!({"waypoints": [request.start, request.goal], "toy": true}))
+}
+
+#[tokio::main]
+async fn main() -> zenoh::Result<()> {
+    rpc::run(&[("plan", plan)]).await
+}

--- a/native/rust/dimos-module/src/lib.rs
+++ b/native/rust/dimos-module/src/lib.rs
@@ -21,6 +21,7 @@ pub mod host;
 pub mod lcm;
 pub mod log;
 pub mod module;
+pub mod rpc;
 pub mod tf;
 pub mod transport;
 pub mod workers;

--- a/native/rust/dimos-module/src/rpc.rs
+++ b/native/rust/dimos-module/src/rpc.rs
@@ -1,0 +1,180 @@
+// Copyright 2026 Dimensional Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::io;
+
+use serde::Deserialize;
+use serde_json::{json, Value};
+use zenoh::bytes::Encoding;
+
+use crate::ZenohTransport;
+
+pub struct Error {
+    pub code: i32,
+    pub message: String,
+}
+
+pub type Handler = fn(Value) -> Result<Value, Error>;
+
+#[derive(Deserialize)]
+struct Registration {
+    name: String,
+    methods: Vec<String>,
+    token: String,
+}
+
+fn error(id: Value, code: i32, message: &str) -> Value {
+    json!({"jsonrpc": "2.0", "id": id, "error": {"code": code, "message": message}})
+}
+
+fn respond(
+    payload: &[u8],
+    route: &str,
+    methods: &BTreeMap<&str, Handler>,
+    token: &str,
+) -> Option<Value> {
+    let request: Value = match serde_json::from_slice(payload) {
+        Ok(value) => value,
+        Err(_) => return Some(error(Value::Null, -32700, "Parse error")),
+    };
+    let id = request.get("id").cloned().unwrap_or(Value::Null);
+    if !request.is_object()
+        || request["jsonrpc"] != "2.0"
+        || !request["method"].is_string()
+        || !(id.is_null() || id.is_string() || id.is_number())
+    {
+        return Some(error(Value::Null, -32600, "Invalid Request"));
+    }
+    // This request/reply subset does not execute notifications.
+    request.get("id")?;
+    if request["method"] != route {
+        return Some(error(id, -32600, "Method does not match route"));
+    }
+    let params = request.get("params").cloned().unwrap_or_else(|| json!({}));
+    if !params.is_object() {
+        return Some(error(id, -32602, "Expected named parameters"));
+    }
+    let method = route.rsplit('/').next().unwrap_or_default();
+    let result = if method == "_ready" {
+        if params != json!({}) {
+            return Some(error(id, -32602, "_ready takes no parameters"));
+        }
+        Ok(json!({"methods": methods.keys().collect::<Vec<_>>(), "token": token}))
+    } else if let Some(handler) = methods.get(method) {
+        match std::panic::catch_unwind(|| handler(params)) {
+            Ok(result) => result,
+            Err(_) => return Some(error(id, -32603, "Handler panicked")),
+        }
+    } else {
+        return Some(error(id, -32601, "Method not found"));
+    };
+    Some(match result {
+        Ok(value) => json!({"jsonrpc": "2.0", "id": id, "result": value}),
+        Err(e) => error(id, e.code, &e.message),
+    })
+}
+
+/// Run an RPC-only native process using NativeModule's stdin launch settings.
+pub async fn run(handlers: &[(&str, Handler)]) -> zenoh::Result<()> {
+    crate::module::init_tracing();
+    if std::env::var("DIMOS_TRANSPORT").as_deref() != Ok("zenoh") {
+        return Err(io::Error::other("native RPC requires Zenoh").into());
+    }
+    let launch = crate::module::read_launch_config().await?;
+    let registration: Registration = serde_json::from_value(launch["rpc"].clone())?;
+    let methods: BTreeMap<_, _> = handlers.iter().copied().collect();
+    let declared: BTreeSet<_> = registration.methods.iter().map(String::as_str).collect();
+    if methods.len() != handlers.len()
+        || declared.len() != registration.methods.len()
+        || declared != methods.keys().copied().collect()
+        || methods
+            .keys()
+            .any(|name| name.starts_with('_') || name.contains('/') || name.contains('*'))
+        || registration.name.is_empty()
+        || registration.name.contains('*')
+    {
+        return Err(io::Error::other("native RPC declarations do not match handlers").into());
+    }
+    let transport = ZenohTransport::from_launch(&launch).await?;
+    let prefix = format!("dimos/rpc/v1/{}", registration.name);
+    let queryable = transport
+        .session()
+        .declare_queryable(format!("{prefix}/*"))
+        .complete(true)
+        .await?;
+    loop {
+        let query = queryable.recv_async().await?;
+        let payload = query
+            .payload()
+            .map(|p| p.to_bytes().into_owned())
+            .unwrap_or_default();
+        let route = query
+            .key_expr()
+            .as_str()
+            .strip_prefix("dimos/rpc/v1/")
+            .unwrap_or_default();
+        if let Some(reply) = respond(&payload, route, &methods, &registration.token) {
+            query
+                .reply(query.key_expr().clone(), serde_json::to_vec(&reply)?)
+                .encoding(Encoding::APPLICATION_JSON)
+                .await?;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn handler_panic_does_not_stop_dispatch() {
+        let methods: BTreeMap<&str, Handler> = BTreeMap::from([
+            ("panic", (|_| panic!("test panic")) as Handler),
+            ("health", (|_| Ok(json!({"ok": true}))) as Handler),
+        ]);
+        for (method, expected) in [
+            ("panic", error(json!(1), -32603, "Handler panicked")),
+            (
+                "health",
+                json!({"jsonrpc": "2.0", "id": 1, "result": {"ok": true}}),
+            ),
+        ] {
+            let route = format!("Toy/{method}");
+            let request = json!({"jsonrpc": "2.0", "id": 1, "method": route}).to_string();
+            assert_eq!(
+                respond(request.as_bytes(), &route, &methods, "test"),
+                Some(expected)
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_bad_wire_requests() {
+        let methods = BTreeMap::new();
+        for (payload, code) in [
+            ("not json", -32700),
+            (r#"{"jsonrpc":"1.0","id":1,"method":"Toy/plan"}"#, -32600),
+            (r#"{"jsonrpc":"2.0","id":1,"method":"Other/plan"}"#, -32600),
+            (
+                r#"{"jsonrpc":"2.0","id":1,"method":"Toy/plan","params":[]}"#,
+                -32602,
+            ),
+            (r#"{"jsonrpc":"2.0","id":1,"method":"Toy/plan"}"#, -32601),
+        ] {
+            let response = respond(payload.as_bytes(), "Toy/plan", &methods, "test").unwrap();
+            assert_eq!(response["error"]["code"], code);
+        }
+    }
+}

--- a/native/rust/dimos-module/src/zenoh.rs
+++ b/native/rust/dimos-module/src/zenoh.rs
@@ -221,6 +221,10 @@ async fn await_connect(session: &Session, endpoints: &[String], mode: Mode, time
 }
 
 impl ZenohTransport {
+    pub(crate) fn session(&self) -> &Session {
+        &self.session
+    }
+
     /// Open the session the launch config describes.
     pub(crate) async fn from_launch(launch: &serde_json::Value) -> io::Result<Self> {
         match SessionSettings::from_launch(launch)? {


### PR DESCRIPTION
Refs dimensionalOS/dimos#3506 and dimensionalOS/dimos#3516.

#4152 adds the reusable Python RPC transport. This draft still needs to be updated to use it.

This draft gets Python calling a Rust `NativeModule` over Zenoh with JSON-RPC 2.0

My recommendation is to make JSON-RPC an `RPCSpec` implementation next so Python and native modules can use the same RPC interface, while existing calls stay on pickle and move later one by one

`dimos/rpc/v1` is our DimOS protocol version  
JSON-RPC 2.0 is the request and reply format

This draft keeps discovery in the existing method list. Choosing a version, running versions side by side, and adding other encodings are follow-up work

There’s also a small toy planner example. Startup checks method names and a launch token. Native calls don’t retry automatically.

This draft is scoped to small, JSON-compatible commands and replies. It does not yet add RPC to an existing Rust module or define how types like `Twist` cross the wire. Large data, such as point clouds, should stay binary. [Microduck](https://github.com/pollen-robotics/microduck/blob/6507d2e960417aaa4ecd38eccf59b2dcf586ecd2/docs/design/architecture.md#L172-L197) uses a similar split: JSON-RPC for control, with video and audio on a separate path. [`rmw_zenoh`](https://github.com/ros2/rmw_zenoh/blob/c833e326048d97b26ea58882b247d2c642710e4d/docs/design.md#L100-L107) serializes ROS messages as CDR bytes over Zenoh.

```
uv run pytest examples/native_rpc/test_native_rpc.py --no-cov
```

49 tests pass locally.

Used Codex.
