### PR TITLE
fix(data): resolve every LFS dataset name for --replay-db

### DIFF
--- a/dimos/robot/unitree/go2/connection.py
+++ b/dimos/robot/unitree/go2/connection.py
@@ -32,8 +32,8 @@ from dimos.core.global_config import GlobalConfig
 from dimos.core.module import Module, ModuleConfig
 from dimos.core.resource import CompositeResource
 from dimos.core.stream import In, Out
+from dimos.memory.cli.dataset import open_store
 from dimos.memory.replay import Replay, ReplayStream, resolve_db_path
-from dimos.memory.store.sqlite import SqliteStore
 from dimos.msgs.geometry_msgs.PoseStamped import PoseStamped
 from dimos.msgs.geometry_msgs.Quaternion import Quaternion
 from dimos.msgs.geometry_msgs.Transform import Transform
@@ -179,9 +179,7 @@ class ReplayConnection(UnitreeWebRTCConnection, CompositeResource):
     def replay(self) -> Replay:
         # One shared store + Replay so lidar/odom/video advance against the
         # same wall-clock anchor on subscribe.
-        store = self.register_disposable(
-            SqliteStore(path=str(resolve_db_path(self.dataset)), must_exist=True)
-        )
+        store = self.register_disposable(open_store(resolve_db_path(self.dataset)))
         store.start()
         return store.replay(loop=self._loop, seek=self._seek, duration=self._duration)
 

--- a/dimos/utils/data.py
+++ b/dimos/utils/data.py
@@ -115,19 +115,38 @@ def get_data_dir(extra_path: str | None = None) -> Path:
 
 
 def resolve_named_path(name: str | Path, suffix: str = "") -> Path:
+    """Resolve *name* to a path: as given, under the project root, then as LFS data.
+
+    A bare name (no extension) also tries ``name + suffix``. A directory
+    dataset resolves to its single ``*suffix`` file when it has exactly one.
+    """
     s = str(name)
     p = Path(s)
     if p.is_absolute() or p.exists():
         return p
     if (DIMOS_PROJECT_ROOT / p).exists():
         return DIMOS_PROJECT_ROOT / p
-    if suffix and not s.endswith(suffix):
-        p = Path(s + suffix)
-        if p.is_absolute() or p.exists():
-            return p
-        if (DIMOS_PROJECT_ROOT / p).exists():
-            return DIMOS_PROJECT_ROOT / p
-    return get_data(p.name)
+    candidates = [p.name]
+    if suffix and not p.suffix:
+        if Path(s + suffix).exists():
+            return Path(s + suffix)
+        if (DIMOS_PROJECT_ROOT / (s + suffix)).exists():
+            return DIMOS_PROJECT_ROOT / (s + suffix)
+        candidates.insert(0, p.name + suffix)
+    for candidate in candidates:
+        try:
+            resolved = get_data(candidate)
+        except FileNotFoundError:
+            continue
+        if suffix and resolved.is_dir():
+            matches = sorted(resolved.glob(f"*{suffix}"))
+            if len(matches) == 1:
+                return matches[0]
+        return resolved
+    raise FileNotFoundError(
+        f"{name!r} is not a path and no LFS archive matches "
+        f"{' or '.join(c + '.tar.gz' for c in candidates)} under {_get_lfs_dir()}"
+    )
 
 
 def backup_file(path: str | Path, keep_last: int = 3) -> Path | None:
@@ -244,8 +263,8 @@ def _pull_lfs_archive(filename: str | Path) -> Path:
     # Check if file exists
     if not file_path.exists():
         raise FileNotFoundError(
-            f"Test file '{filename}' not found at {file_path}. "
-            f"Make sure the file is committed to Git LFS in the tests/data directory."
+            f"LFS archive '{filename}.tar.gz' not found at {file_path}. "
+            f"Make sure it is committed to Git LFS under data/.lfs."
         )
 
     # If it's an LFS pointer file, ensure LFS is set up and pull the file

--- a/dimos/utils/test_data.py
+++ b/dimos/utils/test_data.py
@@ -16,7 +16,7 @@ import hashlib
 import os
 from pathlib import Path
 import subprocess
-from unittest.mock import call
+from unittest.mock import MagicMock, call
 
 import pytest
 from pytest_mock import MockerFixture
@@ -490,3 +490,45 @@ def test_lfs_path_multiple_instances() -> None:
 
     # Both caches should point to the same file
     assert cache_1 == cache_2
+
+
+def _fake_get_data(mocker: MockerFixture, available: dict[str, Path]) -> MagicMock:
+    def get_data(name: str | Path) -> Path:
+        try:
+            return available[str(name)]
+        except KeyError:
+            raise FileNotFoundError(name) from None
+
+    return mocker.patch.object(data, "get_data", side_effect=get_data)
+
+
+def test_resolve_named_path_keeps_foreign_suffix(mocker: MockerFixture, tmp_path: Path) -> None:
+    mcap = tmp_path / "go2_dds_stairs.mcap"
+    get_data = _fake_get_data(mocker, {"go2_dds_stairs.mcap": mcap})
+
+    assert data.resolve_named_path("go2_dds_stairs.mcap", ".db") == mcap
+    get_data.assert_called_once_with("go2_dds_stairs.mcap")
+
+
+def test_resolve_named_path_falls_back_to_plain_archive(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    dataset = tmp_path / "unitree_go2_bigoffice"
+    dataset.mkdir()
+    db = dataset / "recording.db"
+    db.touch()
+    get_data = _fake_get_data(mocker, {"unitree_go2_bigoffice": dataset})
+
+    assert data.resolve_named_path("unitree_go2_bigoffice", ".db") == db
+    assert get_data.call_args_list == [
+        call("unitree_go2_bigoffice.db"),
+        call("unitree_go2_bigoffice"),
+    ]
+
+
+def test_resolve_named_path_missing_names_candidates(mocker: MockerFixture, tmp_path: Path) -> None:
+    _fake_get_data(mocker, {})
+    mocker.patch.object(data, "_get_lfs_dir", return_value=tmp_path)
+
+    with pytest.raises(FileNotFoundError, match=r"nope\.db\.tar\.gz or nope\.tar\.gz"):
+        data.resolve_named_path("nope", ".db")


### PR DESCRIPTION
`--replay-db <name>` only worked for datasets stored in LFS as `<name>.db.tar.gz`.

`resolve_named_path` appended the suffix to any name that did not already end in it, so `go2_dds_stairs.mcap` was looked up as `go2_dds_stairs.mcap.db.tar.gz`, and it never fell back to the plain archive name, so directory datasets such as `unitree_go2_bigoffice.tar.gz` could not be resolved at all.

- append the suffix only to bare names, and try `<name><suffix>.tar.gz` then `<name>.tar.gz`
- a directory dataset resolves to its single `*<suffix>` file
- `ReplayConnection` opens the resolved path through `open_store`, so `.mcap` datasets replay
- the LFS miss error now names the archives it looked for instead of a `tests/data` directory that no longer exists

Tests: `dimos/utils/test_data.py` covers the foreign suffix, the plain-archive fallback, and the error text.