### PR TITLE
chore(codeowners): add @TomCC7 to /dimos/manipulation/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,7 @@
 * @leshy @paul-nechifor @spomichter @mustafab0 @Dreamsorcerer @aclauer
 /.github/ @Dreamsorcerer @leshy @paul-nechifor @spomichter
 /dimos/mapping/ @leshy @paul-nechifor @spomichter @aclauer
+/dimos/manipulation/ @leshy @paul-nechifor @spomichter @mustafab0 @TomCC7
 
 # Any experimental/ dir, anywhere
 # Last match wins, so this must stay at the bottom.


### PR DESCRIPTION
Adds @TomCC7 as a code owner for dimos/manipulation/, so manipulation changes can be approved by the person actually working in there.


