### PR TITLE
test: keep the developer's robot out of the suite

### DIFF
--- a/dimos/conftest.py
+++ b/dimos/conftest.py
@@ -68,6 +68,10 @@ else:
     os.environ.setdefault("LCM_DEFAULT_URL", f"udpm://239.255.76.67:{7700 + _BUCKET}?ttl=0")
     os.environ.setdefault("ZENOH_SCOUT_ADDR", f"224.0.0.224:{17700 + _BUCKET}")
 
+# GlobalConfig reads .env itself, so a developer's robot must be blanked, not just unset.
+for _k in ("ROBOT_IP", "ROBOT_IPS", "ZENOH_CONNECT"):
+    os.environ[_k] = ""
+
 # Raise the open-file limit. Each LCM transport opens at least one
 # multicast socket; with pytest-xdist workers running many in parallel,
 # the macOS default soft cap (~256) gets exhausted and tests fail with

--- a/dimos/core/coordination/blueprint_config/test_sources.py
+++ b/dimos/core/coordination/blueprint_config/test_sources.py
@@ -50,6 +50,8 @@ def test_default_environment_reads_dotenv_at_environment_precedence(
     config_path = tmp_path / "config.json"
     config_path.write_text('{"g":{"robot_ip":"config"},"primarymodule":{"speed":2}}')
     monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("ROBOT_IP", raising=False)
+    monkeypatch.delenv("PRIMARYMODULE__SPEED", raising=False)
 
     parsed = BlueprintConfigParser(PrimaryModule.blueprint()).parse(
         config_path=config_path,


### PR DESCRIPTION
## Problem

GlobalConfig reads .env itself, so a ROBOT_IP in the checkout makes every zenoh session dial the robot and stall 1 s; 5 async-module tests fail and the suite runs 3x slower.

## Solution

conftest blanks ROBOT_IP/ROBOT_IPS/ZENOH_CONNECT before dimos imports; the dotenv precedence test drops them too. Popping is not enough because pydantic-settings reads the file directly.

## How to test

```bash
echo ROBOT_IP=10.0.0.1 >> .env
uv run pytest dimos/core/test_async_module_rpc.py dimos/core/coordination/blueprint_config/test_sources.py
```

19 passed across the six affected files with ROBOT_IP set; 5 failed before.


## AI assistance

Used Fable 5.1 extensively for root cause analysis, fix and testing.

## Checklist

- [ ] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
