### PR TITLE
fix(shm): new subscribers skip the frame left in a reused segment

### DIFF
--- a/dimos/protocol/pubsub/impl/shmpubsub.py
+++ b/dimos/protocol/pubsub/impl/shmpubsub.py
@@ -268,6 +268,9 @@ class SharedMemoryPubSubBase(PubSub[str, Any]):
                 **self._channel_kwargs,
             )
             st = SharedMemoryPubSubBase._TopicState(ch, cap, None)
+            if isinstance(ch, CpuShmChannel):
+                # A frame left in the segment by an earlier owner is not new.
+                st.last_seq = ch.read(require_new=False)[0]
             self._topics[topic] = st
             return st
 

--- a/dimos/protocol/pubsub/impl/shmpubsub.py
+++ b/dimos/protocol/pubsub/impl/shmpubsub.py
@@ -203,6 +203,9 @@ class SharedMemoryPubSubBase(PubSub[str, Any]):
         st = self._ensure_topic(topic)
         st.subs.append(callback)
         if st.thread is None:
+            if isinstance(st.channel, CpuShmChannel):
+                # Frames already in the segment predate this subscriber.
+                st.last_seq = st.channel.current_seq()
             st.thread = threading.Thread(target=self._fanout_loop, args=(topic, st), daemon=True)
             st.thread.start()
 
@@ -268,9 +271,6 @@ class SharedMemoryPubSubBase(PubSub[str, Any]):
                 **self._channel_kwargs,
             )
             st = SharedMemoryPubSubBase._TopicState(ch, cap, None)
-            if isinstance(ch, CpuShmChannel):
-                # A frame left in the segment by an earlier owner is not new.
-                st.last_seq = ch.read(require_new=False)[0]
             self._topics[topic] = st
             return st
 

--- a/dimos/protocol/pubsub/impl/test_shmpubsub.py
+++ b/dimos/protocol/pubsub/impl/test_shmpubsub.py
@@ -1,0 +1,39 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+from typing import Any
+
+from dimos.protocol.pubsub.impl.shmpubsub import PickleSharedMemory
+
+
+def test_new_subscriber_ignores_frame_left_in_segment(wait_until: Any) -> None:
+    topic = "/shm_stale_frame"
+    owner = PickleSharedMemory(prefer="cpu")
+    owner.start()
+    owner.publish(topic, b"stale")
+
+    reader = PickleSharedMemory(prefer="cpu")
+    reader.start()
+    got: list[bytes] = []
+    reader.subscribe(topic, lambda msg, _topic: got.append(msg))
+    try:
+        time.sleep(0.2)
+        assert got == []
+
+        owner.publish(topic, b"fresh")
+        wait_until(lambda: got == [b"fresh"], timeout=2.0)
+    finally:
+        reader.stop()
+        owner.stop()

--- a/dimos/protocol/pubsub/impl/test_shmpubsub.py
+++ b/dimos/protocol/pubsub/impl/test_shmpubsub.py
@@ -37,3 +37,28 @@ def test_new_subscriber_ignores_frame_left_in_segment(wait_until: Any) -> None:
     finally:
         reader.stop()
         owner.stop()
+
+
+def test_resubscribe_ignores_frames_published_while_unsubscribed(wait_until: Any) -> None:
+    topic = "/shm_resubscribe"
+    owner = PickleSharedMemory(prefer="cpu")
+    owner.start()
+    reader = PickleSharedMemory(prefer="cpu")
+    reader.start()
+    got: list[bytes] = []
+    try:
+        unsubscribe = reader.subscribe(topic, lambda msg, _topic: got.append(msg))
+        owner.publish(topic, b"first")
+        wait_until(lambda: got == [b"first"], timeout=2.0)
+        unsubscribe()
+
+        owner.publish(topic, b"missed")
+        reader.subscribe(topic, lambda msg, _topic: got.append(msg))
+        time.sleep(0.2)
+        assert got == [b"first"]
+
+        owner.publish(topic, b"second")
+        wait_until(lambda: got == [b"first", b"second"], timeout=2.0)
+    finally:
+        reader.stop()
+        owner.stop()

--- a/dimos/protocol/pubsub/shm/ipc_factory.py
+++ b/dimos/protocol/pubsub/shm/ipc_factory.py
@@ -201,6 +201,9 @@ class CpuShmChannel(FrameChannel):
         self._ctrl[2] = inactive
         self._ctrl[0] += 1
 
+    def current_seq(self) -> int:
+        return int(self._ctrl[0])
+
     def read(self, last_seq: int = -1, require_new: bool = True):  # type: ignore[no-untyped-def]
         for _ in range(3):
             seq1 = int(self._ctrl[0])


### PR DESCRIPTION
## Problem

A /dev/shm segment left by a killed owner is attached by the next process, and its first read delivers the old frame as new. test_async_iterator[shared_memory_cpu] fails until the segment is removed by hand. Same code since v0.0.13.

## Solution

A new topic state starts at the segment's current seq instead of 0, so subscribers only see frames published after they joined, like the other transports. Streaming channel only; RPC queue untouched. Regression test included.

## How to test

```bash
uv run pytest dimos/protocol/pubsub/impl/test_shmpubsub.py dimos/protocol/pubsub/test_spec.py -k shared_memory
```

Regression test fails on main, passes with the fix; 28 existing shm/rpc tests pass.

## AI assistance

Used Fable 5.1 extensively for root cause analysis, fix and testing.

## Checklist

- [ ] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
