### PR TITLE
fix(tests): ignore .env under pytest except the LLM API keys

### DIFF
--- a/dimos/agents/conftest.py
+++ b/dimos/agents/conftest.py
@@ -16,7 +16,6 @@ import os
 from pathlib import Path
 from threading import Event
 
-from dotenv import load_dotenv
 from langchain_core.messages.base import BaseMessage
 import pytest
 
@@ -27,8 +26,6 @@ from dimos.core.coordination.blueprints import autoconnect
 from dimos.core.coordination.module_coordinator import ModuleCoordinator
 from dimos.core.global_config import global_config
 from dimos.core.transport import pLCMTransport
-
-load_dotenv()
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures"
 

--- a/dimos/agents/mcp/conftest.py
+++ b/dimos/agents/mcp/conftest.py
@@ -16,7 +16,6 @@ import os
 from pathlib import Path
 from threading import Event
 
-from dotenv import load_dotenv
 from langchain_core.messages.base import BaseMessage
 import pytest
 
@@ -27,8 +26,6 @@ from dimos.core.coordination.blueprints import autoconnect
 from dimos.core.coordination.module_coordinator import ModuleCoordinator
 from dimos.core.global_config import global_config
 from dimos.core.transport import pLCMTransport
-
-load_dotenv()
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures"
 

--- a/dimos/cli/dimos.py
+++ b/dimos/cli/dimos.py
@@ -67,6 +67,7 @@ from dimos.cli.commands.tuis import agentspy, humancli, lcmspy, spy, top
 from dimos.cli.hardware_cli import app as hardware_app
 from dimos.cli.shell import shell
 from dimos.cli.vqa import app as vqa_app
+from dimos.core.global_config import ENV_FILE
 from dimos.robot.unitree.go2.cli.go2tool import app as go2tool_app
 
 main = typer.Typer(
@@ -74,7 +75,8 @@ main = typer.Typer(
     no_args_is_help=True,
 )
 
-load_dotenv()
+if ENV_FILE is not None:
+    load_dotenv()
 
 SIMULATORS = ("mujoco", "dimsim")
 RECORDERS = ("sqlite", "mcap")

--- a/dimos/conftest.py
+++ b/dimos/conftest.py
@@ -83,7 +83,7 @@ with suppress(ImportError, ValueError, OSError):
     if soft < target:
         resource.setrlimit(resource.RLIMIT_NOFILE, (target, hard))
 
-from dotenv import load_dotenv
+from dotenv import dotenv_values
 import pytest
 import tqdm
 
@@ -96,7 +96,10 @@ from dimos.utils.testing.waiting import retry_until as _retry_until, wait_until 
 # monitor only re-tunes miniters for smooth interactive rendering, so disable it for tests.
 tqdm.tqdm.monitor_interval = 0
 
-load_dotenv()
+_dotenv = dotenv_values()
+for _key in ("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "ALIBABA_API_KEY"):
+    if _dotenv.get(_key):
+        os.environ.setdefault(_key, _dotenv[_key])
 
 
 def _has_ros() -> bool:

--- a/dimos/core/coordination/blueprint_config/sources.py
+++ b/dimos/core/coordination/blueprint_config/sources.py
@@ -37,7 +37,7 @@ from dimos.core.coordination.blueprint_config.schema import (
     normalize_option_name,
 )
 from dimos.core.coordination.blueprint_config.values import deep_set, plain_mapping
-from dimos.core.global_config import GlobalConfig
+from dimos.core.global_config import ENV_FILE, GlobalConfig
 
 
 def global_schema_defaults() -> dict[str, Any]:
@@ -51,7 +51,11 @@ def configuration_environment(
 ) -> Mapping[str, str]:
     if environ is not None:
         return environ
-    from_dotenv = {key: value for key, value in dotenv_values(".env").items() if value is not None}
+    if ENV_FILE is None:
+        return os.environ
+    from_dotenv = {
+        key: value for key, value in dotenv_values(ENV_FILE).items() if value is not None
+    }
     return {**from_dotenv, **os.environ}
 
 

--- a/dimos/core/coordination/blueprint_config/test_sources.py
+++ b/dimos/core/coordination/blueprint_config/test_sources.py
@@ -50,6 +50,8 @@ def test_default_environment_reads_dotenv_at_environment_precedence(
     config_path = tmp_path / "config.json"
     config_path.write_text('{"g":{"robot_ip":"config"},"primarymodule":{"speed":2}}')
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("dimos.core.coordination.blueprint_config.sources.ENV_FILE", ".env")
+    monkeypatch.delenv("ROBOT_IP", raising=False)
 
     parsed = BlueprintConfigParser(PrimaryModule.blueprint()).parse(
         config_path=config_path,

--- a/dimos/core/global_config.py
+++ b/dimos/core/global_config.py
@@ -36,6 +36,11 @@ ZenohMode: TypeAlias = Literal["peer", "client", "router"]
 # process can hold, so it is pinned on the one session that owns that port.
 ZenohProcessMode: TypeAlias = Literal["peer", "client"]
 
+# pytest exports PYTEST_VERSION to the whole process tree. Tests must not pick up
+# a developer's .env (ROBOT_IP, SIMULATION, ...); dimos/conftest.py exports the
+# LLM API keys itself.
+ENV_FILE = None if "PYTEST_VERSION" in os.environ else ".env"
+
 
 def _get_all_numbers(s: str) -> list[float]:
     return [float(x) for x in re.findall(r"-?\d+\.?\d*", s)]
@@ -143,7 +148,7 @@ class GlobalConfig(BaseSettings):
     dimos_staging_dir: Path | None = None
 
     model_config = SettingsConfigDict(
-        env_file=".env",
+        env_file=ENV_FILE,
         env_file_encoding="utf-8",
         extra="ignore",
         validate_assignment=True,

--- a/dimos/core/test_global_config.py
+++ b/dimos/core/test_global_config.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pathlib import Path
+
 from pydantic import ValidationError
 import pytest
 
@@ -48,3 +50,11 @@ def test_encoding_threads_require_rust() -> None:
 
     config = GlobalConfig.model_validate({"record_engine": "rust", "record_encoding_threads": 8})
     assert config.record_encoding_threads == 8
+
+
+def test_dotenv_is_ignored_under_pytest(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    (tmp_path / ".env").write_text("ROBOT_IP=192.0.2.17\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("ROBOT_IP", raising=False)
+
+    assert GlobalConfig().robot_ip is None

--- a/dimos/perception/experimental/temporal_memory/test_temporal_memory_module.py
+++ b/dimos/perception/experimental/temporal_memory/test_temporal_memory_module.py
@@ -23,7 +23,6 @@ import time
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, create_autospec, patch
 
-from dotenv import load_dotenv
 import numpy as np
 import pytest
 from reactivex import operators as ops
@@ -52,7 +51,6 @@ from dimos.utils.logging_config import setup_logger
 if TYPE_CHECKING:
     from pathlib import Path
 
-load_dotenv()
 
 logger = setup_logger()
 


### PR DESCRIPTION
## Problem

ROBOT_IP in .env (and others) leaked into tests.

## Solution

Ignore `.env` when running tests (but do add OPENAI_API_KEY and a few others we use).