### PR TITLE
feat(go2): render lidar and map clouds as screen-space points in rerun

### DIFF
--- a/dimos/msgs/sensor_msgs/PointCloud2.py
+++ b/dimos/msgs/sensor_msgs/PointCloud2.py
@@ -850,7 +850,7 @@ class PointCloud2(Timestamped):
         self,
         voxel_size: float = 0.05,
         colors: list[int] | None = None,
-        mode: str = "spheres",
+        mode: str = "points",
         fill_mode: str = "solid",
         bottom_cutoff: float | None = None,
         ui_radius: float = 2.0,
@@ -864,9 +864,9 @@ class PointCloud2(Timestamped):
             colors: Optional RGB color [r, g, b] for all points (0-255).
                 If None, uses height-based turbo colormap via class_ids
                 (requires register_colormap_annotation() called once).
-            mode: "points" for flat screen-space dots, "boxes" for cubes, or
-                "spheres" (default) for world-sized spheres. Only "points" holds a
-                constant on-screen size as you zoom; the others scale with voxel_size.
+            mode: "points" (default) for flat screen-space dots, "boxes" for cubes,
+                or "spheres" for world-sized spheres. Only "points" holds a constant
+                on-screen size as you zoom; the others scale with voxel_size.
             fill_mode: Fill mode for boxes - "solid", "majorwireframe", or "densewireframe"
             ui_radius: Dot radius in screen-space UI points; "points" mode only.
             rgb: Paint with the cloud's own per-point colors when it has any (an


### PR DESCRIPTION
Spheres scale with voxel_size and are shaded per point; points hold a constant 1 UI-pt radius like the realsense and habitat blueprints.

## Contribution path

<!-- See CONTRIBUTING.md. Small, safe changes can skip the issue. -->

- Small, safe change that does not need a tracking issue
- Linked issue or discussion: DIM-XXX / #XXX / URL

## Problem

<!-- What feature are you adding or fixing? -->

## Solution

<!-- What you changed and why this approach -->
<!-- Key design decisions / tradeoffs -->
<!-- Keep it high-signal; deep planning belongs in the issue. -->

## How to Test

<!-- Oneliner required to run the actual feature -->
<!-- for example `dimos run unitree-go2-myfeature` -->

## AI assistance

<!-- Required by AI_POLICY.md. Name the tool and the model (e.g. "Claude Code with Opus 4.8") and how much they were involved. Write "None" if unassisted. -->
<!-- You should understand every line of code in your PR -->

## Checklist

- [ ] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
