### PR TITLE
chore: ignore downloads/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ data/*
 # Runtime output
 /logs
 /recordings
+/downloads
 results/
 /assets/output/
 /assets/rgbd_data/


### PR DESCRIPTION
`DOWNLOADS_DIR` in `dimos/constants.py` resolves to `<repo>/downloads` when running from a checkout, the same way `logs/` and `recordings/` do, but it was never in `.gitignore`. It shows up as untracked in `git status` after any run that downloads a dataset (25 GB on my box).