### PR TITLE
feat(evals): add DimSim apartment QA suite

### DIFF
--- a/benchmarkQA.md
+++ b/benchmarkQA.md
@@ -6,7 +6,7 @@
 4. Universal Relation - Determine whether every object of one class has a stated relationship to another object.
 5. Room Counting - Count the rooms in the house.
 6. Room Size - Ask for either the largest room's name or its approximate area, with one answer per question.
-7. Object Dimensions - Estimate an object's height, length, width, or footprint area.
+7. Object Dimensions - Estimate an object's height, length, width, diagonal, or footprint area.
 8. Boundary Perimeter - Estimate the perimeter of the house or a room.
 9. Doorway Counting - Count doorways connecting specified spaces.
 10. Passage Clearance - Estimate the largest robot radius that fits through specified doorways.
@@ -15,7 +15,7 @@
 13. Room Connectivity - Count the minimum doorway crossings between two rooms.
 14. Clearance Counterfactual - Determine whether a hypothetical object-state change would affect passage through the scene.
 15. Wall Separation - Identify objects on opposite sides of the same wall.
-16. Spatial Ordering - Select the closest object under a specified distance measure; ask straight-line and travel-distance comparisons separately.
+16. Spatial Ordering - Select the closest object or rank objects from nearest to farthest under a specified distance measure.
 17. Coverage Confidence - Determine whether a specified set of observations is sufficient to answer a question.
 
 ### Questions apartment
@@ -46,9 +46,7 @@
    - **Answer type:** Plain count, e.g. `2`; parsed with `first_number()` and compared by value.
    - **Scoring:** Integer count **2** = **1**, otherwise **0**.
 
-7. [Object Counting] How many wall-mounted kitchen cabinets are in the house?
-   - **Answer type:** Plain count, e.g. `3`; parsed with `first_number()` and compared by value.
-   - **Scoring:** Integer count **3** = **1**, otherwise **0**.
+<!-- Q7 (kitchen cabinet count) removed. Keep original question IDs for reference. -->
 
 8. [Universal Relation] Does every work desk in the house have a laptop on it?
    - **Answer type:** Yes/no; return only `yes` or `no`.
@@ -66,9 +64,9 @@
     - **Answer type:** Plain numerical estimate in meters, parsed with `first_number()`.
     - **Scoring:** `numeric(1.80, first_number(answer), tolerance=0.10, band=0.40)`. **1** for **1.70–1.90 m**; linear partial credit out to **1.40/2.20 m**; **0** at or beyond those outer limits.
 
-12. [Object Dimensions] What are the approximate length and width of the dining table, in meters?
-    - **Answer type:** Two positive numbers in meters separated by a comma: `length, width`, e.g. `2.2, 1.1`.
-    - **Scoring:** Parse exactly two comma-separated floats and normalize the larger to length. Average **0.5 × length score + 0.5 × width score**. Length reference **2.20 m**, `tolerance=0.10`, `band=0.40`: full credit **2.10–2.30 m**, zero at or outside **1.80–2.60 m**. Width reference **1.10 m**, `tolerance=0.05`, `band=0.25`: full credit **1.05–1.15 m**, zero at or outside **0.85–1.35 m**. Intermediate errors receive linear partial credit. Swapping the dimensions does not lose points; missing, extra, non-finite, or nonpositive values score zero.
+12. [Object Dimensions] What is the approximate diagonal length of the rectangular dining table, in meters?
+    - **Answer type:** One plain numerical estimate in meters, parsed with `first_number()`.
+    - **Scoring:** `numeric(2.46, first_number(answer), tolerance=0.10, band=0.40)`: full credit **2.36–2.56 m**, linear partial credit out to **2.06/2.86 m**, and **0** at or beyond those outer limits. Uses the standard numerical scorer with no table-specific helper.
 
 13. [Object Dimensions] What is the approximate footprint area of the bed frame, in square meters?
     - **Answer type:** Plain numerical estimate in m², parsed with `first_number()`.
@@ -82,9 +80,9 @@
     - **Answer type:** Plain count, e.g. `2`; parsed with `first_number()` and compared by value.
     - **Scoring:** Integer count **2** = **1**, otherwise **0**, after confirming the two exterior openings correspond to the intended door count.
 
-16. [Passage Clearance] What is the largest robot radius that can fit through all the doorways, in meters?
+16. [Passage Clearance] What is the largest robot radius that can fit through all the doorways in 2D, in meters?
     - **Answer type:** Plain numerical estimate in meters, parsed with `first_number()`.
-    - **Scoring:** **Pending actual-clearance ground truth.** For validated reference radius `r`, propose `numeric(r, first_number(answer), tolerance=0.025, band=0.10)`: full credit within **±2.5 cm**, linear partial credit out to **±10 cm**, then **0**. Do not substitute the structural upper bound for an unvalidated actual-clearance answer.
+    - **Scoring:** `numeric(0.50, first_number(answer), tolerance=0.025, band=0.10)`: full credit **0.475–0.525 m**, linear partial credit out to **0.40/0.60 m**, then **0**. Reference is half the narrowest structural doorway width, using the agreed 2D width-only convention.
 
 17. [Object Displacement] What is the approximate straight-line distance between the refrigerator and television, in meters?
     - **Answer type:** Plain numerical estimate in meters, parsed with `first_number()`.
@@ -101,7 +99,7 @@
 
 20. [Clearance Counterfactual] Would opening the refrigerator change whether a robot of radius 0.25 m can pass from the kitchen doorway to the sink?
     - **Answer type:** Yes/no; return only `yes` or `no`.
-    - **Scoring:** **Pending geometric comparison.** Once expected answer `b` is established as `"yes"` or `"no"`, use `exact(b, yes_no(answer))`: correct = **1**, otherwise **0**. Compare whether a route exists in each state, not merely whether its width or length changes.
+    - **Scoring:** `exact("no", yes_no(answer))`: **no** = **1**, otherwise **0**. User-confirmed reference: opening the refrigerator does not change access to the sink.
 
 21. [Wall Separation] Which pair of objects is on opposite sides of the same wall?
     - **Options:** A) Sofa and television; B) Work desk and bed; C) Refrigerator and work desk; D) Bathtub and toilet.
@@ -113,10 +111,10 @@
     - **Answer type:** Single-choice letter. Return only A, B, or C.
     - **Scoring:** `exact("B", answer.strip().upper())`: **B** = **1**, otherwise **0**. Reference remains provisional until the center-based distance calculation is validated. No partial credit for selecting the second-closest object.
 
-23. [Spatial Ordering] Which object is closest to the sofa by collision-free travel distance for a robot of radius 0.25 m?
+23. [Spatial Ordering] What is the order of these objects from nearest to farthest from the sofa by collision-free travel distance for a robot of radius 0.25 m?
     - **Options:** A) Refrigerator; B) Dining table; C) Work desk.
-    - **Answer type:** Single-choice letter. Return only A, B, or C.
-    - **Scoring:** **Pending path-based ground truth.** Map the validated closest object to its option letter, then use `exact(expected_letter, answer.strip().upper())`: correct = **1**, otherwise **0**. Validate a unique winner before finalizing this single-choice case; if there is a tie, revise the options or explicitly use multi-select. Do not assume Q22's answer applies.
+    - **Answer type:** Complete ordered sequence of labels; return each letter once, e.g. `BCA` or `B, C, A`, with no explanation. Commas, whitespace, and case are normalized; a JSON list is not required or accepted.
+    - **Scoring:** `rank_order("BCA", ranking(answer))`. Each of the three correct pairwise relationships earns **1/3**: B before C, B before A, and C before A. **BCA = 1**; **BAC or CBA = 2/3**; **ABC or CAB = 1/3**; **ACB = 0**. Missing, repeated, extra, or unknown labels score **0**. This rewards mostly correct rankings instead of requiring an all-or-nothing match. The full-credit reference is the same at both tested grid resolutions.
 
 24. [Coverage Confidence] Is observing only the living room and kitchen sufficient to determine how many bedside tables are in the house?
     - **Answer type:** Yes/no; return only `yes` or `no`.
@@ -124,18 +122,19 @@
 
 ### Scoring conventions
 
-- **All references and tolerance bands above are draft for review.** The 21 cases with draft answers are implemented in `dimos/evals/suites/dimsim_apartment_qa.py`; Q16, Q20, and Q23 remain pending. Keep reference values author-side; send only questions, answer-format instructions, and options to the agent. No JSON response is required.
+- **References and tolerance bands remain available for review.** All 23 retained questions are implemented in `dimos/evals/suites/dimsim_apartment_qa.py`. Original question IDs are preserved; Q7 was removed. Q16 uses the agreed 2D width convention, Q20 is user-confirmed, and Q23 has an offline geometric estimate. Keep reference values author-side; send only questions, answer-format instructions, and options to the agent. No JSON response is required.
 - **Parsing and scoring are separate:** Reuse the existing `first_number()` and `yes_no()` parsers. Suite-local `_parsed()` catches parser `ValueError` and assigns zero; scorers compare the resulting typed values. The global parsers retain their existing behavior.
 - **Boolean:** Request `yes` or `no`; use `exact(expected, yes_no(answer))`. The existing parser normalizes case and accepts replies beginning with yes/no, including explanations. A reply of `true`/`false` is not the requested yes/no format and is unparseable by this parser.
 - **Exact count:** Request the count and use `exact(reference, first_number(answer))`. `4`, `4.0`, and prose whose first number is 4 are equivalent. A fractional value such as 4.5 does not match 4. Counts get **1 or 0**, not partial credit.
-- **Single-choice:** Provide labeled options separately from the question and request only one letter. Trim whitespace and uppercase the reply, then exact-match the expected letter. Full option strings, JSON wrappers, explanations, and multiple selections receive zero under this bare-letter contract. Q1, Q2, Q18, Q21, Q22, and Q23 use this format.
+- **Single-choice:** Provide labeled options separately from the question and request only one letter. Trim whitespace and uppercase the reply, then exact-match the expected letter. Full option strings, JSON wrappers, explanations, and multiple selections receive zero under this bare-letter contract. Q1, Q2, Q18, Q21, and Q22 use this format.
+- **Ranking (Q23):** Parse letter sequences with `ranking()`, then compare typed sequences with `rank_order()`. A valid answer must be a complete permutation of the options. Score is the fraction of correctly ordered pairs; for N objects there are `N × (N - 1) / 2` pairs. Order matters, unlike multi-select. Only the fully correct order reaches the default pass threshold of 1.0.
 - **Choice design:** Use plausible alternatives of the same kind and exactly one correct option. Use two or three options when natural rather than padding to four. Balance correct-answer positions across the suite after references are validated. Keep option order identical across harnesses; any shuffle must be reproducibly seeded and update the reference-letter mapping. Measurements retain numerical answers and tolerance scoring rather than multiple-choice ranges.
 - **Numerical estimate:** Use `numeric(reference, first_number(answer), tolerance=t, band=b)`. Let `e = abs(value - reference)`: score **1** for `e <= t`, **(b - e) / (b - t)** for `t < e < b`, and **0** for `e >= b`. Non-finite observations score zero. A small rounding allowance handles decimal endpoints without consuming a meaningful portion of the band. `numeric()` is a general typed-value scorer, so negative values are not inherently invalid; negative measurements fall outside every active case's accepted band. Units are those requested by the question; there is no unit conversion.
 - **Parser limits:** `first_number()` uses the existing decimal-number extraction, not a strict whole-answer validator. Ask for ordinary decimal notation without thousands separators or scientific notation; do not assume the parser understands those formats. Unparseable responses score zero. These parser semantics are shared with existing evals rather than changed globally by this suite.
 - **Example:** For reference **400**, `tolerance=10`, `band=50`: **390–410** gets **1**; **370 or 430** gets **0.5**; **350 or 450**, and anything farther away, gets **0**. Partial credit varies continuously with error.
-- **Two measurements (Q12):** Parse exactly two comma-separated positive finite numbers, normalize length/width ordering, score each independently, then average. A completely wrong dimension and a fully correct other dimension give **0.5**; both must be within their tolerances for full credit.
+- **Table diagonal (Q12):** One numerical measurement, scored just like height or distance. The reference is the horizontal corner-to-corner diagonal, not a 3D bounding-box diagonal including table height.
 - **Multi-select:** None of the current questions requests multiple selections; no multi-select parser or scorer is added.
-- **Unvalidated references:** Leave the case ungraded until its reference is approved; do not assign a fabricated expected answer or score all attempts zero. This applies especially to Q16, Q20, and Q23.
+- **Reference status:** Draft-reference tags identify cases still needing human review. Q23's ranking is supported by an approximate offline path calculation, not a live simulator traversal.
 - **Pass/fail:** A proposed `EvalCase.threshold=1.0` means only full-credit answers pass. Partial scores remain available for aggregate comparison and diagnosis.
 
 ### Other questions
@@ -169,23 +168,24 @@ Reference conventions, kept out of the question wording:
 | 4 | **Candidate: false; validate visually before use.** | No washing-machine entry in the manifest; there is a dishwasher. Manifest absence alone does not exclude an object embedded in another GLB or the static structure. |
 | 5 | **4.** | Four `Dining chair` entries. |
 | 6 | **2.** | Two `Bedside table` entries referencing the same asset-state files. |
-| 7 | **3.** | Three `kitchen wall cabinet` entries, distinct from three base cabinets. |
 | 8 | **Candidate: true.** | One work desk and one laptop. Horizontal anchors are approximately `(-1.730, -0.433)` and `(-1.700, -0.410)`; the laptop is above the desktop. Validate the rendered support relationship. With only one qualifying desk this is a weak test of universal reasoning. |
 | 9 | **4.** | Living/dining, kitchen, bedroom, bathroom. Main partition near scene `z=0`, kitchen partition at `x=-2` on the positive-Z side, bathroom partition at `x=1` on the negative-Z side. The #3879 mapping-suite reference also uses four. Validate semantic room boundaries. |
 | 10 | **Approximately 37.8 m².** | The largest room is living/dining, but the requested answer is only its area. Approximate inside-face bounds: scene X `[-1.925, 5.9]`, Z `[0.075, 4.9]`; `7.825 × 4.825 = 37.755625`. A small offset of the main-left wall makes this approximate; validate the final floor polygon. Wall-centerline dimensions give 40 m², relevant when setting a reasonable estimation tolerance. |
 | 11 | **Approximately 1.801 m.** | Closed refrigerator GLB vertical extent `1.80074978 m`; placement scale is one. Appliance height rather than its center elevation. |
-| 12 | **Approximately 2.20 m × 1.10 m.** | Selected dining-table GLB horizontal extents; placement scale is one. |
+| 12 | **Approximately 2.46 m.** | Selected dining-table GLB horizontal extents are `2.20 × 1.10 m`, with unit placement scale. Rectangular footprint diagonal: `sqrt(2.20² + 1.10²) ≈ 2.45967 m`. |
 | 13 | **Approximately 3.52 m².** | Complete bed-frame GLB horizontal extents approximately `1.60 × 2.20 m`, including the headboard. Rectangular footprint, not mattress area or mesh surface area. |
 | 14 | **Approximately 44 m using the floor-slab outline.** | `apartment-floor` spans scene X `[-6, 6]`, Z `[-5, 5]`: `2 × (12 + 10)`. The outside faces of the 0.2 m thick exterior walls give an approximate rectangular envelope of `12.2 × 10.2 m`, or 44.8 m perimeter. Validate the intended boundary and tolerance for the broader house-perimeter wording; exclude the yard. |
 | 15 | **2 exterior openings; validate the rendered door interpretation.** | Openings under `wall-south-header-entrance` and `wall-south-header-sliding` connect the house to the yard. The earlier total of five also counted three interior openings, which this question no longer asks about. |
-| 16 | **Structural upper bound: approximately 0.50 m radius; actual passable radius pending validation.** | Structural openings are approximately `1, 1, 1, 1, 2 m` wide, so half the minimum width is `0.50 m`. Positive clearance requires a smaller radius. The short question no longer excludes panels or furniture, so check the actual bottleneck before using this as a final ground truth. A tolerance alone does not establish actual passability. |
+| 16 | **0.50 m radius.** | Agreed 2D width-only definition: openings are approximately `1, 1, 1, 1, 2 m` wide; `min(widths) / 2 = 0.50 m`. No height, furniture-route, or live motion analysis is part of this question. |
 | 17 | **Approximately 8.37 m horizontally, using asset anchors as center proxies.** | Refrigerator-to-TV scene-plane displacement approximately `(ΔX, ΔZ) = (+7.139, +4.361) m`; distance `8.36548 m`. ROS horizontal displacement is `(+4.361, +7.139) m`. Validate geometric centers. Height difference is approximately 0.659 m, so a 3D interpretation gives approximately 8.39 m; account for this when setting tolerance. |
 | 18 | **Closed.** | Refrigerator `currentStateId=state-default`, state name `closed`. |
 | 19 | **Candidate: 3 crossings.** | The structural room graph suggests kitchen → living/dining → bedroom → bathroom. Validate the passage connectivity against the full geometry; this is a topological count, not a measured route length. |
-| 20 | **Pending geometric validation.** | Compare the closed and open refrigerator geometry with the sink approach and a 0.25 m circular footprint. Do not infer the answer from the existence of an open-state asset alone. |
+| 20 | **No.** | User validated that opening the refrigerator does not change access to the sink. This reference was supplied by the user, not derived from the offline path calculation. |
 | 21 | **Candidate: C, refrigerator and work desk.** | The refrigerator is at scene Z approximately `+0.519` and the desk at `-0.433`, on opposite sides of the main-left partition near `z=0`. Their connecting line crosses that partition. The other pairs occupy the same respective room. Validate against the rendered scene. This is wall separation, not viewpoint-dependent occlusion. |
 | 22 | **Candidate: dining table.** | Manifest anchors put the table approximately 5.49 m from the sofa, versus approximately 6.29 m for the desk and 7.04 m for the refrigerator in the horizontal plane. Validate geometric centers before finalizing. |
-| 23 | **Pending path computation.** | Requires shortest collision-free paths and consistent reachable approach points around the sofa and each candidate object; object centers themselves can lie inside obstacles. Do not reuse the straight-line answer without checking. |
+| 23 | **BCA — Dining table → work desk → refrigerator (offline geometric estimate).** | Using a 0.25 m circular footprint, shortest paths between reachable sofa/target approach regions give the same order at both resolutions: **5 cm grid:** table 1.55 m, desk 3.47 m, refrigerator 3.84 m; **2.5 cm grid:** table 1.54 m, desk 3.10 m, refrigerator 3.81 m. See the computation convention below. |
 | 24 | **Candidate: false.** | The bedside tables are in the bedroom. This tests evidence sufficiency, not the total count itself. Validate the restricted observation set: it must not already reveal both tables through a doorway or provide an earlier complete-house view. |
 
-All references remain draft for user validation. Questions with pending geometry or observation checks should not receive fixed-answer scorers until those checks are complete. Expected answer types are single-choice letters, booleans, counts, or numerical measurements; none requires a descriptive essay or evidence narrative.
+Q23 computation convention: load `structure.glb` and all 87 placed manifest assets in their selected states, applying GLB node transforms and placement transforms. Conservatively project triangles intersecting the body-height slab **scene Y=0.12–0.90 m** onto the horizontal plane. Rasterize at **0.05 m and 0.025 m**, inflate obstacles by **0.25 m** plus a half-cell-diagonal discretization allowance, and run multi-source eight-neighbor Dijkstra with diagonal corner-cutting prohibited. Approach regions are free robot-center positions within **0.75 m of each asset's horizontal bounding box**. The distance is the minimum between the sofa approach region and each target approach region, not a path between centers inside furniture. Restrict paths to the house envelope. These conservative projected-geometry estimates establish a clear winning option under this convention; they are not exact Rapier collision distances. In particular, the desk distance changes with grid resolution, while the table remains clearly closest. The runner's actual robot height or a fixed start on a particular side of the sofa would define a different metric and should not silently replace this convention.
+
+Expected answer types are single-choice letters, ordered letter sequences, yes/no, counts, or numerical measurements; none requires a descriptive essay or evidence narrative. Remaining provisional references are labeled for user validation.

--- a/benchmarkQA.md
+++ b/benchmarkQA.md
@@ -1,0 +1,191 @@
+### Templates
+
+1. Object Location - Identify which room contains a named object.
+2. Object Existence - Determine whether a specified object exists in the house.
+3. Object Counting - Count instances of a specified object class.
+4. Universal Relation - Determine whether every object of one class has a stated relationship to another object.
+5. Room Counting - Count the rooms in the house.
+6. Room Size - Ask for either the largest room's name or its approximate area, with one answer per question.
+7. Object Dimensions - Estimate an object's height, length, width, or footprint area.
+8. Boundary Perimeter - Estimate the perimeter of the house or a room.
+9. Doorway Counting - Count doorways connecting specified spaces.
+10. Passage Clearance - Estimate the largest robot radius that fits through specified doorways.
+11. Object Displacement - Estimate straight-line distance or displacement between two objects.
+12. Object State - Identify an object's state in the static scene.
+13. Room Connectivity - Count the minimum doorway crossings between two rooms.
+14. Clearance Counterfactual - Determine whether a hypothetical object-state change would affect passage through the scene.
+15. Wall Separation - Identify objects on opposite sides of the same wall.
+16. Spatial Ordering - Select the closest object under a specified distance measure; ask straight-line and travel-distance comparisons separately.
+17. Coverage Confidence - Determine whether a specified set of observations is sufficient to answer a question.
+
+### Questions apartment
+
+1. [Object Location] Which room contains the refrigerator?
+   - **Options:** A) Bedroom; B) Kitchen; C) Bathroom; D) Living room.
+   - **Answer type:** Single-choice letter. Return only A, B, C, or D.
+   - **Scoring:** `exact("B", answer.strip().upper())`: **B** = **1**, otherwise **0**.
+
+2. [Object Location] Which room contains the work desk?
+   - **Options:** A) Kitchen; B) Bathroom; C) Living room; D) Bedroom.
+   - **Answer type:** Single-choice letter. Return only A, B, C, or D.
+   - **Scoring:** `exact("D", answer.strip().upper())`: **D** = **1**, otherwise **0**.
+
+3. [Object Existence] Does the house contain a bathtub?
+   - **Answer type:** Yes/no; return only `yes` or `no`.
+   - **Scoring:** `exact("yes", yes_no(answer))`: correct = **1**, incorrect or unparseable = **0**.
+
+4. [Object Existence] Does the house contain a washing machine?
+   - **Answer type:** Yes/no; return only `yes` or `no`.
+   - **Scoring:** After validating absence, `exact("no", yes_no(answer))`: correct = **1**, otherwise **0**. **Reference remains provisional.**
+
+5. [Object Counting] How many dining chairs are in the house?
+   - **Answer type:** Plain count, e.g. `4`; parsed with `first_number()` and compared by value.
+   - **Scoring:** Integer count **4** = **1**, any other count = **0**. No partial credit for these small, discrete counts.
+
+6. [Object Counting] How many bedside tables are in the house?
+   - **Answer type:** Plain count, e.g. `2`; parsed with `first_number()` and compared by value.
+   - **Scoring:** Integer count **2** = **1**, otherwise **0**.
+
+7. [Object Counting] How many wall-mounted kitchen cabinets are in the house?
+   - **Answer type:** Plain count, e.g. `3`; parsed with `first_number()` and compared by value.
+   - **Scoring:** Integer count **3** = **1**, otherwise **0**.
+
+8. [Universal Relation] Does every work desk in the house have a laptop on it?
+   - **Answer type:** Yes/no; return only `yes` or `no`.
+   - **Scoring:** After validating the support relationship, `exact("yes", yes_no(answer))`: correct = **1**, otherwise **0**. **Reference remains provisional.**
+
+9. [Room Counting] How many rooms are in the house?
+   - **Answer type:** Plain count, e.g. `4`; parsed with `first_number()` and compared by value.
+   - **Scoring:** Integer count **4** = **1**, otherwise **0**, once the room-count convention is approved. No partial credit.
+
+10. [Room Size] What is the approximate area of the largest room, in square meters?
+    - **Answer type:** Plain numerical estimate in m², parsed with `first_number()`.
+    - **Scoring:** `numeric(37.8, first_number(answer), tolerance=2.5, band=8.0)`. **1** for **35.3–40.3 m²**; linear partial credit out to **29.8/45.8 m²**; **0** at or beyond those outer limits. Validate the floor polygon before finalizing the reference.
+
+11. [Object Dimensions] What is the approximate height of the refrigerator, in meters?
+    - **Answer type:** Plain numerical estimate in meters, parsed with `first_number()`.
+    - **Scoring:** `numeric(1.80, first_number(answer), tolerance=0.10, band=0.40)`. **1** for **1.70–1.90 m**; linear partial credit out to **1.40/2.20 m**; **0** at or beyond those outer limits.
+
+12. [Object Dimensions] What are the approximate length and width of the dining table, in meters?
+    - **Answer type:** Two positive numbers in meters separated by a comma: `length, width`, e.g. `2.2, 1.1`.
+    - **Scoring:** Parse exactly two comma-separated floats and normalize the larger to length. Average **0.5 × length score + 0.5 × width score**. Length reference **2.20 m**, `tolerance=0.10`, `band=0.40`: full credit **2.10–2.30 m**, zero at or outside **1.80–2.60 m**. Width reference **1.10 m**, `tolerance=0.05`, `band=0.25`: full credit **1.05–1.15 m**, zero at or outside **0.85–1.35 m**. Intermediate errors receive linear partial credit. Swapping the dimensions does not lose points; missing, extra, non-finite, or nonpositive values score zero.
+
+13. [Object Dimensions] What is the approximate footprint area of the bed frame, in square meters?
+    - **Answer type:** Plain numerical estimate in m², parsed with `first_number()`.
+    - **Scoring:** `numeric(3.52, first_number(answer), tolerance=0.25, band=1.0)`. **1** for **3.27–3.77 m²**; linear partial credit out to **2.52/4.52 m²**; **0** at or beyond those outer limits.
+
+14. [Boundary Perimeter] What is the approximate perimeter of the house, in meters?
+    - **Answer type:** Plain numerical estimate in meters, parsed with `first_number()`.
+    - **Scoring:** `numeric(44.0, first_number(answer), tolerance=1.0, band=5.0)`. **1** for **43–45 m**, covering both the slab outline and outer-wall envelope. Linear partial credit out to **39/49 m**; **0** at or beyond those outer limits. Confirm the house boundary before finalizing.
+
+15. [Doorway Counting] How many doors connect the house to the yard?
+    - **Answer type:** Plain count, e.g. `2`; parsed with `first_number()` and compared by value.
+    - **Scoring:** Integer count **2** = **1**, otherwise **0**, after confirming the two exterior openings correspond to the intended door count.
+
+16. [Passage Clearance] What is the largest robot radius that can fit through all the doorways, in meters?
+    - **Answer type:** Plain numerical estimate in meters, parsed with `first_number()`.
+    - **Scoring:** **Pending actual-clearance ground truth.** For validated reference radius `r`, propose `numeric(r, first_number(answer), tolerance=0.025, band=0.10)`: full credit within **±2.5 cm**, linear partial credit out to **±10 cm**, then **0**. Do not substitute the structural upper bound for an unvalidated actual-clearance answer.
+
+17. [Object Displacement] What is the approximate straight-line distance between the refrigerator and television, in meters?
+    - **Answer type:** Plain numerical estimate in meters, parsed with `first_number()`.
+    - **Scoring:** `numeric(8.37, first_number(answer), tolerance=0.30, band=1.50)`. **1** for **8.07–8.67 m**; linear partial credit out to **6.87/9.87 m**; **0** at or beyond those outer limits. Validate the object-center convention before finalizing.
+
+18. [Object State] Is the refrigerator open or closed?
+    - **Options:** A) Closed; B) Open.
+    - **Answer type:** Single-choice letter. Return only A or B.
+    - **Scoring:** `exact("A", answer.strip().upper())`: **A** = **1**, otherwise **0**.
+
+19. [Room Connectivity] What is the minimum number of doorway crossings between the kitchen and bathroom without leaving the house?
+    - **Answer type:** Plain count, e.g. `3`; parsed with `first_number()` and compared by value.
+    - **Scoring:** Provisional integer count **3** = **1**, otherwise **0**. Finalize only after checking the room-connectivity reference; no partial credit for crossing count.
+
+20. [Clearance Counterfactual] Would opening the refrigerator change whether a robot of radius 0.25 m can pass from the kitchen doorway to the sink?
+    - **Answer type:** Yes/no; return only `yes` or `no`.
+    - **Scoring:** **Pending geometric comparison.** Once expected answer `b` is established as `"yes"` or `"no"`, use `exact(b, yes_no(answer))`: correct = **1**, otherwise **0**. Compare whether a route exists in each state, not merely whether its width or length changes.
+
+21. [Wall Separation] Which pair of objects is on opposite sides of the same wall?
+    - **Options:** A) Sofa and television; B) Work desk and bed; C) Refrigerator and work desk; D) Bathtub and toilet.
+    - **Answer type:** Single-choice letter. Return only A, B, C, or D.
+    - **Scoring:** `exact("C", answer.strip().upper())`: **C** = **1**, otherwise **0**, after validating the pair geometry. A list of several options is invalid; this is not multi-select.
+
+22. [Spatial Ordering] Which object is closest to the sofa by straight-line distance?
+    - **Options:** A) Refrigerator; B) Dining table; C) Work desk.
+    - **Answer type:** Single-choice letter. Return only A, B, or C.
+    - **Scoring:** `exact("B", answer.strip().upper())`: **B** = **1**, otherwise **0**. Reference remains provisional until the center-based distance calculation is validated. No partial credit for selecting the second-closest object.
+
+23. [Spatial Ordering] Which object is closest to the sofa by collision-free travel distance for a robot of radius 0.25 m?
+    - **Options:** A) Refrigerator; B) Dining table; C) Work desk.
+    - **Answer type:** Single-choice letter. Return only A, B, or C.
+    - **Scoring:** **Pending path-based ground truth.** Map the validated closest object to its option letter, then use `exact(expected_letter, answer.strip().upper())`: correct = **1**, otherwise **0**. Validate a unique winner before finalizing this single-choice case; if there is a tie, revise the options or explicitly use multi-select. Do not assume Q22's answer applies.
+
+24. [Coverage Confidence] Is observing only the living room and kitchen sufficient to determine how many bedside tables are in the house?
+    - **Answer type:** Yes/no; return only `yes` or `no`.
+    - **Scoring:** Provisional `exact("no", yes_no(answer))`: correct = **1**, otherwise **0**. Requires validation of the observation premise described in the reference notes.
+
+### Scoring conventions
+
+- **All references and tolerance bands above are draft for review.** The 21 cases with draft answers are implemented in `dimos/evals/suites/dimsim_apartment_qa.py`; Q16, Q20, and Q23 remain pending. Keep reference values author-side; send only questions, answer-format instructions, and options to the agent. No JSON response is required.
+- **Parsing and scoring are separate:** Reuse the existing `first_number()` and `yes_no()` parsers. Suite-local `_parsed()` catches parser `ValueError` and assigns zero; scorers compare the resulting typed values. The global parsers retain their existing behavior.
+- **Boolean:** Request `yes` or `no`; use `exact(expected, yes_no(answer))`. The existing parser normalizes case and accepts replies beginning with yes/no, including explanations. A reply of `true`/`false` is not the requested yes/no format and is unparseable by this parser.
+- **Exact count:** Request the count and use `exact(reference, first_number(answer))`. `4`, `4.0`, and prose whose first number is 4 are equivalent. A fractional value such as 4.5 does not match 4. Counts get **1 or 0**, not partial credit.
+- **Single-choice:** Provide labeled options separately from the question and request only one letter. Trim whitespace and uppercase the reply, then exact-match the expected letter. Full option strings, JSON wrappers, explanations, and multiple selections receive zero under this bare-letter contract. Q1, Q2, Q18, Q21, Q22, and Q23 use this format.
+- **Choice design:** Use plausible alternatives of the same kind and exactly one correct option. Use two or three options when natural rather than padding to four. Balance correct-answer positions across the suite after references are validated. Keep option order identical across harnesses; any shuffle must be reproducibly seeded and update the reference-letter mapping. Measurements retain numerical answers and tolerance scoring rather than multiple-choice ranges.
+- **Numerical estimate:** Use `numeric(reference, first_number(answer), tolerance=t, band=b)`. Let `e = abs(value - reference)`: score **1** for `e <= t`, **(b - e) / (b - t)** for `t < e < b`, and **0** for `e >= b`. Non-finite observations score zero. A small rounding allowance handles decimal endpoints without consuming a meaningful portion of the band. `numeric()` is a general typed-value scorer, so negative values are not inherently invalid; negative measurements fall outside every active case's accepted band. Units are those requested by the question; there is no unit conversion.
+- **Parser limits:** `first_number()` uses the existing decimal-number extraction, not a strict whole-answer validator. Ask for ordinary decimal notation without thousands separators or scientific notation; do not assume the parser understands those formats. Unparseable responses score zero. These parser semantics are shared with existing evals rather than changed globally by this suite.
+- **Example:** For reference **400**, `tolerance=10`, `band=50`: **390–410** gets **1**; **370 or 430** gets **0.5**; **350 or 450**, and anything farther away, gets **0**. Partial credit varies continuously with error.
+- **Two measurements (Q12):** Parse exactly two comma-separated positive finite numbers, normalize length/width ordering, score each independently, then average. A completely wrong dimension and a fully correct other dimension give **0.5**; both must be within their tolerances for full credit.
+- **Multi-select:** None of the current questions requests multiple selections; no multi-select parser or scorer is added.
+- **Unvalidated references:** Leave the case ungraded until its reference is approved; do not assign a fabricated expected answer or score all attempts zero. This applies especially to Q16, Q20, and Q23.
+- **Pass/fail:** A proposed `EvalCase.threshold=1.0` means only full-credit answers pass. Partial scores remain available for aggregate comparison and diagnosis.
+
+### Other questions
+
+### Ground truths apartment
+
+Author-only draft references for user validation. The questions request answers, not movement or observation procedures. They are independent of dimOS tools and are not executable EvalCases. Keep source data and reference answers separate from the evaluated agent's context.
+
+Sources inspected at checkout commit `c5b78bd9a23344db91a59aabdd7f7db614998ab8`:
+
+- `misc/DimSim/scenes/apartment/index.js`: assembly, structure loading, object manifest loading, and authored spawn.
+- `misc/DimSim/scenes/apartment/objects/manifest.json`: 87 placed asset entries, transforms, and selected states.
+- `misc/DimSim/scenes/apartment/structure.glb`: named structural meshes, node transforms, and position bounds.
+- Selected object-state GLBs: scene-graph bounding extents, including internal node transforms. The measured refrigerator, dining table, and bed have unit placement scale; the table and bed are rotated 90 degrees around the vertical axis, which does not change their length/width or footprint area.
+
+Reference conventions, kept out of the question wording:
+
+- Scene coordinates are **Three.js coordinates**, in meters: X/Z horizontal, Y up. The bridge maps them to ROS coordinates as `(x, y, z) -> (z, x, y)`.
+- The authored spawn is `(2, 0.5, 3)`, not the origin. The runner handles the agreed common start and any origin rebasing. Source positions below remain in the authored frame.
+- The benchmark scene stays static. State answers refer to the selected states in the manifest; no state-change episodes are required. Question 20 asks about a hypothetical change, not an actual state-changing task.
+- Count interior rooms, with the open-plan living/dining area treated as one room and the yard excluded. Count physical object instances, not meshes or alternate state files.
+- Room area is floor area between inside wall faces, including furniture-occupied floor. Object dimensions use complete asset bounds; the bed footprint includes the headboard but excludes separate furniture and loose bedding.
+- Distance references below use horizontal object-center distance. Placed asset anchors are preliminary center proxies, requiring validation. Doorway-radius calculations assume a circular footprint; actual traversability also depends on door panels, furniture, and height.
+- Numerical tolerances are for the user to validate. Source precision below is not required answer precision. If different reasonable interpretations of a short question produce materially different answers, accept the relevant range or clarify that question before scoring.
+
+| Question | Draft ground truth | Evidence and validation needed |
+|---|---|---|
+| 1 | **Kitchen.** | Refrigerator asset `b500b00d33e638-19c735e91d7`, scene anchor approximately `(-2.639, 0.988, 0.519)`, lies on the kitchen side of the partition. Grade room identification, not navigation. |
+| 2 | **Bedroom.** | Work-desk asset `bc6db6f4cbd0a-19c732ef8c8`, scene anchor approximately `(-1.730, 0.465, -0.433)`. Grade room identification, not navigation. |
+| 3 | **True.** | One placed bathtub entry: `Freestanding oval soaking bathtub with chrome fl...`. |
+| 4 | **Candidate: false; validate visually before use.** | No washing-machine entry in the manifest; there is a dishwasher. Manifest absence alone does not exclude an object embedded in another GLB or the static structure. |
+| 5 | **4.** | Four `Dining chair` entries. |
+| 6 | **2.** | Two `Bedside table` entries referencing the same asset-state files. |
+| 7 | **3.** | Three `kitchen wall cabinet` entries, distinct from three base cabinets. |
+| 8 | **Candidate: true.** | One work desk and one laptop. Horizontal anchors are approximately `(-1.730, -0.433)` and `(-1.700, -0.410)`; the laptop is above the desktop. Validate the rendered support relationship. With only one qualifying desk this is a weak test of universal reasoning. |
+| 9 | **4.** | Living/dining, kitchen, bedroom, bathroom. Main partition near scene `z=0`, kitchen partition at `x=-2` on the positive-Z side, bathroom partition at `x=1` on the negative-Z side. The #3879 mapping-suite reference also uses four. Validate semantic room boundaries. |
+| 10 | **Approximately 37.8 m².** | The largest room is living/dining, but the requested answer is only its area. Approximate inside-face bounds: scene X `[-1.925, 5.9]`, Z `[0.075, 4.9]`; `7.825 × 4.825 = 37.755625`. A small offset of the main-left wall makes this approximate; validate the final floor polygon. Wall-centerline dimensions give 40 m², relevant when setting a reasonable estimation tolerance. |
+| 11 | **Approximately 1.801 m.** | Closed refrigerator GLB vertical extent `1.80074978 m`; placement scale is one. Appliance height rather than its center elevation. |
+| 12 | **Approximately 2.20 m × 1.10 m.** | Selected dining-table GLB horizontal extents; placement scale is one. |
+| 13 | **Approximately 3.52 m².** | Complete bed-frame GLB horizontal extents approximately `1.60 × 2.20 m`, including the headboard. Rectangular footprint, not mattress area or mesh surface area. |
+| 14 | **Approximately 44 m using the floor-slab outline.** | `apartment-floor` spans scene X `[-6, 6]`, Z `[-5, 5]`: `2 × (12 + 10)`. The outside faces of the 0.2 m thick exterior walls give an approximate rectangular envelope of `12.2 × 10.2 m`, or 44.8 m perimeter. Validate the intended boundary and tolerance for the broader house-perimeter wording; exclude the yard. |
+| 15 | **2 exterior openings; validate the rendered door interpretation.** | Openings under `wall-south-header-entrance` and `wall-south-header-sliding` connect the house to the yard. The earlier total of five also counted three interior openings, which this question no longer asks about. |
+| 16 | **Structural upper bound: approximately 0.50 m radius; actual passable radius pending validation.** | Structural openings are approximately `1, 1, 1, 1, 2 m` wide, so half the minimum width is `0.50 m`. Positive clearance requires a smaller radius. The short question no longer excludes panels or furniture, so check the actual bottleneck before using this as a final ground truth. A tolerance alone does not establish actual passability. |
+| 17 | **Approximately 8.37 m horizontally, using asset anchors as center proxies.** | Refrigerator-to-TV scene-plane displacement approximately `(ΔX, ΔZ) = (+7.139, +4.361) m`; distance `8.36548 m`. ROS horizontal displacement is `(+4.361, +7.139) m`. Validate geometric centers. Height difference is approximately 0.659 m, so a 3D interpretation gives approximately 8.39 m; account for this when setting tolerance. |
+| 18 | **Closed.** | Refrigerator `currentStateId=state-default`, state name `closed`. |
+| 19 | **Candidate: 3 crossings.** | The structural room graph suggests kitchen → living/dining → bedroom → bathroom. Validate the passage connectivity against the full geometry; this is a topological count, not a measured route length. |
+| 20 | **Pending geometric validation.** | Compare the closed and open refrigerator geometry with the sink approach and a 0.25 m circular footprint. Do not infer the answer from the existence of an open-state asset alone. |
+| 21 | **Candidate: C, refrigerator and work desk.** | The refrigerator is at scene Z approximately `+0.519` and the desk at `-0.433`, on opposite sides of the main-left partition near `z=0`. Their connecting line crosses that partition. The other pairs occupy the same respective room. Validate against the rendered scene. This is wall separation, not viewpoint-dependent occlusion. |
+| 22 | **Candidate: dining table.** | Manifest anchors put the table approximately 5.49 m from the sofa, versus approximately 6.29 m for the desk and 7.04 m for the refrigerator in the horizontal plane. Validate geometric centers before finalizing. |
+| 23 | **Pending path computation.** | Requires shortest collision-free paths and consistent reachable approach points around the sofa and each candidate object; object centers themselves can lie inside obstacles. Do not reuse the straight-line answer without checking. |
+| 24 | **Candidate: false.** | The bedside tables are in the bedroom. This tests evidence sufficiency, not the total count itself. Validate the restricted observation set: it must not already reveal both tables through a doorway or provide an earlier complete-house view. |
+
+All references remain draft for user validation. Questions with pending geometry or observation checks should not receive fixed-answer scorers until those checks are complete. Expected answer types are single-choice letters, booleans, counts, or numerical measurements; none requires a descriptive essay or evidence narrative.

--- a/dimos/evals/scorers.py
+++ b/dimos/evals/scorers.py
@@ -27,6 +27,7 @@ subclass): factories return evaluators called with
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
+import math
 from typing import TypeVar
 
 T = TypeVar("T")
@@ -34,6 +35,26 @@ T = TypeVar("T")
 
 def exact(expected: T, got: T) -> float:
     return float(expected == got)
+
+
+def numeric(expected: float, got: float, *, tolerance: float, band: float) -> float:
+    """Compare numbers: full credit within tolerance, linear to zero at band.
+
+    Parse model text separately, e.g. with ``first_number``. Non-finite
+    observations receive zero; invalid scoring parameters raise ValueError.
+    """
+    if not all(math.isfinite(v) for v in (expected, tolerance, band)) or not 0 <= tolerance < band:
+        raise ValueError("Require finite reference and 0 <= tolerance < band")
+    if not math.isfinite(got):
+        return 0.0
+    error = abs(got - expected)
+    # Allow only a few floating-point ULPs, capped relative to the score band.
+    rounding = min(4 * max(math.ulp(got), math.ulp(expected)), (band - tolerance) * 1e-12)
+    if error <= tolerance or abs(error - tolerance) <= rounding:
+        return 1.0
+    if error >= band or abs(error - band) <= rounding:
+        return 0.0
+    return max(0.0, min(1.0, (band - error) / (band - tolerance)))
 
 
 # -- parsers (model text -> typed answer) -----------------------------------------

--- a/dimos/evals/scorers.py
+++ b/dimos/evals/scorers.py
@@ -37,6 +37,21 @@ def exact(expected: T, got: T) -> float:
     return float(expected == got)
 
 
+def rank_order(expected: Sequence[str], got: Sequence[str]) -> float:
+    """Fraction of correctly ordered pairs in a complete, unique-label ranking."""
+    if len(expected) < 2 or len(set(expected)) != len(expected):
+        raise ValueError("Expected ranking must contain at least two unique labels")
+    if len(got) != len(expected) or set(got) != set(expected):
+        return 0.0
+    positions = {label: i for i, label in enumerate(got)}
+    correct = sum(
+        positions[left] < positions[right]
+        for i, left in enumerate(expected)
+        for right in expected[i + 1 :]
+    )
+    return correct / (len(expected) * (len(expected) - 1) / 2)
+
+
 def numeric(expected: float, got: float, *, tolerance: float, band: float) -> float:
     """Compare numbers: full credit within tolerance, linear to zero at band.
 
@@ -58,6 +73,14 @@ def numeric(expected: float, got: float, *, tolerance: float, band: float) -> fl
 
 
 # -- parsers (model text -> typed answer) -----------------------------------------
+
+
+def ranking(text: str) -> tuple[str, ...]:
+    """Parse single-letter labels, contiguous or separated by commas/whitespace.
+
+    Vocabulary, completeness, and uniqueness are checked by ``rank_order``.
+    """
+    return tuple(c for c in text.strip().upper() if c != "," and not c.isspace())
 
 
 def first_number(text: str) -> float:

--- a/dimos/evals/suites/dimsim_apartment_qa.py
+++ b/dimos/evals/suites/dimsim_apartment_qa.py
@@ -23,16 +23,18 @@ horizontal asset-center proxies. Tolerances are draft, not measurement precision
 Each case starts a fresh simulation with the authored spawn and static states.
 The runner/agent adapter owns tool access; prompts do not prescribe a navigation API.
 
-Pending references (not scored): maximum passable radius, refrigerator-open
-passability change, and closest object by collision-free travel distance.
+Doorway radius uses the agreed 2D width-only convention (minimum width / 2).
+Refrigerator-open passability is user-validated. Closest-by-route uses offline
+projected geometry: radius 0.25 m, body slab scene Y=0.12..0.9 m, and reachable
+regions within 0.75 m of each object's horizontal bounding box. The dining table
+wins at both 0.05 m and 0.025 m grid resolution; distances are approximate.
 """
 
 from collections.abc import Callable
-import math
 from typing import TypeVar
 
 from dimos.evals.environments.sim import Sim
-from dimos.evals.scorers import exact, first_number, numeric, yes_no
+from dimos.evals.scorers import exact, first_number, numeric, rank_order, ranking, yes_no
 from dimos.evals.types import EvalCase, Outcome, Suite
 
 T = TypeVar("T")
@@ -60,21 +62,6 @@ def _environment() -> Sim:
     )
 
 
-def _table_dimensions(o: Outcome) -> float:
-    """Accept swapped dimensions, but require both finite positive measurements."""
-    try:
-        length, width = sorted(
-            (float(v.strip()) for v in o.trajectory.final_answer.split(",")), reverse=True
-        )
-        if not all(math.isfinite(v) and v > 0 for v in (length, width)):
-            return 0.0
-    except ValueError:
-        return 0.0
-    return 0.5 * numeric(2.2, length, tolerance=0.1, band=0.4) + 0.5 * numeric(
-        1.1, width, tolerance=0.05, band=0.25
-    )
-
-
 SUITE: Suite = [
     EvalCase(
         id="dimsim_apartment_refrigerator_location",
@@ -82,7 +69,7 @@ SUITE: Suite = [
         environment=_environment(),
         grade=lambda o: exact("B", o.trajectory.final_answer.strip().upper()),
         timeout_s=1200.0,
-        tags=frozenset({"dimsim", "apartment", "qa", "object-location", "single-choice"}),
+        tags=frozenset({"object-location", "single-choice"}),
     ),
     EvalCase(
         id="dimsim_apartment_work_desk_location",
@@ -90,7 +77,7 @@ SUITE: Suite = [
         environment=_environment(),
         grade=lambda o: exact("D", o.trajectory.final_answer.strip().upper()),
         timeout_s=1200.0,
-        tags=frozenset({"dimsim", "apartment", "qa", "object-location", "single-choice"}),
+        tags=frozenset({"object-location", "single-choice"}),
     ),
     EvalCase(
         id="dimsim_apartment_bathtub_exists",
@@ -98,7 +85,7 @@ SUITE: Suite = [
         environment=_environment(),
         grade=_parsed(yes_no, lambda value: exact("yes", value)),
         timeout_s=1200.0,
-        tags=frozenset({"dimsim", "apartment", "qa", "existence", "boolean"}),
+        tags=frozenset({"existence", "boolean"}),
     ),
     EvalCase(
         id="dimsim_apartment_washing_machine_exists",
@@ -106,7 +93,7 @@ SUITE: Suite = [
         environment=_environment(),
         grade=_parsed(yes_no, lambda value: exact("no", value)),
         timeout_s=1200.0,
-        tags=frozenset({"dimsim", "apartment", "qa", "existence", "boolean", "draft-reference"}),
+        tags=frozenset({"existence", "boolean", "draft-reference"}),
     ),
     EvalCase(
         id="dimsim_apartment_dining_chair_count",
@@ -114,7 +101,7 @@ SUITE: Suite = [
         environment=_environment(),
         grade=_parsed(first_number, lambda value: exact(4, value)),
         timeout_s=1200.0,
-        tags=frozenset({"dimsim", "apartment", "qa", "object-count", "count"}),
+        tags=frozenset({"object-count", "count"}),
     ),
     EvalCase(
         id="dimsim_apartment_bedside_table_count",
@@ -122,15 +109,7 @@ SUITE: Suite = [
         environment=_environment(),
         grade=_parsed(first_number, lambda value: exact(2, value)),
         timeout_s=1200.0,
-        tags=frozenset({"dimsim", "apartment", "qa", "object-count", "count"}),
-    ),
-    EvalCase(
-        id="dimsim_apartment_wall_cabinet_count",
-        inputs="How many wall-mounted kitchen cabinets are in the house? Return only the count.",
-        environment=_environment(),
-        grade=_parsed(first_number, lambda value: exact(3, value)),
-        timeout_s=1200.0,
-        tags=frozenset({"dimsim", "apartment", "qa", "object-count", "count"}),
+        tags=frozenset({"object-count", "count"}),
     ),
     EvalCase(
         id="dimsim_apartment_every_desk_has_laptop",
@@ -138,9 +117,7 @@ SUITE: Suite = [
         environment=_environment(),
         grade=_parsed(yes_no, lambda value: exact("yes", value)),
         timeout_s=1200.0,
-        tags=frozenset(
-            {"dimsim", "apartment", "qa", "spatial-relation", "boolean", "draft-reference"}
-        ),
+        tags=frozenset({"spatial-relation", "boolean", "draft-reference"}),
     ),
     EvalCase(
         id="dimsim_apartment_room_count",
@@ -148,7 +125,7 @@ SUITE: Suite = [
         environment=_environment(),
         grade=_parsed(first_number, lambda value: exact(4, value)),
         timeout_s=1200.0,
-        tags=frozenset({"dimsim", "apartment", "qa", "rooms", "count"}),
+        tags=frozenset({"rooms", "count"}),
     ),
     EvalCase(
         id="dimsim_apartment_largest_room_area",
@@ -156,9 +133,7 @@ SUITE: Suite = [
         environment=_environment(),
         grade=_parsed(first_number, lambda value: numeric(37.8, value, tolerance=2.5, band=8.0)),
         timeout_s=1200.0,
-        tags=frozenset(
-            {"dimsim", "apartment", "qa", "rooms", "area", "numeric", "draft-reference"}
-        ),
+        tags=frozenset({"rooms", "area", "numeric", "draft-reference"}),
     ),
     EvalCase(
         id="dimsim_apartment_refrigerator_height",
@@ -166,15 +141,15 @@ SUITE: Suite = [
         environment=_environment(),
         grade=_parsed(first_number, lambda value: numeric(1.8, value, tolerance=0.1, band=0.4)),
         timeout_s=1200.0,
-        tags=frozenset({"dimsim", "apartment", "qa", "dimensions", "numeric"}),
+        tags=frozenset({"dimensions", "numeric"}),
     ),
     EvalCase(
-        id="dimsim_apartment_dining_table_dimensions",
-        inputs="What are the approximate length and width of the dining table, in meters? Return only two positive numbers separated by a comma: length, width.",
+        id="dimsim_apartment_dining_table_diagonal",
+        inputs="What is the approximate diagonal length of the rectangular dining table, in meters? Return only the number.",
         environment=_environment(),
-        grade=_table_dimensions,
+        grade=_parsed(first_number, lambda value: numeric(2.46, value, tolerance=0.1, band=0.4)),
         timeout_s=1200.0,
-        tags=frozenset({"dimsim", "apartment", "qa", "dimensions", "numeric"}),
+        tags=frozenset({"dimensions", "numeric"}),
     ),
     EvalCase(
         id="dimsim_apartment_bed_footprint_area",
@@ -182,7 +157,7 @@ SUITE: Suite = [
         environment=_environment(),
         grade=_parsed(first_number, lambda value: numeric(3.52, value, tolerance=0.25, band=1.0)),
         timeout_s=1200.0,
-        tags=frozenset({"dimsim", "apartment", "qa", "dimensions", "area", "numeric"}),
+        tags=frozenset({"dimensions", "area", "numeric"}),
     ),
     EvalCase(
         id="dimsim_apartment_house_perimeter",
@@ -190,7 +165,7 @@ SUITE: Suite = [
         environment=_environment(),
         grade=_parsed(first_number, lambda value: numeric(44.0, value, tolerance=1.0, band=5.0)),
         timeout_s=1200.0,
-        tags=frozenset({"dimsim", "apartment", "qa", "geometry", "perimeter", "numeric"}),
+        tags=frozenset({"geometry", "perimeter", "numeric"}),
     ),
     EvalCase(
         id="dimsim_apartment_yard_door_count",
@@ -198,7 +173,15 @@ SUITE: Suite = [
         environment=_environment(),
         grade=_parsed(first_number, lambda value: exact(2, value)),
         timeout_s=1200.0,
-        tags=frozenset({"dimsim", "apartment", "qa", "doors", "count", "draft-reference"}),
+        tags=frozenset({"doors", "count", "draft-reference"}),
+    ),
+    EvalCase(
+        id="dimsim_apartment_doorway_radius",
+        inputs="What is the largest robot radius that can fit through all the doorways in 2D, in meters? Return only the number.",
+        environment=_environment(),
+        grade=_parsed(first_number, lambda value: numeric(0.5, value, tolerance=0.025, band=0.1)),
+        timeout_s=1200.0,
+        tags=frozenset({"clearance", "numeric"}),
     ),
     EvalCase(
         id="dimsim_apartment_refrigerator_tv_distance",
@@ -206,7 +189,7 @@ SUITE: Suite = [
         environment=_environment(),
         grade=_parsed(first_number, lambda value: numeric(8.37, value, tolerance=0.3, band=1.5)),
         timeout_s=1200.0,
-        tags=frozenset({"dimsim", "apartment", "qa", "distance", "numeric", "draft-reference"}),
+        tags=frozenset({"distance", "numeric", "draft-reference"}),
     ),
     EvalCase(
         id="dimsim_apartment_refrigerator_state",
@@ -214,7 +197,7 @@ SUITE: Suite = [
         environment=_environment(),
         grade=lambda o: exact("A", o.trajectory.final_answer.strip().upper()),
         timeout_s=1200.0,
-        tags=frozenset({"dimsim", "apartment", "qa", "object-state", "single-choice"}),
+        tags=frozenset({"object-state", "single-choice"}),
     ),
     EvalCase(
         id="dimsim_apartment_kitchen_bathroom_crossings",
@@ -222,7 +205,15 @@ SUITE: Suite = [
         environment=_environment(),
         grade=_parsed(first_number, lambda value: exact(3, value)),
         timeout_s=1200.0,
-        tags=frozenset({"dimsim", "apartment", "qa", "connectivity", "count", "draft-reference"}),
+        tags=frozenset({"connectivity", "count", "draft-reference"}),
+    ),
+    EvalCase(
+        id="dimsim_apartment_refrigerator_open_passability",
+        inputs="Would opening the refrigerator change whether a robot of radius 0.25 m can pass from the kitchen doorway to the sink? Return only yes or no.",
+        environment=_environment(),
+        grade=_parsed(yes_no, lambda value: exact("no", value)),
+        timeout_s=1200.0,
+        tags=frozenset({"counterfactual", "clearance", "boolean"}),
     ),
     EvalCase(
         id="dimsim_apartment_wall_separated_objects",
@@ -230,9 +221,7 @@ SUITE: Suite = [
         environment=_environment(),
         grade=lambda o: exact("C", o.trajectory.final_answer.strip().upper()),
         timeout_s=1200.0,
-        tags=frozenset(
-            {"dimsim", "apartment", "qa", "spatial-relation", "single-choice", "draft-reference"}
-        ),
+        tags=frozenset({"spatial-relation", "single-choice", "draft-reference"}),
     ),
     EvalCase(
         id="dimsim_apartment_closest_to_sofa",
@@ -240,9 +229,15 @@ SUITE: Suite = [
         environment=_environment(),
         grade=lambda o: exact("B", o.trajectory.final_answer.strip().upper()),
         timeout_s=1200.0,
-        tags=frozenset(
-            {"dimsim", "apartment", "qa", "spatial-ordering", "single-choice", "draft-reference"}
-        ),
+        tags=frozenset({"spatial-ordering", "single-choice", "draft-reference"}),
+    ),
+    EvalCase(
+        id="dimsim_apartment_object_order_by_path",
+        inputs="What is the order of these objects from nearest to farthest from the sofa by collision-free travel distance for a robot of radius 0.25 m? A: Refrigerator; B: Dining table; C: Work desk. Return all three letters once, in order, optionally separated by commas. Do not include an explanation.",
+        environment=_environment(),
+        grade=_parsed(ranking, lambda value: rank_order("BCA", value)),
+        timeout_s=1200.0,
+        tags=frozenset({"spatial-ordering", "ranking", "draft-reference"}),
     ),
     EvalCase(
         id="dimsim_apartment_bedside_table_coverage",
@@ -250,6 +245,6 @@ SUITE: Suite = [
         environment=_environment(),
         grade=_parsed(yes_no, lambda value: exact("no", value)),
         timeout_s=1200.0,
-        tags=frozenset({"dimsim", "apartment", "qa", "coverage", "boolean", "draft-reference"}),
+        tags=frozenset({"coverage", "boolean", "draft-reference"}),
     ),
 ]

--- a/dimos/evals/suites/dimsim_apartment_qa.py
+++ b/dimos/evals/suites/dimsim_apartment_qa.py
@@ -14,8 +14,12 @@
 
 """Draft answer-only QA for the static DimSim apartment.
 
-    DIMOS_TRANSPORT=lcm dimos evals run dimos.evals.suites.dimsim_apartment_qa \
+    DIMOS_TRANSPORT=lcm VIEWER=none DIMSIM_HEADLESS=true \
+        dimos evals run dimos.evals.suites.dimsim_apartment_qa \
         --agent dimos.evals.agents.pi
+
+For only the room-count question, append ``--tags rooms --limit 1``.
+Use ``--set max_steps=100`` to give Pi room for active exploration.
 
 References derive from the apartment manifest and GLBs at c5b78bd9a23344db91a59aabdd7f7db614998ab8
 and await human validation. Room area uses inside wall faces; distance uses
@@ -38,6 +42,16 @@ from dimos.evals.scorers import exact, first_number, numeric, rank_order, rankin
 from dimos.evals.types import EvalCase, Outcome, Suite
 
 T = TypeVar("T")
+
+INSTRUCTION = (
+    "You are answering questions about a live simulated house. "
+    "You control the robot, and its sensor recording grows as it observes "
+    "the environment. Initial observations do not cover the whole house. "
+    "Move around to gather the evidence needed to answer the question. "
+    "For whole-house counts or absence claims, inspect all relevant rooms. "
+    "Use observations rather than assumptions about a typical house. "
+    "When you have enough evidence, return the answer in the requested format."
+)
 
 
 def _parsed(parser: Callable[[str], T], score: Callable[[T], float]) -> Callable[[Outcome], float]:
@@ -65,7 +79,9 @@ def _environment() -> Sim:
 SUITE: Suite = [
     EvalCase(
         id="dimsim_apartment_refrigerator_location",
-        inputs="Which room contains the refrigerator? A: Bedroom; B: Kitchen; C: Bathroom; D: Living room. Return only A, B, C, or D.",
+        inputs=INSTRUCTION
+        + "\n\n"
+        + "Which room contains the refrigerator? A: Bedroom; B: Kitchen; C: Bathroom; D: Living room. Return only A, B, C, or D.",
         environment=_environment(),
         grade=lambda o: exact("B", o.trajectory.final_answer.strip().upper()),
         timeout_s=1200.0,
@@ -73,7 +89,9 @@ SUITE: Suite = [
     ),
     EvalCase(
         id="dimsim_apartment_work_desk_location",
-        inputs="Which room contains the work desk? A: Kitchen; B: Bathroom; C: Living room; D: Bedroom. Return only A, B, C, or D.",
+        inputs=INSTRUCTION
+        + "\n\n"
+        + "Which room contains the work desk? A: Kitchen; B: Bathroom; C: Living room; D: Bedroom. Return only A, B, C, or D.",
         environment=_environment(),
         grade=lambda o: exact("D", o.trajectory.final_answer.strip().upper()),
         timeout_s=1200.0,
@@ -81,7 +99,7 @@ SUITE: Suite = [
     ),
     EvalCase(
         id="dimsim_apartment_bathtub_exists",
-        inputs="Does the house contain a bathtub? Return only yes or no.",
+        inputs=INSTRUCTION + "\n\n" + "Does the house contain a bathtub? Return only yes or no.",
         environment=_environment(),
         grade=_parsed(yes_no, lambda value: exact("yes", value)),
         timeout_s=1200.0,
@@ -89,7 +107,9 @@ SUITE: Suite = [
     ),
     EvalCase(
         id="dimsim_apartment_washing_machine_exists",
-        inputs="Does the house contain a washing machine? Return only yes or no.",
+        inputs=INSTRUCTION
+        + "\n\n"
+        + "Does the house contain a washing machine? Return only yes or no.",
         environment=_environment(),
         grade=_parsed(yes_no, lambda value: exact("no", value)),
         timeout_s=1200.0,
@@ -97,7 +117,9 @@ SUITE: Suite = [
     ),
     EvalCase(
         id="dimsim_apartment_dining_chair_count",
-        inputs="How many dining chairs are in the house? Return only the count.",
+        inputs=INSTRUCTION
+        + "\n\n"
+        + "How many dining chairs are in the house? Return only the count.",
         environment=_environment(),
         grade=_parsed(first_number, lambda value: exact(4, value)),
         timeout_s=1200.0,
@@ -105,7 +127,9 @@ SUITE: Suite = [
     ),
     EvalCase(
         id="dimsim_apartment_bedside_table_count",
-        inputs="How many bedside tables are in the house? Return only the count.",
+        inputs=INSTRUCTION
+        + "\n\n"
+        + "How many bedside tables are in the house? Return only the count.",
         environment=_environment(),
         grade=_parsed(first_number, lambda value: exact(2, value)),
         timeout_s=1200.0,
@@ -113,7 +137,9 @@ SUITE: Suite = [
     ),
     EvalCase(
         id="dimsim_apartment_every_desk_has_laptop",
-        inputs="Does every work desk in the house have a laptop on it? Return only yes or no.",
+        inputs=INSTRUCTION
+        + "\n\n"
+        + "Does every work desk in the house have a laptop on it? Return only yes or no.",
         environment=_environment(),
         grade=_parsed(yes_no, lambda value: exact("yes", value)),
         timeout_s=1200.0,
@@ -121,7 +147,7 @@ SUITE: Suite = [
     ),
     EvalCase(
         id="dimsim_apartment_room_count",
-        inputs="How many rooms are in the house? Return only the count.",
+        inputs=INSTRUCTION + "\n\n" + "How many rooms are in the house? Return only the count.",
         environment=_environment(),
         grade=_parsed(first_number, lambda value: exact(4, value)),
         timeout_s=1200.0,
@@ -129,7 +155,9 @@ SUITE: Suite = [
     ),
     EvalCase(
         id="dimsim_apartment_largest_room_area",
-        inputs="What is the approximate area of the largest room, in square meters? Return only the number.",
+        inputs=INSTRUCTION
+        + "\n\n"
+        + "What is the approximate area of the largest room, in square meters? Return only the number.",
         environment=_environment(),
         grade=_parsed(first_number, lambda value: numeric(37.8, value, tolerance=2.5, band=8.0)),
         timeout_s=1200.0,
@@ -137,7 +165,9 @@ SUITE: Suite = [
     ),
     EvalCase(
         id="dimsim_apartment_refrigerator_height",
-        inputs="What is the approximate height of the refrigerator, in meters? Return only the number.",
+        inputs=INSTRUCTION
+        + "\n\n"
+        + "What is the approximate height of the refrigerator, in meters? Return only the number.",
         environment=_environment(),
         grade=_parsed(first_number, lambda value: numeric(1.8, value, tolerance=0.1, band=0.4)),
         timeout_s=1200.0,
@@ -145,7 +175,9 @@ SUITE: Suite = [
     ),
     EvalCase(
         id="dimsim_apartment_dining_table_diagonal",
-        inputs="What is the approximate diagonal length of the rectangular dining table, in meters? Return only the number.",
+        inputs=INSTRUCTION
+        + "\n\n"
+        + "What is the approximate diagonal length of the rectangular dining table, in meters? Return only the number.",
         environment=_environment(),
         grade=_parsed(first_number, lambda value: numeric(2.46, value, tolerance=0.1, band=0.4)),
         timeout_s=1200.0,
@@ -153,7 +185,9 @@ SUITE: Suite = [
     ),
     EvalCase(
         id="dimsim_apartment_bed_footprint_area",
-        inputs="What is the approximate footprint area of the bed frame, in square meters? Return only the number.",
+        inputs=INSTRUCTION
+        + "\n\n"
+        + "What is the approximate footprint area of the bed frame, in square meters? Return only the number.",
         environment=_environment(),
         grade=_parsed(first_number, lambda value: numeric(3.52, value, tolerance=0.25, band=1.0)),
         timeout_s=1200.0,
@@ -161,7 +195,9 @@ SUITE: Suite = [
     ),
     EvalCase(
         id="dimsim_apartment_house_perimeter",
-        inputs="What is the approximate perimeter of the house, in meters? Return only the number.",
+        inputs=INSTRUCTION
+        + "\n\n"
+        + "What is the approximate perimeter of the house, in meters? Return only the number.",
         environment=_environment(),
         grade=_parsed(first_number, lambda value: numeric(44.0, value, tolerance=1.0, band=5.0)),
         timeout_s=1200.0,
@@ -169,7 +205,9 @@ SUITE: Suite = [
     ),
     EvalCase(
         id="dimsim_apartment_yard_door_count",
-        inputs="How many doors connect the house to the yard? Return only the count.",
+        inputs=INSTRUCTION
+        + "\n\n"
+        + "How many doors connect the house to the yard? Return only the count.",
         environment=_environment(),
         grade=_parsed(first_number, lambda value: exact(2, value)),
         timeout_s=1200.0,
@@ -177,7 +215,9 @@ SUITE: Suite = [
     ),
     EvalCase(
         id="dimsim_apartment_doorway_radius",
-        inputs="What is the largest robot radius that can fit through all the doorways in 2D, in meters? Return only the number.",
+        inputs=INSTRUCTION
+        + "\n\n"
+        + "What is the largest robot radius that can fit through all the doorways in 2D, in meters? Return only the number.",
         environment=_environment(),
         grade=_parsed(first_number, lambda value: numeric(0.5, value, tolerance=0.025, band=0.1)),
         timeout_s=1200.0,
@@ -185,7 +225,9 @@ SUITE: Suite = [
     ),
     EvalCase(
         id="dimsim_apartment_refrigerator_tv_distance",
-        inputs="What is the approximate straight-line distance between the refrigerator and television, in meters? Return only the number.",
+        inputs=INSTRUCTION
+        + "\n\n"
+        + "What is the approximate straight-line distance between the refrigerator and television, in meters? Return only the number.",
         environment=_environment(),
         grade=_parsed(first_number, lambda value: numeric(8.37, value, tolerance=0.3, band=1.5)),
         timeout_s=1200.0,
@@ -193,7 +235,9 @@ SUITE: Suite = [
     ),
     EvalCase(
         id="dimsim_apartment_refrigerator_state",
-        inputs="Is the refrigerator open or closed? A: Closed; B: Open. Return only A or B.",
+        inputs=INSTRUCTION
+        + "\n\n"
+        + "Is the refrigerator open or closed? A: Closed; B: Open. Return only A or B.",
         environment=_environment(),
         grade=lambda o: exact("A", o.trajectory.final_answer.strip().upper()),
         timeout_s=1200.0,
@@ -201,7 +245,9 @@ SUITE: Suite = [
     ),
     EvalCase(
         id="dimsim_apartment_kitchen_bathroom_crossings",
-        inputs="What is the minimum number of doorway crossings between the kitchen and bathroom without leaving the house? Return only the count.",
+        inputs=INSTRUCTION
+        + "\n\n"
+        + "What is the minimum number of doorway crossings between the kitchen and bathroom without leaving the house? Return only the count.",
         environment=_environment(),
         grade=_parsed(first_number, lambda value: exact(3, value)),
         timeout_s=1200.0,
@@ -209,7 +255,9 @@ SUITE: Suite = [
     ),
     EvalCase(
         id="dimsim_apartment_refrigerator_open_passability",
-        inputs="Would opening the refrigerator change whether a robot of radius 0.25 m can pass from the kitchen doorway to the sink? Return only yes or no.",
+        inputs=INSTRUCTION
+        + "\n\n"
+        + "Would opening the refrigerator change whether a robot of radius 0.25 m can pass from the kitchen doorway to the sink? Return only yes or no.",
         environment=_environment(),
         grade=_parsed(yes_no, lambda value: exact("no", value)),
         timeout_s=1200.0,
@@ -217,7 +265,9 @@ SUITE: Suite = [
     ),
     EvalCase(
         id="dimsim_apartment_wall_separated_objects",
-        inputs="Which pair of objects is on opposite sides of the same wall? A: Sofa and television; B: Work desk and bed; C: Refrigerator and work desk; D: Bathtub and toilet. Return only A, B, C, or D.",
+        inputs=INSTRUCTION
+        + "\n\n"
+        + "Which pair of objects is on opposite sides of the same wall? A: Sofa and television; B: Work desk and bed; C: Refrigerator and work desk; D: Bathtub and toilet. Return only A, B, C, or D.",
         environment=_environment(),
         grade=lambda o: exact("C", o.trajectory.final_answer.strip().upper()),
         timeout_s=1200.0,
@@ -225,7 +275,9 @@ SUITE: Suite = [
     ),
     EvalCase(
         id="dimsim_apartment_closest_to_sofa",
-        inputs="Which object is closest to the sofa by straight-line distance? A: Refrigerator; B: Dining table; C: Work desk. Return only A, B, or C.",
+        inputs=INSTRUCTION
+        + "\n\n"
+        + "Which object is closest to the sofa by straight-line distance? A: Refrigerator; B: Dining table; C: Work desk. Return only A, B, or C.",
         environment=_environment(),
         grade=lambda o: exact("B", o.trajectory.final_answer.strip().upper()),
         timeout_s=1200.0,
@@ -233,7 +285,9 @@ SUITE: Suite = [
     ),
     EvalCase(
         id="dimsim_apartment_object_order_by_path",
-        inputs="What is the order of these objects from nearest to farthest from the sofa by collision-free travel distance for a robot of radius 0.25 m? A: Refrigerator; B: Dining table; C: Work desk. Return all three letters once, in order, optionally separated by commas. Do not include an explanation.",
+        inputs=INSTRUCTION
+        + "\n\n"
+        + "What is the order of these objects from nearest to farthest from the sofa by collision-free travel distance for a robot of radius 0.25 m? A: Refrigerator; B: Dining table; C: Work desk. Return all three letters once, in order, optionally separated by commas. Do not include an explanation.",
         environment=_environment(),
         grade=_parsed(ranking, lambda value: rank_order("BCA", value)),
         timeout_s=1200.0,
@@ -241,7 +295,9 @@ SUITE: Suite = [
     ),
     EvalCase(
         id="dimsim_apartment_bedside_table_coverage",
-        inputs="Is observing only the living room and kitchen sufficient to determine how many bedside tables are in the house? Return only yes or no.",
+        inputs=INSTRUCTION
+        + "\n\n"
+        + "Is observing only the living room and kitchen sufficient to determine how many bedside tables are in the house? Return only yes or no.",
         environment=_environment(),
         grade=_parsed(yes_no, lambda value: exact("no", value)),
         timeout_s=1200.0,

--- a/dimos/evals/suites/dimsim_apartment_qa.py
+++ b/dimos/evals/suites/dimsim_apartment_qa.py
@@ -1,0 +1,255 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Draft answer-only QA for the static DimSim apartment.
+
+    DIMOS_TRANSPORT=lcm dimos evals run dimos.evals.suites.dimsim_apartment_qa \
+        --agent dimos.evals.agents.pi
+
+References derive from the apartment manifest and GLBs at c5b78bd9a23344db91a59aabdd7f7db614998ab8
+and await human validation. Room area uses inside wall faces; distance uses
+horizontal asset-center proxies. Tolerances are draft, not measurement precision.
+Each case starts a fresh simulation with the authored spawn and static states.
+The runner/agent adapter owns tool access; prompts do not prescribe a navigation API.
+
+Pending references (not scored): maximum passable radius, refrigerator-open
+passability change, and closest object by collision-free travel distance.
+"""
+
+from collections.abc import Callable
+import math
+from typing import TypeVar
+
+from dimos.evals.environments.sim import Sim
+from dimos.evals.scorers import exact, first_number, numeric, yes_no
+from dimos.evals.types import EvalCase, Outcome, Suite
+
+T = TypeVar("T")
+
+
+def _parsed(parser: Callable[[str], T], score: Callable[[T], float]) -> Callable[[Outcome], float]:
+    """Keep answer parsing separate from scoring; unparseable answers earn zero."""
+
+    def grade(o: Outcome) -> float:
+        try:
+            value = parser(o.trajectory.final_answer)
+        except ValueError:
+            return 0.0
+        return score(value)
+
+    return grade
+
+
+def _environment() -> Sim:
+    return Sim(
+        blueprint=["unitree-go2", "mcp-server", "unitree-skill-container"],
+        disable=("wavefront-frontier-explorer", "patrolling-module"),
+        simulator="dimsim",
+        scene="apartment",
+    )
+
+
+def _table_dimensions(o: Outcome) -> float:
+    """Accept swapped dimensions, but require both finite positive measurements."""
+    try:
+        length, width = sorted(
+            (float(v.strip()) for v in o.trajectory.final_answer.split(",")), reverse=True
+        )
+        if not all(math.isfinite(v) and v > 0 for v in (length, width)):
+            return 0.0
+    except ValueError:
+        return 0.0
+    return 0.5 * numeric(2.2, length, tolerance=0.1, band=0.4) + 0.5 * numeric(
+        1.1, width, tolerance=0.05, band=0.25
+    )
+
+
+SUITE: Suite = [
+    EvalCase(
+        id="dimsim_apartment_refrigerator_location",
+        inputs="Which room contains the refrigerator? A: Bedroom; B: Kitchen; C: Bathroom; D: Living room. Return only A, B, C, or D.",
+        environment=_environment(),
+        grade=lambda o: exact("B", o.trajectory.final_answer.strip().upper()),
+        timeout_s=1200.0,
+        tags=frozenset({"dimsim", "apartment", "qa", "object-location", "single-choice"}),
+    ),
+    EvalCase(
+        id="dimsim_apartment_work_desk_location",
+        inputs="Which room contains the work desk? A: Kitchen; B: Bathroom; C: Living room; D: Bedroom. Return only A, B, C, or D.",
+        environment=_environment(),
+        grade=lambda o: exact("D", o.trajectory.final_answer.strip().upper()),
+        timeout_s=1200.0,
+        tags=frozenset({"dimsim", "apartment", "qa", "object-location", "single-choice"}),
+    ),
+    EvalCase(
+        id="dimsim_apartment_bathtub_exists",
+        inputs="Does the house contain a bathtub? Return only yes or no.",
+        environment=_environment(),
+        grade=_parsed(yes_no, lambda value: exact("yes", value)),
+        timeout_s=1200.0,
+        tags=frozenset({"dimsim", "apartment", "qa", "existence", "boolean"}),
+    ),
+    EvalCase(
+        id="dimsim_apartment_washing_machine_exists",
+        inputs="Does the house contain a washing machine? Return only yes or no.",
+        environment=_environment(),
+        grade=_parsed(yes_no, lambda value: exact("no", value)),
+        timeout_s=1200.0,
+        tags=frozenset({"dimsim", "apartment", "qa", "existence", "boolean", "draft-reference"}),
+    ),
+    EvalCase(
+        id="dimsim_apartment_dining_chair_count",
+        inputs="How many dining chairs are in the house? Return only the count.",
+        environment=_environment(),
+        grade=_parsed(first_number, lambda value: exact(4, value)),
+        timeout_s=1200.0,
+        tags=frozenset({"dimsim", "apartment", "qa", "object-count", "count"}),
+    ),
+    EvalCase(
+        id="dimsim_apartment_bedside_table_count",
+        inputs="How many bedside tables are in the house? Return only the count.",
+        environment=_environment(),
+        grade=_parsed(first_number, lambda value: exact(2, value)),
+        timeout_s=1200.0,
+        tags=frozenset({"dimsim", "apartment", "qa", "object-count", "count"}),
+    ),
+    EvalCase(
+        id="dimsim_apartment_wall_cabinet_count",
+        inputs="How many wall-mounted kitchen cabinets are in the house? Return only the count.",
+        environment=_environment(),
+        grade=_parsed(first_number, lambda value: exact(3, value)),
+        timeout_s=1200.0,
+        tags=frozenset({"dimsim", "apartment", "qa", "object-count", "count"}),
+    ),
+    EvalCase(
+        id="dimsim_apartment_every_desk_has_laptop",
+        inputs="Does every work desk in the house have a laptop on it? Return only yes or no.",
+        environment=_environment(),
+        grade=_parsed(yes_no, lambda value: exact("yes", value)),
+        timeout_s=1200.0,
+        tags=frozenset(
+            {"dimsim", "apartment", "qa", "spatial-relation", "boolean", "draft-reference"}
+        ),
+    ),
+    EvalCase(
+        id="dimsim_apartment_room_count",
+        inputs="How many rooms are in the house? Return only the count.",
+        environment=_environment(),
+        grade=_parsed(first_number, lambda value: exact(4, value)),
+        timeout_s=1200.0,
+        tags=frozenset({"dimsim", "apartment", "qa", "rooms", "count"}),
+    ),
+    EvalCase(
+        id="dimsim_apartment_largest_room_area",
+        inputs="What is the approximate area of the largest room, in square meters? Return only the number.",
+        environment=_environment(),
+        grade=_parsed(first_number, lambda value: numeric(37.8, value, tolerance=2.5, band=8.0)),
+        timeout_s=1200.0,
+        tags=frozenset(
+            {"dimsim", "apartment", "qa", "rooms", "area", "numeric", "draft-reference"}
+        ),
+    ),
+    EvalCase(
+        id="dimsim_apartment_refrigerator_height",
+        inputs="What is the approximate height of the refrigerator, in meters? Return only the number.",
+        environment=_environment(),
+        grade=_parsed(first_number, lambda value: numeric(1.8, value, tolerance=0.1, band=0.4)),
+        timeout_s=1200.0,
+        tags=frozenset({"dimsim", "apartment", "qa", "dimensions", "numeric"}),
+    ),
+    EvalCase(
+        id="dimsim_apartment_dining_table_dimensions",
+        inputs="What are the approximate length and width of the dining table, in meters? Return only two positive numbers separated by a comma: length, width.",
+        environment=_environment(),
+        grade=_table_dimensions,
+        timeout_s=1200.0,
+        tags=frozenset({"dimsim", "apartment", "qa", "dimensions", "numeric"}),
+    ),
+    EvalCase(
+        id="dimsim_apartment_bed_footprint_area",
+        inputs="What is the approximate footprint area of the bed frame, in square meters? Return only the number.",
+        environment=_environment(),
+        grade=_parsed(first_number, lambda value: numeric(3.52, value, tolerance=0.25, band=1.0)),
+        timeout_s=1200.0,
+        tags=frozenset({"dimsim", "apartment", "qa", "dimensions", "area", "numeric"}),
+    ),
+    EvalCase(
+        id="dimsim_apartment_house_perimeter",
+        inputs="What is the approximate perimeter of the house, in meters? Return only the number.",
+        environment=_environment(),
+        grade=_parsed(first_number, lambda value: numeric(44.0, value, tolerance=1.0, band=5.0)),
+        timeout_s=1200.0,
+        tags=frozenset({"dimsim", "apartment", "qa", "geometry", "perimeter", "numeric"}),
+    ),
+    EvalCase(
+        id="dimsim_apartment_yard_door_count",
+        inputs="How many doors connect the house to the yard? Return only the count.",
+        environment=_environment(),
+        grade=_parsed(first_number, lambda value: exact(2, value)),
+        timeout_s=1200.0,
+        tags=frozenset({"dimsim", "apartment", "qa", "doors", "count", "draft-reference"}),
+    ),
+    EvalCase(
+        id="dimsim_apartment_refrigerator_tv_distance",
+        inputs="What is the approximate straight-line distance between the refrigerator and television, in meters? Return only the number.",
+        environment=_environment(),
+        grade=_parsed(first_number, lambda value: numeric(8.37, value, tolerance=0.3, band=1.5)),
+        timeout_s=1200.0,
+        tags=frozenset({"dimsim", "apartment", "qa", "distance", "numeric", "draft-reference"}),
+    ),
+    EvalCase(
+        id="dimsim_apartment_refrigerator_state",
+        inputs="Is the refrigerator open or closed? A: Closed; B: Open. Return only A or B.",
+        environment=_environment(),
+        grade=lambda o: exact("A", o.trajectory.final_answer.strip().upper()),
+        timeout_s=1200.0,
+        tags=frozenset({"dimsim", "apartment", "qa", "object-state", "single-choice"}),
+    ),
+    EvalCase(
+        id="dimsim_apartment_kitchen_bathroom_crossings",
+        inputs="What is the minimum number of doorway crossings between the kitchen and bathroom without leaving the house? Return only the count.",
+        environment=_environment(),
+        grade=_parsed(first_number, lambda value: exact(3, value)),
+        timeout_s=1200.0,
+        tags=frozenset({"dimsim", "apartment", "qa", "connectivity", "count", "draft-reference"}),
+    ),
+    EvalCase(
+        id="dimsim_apartment_wall_separated_objects",
+        inputs="Which pair of objects is on opposite sides of the same wall? A: Sofa and television; B: Work desk and bed; C: Refrigerator and work desk; D: Bathtub and toilet. Return only A, B, C, or D.",
+        environment=_environment(),
+        grade=lambda o: exact("C", o.trajectory.final_answer.strip().upper()),
+        timeout_s=1200.0,
+        tags=frozenset(
+            {"dimsim", "apartment", "qa", "spatial-relation", "single-choice", "draft-reference"}
+        ),
+    ),
+    EvalCase(
+        id="dimsim_apartment_closest_to_sofa",
+        inputs="Which object is closest to the sofa by straight-line distance? A: Refrigerator; B: Dining table; C: Work desk. Return only A, B, or C.",
+        environment=_environment(),
+        grade=lambda o: exact("B", o.trajectory.final_answer.strip().upper()),
+        timeout_s=1200.0,
+        tags=frozenset(
+            {"dimsim", "apartment", "qa", "spatial-ordering", "single-choice", "draft-reference"}
+        ),
+    ),
+    EvalCase(
+        id="dimsim_apartment_bedside_table_coverage",
+        inputs="Is observing only the living room and kitchen sufficient to determine how many bedside tables are in the house? Return only yes or no.",
+        environment=_environment(),
+        grade=_parsed(yes_no, lambda value: exact("no", value)),
+        timeout_s=1200.0,
+        tags=frozenset({"dimsim", "apartment", "qa", "coverage", "boolean", "draft-reference"}),
+    ),
+]

--- a/dimos/evals/test_apartment_qa.py
+++ b/dimos/evals/test_apartment_qa.py
@@ -14,7 +14,7 @@
 
 import pytest
 
-from dimos.evals.scorers import numeric
+from dimos.evals.scorers import numeric, rank_order
 from dimos.evals.suites.dimsim_apartment_qa import SUITE
 from dimos.evals.types import AgentInfo, FinalMetrics, Outcome, RunExtra, Step, Trajectory
 
@@ -103,28 +103,73 @@ def test_measurement_answers(answer: str, score: float) -> None:
 @pytest.mark.parametrize(
     "answer,score",
     [
-        ("2.2, 1.1", 1),
-        ("1.1, 2.2", 1),
-        ("3.0, 1.1", 0.5),
-        ("2.2", 0),
-        ("true, 1.1", 0),
-        ("2.2, -1.1", 0),
-        ("2.2, 1.1, 0.5", 0),
-        ("2.2, nan", 0),
-        ("inf, 1.1", 0),
+        ("2.46", 1),
+        ("2.36", 1),
+        ("2.56", 1),
+        ("2.71", 0.5),
+        ("2.86", 0),
+        ("unknown", 0),
     ],
 )
-def test_table_dimension_scoring(answer: str, score: float) -> None:
-    case = next(c for c in SUITE if c.id.endswith("dining_table_dimensions"))
+def test_table_diagonal_scoring(answer: str, score: float) -> None:
+    case = next(c for c in SUITE if c.id.endswith("dining_table_diagonal"))
     assert case.grade(_outcome(answer)) == pytest.approx(score)
 
 
+@pytest.mark.parametrize(
+    "suffix,answer,score",
+    [
+        ("doorway_radius", "0.5", 1),
+        ("doorway_radius", "0.475", 1),
+        ("doorway_radius", "0.4", 0),
+        ("refrigerator_open_passability", "no", 1),
+        ("refrigerator_open_passability", "yes", 0),
+    ],
+)
+def test_new_references(suffix: str, answer: str, score: float) -> None:
+    case = next(c for c in SUITE if c.id.endswith(suffix))
+    assert case.grade(_outcome(answer)) == score
+
+
+@pytest.mark.parametrize(
+    "answer,score",
+    [
+        ("BCA", 1),
+        (" b, c, a ", 1),
+        ("B C A", 1),
+        ("BAC", 2 / 3),
+        ("CBA", 2 / 3),
+        ("CAB", 1 / 3),
+        ("ABC", 1 / 3),
+        ("ACB", 0),
+        ("B", 0),
+        ("BBA", 0),
+        ("BCD", 0),
+        ("BCAA", 0),
+        ('["B", "C", "A"]', 0),
+        ("BCA because the table is closest", 0),
+    ],
+)
+def test_path_ranking(answer: str, score: float) -> None:
+    case = next(c for c in SUITE if c.id.endswith("object_order_by_path"))
+    assert case.grade(_outcome(answer)) == pytest.approx(score)
+
+
+def test_ranking_scorer_generalizes_to_more_labels() -> None:
+    assert rank_order(
+        ("desk", "sofa", "bed", "fridge"), ("sofa", "desk", "bed", "fridge")
+    ) == pytest.approx(5 / 6)
+    with pytest.raises(ValueError):
+        rank_order("AAB", "ABC")
+
+
 def test_suite_contract() -> None:
-    assert len(SUITE) == 21
-    assert len({c.id for c in SUITE}) == 21
-    assert len({id(c.environment) for c in SUITE}) == 21
+    assert len(SUITE) == 23
+    assert len({c.id for c in SUITE}) == 23
+    assert len({id(c.environment) for c in SUITE}) == 23
+    assert not any(c.id.endswith("wall_cabinet_count") for c in SUITE)
     for case in SUITE:
-        assert {"dimsim", "apartment", "qa"} <= case.tags
+        assert case.tags
         assert case.timeout_s == 1200
         assert case.threshold == 1
         assert case.grade(_outcome("invalid answer")) == 0

--- a/dimos/evals/test_apartment_qa.py
+++ b/dimos/evals/test_apartment_qa.py
@@ -1,0 +1,132 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from dimos.evals.scorers import numeric
+from dimos.evals.suites.dimsim_apartment_qa import SUITE
+from dimos.evals.types import AgentInfo, FinalMetrics, Outcome, RunExtra, Step, Trajectory
+
+
+def _outcome(answer: str) -> Outcome:
+    return Outcome(
+        trajectory=Trajectory(
+            agent=AgentInfo(name="test", version="1", model_name="test"),
+            steps=(Step(step_id=1, timestamp="", source="agent", message=answer),),
+            final_metrics=FinalMetrics(
+                total_prompt_tokens=0,
+                total_completion_tokens=0,
+                total_cached_tokens=0,
+                total_cost_usd=0,
+                total_steps=1,
+            ),
+            extra=RunExtra(ended_by="answer"),
+        ),
+        artifacts={},
+    )
+
+
+@pytest.mark.parametrize(
+    "value,score",
+    [(349, 0), (350, 0), (370, 0.5), (390, 1), (400, 1), (410, 1), (430, 0.5), (450, 0), (451, 0)],
+)
+def test_numeric_credit_bands(value: int, score: float) -> None:
+    assert numeric(400, value, tolerance=10, band=50) == score
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_nonfinite_numeric_values(value: float) -> None:
+    assert numeric(4, value, tolerance=0.1, band=1) == 0
+
+
+@pytest.mark.parametrize(
+    "answer,score",
+    [
+        ("4", 1),
+        ("4.0", 1),
+        ("There are 4 chairs.", 1),
+        ("3", 0),
+        ("4.5", 0),
+        ("-4", 0),
+        ("unknown", 0),
+    ],
+)
+def test_count_answers(answer: str, score: float) -> None:
+    case = next(c for c in SUITE if c.id.endswith("dining_chair_count"))
+    assert case.grade(_outcome(answer)) == score
+
+
+@pytest.mark.parametrize(
+    "answer,score",
+    [("yes", 1), (" YES ", 1), ("Yes, there is.", 1), ("no", 0), ("unknown", 0), ("true", 0)],
+)
+def test_boolean_answers(answer: str, score: float) -> None:
+    case = next(c for c in SUITE if c.id.endswith("bathtub_exists"))
+    assert case.grade(_outcome(answer)) == score
+
+
+@pytest.mark.parametrize("value,score", [(1.7, 1), (1.9, 1), (1.4, 0), (2.2, 0)])
+def test_decimal_boundaries(value: float, score: float) -> None:
+    assert numeric(1.8, value, tolerance=0.1, band=0.4) == score
+
+
+@pytest.mark.parametrize("tolerance,band", [(-1, 2), (1, 1), (2, 1), (0, float("inf"))])
+def test_invalid_bands(tolerance: float, band: float) -> None:
+    with pytest.raises(ValueError):
+        numeric(1, 1, tolerance=tolerance, band=band)
+
+
+def test_tiny_band_retains_partial_credit() -> None:
+    assert numeric(0, 2e-15, tolerance=1e-15, band=3e-15) == pytest.approx(0.5)
+
+
+@pytest.mark.parametrize(
+    "answer,score",
+    [("1.80", 1), ("About 1.8 meters", 1), ("1.55", 0.5), ("-1.8", 0), ("unknown", 0)],
+)
+def test_measurement_answers(answer: str, score: float) -> None:
+    case = next(c for c in SUITE if c.id.endswith("refrigerator_height"))
+    assert case.grade(_outcome(answer)) == pytest.approx(score)
+
+
+@pytest.mark.parametrize(
+    "answer,score",
+    [
+        ("2.2, 1.1", 1),
+        ("1.1, 2.2", 1),
+        ("3.0, 1.1", 0.5),
+        ("2.2", 0),
+        ("true, 1.1", 0),
+        ("2.2, -1.1", 0),
+        ("2.2, 1.1, 0.5", 0),
+        ("2.2, nan", 0),
+        ("inf, 1.1", 0),
+    ],
+)
+def test_table_dimension_scoring(answer: str, score: float) -> None:
+    case = next(c for c in SUITE if c.id.endswith("dining_table_dimensions"))
+    assert case.grade(_outcome(answer)) == pytest.approx(score)
+
+
+def test_suite_contract() -> None:
+    assert len(SUITE) == 21
+    assert len({c.id for c in SUITE}) == 21
+    assert len({id(c.environment) for c in SUITE}) == 21
+    for case in SUITE:
+        assert {"dimsim", "apartment", "qa"} <= case.tags
+        assert case.timeout_s == 1200
+        assert case.threshold == 1
+        assert case.grade(_outcome("invalid answer")) == 0
+        assert case.environment.config.scene == "apartment"
+        assert "JSON" not in case.inputs


### PR DESCRIPTION
## Contribution path
Related: #3879.

## Problem
Add scene-grounded apartment QA for agent evaluation.

## Solution
23 plain-answer cases with shared exploration instructions, numerical/ranking scoring, and draft reference notes.

## How to Test
Room-count case, headless with LCM:
```bash
DIMOS_TRANSPORT=lcm VIEWER=none DIMSIM_HEADLESS=true dimos evals run dimos.evals.suites.dimsim_apartment_qa --agent dimos.evals.agents.pi --set max_steps=100
```
Pre-commit passed with the approved local-data `lfs_check` skip.

## AI assistance

## Checklist
- [ ] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).