### PR TITLE
Fix broken tests

### DIFF
--- a/bin/build-test-natives
+++ b/bin/build-test-natives
@@ -9,12 +9,14 @@ set -euo pipefail
 
 python setup.py build_ext --inplace
 
-# PyO3 Rust extension modules (separate distributions installed into the venv).
+# PyO3 Rust extension modules (separate distributions installed into the venv)
+# and the rust native-module binaries the livox e2e tests spawn from target/release.
 if command -v cargo &>/dev/null; then
   maturin develop --uv -m dimos/mapping/ray_tracing/rust/py/Cargo.toml
   maturin develop --uv -m dimos/navigation/nav_3d/mls_planner/rust/py/Cargo.toml
+  cargo build --release --locked -p dimos-livox -p dimos-virtual-mid360
 else
-  echo "warning: cargo not found; skipping Rust extension builds, their tests will skip." >&2
+  echo "warning: cargo not found; skipping Rust builds, their tests will skip or fail." >&2
   echo "         Install Rust via https://rustup.rs" >&2
 fi
 

--- a/dimos/conftest.py
+++ b/dimos/conftest.py
@@ -218,20 +218,36 @@ def pytest_configure(config):
         )
 
 
-@pytest.fixture(autouse=True)
-def _restore_global_config():
-    """Undo global_config mutations after every test.
-
-    A build from a parsed config resets the singleton to the parse's full
-    resolution. With a hermetic parse (environ={}) that reverts mcp_port to
-    its schema default, and every later test on the worker then binds the
-    port every other worker also defaults to.
-    """
+def _global_config_guard():
     from dimos.core.global_config import global_config
 
     snapshot = global_config.model_dump()
     yield
     global_config.update(**snapshot)
+
+
+# Undo global_config mutations when the scope that made them ends. Without
+# the class and module guards, a class-scoped fixture's
+# `global_config.update(viewer="none", n_workers=1)` stays in effect for
+# every later test in the session.
+#
+# A build from a parsed config resets the singleton to the parse's full
+# resolution. With a hermetic parse (environ={}) that reverts mcp_port to
+# its schema default, and every later test on the worker then binds the
+# port every other worker also defaults to.
+@pytest.fixture(autouse=True)
+def _restore_global_config():
+    yield from _global_config_guard()
+
+
+@pytest.fixture(autouse=True, scope="class")
+def _restore_global_config_class():
+    yield from _global_config_guard()
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _restore_global_config_module():
+    yield from _global_config_guard()
 
 
 @pytest.fixture(scope="session")

--- a/dimos/experimental/isolated_python/README.md
+++ b/dimos/experimental/isolated_python/README.md
@@ -66,9 +66,11 @@ a contract stub or changes its signature or classification.
 
 ## Runtime behavior
 
-During `build()`, dimOS runs `uv sync` in the sibling project. If `pixi.toml`
-exists, Pixi supplies `uv`. If `uv.lock` exists, dimOS uses `--frozen` and treats
-the lockfile as the source of truth.
+During `build()`, dimOS syncs the sibling project and installs the host dimOS
+with its dependencies into a cached `uv run --with` overlay. The first build can
+take minutes to download; later builds reuse the cache. If `pixi.toml` exists,
+Pixi supplies `uv`. If `uv.lock` exists, dimOS uses `--frozen` and treats the
+lockfile as the source of truth.
 
 Source checkouts make the current dimOS checkout available to the runtime.
 Installed hosts let `uv` resolve `dimos`, so the host and runtime versions may

--- a/dimos/experimental/isolated_python/module.py
+++ b/dimos/experimental/isolated_python/module.py
@@ -122,17 +122,11 @@ class IsolatedPythonModule(NativeModule):
             )
         return project
 
-    def _uv_command(self, *args: str) -> list[str]:
-        command = ["uv", *args]
-        if (self.runtime_project / "pixi.toml").is_file():
-            return ["pixi", "run", "--executable", *command]
-        return command
-
     def _prepare_command(self) -> list[str]:
-        args = ["sync"]
-        if (self.runtime_project / "uv.lock").is_file():
-            args.append("--frozen")
-        return self._uv_command(*args)
+        # `uv run` syncs the sibling project and builds the cached overlay that
+        # holds the host DimOS with its dependencies. Doing it here keeps the
+        # first install, which can take minutes, out of the startup timeout.
+        return isolated_python_run_command(self.runtime_project, "python", "-c", "pass")
 
     def _launch_command(self, handshake_fd: int) -> list[str]:
         return isolated_python_run_command(

--- a/dimos/experimental/isolated_python/test_module.py
+++ b/dimos/experimental/isolated_python/test_module.py
@@ -65,7 +65,16 @@ def test_uv_lock_enables_frozen_commands(tmp_path: Path, monkeypatch: pytest.Mon
     try:
         command = module._launch_command(7)
 
-        assert module._prepare_command() == ["uv", "sync", "--frozen"]
+        assert module._prepare_command() == [
+            "uv",
+            "run",
+            "--frozen",
+            "--with-editable",
+            str(checkout),
+            "python",
+            "-c",
+            "pass",
+        ]
         assert command[:5] == [
             "uv",
             "run",
@@ -118,7 +127,7 @@ def test_pixi_supplies_uv_when_manifest_exists(
     )
     module = Contract()
     try:
-        assert module._prepare_command() == ["pixi", "run", "--executable", "uv", "sync"]
+        assert module._prepare_command()[:5] == ["pixi", "run", "--executable", "uv", "run"]
     finally:
         module.stop()
 

--- a/dimos/perception/experimental/test_spatial_memory_module.py
+++ b/dimos/perception/experimental/test_spatial_memory_module.py
@@ -24,7 +24,6 @@ from dimos.core.coordination.module_coordinator import ModuleCoordinator
 from dimos.core.core import rpc
 from dimos.core.module import Module, ModuleConfig
 from dimos.core.stream import Out
-from dimos.core.transport import LCMTransport
 from dimos.core.transport_factory import make_transport
 from dimos.msgs.geometry_msgs.Transform import Transform
 from dimos.msgs.sensor_msgs.Image import Image
@@ -141,7 +140,7 @@ async def test_spatial_memory_module_with_replay(dimos, tmp_path):
     # Deploy modules
     # Video replay module
     video_module = dimos.deploy(VideoReplayModule, video_path=video_path)
-    video_module.video_out.transport = LCMTransport("/test_video", Image)
+    video_module.video_out.transport = make_transport("/test_video", Image)
 
     # Odometry replay module (publishes to tf system directly)
     odom_module = dimos.deploy(OdometryReplayModule, odom_path=odom_path)


### PR DESCRIPTION
## Problem

These tests were failing when running `./bin/pytest-slow`:

```
FAILED dimos/experimental/isolated_python/test_end_to_end.py::test_isolated_python_rpc_refs_and_restart - ExceptionGroup: safe_thread_map failed (1 sub-exception)
FAILED dimos/experimental/isolated_python/test_end_to_end.py::test_example_script_exits_after_printing_results - subprocess.TimeoutExpired: Command '['/home/p/pro/dimensional/dimos/.venv/bin/python', '-m', 'dimos.experimental.isolated_python.example.run']' timed out after 30 seconds
FAILED dimos/hardware/sensors/lidar/livox/test_e2e.py::test_real_capture_replay_publishes_streams - Failed: /home/p/pro/dimensional/dimos/target/release/mid360_native missing; run: cargo build --release -p dimos-livox -p dimos-virtual-mid360
FAILED dimos/hardware/sensors/lidar/livox/test_e2e.py::test_live_loopback_handshake_and_stream - Failed: /home/p/pro/dimensional/dimos/target/release/mid360_native missing; run: cargo build --release -p dimos-livox -p dimos-virtual-mid360
FAILED dimos/perception/experimental/test_spatial_memory_module.py::test_spatial_memory_module_with_replay - AssertionError: No frames processed within 10.0 seconds
```

## Solution

Fix them.
