### PR TITLE
fix(teleop): keyboard teleop publishes only while a key is held

### DIFF
--- a/dimos/robot/unitree/keyboard_teleop.py
+++ b/dimos/robot/unitree/keyboard_teleop.py
@@ -91,7 +91,7 @@ class KeyboardTeleop(Module):
         angular_speed: float = DEFAULT_ANGULAR_SPEED,
         boost_multiplier: float = DEFAULT_BOOST_MULTIPLIER,
         slow_multiplier: float = DEFAULT_SLOW_MULTIPLIER,
-        publish_only_when_active: bool = False,
+        publish_only_when_active: bool = True,
         disable_movement: bool = False,
         **kwargs: Any,
     ) -> None:


### PR DESCRIPTION
## Problem

KeyboardTeleop publishes a zero Twist to cmd_vel at 50 Hz whenever no key is held. Composed with a blueprint that has a MovementManager (e.g. `dimos run unitree-go2 keyboard-teleop`), that idle stream interleaves with Rerun and command-center teleop on the same topic and the Go2 freezes in place, obeying move/stop in turn. Seen on two dogs.

More details: https://linear.app/dimensional/issue/DIM-1672/hardware-testing-problematic-teleop-cmd-vel-in-multiblueprint-testing

## Solution

Default publish_only_when_active to True: publish while a key is held, one zero on release, then silence. The holonomic, RPP and webrtc teleop blueprints already set this explicitly.

## How to test

uv run dimos run unitree-go2 keyboard-teleop

Drive from the pygame window, then from the Rerun WASD panel with the pygame window still open. Both move the dog cleanly; `dimos spy` shows cmd_vel silent when no key is held. Verified on Go2 hardware.


## AI assistance

Claude Code (Fable 5.1) assisted extensively with implementation, tests and the PR description under my direction. All hardware validation was done by me on the robot.


## Checklist

- [ ] I have read and approved the [CLA](https://github.com/dimensionalOS/dimos/blob/main/CLA.md).
