### PR TITLE
feat(evals): beanbag count from pointcloud (unitree go2)

### DIFF
--- a/data/.lfs/go2_beanbag.db.tar.gz
+++ b/data/.lfs/go2_beanbag.db.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b37e13c840f6b8ec8033fd1a04ed39fa0989585bbf3401b8521548f7dcf5a84
+size 91948076

--- a/dimos/evals/suites/beanbag_count.py
+++ b/dimos/evals/suites/beanbag_count.py
@@ -1,0 +1,45 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Beanbag count from point cloud alone (unitree go2).
+
+Pointcloud-only: the agent sees the final ``global_map`` frame via
+``PointCloud2.agent_encode`` and nothing else. Tests whether the cloud alone
+carries enough to count circular beanbags on the ground.
+
+    dimos evals run dimos.evals.suites.beanbag_count --agent dimos.evals.agents.question_answer
+"""
+
+from __future__ import annotations
+
+from dimos.evals.environments.dataset import Dataset
+from dimos.evals.scorers import first_number, within
+from dimos.evals.types import EvalCase, Suite
+
+DATASET = "go2_beanbag"
+
+
+SUITE: Suite = [
+    EvalCase(
+        id="pc_beanbag_count",
+        inputs="How many circular beanbags do you see on the ground? Answer with just the number.",
+        environment=Dataset(
+            DATASET,
+            # final accumulated map frame; point cloud only, no camera
+            select=(lambda s: s.streams.global_map.at(s.streams.global_map.last().ts, 1.0),),
+        ),
+        grade=lambda o: within(1.0)(3.0, first_number(o.trajectory.final_answer)),
+        tags=frozenset({"pointcloud", "count", "beanbag"}),
+    ),
+]


### PR DESCRIPTION
## Problem

## Solution

- new suite `dimos.evals.suites.beanbag_count` — one case. the agent sees the final `global_map` frame (via `agent_encode`) and nothing else.
- full recording (all streams, untruncated) ships in LFS as `go2_beanbag.db`.

question + ground truth:
- how many circular beanbags do you see on the ground -> 3
<img width="1881" height="1066" alt="image" src="https://github.com/user-attachments/assets/58de7154-43a1-4e3f-9ef4-24c3ea8238ce" />

## Breaking Changes

None

## How to Test

one line (checkout pulls the LFS dataset, then run):

```bash
uv run dimos evals run dimos.evals.suites.beanbag_count --agent dimos.evals.agents.question_answer
```

baseline: question_answer scores 0.00 with gpt-5.6-luna — answers 4 vs the true 3, off by one. the cloud alone doesnt cleanly resolve the three beanbags, which is the signal.

## Contributor License Agreement
- [x] I have read and approved the CLA
