### PR TITLE
test: skip voice tests without ffmpeg, add ffmpeg to install docs

### DIFF
--- a/dimos/agents/test_voice_input.py
+++ b/dimos/agents/test_voice_input.py
@@ -40,6 +40,8 @@ from dimos.stream.audio.stt import node_whisper as whisper_module
 from dimos.web.relay_bridge.audio_codec import AudioChunk
 from dimos.web.relay_bridge.module_test_support import FakeTransport
 
+pytestmark = pytest.mark.skipif_no_ffmpeg
+
 
 def _chunk(sid: str = "u1", seq: int = 0, data: bytes = b"", final: bool = False) -> AudioChunk:
     return AudioChunk(sid=sid, seq=seq, mime="audio/webm", data=data, final=final)

--- a/dimos/conftest.py
+++ b/dimos/conftest.py
@@ -19,6 +19,7 @@ import hashlib
 import os
 import pathlib
 import platform
+import shutil
 import tempfile
 import threading
 import time
@@ -197,6 +198,9 @@ def pytest_configure(config):
         "skipif_no_turbojpeg: skip when native libturbojpeg is missing — "
         "except in CI, where it runs anyway so a missing dep fails loudly",
     )
+    config.addinivalue_line(
+        "markers", "skipif_no_ffmpeg: skip when the ffmpeg binary is missing, except in CI"
+    )
     config.addinivalue_line("markers", "skipif_macos_bug: skip known-buggy tests on macOS")
     config.addinivalue_line("markers", "skipif_macos: skip tests not intended to run on macOS")
     config.addinivalue_line(
@@ -270,6 +274,10 @@ def pytest_collection_modifyitems(config, items):
         "skipif_no_turbojpeg": (
             not _has_turbojpeg() and not os.getenv("CI"),
             "native libturbojpeg unavailable",
+        ),
+        "skipif_no_ffmpeg": (
+            shutil.which("ffmpeg") is None and not os.getenv("CI"),
+            "ffmpeg not installed",
         ),
         "skipif_macos_bug": (_is_macos(), "Some tests are buggy on Mac OS"),
         "skipif_macos": (_is_macos(), "Not intended to run on macOS"),

--- a/docs/installation/ubuntu.md
+++ b/docs/installation/ubuntu.md
@@ -2,7 +2,7 @@
 
 ```sh skip
 sudo apt-get update
-sudo apt-get install -y curl g++ portaudio19-dev git-lfs libturbojpeg python3-dev pre-commit
+sudo apt-get install -y curl g++ portaudio19-dev git-lfs libturbojpeg ffmpeg python3-dev pre-commit
 
 # install uv
 curl -LsSf https://astral.sh/uv/install.sh | sh && export PATH="$HOME/.local/bin:$PATH"

--- a/misc/fresh-ubuntu-tests/suite/setup.sh
+++ b/misc/fresh-ubuntu-tests/suite/setup.sh
@@ -9,7 +9,7 @@ export GIT_LFS_SKIP_SMUDGE=1
 
 # system dependencies (docs/installation/ubuntu.md)
 sudo apt-get update
-sudo apt-get install -y curl g++ portaudio19-dev git-lfs libturbojpeg python3-dev pre-commit
+sudo apt-get install -y curl g++ portaudio19-dev git-lfs libturbojpeg ffmpeg python3-dev pre-commit
 
 # uv
 curl -LsSf https://astral.sh/uv/install.sh | sh


### PR DESCRIPTION
## Problem

VoiceInput needs the ffmpeg binary. The install docs never mention it, so 13 test_voice_input tests fail on a fresh Ubuntu.

## Solution

Add ffmpeg to the apt line in docs/installation/ubuntu.md and the fresh-ubuntu VM suite. Add a skipif_no_ffmpeg marker (same pattern as skipif_no_turbojpeg: skips locally, runs in CI).

## How to test

```bash
uv run pytest dimos/agents/test_voice_input.py
```

13 passed with ffmpeg, 13 skipped without it.

## AI assistance

Used Fable 5.1 extensively for root cause analysis, fix and testing.

## Checklist

- [ ] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
