### PR TITLE
ci: reject Git sources in root pyproject.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,6 +252,26 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+      - name: Reject Git sources in root pyproject.toml
+        run: |
+          python3 - <<'PY'
+          import sys
+          import tomllib
+
+          with open("pyproject.toml", "rb") as file:
+              config = tomllib.load(file)
+          sources = config.get("tool", {}).get("uv", {}).get("sources", {})
+          rejected = []
+          for name, source in sources.items():
+              entries = source if isinstance(source, list) else [source]
+              if any("git" in entry for entry in entries):
+                  rejected.append(name)
+          if rejected:
+              sys.exit(
+                  "::error file=pyproject.toml::Git sources are not allowed in root "
+                  "pyproject.toml. Use published packages instead: " + ", ".join(rejected)
+              )
+          PY
       - name: Install uv
         uses: astral-sh/setup-uv@v10.0.1
         with:


### PR DESCRIPTION
## Contribution path

- Small, safe change that does not need a tracking issue

## Problem

The root `pyproject.toml` can acquire Git source overrides such as the pinned GraspGenX checkout. We want CI to enforce a published-package policy for this PyPI project.

## Solution

Add a check at the start of the existing lint job, before dependency installation. Python's standard-library TOML parser detects `git` keys in `[tool.uv.sources]`, including separate source tables and conditional source lists, and reports the offending package names. Comments and index sources are allowed. The existing required `ci-complete` job already depends on lint.

**This draft intentionally fails on the existing `graspgenx` Git source.** That dependency needs to be addressed before merging; this PR only adds the guard.

## How to Test

Run the workflow step locally from the repository root:

```sh
sed -n '/      - name: Reject Git sources in root pyproject.toml/,/      - name: Install uv/p' .github/workflows/ci.yml | sed '1,2d;$d;s/^          //' | bash -e
```

Verified eight cases locally: existing GraspGenX source, index sources, absent sources, commented Git source, separate source table with a quoted key, conditional Git source, malformed TOML, and the current file with the Git override removed. All produced the expected exit status. YAML parsing, `git diff --check`, and commit hooks passed.

## AI assistance

Implemented and verified by Codex (GPT-6).

## Checklist

- [x] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).

— Codex
